### PR TITLE
Added compartment to AccessPolicy json schema

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61536,6 +61536,10 @@
           "description": "A name associated with the AccessPolicy.",
           "$ref": "#/definitions/string"
         },
+        "compartment": {
+          "description": "Optional compartment restriction for the user account.",
+          "$ref": "#/definitions/Reference"
+        },
         "resource": {
           "description": "Access details for a resource type.",
           "items": {


### PR DESCRIPTION
The "compartment" property is in the `StructureDefinition` and the `AccessPolicy` interface definition, just not in the fhir.schema.json file.  

Before: the system repository could create and edit access policies, but the API routes could not because it would fail schema validation.

After: works as expected.

The proper fix for this is the backlog item "Auto generate fhir.schema.json from StructureDefinitions", which would eliminate the need to add the field in multiple places.