### PR TITLE
Dockerfile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # TypeScript incremental build
 tsconfig.tsbuildinfo
 
+# Server tarball
+medplum-server.tar.gz
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16
+ENV NODE_ENV production
+WORKDIR /usr/src/medplum
+ADD ./medplum-server.tar.gz ./
+RUN npm ci
+EXPOSE 5000
+ENTRYPOINT [ "node", "packages/server/dist/index.js" ]

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,9 +1,0 @@
-FROM node:16
-ENV NODE_ENV production
-WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm i --only=production --legacy-peer-deps
-COPY dist/ dist/
-COPY templates/ templates/
-EXPOSE 5000
-ENTRYPOINT [ "node", "dist/index.js" ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,3 +28,15 @@ npx jest --runInBand
 
 # Lint
 npm run lint --workspaces
+
+# Build server tar
+tar -czvf medplum-server.tar.gz \
+  package.json \
+  package-lock.json \
+  packages/core/package.json \
+  packages/core/dist \
+  packages/definitions/package.json \
+  packages/definitions/dist \
+  packages/server/package.json \
+  packages/server/dist \
+  packages/server/templates

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Go into server directory
-pushd packages/server
-
 # Login to AWS ECR
 aws ecr get-login-password --profile medplum --region us-east-1 | docker login --username AWS --password-stdin 647991932601.dkr.ecr.us-east-1.amazonaws.com
 
@@ -20,6 +17,3 @@ aws ecs update-service \
   --cluster MedplumStack-BackEndCluster6B6DC4A8-b7rLxsX1zQdL \
   --service MedplumStack-BackEndFargateServiceD3B260C0-S35OIZcOSp1P \
   --force-new-deployment
-
-# Return to original directory
-popd


### PR DESCRIPTION
* Better support for monorepo. Before, used hacky model of `npm i`.  Now, uses proper `npm ci`
* Does not use npm packages for medplum dependencies.  This means npm publish is not required for a server release.