### PR TITLE
Resource timeline update

### DIFF
--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -21,6 +21,7 @@ const practitioner: Practitioner = {
 
 const practitionerHistory: Bundle = {
   resourceType: 'Bundle',
+  type: 'history',
   entry: [{
     resource: practitioner
   }]
@@ -73,6 +74,14 @@ const patient: Patient = {
   meta: {
     versionId: '456'
   }
+};
+
+const patientHistory: Bundle = {
+  resourceType: 'Bundle',
+  type: 'history',
+  entry: [{
+    resource: patient
+  }]
 };
 
 const patientSearchBundle: Bundle = {
@@ -143,6 +152,15 @@ const medplum = new MockClient({
   },
   'fhir/R4/DiagnosticReport/123': {
     'GET': diagnosticReport
+  },
+  'fhir/R4': {
+    'POST': {
+      resourceType: 'Bundle',
+      type: 'batch-response',
+      entry: [
+        { resource: patientHistory },
+      ]
+    }
   },
 });
 

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -705,4 +705,29 @@ describe('Batch', () => {
     }
   });
 
+  test('Process batch read history', async () => {
+    const [createOutcome, patient] = await repo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ family: 'Foo', given: ['Bar'] }]
+    });
+    assertOk(createOutcome);
+
+    const [outcome, bundle] = await processBatch(repo, {
+      resourceType: 'Bundle',
+      type: 'batch',
+      entry: [
+        {
+          request: {
+            method: 'GET',
+            url: `Patient/${patient?.id}/_history`
+          }
+        }
+      ]
+    });
+
+    expect(isOk(outcome)).toBe(true);
+    expect(bundle).toBeDefined();
+    expect(bundle?.entry).toBeDefined();
+  });
+
 });

--- a/packages/server/src/fhir/batch.ts
+++ b/packages/server/src/fhir/batch.ts
@@ -125,6 +125,9 @@ class BatchProcessor {
     if (path.length === 3) {
       return this.processReadResource(path[1], path[2]);
     }
+    if (path.length === 4 && path[3] === '_history') {
+      return this.processReadHistory(path[1], path[2]);
+    }
     return buildBundleResponse(notFound);
   }
 
@@ -148,6 +151,18 @@ class BatchProcessor {
    */
   private async processReadResource(resourceType: string, id: string): Promise<BundleEntry> {
     const [outcome, resource] = await this.repo.readResource(resourceType, id);
+    return buildBundleResponse(outcome, resource, true);
+  }
+
+  /**
+   * Process a batch read history request.
+   * @param repo The FHIR respostory.
+   * @param resourceType The FHIR resource type.
+   * @param id The FHIR resource ID.
+   * @returns The bundle entry response.
+   */
+  private async processReadHistory(resourceType: string, id: string): Promise<BundleEntry> {
+    const [outcome, resource] = await this.repo.readHistory(resourceType, id);
     return buildBundleResponse(outcome, resource, true);
   }
 

--- a/packages/ui/src/DefaultResourceTimeline.test.tsx
+++ b/packages/ui/src/DefaultResourceTimeline.test.tsx
@@ -17,6 +17,7 @@ const subscription: Subscription = {
 
 const subscriptionHistory: Bundle = {
   resourceType: 'Bundle',
+  type: 'history',
   entry: [{
     resource: subscription
   }]
@@ -50,12 +51,16 @@ const medplum = new MockClient({
   'fhir/R4/Subscription/123': {
     'GET': subscription
   },
-  'fhir/R4/Subscription/123/_history': {
-    'GET': subscriptionHistory
+  'fhir/R4': {
+    'POST': {
+      resourceType: 'Bundle',
+      type: 'batch-response',
+      entry: [
+        { resource: subscriptionHistory },
+        { resource: auditEvents },
+      ]
+    }
   },
-  'fhir/R4/AuditEvent?_count=100&_sort=-_lastUpdated&entity=Subscription/123': {
-    'GET': auditEvents
-  }
 });
 
 describe('DefaultResourceTimeline', () => {

--- a/packages/ui/src/DefaultResourceTimeline.tsx
+++ b/packages/ui/src/DefaultResourceTimeline.tsx
@@ -1,4 +1,4 @@
-import { getReferenceString, Operator, Reference, Resource } from '@medplum/core';
+import { getReferenceString, Reference, Resource } from '@medplum/core';
 import React from 'react';
 import { ResourceTimeline } from './ResourceTimeline';
 
@@ -10,23 +10,24 @@ export function DefaultResourceTimeline(props: DefaultResourceTimelineProps): JS
   return (
     <ResourceTimeline
       value={props.resource}
-      buildSearchRequests={(resource: Resource) => {
-        return [
+      buildSearchRequests={(resource: Resource) => ({
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
           {
-            resourceType: 'AuditEvent',
-            filters: [{
-              code: 'entity',
-              operator: Operator.EQUALS,
-              value: getReferenceString(resource)
-            }],
-            sortRules: [{
-              code: '_lastUpdated',
-              descending: true
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `${getReferenceString(resource)}/_history`
+            }
+          },
+          {
+            request: {
+              method: 'GET',
+              url: `AuditEvent?entity=${getReferenceString(resource)}`
+            }
           }
-        ];
-      }}
+        ]
+      })}
     />
   );
 }

--- a/packages/ui/src/EncounterTimeline.test.tsx
+++ b/packages/ui/src/EncounterTimeline.test.tsx
@@ -17,6 +17,7 @@ const encounter: Encounter = {
 
 const encounterHistory: Bundle = {
   resourceType: 'Bundle',
+  type: 'history',
   entry: [{
     resource: encounter
   }]
@@ -91,14 +92,16 @@ const medplum = new MockClient({
   'fhir/R4/Encounter/123': {
     'GET': encounter
   },
-  'fhir/R4/Encounter/123/_history': {
-    'GET': encounterHistory
-  },
-  'fhir/R4/Communication?_count=100&encounter=Encounter/123': {
-    'GET': communications
-  },
-  'fhir/R4/Media?_count=100&encounter=Encounter/123': {
-    'GET': media
+  'fhir/R4': {
+    'POST': {
+      resourceType: 'Bundle',
+      type: 'batch-response',
+      entry: [
+        { resource: encounterHistory },
+        { resource: communications },
+        { resource: media },
+      ]
+    }
   },
   'fhir/R4/Communication': {
     'POST': newComment

--- a/packages/ui/src/EncounterTimeline.tsx
+++ b/packages/ui/src/EncounterTimeline.tsx
@@ -1,4 +1,4 @@
-import { Attachment, createReference, Encounter, getReferenceString, Operator, ProfileResource, Reference, Resource } from '@medplum/core';
+import { Attachment, createReference, Encounter, getReferenceString, ProfileResource, Reference, Resource } from '@medplum/core';
 import React from 'react';
 import { ResourceTimeline } from './ResourceTimeline';
 
@@ -10,29 +10,30 @@ export function EncounterTimeline(props: EncounterTimelineProps): JSX.Element {
   return (
     <ResourceTimeline
       value={props.encounter}
-      buildSearchRequests={(encounter: Resource) => {
-        const encounterReference = getReferenceString(encounter);
-        return [
+      buildSearchRequests={(resource: Resource) => ({
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
           {
-            resourceType: 'Communication',
-            filters: [{
-              code: 'encounter',
-              operator: Operator.EQUALS,
-              value: encounterReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `${getReferenceString(resource)}/_history`
+            }
           },
           {
-            resourceType: 'Media',
-            filters: [{
-              code: 'encounter',
-              operator: Operator.EQUALS,
-              value: encounterReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `Communication?encounter=${getReferenceString(resource)}`
+            }
+          },
+          {
+            request: {
+              method: 'GET',
+              url: `Media?encounter=${getReferenceString(resource)}`
+            }
           }
-        ];
-      }}
+        ]
+      })}
       createCommunication={(resource: Encounter, sender: ProfileResource, text: string) => ({
         resourceType: 'Communication',
         encounter: createReference(resource),

--- a/packages/ui/src/PatientTimeline.test.tsx
+++ b/packages/ui/src/PatientTimeline.test.tsx
@@ -1,4 +1,4 @@
-import { Bundle, Communication, Media, Patient } from '@medplum/core';
+import { Bundle, Communication, Media, Patient, Practitioner } from '@medplum/core';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { randomUUID } from 'crypto';
 import React from 'react';
@@ -20,6 +20,15 @@ const patientHistory: Bundle = {
   type: 'history',
   entry: [{
     resource: patient
+  }]
+};
+
+const practitioner: Practitioner = {
+  resourceType: 'Practitioner',
+  id: '123',
+  name: [{
+    given: ['John'],
+    family: 'Doe',
   }]
 };
 
@@ -90,6 +99,32 @@ const serviceRequest: Bundle = {
   ]
 };
 
+const serviceRequestStructureBundle: Bundle = {
+  resourceType: 'Bundle',
+  entry: [{
+    resource: {
+      resourceType: 'StructureDefinition',
+      name: 'ServiceRequest',
+      snapshot: {
+        element: [
+          {
+            path: 'ServiceRequest.id',
+            type: [{
+              code: 'code'
+            }]
+          },
+          {
+            path: 'ServiceRequest.code',
+            type: [{
+              code: 'CodeableConcept'
+            }]
+          }
+        ]
+      }
+    }
+  }]
+};
+
 const newComment: Communication = {
   resourceType: 'Communication',
   id: randomUUID(),
@@ -116,6 +151,9 @@ const medplum = new MockClient({
   'fhir/R4/Patient/123': {
     'GET': patient
   },
+  'fhir/R4/Practitioner/123': {
+    'GET': practitioner
+  },
   'fhir/R4': {
     'POST': {
       resourceType: 'Bundle',
@@ -133,6 +171,9 @@ const medplum = new MockClient({
   },
   'fhir/R4/Media': {
     'POST': newMedia
+  },
+  'fhir/R4/StructureDefinition?name:exact=ServiceRequest': {
+    'GET': serviceRequestStructureBundle
   },
 });
 
@@ -199,7 +240,7 @@ describe('PatientTimeline', () => {
 
     const items = screen.getAllByTestId('timeline-item');
     expect(items).toBeDefined();
-    expect(items.length).toEqual(4);
+    expect(items.length).toEqual(5);
   });
 
   test('Upload media', async () => {
@@ -225,7 +266,7 @@ describe('PatientTimeline', () => {
 
     const items = screen.getAllByTestId('timeline-item');
     expect(items).toBeDefined();
-    expect(items.length).toEqual(4);
+    expect(items.length).toEqual(5);
   });
 
 });

--- a/packages/ui/src/PatientTimeline.test.tsx
+++ b/packages/ui/src/PatientTimeline.test.tsx
@@ -17,6 +17,7 @@ const patient: Patient = {
 
 const patientHistory: Bundle = {
   resourceType: 'Bundle',
+  type: 'history',
   entry: [{
     resource: patient
   }]
@@ -91,14 +92,16 @@ const medplum = new MockClient({
   'fhir/R4/Patient/123': {
     'GET': patient
   },
-  'fhir/R4/Patient/123/_history': {
-    'GET': patientHistory
-  },
-  'fhir/R4/Communication?_count=100&subject=Patient/123': {
-    'GET': communications
-  },
-  'fhir/R4/Media?_count=100&subject=Patient/123': {
-    'GET': media
+  'fhir/R4': {
+    'POST': {
+      resourceType: 'Bundle',
+      type: 'batch-response',
+      entry: [
+        { resource: patientHistory },
+        { resource: communications },
+        { resource: media },
+      ]
+    }
   },
   'fhir/R4/Communication': {
     'POST': newComment

--- a/packages/ui/src/PatientTimeline.test.tsx
+++ b/packages/ui/src/PatientTimeline.test.tsx
@@ -66,6 +66,30 @@ const media: Bundle = {
   ]
 };
 
+const serviceRequest: Bundle = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      resource: {
+        resourceType: 'ServiceRequest',
+        id: randomUUID(),
+        meta: {
+          lastUpdated: new Date().toISOString(),
+          author: {
+            reference: 'Practitioner/123'
+          }
+        },
+        code: {
+          coding: [{
+            system: 'http://snomed.info/sct',
+            code: 'SERVICE_REQUEST_CODE',
+          }]
+        }
+      }
+    }
+  ]
+};
+
 const newComment: Communication = {
   resourceType: 'Communication',
   id: randomUUID(),
@@ -100,6 +124,7 @@ const medplum = new MockClient({
         { resource: patientHistory },
         { resource: communications },
         { resource: media },
+        { resource: serviceRequest },
       ]
     }
   },
@@ -132,7 +157,8 @@ describe('PatientTimeline', () => {
 
     const items = screen.getAllByTestId('timeline-item');
     expect(items).toBeDefined();
-    expect(items.length).toEqual(3);
+    expect(items.length).toEqual(4);
+    expect(screen.getByText('SERVICE_REQUEST_CODE')).toBeInTheDocument();
   });
 
   test('Renders resource', async () => {
@@ -144,7 +170,8 @@ describe('PatientTimeline', () => {
 
     const items = screen.getAllByTestId('timeline-item');
     expect(items).toBeDefined();
-    expect(items.length).toEqual(3);
+    expect(items.length).toEqual(4);
+    expect(screen.getByText('SERVICE_REQUEST_CODE')).toBeInTheDocument();
   });
 
   test('Create comment', async () => {

--- a/packages/ui/src/PatientTimeline.tsx
+++ b/packages/ui/src/PatientTimeline.tsx
@@ -1,4 +1,4 @@
-import { Attachment, createReference, getReferenceString, Operator, Patient, ProfileResource, Reference, Resource } from '@medplum/core';
+import { Attachment, createReference, getReferenceString, Patient, ProfileResource, Reference, Resource } from '@medplum/core';
 import React from 'react';
 import { ResourceTimeline } from './ResourceTimeline';
 
@@ -10,47 +10,42 @@ export function PatientTimeline(props: PatientTimelineProps): JSX.Element {
   return (
     <ResourceTimeline
       value={props.patient}
-      buildSearchRequests={(patient: Resource) => {
-        const patientReference = getReferenceString(patient);
-        return [
+      buildSearchRequests={(resource: Resource) => ({
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
           {
-            resourceType: 'Communication',
-            filters: [{
-              code: 'subject',
-              operator: Operator.EQUALS,
-              value: patientReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `${getReferenceString(resource)}/_history`
+            }
           },
           {
-            resourceType: 'Media',
-            filters: [{
-              code: 'subject',
-              operator: Operator.EQUALS,
-              value: patientReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `Communication?subject=${getReferenceString(resource)}`
+            }
           },
           {
-            resourceType: 'ServiceRequest',
-            filters: [{
-              code: 'subject',
-              operator: Operator.EQUALS,
-              value: patientReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `Media?subject=${getReferenceString(resource)}`
+            }
           },
           {
-            resourceType: 'DiagnosticReport',
-            filters: [{
-              code: 'subject',
-              operator: Operator.EQUALS,
-              value: patientReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `ServiceRequest?subject=${getReferenceString(resource)}`
+            }
+          },
+          {
+            request: {
+              method: 'GET',
+              url: `DiagnosticReport?subject=${getReferenceString(resource)}`
+            }
           }
-        ];
-      }}
+        ]
+      })}
       createCommunication={(resource: Patient, sender: ProfileResource, text: string) => ({
         resourceType: 'Communication',
         subject: createReference(resource),

--- a/packages/ui/src/ResourceTable.test.tsx
+++ b/packages/ui/src/ResourceTable.test.tsx
@@ -31,6 +31,12 @@ const practitionerStructureBundle: Bundle = {
               code: 'HumanName'
             }],
             max: '*'
+          },
+          {
+            path: 'Practitioner.gender',
+            type: [{
+              code: 'code'
+            }]
           }
         ]
       }
@@ -68,8 +74,7 @@ describe('ResourceTable', () => {
       await waitFor(() => screen.getByText('Resource Type'));
     });
 
-    const control = screen.getByText('Resource Type');
-    expect(control).toBeDefined();
+    expect(screen.getByText('Resource Type')).toBeInTheDocument();
   });
 
   test('Renders Practitioner resource', async () => {
@@ -83,8 +88,24 @@ describe('ResourceTable', () => {
       await waitFor(() => screen.getByText('Resource Type'));
     });
 
-    const control = screen.getByText('Resource Type');
-    expect(control).toBeDefined();
+    expect(screen.getByText('Resource Type')).toBeInTheDocument();
+    expect(screen.getByText('Gender')).toBeInTheDocument();
+  });
+
+  test('Ignore missing values', async () => {
+    setup({
+      value: {
+        reference: 'Practitioner/123'
+      },
+      ignoreMissingValues: true
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Resource Type'));
+    });
+
+    expect(screen.getByText('Resource Type')).toBeInTheDocument();
+    expect(screen.queryByText('Gender')).toBeNull();
   });
 
 });

--- a/packages/ui/src/ResourceTable.tsx
+++ b/packages/ui/src/ResourceTable.tsx
@@ -8,6 +8,7 @@ import { useResource } from './useResource';
 
 export interface ResourceTableProps {
   value: Resource | Reference;
+  ignoreMissingValues?: boolean;
 }
 
 export function ResourceTable(props: ResourceTableProps) {
@@ -40,12 +41,16 @@ export function ResourceTable(props: ResourceTableProps) {
           return null;
         }
         const property = entry[1];
+        const propertyValue = (value as any)[key];
+        if (props.ignoreMissingValues && !propertyValue) {
+          return null;
+        }
         return (
           <DescriptionListEntry key={key} term={getPropertyDisplayName(property)}>
             <ResourcePropertyDisplay
               schema={schema}
               property={property}
-              value={(value as any)[key]}
+              value={propertyValue}
             />
           </DescriptionListEntry>
         );

--- a/packages/ui/src/ResourceTimeline.tsx
+++ b/packages/ui/src/ResourceTimeline.tsx
@@ -1,4 +1,4 @@
-import { Attachment, AuditEvent, Bundle, BundleEntry, Communication, DiagnosticReport, Media, ProfileResource, Reference, Resource, SearchRequest, stringify } from '@medplum/core';
+import { Attachment, AuditEvent, Bundle, BundleEntry, Communication, DiagnosticReport, Media, ProfileResource, Reference, Resource, stringify } from '@medplum/core';
 import React, { useEffect, useRef, useState } from 'react';
 import { AttachmentDisplay } from './AttachmentDisplay';
 import { Button } from './Button';
@@ -7,16 +7,17 @@ import { Form } from './Form';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
 import { ResourceDiff } from './ResourceDiff';
+import { ResourceTable } from './ResourceTable';
+import './ResourceTimeline.css';
 import { TextField } from './TextField';
 import { Timeline, TimelineItem } from './Timeline';
 import { UploadButton } from './UploadButton';
 import { useResource } from './useResource';
-import { sortBundleByDate, sortByDate } from './utils/format';
-import './ResourceTimeline.css';
+import { sortByDate } from './utils/format';
 
 export interface ResourceTimelineProps<T extends Resource> {
   value: T | Reference<T>;
-  buildSearchRequests: (resource: T) => SearchRequest[];
+  buildSearchRequests: (resource: T) => Bundle;
   createCommunication?: (resource: T, sender: ProfileResource, text: string) => Communication;
   createMedia?: (resource: T, operator: ProfileResource, attachment: Attachment) => Media;
 }
@@ -38,28 +39,36 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
   function loadItems(): void {
     if (!resource) {
       setItems([]);
+      setHistory({} as Bundle);
       return;
     }
 
-    medplum.readHistory(resource.resourceType, resource.id as string).then(bundle => {
-      sortBundleByDate(bundle); // Sort oldest to newest
-      setHistory(bundle);
-      addBundle(bundle);
-    });
+    const bathRequest = props.buildSearchRequests(resource);
+    medplum.post('fhir/R4', bathRequest)
+      .then(batchResponse => {
+        const newItems = [];
 
-    props.buildSearchRequests(resource).forEach(searchRequest => {
-      medplum.search(searchRequest).then(addBundle);
-    });
-  }
+        for (const batchEntry of batchResponse.entry) {
+          const bundle = batchEntry.resource as Bundle;
 
-  /**
-   * Adds a bundle of resources to the timeline.
-   * @param bundle Bundle of new resources for the timeline.
-   */
-  function addBundle(bundle: Bundle): void {
-    if (bundle.entry) {
-      addResources(bundle.entry?.map(entry => entry.resource as Resource));
-    }
+          if (bundle.type === 'history') {
+            setHistory(batchEntry.resource as Bundle);
+          }
+
+          if (bundle.entry) {
+            for (const entry of bundle.entry) {
+              const resource = entry.resource;
+              if (resource) {
+                newItems.push(resource);
+              }
+            }
+          }
+        }
+
+        sortByDate(newItems);
+        newItems.reverse();
+        setItems(newItems);
+      });
   }
 
   /**
@@ -148,7 +157,11 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
           case 'Media':
             return <MediaTimelineItem key={item.id} media={item} />;
           default:
-            return null;
+            return (
+              <TimelineItem key={item.id} resource={item} padding={true}>
+                <ResourceTable value={item} ignoreMissingValues={true} />
+              </TimelineItem>
+            );
         }
       })}
     </Timeline>
@@ -180,10 +193,10 @@ function HistoryTimelineItem(props: HistoryTimelineItemProps) {
 function getPrevious(history: Bundle, version: Resource): Resource | undefined {
   const entries = history.entry as BundleEntry[];
   const index = entries.findIndex(entry => entry.resource?.meta?.versionId === version.meta?.versionId);
-  if (index === 0) {
+  if (index >= entries.length - 1) {
     return undefined;
   }
-  return entries[index - 1].resource;
+  return entries[index + 1].resource;
 }
 
 interface CommunicationTimelineItemProps {

--- a/packages/ui/src/ResourceTimeline.tsx
+++ b/packages/ui/src/ResourceTimeline.tsx
@@ -8,12 +8,12 @@ import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
 import { ResourceDiff } from './ResourceDiff';
 import { ResourceTable } from './ResourceTable';
-import './ResourceTimeline.css';
 import { TextField } from './TextField';
 import { Timeline, TimelineItem } from './Timeline';
 import { UploadButton } from './UploadButton';
 import { useResource } from './useResource';
 import { sortByDate } from './utils/format';
+import './ResourceTimeline.css';
 
 export interface ResourceTimelineProps<T extends Resource> {
   value: T | Reference<T>;
@@ -52,15 +52,12 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
           const bundle = batchEntry.resource as Bundle;
 
           if (bundle.type === 'history') {
-            setHistory(batchEntry.resource as Bundle);
+            setHistory(bundle);
           }
 
           if (bundle.entry) {
             for (const entry of bundle.entry) {
-              const resource = entry.resource;
-              if (resource) {
-                newItems.push(resource);
-              }
+              newItems.push(entry.resource as Resource);
             }
           }
         }

--- a/packages/ui/src/ServiceRequestTimeline.test.tsx
+++ b/packages/ui/src/ServiceRequestTimeline.test.tsx
@@ -17,6 +17,7 @@ const serviceRequest: ServiceRequest = {
 
 const serviceRequestHistory: Bundle = {
   resourceType: 'Bundle',
+  type: 'history',
   entry: [{
     resource: serviceRequest
   }]
@@ -91,14 +92,16 @@ const medplum = new MockClient({
   'fhir/R4/ServiceRequest/123': {
     'GET': serviceRequest
   },
-  'fhir/R4/ServiceRequest/123/_history': {
-    'GET': serviceRequestHistory
-  },
-  'fhir/R4/Communication?_count=100&based-on=ServiceRequest/123': {
-    'GET': communications
-  },
-  'fhir/R4/Media?_count=100&based-on=ServiceRequest/123': {
-    'GET': media
+  'fhir/R4': {
+    'POST': {
+      resourceType: 'Bundle',
+      type: 'batch-response',
+      entry: [
+        { resource: serviceRequestHistory },
+        { resource: communications },
+        { resource: media },
+      ]
+    }
   },
   'fhir/R4/Communication': {
     'POST': newComment

--- a/packages/ui/src/ServiceRequestTimeline.tsx
+++ b/packages/ui/src/ServiceRequestTimeline.tsx
@@ -1,4 +1,4 @@
-import { Attachment, createReference, getReferenceString, Group, Operator, Patient, ProfileResource, Reference, Resource, ServiceRequest } from '@medplum/core';
+import { Attachment, createReference, getReferenceString, Group, Patient, ProfileResource, Reference, Resource, ServiceRequest } from '@medplum/core';
 import React from 'react';
 import { ResourceTimeline } from './ResourceTimeline';
 
@@ -10,38 +10,36 @@ export function ServiceRequestTimeline(props: ServiceRequestTimelineProps): JSX.
   return (
     <ResourceTimeline
       value={props.serviceRequest}
-      buildSearchRequests={(serviceRequest: Resource) => {
-        const serviceRequestReference = getReferenceString(serviceRequest);
-        return [
+      buildSearchRequests={(resource: Resource) => ({
+        resourceType: 'Bundle',
+        type: 'batch',
+        entry: [
           {
-            resourceType: 'Communication',
-            filters: [{
-              code: 'based-on',
-              operator: Operator.EQUALS,
-              value: serviceRequestReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `${getReferenceString(resource)}/_history`
+            }
           },
           {
-            resourceType: 'Media',
-            filters: [{
-              code: 'based-on',
-              operator: Operator.EQUALS,
-              value: serviceRequestReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `Communication?based-on=${getReferenceString(resource)}`
+            }
           },
           {
-            resourceType: 'DiagnosticReport',
-            filters: [{
-              code: 'based-on',
-              operator: Operator.EQUALS,
-              value: serviceRequestReference
-            }],
-            count: 100
+            request: {
+              method: 'GET',
+              url: `Media?based-on=${getReferenceString(resource)}`
+            }
+          },
+          {
+            request: {
+              method: 'GET',
+              url: `DiagnosticReport?based-on=${getReferenceString(resource)}`
+            }
           }
-        ];
-      }}
+        ]
+      })}
       createCommunication={(resource: ServiceRequest, sender: ProfileResource, text: string) => ({
         resourceType: 'Communication',
         basedOn: [createReference(resource)],


### PR DESCRIPTION
2 significant changes:

* How timeline requests are made
  * Before: Send multiple parallel HTTP requests to search for resources
  * Now: Send one HTTP batch request
* Default resource rendering in the timeline
  * Before: Ignore resources without dedicated timeline rendering code
  * Now: Use a version of `<ResourceTable>` that ignores empty and missing properties 