### PR TITLE
Fixed unnecessary directory imports

### DIFF
--- a/packages/core/src/fhirpath/parse.test.ts
+++ b/packages/core/src/fhirpath/parse.test.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@medplum/definitions';
-import { AuditEvent } from '..';
+import { AuditEvent } from '../fhir/AuditEvent';
 import { Bundle, BundleEntry } from '../fhir/Bundle';
 import { Observation } from '../fhir/Observation';
 import { SearchParameter } from '../fhir/SearchParameter';

--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -1,5 +1,4 @@
-import { gone, isGone } from '.';
-import { allOk, assertOk, badRequest, created, getStatus, isNotFound, isOk, notFound, notModified } from './outcomes';
+import { allOk, assertOk, badRequest, created, getStatus, gone, isGone, isNotFound, isOk, notFound, notModified } from './outcomes';
 
 describe('Outcomes', () => {
 

--- a/packages/core/src/searchparams.test.ts
+++ b/packages/core/src/searchparams.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { Bundle, BundleEntry, indexStructureDefinition, isLowerCase, Resource, SearchParameter } from '.';
+import { Bundle, BundleEntry, Resource, SearchParameter } from './fhir';
 import { getSearchParameterDetails, SearchParameterType } from './searchparams';
-import { IndexedStructureDefinition } from './types';
+import { IndexedStructureDefinition, indexStructureDefinition } from './types';
+import { isLowerCase } from './utils';
 
 const searchParams = readJson('fhir/r4/search-parameters.json');
 const structureDefinitions = { types: {} } as IndexedStructureDefinition;

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -1,11 +1,10 @@
 import { assertOk, Bundle, BundleEntry, isOk, Observation, OperationOutcome, Patient } from '@medplum/core';
 import { randomUUID } from 'crypto';
-import { Repository } from '.';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { seedDatabase } from '../seed';
 import { processBatch } from './batch';
-import { repo } from './repo';
+import { repo, Repository } from './repo';
 
 describe('Batch', () => {
 

--- a/packages/ui/src/QuestionnaireBuilder.test.tsx
+++ b/packages/ui/src/QuestionnaireBuilder.test.tsx
@@ -1,10 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { QuestionnaireItemType } from '.';
 import { MedplumProvider } from './MedplumProvider';
 import { MockClient } from './MockClient';
 import { QuestionnaireBuilder, QuestionnaireBuilderProps } from './QuestionnaireBuilder';
+import { QuestionnaireItemType } from './QuestionnaireUtils';
 
 const medplum = new MockClient({});
 

--- a/packages/ui/src/QuestionnaireBuilder.tsx
+++ b/packages/ui/src/QuestionnaireBuilder.tsx
@@ -1,8 +1,8 @@
 import { Questionnaire, QuestionnaireItem, Reference } from '@medplum/core';
 import React, { useEffect, useRef, useState } from 'react';
-import { QuestionnaireItemType } from '.';
 import { Button } from './Button';
 import { Form } from './Form';
+import { QuestionnaireItemType } from './QuestionnaireUtils';
 import { useResource } from './useResource';
 import './QuestionnaireBuilder.css';
 

--- a/packages/ui/src/ResourceInput.tsx
+++ b/packages/ui/src/ResourceInput.tsx
@@ -1,10 +1,10 @@
 import { Bundle, BundleEntry, Operator, Reference, Resource } from '@medplum/core';
 import React, { useEffect, useRef, useState } from 'react';
-import { useResource } from '.';
 import { Autocomplete } from './Autocomplete';
 import { Avatar } from './Avatar';
 import { useMedplum } from './MedplumProvider';
 import { ResourceName } from './ResourceName';
+import { useResource } from './useResource';
 
 export interface ResourceInputProps<T extends Resource = Resource> {
   readonly resourceType: string;

--- a/packages/ui/src/SignInForm.tsx
+++ b/packages/ui/src/SignInForm.tsx
@@ -1,6 +1,6 @@
 import { GoogleCredentialResponse, OperationOutcome, ProjectMembership } from '@medplum/core';
 import React, { useState } from 'react';
-import { Avatar } from '.';
+import { Avatar } from './Avatar';
 import { Button } from './Button';
 import { Document } from './Document';
 import { Form } from './Form';


### PR DESCRIPTION
When using VS Code, sometimes autocomplete inserts `import { x } from '.'` rather than `import { x } from './foo';`

In general, that's fine, and doesn't really affect performance or anything important.

However, there is one case where it can be annoying:  if you run a test that uses `from '.'` and you calculate code coverage, then all files in the directory are included in the output, which is unnecessarily noisy.