### PR TITLE
Handle unresolved ElementDefinition.contentReference

### DIFF
--- a/packages/ui/src/BackboneElementInput.test.tsx
+++ b/packages/ui/src/BackboneElementInput.test.tsx
@@ -36,6 +36,20 @@ const nameProperty: ElementDefinition = {
   max: '1'
 };
 
+const valueSetExcludeProperty: ElementDefinition = {
+  id: 'ValueSet.compose.exclude',
+  path: 'ValueSet.compose.exclude',
+  short: 'Explicitly exclude codes from a code system or other value sets',
+  min: 0,
+  max: '*',
+  base: {
+    path: 'ValueSet.compose.exclude',
+    min: 0,
+    max: '*'
+  },
+  contentReference: '#ValueSet.compose.include'
+};
+
 const schema: IndexedStructureDefinition = {
   types: {
     Patient: {
@@ -49,6 +63,12 @@ const schema: IndexedStructureDefinition = {
       properties: {
         id: idProperty,
         name: nameProperty
+      }
+    },
+    ValueSet: {
+      display: 'Value Set',
+      properties: {
+        valueSetExcludeProperty
       }
     }
   }
@@ -75,6 +95,15 @@ describe('BackboneElementInput', () => {
       name: 'contact'
     });
     expect(screen.getByText('Name')).toBeDefined();
+  });
+
+  test('Handles content reference', () => {
+    setup({
+      schema,
+      property: valueSetExcludeProperty,
+      name: 'exclude'
+    });
+    expect(screen.queryByText('Exclude')).toBeNull();
   });
 
 });

--- a/packages/ui/src/BackboneElementInput.test.tsx
+++ b/packages/ui/src/BackboneElementInput.test.tsx
@@ -53,7 +53,20 @@ const valueSetComposeProperty: ElementDefinition = {
   ]
 };
 
-const valueSetExcludeProperty: ElementDefinition = {
+const valueSetComposeLockedDateProperty: ElementDefinition = {
+  id: 'ValueSet.compose.lockedDate',
+  path: 'ValueSet.compose.lockedDate',
+  short: 'Locked date',
+  min: 0,
+  max: '1',
+  type: [
+    {
+      code: 'date'
+    }
+  ]
+};
+
+const valueSetComposeExcludeProperty: ElementDefinition = {
   id: 'ValueSet.compose.exclude',
   path: 'ValueSet.compose.exclude',
   short: 'Explicitly exclude codes from a code system or other value sets',
@@ -91,7 +104,8 @@ const schema: IndexedStructureDefinition = {
     ValueSetCompose: {
       display: 'Value Set Compose',
       properties: {
-        exclude: valueSetExcludeProperty
+        lockedDate: valueSetComposeLockedDateProperty,
+        exclude: valueSetComposeExcludeProperty
       }
     }
   }
@@ -126,7 +140,7 @@ describe('BackboneElementInput', () => {
       property: valueSetComposeProperty,
       name: 'compose'
     });
-    expect(screen.getByText('Compose')).toBeInTheDocument();
+    expect(screen.getByText('Locked Date')).toBeInTheDocument();
     expect(screen.queryByText('Exclude')).toBeNull();
   });
 

--- a/packages/ui/src/BackboneElementInput.test.tsx
+++ b/packages/ui/src/BackboneElementInput.test.tsx
@@ -36,6 +36,23 @@ const nameProperty: ElementDefinition = {
   max: '1'
 };
 
+const valueSetComposeProperty: ElementDefinition = {
+  id: 'ValueSet.compose',
+  path: 'ValueSet.compose',
+  min: 0,
+  max: '1',
+  base: {
+    path: 'ValueSet.compose',
+    min: 0,
+    max: '1'
+  },
+  type: [
+    {
+      code: 'BackboneElement'
+    }
+  ]
+};
+
 const valueSetExcludeProperty: ElementDefinition = {
   id: 'ValueSet.compose.exclude',
   path: 'ValueSet.compose.exclude',
@@ -68,7 +85,13 @@ const schema: IndexedStructureDefinition = {
     ValueSet: {
       display: 'Value Set',
       properties: {
-        valueSetExcludeProperty
+        compose: valueSetComposeProperty
+      }
+    },
+    ValueSetCompose: {
+      display: 'Value Set Compose',
+      properties: {
+        exclude: valueSetExcludeProperty
       }
     }
   }
@@ -100,9 +123,10 @@ describe('BackboneElementInput', () => {
   test('Handles content reference', () => {
     setup({
       schema,
-      property: valueSetExcludeProperty,
-      name: 'exclude'
+      property: valueSetComposeProperty,
+      name: 'compose'
     });
+    expect(screen.getByText('Compose')).toBeInTheDocument();
     expect(screen.queryByText('Exclude')).toBeNull();
   });
 

--- a/packages/ui/src/BackboneElementInput.tsx
+++ b/packages/ui/src/BackboneElementInput.tsx
@@ -38,6 +38,9 @@ export function BackboneElementInput(props: BackboneElementInputProps) {
           return null;
         }
         const property = entry[1];
+        if (!property.type) {
+          return null;
+        }
         return (
           <FormSection key={key} title={getPropertyDisplayName(property)} description={property.definition}>
             <ResourcePropertyInput

--- a/packages/ui/src/stories/ResourceForm.stories.tsx
+++ b/packages/ui/src/stories/ResourceForm.stories.tsx
@@ -125,3 +125,30 @@ export const Subscription = () => (
     />
   </Document>
 );
+
+export const ValueSet = () => (
+  <Document>
+    <ResourceForm
+      defaultValue={{
+        resourceType: 'ValueSet'
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const DeviceRequest = () => (
+  <Document>
+    <ResourceForm
+      defaultValue={{
+        resourceType: 'DeviceRequest'
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+


### PR DESCRIPTION
We use FHIR `StructureDefinition` resources to dynamically generate the input form.

A `StructureDefinition` resource is composed of many `ElementDefinition` objects, roughly one for each property.

The `ElementDefinition` has a feature called `contentReference`, which basically says "copy everything from this other `ElementDefinition`", which is useful when you have multiple complex property types that are almost identical.

Unfortunately our dynamic form generator isn't set up to handle this at the moment.  It would require a bunch of extra metadata searching, and could actually reference entirely different `StructureDefinition` resources, which could generate additional HTTP requests, oh my.

So instead, this PR just silently ignores properties that are missing their own type information.  The `contentReference` feature is rarely used, so we can punt until it becomes necessary.

To be clear, this is only for the dynamic form generator.  Users can still use the API or edit the JSON directly if necessary.