### PR TITLE
Change tsconfig target to ES6

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react",


### PR DESCRIPTION
Before: Our TypeScript configuration targeted "esnext", which means the output JavaScript could use any of the latest JavaScript features.  The rational was: any developer project will use a bundler, which will transpile the JavaScript into whatever version they want to ship.

Unfortunately, the default configuration for [`create-react-app`](https://create-react-app.dev/) does not support this philosophy :(

After: Our TypeScript configuration targets "es6", a much older and more conservative target.

For example, we use "optional chaining":

```js
let name = patient?.name?.[0]?.given?.[0];
```

That feature was added in ES2020.  To be used by `create-react-app`, it needs to be transpiled into ES6:

```js
let name = patient && patient.name && patient.name.length && patient.name[0].given && patient.name[0].given[0];
```

`create-react-app` throws errors if a dependency uses ES2020 features.