### PR TITLE
Added resource version page

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,6 +20,7 @@ import { HomePage } from './HomePage';
 import { RegisterPage } from './RegisterPage';
 import { ResetPasswordPage } from './ResetPasswordPage';
 import { ResourcePage } from './ResourcePage';
+import { ResourceVersionPage } from './ResourceVersionPage';
 import { SetPasswordPage } from './SetPasswordPage';
 import { SignInPage } from './SignInPage';
 
@@ -89,6 +90,8 @@ export function App() {
         <Route path="/admin/projects/:id" element={<ProjectPage />} />
         <Route path="/admin/projects/:id/invite" element={<InvitePage />} />
         <Route path="/admin/projects/:projectId/members/:membershipId" element={<EditMembershipPage />} />
+        <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
+        <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
         <Route path="/:resourceType/new" element={<CreateResourcePage />} />
         <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
         <Route path="/:resourceType/:id" element={<ResourcePage />} />

--- a/packages/app/src/ResourceVersionPage.test.tsx
+++ b/packages/app/src/ResourceVersionPage.test.tsx
@@ -1,0 +1,280 @@
+import { Bundle, MedplumClient, notFound, Practitioner, User } from '@medplum/core';
+import { MedplumProvider } from '@medplum/ui';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ResourceVersionPage } from './ResourceVersionPage';
+
+const user: User = {
+  resourceType: 'User',
+  id: '123'
+};
+
+const practitioner: Practitioner = {
+  resourceType: 'Practitioner',
+  id: '123',
+  name: [{ given: ['Medplum'], family: 'Admin' }],
+  active: true,
+  meta: {
+    versionId: '2',
+    lastUpdated: '2021-01-02T12:00:00Z',
+    author: {
+      reference: 'Practitioner/123'
+    }
+  }
+};
+
+const practitionerHistory: Bundle = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      resource: practitioner
+    },
+    {
+      resource: {
+        resourceType: 'Practitioner',
+        id: '123',
+        name: [{ given: ['Medplum'], family: 'Admin' }],
+        meta: {
+          versionId: '1',
+          lastUpdated: '2021-01-01T12:00:00Z',
+          author: {
+            reference: 'Practitioner/123'
+          }
+        }
+      }
+    }
+  ]
+};
+
+// const practitionerStructureBundle: Bundle = {
+//   resourceType: 'Bundle',
+//   entry: [{
+//     resource: {
+//       resourceType: 'StructureDefinition',
+//       name: 'Practitioner',
+//       snapshot: {
+//         element: [
+//           {
+//             path: 'Practitioner.id',
+//             type: [{
+//               code: 'code'
+//             }]
+//           }
+//         ]
+//       }
+//     }
+//   }]
+// };
+
+// const practitionerSearchParameter: Bundle = {
+//   resourceType: 'Bundle',
+//   entry: [{
+//     resource: {
+//       resourceType: 'SearchParameter',
+//       id: 'Practitioner-name',
+//       code: 'name',
+//       name: 'name'
+//     }
+//   }]
+// };
+
+// const patient: Patient = {
+//   resourceType: 'Patient',
+//   id: '123',
+//   identifier: [
+//     { system: 'abc', value: '123' },
+//     { system: 'def', value: '456' }
+//   ],
+//   name: [{
+//     given: ['Alice'],
+//     family: 'Smith'
+//   }],
+//   birthDate: '1990-01-01'
+// };
+
+// const patientSearchBundle: Bundle = {
+//   resourceType: 'Bundle',
+//   total: 100,
+//   entry: [{
+//     resource: patient
+//   }]
+// };
+
+// const questionnaire: Questionnaire = {
+//   resourceType: 'Questionnaire',
+//   id: '123',
+//   item: [{
+//     linkId: '1',
+//     text: 'Hello',
+//     type: 'string'
+//   }]
+// };
+
+// const bot: Bot = {
+//   resourceType: 'Bot',
+//   id: '123',
+//   name: 'Test Bot',
+//   code: 'console.log("hello world");'
+// };
+
+// const diagnosticReport: DiagnosticReport = {
+//   resourceType: 'DiagnosticReport',
+//   id: '123',
+//   status: 'final',
+//   result: [
+//     { reference: 'Observation/123' }
+//   ]
+// };
+
+function mockFetch(url: string, options: any): Promise<any> {
+  const method = options.method ?? 'GET';
+  let result: any;
+
+  if (method === 'POST' && url.endsWith('/auth/login')) {
+    result = {
+      user,
+      profile: 'Practitioner/123'
+    };
+    // } else if (method === 'GET' && url.includes('/fhir/R4/StructureDefinition?name:exact=Practitioner')) {
+    //   result = practitionerStructureBundle;
+    // } else if (method === 'GET' && url.includes('/fhir/R4/SearchParameter?name=Practitioner')) {
+    //   result = practitionerSearchParameter;
+    // } else if (method === 'GET' && url.includes('/fhir/R4/Patient?')) {
+    //   result = patientSearchBundle;
+    // } else if (method === 'GET' && url.includes('/fhir/R4/Patient/123')) {
+    //   result = patient;
+    // } else if (method === 'GET' && url.includes('/fhir/R4/Patient/123/_history')) {
+    //   result = patientSearchBundle;
+  } else if (method === 'GET' && url.endsWith('/fhir/R4/Practitioner/123')) {
+    result = practitioner;
+    // } else if (method === 'PUT' && url.endsWith('/fhir/R4/Practitioner/123')) {
+    //   result = practitioner;
+  } else if (method === 'GET' && url.endsWith('/fhir/R4/Practitioner/123/_history')) {
+    result = practitionerHistory;
+  } else if (method === 'GET' && url.endsWith('/fhir/R4/Practitioner/not-found/_history')) {
+    result = notFound
+    // } else if (method === 'GET' && url.endsWith('/fhir/R4/Questionnaire/123')) {
+    //   result = questionnaire;
+    // } else if (method === 'GET' && url.includes('/fhir/R4/Bot/123')) {
+    //   result = bot;
+    // } else if (method === 'GET' && url.includes('/fhir/R4/DiagnosticReport/123')) {
+    //   result = diagnosticReport;
+  }
+
+  const response: any = {
+    request: {
+      url,
+      options
+    },
+    ...result
+  };
+
+  return Promise.resolve({
+    blob: () => Promise.resolve(response),
+    json: () => Promise.resolve(response)
+  });
+}
+
+const medplum = new MedplumClient({
+  baseUrl: 'https://example.com/',
+  clientId: 'my-client-id',
+  fetch: mockFetch
+});
+
+describe('ResourcePage', () => {
+
+  beforeAll(async () => {
+    await medplum.signIn('admin@medplum.com', 'admin', 'practitioner', 'openid');
+  });
+
+  const setup = (url: string) => {
+    return render(
+      <MedplumProvider medplum={medplum}>
+        <MemoryRouter initialEntries={[url]} initialIndex={0}>
+          <Routes>
+            <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
+            <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
+          </Routes>
+        </MemoryRouter>
+      </MedplumProvider>
+    );
+  };
+
+  test('Resource not found', async () => {
+    await act(async () => {
+      setup('/Practitioner/not-found/_history/1');
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Resource not found'));
+    });
+
+    expect(screen.getByText('Resource not found')).toBeInTheDocument();
+  });
+
+  test('Version not found', async () => {
+    await act(async () => {
+      setup('/Practitioner/123/_history/3');
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Version not found'));
+    });
+
+    expect(screen.getByText('Version not found')).toBeInTheDocument();
+  });
+
+  test('Diff tab renders', async () => {
+    await act(async () => {
+      setup('/Practitioner/123/_history/1');
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Diff'));
+    });
+
+    expect(screen.getByText('Diff')).toBeInTheDocument();
+  });
+
+  test('Diff tab renders last version', async () => {
+    await act(async () => {
+      setup('/Practitioner/123/_history/2');
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Diff'));
+    });
+
+    expect(screen.getByText('Diff')).toBeInTheDocument();
+  });
+
+  test('Raw tab renders', async () => {
+    await act(async () => {
+      setup('/Practitioner/123/_history/1/raw');
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Raw'));
+    });
+
+    expect(screen.getByText('Raw')).toBeInTheDocument();
+  });
+
+  test('Change tab', async () => {
+    await act(async () => {
+      setup('/Practitioner/123/_history/1');
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Diff'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Raw'));
+    });
+
+    expect(screen.getByText('Raw')).toBeInTheDocument();
+  });
+
+});

--- a/packages/app/src/ResourceVersionPage.test.tsx
+++ b/packages/app/src/ResourceVersionPage.test.tsx
@@ -47,86 +47,6 @@ const practitionerHistory: Bundle = {
   ]
 };
 
-// const practitionerStructureBundle: Bundle = {
-//   resourceType: 'Bundle',
-//   entry: [{
-//     resource: {
-//       resourceType: 'StructureDefinition',
-//       name: 'Practitioner',
-//       snapshot: {
-//         element: [
-//           {
-//             path: 'Practitioner.id',
-//             type: [{
-//               code: 'code'
-//             }]
-//           }
-//         ]
-//       }
-//     }
-//   }]
-// };
-
-// const practitionerSearchParameter: Bundle = {
-//   resourceType: 'Bundle',
-//   entry: [{
-//     resource: {
-//       resourceType: 'SearchParameter',
-//       id: 'Practitioner-name',
-//       code: 'name',
-//       name: 'name'
-//     }
-//   }]
-// };
-
-// const patient: Patient = {
-//   resourceType: 'Patient',
-//   id: '123',
-//   identifier: [
-//     { system: 'abc', value: '123' },
-//     { system: 'def', value: '456' }
-//   ],
-//   name: [{
-//     given: ['Alice'],
-//     family: 'Smith'
-//   }],
-//   birthDate: '1990-01-01'
-// };
-
-// const patientSearchBundle: Bundle = {
-//   resourceType: 'Bundle',
-//   total: 100,
-//   entry: [{
-//     resource: patient
-//   }]
-// };
-
-// const questionnaire: Questionnaire = {
-//   resourceType: 'Questionnaire',
-//   id: '123',
-//   item: [{
-//     linkId: '1',
-//     text: 'Hello',
-//     type: 'string'
-//   }]
-// };
-
-// const bot: Bot = {
-//   resourceType: 'Bot',
-//   id: '123',
-//   name: 'Test Bot',
-//   code: 'console.log("hello world");'
-// };
-
-// const diagnosticReport: DiagnosticReport = {
-//   resourceType: 'DiagnosticReport',
-//   id: '123',
-//   status: 'final',
-//   result: [
-//     { reference: 'Observation/123' }
-//   ]
-// };
-
 function mockFetch(url: string, options: any): Promise<any> {
   const method = options.method ?? 'GET';
   let result: any;
@@ -136,30 +56,12 @@ function mockFetch(url: string, options: any): Promise<any> {
       user,
       profile: 'Practitioner/123'
     };
-    // } else if (method === 'GET' && url.includes('/fhir/R4/StructureDefinition?name:exact=Practitioner')) {
-    //   result = practitionerStructureBundle;
-    // } else if (method === 'GET' && url.includes('/fhir/R4/SearchParameter?name=Practitioner')) {
-    //   result = practitionerSearchParameter;
-    // } else if (method === 'GET' && url.includes('/fhir/R4/Patient?')) {
-    //   result = patientSearchBundle;
-    // } else if (method === 'GET' && url.includes('/fhir/R4/Patient/123')) {
-    //   result = patient;
-    // } else if (method === 'GET' && url.includes('/fhir/R4/Patient/123/_history')) {
-    //   result = patientSearchBundle;
   } else if (method === 'GET' && url.endsWith('/fhir/R4/Practitioner/123')) {
     result = practitioner;
-    // } else if (method === 'PUT' && url.endsWith('/fhir/R4/Practitioner/123')) {
-    //   result = practitioner;
   } else if (method === 'GET' && url.endsWith('/fhir/R4/Practitioner/123/_history')) {
     result = practitionerHistory;
   } else if (method === 'GET' && url.endsWith('/fhir/R4/Practitioner/not-found/_history')) {
     result = notFound
-    // } else if (method === 'GET' && url.endsWith('/fhir/R4/Questionnaire/123')) {
-    //   result = questionnaire;
-    // } else if (method === 'GET' && url.includes('/fhir/R4/Bot/123')) {
-    //   result = bot;
-    // } else if (method === 'GET' && url.includes('/fhir/R4/DiagnosticReport/123')) {
-    //   result = diagnosticReport;
   }
 
   const response: any = {

--- a/packages/app/src/ResourceVersionPage.tsx
+++ b/packages/app/src/ResourceVersionPage.tsx
@@ -1,0 +1,113 @@
+import {
+  Bundle,
+  BundleEntry,
+  OperationOutcomeError,
+  Resource
+} from '@medplum/core';
+import {
+  Document,
+  Loading,
+  MedplumLink, ResourceDiff, Tab,
+  TabBar,
+  TabPanel,
+  TabSwitch,
+  TitleBar,
+  useMedplum
+} from '@medplum/ui';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+export function ResourceVersionPage() {
+  const navigate = useNavigate();
+  const { resourceType, id, versionId, tab } = useParams() as { resourceType: string, id: string, versionId: string, tab: string };
+  const medplum = useMedplum();
+  const [loading, setLoading] = useState<boolean>(true);
+  const [historyBundle, setHistoryBundle] = useState<Bundle | undefined>();
+  const [error, setError] = useState<OperationOutcomeError | undefined>();
+
+  function loadResource(): Promise<void> {
+    setError(undefined);
+    setLoading(true);
+    return medplum.readHistory(resourceType, id)
+      .then(result => setHistoryBundle(result))
+      .then(() => setLoading(false))
+      .catch(reason => {
+        setError(reason);
+        setLoading(false);
+      });
+  }
+
+  useEffect(() => {
+    loadResource();
+  }, [resourceType, id]);
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  if (!historyBundle) {
+    return (
+      <Document>
+        <h1>Resource not found</h1>
+        <MedplumLink to={`/${resourceType}`}>Return to search page</MedplumLink>
+      </Document>
+    );
+  }
+
+  const entries = historyBundle.entry as BundleEntry[];
+  const index = entries.findIndex(entry => entry.resource?.meta?.versionId === versionId);
+  if (index === -1) {
+    return (
+      <Document>
+        <h1>Version not found</h1>
+        <MedplumLink to={`/${resourceType}/${id}`}>Return to resource</MedplumLink>
+      </Document>
+    );
+  }
+
+  const value = entries[index].resource as Resource;
+  const prev = index < entries.length - 1 ? entries[index + 1].resource : undefined;
+  const defaultTab = 'diff';
+  return (
+    <>
+      <TitleBar>
+        <h1>{`${resourceType} ${id}`}</h1>
+      </TitleBar>
+      <TabBar
+        value={tab || defaultTab}
+        onChange={(name: string) => navigate(`/${resourceType}/${id}/_history/${versionId}/${name}`)}>
+        <Tab name="diff" label="Diff" />
+        <Tab name="raw" label="Raw" />
+      </TabBar>
+      <Document>
+        {error && (
+          <pre data-testid="error">{JSON.stringify(error, undefined, 2)}</pre>
+        )}
+        <TabSwitch value={tab || defaultTab}>
+          <TabPanel name="diff">
+            {prev ? (
+              <>
+                <ul>
+                  <li>Current: {value.meta?.versionId}</li>
+                  <li>Previous: <MedplumLink to={`/${resourceType}/${id}/_history/${prev.meta?.versionId}`}>{prev.meta?.versionId}</MedplumLink></li>
+                </ul>
+                <ResourceDiff original={prev} revised={value} />
+              </>
+            ) : (
+              <>
+                <ul>
+                  <li>Current: {value.meta?.versionId}</li>
+                  <li>Previous: (none)</li>
+                </ul>
+                <pre>{JSON.stringify(value, undefined, 2)}</pre>
+              </>
+            )}
+          </TabPanel>
+          <TabPanel name="raw">
+            <pre>{JSON.stringify(value, undefined, 2)}</pre>
+          </TabPanel>
+        </TabSwitch>
+      </Document>
+    </>
+  );
+}

--- a/packages/app/src/ResourceVersionPage.tsx
+++ b/packages/app/src/ResourceVersionPage.tsx
@@ -7,7 +7,9 @@ import {
 import {
   Document,
   Loading,
-  MedplumLink, ResourceDiff, Tab,
+  MedplumLink,
+  ResourceDiff,
+  Tab,
   TabBar,
   TabPanel,
   TabSwitch,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -40,6 +40,7 @@ export * from './ResourceArrayDisplay';
 export * from './ResourceArrayInput';
 export * from './ResourceBadge';
 export * from './ResourceBlame';
+export * from './ResourceDiff';
 export * from './ResourceForm';
 export * from './ResourceHistoryTable';
 export * from './ResourceName';


### PR DESCRIPTION
Before:  On the resource history page, links to version details were broken:

![image](https://user-images.githubusercontent.com/749094/142952302-a813bda4-a838-4277-82bf-cbc212c9c8d3.png)

Now:  Page that shows the diff and the raw contents of the version:

![image](https://user-images.githubusercontent.com/749094/142952472-43d04260-d4db-47de-959c-e984c0e9d9e3.png)

This is useful for debugging, figuring out what changed over time.  The data has always been available, just not in an easy-to-consume format.
