### PR TITLE
Return 403 Forbidden for protected resource types

### DIFF
--- a/packages/server/src/auth/register.test.ts
+++ b/packages/server/src/auth/register.test.ts
@@ -89,7 +89,29 @@ describe('Register', () => {
       .get(`/fhir/R4/${res.body.project.reference}`)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
 
-    expect(res2.status).toBe(404);
+    expect(res2.status).toBe(403);
+  });
+
+  test('Cannot access ProjectMembership resource', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .type('json')
+      .send({
+        firstName: 'Alexander',
+        lastName: 'Hamilton',
+        projectName: 'Hamilton Project',
+        email: `alex${randomUUID()}@example.com`,
+        password: 'password!@#'
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.project.reference).toBeDefined();
+
+    const res2 = await request(app)
+      .get(`/fhir/R4/ProjectMembership`)
+      .set('Authorization', 'Bearer ' + res.body.accessToken);
+
+    expect(res2.status).toBe(403);
   });
 
   test('Can access Practitioner resource', async () => {

--- a/packages/server/src/auth/register.test.ts
+++ b/packages/server/src/auth/register.test.ts
@@ -90,6 +90,18 @@ describe('Register', () => {
       .set('Authorization', 'Bearer ' + res.body.accessToken);
 
     expect(res2.status).toBe(403);
+
+    const res3 = await request(app)
+      .post(`/fhir/R4/Project`)
+      .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .type('json')
+      .send({
+        resourceType: 'Project',
+        name: 'Project 1',
+        owner: { reference: 'Project/' + randomUUID() },
+      });
+
+    expect(res3.status).toBe(403);
   });
 
   test('Cannot access ProjectMembership resource', async () => {
@@ -112,6 +124,19 @@ describe('Register', () => {
       .set('Authorization', 'Bearer ' + res.body.accessToken);
 
     expect(res2.status).toBe(403);
+
+    const res3 = await request(app)
+      .post(`/fhir/R4/ProjectMembership`)
+      .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .type('json')
+      .send({
+        resourceType: 'ProjectMembership',
+        project: { reference: 'Project/' + randomUUID() },
+        user: { reference: 'Project/' + randomUUID() },
+        profile: { reference: 'Project/' + randomUUID() },
+      });
+
+    expect(res3.status).toBe(403);
   });
 
   test('Can access Practitioner resource', async () => {

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -44,9 +44,6 @@ export async function createProjectMembership(
   logger.info('Create project membership: ' + project.name);
   const [outcome, result] = await repo.createResource<ProjectMembership>({
     resourceType: 'ProjectMembership',
-    meta: {
-      project: project.id
-    },
     project: createReference(project),
     user: createReference(user),
     profile: createReference(practitioner),

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -896,6 +896,9 @@ export class Repository {
     if (this.isSystem() || this.isAdmin()) {
       return true;
     }
+    if (protectedResourceTypes.includes(resourceType)) {
+      return false;
+    }
     if (publicResourceTypes.includes(resourceType)) {
       return true;
     }
@@ -920,6 +923,9 @@ export class Repository {
   private canWriteResourceType(resourceType: string): boolean {
     if (this.isSystem() || this.isAdmin()) {
       return true;
+    }
+    if (protectedResourceTypes.includes(resourceType)) {
+      return false;
     }
     if (publicResourceTypes.includes(resourceType)) {
       return false;


### PR DESCRIPTION
Before:  "Protected Resources" (i.e., "User", "Project", "ProjectMembership") were not accessible to normal users because they did not have `meta.project` populated.  This meant users could search for them, but the server would always return 404 or empty search results.

Now: "Protected Resources" are explicitly forbidden.  Any attempt to read, create, update, or delete by a user other than super admin or system account will return 403 Forbidden.