### PR TITLE
Stop subscription retries if status not active

### DIFF
--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -256,6 +256,11 @@ export async function sendSubscription(job: Job<SubscriptionJobData>): Promise<v
   const [subscriptionOutcome, subscription] = await repo.readResource<Subscription>('Subscription', subscriptionId);
   assertOk(subscriptionOutcome);
 
+  if (subscription?.status !== 'active') {
+    // If the subscription has been disabled, then stop processing it.
+    return;
+  }
+
   const [resourceOutcome, resource] = await repo.readVersion(resourceType, id, versionId);
   assertOk(resourceOutcome);
 


### PR DESCRIPTION
Before:  We evaluated `Subscription.active` at the time a resource changed.

Now:  We evaluate `Subscription.active` at the time a resource changed, and again on every retry.

This helps for when Subscriptions get into bad states, and the user wants to minimize the onslaught of retries.