### PR TITLE
Remove the User resource from the signin flow

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -53,7 +53,7 @@ function mockFetch(url: string, options: any): Promise<any> {
 
   if (method === 'POST' && url.endsWith('auth/login')) {
     result = {
-      user: { resourceType: 'User', id: '123' },
+      profile: { resourceType: 'Practitioner', id: '123' },
       accessToken: '123',
       refreshToken: '456'
     };
@@ -153,7 +153,7 @@ test('Client signIn', async () => {
   const client = new MedplumClient(defaultOptions);
   const result = await client.signIn('admin@medplum.com', 'admin', 'practitioner', 'openid');
   expect(result).not.toBeUndefined();
-  expect(result.resourceType).toBe('User');
+  expect(result.resourceType).toBe('Practitioner');
 });
 
 test('Client signInWithRedirect', async () => {

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -82,7 +82,6 @@ describe('Google Auth', () => {
         credential: 'xyz'
       });
     expect(res.status).toBe(200);
-    expect(res.body.user).not.toBeUndefined();
     expect(res.body.profile).not.toBeUndefined();
     expect(res.body.idToken).not.toBeUndefined();
     expect(res.body.accessToken).not.toBeUndefined();

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -77,7 +77,6 @@ export async function googleHandler(req: Request, res: Response) {
 
   return res.status(200).json({
     ...loginDetails.tokens,
-    user: loginDetails.user,
     profile: loginDetails.profile
   });
 }

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -101,7 +101,6 @@ describe('Login', () => {
         role: 'practitioner'
       });
     expect(res.status).toBe(200);
-    expect(res.body.user).not.toBeUndefined();
     expect(res.body.profile).not.toBeUndefined();
     expect(res.body.idToken).not.toBeUndefined();
     expect(res.body.accessToken).not.toBeUndefined();

--- a/packages/server/src/auth/login.ts
+++ b/packages/server/src/auth/login.ts
@@ -34,7 +34,6 @@ export async function loginHandler(req: Request, res: Response) {
   const loginDetails = await finalizeLogin(login as Login);
   return res.status(200).json({
     ...loginDetails.tokens,
-    user: loginDetails.user,
     profile: loginDetails.profile
   });
 }

--- a/packages/server/src/auth/register.test.ts
+++ b/packages/server/src/auth/register.test.ts
@@ -36,7 +36,6 @@ describe('Register', () => {
       });
 
     expect(res.status).toBe(200);
-    expect(res.body.user).not.toBeUndefined();
     expect(res.body.profile).not.toBeUndefined();
     expect(res.body.idToken).not.toBeUndefined();
     expect(res.body.accessToken).not.toBeUndefined();
@@ -58,7 +57,7 @@ describe('Register', () => {
       .send(registerRequest);
 
     expect(res.status).toBe(200);
-    expect(res.body.user).not.toBeUndefined();
+    expect(res.body.profile).not.toBeUndefined();
 
     const res2 = await request(app)
       .post('/auth/register')

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -20,7 +20,6 @@ export interface RegisterRequest {
 }
 
 export interface RegisterResponse {
-  user: User;
   project: Project;
   profile: ProfileResource;
 }
@@ -75,7 +74,6 @@ export async function registerNew(request: RegisterRequest): Promise<RegisterRes
   const practitioner = await createPractitioner(request, project);
   await createProjectMembership(user, project, practitioner);
   return {
-    user,
     project,
     profile: practitioner
   }

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -56,7 +56,7 @@ describe('Reset Password', () => {
         password: 'password!@#'
       })
     expect(res.status).toBe(200);
-    expect(res.body.user).not.toBeUndefined();
+    expect(res.body.profile).not.toBeUndefined();
 
     const res2 = await request(app)
       .post('/auth/resetpassword')

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -608,7 +608,7 @@ test('Compartment permissions', async () => {
   };
 
   const result1 = await registerNew(registration1);
-  expect(result1.user).not.toBeUndefined();
+  expect(result1.profile).not.toBeUndefined();
 
   const [loginOutcome1, login1] = await tryLogin({
     authMethod: 'password',
@@ -647,7 +647,7 @@ test('Compartment permissions', async () => {
   };
 
   const result2 = await registerNew(registration2);
-  expect(result2.user).not.toBeUndefined();
+  expect(result2.profile).not.toBeUndefined();
 
   const [loginOutcome2, login2] = await tryLogin({
     authMethod: 'password',

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -27,7 +27,6 @@ export interface TokenResult {
 
 export interface LoginResult {
   readonly tokens: TokenResult;
-  readonly user: User;
   readonly profile: Resource;
 }
 
@@ -198,15 +197,11 @@ export async function finalizeLogin(login: Login): Promise<LoginResult> {
   const [tokensOutcome, tokens] = await getAuthTokens(login);
   assertOk(tokensOutcome);
 
-  const [userOutcome, user] = await repo.readReference<User>(login?.user as Reference);
-  assertOk(userOutcome);
-
   const [profileOutcome, profile] = await repo.readReference<ProfileResource>(login?.profile as Reference);
   assertOk(profileOutcome);
 
   return {
     tokens: tokens as TokenResult,
-    user: user as User,
     profile: profile as ProfileResource
   };
 }

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -1,4 +1,4 @@
-import { Bundle, BundleEntry, ClientApplication, CodeSystem, CodeSystemConcept, createReference, isOk, OperationOutcomeError, Project, Resource, SearchParameter, StructureDefinition, User, ValueSet } from '@medplum/core';
+import { Bundle, BundleEntry, ClientApplication, CodeSystem, CodeSystemConcept, isOk, OperationOutcomeError, Project, Resource, SearchParameter, StructureDefinition, ValueSet } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { randomUUID } from 'crypto';
 import { Pool } from 'pg';
@@ -16,7 +16,7 @@ export async function seedDatabase(): Promise<void> {
     return;
   }
 
-  const result = await registerNew({
+  await registerNew({
     admin: true,
     firstName: 'Medplum',
     lastName: 'Admin',
@@ -25,7 +25,7 @@ export async function seedDatabase(): Promise<void> {
     password: 'admin'
   });
 
-  await createPublicProject(result.user);
+  await createPublicProject();
   await createClientApplication();
   await createValueSetElements();
   await createSearchParameters();
@@ -54,13 +54,12 @@ async function isSeeded(): Promise<boolean> {
  * This is a special project that is available to all users.
  * It includes 'implementation' resources such as CapabilityStatement.
  */
-async function createPublicProject(owner: User): Promise<void> {
+async function createPublicProject(): Promise<void> {
   logger.info('Create Public project...');
   const [outcome, result] = await repo.updateResource<Project>({
     resourceType: 'Project',
     id: PUBLIC_PROJECT_ID,
-    name: 'Public',
-    owner: createReference(owner)
+    name: 'Public'
   });
 
   if (!isOk(outcome)) {

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -59,7 +59,10 @@ async function createPublicProject(): Promise<void> {
   const [outcome, result] = await repo.updateResource<Project>({
     resourceType: 'Project',
     id: PUBLIC_PROJECT_ID,
-    name: 'Public'
+    name: 'Public',
+    owner: {
+      reference: 'Project/' + PUBLIC_PROJECT_ID
+    }
   });
 
   if (!isOk(outcome)) {

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -2,11 +2,11 @@ import { HumanName, ProfileResource } from '@medplum/core';
 import React, { useState } from 'react';
 import { Avatar } from './Avatar';
 import { Button } from './Button';
-import './Header.css';
 import { HumanNameDisplay } from './HumanNameDisplay';
 import { MedplumLink } from './MedplumLink';
 import { useMedplumContext } from './MedplumProvider';
 import { Popup } from './Popup';
+import './Header.css';
 
 export interface HeaderProps {
   onLogo?: () => void;
@@ -43,7 +43,7 @@ export function Header(props: HeaderProps) {
           <MedplumLink testid="header-logo" onClick={props.onLogo}>
             Medplum
           </MedplumLink>
-          {auth.user && (
+          {auth.profile && (
             <div className="medplum-nav-search-container">
               <form role="search">
                 <input
@@ -80,7 +80,7 @@ export function Header(props: HeaderProps) {
             </div>
           )}
         </div>
-        {auth.user && (
+        {auth.profile && (
           <div className="medplum-nav-menu-container">
             <MedplumLink testid="header-profile-menu-button" onClick={() => setUserMenuVisible(true)}>
               <Avatar size="small" color="#f68d42" value={auth.profile as ProfileResource} />
@@ -97,7 +97,6 @@ export function Header(props: HeaderProps) {
                 <hr />
                 <div style={{ margin: 'auto', padding: '8px' }}>
                   <div style={{ margin: '4px auto 4px auto', fontWeight: 'bold' }}><HumanNameDisplay value={auth.profile?.name?.[0] as HumanName} /></div>
-                  <div style={{ margin: '4px auto 8px auto' }}>{auth.user?.email}</div>
                   <Button testid="header-profile-link" onClick={() => {
                     setUserMenuVisible(false);
                     if (props.onProfile) {

--- a/packages/ui/src/MedplumProvider.tsx
+++ b/packages/ui/src/MedplumProvider.tsx
@@ -1,4 +1,4 @@
-import { MedplumClient, ProfileResource, User } from '@medplum/core';
+import { MedplumClient, ProfileResource } from '@medplum/core';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const reactContext = createContext(undefined as MedplumContext | undefined);
@@ -12,7 +12,6 @@ export interface MedplumProviderProps {
 export interface MedplumContext {
   medplum: MedplumClient;
   router: MedplumRouter;
-  user?: User;
   profile?: ProfileResource;
   loading: boolean;
 }
@@ -71,7 +70,6 @@ export function useMedplumRouter(): MedplumRouter {
  */
 function createMedplumContext(medplum: MedplumClient, router: MedplumRouter): MedplumContext {
   const [state, setState] = useState({
-    user: medplum.getUser(),
     profile: medplum.getProfile(),
     loading: false
   });
@@ -79,7 +77,6 @@ function createMedplumContext(medplum: MedplumClient, router: MedplumRouter): Me
   useEffect(() => {
     const eventListener = () => setState({
       ...state,
-      user: medplum.getUser(),
       profile: medplum.getProfile()
     });
 


### PR DESCRIPTION
Context: the HTTP request that authenticates the user (either "/auth/login", "/auth/register", or "/auth/google")

Before: the responses would include both "user" and "profile"

Now:  the responses only include "profile"

Why?  The "User" object is increasingly an internal implementation detail.  It is not a standard FHIR resource, and end-users shouldn't ever really interact with it.