### PR TITLE
Make blame durable to sort order

### DIFF
--- a/packages/ui/src/utils/blame.test.ts
+++ b/packages/ui/src/utils/blame.test.ts
@@ -3,7 +3,7 @@ import { blame } from './blame';
 
 describe('Blame', () => {
 
-  test('blame', () => {
+  test('blame oldest to newest', () => {
     const history: Bundle = {
       resourceType: 'Bundle',
       entry: [
@@ -12,7 +12,8 @@ describe('Blame', () => {
             resourceType: 'Patient',
             id: '123',
             meta: {
-              versionId: '1'
+              versionId: '1',
+              lastUpdated: '2021-01-01T12:00:00Z'
             }
           }
         },
@@ -21,7 +22,8 @@ describe('Blame', () => {
             resourceType: 'Patient',
             id: '123',
             meta: {
-              versionId: '2'
+              versionId: '2',
+              lastUpdated: '2021-01-01T12:01:00Z'
             },
             name: [{ given: ['Alice'], family: 'Smith' }],
             active: true
@@ -32,7 +34,8 @@ describe('Blame', () => {
             resourceType: 'Patient',
             id: '123',
             meta: {
-              versionId: '3'
+              versionId: '3',
+              lastUpdated: '2021-01-01T12:02:00Z'
             },
             name: [{ given: ['Alice'], family: 'Smith' }],
             active: false
@@ -43,6 +46,71 @@ describe('Blame', () => {
 
     const result = blame(history);
     expect(result).toBeDefined();
+    expect(result.length).toBe(17);
+    expect(result[0]).toMatchObject({
+      "id": "1",
+      "meta": {
+        "versionId": "1",
+        "lastUpdated": "2021-01-01T12:00:00Z"
+      },
+      "value": "{",
+      "span": 4
+    });
+  });
+
+  test('blame newest to oldest', () => {
+    const history: Bundle = {
+      resourceType: 'Bundle',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '123',
+            meta: {
+              versionId: '3',
+              lastUpdated: '2021-01-01T12:02:00Z'
+            },
+            name: [{ given: ['Alice'], family: 'Smith' }],
+            active: false
+          }
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '123',
+            meta: {
+              versionId: '2',
+              lastUpdated: '2021-01-01T12:01:00Z'
+            },
+            name: [{ given: ['Alice'], family: 'Smith' }],
+            active: true
+          }
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '123',
+            meta: {
+              versionId: '1',
+              lastUpdated: '2021-01-01T12:00:00Z'
+            }
+          }
+        }
+      ]
+    };
+
+    const result = blame(history);
+    expect(result).toBeDefined();
+    expect(result.length).toBe(17);
+    expect(result[0]).toMatchObject({
+      "id": "1",
+      "meta": {
+        "versionId": "1",
+        "lastUpdated": "2021-01-01T12:00:00Z"
+      },
+      "value": "{",
+      "span": 4
+    });
   });
 
 });

--- a/packages/ui/src/utils/blame.ts
+++ b/packages/ui/src/utils/blame.ts
@@ -10,10 +10,12 @@ export interface BlameRow {
 
 export function blame(history: Bundle): BlameRow[] {
   // Convert to array of array of lines
-  const versions = (history.entry as BundleEntry[]).map(entry => ({
-    meta: entry.resource?.meta as Meta,
-    lines: stringify(entry.resource, true).match(/[^\r\n]+/g) as string[]
-  }));
+  const versions = (history.entry as BundleEntry[])
+    .map(entry => ({
+      meta: entry.resource?.meta as Meta,
+      lines: stringify(entry.resource, true).match(/[^\r\n]+/g) as string[]
+    }))
+    .sort((a, b) => (a.meta.lastUpdated as string).localeCompare(b.meta.lastUpdated as string));
 
   // Start with array of lines from the first version
   const table: BlameRow[] = versions[0].lines.map(line => ({


### PR DESCRIPTION
Before:  `blame` assumed that versions were sorted oldest to newest.

Early versions of the FHIR server returned versions oldest to newest, so that was fine.

Later, the FHIR server followed the spec recommendation that versions be returned newest to oldest.  That broke `blame`.

Now: `blame` assumes nothing, and sorts versions by `meta.lastUpdated`.