### PR TITLE
Show Patient birth date as helper text in autocomplete

### DIFF
--- a/packages/ui/src/Autocomplete.css
+++ b/packages/ui/src/Autocomplete.css
@@ -32,6 +32,7 @@
   display: inline-block;
   list-style: none;
   white-space: nowrap;
+  user-select: none;
 }
 
 .medplum-autocomplete-container>ul>li.choice {
@@ -84,6 +85,8 @@
 
 .medplum-autocomplete-row {
   display: flex;
+  align-items: center;
+  justify-content: center;
   height: 48px;
   margin: 0;
   padding: 0;
@@ -104,6 +107,16 @@
 
 .medplum-autocomplete-label {
   flex: 1;
-  padding: 8px 0 8px 8px;
+  padding: 0 0 0 8px;
   cursor: pointer;
+  user-select: none;
+}
+
+.medplum-autocomplete-label div {
+  line-height: 18px;
+}
+
+.medplum-autocomplete-label .medplum-autocomplete-help-text {
+  font-size: 12px;
+  color: var(--medplum-gray-500);
 }

--- a/packages/ui/src/Autocomplete.tsx
+++ b/packages/ui/src/Autocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { killEvent } from './utils/dom';
 import './Autocomplete.css';
+import { killEvent } from './utils/dom';
 
 export interface AutocompleteProps<T> {
   name: string;
@@ -14,6 +14,7 @@ export interface AutocompleteProps<T> {
   getId: (item: T) => string;
   getIcon?: (item: T) => JSX.Element;
   getDisplay: (item: T) => JSX.Element;
+  getHelpText?: (item: T) => string | undefined;
   onChange?: (values: T[]) => void;
   onCreateNew?: () => void;
 }
@@ -300,9 +301,18 @@ export function Autocomplete<T>(props: AutocompleteProps<T>) {
               onClick={e => handleDropDownClick(e, option)}
             >
               {props.getIcon && (
-                <div className="medplum-autocomplete-icon">{props.getIcon(option)}</div>
+                <div className="medplum-autocomplete-icon">
+                  {props.getIcon(option)}
+                </div>
               )}
-              <div className="medplum-autocomplete-label">{props.getDisplay(option)}</div>
+              <div className="medplum-autocomplete-label">
+                {props.getDisplay(option)}
+                {props.getHelpText && (
+                  <div className="medplum-autocomplete-help-text">
+                    {props.getHelpText(option)}
+                  </div>
+                )}
+              </div>
             </div>
           ))}
           {props.onCreateNew && (

--- a/packages/ui/src/Avatar.tsx
+++ b/packages/ui/src/Avatar.tsx
@@ -20,13 +20,21 @@ export function Avatar(props: AvatarProps) {
   const [imageUrl, setImageUrl] = useState<string | undefined>(props.src);
 
   useEffect(() => {
+    let isMounted = true;
     if (resource) {
       const attachmentUrl = getImageSrc(resource);
       if (attachmentUrl) {
-        medplum.readCachedBlobAsObjectUrl(attachmentUrl).then(url => setImageUrl(url));
+        medplum.readCachedBlobAsObjectUrl(attachmentUrl)
+          .then(url => {
+            if (isMounted) {
+              setImageUrl(url);
+            }
+          });
       }
     }
-
+    return () => {
+      isMounted = false;
+    };
   }, [resource]);
 
   const className = props.size ? 'medplum-avatar ' + props.size : 'medplum-avatar';

--- a/packages/ui/src/Header.css
+++ b/packages/ui/src/Header.css
@@ -82,6 +82,7 @@ div.medplum-nav-search-container {
   display: inline-block;
   list-style: none;
   white-space: nowrap;
+  user-select: none;
 }
 
 .medplum-nav-search-container>ul>li.choice {

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -1,13 +1,12 @@
-import { Bundle, BundleEntry, getDisplayString, HumanName, Operator, Resource } from '@medplum/core';
+import { getDisplayString, HumanName, Patient } from '@medplum/core';
 import React, { useState } from 'react';
-import { Autocomplete } from './Autocomplete';
 import { Avatar } from './Avatar';
 import { Button } from './Button';
 import { HumanNameDisplay } from './HumanNameDisplay';
 import { MedplumLink } from './MedplumLink';
 import { useMedplumContext } from './MedplumProvider';
 import { Popup } from './Popup';
-import { ResourceName } from './ResourceName';
+import { ResourceInput } from './ResourceInput';
 import './Header.css';
 
 export interface HeaderProps {
@@ -48,30 +47,13 @@ export function Header(props: HeaderProps) {
             Medplum
           </MedplumLink>
           {context.profile && (
-            <Autocomplete
+            <ResourceInput
+              resourceType="Patient"
               name="search"
               className="medplum-nav-search-container"
               placeholder="Search"
-              loadOptions={(input: string): Promise<Resource[]> => {
-                return medplum.search({
-                  resourceType: 'Patient',
-                  filters: [{
-                    code: 'name',
-                    operator: Operator.CONTAINS,
-                    value: input
-                  }]
-                })
-                  .then((bundle: Bundle) => (bundle.entry as BundleEntry[]).map(entry => entry.resource as Resource));
-              }}
-              getId={(item: Resource) => {
-                return item.id as string;
-              }}
-              getIcon={(item: Resource) => <Avatar value={item} />}
-              getDisplay={(item: Resource) => <ResourceName value={item} />}
-              onChange={(items: (Resource)[]) => {
-                if (items.length > 0) {
-                  router.push(`/${items[0].resourceType}/${items[0].id}`);
-                }
+              onChange={(patient: Patient) => {
+                router.push(`/${patient.resourceType}/${patient.id}`);
               }}
             />
           )}

--- a/packages/ui/src/ReferenceInput.tsx
+++ b/packages/ui/src/ReferenceInput.tsx
@@ -1,9 +1,6 @@
-import { Bundle, BundleEntry, createReference, ElementDefinition, Operator, Reference, Resource } from '@medplum/core';
+import { createReference, ElementDefinition, Reference, Resource } from '@medplum/core';
 import React, { useRef, useState } from 'react';
-import { Autocomplete } from './Autocomplete';
-import { Avatar } from './Avatar';
-import { useMedplum } from './MedplumProvider';
-import { ResourceName } from './ResourceName';
+import { ResourceInput } from './ResourceInput';
 
 export interface ReferenceInputProps {
   property?: ElementDefinition;
@@ -15,7 +12,6 @@ export interface ReferenceInputProps {
 export function ReferenceInput(props: ReferenceInputProps) {
   const targetTypes = getTargetTypes(props.property);
   const initialResourceType = getInitialResourceType(props.defaultValue, targetTypes);
-  const medplum = useMedplum();
   const [value, setValue] = useState<Reference | undefined>(props.defaultValue);
   const [resourceType, setResourceType] = useState<string | undefined>(initialResourceType);
 
@@ -61,39 +57,12 @@ export function ReferenceInput(props: ReferenceInputProps) {
           </td>
           <td>
             {resourceType && (
-              <Autocomplete
-                loadOptions={(input: string): Promise<(Reference | Resource)[]> => {
-                  return medplum.search({
-                    resourceType: resourceTypeRef.current as string,
-                    filters: [{
-                      code: 'name',
-                      operator: Operator.EQUALS,
-                      value: input
-                    }]
-                  })
-                    .then((bundle: Bundle) => (bundle.entry as BundleEntry[]).map(entry => entry.resource as Resource));
-                }}
-                getId={(item: Reference | Resource) => {
-                  if ('resourceType' in item) {
-                    return item.id as string;
-                  }
-                  if ('reference' in item) {
-                    return item.reference as string;
-                  }
-                  return item.toString();
-                }}
-                getIcon={(item: Reference | Resource) => <Avatar value={item} />}
-                getDisplay={(item: Reference | Resource) => <ResourceName value={item} />}
+              <ResourceInput
+                resourceType={resourceType}
                 name={props.name + '-id'}
-                defaultValue={props.defaultValue ? [props.defaultValue] : undefined}
-                onChange={(items: (Reference | Resource)[]) => {
-                  if (items.length > 0) {
-                    if ('resourceType' in items[0]) {
-                      setValueHelper(createReference(items[0]));
-                    } else if ('reference' in items[0]) {
-                      setValueHelper(items[0]);
-                    }
-                  }
+                defaultValue={props.defaultValue}
+                onChange={(item: Resource) => {
+                  setValueHelper(createReference(item));
                 }}
               />
             )}

--- a/packages/ui/src/ResourceInput.tsx
+++ b/packages/ui/src/ResourceInput.tsx
@@ -1,0 +1,62 @@
+import { Bundle, BundleEntry, Operator, Reference, Resource } from '@medplum/core';
+import React, { useRef } from 'react';
+import { useResource } from '.';
+import { Autocomplete } from './Autocomplete';
+import { Avatar } from './Avatar';
+import { useMedplum } from './MedplumProvider';
+import { ResourceName } from './ResourceName';
+
+export interface ResourceInputProps<T extends Resource = Resource> {
+  readonly resourceType: string;
+  readonly name: string;
+  readonly defaultValue?: T | Reference<T>;
+  readonly className?: string;
+  readonly placeholder?: string;
+  readonly onChange?: (value: T) => void;
+}
+
+export function ResourceInput<T extends Resource = Resource>(props: ResourceInputProps<T>) {
+  const medplum = useMedplum();
+  const defaultResource = useResource(props.defaultValue);
+
+  const resourceTypeRef = useRef<string>(props.resourceType);
+  resourceTypeRef.current = props.resourceType;
+
+  return (
+    <Autocomplete
+      loadOptions={(input: string): Promise<T[]> => {
+        return medplum.search({
+          resourceType: resourceTypeRef.current,
+          filters: [{
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: input
+          }]
+        })
+          .then((bundle: Bundle) => (bundle.entry as BundleEntry[]).map(entry => entry.resource as T));
+      }}
+      getId={(item: T) => {
+        return item.id as string;
+      }}
+      getIcon={(item: T) => <Avatar value={item} />}
+      getDisplay={(item: T) => <ResourceName value={item} />}
+      getHelpText={(item: T) => {
+        if (item.resourceType === 'Patient' && item.birthDate) {
+          return 'DoB: ' + item.birthDate;
+        }
+        return undefined;
+      }}
+      name={props.name}
+      defaultValue={defaultResource ? [defaultResource] : undefined}
+      className={props.className}
+      placeholder={props.placeholder}
+      onChange={(items: T[]) => {
+        if (items.length > 0) {
+          if (props.onChange) {
+            props.onChange(items[0]);
+          }
+        }
+      }}
+    />
+  );
+}

--- a/packages/ui/src/stories/Autocomplete.stories.tsx
+++ b/packages/ui/src/stories/Autocomplete.stories.tsx
@@ -99,3 +99,17 @@ export const Prefilled = () => (
     />
   </Document>
 );
+
+export const HelpText = () => (
+  <Document>
+    <Autocomplete
+      name="foo"
+      loadOptions={search}
+      getId={(option: string) => option}
+      getDisplay={(option: string) => (
+        <div>{option}</div>
+      )}
+      getHelpText={(option: string) => option.length + ' chars'}
+    />
+  </Document>
+);


### PR DESCRIPTION
Show DoB in helper text:
![image](https://user-images.githubusercontent.com/749094/140188471-7561360c-1c53-4a69-8dce-86d7222c7025.png)

The diff is a little big for two reasons:
1. Our autocomplete widget didn't really have support for the "helper text" as a 2nd line.  I wanted to mimic how Gmail does it with name+email.  I also wanted to try to follow API best practices from popular projects such as [react-select](), which it turns out (surprisingly) does not support the 2nd line feature 🤷‍♂️
2. We have an `<Autocomplete>` component, which is a low level control -- the developer has to write functions for "how to fetch the data", and "how to render a row in the dropdown".  We have a `<ReferenceInput>` component, which can be used for FHIR [Reference]() objects, and is quite high level -- no code necessary for fetching or rendering.  But a `Reference` and `<ReferenceInput>` capture 2 inputs: both the `resourceType` and the `id`.  So if you want a control that is only for Patients, you're still going to have this awkward 2nd input for the resource type.  To solve this, the diff introduces a  `<ResourceInput>` component to fill the gap.