### PR TITLE
Fixed inconsistent border thickness bug

### DIFF
--- a/packages/ui/src/Autocomplete.css
+++ b/packages/ui/src/Autocomplete.css
@@ -1,5 +1,5 @@
 .medplum-autocomplete-container {
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 3px;
   background: var(--medplum-surface);
   box-shadow: 0 1px 1px 0 var(--medplum-gray-200);
@@ -14,7 +14,7 @@
 .medplum-autocomplete-container.focused {
   background: var(--medplum-surface);
   color: var(--medplum-gray-900);
-  border: thin solid var(--medplum-blue-300);
+  border: 0.1px solid var(--medplum-blue-300);
   box-shadow: 0 0 0 2px var(--medplum-blue-200);
 }
 
@@ -38,7 +38,7 @@
 .medplum-autocomplete-container>ul>li.choice {
   margin: 1px 0 1px 4px;
   padding: 0 6px;
-  border: thin solid var(--medplum-orange-200);
+  border: 0.1px solid var(--medplum-orange-200);
   border-radius: 4px;
   background-color: var(--medplum-gray-50);
   cursor: move;
@@ -46,7 +46,7 @@
 }
 
 .medplum-autocomplete-container>ul>li.unstructured {
-  border: thin dashed var(--medplum-red-700) !important;
+  border: 0.1px dashed var(--medplum-red-700) !important;
 }
 
 .medplum-autocomplete-container>ul>li>input {
@@ -77,7 +77,7 @@
   width: 300px;
   z-index: 1;
   cursor: pointer;
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 2px;
   box-shadow: 0 2px 4px var(--medplum-shadow);
   transition: opacity .218s;

--- a/packages/ui/src/Button.css
+++ b/packages/ui/src/Button.css
@@ -1,5 +1,5 @@
 .btn {
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 4px;
   background: var(--medplum-gray-50);
   outline: none;

--- a/packages/ui/src/CssBaseline.css
+++ b/packages/ui/src/CssBaseline.css
@@ -34,7 +34,7 @@ a:hover {
 }
 
 a:focus {
-  outline: thin solid var(--medplum-blue-500);
+  outline: 0.1px solid var(--medplum-blue-500);
 }
 
 th, strong {
@@ -93,6 +93,6 @@ table.table {
 
 table.table th,
 table.table td {
-  border: thin solid var(--medplum-gray-400);
+  border: 0.1px solid var(--medplum-gray-400);
   padding: 4px 6px;
 }

--- a/packages/ui/src/DescriptionList.css
+++ b/packages/ui/src/DescriptionList.css
@@ -6,5 +6,5 @@ dl.medplum-description-list {
 dl.medplum-description-list dt,
 dl.medplum-description-list dd {
   padding: 16px 8px;
-  border-top: thin solid var(--medplum-gray-300);
+  border-top: 0.1px solid var(--medplum-gray-300);
 }

--- a/packages/ui/src/DiagnosticReportDisplay.css
+++ b/packages/ui/src/DiagnosticReportDisplay.css
@@ -1,13 +1,13 @@
 
 .medplum-observation-table {
   border-collapse: collapse;
-  border-top: thin solid var(--medplum-gray-500);
-  border-left: thin solid var(--medplum-gray-500);
+  border-top: 0.1px solid var(--medplum-gray-500);
+  border-left: 0.1px solid var(--medplum-gray-500);
 }
 
 .medplum-observation-table td,
 .medplum-observation-table th {
-  border-bottom: thin solid var(--medplum-gray-500);
-  border-right: thin solid var(--medplum-gray-500);
+  border-bottom: 0.1px solid var(--medplum-gray-500);
+  border-right: 0.1px solid var(--medplum-gray-500);
   padding: 4px 8px;
 }

--- a/packages/ui/src/Dialog.css
+++ b/packages/ui/src/Dialog.css
@@ -1,6 +1,6 @@
 .modal-dialog {
   background:var(--medplum-gray-600);
-  border: thin solid var(--medplum-gray-700);
+  border: 0.1px solid var(--medplum-gray-700);
   color: var(--medplum-foreground);
   padding: 0;
   position: absolute;

--- a/packages/ui/src/Document.css
+++ b/packages/ui/src/Document.css
@@ -11,7 +11,7 @@ article {
   margin: 8px auto 16px auto;
   padding: 15px 25px;
   text-align: left;
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 8px;
   box-shadow: 0 1px 3px 0 var(--medplum-gray-300);
 }

--- a/packages/ui/src/FormSection.css
+++ b/packages/ui/src/FormSection.css
@@ -7,7 +7,7 @@ fieldset {
 }
 
 fieldset.bordered {
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 6px;
   margin: 6px 0 16px 0;
   padding: 2px 8px 8px 8px;

--- a/packages/ui/src/Header.css
+++ b/packages/ui/src/Header.css
@@ -64,7 +64,7 @@ div.medplum-nav-search-container {
 .medplum-nav-search-container.focused {
   background: var(--medplum-surface);
   color: var(--medplum-gray-900);
-  border: thin solid var(--medplum-blue-300);
+  border: 0.1px solid var(--medplum-blue-300);
   box-shadow: 0 0 0 2px var(--medplum-blue-200);
 }
 
@@ -88,7 +88,7 @@ div.medplum-nav-search-container {
 .medplum-nav-search-container>ul>li.choice {
   margin: 1px 0 1px 4px;
   padding: 0 6px;
-  border: thin solid var(--medplum-orange-200);
+  border: 0.1px solid var(--medplum-orange-200);
   border-radius: 4px;
   background-color: var(--medplum-gray-50);
   cursor: move;
@@ -97,7 +97,7 @@ div.medplum-nav-search-container {
 }
 
 .medplum-nav-search-container>ul>li.unstructured {
-  border: thin dashed var(--medplum-red-700) !important;
+  border: 0.1px dashed var(--medplum-red-700) !important;
 }
 
 .medplum-nav-search-container>ul>li>input {
@@ -140,7 +140,7 @@ div.medplum-nav-menu-container {
   top: 0;
   right: 0;
   transform: translate(0px, 32px);
-  border: thin solid var(--medplum-gray-400);
+  border: 0.1px solid var(--medplum-gray-400);
   border-radius: 4px;
   background-color: var(--medplum-surface);
   color: var(--medplum-gray-600);

--- a/packages/ui/src/MenuSeparator.css
+++ b/packages/ui/src/MenuSeparator.css
@@ -1,6 +1,6 @@
 
 .medplum-menu-separator {
-  border-top: thin solid var(--medplum-gray-400);
+  border-top: 0.1px solid var(--medplum-gray-400);
   margin: 4px 0;
   padding: 0;
 }

--- a/packages/ui/src/Popup.css
+++ b/packages/ui/src/Popup.css
@@ -8,7 +8,7 @@
   border-radius: 0;
   box-shadow: 0 2px 4px var(--medplum-shadow);
   transition: opacity .2s;
-  border: thin solid var(--medplum-gray-400);
+  border: 0.1px solid var(--medplum-gray-400);
 }
 
 .medplum-backdrop {

--- a/packages/ui/src/ResourceBlame.css
+++ b/packages/ui/src/ResourceBlame.css
@@ -1,5 +1,5 @@
 .medplum-blame {
-  border: thin solid rgba(0, 0, 0, 0.15);
+  border: 0.1px solid rgba(0, 0, 0, 0.15);
   border-collapse: collapse;
   border-radius: 4px;
   border-spacing: 0;
@@ -7,7 +7,7 @@
 }
 
 .medplum-blame .start-row {
-  border-top: thin solid rgba(0, 0, 0, 0.15);
+  border-top: 0.1px solid rgba(0, 0, 0, 0.15);
 }
 
 .medplum-blame .normal-row {
@@ -15,7 +15,7 @@
 }
 
 .medplum-blame .details {
-  border-right: thin solid rgba(0, 0, 0, 0.15);
+  border-right: 0.1px solid rgba(0, 0, 0, 0.15);
   padding: 4px;
   font-size: 10px;
   line-height: 10px;

--- a/packages/ui/src/SearchControl.css
+++ b/packages/ui/src/SearchControl.css
@@ -12,12 +12,12 @@
 .medplum-search-control>table {
   width: 100%;
   clear: both;
-  border-top: thin solid var(--medplum-gray-300);
+  border-top: 0.1px solid var(--medplum-gray-300);
   border-collapse: collapse;
 }
 
 .medplum-search-control>table tr {
-  border-bottom: thin solid var(--medplum-gray-300);
+  border-bottom: 0.1px solid var(--medplum-gray-300);
 }
 
 .medplum-search-control>table td, .medplum-search-control>table th {
@@ -40,7 +40,7 @@
   background-color: var(--medplum-blue-50);
   white-space: nowrap;
   color: var(--medplum-gray-700);
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   position: relative;
 }
 
@@ -85,12 +85,12 @@
 
 .medplum-search-control>table tbody td {
   color: var(--medplum-gray-800);
-  border-right: thin solid var(--medplum-gray-100);
+  border-right: 0.1px solid var(--medplum-gray-100);
 }
 
 .medplum-search-control .medplum-empty-search {
   background: var(--medplum-gray-100);
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   color: var(--medplum-gray-500);
   text-align: center;
   padding: 40px;
@@ -106,7 +106,7 @@ a.paginate_button, a.paginate_active {
   padding: 8px 12px;
   margin-left: 2px;
   cursor: pointer;
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
 }
 
 a.paginate_button:hover {
@@ -140,7 +140,7 @@ a.paginate_button_disabled:hover {
 .medplum-search-icon-cell input[type=checkbox] {
   margin: 0;
   padding: 0;
-  border: thin solid var(--medplum-gray-600);
+  border: 0.1px solid var(--medplum-gray-600);
   outline: 0;
 }
 

--- a/packages/ui/src/SignInForm.css
+++ b/packages/ui/src/SignInForm.css
@@ -25,7 +25,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-top: thin solid var(--medplum-gray-200);
+  border-top: 0.1px solid var(--medplum-gray-200);
 }
 
 .medplum-signin-google-icon {

--- a/packages/ui/src/TextField.css
+++ b/packages/ui/src/TextField.css
@@ -5,7 +5,7 @@ input[type=tel],
 input[type=text],
 input[type=datetime-local],
 select {
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 3px;
   background: var(--medplum-surface);
   box-shadow: 0 1px 1px 0 var(--medplum-gray-200);
@@ -33,7 +33,7 @@ input[type=datetime-local]:focus,
 select:focus {
   background: var(--medplum-surface);
   color: var(--medplum-gray-900);
-  border: thin solid var(--medplum-blue-300);
+  border: 0.1px solid var(--medplum-blue-300);
   box-shadow: 0 0 0 2px var(--medplum-blue-200);
 }
 
@@ -87,7 +87,7 @@ select.large:not([size]) {
 
 input[type=checkbox],
 input[type=radio] {
-  border: thin solid var(--medplum-gray-300);
+  border: 0.1px solid var(--medplum-gray-300);
   border-radius: 0;
   background: var(--medplum-surface);
   box-shadow: 0 1px 1px 0 var(--medplum-gray-200);
@@ -97,7 +97,7 @@ input[type=checkbox]:focus,
 input[type=radio]:focus {
   background: var(--medplum-surface);
   color: var(--medplum-gray-900);
-  border: thin solid var(--medplum-blue-300);
+  border: 0.1px solid var(--medplum-blue-300);
   box-shadow: 0 0 0 2px var(--medplum-blue-200);
 }
 

--- a/packages/ui/src/Timeline.css
+++ b/packages/ui/src/Timeline.css
@@ -30,7 +30,7 @@ article.medplum-timeline-item {
 .medplum-timeline-item-footer {
   display: flex;
   padding: 8px;
-  border-top: thin solid var(--medplum-gray-200);
+  border-top: 0.1px solid var(--medplum-gray-200);
 }
 
 .medplum-timeline-icon {


### PR DESCRIPTION
Chrome changed how it renders borders when browser or OS zoom are not 100%, which can lead to inconsistent border thicknesses.

Known work around is to use border thickness "0.1px" rather than "thin" or "1px".

See more details here: https://stackoverflow.com/questions/69828326/consistent-css-border-width-with-zoom

This PR is only CSS changes, no JS or TS.