### PR TITLE
Minor improvements to ResourceForm

### DIFF
--- a/packages/ui/src/AttachmentArrayInput.test.tsx
+++ b/packages/ui/src/AttachmentArrayInput.test.tsx
@@ -85,7 +85,7 @@ describe('AttachmentArrayInput', () => {
       fireEvent.change(screen.getByTestId('upload-file-input'), { target: { files } });
     });
 
-    expect(screen.getByText('text/plain')).toBeInTheDocument();
+    expect(screen.getByText('hello.txt')).toBeInTheDocument();
   });
 
   test('Renders attachments', async () => {

--- a/packages/ui/src/AttachmentInput.css
+++ b/packages/ui/src/AttachmentInput.css
@@ -1,0 +1,3 @@
+.medplum-attachment-input {
+  max-width: 200px;
+}

--- a/packages/ui/src/AttachmentInput.tsx
+++ b/packages/ui/src/AttachmentInput.tsx
@@ -1,5 +1,7 @@
 import { Attachment } from '@medplum/core';
 import React from 'react';
+import { AttachmentDisplay } from './AttachmentDisplay';
+import './AttachmentInput.css';
 
 export interface AttachmentInputProps {
   name: string;
@@ -8,14 +10,10 @@ export interface AttachmentInputProps {
 
 export function AttachmentInput(props: AttachmentInputProps) {
   const value = props.defaultValue;
-  const { contentType, url } = value ?? {};
-
   return (
-    <div data-testid="attachment-input">
-      <div>{value?.contentType}</div>
-      <div>{value?.url}</div>
-      {contentType?.startsWith('image/') && url && (
-        <img style={{ maxWidth: 100 }} src={url} />
+    <div className="medplum-attachment-input" data-testid="attachment-input">
+      {value && (
+        <AttachmentDisplay value={value} />
       )}
     </div>
   );

--- a/packages/ui/src/BackboneElementInput.test.tsx
+++ b/packages/ui/src/BackboneElementInput.test.tsx
@@ -1,0 +1,80 @@
+import { ElementDefinition, IndexedStructureDefinition } from '@medplum/core';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { BackboneElementInput, BackboneElementInputProps } from './BackboneElementInput';
+import { MedplumProvider } from './MedplumProvider';
+import { MockClient } from './MockClient';
+
+const contactProperty: ElementDefinition = {
+  id: 'Patient.contact',
+  path: 'Patient.contact',
+  type: [{
+    code: 'BackboneElement'
+  }],
+  min: 0,
+  max: '*'
+};
+
+const idProperty: ElementDefinition = {
+  id: 'Patient.contact.id',
+  path: 'Patient.contact.id',
+  type: [{
+    code: 'string'
+  }],
+  min: 0,
+  max: '1'
+};
+
+const nameProperty: ElementDefinition = {
+  id: 'Patient.contact.name',
+  path: 'Patient.contact.name',
+  type: [{
+    code: 'HumanName'
+  }],
+  min: 0,
+  max: '1'
+};
+
+const schema: IndexedStructureDefinition = {
+  types: {
+    Patient: {
+      display: 'Patient',
+      properties: {
+        contact: contactProperty
+      }
+    },
+    PatientContact: {
+      display: 'Patient Contact',
+      properties: {
+        id: idProperty,
+        name: nameProperty
+      }
+    }
+  }
+};
+
+const medplum = new MockClient({});
+
+describe('BackboneElementInput', () => {
+
+  const setup = (args: BackboneElementInputProps) => {
+    return render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <BackboneElementInput {...args} />
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+  };
+
+  test('Renders', () => {
+    setup({
+      schema,
+      property: contactProperty,
+      name: 'contact'
+    });
+    expect(screen.getByText('Name')).toBeDefined();
+  });
+
+});

--- a/packages/ui/src/BackboneElementInput.tsx
+++ b/packages/ui/src/BackboneElementInput.tsx
@@ -1,6 +1,7 @@
 import { buildTypeName, ElementDefinition, getPropertyDisplayName, IndexedStructureDefinition } from '@medplum/core';
 import React from 'react';
 import { FormSection } from './FormSection';
+import { DEFAULT_IGNORED_PROPERTIES } from './ResourceForm';
 import { ResourcePropertyInput } from './ResourcePropertyInput';
 
 export interface BackboneElementInputProps {
@@ -22,6 +23,9 @@ export function BackboneElementInput(props: BackboneElementInputProps) {
     <>
       {Object.entries(typeSchema.properties).map(entry => {
         const key = entry[0];
+        if (DEFAULT_IGNORED_PROPERTIES.indexOf(key) >= 0) {
+          return null;
+        }
         const property = entry[1];
         return (
           <FormSection key={key} title={getPropertyDisplayName(property)} description={property.definition}>

--- a/packages/ui/src/ResourceForm.tsx
+++ b/packages/ui/src/ResourceForm.tsx
@@ -6,7 +6,7 @@ import { useMedplum } from './MedplumProvider';
 import { ResourcePropertyInput } from './ResourcePropertyInput';
 import { useResource } from './useResource';
 
-const DEFAULT_IGNORED_PROPERTIES = [
+export const DEFAULT_IGNORED_PROPERTIES = [
   'id',
   'meta',
   'implicitRules',

--- a/packages/ui/src/ResourcePropertyInput.test.tsx
+++ b/packages/ui/src/ResourcePropertyInput.test.tsx
@@ -138,7 +138,8 @@ describe('ResourcePropertyInput', () => {
   test('Renders Attachment property', () => {
     const photo: Attachment[] = [{
       contentType: 'text/plain',
-      url: 'https://example.com/hello.txt'
+      url: 'https://example.com/hello.txt',
+      title: 'hello.txt'
     }];
 
     setup({
@@ -147,7 +148,7 @@ describe('ResourcePropertyInput', () => {
       name: 'photo',
       defaultValue: photo
     });
-    expect(screen.getByText('text/plain')).toBeDefined();
+    expect(screen.getByText('hello.txt')).toBeDefined();
   });
 
   test('Renders CodeableConcept property', () => {


### PR DESCRIPTION
* Hide common but rarely used properties such as "extension" and "modifierExtension"
  * We already hid these on top level types, but not on sub types
* Cleaned up attachment input display
  * Before we showed a dump of debug details including the content type and URL
  * When we used simple `Binary/id` URL's in the past, it was ugly, but manageable
  * Since we changed to CloudFront presigned URL's, it has been bad -- big long URL's, poor wrapping, horizontal scroll bars
  * Now use the `<AttachmentDisplay>` component for nice rendering