### PR TITLE
Update webhook job model

### DIFF
--- a/packages/infra/src/backend.ts
+++ b/packages/infra/src/backend.ts
@@ -92,7 +92,8 @@ export class BackEnd extends cdk.Construct {
         secretStringTemplate: JSON.stringify({
           host: redisCluster.attrPrimaryEndPointAddress,
           port: redisCluster.attrPrimaryEndPointPort,
-          password: redisPassword.secretValueFromJson('password').toString()
+          password: redisPassword.secretValueFromJson('password').toString(),
+          tls: {}
         }),
         generateStringKey: 'unused'
       }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -6,7 +6,7 @@ import validator from 'validator';
 import { MEDPLUM_PROJECT_ID, PUBLIC_PROJECT_ID } from '../constants';
 import { getClient } from '../database';
 import { logger } from '../logger';
-import { addWebhookJobData } from '../workers/webhooks';
+import { addSubscriptionJobs } from '../workers/webhooks';
 import { AddressTable, ContactPointTable, HumanNameTable, IdentifierTable, LookupTable } from './lookups';
 import { definitions, validateResource, validateResourceType } from './schema';
 import { getSearchParameter, getSearchParameters } from './search';
@@ -472,12 +472,7 @@ export class Repository {
   private async write(resource: Resource): Promise<void> {
     await this.writeResource(resource);
     await this.writeLookupTables(resource);
-
-    addWebhookJobData({
-      resourceType: resource.resourceType,
-      id: resource.id as string,
-      versionId: resource.meta?.versionId as string
-    });
+    await addSubscriptionJobs(resource);
   }
 
   private async writeResource(resource: Resource): Promise<void> {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,7 +21,10 @@ async function main() {
   await initKeys(config);
   await seedDatabase();
   initBinaryStorage(config.binaryStorage);
+
+  logger.debug('Initializing webhooks...');
   initWebhookWorker(config.redis);
+  logger.debug('Webhooks initialized');
 
   const app = await initApp(express());
   app.listen(5000);


### PR DESCRIPTION
* Set Redis TLS settings from CDK
* Add BullMQ QueueScheduler to help with failed jobs
* Set exponential backoff policy
* Keep individual webhooks in separate jobs for separate retry logic
* Evaluate Subscriptions at the time resource is created/updated, not every retry