### PR TITLE
Use User.email for Reference display string

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -44,6 +44,8 @@ describe('Core Utils', () => {
     expect(getDisplayString({ resourceType: 'Device', deviceName: [{ name: 'Foo' }] })).toEqual('Foo');
     expect(getDisplayString({ resourceType: 'Device', id: '123', deviceName: [{}] })).toEqual('Device/123');
     expect(getDisplayString({ resourceType: 'Device', id: '123', deviceName: [] })).toEqual('Device/123');
+    expect(getDisplayString({ resourceType: 'User', email: 'foo@example.com' })).toEqual('foo@example.com');
+    expect(getDisplayString({ resourceType: 'User', id: '123' })).toEqual('User/123');
   });
 
   test('getImageSrc', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -52,6 +52,11 @@ export function getDisplayString(resource: Resource): string {
       return deviceName;
     }
   }
+  if (resource.resourceType === 'User') {
+    if (resource.email) {
+      return resource.email;
+    }
+  }
   const simpleName = (resource as any).name;
   if (simpleName && typeof simpleName === 'string') {
     return simpleName;


### PR DESCRIPTION
As a super admin, when debugging `User`, `Login`, `ProjectMembership` issues, you will see FHIR `Reference` objects for a `User` resource.

Before, they appeared as `User/bb9a66d0-4f0d-4e0d-995e-100013112aaf`

Now, they will appear as `name@example.com`

Note that we intentionally keep the `User` resource minimalist on user details.  User details should exist on the connected profile resources such as `Practitioner` or `Patient`.