### PR TITLE
Fixed boolean property inputs

### DIFF
--- a/packages/ui/src/ResourcePropertyInput.test.tsx
+++ b/packages/ui/src/ResourcePropertyInput.test.tsx
@@ -14,6 +14,14 @@ const patientNameProperty: ElementDefinition = {
   max: '*'
 };
 
+const patientActiveProperty: ElementDefinition = {
+  id: 'Patient.active',
+  path: 'Patient.active',
+  type: [{
+    code: 'boolean'
+  }]
+};
+
 const patientBirthDateProperty: ElementDefinition = {
   id: 'Patient.birthDate',
   path: 'Patient.birthDate',
@@ -91,6 +99,7 @@ const schema: IndexedStructureDefinition = {
       display: 'Patient',
       properties: {
         name: patientNameProperty,
+        active: patientActiveProperty,
         birthDate: patientBirthDateProperty,
         address: patientAddressProperty,
         photo: patientPhotoProperty,
@@ -120,6 +129,25 @@ describe('ResourcePropertyInput', () => {
       </MedplumProvider>
     );
   }
+
+  test('Renders boolean property', () => {
+    const onChange = jest.fn();
+
+    setup({
+      schema,
+      property: patientActiveProperty,
+      name: 'active',
+      defaultValue: undefined,
+      onChange
+    });
+    expect(screen.getByTestId('active')).toBeDefined();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('active'));
+    });
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
 
   test('Renders Address property', () => {
     const address: Address[] = [{

--- a/packages/ui/src/ResourcePropertyInput.tsx
+++ b/packages/ui/src/ResourcePropertyInput.tsx
@@ -162,8 +162,10 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
         <input
           type="checkbox"
           name={name}
-          defaultChecked={!!value} value="true"
-          onChange={(e: React.ChangeEvent) => props.onChange && props.onChange((e.target as HTMLInputElement).value)}
+          data-testid={name}
+          defaultChecked={!!value} 
+          value="true"
+          onChange={(e: React.ChangeEvent) => props.onChange && props.onChange((e.target as HTMLInputElement).value === 'true')}
         />
       );
     case PropertyType.markdown:


### PR DESCRIPTION
Before:  The autogenerated form element for boolean would set the property to a string value of `"true"`

Now: The form element correctly sets it to a boolean `true`