### PR TITLE
Better null handling in FormUtils

### DIFF
--- a/packages/ui/src/FormUtils.test.ts
+++ b/packages/ui/src/FormUtils.test.ts
@@ -151,4 +151,7 @@ describe('FormUtils', () => {
     expect(resource.item?.[0]?.text).toEqual('XYZ');
   });
 
+  test('Ensure keys handles null', () => {
+    expect(ensureKeys([null])).toMatchObject([null]);
+  });
 });

--- a/packages/ui/src/FormUtils.ts
+++ b/packages/ui/src/FormUtils.ts
@@ -21,7 +21,7 @@ export function ensureKeys<T>(array: T[] | undefined): T[] {
   }
 
   array.forEach(obj => {
-    if (typeof obj === 'object') {
+    if (obj && typeof obj === 'object') {
       const objAsAny = obj as any;
       if (!objAsAny.__key) {
         objAsAny.__key = generateKey();


### PR DESCRIPTION
`typeof null === 'object'` 😠