### PR TITLE
Fixed display of compound organizations

### DIFF
--- a/packages/ui/src/DiagnosticReportDisplay.test.tsx
+++ b/packages/ui/src/DiagnosticReportDisplay.test.tsx
@@ -14,6 +14,7 @@ const diagnosticReport: DiagnosticReport = {
     { reference: 'Observation/3' },
     { reference: 'Observation/4' },
     { reference: 'Observation/5' },
+    { reference: 'Observation/6' },
   ]
 };
 
@@ -82,6 +83,26 @@ const observation5: Observation = {
   interpretation: [{}]
 };
 
+const observation6: Observation = {
+  resourceType: 'Observation',
+  component: [
+    {
+      valueQuantity: {
+        value: 110,
+        unit: 'mmHg',
+        system: 'http://unitsofmeasure.org'
+      }
+    },
+    {
+      valueQuantity: {
+        value: 75,
+        unit: 'mmHg',
+        system: 'http://unitsofmeasure.org'
+      }
+    }
+  ]
+};
+
 const mockRouter = {
   push: (path: string, state: any) => {
     alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
@@ -105,6 +126,8 @@ function mockFetch(url: string, options: any): Promise<any> {
     result = observation4;
   } else if (url.endsWith('/Observation/5')) {
     result = observation5;
+  } else if (url.endsWith('/Observation/6')) {
+    result = observation6;
   }
 
   const response: any = {
@@ -146,6 +169,7 @@ describe('DiagnosticReportDisplay', () => {
       setup({ value: diagnosticReport });
     });
     expect(screen.getByText('Diagnostic Report')).not.toBeUndefined();
+    expect(screen.getByText('110/75'));
   });
 
   test('Renders by reference', async () => {
@@ -153,6 +177,7 @@ describe('DiagnosticReportDisplay', () => {
       setup({ value: { reference: 'DiagnosticReport/123' } });
     });
     expect(screen.getByText('Diagnostic Report')).not.toBeUndefined();
+    expect(screen.getByText('110/75'));
   });
 
 });

--- a/packages/ui/src/DiagnosticReportDisplay.tsx
+++ b/packages/ui/src/DiagnosticReportDisplay.tsx
@@ -1,7 +1,7 @@
-import { DiagnosticReport, Observation, ObservationReferenceRange, Reference } from '@medplum/core';
+import { DiagnosticReport, Observation, ObservationComponent, ObservationReferenceRange, Reference } from '@medplum/core';
 import React from 'react';
-import { MedplumLink } from './MedplumLink';
 import { CodeableConceptDisplay } from './CodeableConceptDisplay';
+import { MedplumLink } from './MedplumLink';
 import { useResource } from './useResource';
 import './DiagnosticReportDisplay.css';
 
@@ -68,8 +68,8 @@ function ObservationRow(props: ObservationRowProps): JSX.Element | null {
           <CodeableConceptDisplay value={observation.code} />
         </MedplumLink>
       </td>
-      <td>{observation.valueQuantity?.unit}</td>
-      <td>{observation.valueQuantity?.value ?? observation.valueString}</td>
+      <td>{getUnitsDisplayString(observation)}</td>
+      <td>{getValueDisplayString(observation)}</td>
       <td><ReferenceRangeDisplay value={observation.referenceRange} /></td>
       <td>
         {observation.interpretation && observation.interpretation.length > 0 && (
@@ -78,6 +78,34 @@ function ObservationRow(props: ObservationRowProps): JSX.Element | null {
       </td>
     </tr>
   );
+}
+
+function getUnitsDisplayString(observation: Observation | ObservationComponent): string | undefined {
+  if (observation.valueQuantity?.unit) {
+    return observation.valueQuantity.unit;
+  }
+
+  if ('component' in observation && observation.component) {
+    return observation.component.map(c => getUnitsDisplayString(c)).join('/');
+  }
+
+  return undefined;
+}
+
+function getValueDisplayString(observation: Observation | ObservationComponent): string | number | undefined {
+  if (observation.valueQuantity?.value) {
+    return observation.valueQuantity.value;
+  }
+
+  if (observation.valueString) {
+    return observation.valueString;
+  }
+
+  if ('component' in observation && observation.component) {
+    return observation.component.map(c => getValueDisplayString(c)).join('/');
+  }
+
+  return undefined;
 }
 
 interface ReferenceRangeProps {


### PR DESCRIPTION
Added display support for compound Observations.  Most observations simply have a single value.  Some observations, like blood pressure, are actually multiple values.

Before:
![image](https://user-images.githubusercontent.com/749094/138005360-12a7ec47-e861-46f9-966b-a832e9800bfc.png)

After:
![image](https://user-images.githubusercontent.com/749094/138005412-dc3f9aa0-c9c0-406d-8d8f-3cdaff9432f0.png)
