### PR TITLE
Added 'Delete' button

### DIFF
--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -193,7 +193,7 @@ describe('ResourcePage', () => {
     expect(screen.getByText('Edit')).toBeInTheDocument();
   });
 
-  test('Delete button', async () => {
+  test('Delete button confirm', async () => {
     window.confirm = jest.fn(() => true);
 
     setup('/Practitioner/123/edit');
@@ -207,6 +207,26 @@ describe('ResourcePage', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Delete'));
     });
+
+    expect(window.confirm).toHaveBeenCalled();
+  });
+
+  test('Delete button decline', async () => {
+    window.confirm = jest.fn(() => false);
+
+    setup('/Practitioner/123/edit');
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Delete'));
+    });
+
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Delete'));
+    });
+
+    expect(window.confirm).toHaveBeenCalled();
   });
 
   test('History tab renders', async () => {

--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -3,6 +3,7 @@ import { MedplumProvider, MockClient } from '@medplum/ui';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { HomePage } from './HomePage';
 import { ResourcePage } from './ResourcePage';
 
 const practitioner: Practitioner = {
@@ -155,6 +156,7 @@ describe('ResourcePage', () => {
           <Routes>
             <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
             <Route path="/:resourceType/:id" element={<ResourcePage />} />
+            <Route path="/:resourceType" element={<HomePage />} />
           </Routes>
         </MemoryRouter>
       </MedplumProvider>
@@ -189,6 +191,22 @@ describe('ResourcePage', () => {
     });
 
     expect(screen.getByText('Edit')).toBeInTheDocument();
+  });
+
+  test('Delete button', async () => {
+    window.confirm = jest.fn(() => true);
+
+    setup('/Practitioner/123/edit');
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Delete'));
+    });
+
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Delete'));
+    });
   });
 
   test('History tab renders', async () => {

--- a/packages/app/src/ResourcePage.tsx
+++ b/packages/app/src/ResourcePage.tsx
@@ -153,6 +153,13 @@ export function ResourcePage() {
                     .then(loadResource)
                     .catch(setError);
                 }}
+                onDelete={() => {
+                  if (window.confirm('Are you sure you want to delete this resource?')) {
+                    medplum.deleteResource(resourceType, id)
+                      .then(() => navigate(`/${resourceType}`))
+                      .catch(setError);
+                  }
+                }}
                 outcome={error?.outcome}
               />
             </TabPanel>
@@ -168,6 +175,7 @@ interface ResourceTabProps {
   resource: Resource;
   resourceHistory: Bundle;
   onSubmit: (resource: Resource) => void;
+  onDelete: (resource: Resource) => void;
   outcome?: OperationOutcome;
 }
 
@@ -179,7 +187,12 @@ function ResourceTab(props: ResourceTabProps): JSX.Element | null {
       );
     case 'edit':
       return (
-        <ResourceForm defaultValue={props.resource} onSubmit={props.onSubmit} outcome={props.outcome} />
+        <ResourceForm
+          defaultValue={props.resource}
+          onSubmit={props.onSubmit}
+          onDelete={props.onDelete}
+          outcome={props.outcome}
+        />
       );
     case 'history':
       return (

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -410,6 +410,14 @@ describe('Client', () => {
     expect((result as any).request.url).toBe('https://x/fhir/R4/Binary');
   });
 
+  test('Delete resource', async () => {
+    const client = new MedplumClient(defaultOptions);
+    const result = await client.deleteResource('Patient', 'xyz');
+    expect(result).toBeDefined();
+    expect((result as any).request.options.method).toBe('DELETE');
+    expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/xyz');
+  });
+
   test('Get schema', async () => {
     const client = new MedplumClient(defaultOptions);
     const schema = await client.getTypeDefinition('Patient');

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -201,6 +201,10 @@ export class MedplumClient extends EventTarget {
     return this.request('PUT', url, contentType, body);
   }
 
+  delete(url: string): Promise<any> {
+    return this.request('DELETE', url);
+  }
+
   /**
    * Tries to register a new user.
    * @param request The registration request.
@@ -412,6 +416,10 @@ export class MedplumClient extends EventTarget {
     return this.request('PATCH', this.fhirUrl(resourceType, id), PATCH_CONTENT_TYPE, operations);
   }
 
+  deleteResource(resourceType: string, id: string): Promise<any> {
+    return this.delete(this.fhirUrl(resourceType, id));
+  }
+
   graphql(gql: any): Promise<any> {
     return this.post(this.fhirUrl('$graphql'), gql, JSON_CONTENT_TYPE);
   }
@@ -531,8 +539,8 @@ export class MedplumClient extends EventTarget {
       return this.handleUnauthenticated(method, url, contentType, body);
     }
 
-    if (response.status === 304) {
-      // No change
+    if (response.status === 204 || response.status === 304) {
+      // No content or change
       return undefined;
     }
 

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -207,7 +207,7 @@ protectedRoutes.delete('/:resourceType/:id', asyncWrap(async (req: Request, res:
   const repo = res.locals.repo as Repository;
   const [outcome] = await repo.deleteResource(resourceType, id);
   assertOk(outcome);
-  res.sendStatus(getStatus(outcome));
+  sendOutcome(res, outcome);
 }));
 
 // Patch resource

--- a/packages/ui/src/ResourceForm.test.tsx
+++ b/packages/ui/src/ResourceForm.test.tsx
@@ -248,4 +248,29 @@ describe('ResourceForm', () => {
     expect(result.valueString).toBe('hello');
   });
 
+  test('Delete', async () => {
+    const onSubmit = jest.fn();
+    const onDelete = jest.fn();
+
+    await act(async () => {
+      setup({
+        defaultValue: {
+          resourceType: 'Practitioner',
+          id: 'xyz'
+        },
+        onSubmit,
+        onDelete
+      });
+    });
+
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Delete'));
+    });
+
+    expect(onSubmit).not.toBeCalled();
+    expect(onDelete).toBeCalled();
+  });
+
 });

--- a/packages/ui/src/ResourceForm.tsx
+++ b/packages/ui/src/ResourceForm.tsx
@@ -20,7 +20,8 @@ export const DEFAULT_IGNORED_PROPERTIES = [
 export interface ResourceFormProps {
   defaultValue: Resource | Reference;
   outcome?: OperationOutcome;
-  onSubmit: (formData: any) => void;
+  onSubmit: (resource: Resource) => void;
+  onDelete?: (resource: Resource) => void;
 }
 
 export function ResourceForm(props: ResourceFormProps) {
@@ -89,6 +90,11 @@ export function ResourceForm(props: ResourceFormProps) {
         );
       })}
       <Button type="submit" size="large">OK</Button>
+      {props.onDelete && (
+        <Button type="button" size="large" onClick={() => {
+          (props.onDelete as (resource: Resource) => void)(value);
+        }}>Delete</Button>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
Finally added a "Delete" button to the UI.  Delete functionality has existed for a long time, but you had to curl it manually.

There were a few sprawling changes:
* Before: The server used `sendStatus` which sends the content "OK" with content-type "text/plain"
* Now: The server uses `sendOutcome` which sends an `OperationOutcome` with content-type "application/fhir+json"
* Before: The `MedplumClient` class would choke on responses without content body
* Now: The `MedplumClient` class gracefully ignores responses without content body