### PR TITLE
Default router, useMedplumProfile

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -5,6 +5,7 @@ import {
   FooterLinks,
   Header,
   useMedplum,
+  useMedplumProfile,
   useMedplumRouter
 } from '@medplum/ui';
 import React from 'react';
@@ -27,7 +28,7 @@ import { SignInPage } from './SignInPage';
 export function App() {
   const medplum = useMedplum();
   const router = useMedplumRouter();
-  const profile = medplum.getProfile();
+  const profile = useMedplumProfile();
   return (
     <Router history={history}>
       <CssBaseline />

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -1,5 +1,5 @@
 import { MedplumClient } from '@medplum/core';
-import { Document, MedplumProvider, SignInForm, useMedplumContext } from '@medplum/ui';
+import { Document, MedplumProvider, SignInForm, useMedplumProfile } from '@medplum/ui';
 import GraphiQL from 'graphiql';
 import React from 'react';
 import { render } from 'react-dom';
@@ -45,7 +45,7 @@ const router = {
 };
 
 function App() {
-  const profile = useMedplumContext().profile;
+  const profile = useMedplumProfile();
   return profile ? (
     <GraphiQL
       fetcher={async graphQLParams => medplum.graphql(graphQLParams)}

--- a/packages/ui/src/AttachmentArrayInput.test.tsx
+++ b/packages/ui/src/AttachmentArrayInput.test.tsx
@@ -5,13 +5,6 @@ import React from 'react';
 import { AttachmentArrayInput, AttachmentArrayInputProps } from './AttachmentArrayInput';
 import { MedplumProvider } from './MedplumProvider';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   let result: any = {};
 
@@ -46,7 +39,7 @@ const medplum = new MedplumClient({
 
 const setup = (args?: AttachmentArrayInputProps) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <AttachmentArrayInput name="test" {...args} />
     </MedplumProvider>
   );

--- a/packages/ui/src/AttachmentDisplay.test.tsx
+++ b/packages/ui/src/AttachmentDisplay.test.tsx
@@ -4,13 +4,6 @@ import React from 'react';
 import { AttachmentDisplay, AttachmentDisplayProps } from './AttachmentDisplay';
 import { MedplumProvider } from './MedplumProvider';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const result: any = {};
 
@@ -36,7 +29,7 @@ const medplum = new MedplumClient({
 
 const setup = (args?: AttachmentDisplayProps) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <AttachmentDisplay {...args} />
     </MedplumProvider>
   );

--- a/packages/ui/src/Avatar.test.tsx
+++ b/packages/ui/src/Avatar.test.tsx
@@ -18,13 +18,6 @@ const patient: Patient = {
   }]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -55,7 +48,7 @@ describe('Avatar', () => {
 
   const setup = (args: AvatarProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <Avatar {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/CodeInput.test.tsx
+++ b/packages/ui/src/CodeInput.test.tsx
@@ -11,13 +11,6 @@ const statusProperty: ElementDefinition = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 const valueSet: ValueSet = {
   resourceType: 'ValueSet',
   expansion: {
@@ -75,7 +68,7 @@ describe('CodeInput', () => {
 
   test('Renders', () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodeInput property={statusProperty} name="test" />
       </MedplumProvider>
     );
@@ -85,7 +78,7 @@ describe('CodeInput', () => {
 
   test('Renders string default value', () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodeInput property={statusProperty} name="test" defaultValue="xyz" />
       </MedplumProvider>
     );
@@ -96,7 +89,7 @@ describe('CodeInput', () => {
 
   test('Searches for results', async () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodeInput property={statusProperty} name="test" />
       </MedplumProvider>
     );

--- a/packages/ui/src/CodeableConceptInput.test.tsx
+++ b/packages/ui/src/CodeableConceptInput.test.tsx
@@ -11,13 +11,6 @@ const statusProperty: ElementDefinition = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 const valueSet: ValueSet = {
   resourceType: 'ValueSet',
   expansion: {
@@ -75,7 +68,7 @@ describe('CodeableConceptInput', () => {
 
   test('Renders', () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodeableConceptInput property={statusProperty} name="test" />
       </MedplumProvider>
     );
@@ -85,7 +78,7 @@ describe('CodeableConceptInput', () => {
 
   test('Renders CodeableConcept default value', () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodeableConceptInput property={statusProperty} name="test" defaultValue={{ coding: [{ code: 'abc' }] }} />
       </MedplumProvider>
     );
@@ -96,7 +89,7 @@ describe('CodeableConceptInput', () => {
 
   test('Searches for results', async () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodeableConceptInput property={statusProperty} name="test" />
       </MedplumProvider>
     );

--- a/packages/ui/src/CodingInput.test.tsx
+++ b/packages/ui/src/CodingInput.test.tsx
@@ -11,13 +11,6 @@ const statusProperty: ElementDefinition = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 const valueSet: ValueSet = {
   resourceType: 'ValueSet',
   expansion: {
@@ -75,7 +68,7 @@ describe('CodingInput', () => {
 
   test('Renders', () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodingInput property={statusProperty} name="test" />
       </MedplumProvider>
     );
@@ -85,7 +78,7 @@ describe('CodingInput', () => {
 
   test('Renders Coding default value', () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodingInput property={statusProperty} name="test" defaultValue={{ code: 'abc' }} />
       </MedplumProvider>
     );
@@ -96,7 +89,7 @@ describe('CodingInput', () => {
 
   test('Searches for results', async () => {
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <CodingInput property={statusProperty} name="test" />
       </MedplumProvider>
     );

--- a/packages/ui/src/DefaultResourceTimeline.test.tsx
+++ b/packages/ui/src/DefaultResourceTimeline.test.tsx
@@ -30,13 +30,6 @@ const auditEvents: Bundle = {
   ]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -82,7 +75,7 @@ describe('DefaultResourceTimeline', () => {
 
   const setup = (args: DefaultResourceTimelineProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <DefaultResourceTimeline {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/DiagnosticReportDisplay.test.tsx
+++ b/packages/ui/src/DiagnosticReportDisplay.test.tsx
@@ -103,13 +103,6 @@ const observation6: Observation = {
   ]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   let result = {};
 
@@ -158,7 +151,7 @@ describe('DiagnosticReportDisplay', () => {
 
   const setup = (args: DiagnosticReportDisplayProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <DiagnosticReportDisplay {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/EncounterTimeline.test.tsx
+++ b/packages/ui/src/EncounterTimeline.test.tsx
@@ -72,13 +72,6 @@ const newMedia: Media = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -130,7 +123,7 @@ describe('EncounterTimeline', () => {
 
   const setup = (args: EncounterTimelineProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <EncounterTimeline {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/FooterLinks.test.tsx
+++ b/packages/ui/src/FooterLinks.test.tsx
@@ -6,13 +6,6 @@ import { FooterLinks } from './FooterLinks';
 import { MedplumLink } from './MedplumLink';
 import { MedplumProvider } from './MedplumProvider';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 const medplum = new MedplumClient({
   baseUrl: 'https://example.com/',
   clientId: 'my-client-id',
@@ -25,7 +18,7 @@ describe('FooterLinks', () => {
     const onHelp = jest.fn();
 
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <FooterLinks>
           <MedplumLink onClick={onHelp}>Help</MedplumLink>
         </FooterLinks>

--- a/packages/ui/src/Header.test.tsx
+++ b/packages/ui/src/Header.test.tsx
@@ -6,13 +6,6 @@ import { act } from 'react-dom/test-utils';
 import { Header, HeaderProps } from './Header';
 import { MedplumProvider } from './MedplumProvider';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockSearch(): Bundle {
   return {
     resourceType: 'Bundle',
@@ -116,7 +109,7 @@ const medplum = new MedplumClient({
 
 function setup(props?: HeaderProps) {
   render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <Header {...props} />
     </MedplumProvider>
   );

--- a/packages/ui/src/MedplumProvider.tsx
+++ b/packages/ui/src/MedplumProvider.tsx
@@ -5,7 +5,7 @@ const reactContext = createContext(undefined as MedplumContext | undefined);
 
 export interface MedplumProviderProps {
   medplum: MedplumClient;
-  router: MedplumRouter;
+  router?: MedplumRouter;
   children: React.ReactNode;
 }
 
@@ -66,9 +66,18 @@ export function useMedplumRouter(): MedplumRouter {
 }
 
 /**
+ * Returns the current Medplum user profile (if signed in).
+ * This is a shortcut for useMedplumContext().profile.
+ * @returns The current user profile.
+ */
+export function useMedplumProfile(): ProfileResource | undefined {
+  return useMedplumContext().profile;
+}
+
+/**
  * Creates the auth object that handles user state.
  */
-function createMedplumContext(medplum: MedplumClient, router: MedplumRouter): MedplumContext {
+function createMedplumContext(medplum: MedplumClient, router: MedplumRouter | undefined): MedplumContext {
   const [state, setState] = useState({
     profile: medplum.getProfile(),
     loading: false
@@ -84,5 +93,19 @@ function createMedplumContext(medplum: MedplumClient, router: MedplumRouter): Me
     return () => medplum.removeEventListeneer('change', eventListener);
   }, []);
 
-  return { ...state, medplum, router };
+  return {
+    ...state,
+    medplum,
+    router: router ?? NOOP_ROUTER
+  };
 }
+
+/**
+ * Default "no-op" router.
+ * Most applications will provide their own router.
+ * This is a simple implementation that can be used for testing.
+ */
+const NOOP_ROUTER: MedplumRouter = {
+  push: () => undefined,
+  listen: () => (() => undefined)
+};

--- a/packages/ui/src/PatientTimeline.test.tsx
+++ b/packages/ui/src/PatientTimeline.test.tsx
@@ -72,12 +72,6 @@ const newMedia: Media = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
 
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
@@ -130,7 +124,7 @@ describe('PatientTimeline', () => {
 
   const setup = (args: PatientTimelineProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <PatientTimeline {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/QuestionnaireForm.test.tsx
+++ b/packages/ui/src/QuestionnaireForm.test.tsx
@@ -4,13 +4,6 @@ import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { QuestionnaireForm, QuestionnaireFormProps } from './QuestionnaireForm';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   let result: any;
 
@@ -49,7 +42,7 @@ const medplum = new MedplumClient({
 
 const setup = (args: QuestionnaireFormProps) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <QuestionnaireForm {...args} />
     </MedplumProvider>
   );

--- a/packages/ui/src/ReferenceInput.test.tsx
+++ b/packages/ui/src/ReferenceInput.test.tsx
@@ -5,13 +5,6 @@ import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { ReferenceInput, ReferenceInputProps } from './ReferenceInput';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockSearch(): Bundle {
   return {
     resourceType: 'Bundle',
@@ -87,7 +80,7 @@ const medplum = new MedplumClient({
 
 const setup = (args: ReferenceInputProps) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <ReferenceInput {...args} />
     </MedplumProvider>
   );

--- a/packages/ui/src/ResourceBadge.test.tsx
+++ b/packages/ui/src/ResourceBadge.test.tsx
@@ -14,13 +14,6 @@ const patient: Patient = {
   }]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -48,7 +41,7 @@ beforeAll(async () => {
 
 const setup = (args: ResourceBadgeProps) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <ResourceBadge {...args} />
     </MedplumProvider>
   );

--- a/packages/ui/src/ResourceBlame.test.tsx
+++ b/packages/ui/src/ResourceBlame.test.tsx
@@ -50,13 +50,6 @@ const historyBundle: Bundle = {
   ]
 }
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -86,7 +79,7 @@ describe('ResourceBlame', () => {
 
   const setup = (args: ResourceBlameProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourceBlame {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ResourceForm.test.tsx
+++ b/packages/ui/src/ResourceForm.test.tsx
@@ -54,13 +54,6 @@ const practitionerSearchParameter: Bundle = {
   }]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -106,7 +99,7 @@ describe('ResourceForm', () => {
 
   function setup(props: ResourceFormProps) {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourceForm {...props} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ResourceHistoryTable.test.tsx
+++ b/packages/ui/src/ResourceHistoryTable.test.tsx
@@ -50,13 +50,6 @@ const historyBundle: Bundle = {
   ]
 }
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -86,7 +79,7 @@ describe('ResourceHistoryTable', () => {
 
   const setup = (args: ResourceHistoryTableProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourceHistoryTable {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ResourceInput.test.tsx
+++ b/packages/ui/src/ResourceInput.test.tsx
@@ -5,13 +5,6 @@ import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { ResourceInput, ResourceInputProps } from './ResourceInput';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockSearch(): Bundle {
   return {
     resourceType: 'Bundle',
@@ -94,7 +87,7 @@ const medplum = new MedplumClient({
 
 const setup = (args: ResourceInputProps) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <ResourceInput {...args} />
     </MedplumProvider>
   );

--- a/packages/ui/src/ResourceName.test.tsx
+++ b/packages/ui/src/ResourceName.test.tsx
@@ -14,13 +14,6 @@ const patient: Patient = {
   }]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    alert('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -50,7 +43,7 @@ describe('ResourceName', () => {
 
   const setup = (args: ResourceNameProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourceName {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ResourcePropertyInput.test.tsx
+++ b/packages/ui/src/ResourcePropertyInput.test.tsx
@@ -106,13 +106,6 @@ const schema: IndexedStructureDefinition = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -141,7 +134,7 @@ describe('ResourcePropertyInput', () => {
 
   function setup(props: ResourcePropertyInputProps) {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourcePropertyInput {...props} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ResourceTable.test.tsx
+++ b/packages/ui/src/ResourceTable.test.tsx
@@ -54,13 +54,6 @@ const practitionerSearchParameter: Bundle = {
   }]
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -106,7 +99,7 @@ describe('ResourceTable', () => {
 
   function setup(props: ResourceTableProps) {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourceTable {...props} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ResourceTimeline.test.tsx
+++ b/packages/ui/src/ResourceTimeline.test.tsx
@@ -72,13 +72,6 @@ const newMedia: Media = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -154,7 +147,7 @@ describe('ResourceTimeline', () => {
 
   function setup<T extends Resource>(args: ResourceTimelineProps<T>) {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ResourceTimeline {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/SearchPopupMenu.test.tsx
+++ b/packages/ui/src/SearchPopupMenu.test.tsx
@@ -42,13 +42,6 @@ const schema: IndexedStructureDefinition = {
 
 describe('SearchPopupMenu', () => {
 
-  const mockRouter = {
-    push: (path: string, state: any) => {
-      console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-    },
-    listen: () => (() => undefined) // Return mock "unlisten" handler
-  }
-
   function mockFetch(url: string, options: any): Promise<any> {
     const response: any = {
       request: {
@@ -74,7 +67,7 @@ describe('SearchPopupMenu', () => {
 
   function setup(props: SearchPopupMenuProps) {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <SearchPopupMenu {...props} />
       </MedplumProvider>
     );

--- a/packages/ui/src/ServiceRequestTimeline.test.tsx
+++ b/packages/ui/src/ServiceRequestTimeline.test.tsx
@@ -72,13 +72,6 @@ const newMedia: Media = {
   }
 };
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -130,7 +123,7 @@ describe('ServiceRequestTimeline', () => {
 
   const setup = (args: ServiceRequestTimelineProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <ServiceRequestTimeline {...args} />
       </MedplumProvider>
     );

--- a/packages/ui/src/SignInForm.test.tsx
+++ b/packages/ui/src/SignInForm.test.tsx
@@ -4,13 +4,6 @@ import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { SignInForm, SignInFormProps } from './SignInForm';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   let status = 404;
   let result: any;
@@ -69,7 +62,7 @@ const setup = (args?: SignInFormProps) => {
     ...args
   };
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       <SignInForm {...props} />
     </MedplumProvider>
   );

--- a/packages/ui/src/SubMenu.test.tsx
+++ b/packages/ui/src/SubMenu.test.tsx
@@ -7,11 +7,6 @@ import { MenuItem } from './MenuItem';
 import { MenuSeparator } from './MenuSeparator';
 import { SubMenu } from './SubMenu';
 
-const mockRouter = {
-  push: () => undefined,
-  listen: () => (() => undefined)
-}
-
 const medplum = new MedplumClient({
   baseUrl: 'https://example.com/',
   clientId: 'my-client-id',
@@ -20,7 +15,7 @@ const medplum = new MedplumClient({
 
 const setup = (children: React.ReactNode) => {
   return render(
-    <MedplumProvider medplum={medplum} router={mockRouter}>
+    <MedplumProvider medplum={medplum}>
       {children}
     </MedplumProvider>
   );

--- a/packages/ui/src/Timeline.test.tsx
+++ b/packages/ui/src/Timeline.test.tsx
@@ -4,13 +4,6 @@ import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { Timeline, TimelineItem } from './Timeline';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 const medplum = new MedplumClient({
   baseUrl: 'https://example.com/',
   clientId: 'my-client-id',
@@ -25,7 +18,7 @@ describe('Timeline', () => {
     };
 
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <Timeline>
           <TimelineItem resource={resource}>test</TimelineItem>
         </Timeline>
@@ -43,7 +36,7 @@ describe('Timeline', () => {
     };
 
     render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <Timeline>
           <TimelineItem resource={resource} socialEnabled={true}>test</TimelineItem>
         </Timeline>

--- a/packages/ui/src/UploadButton.test.tsx
+++ b/packages/ui/src/UploadButton.test.tsx
@@ -4,13 +4,6 @@ import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { UploadButton, UploadButtonProps } from './UploadButton';
 
-const mockRouter = {
-  push: (path: string, state: any) => {
-    console.log('Navigate to: ' + path + ' (state=' + JSON.stringify(state) + ')');
-  },
-  listen: () => (() => undefined) // Return mock "unlisten" handler
-}
-
 function mockFetch(url: string, options: any): Promise<any> {
   const response: any = {
     request: {
@@ -39,7 +32,7 @@ describe('UploadButton', () => {
 
   const setup = (args?: UploadButtonProps) => {
     return render(
-      <MedplumProvider medplum={medplum} router={mockRouter}>
+      <MedplumProvider medplum={medplum}>
         <UploadButton onUpload={attachment => console.log('upload', attachment)} {...args} />
       </MedplumProvider>
     );


### PR DESCRIPTION
Two developer experience improvements:

1. Make `<MedplumProvider router={...}>` optional.  Before, the dev had to pass in a `router` param for various Medplum React components to know how to navigate (i.e., what happens if you click on a link to a resource).  Now that's optional, and it silently no-ops by default.  Most devs will pass in something, but it's an annoying requirement when first starting.  This also cleans up a bunch of unit tests.

2. Added `useMedplumProfile()` React hook.  Before, you could use `useMedplumContext().profile` but that's ugly and verbose.  Now you can just use `useMedplumProfile()`.