### PR TITLE
Stop subscription retries if resource is deleted

### DIFF
--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -649,4 +649,104 @@ describe('Subscription Worker', () => {
     expect(bundle?.entry?.length).toEqual(0);
   });
 
+  test('Stop retries if Subscription deleted', async () => {
+    const [subscriptionOutcome, subscription] = await repo.createResource<Subscription>({
+      resourceType: 'Subscription',
+      status: 'active',
+      criteria: 'Patient',
+      channel: {
+        type: 'rest-hook',
+        endpoint: 'https://example.com/'
+      }
+    });
+    expect(subscriptionOutcome.id).toEqual('created');
+    expect(subscription).toBeDefined();
+
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [patientOutcome, patient] = await repo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Alice'], family: 'Smith' }]
+    });
+
+    expect(patientOutcome.id).toEqual('created');
+    expect(patient).toBeDefined();
+    expect(queue.add).toHaveBeenCalled();
+
+    // At this point the job should be in the queue
+    // But let's delete the subscription
+    const [deleteOutcome] = await repo.deleteResource('Subscription', subscription?.id as string);
+    assertOk(deleteOutcome);
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
+    await sendSubscription(job);
+
+    // Fetch should not have been called
+    expect(fetch).not.toHaveBeenCalled();
+
+    // No AuditEvent resources should have been created
+    const [searchOutcome, bundle] = await repo.search<AuditEvent>({
+      resourceType: 'AuditEvent',
+      filters: [{
+        code: 'entity',
+        operator: Operator.EQUALS,
+        value: getReferenceString(subscription as Subscription)
+      }]
+    });
+    assertOk(searchOutcome);
+    expect(bundle).toBeDefined();
+    expect(bundle?.entry?.length).toEqual(0);
+  });
+
+  test('Stop retries if Resource deleted', async () => {
+    const [subscriptionOutcome, subscription] = await repo.createResource<Subscription>({
+      resourceType: 'Subscription',
+      status: 'active',
+      criteria: 'Patient',
+      channel: {
+        type: 'rest-hook',
+        endpoint: 'https://example.com/'
+      }
+    });
+    expect(subscriptionOutcome.id).toEqual('created');
+    expect(subscription).toBeDefined();
+
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [patientOutcome, patient] = await repo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Alice'], family: 'Smith' }]
+    });
+
+    expect(patientOutcome.id).toEqual('created');
+    expect(patient).toBeDefined();
+    expect(queue.add).toHaveBeenCalled();
+
+    // At this point the job should be in the queue
+    // But let's delete the resource
+    const [deleteOutcome] = await repo.deleteResource('Patient', patient?.id as string);
+    assertOk(deleteOutcome);
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
+    await sendSubscription(job);
+
+    // Fetch should not have been called
+    expect(fetch).not.toHaveBeenCalled();
+
+    // No AuditEvent resources should have been created
+    const [searchOutcome, bundle] = await repo.search<AuditEvent>({
+      resourceType: 'AuditEvent',
+      filters: [{
+        code: 'entity',
+        operator: Operator.EQUALS,
+        value: getReferenceString(subscription as Subscription)
+      }]
+    });
+    assertOk(searchOutcome);
+    expect(bundle).toBeDefined();
+    expect(bundle?.entry?.length).toEqual(0);
+  });
+
 });


### PR DESCRIPTION
This applies both to the `Subscription` resource and the triggering resource.