### PR TITLE
Allow setting binary project from query param

### DIFF
--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -32,7 +32,10 @@ binaryRouter.put('/:id', asyncWrap(async (req: Request, res: Response) => {
   const [outcome, resource] = await repo.updateResource<Binary>({
     resourceType: 'Binary',
     id,
-    contentType: req.get('Content-Type')
+    contentType: req.get('Content-Type'),
+    meta: {
+      project: req.query['_project'] as string | undefined
+    }
   });
   assertOk(outcome);
   await getBinaryStorage().writeBinary(resource as Binary, req);


### PR DESCRIPTION
Similar to https://github.com/medplum/medplum/pull/176

Where that pull request enabled setting project in "create", this pull request enables setting project in "update".

As described in the previous PR, this only applies to highly credentialed users and client applications with access to multiple projects.