### PR TITLE
Form style review

### DIFF
--- a/packages/ui/src/AttachmentArrayInput.tsx
+++ b/packages/ui/src/AttachmentArrayInput.tsx
@@ -1,6 +1,6 @@
 import { Attachment } from '@medplum/core';
 import React, { useRef, useState } from 'react';
-import { AttachmentInput } from './AttachmentInput';
+import { AttachmentDisplay } from './AttachmentDisplay';
 import { UploadButton } from './UploadButton';
 import { killEvent } from './utils/dom';
 
@@ -35,9 +35,7 @@ export function AttachmentArrayInput(props: AttachmentArrayInputProps) {
           {values.map((v: any, index: number) => !v.__removed && (
             <tr key={`${index}-${values.length}`}>
               <td>
-                <AttachmentInput
-                  name={props.name}
-                  defaultValue={v} />
+                <AttachmentDisplay value={v} maxWidth={200} />
               </td>
               <td>
                 <button

--- a/packages/ui/src/AttachmentDisplay.tsx
+++ b/packages/ui/src/AttachmentDisplay.tsx
@@ -11,7 +11,14 @@ export function AttachmentDisplay(props: AttachmentDisplayProps) {
   const { contentType, url } = value ?? {};
 
   if (contentType?.startsWith('image/') && url) {
-    return <img data-testid="attachment-image" style={{ maxWidth: props.maxWidth }} src={url} />;
+    return (
+      <img
+        data-testid="attachment-image"
+        style={{ maxWidth: props.maxWidth }}
+        src={url}
+        alt={value?.title}
+      />
+    );
   }
 
   if (contentType?.startsWith('video/') && url) {

--- a/packages/ui/src/AttachmentInput.css
+++ b/packages/ui/src/AttachmentInput.css
@@ -1,3 +1,0 @@
-.medplum-attachment-input {
-  max-width: 200px;
-}

--- a/packages/ui/src/AttachmentInput.test.tsx
+++ b/packages/ui/src/AttachmentInput.test.tsx
@@ -2,7 +2,7 @@ import { Binary, MedplumClient } from '@medplum/core';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { randomUUID } from 'crypto';
 import React from 'react';
-import { AttachmentArrayInput, AttachmentArrayInputProps } from './AttachmentArrayInput';
+import { AttachmentInput, AttachmentInputProps } from './AttachmentInput';
 import { MedplumProvider } from './MedplumProvider';
 
 function mockFetch(url: string, options: any): Promise<any> {
@@ -37,15 +37,15 @@ const medplum = new MedplumClient({
   fetch: mockFetch
 });
 
-const setup = (args?: AttachmentArrayInputProps) => {
+const setup = (args?: AttachmentInputProps) => {
   return render(
     <MedplumProvider medplum={medplum}>
-      <AttachmentArrayInput name="test" {...args} />
+      <AttachmentInput name="test" {...args} />
     </MedplumProvider>
   );
 };
 
-describe('AttachmentArrayInput', () => {
+describe('AttachmentInput', () => {
 
   beforeAll(async () => {
     global.URL.createObjectURL = jest.fn(() => 'details');
@@ -55,22 +55,15 @@ describe('AttachmentArrayInput', () => {
     setup();
   });
 
-  test('Renders empty array', () => {
-    setup({
-      name: 'test',
-      defaultValue: []
-    });
-  });
-
   test('Renders attachments', async () => {
     await act(async () => {
       await setup({
         name: 'test',
-        defaultValue: [{
+        defaultValue: {
           contentType: 'image/jpeg',
           url: 'https://example.com/test.jpg',
           title: 'test.jpg'
-        }]
+        }
       });
       await waitFor(() => screen.getByAltText('test.jpg'));
     });
@@ -93,11 +86,11 @@ describe('AttachmentArrayInput', () => {
     await act(async () => {
       await setup({
         name: 'test',
-        defaultValue: [{
+        defaultValue: {
           contentType: 'image/jpeg',
           url: 'https://example.com/test.jpg',
           title: 'test.jpg'
-        }]
+        }
       });
     });
 

--- a/packages/ui/src/AttachmentInput.tsx
+++ b/packages/ui/src/AttachmentInput.tsx
@@ -1,20 +1,40 @@
 import { Attachment } from '@medplum/core';
-import React from 'react';
+import React, { useState } from 'react';
 import { AttachmentDisplay } from './AttachmentDisplay';
-import './AttachmentInput.css';
+import { Button } from './Button';
+import { UploadButton } from './UploadButton';
+import { killEvent } from './utils/dom';
 
 export interface AttachmentInputProps {
   name: string;
   defaultValue?: Attachment;
+  arrayElement?: boolean;
+  onChange?: (value: Attachment | undefined) => void;
 }
 
 export function AttachmentInput(props: AttachmentInputProps) {
-  const value = props.defaultValue;
+  const [value, setValue] = useState(props.defaultValue);
+
+  function setValueWrapper(newValue: Attachment | undefined) {
+    setValue(newValue);
+    if (props.onChange) {
+      props.onChange(newValue);
+    }
+  }
+
+  if (value) {
+    return (
+      <>
+        <AttachmentDisplay value={value} maxWidth={200} />
+        <Button onClick={e => {
+          killEvent(e);
+          setValueWrapper(undefined);
+        }}>Remove</Button>
+      </>
+    );
+  }
+
   return (
-    <div className="medplum-attachment-input" data-testid="attachment-input">
-      {value && (
-        <AttachmentDisplay value={value} />
-      )}
-    </div>
+    <UploadButton onUpload={setValueWrapper} />
   );
 }

--- a/packages/ui/src/FormSection.css
+++ b/packages/ui/src/FormSection.css
@@ -26,12 +26,18 @@ fieldset small {
   padding: 2px 0 4px 0;
 }
 
+fieldset input[type=date],
 fieldset input[type=datetime-local],
 fieldset input[type=email],
 fieldset input[type=number],
 fieldset input[type=password],
 fieldset input[type=tel],
 fieldset input[type=text],
+fieldset input[type=time],
+fieldset input[type=url] {
+  width: 400px;
+}
+
 fieldset select,
 fieldset table {
   width: 100%;

--- a/packages/ui/src/FormSection.css
+++ b/packages/ui/src/FormSection.css
@@ -35,7 +35,8 @@ fieldset input[type=tel],
 fieldset input[type=text],
 fieldset input[type=time],
 fieldset input[type=url] {
-  width: 400px;
+  width: 100%;
+  max-width: 400px;
 }
 
 fieldset select,

--- a/packages/ui/src/QuestionnaireForm.test.tsx
+++ b/packages/ui/src/QuestionnaireForm.test.tsx
@@ -231,7 +231,7 @@ describe('QuestionnaireForm', () => {
       onSubmit: jest.fn()
     });
 
-    const input = screen.getByTestId('attachment-input');
+    const input = screen.getByText('Upload...');
     expect(input).toBeInTheDocument();
   });
 

--- a/packages/ui/src/QuestionnaireForm.tsx
+++ b/packages/ui/src/QuestionnaireForm.tsx
@@ -47,6 +47,9 @@ export function QuestionnaireForm(props: QuestionnaireFormProps) {
           props.onSubmit(response);
         }
       }}>
+      {questionnaire.title && (
+        <h1>{questionnaire.title}</h1>
+      )}
       {questionnaire.item && (
         <QuestionnaireFormItemArray items={questionnaire.item} />
       )}
@@ -96,7 +99,6 @@ function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.Element |
 
   switch (type) {
     case QuestionnaireItemType.group:
-    case QuestionnaireItemType.display:
       return (
         <div>
           <h3>{item.text}</h3>
@@ -111,11 +113,11 @@ function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.Element |
       );
     case QuestionnaireItemType.decimal:
       return (
-        <input type="number" id={name} name={name} defaultValue={initial?.valueDecimal} />
+        <input type="number" step={0.01} id={name} name={name} defaultValue={initial?.valueDecimal} />
       );
     case QuestionnaireItemType.integer:
       return (
-        <input type="number" id={name} name={name} defaultValue={initial?.valueInteger} />
+        <input type="number" step={1} id={name} name={name} defaultValue={initial?.valueInteger} />
       );
     case QuestionnaireItemType.date:
       return (

--- a/packages/ui/src/TextField.css
+++ b/packages/ui/src/TextField.css
@@ -1,10 +1,14 @@
+input[type=date],
+input[type=datetime-local],
 input[type=email],
 input[type=number],
 input[type=password],
 input[type=tel],
 input[type=text],
-input[type=datetime-local],
-select {
+input[type=time],
+input[type=url],
+select,
+textarea {
   border: 0.1px solid var(--medplum-gray-300);
   border-radius: 3px;
   background: var(--medplum-surface);
@@ -14,36 +18,48 @@ select {
   font-size: var(--medplum-font-normal);
 }
 
+input[type=date],
+input[type=datetime-local],
 input[type=email],
 input[type=number],
 input[type=password],
 input[type=tel],
 input[type=text],
-input[type=datetime-local] {
+input[type=time],
+input[type=url],
+textarea {
   padding: 2px 8px;
   margin: 0;
 }
 
+input[type=date]:focus,
+input[type=datetime-local]:focus,
 input[type=email]:focus,
 input[type=number]:focus,
 input[type=password]:focus,
 input[type=tel]:focus,
 input[type=text]:focus,
-input[type=datetime-local]:focus,
-select:focus {
+input[type=time]:focus,
+input[type=url]:focus,
+select:focus,
+textarea:focus {
   background: var(--medplum-surface);
   color: var(--medplum-gray-900);
   border: 0.1px solid var(--medplum-blue-300);
   box-shadow: 0 0 0 2px var(--medplum-blue-200);
 }
 
+input[type=date]:disabled,
+input[type=datetime-local]:disabled,
 input[type=email]:disabled,
 input[type=number]:disabled,
 input[type=password]:disabled,
 input[type=tel]:disabled,
 input[type=text]:disabled,
-input[type=datetime-local]:disabled,
-select:disabled {
+input[type=time]:disabled,
+input[type=url]:disabled,
+select:disabled,
+textarea:disabled {
   background: var(--medplum-gray-100);
 }
 

--- a/packages/ui/src/stories/QuestionnaireForm.stories.tsx
+++ b/packages/ui/src/stories/QuestionnaireForm.stories.tsx
@@ -13,6 +13,7 @@ export const Basic = () => (
     <QuestionnaireForm
       questionnaire={{
         resourceType: 'Questionnaire',
+        title: 'Basic Exmple',
         item: [{
           linkId: 'titleDisplay',
           text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
@@ -35,6 +36,7 @@ export const Groups = () => (
     <QuestionnaireForm
       questionnaire={{
         resourceType: 'Questionnaire',
+        title: 'Groups Exmple',
         item: [{
           linkId: 'group1',
           text: 'Group 1',
@@ -64,6 +66,97 @@ export const Groups = () => (
             type: 'string'
           }]
         }]
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const KitchenSink = () => (
+  <Document>
+    <QuestionnaireForm
+      questionnaire={{
+        resourceType: 'Questionnaire',
+        title: 'Kitchen Sink Exmple',
+        item: [
+          {
+            linkId: 'i1',
+            type: 'display',
+            text: 'This is an example of all question types.  See: https://www.hl7.org/fhir/valueset-item-type.html'
+          },
+          {
+            linkId: 'boolean',
+            type: 'boolean',
+            text: 'boolean'
+          },
+          {
+            linkId: 'decimal',
+            type: 'decimal',
+            text: 'decimal'
+          },
+          {
+            linkId: 'integer',
+            type: 'integer',
+            text: 'integer'
+          },
+          {
+            linkId: 'date',
+            type: 'date',
+            text: 'date'
+          },
+          {
+            linkId: 'dateTime',
+            type: 'dateTime',
+            text: 'dateTime'
+          },
+          {
+            linkId: 'time',
+            type: 'time',
+            text: 'time'
+          },
+          {
+            linkId: 'string',
+            type: 'string',
+            text: 'string'
+          },
+          {
+            linkId: 'text',
+            type: 'text',
+            text: 'text'
+          },
+          {
+            linkId: 'url',
+            type: 'url',
+            text: 'url'
+          },
+          {
+            linkId: 'choice',
+            type: 'choice',
+            text: 'choice'
+          },
+          {
+            linkId: 'open-choice',
+            type: 'open-choice',
+            text: 'open-choice'
+          },
+          {
+            linkId: 'attachment',
+            type: 'attachment',
+            text: 'attachment'
+          },
+          {
+            linkId: 'reference',
+            type: 'reference',
+            text: 'reference'
+          },
+          {
+            linkId: 'quantity',
+            type: 'quantity',
+            text: 'quantity'
+          },
+        ]
       }}
       onSubmit={(formData: any) => {
         console.log('submit', formData);


### PR DESCRIPTION
Bunch of tweaks to form input elements for Questionnairs:
* Consistent style for all input types (before "date", "time", and "url" were missing so had default borders)
* Max width of 400px for most input types.  1000px wide inputs for numbers looked silly.
* Fixed `<AttachmentInput>`, which is distinct from the more commonly used `<AttachmentArrayInput>`
* Added "Kitchen Sink" example in Storybook:

![image](https://user-images.githubusercontent.com/749094/144759845-5400631f-0c1a-4c4b-bf51-d905e887275a.png)
