### PR TITLE
Initial support for underscore search params

### DIFF
--- a/packages/ui/src/ReferenceInput.test.tsx
+++ b/packages/ui/src/ReferenceInput.test.tsx
@@ -118,13 +118,15 @@ describe('ReferenceInput', () => {
     expect(screen.getByTestId('reference-input-resource-type-input')).not.toBeUndefined();
   });
 
-  test('Renders default value resource type', () => {
-    setup({
-      name: 'foo',
-      property: {},
-      defaultValue: {
-        reference: 'Patient/123'
-      }
+  test('Renders default value resource type', async () => {
+    await act(async () => {
+      setup({
+        name: 'foo',
+        property: {},
+        defaultValue: {
+          reference: 'Patient/123'
+        }
+      });
     });
     expect(screen.getByTestId('reference-input-resource-type-input')).not.toBeUndefined();
     expect((screen.getByTestId('reference-input-resource-type-input') as HTMLInputElement).value).toBe('Patient');


### PR DESCRIPTION
Support for [3.1.1.4.1 Parameters for all resources](https://www.hl7.org/fhir/search.html#standard)

Also adding `_project`, which is a non-standard "special" parameter for restricting within a project.  This is for the internal "system" user (normal users have this applied automatically).
