### PR TITLE
Add default SignInForm container

### DIFF
--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -1,16 +1,14 @@
-import { Document, SignInForm } from '@medplum/ui';
+import { SignInForm } from '@medplum/ui';
 import React from 'react';
 import { history } from './history';
 
 export function SignInPage() {
   return (
-    <Document width={450}>
-      <SignInForm
-        onSuccess={() => history.push('/')}
-        onForgotPassword={() => history.push('/resetpassword')}
-        onRegister={() => history.push('/register')}
-        googleClientId={process.env.GOOGLE_CLIENT_ID}
-      />
-    </Document>
+    <SignInForm
+      onSuccess={() => history.push('/')}
+      onForgotPassword={() => history.push('/resetpassword')}
+      onRegister={() => history.push('/register')}
+      googleClientId={process.env.GOOGLE_CLIENT_ID}
+    />
   );
 }

--- a/packages/ui/src/SignInForm.css
+++ b/packages/ui/src/SignInForm.css
@@ -27,3 +27,7 @@
   justify-content: center;
   border-top: thin solid var(--medplum-gray-200);
 }
+
+.medplum-signin-google-icon {
+  margin-right: 8px;
+}

--- a/packages/ui/src/SignInForm.tsx
+++ b/packages/ui/src/SignInForm.tsx
@@ -1,6 +1,7 @@
 import { GoogleCredentialResponse, OperationOutcome } from '@medplum/core';
 import React, { useState } from 'react';
 import { Button } from './Button';
+import { Document } from './Document';
 import { Form } from './Form';
 import { FormSection } from "./FormSection";
 import { Logo } from './Logo';
@@ -14,7 +15,7 @@ export interface SignInFormProps {
   scope?: string;
   remember?: boolean;
   googleClientId?: string;
-  onSuccess: () => void;
+  onSuccess?: () => void;
   onForgotPassword?: () => void;
   onRegister?: () => void;
 }
@@ -25,6 +26,12 @@ export function SignInForm(props: SignInFormProps) {
   const role = props.role || 'practitioner';
   const scope = props.scope || 'launch/patient openid fhirUser offline_access user/*.*';
 
+  function handleSuccess(): void {
+    if (props.onSuccess) {
+      props.onSuccess();
+    }
+  }
+
   function handleError(err: any): void {
     if (err.outcome) {
       setOutcome(err.outcome);
@@ -32,53 +39,62 @@ export function SignInForm(props: SignInFormProps) {
   }
 
   return (
-    <Form style={{ maxWidth: 400 }} onSubmit={(formData: Record<string, string>) => {
-      const remember = !!props.remember;
-      medplum.signIn(formData.email, formData.password, role, scope, remember)
-        .then(() => props.onSuccess())
-        .catch(handleError);
-    }}>
-      <div className="center">
-        <Logo size={32} />
-        <h1>Sign in to Medplum</h1>
-      </div>
-      <FormSection title="Email" htmlFor="email" outcome={outcome}>
-        <TextField name="email" type="email" testid="email" required={true} autoFocus={true} outcome={outcome} />
-      </FormSection>
-      <FormSection title="Password" htmlFor="password" outcome={outcome}>
-        <TextField name="password" type="password" testid="password" required={true} outcome={outcome} />
-      </FormSection>
-      <div className="medplum-signin-buttons">
-        <div>
-          {props.onForgotPassword && (
-            <MedplumLink testid="forgotpassword" onClick={props.onForgotPassword}>Forgot password</MedplumLink>
-          )}
-          {props.onRegister && (
-            <MedplumLink testid="register" onClick={props.onRegister}>Register</MedplumLink>
-          )}
+    <Document width={450}>
+      <Form style={{ maxWidth: 400 }} onSubmit={(formData: Record<string, string>) => {
+        const remember = !!props.remember;
+        medplum.signIn(formData.email, formData.password, role, scope, remember)
+          .then(handleSuccess)
+          .catch(handleError);
+      }}>
+        <div className="center">
+          <Logo size={32} />
+          <h1>Sign in to Medplum</h1>
         </div>
-        <div>
-          <Button type="submit" testid="submit">Sign in</Button>
+        <FormSection title="Email" htmlFor="email" outcome={outcome}>
+          <TextField name="email" type="email" testid="email" required={true} autoFocus={true} outcome={outcome} />
+        </FormSection>
+        <FormSection title="Password" htmlFor="password" outcome={outcome}>
+          <TextField name="password" type="password" testid="password" required={true} outcome={outcome} />
+        </FormSection>
+        <div className="medplum-signin-buttons">
+          <div>
+            {props.onForgotPassword && (
+              <MedplumLink testid="forgotpassword" onClick={props.onForgotPassword}>Forgot password</MedplumLink>
+            )}
+            {props.onRegister && (
+              <MedplumLink testid="register" onClick={props.onRegister}>Register</MedplumLink>
+            )}
+          </div>
+          <div>
+            <Button type="submit" testid="submit">Sign in</Button>
+          </div>
         </div>
-      </div>
-      {props.googleClientId && (
-        <div className="medplum-signin-google-container">
-          <Button type="button" onClick={() => {
-            // Sign In With Google JavaScript API reference
-            // https://developers.google.com/identity/gsi/web/reference/js-reference
-            const google = (window as any).google;
-            google.accounts.id.initialize({
-              client_id: props.googleClientId,
-              callback: (response: GoogleCredentialResponse) => {
-                medplum.signInWithGoogle(response)
-                  .then(() => props.onSuccess())
-                  .catch(handleError);
-              }
-            });
-            google.accounts.id.prompt();
-          }}>Sign in with Google</Button>
-        </div>
-      )}
-    </Form>
+        {props.googleClientId && (
+          <div className="medplum-signin-google-container">
+            <Button type="button" onClick={() => {
+              // Sign In With Google JavaScript API reference
+              // https://developers.google.com/identity/gsi/web/reference/js-reference
+              const google = (window as any).google;
+              google.accounts.id.initialize({
+                client_id: props.googleClientId,
+                callback: (response: GoogleCredentialResponse) => {
+                  medplum.signInWithGoogle(response)
+                    .then(handleSuccess)
+                    .catch(handleError);
+                }
+              });
+              google.accounts.id.prompt();
+            }}>
+              <span className="medplum-signin-google-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 40 40">
+                  <path fill="#4285F4" d="M35 20.345c0-1.02-.084-2.045-.264-3.048H20.302v5.776h8.266c-.343 1.863-1.445 3.51-3.06 4.558v3.748h4.932c2.896-2.613 4.56-6.47 4.56-11.034z"></path><path fill="#34A853" d="M20.302 35c4.127 0 7.607-1.328 10.143-3.62l-4.93-3.749c-1.373.915-3.144 1.433-5.207 1.433-3.993 0-7.377-2.64-8.592-6.189H6.627v3.863C9.225 31.804 14.517 35 20.302 35z"></path><path fill="#FBBC04" d="M11.71 22.875c-.64-1.863-.64-3.88 0-5.743V13.27H6.629c-2.17 4.238-2.17 9.231 0 13.47l5.083-3.864z"></path><path fill="#EA4335" d="M20.302 10.937c2.181-.033 4.29.772 5.87 2.249l4.369-4.283c-2.767-2.546-6.438-3.946-10.24-3.902-5.785 0-11.076 3.197-13.674 8.267l5.083 3.864c1.21-3.555 4.6-6.195 8.592-6.195z"></path>
+                </svg>
+              </span>
+              <span>Sign in with Google</span>
+            </Button>
+          </div>
+        )}
+      </Form>
+    </Document>
   );
 }

--- a/packages/ui/src/stories/SignInForm.stories.tsx
+++ b/packages/ui/src/stories/SignInForm.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta } from '@storybook/react';
 import React from 'react';
 import { Button } from '../Button';
-import { Document } from '../Document';
 import { FooterLinks } from '../FooterLinks';
 import { useMedplumContext } from '../MedplumProvider';
 import { SignInForm } from '../SignInForm';
@@ -14,7 +13,7 @@ export default {
 export function Basic() {
   const ctx = useMedplumContext();
   return (
-    <Document width={450}>
+    <>
       {ctx.profile ? (
         <div>
           <pre>User: {JSON.stringify(ctx.profile)}</pre>
@@ -25,14 +24,14 @@ export function Basic() {
       ) : (
         <SignInForm onSuccess={() => alert('Signed in!')} />
       )}
-    </Document>
+    </>
   );
 }
 
 export function WithLinks() {
   const ctx = useMedplumContext();
   return (
-    <Document width={450}>
+    <>
       {ctx.profile ? (
         <div>
           <pre>User: {JSON.stringify(ctx.profile)}</pre>
@@ -47,7 +46,7 @@ export function WithLinks() {
           onRegister={() => alert('Register')}
         />
       )}
-    </Document>
+    </>
   );
 }
 
@@ -55,7 +54,7 @@ export function WithFooter() {
   const ctx = useMedplumContext();
   return (
     <>
-      <Document width={450}>
+      <>
         {ctx.profile ? (
           <div>
             <pre>User: {JSON.stringify(ctx.profile)}</pre>
@@ -70,7 +69,7 @@ export function WithFooter() {
             onRegister={() => alert('Register')}
           />
         )}
-      </Document>
+      </>
       <FooterLinks>
         <a href="#">Help</a>
         <a href="#">Terms</a>
@@ -84,7 +83,7 @@ export function WithGoogle() {
   const ctx = useMedplumContext();
   return (
     <>
-      <Document width={450}>
+      <>
         {ctx.profile ? (
           <div>
             <pre>User: {JSON.stringify(ctx.profile)}</pre>
@@ -100,7 +99,7 @@ export function WithGoogle() {
             googleClientId="xyz"
           />
         )}
-      </Document>
+      </>
       <FooterLinks>
         <a href="#">Help</a>
         <a href="#">Terms</a>


### PR DESCRIPTION
Before:  If you use the `<SignInForm>` component, you typically need to wrap it yourself in a bordered container such as `<Document>`

Now: The border comes by default.

Also made "onSuccess" optional.  It really should have always been optional.  The common case is to use `useMedplumProfile` React hook, which updates automatically on profile changes.

Also fixed the logo on the "Sign in with Google" button.

![image](https://user-images.githubusercontent.com/749094/140411592-54b76375-41d1-4a53-881b-892a1386f614.png)
