### PR TITLE
Update scripts to include fhirpath and fhirtypes

### DIFF
--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -37,21 +37,26 @@ fi
 
 if [[ "$FILES_CHANGED" =~ packages/core ]]; then
   DEPLOY_APP=true
-  DEPLOY_DOCS=true
-  DEPLOY_GRAPHIQL=true
   DEPLOY_SERVER=true
-  DEPLOY_STORYBOOK=true
 fi
 
 if [[ "$FILES_CHANGED" =~ packages/definitions ]]; then
   DEPLOY_APP=true
-  DEPLOY_GRAPHIQL=true
   DEPLOY_SERVER=true
-  DEPLOY_STORYBOOK=true
 fi
 
 if [[ "$FILES_CHANGED" =~ packages/docs ]]; then
   DEPLOY_DOCS=true
+fi
+
+if [[ "$FILES_CHANGED" =~ packages/fhirpath ]]; then
+  DEPLOY_APP=true
+  DEPLOY_SERVER=true
+fi
+
+if [[ "$FILES_CHANGED" =~ packages/fhirtypes ]]; then
+  DEPLOY_APP=true
+  DEPLOY_SERVER=true
 fi
 
 if [[ "$FILES_CHANGED" =~ packages/graphiql ]]; then

--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -6,6 +6,8 @@ rm -rf packages/core/node_modules
 rm -rf packages/docs/node_modules
 rm -rf packages/definitions/node_modules
 rm -rf packages/docs/node_modules
+rm -rf packages/fhirpath/node_modules
+rm -rf packages/fhirtypes/node_modules
 rm -rf packages/generator/node_modules
 rm -rf packages/graphiql/node_modules
 rm -rf packages/infra/node_modules

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -5,6 +5,8 @@ npx ncu -u --packageFile packages/app/package.json
 npx ncu -u --packageFile packages/core/package.json
 npx ncu -u --packageFile packages/definitions/package.json
 npx ncu -u --packageFile packages/docs/package.json
+npx ncu -u --packageFile packages/fhirpath/package.json
+npx ncu -u --packageFile packages/fhirtypes/package.json
 npx ncu -u --packageFile packages/generator/package.json
 npx ncu -u --packageFile packages/graphiql/package.json
 npx ncu -u --packageFile packages/infra/package.json


### PR DESCRIPTION
Before:  The contents of `fhirpath` and `fhirtypes` used to be part of `core`.  We broke them out into separate packages so they can be used as independent libraries.  Some of the helper scripts did not reflect this change.

Now: The `upgrade.sh`, `reinstall.sh`, and `cicd-deploy.sh` scripts all include `fhirpath` and `fhirtypes` packages.

Also: Before, we were over-deploying <https://docs.medplum.com/> on changes that did not actually make any changes to the content.  Reducing the changes that can trigger a docs redeploy.

Docs will be deployed when:
* Change to `package-lock.json` (i.e., dependency upgrades)
* Changes to `docs` directly

Docs will *not* be deployed when:
* Changes to `core`, `definitions`, `fhirtypes`, `fhirpath`, etc