### PR TITLE
Allow setting Binary project by query param

### DIFF
--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -12,7 +12,10 @@ binaryRouter.post('/', asyncWrap(async (req: Request, res: Response) => {
   const repo = res.locals.repo as Repository;
   const [outcome, resource] = await repo.createResource<Binary>({
     resourceType: 'Binary',
-    contentType: req.get('Content-Type')
+    contentType: req.get('Content-Type'),
+    meta: {
+      project: req.query['_project'] as string | undefined
+    }
   });
   assertOk(outcome);
   await getBinaryStorage().writeBinary(resource as Binary, req);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -794,7 +794,15 @@ export class Repository {
       return undefined;
     }
 
-    return resource.meta?.project ?? this.context.project;
+    const submittedProjectId = resource.meta?.project;
+    if (submittedProjectId && this.canWriteMeta()) {
+      // If the resource has an project (whether provided or from existing),
+      // and the current context is allowed to write meta,
+      // then use the provided value.
+      return submittedProjectId;
+    }
+
+    return this.context.project;
   }
 
   /**


### PR DESCRIPTION
This is only useful in the narrow scenario of "data migration into multiple projects".

If a `ClientApplication` has access to multiple projects, there is not a clean way to specify the project of a `Binary` resource, because the HTTP request POSTs the file contents as the request body.

To work around this, we allow `_project` query param.

This only applies to `ClientApplication` resources with adequate "write meta" permissions.