### PR TITLE
Prevent update lastUpdated timestamp

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -441,6 +441,32 @@ describe('FHIR Repo', () => {
     expect(patient?.meta?.lastUpdated).toEqual(lastUpdated);
   });
 
+  test('Update resource with lastUpdated', async () => {
+    const lastUpdated = '2020-01-01T12:00:00Z';
+
+    // System repo has the ability to write custom timestamps
+    const [createOutcome, patient1] = await repo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Alice'], family: 'Smith' }],
+      meta: {
+        lastUpdated
+      }
+    });
+    expect(createOutcome.id).toEqual('created');
+    expect(patient1?.meta?.lastUpdated).toEqual(lastUpdated);
+
+    // But system cannot update the timestamp
+    const [updateOutcome, patient2] = await repo.updateResource<Patient>({
+      ...patient1,
+      active: true,
+      meta: {
+        lastUpdated
+      }
+    });
+    expect(updateOutcome.id).toEqual('ok');
+    expect(patient2?.meta?.lastUpdated).not.toEqual(lastUpdated);
+  });
+
   test('Search for Communications by Encounter', async () => {
     const [outcome1, patient1] = await repo.createResource<Patient>({
       resourceType: 'Patient',

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -259,7 +259,7 @@ export class Repository {
       meta: {
         ...updated?.meta,
         versionId: randomUUID(),
-        lastUpdated: this.getLastUpdated(resource),
+        lastUpdated: this.getLastUpdated(existing, resource),
         author: this.getAuthor(resource)
       }
     }
@@ -764,13 +764,16 @@ export class Repository {
    * @param resource The FHIR resource.
    * @returns The last updated date.
    */
-  private getLastUpdated(resource: Resource): string {
-    // If the resource has a specified "lastUpdated",
-    // and the current context is a ClientApplication (i.e., OAuth client credentials),
-    // then allow the ClientApplication to set the date.
-    const lastUpdated = resource.meta?.lastUpdated;
-    if (lastUpdated && this.canWriteMeta()) {
-      return lastUpdated;
+  private getLastUpdated(existing: Resource | undefined, resource: Resource): string {
+    if (!existing) {
+      // If the resource has a specified "lastUpdated",
+      // and there is no existing version,
+      // and the current context is a ClientApplication (i.e., OAuth client credentials),
+      // then allow the ClientApplication to set the date.
+      const lastUpdated = resource.meta?.lastUpdated;
+      if (lastUpdated && this.canWriteMeta()) {
+        return lastUpdated;
+      }
     }
 
     // Otherwise, use "now"


### PR DESCRIPTION
Before: `ClientApplications` with super admin privileges could update `meta.lastUpdated`.  This was done to enable data migration, preserving historical timestamps.

However, that leads to chaos when multiple edits, because multiple versions can have the same timestamp.

Now:  `ClientApplications` with super admin privileges can *create* resources with custom `meta.lastUpdated`.  But any subsequent changes will use the normal flow and set `meta.lastUpdated` to `Date.now()`.