### PR TITLE
Clean resource meta when submitting ResourcePage

### DIFF
--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -268,6 +268,39 @@ describe('ResourcePage', () => {
     expect(screen.getByTestId('resource-json')).not.toBeUndefined();
   });
 
+  test('JSON submit with meta', async () => {
+    setup('/Practitioner/123/json');
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('resource-json'));
+    });
+
+    await act(async () => {
+      fireEvent.change(
+        screen.getByTestId('resource-json'),
+        {
+          target: {
+            value: JSON.stringify({
+              resourceType: 'Practitioner',
+              id: '123',
+              meta: {
+                lastUpdated: '2020-01-01T00:00:00.000Z',
+                author: {
+                  reference: 'Practitioner/111'
+                }
+              }
+            })
+          }
+        });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('OK'));
+    });
+
+    expect(screen.getByTestId('resource-json')).not.toBeUndefined();
+  });
+
   test('Patient timeline', async () => {
     setup('/Patient/123/timeline');
 

--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -1,4 +1,4 @@
-import { Bundle, MedplumClient, notFound, Patient, Practitioner, Questionnaire, User } from '@medplum/core';
+import { Bot, Bundle, DiagnosticReport, MedplumClient, notFound, Patient, Practitioner, Questionnaire, User } from '@medplum/core';
 import { MedplumProvider } from '@medplum/ui';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -92,7 +92,23 @@ const questionnaire: Questionnaire = {
     text: 'Hello',
     type: 'string'
   }]
-}
+};
+
+const bot: Bot = {
+  resourceType: 'Bot',
+  id: '123',
+  name: 'Test Bot',
+  code: 'console.log("hello world");'
+};
+
+const diagnosticReport: DiagnosticReport = {
+  resourceType: 'DiagnosticReport',
+  id: '123',
+  status: 'final',
+  result: [
+    { reference: 'Observation/123' }
+  ]
+};
 
 const mockRouter = {
   push: (path: string, state: any) => {
@@ -130,6 +146,10 @@ function mockFetch(url: string, options: any): Promise<any> {
     result = notFound
   } else if (method === 'GET' && url.endsWith('/fhir/R4/Questionnaire/123')) {
     result = questionnaire;
+  } else if (method === 'GET' && url.includes('/fhir/R4/Bot/123')) {
+    result = bot;
+  } else if (method === 'GET' && url.includes('/fhir/R4/DiagnosticReport/123')) {
+    result = diagnosticReport;
   }
 
   const response: any = {
@@ -282,6 +302,26 @@ describe('ResourcePage', () => {
     });
 
     expect(screen.getByText('Preview')).not.toBeUndefined();
+  });
+
+  test('Bot editor', async () => {
+    setup('/Bot/123/editor');
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Editor'));
+    });
+
+    expect(screen.getByText('Editor')).not.toBeUndefined();
+  });
+
+  test('DiagnosticReport display', async () => {
+    setup('/DiagnosticReport/123/report');
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Report'));
+    });
+
+    expect(screen.getByText('Report')).not.toBeUndefined();
   });
 
 });

--- a/packages/app/src/ResourcePage.tsx
+++ b/packages/app/src/ResourcePage.tsx
@@ -148,7 +148,7 @@ export function ResourcePage() {
                 resource={value}
                 resourceHistory={historyBundle}
                 onSubmit={(resource: Resource) => {
-                  medplum.update(resource)
+                  medplum.update(cleanResource(resource))
                     .then(loadResource)
                     .catch(setError);
                 }}
@@ -253,4 +253,28 @@ function ResourceTab(props: ResourceTabProps): JSX.Element | null {
       );
   }
   return null;
+}
+
+/**
+ * Cleans a resource of unwanted meta values.
+ * For most users, this will not matter, because meta values are set by the server.
+ * However, some administrative users are allowed to specify some meta values.
+ * The admin use case is sepcial though, and unwanted here on the resource page.
+ * @param resource The input resource.
+ * @returns The cleaned output resource.
+ */
+function cleanResource(resource: Resource): Resource {
+  let meta = resource.meta;
+  if (meta) {
+    meta = {
+      ...meta,
+      lastUpdated: undefined,
+      versionId: undefined,
+      author: undefined
+    };
+  }
+  return {
+    ...resource,
+    meta
+  };
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -245,7 +245,7 @@ export class Repository {
         versionId: randomUUID(),
         lastUpdated: this.getLastUpdated(resource),
         project: this.getProjectId(updated),
-        author: this.getAuthor(updated)
+        author: this.getAuthor(resource)
       }
     }
 
@@ -719,16 +719,18 @@ export class Repository {
   }
 
   /**
-   * Returns the author reference string (resourceType/id).
-   * If the current context is a ClientApplication, handles "on behalf of".
+   * Returns the author reference.
+   * If the current context is allowed to write meta,
+   * and the provided resource includes an author reference,
+   * then use the provided value.
    * Otherwise uses the current context profile.
    * @param resource The FHIR resource.
    * @returns
    */
   private getAuthor(resource: Resource): Reference {
     // If the resource has an author (whether provided or from existing),
-    // and the current context is a ClientApplication (i.e., OAuth client credentials),
-    // then allow the ClientApplication to act on behalf of another user.
+    // and the current context is allowed to write meta,
+    // then use the provided value.
     const author = resource.meta?.author;
     if (author && this.canWriteMeta()) {
       return author;


### PR DESCRIPTION
When on a resource page, clean the resource meta values(i.e., author and lastUpdated) before submitting to the server.

For the vast majority of users and use cases, this will not matter, because meta values are set by the server. However, some administrative users are allowed to specify some meta values. The admin use case is special though, and unwanted here on the resource page.