### PR TITLE
Use Docker image 'node:16-slim'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-slim
 ENV NODE_ENV production
 WORKDIR /usr/src/medplum
 ADD ./medplum-server.tar.gz ./

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -19,6 +19,10 @@ DEPLOY_STORYBOOK=false
 # Inspect files changed
 #
 
+if [[ "$FILES_CHANGED" =~ ^Dockerfile ]]; then
+  DEPLOY_SERVER=true
+fi
+
 if [[ "$FILES_CHANGED" =~ ^package-lock.json ]]; then
   DEPLOY_APP=true
   DEPLOY_DOCS=true


### PR DESCRIPTION
Before:
* Used "node:16" which included extra Linux utilities
* Docker image was 1.07 GB

After:
* Use "node:16-slim" which does not include extra Linux utilities
* Docker image is 334 MB

We never SSH into images (AWS Fargate does not allow it), so extra Linux utilities are pure dead weight.

I looked into "node:16-alpine".  It reduces the image to 260 MB.  It appears to work fine, but there are some open issues regarding DNS errors in cloud environments.  The extra savings does not seem worth the risk.
* https://github.com/gliderlabs/docker-alpine/issues/255