### PR TITLE
Make SearchControl aware of 'Choice of Type'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/@aws-cdk/assets/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-acmpca/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-apigateway/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-applicationautoscaling/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-autoscaling-common/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -400,17 +400,17 @@
       }
     },
     "node_modules/@aws-cdk/aws-autoscaling-hooktargets/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
     },
     "node_modules/@aws-cdk/aws-autoscaling/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-certificatemanager/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-cloudformation/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -542,17 +542,17 @@
       }
     },
     "node_modules/@aws-cdk/aws-cloudfront-origins/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
     },
     "node_modules/@aws-cdk/aws-cloudfront/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-cloudwatch/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-codeguruprofiler/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-codestarnotifications/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-cognito/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-ec2/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -793,9 +793,9 @@
       "license": "MIT"
     },
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -812,9 +812,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-ecr/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-ecs/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-efs/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -942,9 +942,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-elasticache/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-elasticloadbalancing/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1010,9 +1010,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-elasticloadbalancingv2/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-events/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1064,9 +1064,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-globalaccelerator/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1090,9 +1090,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-iam/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1120,9 +1120,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-kms/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1178,9 +1178,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-lambda/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1212,9 +1212,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-logs/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-rds/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1326,17 +1326,17 @@
       }
     },
     "node_modules/@aws-cdk/aws-route53-targets/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
     },
     "node_modules/@aws-cdk/aws-route53/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1392,17 +1392,17 @@
       }
     },
     "node_modules/@aws-cdk/aws-s3-assets/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
     },
     "node_modules/@aws-cdk/aws-s3/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1424,9 +1424,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-sam/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1460,9 +1460,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-secretsmanager/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1490,9 +1490,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-servicediscovery/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-signer/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1576,17 +1576,17 @@
       }
     },
     "node_modules/@aws-cdk/aws-sns-subscriptions/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
     },
     "node_modules/@aws-cdk/aws-sns/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1614,9 +1614,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-sqs/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-ssm/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@aws-cdk/aws-stepfunctions/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1802,9 +1802,9 @@
       "license": "MIT"
     },
     "node_modules/@aws-cdk/core/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -1895,9 +1895,9 @@
       }
     },
     "node_modules/@aws-cdk/custom-resources/node_modules/constructs": {
-      "version": "3.3.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-      "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ==",
+      "version": "3.3.168",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+      "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw==",
       "engines": {
         "node": ">= 12.7.0"
       }
@@ -5397,9 +5397,9 @@
       "dev": true
     },
     "node_modules/@codemirror/view": {
-      "version": "0.19.34",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.34.tgz",
-      "integrity": "sha512-X62xoOXVOMugVif/Wj6aVKUApZO1dc/gRPEKt6vearaq4Wke4uMnsR3raEqGHw5w6X0SSuN2xpAer+Pgx7qh3A==",
+      "version": "0.19.35",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.35.tgz",
+      "integrity": "sha512-PSBtbClHKvF9DHfYh0QH7puzjF268MrP8sK/I31Q0AgqBCiJvpGIXrbGTZJBDZ93F7tvsvj2BKd4jQuYlJPSYw==",
       "dev": true,
       "dependencies": {
         "@codemirror/rangeset": "^0.19.4",
@@ -22911,9 +22911,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg==",
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw==",
       "dev": true
     },
     "node_modules/codemirror-graphql": {
@@ -23895,9 +23895,9 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.8.tgz",
-      "integrity": "sha512-mJmzyt7GYFlSiDOJ0pQYj2YHIpeLSqO4TfsTQWYxfwPueKHbCzWFunfe2zcsEtGISAcR3EfZMB89aDzYXlb8Yg==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.12.tgz",
+      "integrity": "sha512-JNUr0ANEwc3MEUT5xBl2fVnCJqcPa7hpQfEYNsrCG/7/M4pUH5W0nQOe6FKAQGB6SqFPyAeoEn8G375QXWxwWQ==",
       "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -24161,12 +24161,11 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.13.tgz",
-      "integrity": "sha512-cAmLruIF28a7vKIOieXCTrllaLwbouxV1PPi8Z4M+XloXbmeooWAu4KhJgASo4vQUwbs2pqDgAlnZ1ZKJZKtuw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.14.tgz",
+      "integrity": "sha512-qzhRkFvBhv08tbyKCIfWbxBXmkIpLl1uNblt8SpTHkgLfON5OCPX/CCnkdNmEosvo8bANQYmTTMEgcVBlisHaw==",
       "dependencies": {
         "cssnano-preset-default": "^5.1.9",
-        "is-resolvable": "^1.1.0",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
       },
@@ -29166,11 +29165,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "node_modules/is-root": {
       "version": "2.1.0",
@@ -42799,6 +42793,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@medplum/core": "0.3.0",
+        "@medplum/fhirpath": "0.3.0",
         "@medplum/fhirtypes": "0.3.0",
         "@storybook/addon-actions": "6.4.9",
         "@storybook/addon-essentials": "6.4.9",
@@ -42828,6 +42823,7 @@
       },
       "peerDependencies": {
         "@medplum/core": "0.3.0",
+        "@medplum/fhirpath": "0.3.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-router-dom": "6.1.1",
@@ -42988,9 +42984,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43004,9 +43000,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43032,9 +43028,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43051,9 +43047,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43074,9 +43070,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43091,9 +43087,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43114,9 +43110,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43135,9 +43131,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43156,9 +43152,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43181,9 +43177,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43201,9 +43197,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43218,9 +43214,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43235,9 +43231,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43251,9 +43247,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43273,9 +43269,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         },
         "punycode": {
           "version": "2.1.1",
@@ -43303,9 +43299,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43321,9 +43317,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43359,9 +43355,9 @@
           "bundled": true
         },
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         },
         "minimatch": {
           "version": "3.0.4",
@@ -43406,9 +43402,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43427,9 +43423,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43443,9 +43439,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43460,9 +43456,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43485,9 +43481,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43502,9 +43498,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43520,9 +43516,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43537,9 +43533,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43556,9 +43552,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43589,9 +43585,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43610,9 +43606,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43635,9 +43631,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43656,9 +43652,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43683,9 +43679,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43703,9 +43699,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43724,9 +43720,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43740,9 +43736,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43762,9 +43758,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43781,9 +43777,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43797,9 +43793,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43819,9 +43815,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43840,9 +43836,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43859,9 +43855,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43878,9 +43874,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43899,9 +43895,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -43978,9 +43974,9 @@
           "bundled": true
         },
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         },
         "fs-extra": {
           "version": "9.1.0",
@@ -44037,9 +44033,9 @@
       },
       "dependencies": {
         "constructs": {
-          "version": "3.3.167",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.167.tgz",
-          "integrity": "sha512-yKat/bVJRfqqDGFAZr+DXKkfXfDoHaz+QNREAsFfsBqHUV/TFYVT+GSU/aSSddiW8wjfBT3tY1+3Ubcn77FOKQ=="
+          "version": "3.3.168",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.168.tgz",
+          "integrity": "sha512-9DwVLINNDwzZ5sbzYZ1SZNck43T4BzM4Qua0TGLTdgNZXshW+Q9/93jsKCp3cvuG6Y5ReMby84K9WsEfwiWHKw=="
         }
       }
     },
@@ -46863,9 +46859,9 @@
       "dev": true
     },
     "@codemirror/view": {
-      "version": "0.19.34",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.34.tgz",
-      "integrity": "sha512-X62xoOXVOMugVif/Wj6aVKUApZO1dc/gRPEKt6vearaq4Wke4uMnsR3raEqGHw5w6X0SSuN2xpAer+Pgx7qh3A==",
+      "version": "0.19.35",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.35.tgz",
+      "integrity": "sha512-PSBtbClHKvF9DHfYh0QH7puzjF268MrP8sK/I31Q0AgqBCiJvpGIXrbGTZJBDZ93F7tvsvj2BKd4jQuYlJPSYw==",
       "dev": true,
       "requires": {
         "@codemirror/rangeset": "^0.19.4",
@@ -49435,6 +49431,7 @@
       "version": "file:packages/ui",
       "requires": {
         "@medplum/core": "0.3.0",
+        "@medplum/fhirpath": "0.3.0",
         "@medplum/fhirtypes": "0.3.0",
         "@storybook/addon-actions": "6.4.9",
         "@storybook/addon-essentials": "6.4.9",
@@ -61184,9 +61181,9 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg==",
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw==",
       "dev": true
     },
     "codemirror-graphql": {
@@ -61979,9 +61976,9 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.8.tgz",
-      "integrity": "sha512-mJmzyt7GYFlSiDOJ0pQYj2YHIpeLSqO4TfsTQWYxfwPueKHbCzWFunfe2zcsEtGISAcR3EfZMB89aDzYXlb8Yg==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.12.tgz",
+      "integrity": "sha512-JNUr0ANEwc3MEUT5xBl2fVnCJqcPa7hpQfEYNsrCG/7/M4pUH5W0nQOe6FKAQGB6SqFPyAeoEn8G375QXWxwWQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -62169,12 +62166,11 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.13.tgz",
-      "integrity": "sha512-cAmLruIF28a7vKIOieXCTrllaLwbouxV1PPi8Z4M+XloXbmeooWAu4KhJgASo4vQUwbs2pqDgAlnZ1ZKJZKtuw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.14.tgz",
+      "integrity": "sha512-qzhRkFvBhv08tbyKCIfWbxBXmkIpLl1uNblt8SpTHkgLfON5OCPX/CCnkdNmEosvo8bANQYmTTMEgcVBlisHaw==",
       "requires": {
         "cssnano-preset-default": "^5.1.9",
-        "is-resolvable": "^1.1.0",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
       }
@@ -66023,11 +66019,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
     "is-root": {
       "version": "2.1.0",

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -102,6 +102,9 @@ export function getDefaultSearchForResourceType(resourceType: string): SearchReq
     case 'ValueSet':
       fields.push('name', 'title', 'status');
       break;
+    case 'Condition':
+      fields.push('subject', 'code', 'clinicalStatus');
+      break;
     case 'DiagnosticReport':
     case 'Observation':
       fields.push('subject', 'code', 'status');

--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -47,6 +47,23 @@ const practitionerStructureBundle: Bundle = {
                 },
               ],
             },
+            {
+              path: 'Practitioner.name',
+              type: [
+                {
+                  code: 'HumanName',
+                },
+              ],
+              max: '*',
+            },
+            {
+              path: 'Practitioner.gender',
+              type: [
+                {
+                  code: 'code',
+                },
+              ],
+            },
           ],
         },
       },
@@ -206,10 +223,10 @@ describe('ResourcePage', () => {
     setup('/Practitioner/123');
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Resource Type'));
+      await waitFor(() => screen.getByText('Name'));
     });
 
-    expect(screen.getByText('Resource Type')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
   test('Edit tab renders', async () => {

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,0 +1,9 @@
+import { getPropertyDisplayName } from './types';
+
+describe('Type Utils', () => {
+  test('getPropertyDisplayName', () => {
+    expect(getPropertyDisplayName({ path: 'Patient.name' })).toEqual('Name');
+    expect(getPropertyDisplayName({ path: 'Patient.birthDate' })).toEqual('Birth Date');
+    expect(getPropertyDisplayName({ path: 'DeviceDefinition.manufacturer[x]' })).toEqual('Manufacturer');
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -206,7 +206,7 @@ export function getPropertyDisplayName(property: ElementDefinition): string {
   // Get the property name, which is the remainder after the last period
   // For example, for path "Patient.birthDate"
   // the property name is "birthDate"
-  const propertyName = (property.path as string).split('.').pop() as string;
+  const propertyName = (property.path as string).replaceAll('[x]', '').split('.').pop() as string;
 
   // Split by capital letters
   // Capitalize the first letter of each word

--- a/packages/fhirpath/src/atoms.ts
+++ b/packages/fhirpath/src/atoms.ts
@@ -59,11 +59,9 @@ export class SymbolAtom implements Atom {
         if (this.name in e) {
           return e[this.name];
         }
-        if (this.name === 'value') {
-          const valuePropertyName = Object.keys(e).find((k) => k.startsWith('value'));
-          if (valuePropertyName) {
-            return e[valuePropertyName];
-          }
+        const propertyName = Object.keys(e).find((k) => k.startsWith(this.name));
+        if (propertyName) {
+          return e[propertyName];
         }
       }
       return undefined;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@medplum/core": "0.3.0",
+    "@medplum/fhirpath": "0.3.0",
     "@medplum/fhirtypes": "0.3.0",
     "@storybook/addon-actions": "6.4.9",
     "@storybook/addon-essentials": "6.4.9",
@@ -49,6 +50,7 @@
   },
   "peerDependencies": {
     "@medplum/core": "0.3.0",
+    "@medplum/fhirpath": "0.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "6.1.1",

--- a/packages/ui/src/BackboneElementDisplay.test.tsx
+++ b/packages/ui/src/BackboneElementDisplay.test.tsx
@@ -77,7 +77,7 @@ describe('BackboneElementDisplay', () => {
   test('Renders null', () => {
     setup({
       schema,
-      property: contactProperty,
+      typeName: 'PatientContact',
       value: null,
     });
   });
@@ -85,7 +85,7 @@ describe('BackboneElementDisplay', () => {
   test('Renders value', () => {
     setup({
       schema,
-      property: contactProperty,
+      typeName: 'PatientContact',
       value: {
         id: '123',
         name: {

--- a/packages/ui/src/BackboneElementDisplay.tsx
+++ b/packages/ui/src/BackboneElementDisplay.tsx
@@ -1,6 +1,5 @@
-import { buildTypeName, getPropertyDisplayName, IndexedStructureDefinition } from '@medplum/core';
+import { getPropertyDisplayName, IndexedStructureDefinition } from '@medplum/core';
 import { evalFhirPath } from '@medplum/fhirpath';
-import { ElementDefinition } from '@medplum/fhirtypes';
 import React from 'react';
 import { DEFAULT_IGNORED_PROPERTIES } from './constants';
 import { DescriptionList, DescriptionListEntry } from './DescriptionList';
@@ -8,8 +7,9 @@ import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 export interface BackboneElementDisplayProps {
   schema: IndexedStructureDefinition;
-  property: ElementDefinition;
+  typeName: string;
   value?: any;
+  compact?: boolean;
   ignoreMissingValues?: boolean;
 }
 
@@ -19,13 +19,13 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps) {
     return null;
   }
 
-  const typeName = buildTypeName(props.property.path?.split('.') as string[]);
+  const typeName = props.typeName;
   const typeSchema = props.schema.types[typeName];
   if (!typeSchema) {
     return <div>Schema not found</div>;
   }
 
-  if (typeof value === 'object' && Object.keys(value).length === 1 && 'name' in value) {
+  if (typeof value === 'object' && 'name' in value && Object.keys(value).length === 1) {
     // Special case for common BackboneElement pattern
     // Where there is an object with a single property 'name'
     // Just display the name value.
@@ -33,7 +33,7 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps) {
   }
 
   return (
-    <DescriptionList compact={true}>
+    <DescriptionList compact={props.compact}>
       {Object.entries(typeSchema.properties).map((entry) => {
         const key = entry[0];
         if (DEFAULT_IGNORED_PROPERTIES.indexOf(key) >= 0) {

--- a/packages/ui/src/BackboneElementDisplay.tsx
+++ b/packages/ui/src/BackboneElementDisplay.tsx
@@ -2,7 +2,7 @@ import { getPropertyDisplayName, IndexedStructureDefinition } from '@medplum/cor
 import React from 'react';
 import { DEFAULT_IGNORED_PROPERTIES } from './constants';
 import { DescriptionList, DescriptionListEntry } from './DescriptionList';
-import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { getValueAndType, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 export interface BackboneElementDisplayProps {
   schema: IndexedStructureDefinition;
@@ -15,11 +15,6 @@ export interface BackboneElementDisplayProps {
 export function BackboneElementDisplay(props: BackboneElementDisplayProps) {
   const value = props.value;
   if (!value) {
-    return null;
-  }
-
-  if (!props.schema) {
-    console.log('no schema?', props);
     return null;
   }
 
@@ -44,13 +39,20 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps) {
           return null;
         }
         const property = entry[1];
+        const [propertyValue, propertyType] = getValueAndType(value, property);
+        if (
+          props.ignoreMissingValues &&
+          (!propertyValue || (Array.isArray(propertyValue) && propertyValue.length === 0))
+        ) {
+          return null;
+        }
         return (
           <DescriptionListEntry key={key} term={getPropertyDisplayName(property)}>
             <ResourcePropertyDisplay
               schema={props.schema}
-              typeName={typeName}
-              propertyName={key}
-              context={value}
+              property={property}
+              propertyType={propertyType}
+              value={propertyValue}
               ignoreMissingValues={props.ignoreMissingValues}
             />
           </DescriptionListEntry>

--- a/packages/ui/src/BackboneElementDisplay.tsx
+++ b/packages/ui/src/BackboneElementDisplay.tsx
@@ -1,5 +1,4 @@
 import { getPropertyDisplayName, IndexedStructureDefinition } from '@medplum/core';
-import { evalFhirPath } from '@medplum/fhirpath';
 import React from 'react';
 import { DEFAULT_IGNORED_PROPERTIES } from './constants';
 import { DescriptionList, DescriptionListEntry } from './DescriptionList';
@@ -16,6 +15,11 @@ export interface BackboneElementDisplayProps {
 export function BackboneElementDisplay(props: BackboneElementDisplayProps) {
   const value = props.value;
   if (!value) {
+    return null;
+  }
+
+  if (!props.schema) {
+    console.log('no schema?', props);
     return null;
   }
 
@@ -40,24 +44,13 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps) {
           return null;
         }
         const property = entry[1];
-        let propertyValue: any = evalFhirPath(key, value);
-        // FHIRPath will always return an array
-        // If the property is not an array property,
-        // then unrap the value.
-        if (propertyValue.length === 0) {
-          propertyValue = null;
-        } else if (property.max !== '*') {
-          propertyValue = propertyValue[0];
-        }
-        if (props.ignoreMissingValues && !propertyValue) {
-          return null;
-        }
         return (
           <DescriptionListEntry key={key} term={getPropertyDisplayName(property)}>
             <ResourcePropertyDisplay
               schema={props.schema}
-              property={property}
-              value={propertyValue}
+              typeName={typeName}
+              propertyName={key}
+              context={value}
               ignoreMissingValues={props.ignoreMissingValues}
             />
           </DescriptionListEntry>

--- a/packages/ui/src/DescriptionList.css
+++ b/packages/ui/src/DescriptionList.css
@@ -8,3 +8,13 @@ dl.medplum-description-list dd {
   padding: 16px 8px;
   border-top: 0.1px solid var(--medplum-gray-300);
 }
+
+dl.medplum-description-list.compact {
+  grid-template-columns: 20% 80%;
+}
+
+dl.medplum-description-list.compact dt,
+dl.medplum-description-list.compact dd {
+  padding: 0 4px 4px 0;
+  border: 0;
+}

--- a/packages/ui/src/DescriptionList.tsx
+++ b/packages/ui/src/DescriptionList.tsx
@@ -3,10 +3,11 @@ import './DescriptionList.css';
 
 export interface DescriptionListProps {
   children: React.ReactNode;
+  compact?: boolean;
 }
 
 export function DescriptionList(props: DescriptionListProps) {
-  return <dl className="medplum-description-list">{props.children}</dl>;
+  return <dl className={'medplum-description-list' + (props.compact ? ' compact' : '')}>{props.children}</dl>;
 }
 
 export interface DescriptionListEntryProps {

--- a/packages/ui/src/ResourceArrayDisplay.tsx
+++ b/packages/ui/src/ResourceArrayDisplay.tsx
@@ -8,6 +8,7 @@ interface ResourceArrayDisplayProps {
   property: ElementDefinition;
   values: any[];
   arrayElement?: boolean;
+  ignoreMissingValues?: boolean;
 }
 
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps) {
@@ -22,6 +23,7 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps) {
           schema={props.schema}
           property={property}
           value={v}
+          ignoreMissingValues={props.ignoreMissingValues}
         />
       ))}
     </>

--- a/packages/ui/src/ResourceArrayDisplay.tsx
+++ b/packages/ui/src/ResourceArrayDisplay.tsx
@@ -1,7 +1,7 @@
-import { IndexedStructureDefinition } from '@medplum/core';
+import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
 import { ElementDefinition } from '@medplum/fhirtypes';
 import React from 'react';
-import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { ElementDisplay } from './ResourcePropertyDisplay';
 
 interface ResourceArrayDisplayProps {
   schema: IndexedStructureDefinition;
@@ -14,14 +14,15 @@ interface ResourceArrayDisplayProps {
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps) {
   const property = props.property;
   const values = props.values ?? [];
+  const propertyType = property.type?.[0]?.code as PropertyType;
   return (
     <>
       {values.map((v: any, index: number) => (
-        <ResourcePropertyDisplay
+        <ElementDisplay
           key={`${index}-${values.length}`}
-          arrayElement={true}
           schema={props.schema}
           property={property}
+          propertyType={propertyType}
           value={v}
           ignoreMissingValues={props.ignoreMissingValues}
         />

--- a/packages/ui/src/ResourceArrayDisplay.tsx
+++ b/packages/ui/src/ResourceArrayDisplay.tsx
@@ -1,7 +1,7 @@
 import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
 import { ElementDefinition } from '@medplum/fhirtypes';
 import React from 'react';
-import { ElementDisplay } from './ResourcePropertyDisplay';
+import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 interface ResourceArrayDisplayProps {
   schema: IndexedStructureDefinition;
@@ -18,8 +18,9 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps) {
   return (
     <>
       {values.map((v: any, index: number) => (
-        <ElementDisplay
+        <ResourcePropertyDisplay
           key={`${index}-${values.length}`}
+          arrayElement={true}
           schema={props.schema}
           property={property}
           propertyType={propertyType}

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { IndexedStructureDefinition } from '@medplum/core';
+import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
 import {
   Address,
   Annotation,
@@ -7,62 +7,1106 @@ import {
   ContactPoint,
   HumanName,
   Identifier,
+  Observation,
+  Patient,
   Quantity,
+  Reference,
+  Subscription,
+  SubscriptionChannel,
 } from '@medplum/fhirtypes';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { MemoryRouter } from 'react-router-dom';
+import { ElementDisplay, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
-const schema = {} as IndexedStructureDefinition;
+const schema: IndexedStructureDefinition = {
+  types: {
+    Observation: {
+      display: 'Observation',
+      properties: {
+        meta: {
+          path: 'Observation.meta',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Meta',
+            },
+          ],
+        },
+        language: {
+          path: 'Observation.language',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        text: {
+          path: 'Observation.text',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Narrative',
+            },
+          ],
+        },
+        identifier: {
+          path: 'Observation.identifier',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Identifier',
+            },
+          ],
+        },
+        basedOn: {
+          path: 'Observation.basedOn',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/CarePlan',
+                'http://hl7.org/fhir/StructureDefinition/DeviceRequest',
+                'http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation',
+                'http://hl7.org/fhir/StructureDefinition/MedicationRequest',
+                'http://hl7.org/fhir/StructureDefinition/NutritionOrder',
+                'http://hl7.org/fhir/StructureDefinition/ServiceRequest',
+              ],
+            },
+          ],
+        },
+        partOf: {
+          path: 'Observation.partOf',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/MedicationAdministration',
+                'http://hl7.org/fhir/StructureDefinition/MedicationDispense',
+                'http://hl7.org/fhir/StructureDefinition/MedicationStatement',
+                'http://hl7.org/fhir/StructureDefinition/Procedure',
+                'http://hl7.org/fhir/StructureDefinition/Immunization',
+                'http://hl7.org/fhir/StructureDefinition/ImagingStudy',
+              ],
+            },
+          ],
+        },
+        status: {
+          path: 'Observation.status',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        category: {
+          path: 'Observation.category',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        code: {
+          path: 'Observation.code',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        subject: {
+          path: 'Observation.subject',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/Patient',
+                'http://hl7.org/fhir/StructureDefinition/Group',
+                'http://hl7.org/fhir/StructureDefinition/Device',
+                'http://hl7.org/fhir/StructureDefinition/Location',
+              ],
+            },
+          ],
+        },
+        focus: {
+          path: 'Observation.focus',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: ['http://hl7.org/fhir/StructureDefinition/Resource'],
+            },
+          ],
+        },
+        encounter: {
+          path: 'Observation.encounter',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: ['http://hl7.org/fhir/StructureDefinition/Encounter'],
+            },
+          ],
+        },
+        'effective[x]': {
+          path: 'Observation.effective[x]',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'dateTime',
+            },
+            {
+              code: 'Period',
+            },
+            {
+              code: 'Timing',
+            },
+            {
+              code: 'instant',
+            },
+          ],
+        },
+        issued: {
+          path: 'Observation.issued',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'instant',
+            },
+          ],
+        },
+        performer: {
+          path: 'Observation.performer',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/Practitioner',
+                'http://hl7.org/fhir/StructureDefinition/PractitionerRole',
+                'http://hl7.org/fhir/StructureDefinition/Organization',
+                'http://hl7.org/fhir/StructureDefinition/CareTeam',
+                'http://hl7.org/fhir/StructureDefinition/Patient',
+                'http://hl7.org/fhir/StructureDefinition/RelatedPerson',
+              ],
+            },
+          ],
+        },
+        'value[x]': {
+          path: 'Observation.value[x]',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Quantity',
+            },
+            {
+              code: 'CodeableConcept',
+            },
+            {
+              code: 'string',
+            },
+            {
+              code: 'boolean',
+            },
+            {
+              code: 'integer',
+            },
+            {
+              code: 'Range',
+            },
+            {
+              code: 'Ratio',
+            },
+            {
+              code: 'SampledData',
+            },
+            {
+              code: 'time',
+            },
+            {
+              code: 'dateTime',
+            },
+            {
+              code: 'Period',
+            },
+          ],
+          condition: ['obs-7'],
+        },
+        dataAbsentReason: {
+          path: 'Observation.dataAbsentReason',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+          condition: ['obs-6'],
+        },
+        interpretation: {
+          path: 'Observation.interpretation',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        note: {
+          path: 'Observation.note',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Annotation',
+            },
+          ],
+        },
+        bodySite: {
+          path: 'Observation.bodySite',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        method: {
+          path: 'Observation.method',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        specimen: {
+          path: 'Observation.specimen',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: ['http://hl7.org/fhir/StructureDefinition/Specimen'],
+            },
+          ],
+        },
+        device: {
+          path: 'Observation.device',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/Device',
+                'http://hl7.org/fhir/StructureDefinition/DeviceMetric',
+              ],
+            },
+          ],
+        },
+        referenceRange: {
+          path: 'Observation.referenceRange',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'BackboneElement',
+            },
+          ],
+        },
+        hasMember: {
+          path: 'Observation.hasMember',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/Observation',
+                'http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse',
+                'http://hl7.org/fhir/StructureDefinition/MolecularSequence',
+              ],
+            },
+          ],
+        },
+        derivedFrom: {
+          path: 'Observation.derivedFrom',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/DocumentReference',
+                'http://hl7.org/fhir/StructureDefinition/ImagingStudy',
+                'http://hl7.org/fhir/StructureDefinition/Media',
+                'http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse',
+                'http://hl7.org/fhir/StructureDefinition/Observation',
+                'http://hl7.org/fhir/StructureDefinition/MolecularSequence',
+              ],
+            },
+          ],
+        },
+        component: {
+          path: 'Observation.component',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'BackboneElement',
+            },
+          ],
+        },
+      },
+    },
+    Patient: {
+      display: 'Patient',
+      properties: {
+        meta: {
+          path: 'Patient.meta',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Meta',
+            },
+          ],
+        },
+        language: {
+          path: 'Patient.language',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        text: {
+          path: 'Patient.text',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Narrative',
+            },
+          ],
+        },
+        identifier: {
+          path: 'Patient.identifier',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Identifier',
+            },
+          ],
+        },
+        active: {
+          path: 'Patient.active',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'boolean',
+            },
+          ],
+          meaningWhenMissing:
+            'This resource is generally assumed to be active if no value is provided for the active element',
+        },
+        name: {
+          path: 'Patient.name',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'HumanName',
+            },
+          ],
+        },
+        telecom: {
+          path: 'Patient.telecom',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'ContactPoint',
+            },
+          ],
+        },
+        gender: {
+          path: 'Patient.gender',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        birthDate: {
+          path: 'Patient.birthDate',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'date',
+            },
+          ],
+        },
+        'deceased[x]': {
+          path: 'Patient.deceased[x]',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'boolean',
+            },
+            {
+              code: 'dateTime',
+            },
+          ],
+        },
+        address: {
+          path: 'Patient.address',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Address',
+            },
+          ],
+        },
+        maritalStatus: {
+          path: 'Patient.maritalStatus',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        'multipleBirth[x]': {
+          path: 'Patient.multipleBirth[x]',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'boolean',
+            },
+            {
+              code: 'integer',
+            },
+          ],
+        },
+        photo: {
+          path: 'Patient.photo',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Attachment',
+            },
+          ],
+        },
+        contact: {
+          path: 'Patient.contact',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'BackboneElement',
+            },
+          ],
+        },
+        communication: {
+          path: 'Patient.communication',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'BackboneElement',
+            },
+          ],
+        },
+        generalPractitioner: {
+          path: 'Patient.generalPractitioner',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/Organization',
+                'http://hl7.org/fhir/StructureDefinition/Practitioner',
+                'http://hl7.org/fhir/StructureDefinition/PractitionerRole',
+              ],
+            },
+          ],
+        },
+        managingOrganization: {
+          path: 'Patient.managingOrganization',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: ['http://hl7.org/fhir/StructureDefinition/Organization'],
+            },
+          ],
+        },
+        link: {
+          path: 'Patient.link',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'BackboneElement',
+            },
+          ],
+        },
+      },
+    },
+    PatientContact: {
+      display: 'PatientContact',
+      parentType: 'Patient',
+      properties: {
+        relationship: {
+          path: 'Patient.contact.relationship',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        name: {
+          path: 'Patient.contact.name',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'HumanName',
+            },
+          ],
+        },
+        telecom: {
+          path: 'Patient.contact.telecom',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'ContactPoint',
+            },
+          ],
+        },
+        address: {
+          path: 'Patient.contact.address',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Address',
+            },
+          ],
+        },
+        gender: {
+          path: 'Patient.contact.gender',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        organization: {
+          path: 'Patient.contact.organization',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: ['http://hl7.org/fhir/StructureDefinition/Organization'],
+            },
+          ],
+          condition: ['pat-1'],
+        },
+        period: {
+          path: 'Patient.contact.period',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Period',
+            },
+          ],
+        },
+      },
+    },
+    PatientCommunication: {
+      display: 'PatientCommunication',
+      parentType: 'Patient',
+      properties: {
+        language: {
+          path: 'Patient.communication.language',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'CodeableConcept',
+            },
+          ],
+        },
+        preferred: {
+          path: 'Patient.communication.preferred',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'boolean',
+            },
+          ],
+        },
+      },
+    },
+    PatientLink: {
+      display: 'PatientLink',
+      parentType: 'Patient',
+      properties: {
+        other: {
+          path: 'Patient.link.other',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'Reference',
+              targetProfile: [
+                'http://hl7.org/fhir/StructureDefinition/Patient',
+                'http://hl7.org/fhir/StructureDefinition/RelatedPerson',
+              ],
+            },
+          ],
+        },
+        type: {
+          path: 'Patient.link.type',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+      },
+    },
+    Subscription: {
+      display: 'Subscription',
+      properties: {
+        meta: {
+          path: 'Subscription.meta',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Meta',
+            },
+          ],
+        },
+        language: {
+          path: 'Subscription.language',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        text: {
+          path: 'Subscription.text',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'Narrative',
+            },
+          ],
+        },
+        status: {
+          path: 'Subscription.status',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        contact: {
+          path: 'Subscription.contact',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'ContactPoint',
+            },
+          ],
+        },
+        end: {
+          path: 'Subscription.end',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'instant',
+            },
+          ],
+        },
+        reason: {
+          path: 'Subscription.reason',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'string',
+            },
+          ],
+        },
+        criteria: {
+          path: 'Subscription.criteria',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'string',
+            },
+          ],
+        },
+        error: {
+          path: 'Subscription.error',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'string',
+            },
+          ],
+        },
+        channel: {
+          path: 'Subscription.channel',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'BackboneElement',
+            },
+          ],
+        },
+      },
+    },
+    SubscriptionChannel: {
+      display: 'SubscriptionChannel',
+      parentType: 'Subscription',
+      properties: {
+        type: {
+          path: 'Subscription.channel.type',
+          min: 1,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        endpoint: {
+          path: 'Subscription.channel.endpoint',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'url',
+            },
+          ],
+        },
+        payload: {
+          path: 'Subscription.channel.payload',
+          min: 0,
+          max: '1',
+          type: [
+            {
+              code: 'code',
+            },
+          ],
+        },
+        header: {
+          path: 'Subscription.channel.header',
+          min: 0,
+          max: '*',
+          type: [
+            {
+              code: 'string',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
 
 describe('ResourcePropertyDisplay', () => {
   test('Renders null value', () => {
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'string' }] }} value="" />);
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="Observation"
+        propertyName="value[x]"
+        context={{ value: null }}
+      />
+    );
+  });
+
+  test('Renders null context', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="Observation"
+        propertyName="value[x]"
+        context={null as any as Observation}
+      />
+    );
+  });
+
+  test('Renders type not found', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="ObservationXYZ"
+        propertyName="value[x]"
+        context={{ value: null }}
+      />
+    );
+  });
+
+  test('Renders property not found', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="Observation"
+        propertyName="valueXyz"
+        context={{ value: null }}
+      />
+    );
+  });
+
+  test('Ignores missing values', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="Observation"
+        propertyName="value[x]"
+        context={{ value: null }}
+        ignoreMissingValues={true}
+      />
+    );
   });
 
   test('Renders boolean', () => {
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'boolean' }] }} value={true} />);
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="Observation"
+        propertyName="value[x]"
+        context={{ valueBoolean: true }}
+      />
+    );
     expect(screen.getByText('true')).toBeDefined();
   });
 
   test('Renders string', () => {
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'string' }] }} value="hello" />);
-    expect(screen.getByText('hello')).toBeDefined();
-  });
-
-  test('Renders canonical', () => {
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'canonical' }] }} value="hello" />);
-    expect(screen.getByText('hello')).toBeDefined();
-  });
-
-  test('Renders url', () => {
-    render(
-      <ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'url' }] }} value="https://example.com" />
-    );
-    expect(screen.getByText('https://example.com')).toBeDefined();
-  });
-
-  test('Renders uri', () => {
-    render(
-      <ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'uri' }] }} value="https://example.com" />
-    );
-    expect(screen.getByText('https://example.com')).toBeDefined();
-  });
-
-  test('Renders string array', () => {
     render(
       <ResourcePropertyDisplay
         schema={schema}
-        property={{ type: [{ code: 'string' }], max: '*' }}
-        value={['hello', 'world']}
+        typeName="Observation"
+        propertyName="value[x]"
+        context={{ valueString: 'hello' }}
+      />
+    );
+    expect(screen.getByText('hello')).toBeDefined();
+  });
+
+  test('Renders CodeableConcept', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="Observation"
+        propertyName="value[x]"
+        context={{
+          valueCodeableConcept: {
+            text: 'foo',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('foo')).toBeDefined();
+  });
+
+  test('Renders string array', () => {
+    const subscription: Subscription = {
+      resourceType: 'Subscription',
+      channel: {
+        type: 'rest-hook',
+        header: ['hello', 'world'],
+      },
+    };
+
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        typeName="SubscriptionChannel"
+        propertyName="header"
+        context={subscription.channel}
       />
     );
     expect(screen.getByText('hello')).toBeDefined();
     expect(screen.getByText('world')).toBeDefined();
   });
 
+  test('Renders Attachment array', () => {
+    const patient: Patient = {
+      resourceType: 'Patient',
+      photo: [
+        {
+          contentType: 'text/plain',
+          url: 'https://example.com/file.txt',
+          title: 'file.txt',
+        },
+        {
+          contentType: 'text/plain',
+          url: 'https://example.com/file2.txt',
+          title: 'file2.txt',
+        },
+      ],
+    };
+
+    render(<ResourcePropertyDisplay schema={schema} typeName="Patient" propertyName="photo" context={patient} />);
+    expect(screen.getByText('file.txt')).toBeDefined();
+    expect(screen.getByText('file2.txt')).toBeDefined();
+  });
+});
+
+describe('ElementDisplay', () => {
+  test('Renders null value', () => {
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'string' }] }}
+        propertyType={PropertyType.string}
+        value=""
+      />
+    );
+  });
+
+  test('Renders boolean', () => {
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'boolean' }] }}
+        propertyType={PropertyType.boolean}
+        value={true}
+      />
+    );
+    expect(screen.getByText('true')).toBeDefined();
+  });
+
+  test('Renders string', () => {
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'string' }] }}
+        propertyType={PropertyType.string}
+        value="hello"
+      />
+    );
+    expect(screen.getByText('hello')).toBeDefined();
+  });
+
+  test('Renders canonical', () => {
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'canonical' }] }}
+        propertyType={PropertyType.canonical}
+        value="hello"
+      />
+    );
+    expect(screen.getByText('hello')).toBeDefined();
+  });
+
+  test('Renders url', () => {
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'url' }] }}
+        propertyType={PropertyType.url}
+        value="https://example.com"
+      />
+    );
+    expect(screen.getByText('https://example.com')).toBeDefined();
+  });
+
+  test('Renders uri', () => {
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'uri' }] }}
+        propertyType={PropertyType.uri}
+        value="https://example.com"
+      />
+    );
+    expect(screen.getByText('https://example.com')).toBeDefined();
+  });
+
   test('Renders markdown', () => {
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'markdown' }] }} value="hello" />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'markdown' }] }}
+        propertyType={PropertyType.markdown}
+        value="hello"
+      />
+    );
     expect(screen.getByText('hello')).toBeDefined();
   });
 
@@ -71,7 +1115,14 @@ describe('ResourcePropertyDisplay', () => {
       city: 'London',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'Address' }] }} value={value} />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Address' }] }}
+        propertyType={PropertyType.Address}
+        value={value}
+      />
+    );
 
     expect(screen.getByText('London')).toBeDefined();
   });
@@ -81,7 +1132,14 @@ describe('ResourcePropertyDisplay', () => {
       text: 'hello',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'Annotation' }] }} value={value} />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Annotation' }] }}
+        propertyType={PropertyType.Annotation}
+        value={value}
+      />
+    );
 
     expect(screen.getByText('hello')).toBeDefined();
   });
@@ -93,31 +1151,16 @@ describe('ResourcePropertyDisplay', () => {
       title: 'file.txt',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'Attachment' }] }} value={value} />);
-
-    expect(screen.getByText('file.txt')).toBeDefined();
-  });
-
-  test('Renders Attachment array', () => {
-    const value: Attachment[] = [
-      {
-        contentType: 'text/plain',
-        url: 'https://example.com/file.txt',
-        title: 'file.txt',
-      },
-      {
-        contentType: 'text/plain',
-        url: 'https://example.com/file2.txt',
-        title: 'file2.txt',
-      },
-    ];
-
     render(
-      <ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'Attachment' }], max: '*' }} value={value} />
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Attachment' }] }}
+        propertyType={PropertyType.Attachment}
+        value={value}
+      />
     );
 
     expect(screen.getByText('file.txt')).toBeDefined();
-    expect(screen.getByText('file2.txt')).toBeDefined();
   });
 
   test('Renders CodeableConcept', () => {
@@ -126,7 +1169,12 @@ describe('ResourcePropertyDisplay', () => {
     };
 
     render(
-      <ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'CodeableConcept' }] }} value={value} />
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'CodeableConcept' }] }}
+        propertyType={PropertyType.CodeableConcept}
+        value={value}
+      />
     );
 
     expect(screen.getByText('foo')).toBeDefined();
@@ -138,7 +1186,14 @@ describe('ResourcePropertyDisplay', () => {
       value: 'foo@example.com',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'ContactPoint' }] }} value={value} />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'ContactPoint' }] }}
+        propertyType={PropertyType.ContactPoint}
+        value={value}
+      />
+    );
 
     expect(screen.getByText('foo@example.com [email]')).toBeDefined();
   });
@@ -148,7 +1203,14 @@ describe('ResourcePropertyDisplay', () => {
       family: 'Smith',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'HumanName' }] }} value={value} />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'HumanName' }] }}
+        propertyType={PropertyType.HumanName}
+        value={value}
+      />
+    );
 
     expect(screen.getByText('Smith')).toBeDefined();
   });
@@ -159,7 +1221,14 @@ describe('ResourcePropertyDisplay', () => {
       value: 'xyz123',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'Identifier' }] }} value={value} />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Identifier' }] }}
+        propertyType={PropertyType.Identifier}
+        value={value}
+      />
+    );
 
     expect(screen.getByText('xyz: xyz123')).toBeDefined();
   });
@@ -170,8 +1239,53 @@ describe('ResourcePropertyDisplay', () => {
       unit: 'mg',
     };
 
-    render(<ResourcePropertyDisplay schema={schema} property={{ type: [{ code: 'Quantity' }] }} value={value} />);
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Quantity' }] }}
+        propertyType={PropertyType.Quantity}
+        value={value}
+      />
+    );
 
     expect(screen.getByText('1 mg')).toBeDefined();
+  });
+
+  test('Renders Reference', () => {
+    const value: Reference = {
+      reference: 'Patient/123',
+      display: 'John Smith',
+    };
+
+    render(
+      <MemoryRouter>
+        <ElementDisplay
+          schema={schema}
+          property={{ type: [{ code: 'Reference' }] }}
+          propertyType={PropertyType.Reference}
+          value={value}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(value.display as string)).toBeDefined();
+  });
+
+  test('Renders BackboneElement', () => {
+    const value: SubscriptionChannel = {
+      type: 'rest-hook',
+      endpoint: 'https://example.com/hook',
+    };
+
+    render(
+      <ElementDisplay
+        schema={schema}
+        property={{ path: 'Subscription.channel', type: [{ code: 'BackboneElement' }] }}
+        propertyType={PropertyType.BackboneElement}
+        value={value}
+      />
+    );
+
+    expect(screen.getByText(value.endpoint as string)).toBeDefined();
   });
 });

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -5,6 +5,7 @@ import {
   Attachment,
   CodeableConcept,
   ContactPoint,
+  ElementDefinition,
   HumanName,
   Identifier,
   Quantity,
@@ -14,7 +15,7 @@ import {
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { getValueAndType, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 const schema: IndexedStructureDefinition = {
   types: {
@@ -893,7 +894,7 @@ describe('ResourcePropertyDisplay', () => {
     );
   });
 
-  test('Renders boolean', () => {
+  test('Renders boolean true', () => {
     render(
       <ResourcePropertyDisplay
         schema={schema}
@@ -903,6 +904,33 @@ describe('ResourcePropertyDisplay', () => {
       />
     );
     expect(screen.getByText('true')).toBeDefined();
+    expect(screen.queryByText('false')).toBeNull();
+  });
+
+  test('Renders boolean false', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        property={schema.types.Observation.properties['value[x]']}
+        propertyType={PropertyType.boolean}
+        value={false}
+      />
+    );
+    expect(screen.getByText('false')).toBeDefined();
+    expect(screen.queryByText('true')).toBeNull();
+  });
+
+  test('Renders boolean undefined', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        property={schema.types.Observation.properties['value[x]']}
+        propertyType={PropertyType.boolean}
+        value={undefined}
+      />
+    );
+    expect(screen.queryByText('true')).toBeNull();
+    expect(screen.queryByText('false')).toBeNull();
   });
 
   test('Renders string', () => {
@@ -1181,5 +1209,16 @@ describe('ResourcePropertyDisplay', () => {
     );
 
     expect(screen.getByText(value.endpoint as string)).toBeDefined();
+  });
+
+  test('getValueAndType', () => {
+    expect(getValueAndType(null, {} as ElementDefinition)[0]).toBeUndefined();
+    expect(getValueAndType({}, {} as ElementDefinition)[0]).toBeUndefined();
+    expect(getValueAndType({}, { path: '' } as ElementDefinition)[0]).toBeUndefined();
+    expect(getValueAndType({}, { path: 'x' } as ElementDefinition)[0]).toBeUndefined();
+    expect(getValueAndType({}, { path: 'x', type: [] } as ElementDefinition)[0]).toBeUndefined();
+    expect(
+      getValueAndType({}, { path: 'x', type: [{ code: 'foo' }, { code: 'bar' }] } as ElementDefinition)[0]
+    ).toBeUndefined();
   });
 });

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -7,17 +7,14 @@ import {
   ContactPoint,
   HumanName,
   Identifier,
-  Observation,
-  Patient,
   Quantity,
   Reference,
-  Subscription,
   SubscriptionChannel,
 } from '@medplum/fhirtypes';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { ElementDisplay, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 const schema: IndexedStructureDefinition = {
   types: {
@@ -889,160 +886,18 @@ describe('ResourcePropertyDisplay', () => {
     render(
       <ResourcePropertyDisplay
         schema={schema}
-        typeName="Observation"
-        propertyName="value[x]"
-        context={{ value: null }}
-      />
-    );
-  });
-
-  test('Renders null context', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="Observation"
-        propertyName="value[x]"
-        context={null as any as Observation}
-      />
-    );
-  });
-
-  test('Renders type not found', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="ObservationXYZ"
-        propertyName="value[x]"
-        context={{ value: null }}
-      />
-    );
-  });
-
-  test('Renders property not found', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="Observation"
-        propertyName="valueXyz"
-        context={{ value: null }}
-      />
-    );
-  });
-
-  test('Ignores missing values', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="Observation"
-        propertyName="value[x]"
-        context={{ value: null }}
-        ignoreMissingValues={true}
-      />
-    );
-  });
-
-  test('Renders boolean', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="Observation"
-        propertyName="value[x]"
-        context={{ valueBoolean: true }}
-      />
-    );
-    expect(screen.getByText('true')).toBeDefined();
-  });
-
-  test('Renders string', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="Observation"
-        propertyName="value[x]"
-        context={{ valueString: 'hello' }}
-      />
-    );
-    expect(screen.getByText('hello')).toBeDefined();
-  });
-
-  test('Renders CodeableConcept', () => {
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="Observation"
-        propertyName="value[x]"
-        context={{
-          valueCodeableConcept: {
-            text: 'foo',
-          },
-        }}
-      />
-    );
-
-    expect(screen.getByText('foo')).toBeDefined();
-  });
-
-  test('Renders string array', () => {
-    const subscription: Subscription = {
-      resourceType: 'Subscription',
-      channel: {
-        type: 'rest-hook',
-        header: ['hello', 'world'],
-      },
-    };
-
-    render(
-      <ResourcePropertyDisplay
-        schema={schema}
-        typeName="SubscriptionChannel"
-        propertyName="header"
-        context={subscription.channel}
-      />
-    );
-    expect(screen.getByText('hello')).toBeDefined();
-    expect(screen.getByText('world')).toBeDefined();
-  });
-
-  test('Renders Attachment array', () => {
-    const patient: Patient = {
-      resourceType: 'Patient',
-      photo: [
-        {
-          contentType: 'text/plain',
-          url: 'https://example.com/file.txt',
-          title: 'file.txt',
-        },
-        {
-          contentType: 'text/plain',
-          url: 'https://example.com/file2.txt',
-          title: 'file2.txt',
-        },
-      ],
-    };
-
-    render(<ResourcePropertyDisplay schema={schema} typeName="Patient" propertyName="photo" context={patient} />);
-    expect(screen.getByText('file.txt')).toBeDefined();
-    expect(screen.getByText('file2.txt')).toBeDefined();
-  });
-});
-
-describe('ElementDisplay', () => {
-  test('Renders null value', () => {
-    render(
-      <ElementDisplay
-        schema={schema}
-        property={{ type: [{ code: 'string' }] }}
+        property={schema.types.Observation.properties['value[x]']}
         propertyType={PropertyType.string}
-        value=""
+        value={null}
       />
     );
   });
 
   test('Renders boolean', () => {
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
-        property={{ type: [{ code: 'boolean' }] }}
+        property={schema.types.Observation.properties['value[x]']}
         propertyType={PropertyType.boolean}
         value={true}
       />
@@ -1052,11 +907,11 @@ describe('ElementDisplay', () => {
 
   test('Renders string', () => {
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
-        property={{ type: [{ code: 'string' }] }}
+        property={schema.types.Observation.properties['value[x]']}
         propertyType={PropertyType.string}
-        value="hello"
+        value={'hello'}
       />
     );
     expect(screen.getByText('hello')).toBeDefined();
@@ -1064,7 +919,7 @@ describe('ElementDisplay', () => {
 
   test('Renders canonical', () => {
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'canonical' }] }}
         propertyType={PropertyType.canonical}
@@ -1076,7 +931,7 @@ describe('ElementDisplay', () => {
 
   test('Renders url', () => {
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'url' }] }}
         propertyType={PropertyType.url}
@@ -1088,7 +943,7 @@ describe('ElementDisplay', () => {
 
   test('Renders uri', () => {
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'uri' }] }}
         propertyType={PropertyType.uri}
@@ -1098,9 +953,22 @@ describe('ElementDisplay', () => {
     expect(screen.getByText('https://example.com')).toBeDefined();
   });
 
+  test('Renders string array', () => {
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        property={schema.types.SubscriptionChannel.properties.header}
+        propertyType={PropertyType.string}
+        value={['hello', 'world']}
+      />
+    );
+    expect(screen.getByText('hello')).toBeDefined();
+    expect(screen.getByText('world')).toBeDefined();
+  });
+
   test('Renders markdown', () => {
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'markdown' }] }}
         propertyType={PropertyType.markdown}
@@ -1116,7 +984,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'Address' }] }}
         propertyType={PropertyType.Address}
@@ -1133,7 +1001,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'Annotation' }] }}
         propertyType={PropertyType.Annotation}
@@ -1152,7 +1020,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'Attachment' }] }}
         propertyType={PropertyType.Attachment}
@@ -1163,15 +1031,41 @@ describe('ElementDisplay', () => {
     expect(screen.getByText('file.txt')).toBeDefined();
   });
 
+  test('Renders Attachment array', () => {
+    const value: Attachment[] = [
+      {
+        contentType: 'text/plain',
+        url: 'https://example.com/file.txt',
+        title: 'file.txt',
+      },
+      {
+        contentType: 'text/plain',
+        url: 'https://example.com/file2.txt',
+        title: 'file2.txt',
+      },
+    ];
+
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        property={schema.types.Patient.properties.photo}
+        propertyType={PropertyType.Attachment}
+        value={value}
+      />
+    );
+    expect(screen.getByText('file.txt')).toBeDefined();
+    expect(screen.getByText('file2.txt')).toBeDefined();
+  });
+
   test('Renders CodeableConcept', () => {
     const value: CodeableConcept = {
       text: 'foo',
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
-        property={{ type: [{ code: 'CodeableConcept' }] }}
+        property={schema.types.Observation.properties['value[x]']}
         propertyType={PropertyType.CodeableConcept}
         value={value}
       />
@@ -1187,7 +1081,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'ContactPoint' }] }}
         propertyType={PropertyType.ContactPoint}
@@ -1204,7 +1098,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'HumanName' }] }}
         propertyType={PropertyType.HumanName}
@@ -1222,7 +1116,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'Identifier' }] }}
         propertyType={PropertyType.Identifier}
@@ -1240,7 +1134,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ type: [{ code: 'Quantity' }] }}
         propertyType={PropertyType.Quantity}
@@ -1259,7 +1153,7 @@ describe('ElementDisplay', () => {
 
     render(
       <MemoryRouter>
-        <ElementDisplay
+        <ResourcePropertyDisplay
           schema={schema}
           property={{ type: [{ code: 'Reference' }] }}
           propertyType={PropertyType.Reference}
@@ -1278,7 +1172,7 @@ describe('ElementDisplay', () => {
     };
 
     render(
-      <ElementDisplay
+      <ResourcePropertyDisplay
         schema={schema}
         property={{ path: 'Subscription.channel', type: [{ code: 'BackboneElement' }] }}
         propertyType={PropertyType.BackboneElement}

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -1,4 +1,4 @@
-import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
+import { buildTypeName, IndexedStructureDefinition, PropertyType } from '@medplum/core';
 import { ElementDefinition, ElementDefinitionType } from '@medplum/fhirtypes';
 import React from 'react';
 import { AddressDisplay } from './AddressDisplay';
@@ -87,8 +87,9 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
       return (
         <BackboneElementDisplay
           schema={props.schema}
-          property={property}
+          typeName={buildTypeName(property.path?.split('.') as string[])}
           value={value}
+          compact={true}
           ignoreMissingValues={props.ignoreMissingValues}
         />
       );

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -15,25 +15,16 @@ import { ResourceArrayDisplay } from './ResourceArrayDisplay';
 
 export interface ResourcePropertyDisplayProps {
   schema: IndexedStructureDefinition;
-  context: any;
-  typeName: string;
-  propertyName: string;
+  property: ElementDefinition;
+  propertyType: PropertyType;
+  value: any;
   arrayElement?: boolean;
   maxWidth?: number;
   ignoreMissingValues?: boolean;
 }
 
 export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
-  const property = props.schema.types[props.typeName]?.properties?.[props.propertyName];
-  if (!property) {
-    return null;
-  }
-
-  const [value, propertyType] = getValueAndType(props.context, property);
-
-  if (props.ignoreMissingValues && (!value || (Array.isArray(value) && value.length === 0))) {
-    return null;
-  }
+  const { property, propertyType, value } = props;
 
   if (property.max === '*' && !props.arrayElement) {
     if (propertyType === 'Attachment') {
@@ -49,29 +40,6 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
     );
   }
 
-  return (
-    <ElementDisplay
-      schema={props.schema}
-      property={property}
-      value={value}
-      propertyType={propertyType}
-      maxWidth={props.maxWidth}
-      ignoreMissingValues={props.ignoreMissingValues}
-    />
-  );
-}
-
-export interface ElementDisplayProps {
-  schema: IndexedStructureDefinition;
-  property: ElementDefinition;
-  propertyType: PropertyType;
-  value: any;
-  maxWidth?: number;
-  ignoreMissingValues?: boolean;
-}
-
-export function ElementDisplay(props: ElementDisplayProps) {
-  const { property, propertyType, value } = props;
   switch (propertyType) {
     case PropertyType.boolean:
       return <div>{value === undefined ? '' : Boolean(value).toString()}</div>;
@@ -121,7 +89,7 @@ export function ElementDisplay(props: ElementDisplayProps) {
   }
 }
 
-function getValueAndType(context: any, property: ElementDefinition): [any, PropertyType] {
+export function getValueAndType(context: any, property: ElementDefinition): [any, PropertyType] {
   if (!context) {
     return [undefined, PropertyType.string];
   }

--- a/packages/ui/src/ResourceTable.test.tsx
+++ b/packages/ui/src/ResourceTable.test.tsx
@@ -78,10 +78,10 @@ describe('ResourceTable', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Resource Type'));
+      await waitFor(() => screen.getByText('Name'));
     });
 
-    expect(screen.getByText('Resource Type')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
   test('Renders Practitioner resource', async () => {
@@ -92,10 +92,10 @@ describe('ResourceTable', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Resource Type'));
+      await waitFor(() => screen.getByText('Name'));
     });
 
-    expect(screen.getByText('Resource Type')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Gender')).toBeInTheDocument();
   });
 
@@ -108,10 +108,10 @@ describe('ResourceTable', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Resource Type'));
+      await waitFor(() => screen.getByText('Name'));
     });
 
-    expect(screen.getByText('Resource Type')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.queryByText('Gender')).toBeNull();
   });
 });

--- a/packages/ui/src/ResourceTable.tsx
+++ b/packages/ui/src/ResourceTable.tsx
@@ -1,11 +1,8 @@
-import { getPropertyDisplayName, IndexedStructureDefinition } from '@medplum/core';
-import { evalFhirPath } from '@medplum/fhirpath';
+import { IndexedStructureDefinition } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
-import { DEFAULT_IGNORED_PROPERTIES } from './constants';
-import { DescriptionList, DescriptionListEntry } from './DescriptionList';
+import { BackboneElementDisplay } from './BackboneElementDisplay';
 import { useMedplum } from './MedplumProvider';
-import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 import { useResource } from './useResource';
 
 export interface ResourceTableProps {
@@ -25,47 +22,15 @@ export function ResourceTable(props: ResourceTableProps) {
   }, [value]);
 
   if (!schema || !value) {
-    return <div>Loading...</div>;
-  }
-
-  const typeSchema = schema.types[value.resourceType];
-  if (!typeSchema) {
-    return <div>Schema not found</div>;
+    return null;
   }
 
   return (
-    <DescriptionList>
-      <DescriptionListEntry term="Resource Type">{value.resourceType}</DescriptionListEntry>
-      <DescriptionListEntry term="ID">{value.id}</DescriptionListEntry>
-      {Object.entries(typeSchema.properties).map((entry) => {
-        const key = entry[0];
-        if (DEFAULT_IGNORED_PROPERTIES.indexOf(key) >= 0) {
-          return null;
-        }
-        const property = entry[1];
-        let propertyValue: any = evalFhirPath(key, value);
-        // FHIRPath will always return an array
-        // If the property is not an array property,
-        // then unrap the value.
-        if (propertyValue.length === 0) {
-          propertyValue = null;
-        } else if (property.max !== '*') {
-          propertyValue = propertyValue[0];
-        }
-        if (props.ignoreMissingValues && !propertyValue) {
-          return null;
-        }
-        return (
-          <DescriptionListEntry key={key} term={getPropertyDisplayName(property)}>
-            <ResourcePropertyDisplay
-              schema={schema}
-              property={property}
-              value={propertyValue}
-              ignoreMissingValues={props.ignoreMissingValues}
-            />
-          </DescriptionListEntry>
-        );
-      })}
-    </DescriptionList>
+    <BackboneElementDisplay
+      schema={schema}
+      typeName={value.resourceType}
+      value={value}
+      ignoreMissingValues={props.ignoreMissingValues}
+    />
   );
 }

--- a/packages/ui/src/SearchControl.test.tsx
+++ b/packages/ui/src/SearchControl.test.tsx
@@ -21,6 +21,7 @@ const patientStructure: StructureDefinition = {
             code: 'HumanName',
           },
         ],
+        max: '*',
       },
     ],
   },
@@ -58,6 +59,9 @@ const aliceSearchBundle: Bundle = {
       resource: {
         resourceType: 'Patient',
         id: '123',
+        meta: {
+          lastUpdated: '2021-12-12T12:12:12',
+        },
         name: [
           {
             given: ['Alice'],
@@ -85,6 +89,9 @@ const medplum = new MockClient({
   'fhir/R4/Patient?name=Alice': {
     GET: aliceSearchBundle,
   },
+  'fhir/R4/Patient?_fields=id,_lastUpdated,name&name=Alice': {
+    GET: aliceSearchBundle,
+  },
   'fhir/R4/Patient?name=Bob': {
     GET: emptySearchBundle,
   },
@@ -101,7 +108,7 @@ describe('SearchControl', () => {
     );
   };
 
-  test('Renders', async () => {
+  test('Renders results', async () => {
     const props = {
       search: {
         resourceType: 'Patient',
@@ -112,6 +119,7 @@ describe('SearchControl', () => {
             value: 'Alice',
           },
         ],
+        fields: ['id', '_lastUpdated', 'name'],
       },
       onLoad: jest.fn(),
     };
@@ -125,6 +133,7 @@ describe('SearchControl', () => {
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
     expect(props.onLoad).toBeCalled();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
   });
 
   test('Renders empty results', async () => {
@@ -164,6 +173,7 @@ describe('SearchControl', () => {
             value: 'Alice',
           },
         ],
+        fields: ['id', '_lastUpdated', 'name'],
       },
       onLoad: jest.fn(),
       checkboxesEnabled: true,

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -7,7 +7,7 @@ import { useMedplum } from './MedplumProvider';
 import { SearchFieldEditor } from './SearchFieldEditor';
 import { SearchFilterEditor } from './SearchFilterEditor';
 import { SearchPopupMenu } from './SearchPopupMenu';
-import { buildFieldNameString, getFilterValueString, getValue, movePage, renderValue } from './SearchUtils';
+import { buildFieldNameString, getFilterValueString, movePage, renderValue } from './SearchUtils';
 import { TitleBar } from './TitleBar';
 import { killEvent } from './utils/dom';
 import './SearchControl.css';
@@ -346,9 +346,7 @@ export function SearchControl(props: SearchControlProps) {
                     </td>
                   )}
                   {fields.map((field) => (
-                    <td key={field}>
-                      {renderValue(schema, props.search.resourceType, field, getValue(resource, field))}
-                    </td>
+                    <td key={field}>{renderValue(schema, resource, field)}</td>
                   ))}
                 </tr>
               )

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -1,7 +1,7 @@
 import { Filter, getPropertyDisplayName, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
 import React from 'react';
-import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { getValueAndType, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 /**
  * Sets the array of filters.
@@ -467,12 +467,22 @@ export function renderValue(
     return new Date(resource.meta?.lastUpdated as string).toLocaleString('en-US');
   }
 
+  const property = schema.types[resource.resourceType].properties[key];
+  if (!property) {
+    return null;
+  }
+
+  const [value, propertyType] = getValueAndType(resource, property);
+  if (!value) {
+    return null;
+  }
+
   return (
     <ResourcePropertyDisplay
       schema={schema}
-      typeName={resource.resourceType}
-      propertyName={key}
-      context={resource}
+      property={property}
+      propertyType={propertyType}
+      value={value}
       maxWidth={200}
       ignoreMissingValues={true}
     />

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -1,5 +1,4 @@
 import { Filter, getPropertyDisplayName, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
-import { evalFhirPath } from '@medplum/fhirpath';
 import { Resource } from '@medplum/fhirtypes';
 import React from 'react';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
@@ -468,19 +467,14 @@ export function renderValue(
     return new Date(resource.meta?.lastUpdated as string).toLocaleString('en-US');
   }
 
-  const property = schema.types[resource.resourceType]?.properties?.[key];
-  if (!property) {
-    return null;
-  }
-
-  let value = evalFhirPath(key, resource);
-  if (value.length === 0) {
-    return null;
-  }
-
-  if (property.max !== '*') {
-    value = value[0];
-  }
-
-  return <ResourcePropertyDisplay schema={schema} property={property} value={value} maxWidth={200} />;
+  return (
+    <ResourcePropertyDisplay
+      schema={schema}
+      typeName={resource.resourceType}
+      propertyName={key}
+      context={resource}
+      maxWidth={200}
+      ignoreMissingValues={true}
+    />
+  );
 }

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -1,11 +1,5 @@
-import {
-  Filter,
-  getPropertyDisplayName,
-  IndexedStructureDefinition,
-  Operator,
-  SearchRequest,
-  stringify,
-} from '@medplum/core';
+import { Filter, getPropertyDisplayName, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
+import { evalFhirPath } from '@medplum/fhirpath';
 import { Resource } from '@medplum/fhirtypes';
 import React from 'react';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
@@ -451,51 +445,41 @@ export function getFilterValueString(filter: Filter): JSX.Element | string {
 }
 
 /**
- * Returns one of the meta fields.
- * TODO: Replace with FHIRPath evaluation.
- *
- * @param {!string} key The field key.
- * @return {*} The value.
- */
-export function getValue(resource: Resource, key: string): any | undefined {
-  if (key === '_lastUpdated') {
-    return resource.meta?.lastUpdated;
-  }
-  try {
-    return key.split('.').reduce((o, i) => o[i], resource as any);
-  } catch (ex) {
-    return undefined;
-  }
-}
-
-/**
- * Returns a HTML fragment to be displayed in the search table for the value.
- *
- * @param {!string} key The field key name.
- * @param {*} value The filter value
- * @return {string} An HTML fragment that represents the value.
+ * Returns a fragment to be displayed in the search table for the value.
+ * @param schema The currently indexed schema.
+ * @param resource The parent resource.
+ * @param key The search code or FHIRPath expression.
+ * @returns The fragment to display.
  */
 export function renderValue(
   schema: IndexedStructureDefinition,
-  resourceType: string,
-  key: string,
-  value: any
-): string | JSX.Element {
-  if (!value) {
-    return <span className="muted">none</span>;
+  resource: Resource,
+  key: string
+): string | JSX.Element | null | undefined {
+  if (key === 'id') {
+    return resource.id;
   }
 
-  if (key === 'id' || key === 'meta.versionId') {
-    return value;
+  if (key === 'meta.versionId') {
+    return resource.meta?.versionId;
   }
 
   if (key === '_lastUpdated') {
-    return new Date(value).toLocaleString('en-US');
+    return new Date(resource.meta?.lastUpdated as string).toLocaleString('en-US');
   }
 
-  const property = schema.types[resourceType]?.properties?.[key];
+  const property = schema.types[resource.resourceType]?.properties?.[key];
   if (!property) {
-    return stringify(value);
+    return null;
+  }
+
+  let value = evalFhirPath(key, resource);
+  if (value.length === 0) {
+    return null;
+  }
+
+  if (property.max !== '*') {
+    value = value[0];
   }
 
   return <ResourcePropertyDisplay schema={schema} property={property} value={value} maxWidth={200} />;

--- a/packages/ui/src/stories/ResourceTable.stories.tsx
+++ b/packages/ui/src/stories/ResourceTable.stories.tsx
@@ -19,3 +19,12 @@ export const Observation = () => (
     <ResourceTable value={{ reference: `Observation/${process.env.SAMPLE_OBSERVATION_ID}` }} />
   </Document>
 );
+
+export const ObservationIgnoreEmpty = () => (
+  <Document>
+    <ResourceTable
+      value={{ reference: `Observation/${process.env.SAMPLE_OBSERVATION_ID}` }}
+      ignoreMissingValues={true}
+    />
+  </Document>
+);

--- a/packages/ui/src/stories/SearchControl.stories.tsx
+++ b/packages/ui/src/stories/SearchControl.stories.tsx
@@ -84,3 +84,23 @@ export const ServiceRequests = () => {
     />
   );
 };
+
+export const DeviceDefinitions = () => {
+  const [search, setSearch] = useState<SearchRequest>({
+    resourceType: 'DeviceDefinition',
+    fields: ['id', '_lastUpdated', 'manufacturer[x]', 'deviceName'],
+  });
+
+  return (
+    <SearchControl
+      search={search}
+      checkboxesEnabled={true}
+      onLoad={(e) => console.log('onLoad', e)}
+      onClick={(e) => console.log('onClick', e)}
+      onChange={(e) => {
+        console.log('onChange', e);
+        setSearch(e.definition);
+      }}
+    />
+  );
+};


### PR DESCRIPTION
Added support for the [Choice of Type]() feature to the `<SearchControl>` component.

Choice of Type is an interesting idiosyncrasy of FHIR.  You sometimes see fields that end with "`[x]`".  Perhaps the most common is "Observation.value[x]".  What it means is:  this property can be one of multiple different types, and can actually use one of multiple different property names.

If it's a string, then the JSON looks like:
```json
{
  "valueString": "My String Name"
}
```

If it's a `Quantity`, then the JSON looks like:
```json
{
  "valueQuantity": {
    "value": 100,
    "unit": "mg"
  }
}
```

Now the `<SearchControl>` component is aware of this complexity, and renders the right value with the right sub-components.

Fun fact:  Github Copilot wrote a big chunk of this!

See: [FHIR Choice of Types](https://hl7.org/fhir/formats.html#choice)