### PR TITLE
ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "root",
   "scripts": {
     "build": "sh ./scripts/build.sh",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/app",
   "version": "0.3.0",
   "description": "Medplum App",

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -1,13 +1,16 @@
-const path = require('path');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const DotenvPlugin = require('dotenv-webpack');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const dotenv = require('dotenv');
+import dotenv from 'dotenv';
+import DotenvPlugin from 'dotenv-webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import path from 'path';
+import url from 'url';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
 dotenv.config();
 
-module.exports = (env, argv) => ({
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+export default (env, argv) => ({
   entry: './src/index.tsx',
   devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
   output: {
@@ -44,6 +47,9 @@ module.exports = (env, argv) => ({
         test: /\.(js|jsx|ts|tsx)$/,
         exclude: '/node_modules/',
         loader: 'babel-loader',
+        resolve: {
+          fullySpecified: false
+        }
       },
       {
         test: /\.css$/i,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/core",
   "version": "0.3.0",
   "description": "Medplum TS/JS Library",

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/definitions",
   "version": "0.3.0",
   "description": "Medplum Data Definitions",

--- a/packages/fhirpath/package.json
+++ b/packages/fhirpath/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/fhirpath",
   "version": "0.3.0",
   "description": "Medplum FHIRPath Library",

--- a/packages/fhirtypes/package.json
+++ b/packages/fhirtypes/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/fhirtypes",
   "version": "0.3.0",
   "description": "Medplum FHIR Type Definitions",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/generator",
   "version": "0.3.0",
   "description": "Medplum Code Generator",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/graphiql",
   "version": "0.3.0",
   "description": "Medplum GraphiQL",

--- a/packages/graphiql/webpack.config.js
+++ b/packages/graphiql/webpack.config.js
@@ -1,8 +1,11 @@
-const path = require('path');
-const DotenvPlugin = require('dotenv-webpack');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+import DotenvPlugin from 'dotenv-webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-module.exports = (env, argv) => ({
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default (env, argv) => ({
   entry: './src/index.tsx',
   devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
   output: {
@@ -25,6 +28,9 @@ module.exports = (env, argv) => ({
         test: /\.(js|jsx|ts|tsx)$/,
         exclude: '/node_modules/',
         loader: 'babel-loader',
+        resolve: {
+          fullySpecified: false
+        }
       },
       {
         test: /\.css$/,

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/infra",
   "version": "0.3.0",
   "description": "Medplum Infra as Code",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/mock",
   "version": "0.3.0",
   "description": "Medplum Mock Client",

--- a/packages/server/jest.sequencer.js
+++ b/packages/server/jest.sequencer.js
@@ -1,10 +1,12 @@
-const Sequencer = require('@jest/test-sequencer').default;
+import testsequencer from '@jest/test-sequencer';
+
+const Sequencer = testsequencer.default;
 
 /**
  * The Sequencer class determines the order of tests.
  * We want to ensure that the seeder test runs first.
  */
-class CustomSequencer extends Sequencer {
+export default class CustomSequencer extends Sequencer {
   sort(tests) {
     // Test structure information
     // https://github.com/facebook/jest/blob/6b8b1404a1d9254e7d5d90a8934087a9c9899dab/packages/jest-runner/src/types.ts#L17-L21
@@ -19,5 +21,3 @@ class CustomSequencer extends Sequencer {
     });
   }
 }
-
-module.exports = CustomSequencer;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/server",
   "version": "0.3.0",
   "description": "Medplum Server",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@medplum/ui",
   "version": "0.3.0",
   "description": "Medplum React Component Library",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "jsx": "react",
     "strict": true,


### PR DESCRIPTION
Tracking PR for ESM experiments.  Migrating to ESM appears inevitable.  We already see some key dependencies that are ESM-only, and we cannot upgrade until the conversion is complete.  

Dependencies that require ESM:
* node-fetch
* react-markdown

Unfortunately, ESM is not ready yet:
* https://github.com/wclr/ts-node-dev/issues/265
* https://github.com/TypeStrong/ts-node/issues/922

As mentioned in https://github.com/TypeStrong/ts-node/issues/922#issuecomment-765008102

> So all in all this can be summarized as: Using TypeScript, node.js and the TypeScript compiler option "module": "esnext" together is next to impossible. So if you're building code that should be ran with node.js, in 2020, you should still choose "module": "commonjs".

----

Update 2021-11-21

Key blockers:
* `ts-node-dev` does not play nice with ESM
* `import` without file extension is still broken

----

Update 2021-12-21

* Migrating from `ts-node-dev` to `nodemon` helps, and gets closer
* Need to launch with:
  * `nodemon --watch "./**/*.ts" --exec "node --experimental-specifier-resolution=node --loader ts-node/esm" src/index.ts`
  * Double quotes are important (?)
  * See: https://www.rockyourcode.com/nodejs-setup-with-typescript-nodemon-and-esm/
* However, CommonJS interoperability is still janky

Example errors:

```
import { Pool } from 'pg';
         ^^^^
SyntaxError: Named export 'Pool' not found. The requested module 'pg' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'pg';
const { Pool } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:179:5)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
    at async Object.loadESM (node:internal/process/esm_loader:68:5)
    at async handleMainPromise (node:internal/modules/run_main:63:12)
[nodemon] app crashed - waiting for file changes before starting...
```

```
import { Queue, QueueScheduler, Worker } from 'bullmq';
         ^^^^^
SyntaxError: Named export 'Queue' not found. The requested module 'bullmq' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'bullmq';
const { Queue, QueueScheduler, Worker } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:179:5)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
    at async Object.loadESM (node:internal/process/esm_loader:68:5)
    at async handleMainPromise (node:internal/modules/run_main:63:12)
[nodemon] app crashed - waiting for file changes before starting...
```

These are logical.  The fix is actionable.  I tried a few, but most dependencies are still CommonJS, which means re-writing a fair amount of import code.  I suspect that as ESM support becomes more common, these libraries will naturally add more named exports.  More waiting.

----

Update 2022-01-15

Now that [Rollup](https://github.com/medplum/medplum/pull/300) is live and we ship dual build ESM/CommonJS for libraries, the urgency for this is reduced.

The main objective now is future-proofing.  Some day, ESM will be the standard for everything, both browser and server.