### PR TITLE
Set Access-Control-Max-Age for CORS preflight requests

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -26,4 +26,11 @@ describe('App', () => {
     expect(res.status).toBe(200);
   });
 
+  test('Preflight max age', async () => {
+    const res = await request(app).options('/');
+    expect(res.status).toBe(204);
+    expect(res.header['access-control-max-age']).toBe('86400');
+    expect(res.header['cache-control']).toBe('public, max-age=86400');
+  });
+
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -18,6 +18,7 @@ import { wellKnownRouter } from './wellknown';
 
 const corsOptions: cors.CorsOptions = {
   credentials: true,
+  maxAge: 86400,
   origin: (origin, callback) => {
     // TODO: Check origin against whitelist
     callback(null, true);
@@ -31,9 +32,13 @@ const corsOptions: cors.CorsOptions = {
  * @param next The next handler.
  */
 function cacheHandler(req: Request, res: Response, next: NextFunction): void {
-  res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
-  res.set('Expires', 'Wed, 21 Oct 2015 07:28:00 GMT');
-  res.set('Pragma', 'no-cache');
+  if (req.method === 'OPTIONS') {
+    res.set('Cache-Control', 'public, max-age=86400');
+  } else {
+    res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+    res.set('Expires', 'Wed, 21 Oct 2015 07:28:00 GMT');
+    res.set('Pragma', 'no-cache');
+  }
   next();
 }
 


### PR DESCRIPTION
Implementing best practices as described here: https://httptoolkit.tech/blog/cache-your-cors/