### PR TITLE
Remove use of aws --profile medplum

### DIFF
--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -5,7 +5,6 @@ pushd packages/docs/build
 # Copy all non-HTML assets
 # Mark as public and cached forever
 aws s3 cp ./ s3://medplum-docs/ \
-  --profile medplum \
   --region us-east-1 \
   --recursive \
   --cache-control "public, max-age=31536000" \
@@ -16,7 +15,6 @@ aws s3 cp ./ s3://medplum-docs/ \
 # Copy index.html
 # Set non-cache so clients revalidate
 aws s3 cp index.html s3://medplum-docs/index.html \
-  --profile medplum \
   --region us-east-1 \
   --content-type "text/html; charset=utf-8" \
   --cache-control "no-cache"
@@ -24,7 +22,6 @@ aws s3 cp index.html s3://medplum-docs/index.html \
 # Copy sitemap.xml
 # Set non-cache so clients revalidate
 aws s3 cp sitemap.xml s3://medplum-docs/sitemap.xml \
-  --profile medplum \
   --region us-east-1 \
   --content-type "application/xml; charset=utf-8" \
   --cache-control "no-cache"
@@ -36,7 +33,6 @@ shopt -s globstar
 for input_file in **/*.html; do
   output_file=${input_file%.html}
   aws s3 cp "$input_file" "s3://medplum-docs/$output_file" \
-    --profile medplum \
     --region us-east-1 \
     --content-type "text/html; charset=utf-8" \
     --cache-control "no-cache"

--- a/scripts/deploy-graphiql.sh
+++ b/scripts/deploy-graphiql.sh
@@ -2,13 +2,11 @@
 
 pushd packages/graphiql
 aws s3 cp dist/ s3://medplum-docs/graphiql/ \
-  --profile medplum \
   --region us-east-1 \
   --recursive \
   --cache-control "public, max-age=31536000" \
   --exclude "*.html"
 aws s3 cp dist/ s3://medplum-docs/graphiql/ \
-  --profile medplum \
   --region us-east-1 \
   --recursive \
   --cache-control "no-cache" \

--- a/scripts/deploy-storybook.sh
+++ b/scripts/deploy-storybook.sh
@@ -3,13 +3,11 @@
 pushd packages/ui
 npm run storybook
 aws s3 cp storybook-static/ s3://medplum-docs/storybook/ \
-  --profile medplum \
   --region us-east-1 \
   --recursive \
   --cache-control "public, max-age=31536000" \
   --exclude "*.html"
 aws s3 cp storybook-static/ s3://medplum-docs/storybook/ \
-  --profile medplum \
   --region us-east-1 \
   --recursive \
   --cache-control "no-cache" \


### PR DESCRIPTION
Removed all uses of `--profile medplum` in the aws deploy scripts.

See broken build: https://github.com/medplum/medplum/runs/4423031632?check_suite_focus=true