### PR TITLE
Improved media/attachment display

### DIFF
--- a/packages/ui/src/AttachmentArrayDisplay.tsx
+++ b/packages/ui/src/AttachmentArrayDisplay.tsx
@@ -4,6 +4,7 @@ import { AttachmentDisplay } from './AttachmentDisplay';
 
 export interface AttachmentArrayDisplayProps {
   values?: Attachment[];
+  maxWidth?: number;
 }
 
 export function AttachmentArrayDisplay(props: AttachmentArrayDisplayProps) {
@@ -11,7 +12,7 @@ export function AttachmentArrayDisplay(props: AttachmentArrayDisplayProps) {
     <div>
       {props.values && props.values.map((v, index) => (
         <div key={'attatchment-' + index}>
-          <AttachmentDisplay value={v} />
+          <AttachmentDisplay value={v} maxWidth={props.maxWidth} />
         </div>
       ))}
     </div>

--- a/packages/ui/src/AttachmentDisplay.tsx
+++ b/packages/ui/src/AttachmentDisplay.tsx
@@ -23,10 +23,6 @@ export function AttachmentDisplay(props: AttachmentDisplayProps) {
   }
 
   return (
-    <div data-testid="attachment-details">
-      <div>{value?.title}</div>
-      <div>{value?.contentType}</div>
-      <div>{value?.url}</div>
-    </div>
+    <a href={value?.url} data-testid="attachment-details">{value?.title}</a>
   );
 }

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { Address, CodeableConcept, ContactPoint, HumanName, Identifier } from '@medplum/core';
+import { Address, Attachment, CodeableConcept, ContactPoint, HumanName, Identifier } from '@medplum/core';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
@@ -7,6 +7,11 @@ describe('ResourcePropertyDisplay', () => {
 
   test('Renders null value', () => {
     render(<ResourcePropertyDisplay property={{ type: [{ code: 'string' }] }} value="" />);
+  });
+
+  test('Renders boolean', () => {
+    render(<ResourcePropertyDisplay property={{ type: [{ code: 'boolean' }] }} value={true} />);
+    expect(screen.getByText('true')).not.toBeUndefined();
   });
 
   test('Renders string', () => {
@@ -35,6 +40,11 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('world')).not.toBeUndefined();
   });
 
+  test('Renders markdown', () => {
+    render(<ResourcePropertyDisplay property={{ type: [{ code: 'markdown' }] }} value="hello" />);
+    expect(screen.getByText('hello')).not.toBeUndefined();
+  });
+
   test('Renders Address', () => {
     const value: Address = {
       city: 'London'
@@ -46,6 +56,44 @@ describe('ResourcePropertyDisplay', () => {
     />);
 
     expect(screen.getByText('London')).not.toBeUndefined();
+  });
+
+  test('Renders Attachment', () => {
+    const value: Attachment = {
+      contentType: 'text/plain',
+      url: 'https://example.com/file.txt',
+      title: 'file.txt'
+    };
+
+    render(<ResourcePropertyDisplay
+      property={{ type: [{ code: 'Attachment' }] }}
+      value={value}
+    />);
+
+    expect(screen.getByText('file.txt')).not.toBeUndefined();
+  });
+
+  test('Renders Attachment array', () => {
+    const value: Attachment[] = [
+      {
+        contentType: 'text/plain',
+        url: 'https://example.com/file.txt',
+        title: 'file.txt'
+      },
+      {
+        contentType: 'text/plain',
+        url: 'https://example.com/file2.txt',
+        title: 'file2.txt'
+      }
+    ];
+
+    render(<ResourcePropertyDisplay
+      property={{ type: [{ code: 'Attachment' }], max: '*' }}
+      value={value}
+    />);
+
+    expect(screen.getByText('file.txt')).not.toBeUndefined();
+    expect(screen.getByText('file2.txt')).not.toBeUndefined();
   });
 
   test('Renders CodeableConcept', () => {

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -15,6 +15,7 @@ export interface ResourcePropertyDisplayProps {
   property: ElementDefinition;
   value: any;
   arrayElement?: boolean;
+  maxWidth?: number;
 }
 
 export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
@@ -24,7 +25,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
 
   if (property.max === '*' && !props.arrayElement) {
     if (propertyType === 'Attachment') {
-      return <AttachmentArrayDisplay values={value} />
+      return <AttachmentArrayDisplay values={value} maxWidth={props.maxWidth} />
     }
     return <ResourceArrayDisplay property={property} values={value} />
   }
@@ -49,7 +50,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
     case PropertyType.Address:
       return <AddressDisplay value={value} />;
     case PropertyType.Attachment:
-      return <AttachmentDisplay value={value} />;
+      return <AttachmentDisplay value={value} maxWidth={props.maxWidth} />;
     case PropertyType.CodeableConcept:
       return <CodeableConceptDisplay value={value} />;
     case PropertyType.ContactPoint:

--- a/packages/ui/src/ResourceTimeline.tsx
+++ b/packages/ui/src/ResourceTimeline.tsx
@@ -1,8 +1,8 @@
 import { Attachment, AuditEvent, Bundle, BundleEntry, Communication, DiagnosticReport, Media, ProfileResource, Reference, Resource, SearchRequest, stringify } from '@medplum/core';
 import React, { useEffect, useRef, useState } from 'react';
-import { DiagnosticReportDisplay } from './DiagnosticReportDisplay';
 import { AttachmentDisplay } from './AttachmentDisplay';
 import { Button } from './Button';
+import { DiagnosticReportDisplay } from './DiagnosticReportDisplay';
 import { Form } from './Form';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
@@ -203,8 +203,10 @@ interface MediaTimelineItemProps {
 }
 
 function MediaTimelineItem(props: MediaTimelineItemProps) {
+  const contentType = props.media.content?.contentType;
+  const padding = contentType && !contentType.startsWith('image/') && !contentType.startsWith('video/');
   return (
-    <TimelineItem resource={props.media}>
+    <TimelineItem resource={props.media} padding={!!padding}>
       <AttachmentDisplay value={props.media.content} />
     </TimelineItem>
   );

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -484,5 +484,5 @@ export function renderValue(schema: IndexedStructureDefinition, resourceType: st
     return stringify(value);
   }
 
-  return <ResourcePropertyDisplay property={property} value={value} />;
+  return <ResourcePropertyDisplay property={property} value={value} maxWidth={200} />;
 }


### PR DESCRIPTION
* Non-image and non-video attachments (i.e., pdf's and txt's) are displayed as proper links
* Set max-width on attachments when viewed in the `<SearchControl>` worklist view