### PR TITLE
Renamed repo to systemRepo

### DIFF
--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -7,7 +7,7 @@ import { resetPassword } from '../auth/resetpassword';
 import { createPractitioner, createProjectMembership } from '../auth/utils';
 import { getConfig } from '../config';
 import { sendEmail } from '../email';
-import { invalidRequest, repo, sendOutcome } from '../fhir';
+import { invalidRequest, systemRepo, sendOutcome } from '../fhir';
 import { logger } from '../logger';
 import { generateSecret } from '../oauth';
 import { verifyProjectAdmin } from './utils';
@@ -94,7 +94,7 @@ export async function inviteUser(request: InviteRequest): Promise<Practitioner> 
 }
 
 async function searchForExisting(email: string): Promise<User | undefined> {
-  const [outcome, bundle] = await repo.search<User>({
+  const [outcome, bundle] = await systemRepo.search<User>({
     resourceType: 'User',
     filters: [
       {
@@ -116,7 +116,7 @@ async function createUser(request: InviteRequest): Promise<User> {
   const password = generateSecret(16);
   logger.info('Create user ' + email);
   const passwordHash = await bcrypt.hash(password, 10);
-  const [outcome, result] = await repo.createResource<User>({
+  const [outcome, result] = await systemRepo.createResource<User>({
     resourceType: 'User',
     email,
     passwordHash,

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -2,7 +2,7 @@ import { assertOk, getStatus } from '@medplum/core';
 import { Project, ProjectMembership } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { authenticateToken } from '../oauth';
 import { inviteHandler, inviteValidators } from './invite';
 import { verifyProjectAdmin } from './utils';
@@ -56,7 +56,7 @@ projectAdminRouter.get(
     }
 
     const { membershipId } = req.params;
-    const [outcome, membership] = await repo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    const [outcome, membership] = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
     assertOk(outcome);
     res.status(getStatus(outcome)).json(membership);
   })
@@ -77,7 +77,7 @@ projectAdminRouter.post(
       return;
     }
 
-    const [outcome, result] = await repo.updateResource(resource);
+    const [outcome, result] = await systemRepo.updateResource(resource);
     assertOk(outcome);
     res.status(getStatus(outcome)).json(result);
   })

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { createTestClient } from '../jest.setup';
 import { generateAccessToken, initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
@@ -26,13 +26,13 @@ describe('Super Admin routes', () => {
 
     client = await createTestClient();
 
-    const [outcome1, practitioner1] = await repo.createResource<Practitioner>({ resourceType: 'Practitioner' });
+    const [outcome1, practitioner1] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
     assertOk(outcome1);
 
-    const [outcome2, practitioner2] = await repo.createResource<Practitioner>({ resourceType: 'Practitioner' });
+    const [outcome2, practitioner2] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
     assertOk(outcome2);
 
-    const [outcome3, user1] = await repo.createResource<User>({
+    const [outcome3, user1] = await systemRepo.createResource<User>({
       resourceType: 'User',
       email: `super${randomUUID()}@example.com`,
       passwordHash: 'abc',
@@ -40,7 +40,7 @@ describe('Super Admin routes', () => {
     });
     assertOk(outcome3);
 
-    const [outcome4, user2] = await repo.createResource<User>({
+    const [outcome4, user2] = await systemRepo.createResource<User>({
       resourceType: 'User',
       email: `normie${randomUUID()}@example.com`,
       passwordHash: 'abc',
@@ -48,7 +48,7 @@ describe('Super Admin routes', () => {
     });
     assertOk(outcome4);
 
-    const [outcome5, login1] = await repo.createResource<Login>({
+    const [outcome5, login1] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       profile: createReference(practitioner1 as Practitioner),
@@ -57,7 +57,7 @@ describe('Super Admin routes', () => {
     });
     assertOk(outcome5);
 
-    const [outcome6, login2] = await repo.createResource<Login>({
+    const [outcome6, login2] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       profile: createReference(practitioner2 as Practitioner),

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -2,7 +2,7 @@ import { accessDenied, allOk, assertOk, isOk } from '@medplum/core';
 import { User } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
-import { repo, sendOutcome, validateResourceType } from '../fhir';
+import { systemRepo, sendOutcome, validateResourceType } from '../fhir';
 import { authenticateToken } from '../oauth';
 import { createStructureDefinitions } from '../seeds/structuredefinitions';
 import { createValueSetElements } from '../seeds/valuesets';
@@ -16,7 +16,7 @@ superAdminRouter.use(authenticateToken);
 superAdminRouter.post(
   '/valuesets',
   asyncWrap(async (req: Request, res: Response) => {
-    const [outcome, user] = await repo.readResource<User>('User', res.locals.user);
+    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
     assertOk(outcome);
 
     if (!user?.admin) {
@@ -34,7 +34,7 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/structuredefinitions',
   asyncWrap(async (req: Request, res: Response) => {
-    const [outcome, user] = await repo.readResource<User>('User', res.locals.user);
+    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
     assertOk(outcome);
 
     if (!user?.admin) {
@@ -52,7 +52,7 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/reindex',
   asyncWrap(async (req: Request, res: Response) => {
-    const [outcome, user] = await repo.readResource<User>('User', res.locals.user);
+    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
     assertOk(outcome);
 
     if (!user?.admin) {
@@ -65,7 +65,7 @@ superAdminRouter.post(
       return sendOutcome(res, validateOutcome);
     }
 
-    const [reindexOutcome] = await repo.reindexResourceType(resourceType);
+    const [reindexOutcome] = await systemRepo.reindexResourceType(resourceType);
     return sendOutcome(res, reindexOutcome);
   })
 );

--- a/packages/server/src/admin/utils.ts
+++ b/packages/server/src/admin/utils.ts
@@ -1,7 +1,7 @@
 import { assertOk, Operator } from '@medplum/core';
 import { Bundle, BundleEntry, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 
 export interface ProjectDetails {
   project: Project;
@@ -19,10 +19,10 @@ export interface ProjectDetails {
 export async function verifyProjectAdmin(req: Request, res: Response): Promise<ProjectDetails | undefined> {
   const { projectId } = req.params;
 
-  const [projectOutcome, project] = await repo.readResource<Project>('Project', projectId);
+  const [projectOutcome, project] = await systemRepo.readResource<Project>('Project', projectId);
   assertOk(projectOutcome);
 
-  const [membershipOutcome, bundle] = await repo.search<ProjectMembership>({
+  const [membershipOutcome, bundle] = await systemRepo.search<ProjectMembership>({
     resourceType: 'ProjectMembership',
     filters: [
       {

--- a/packages/server/src/auth/changepassword.ts
+++ b/packages/server/src/auth/changepassword.ts
@@ -3,7 +3,7 @@ import { OperationOutcome, User } from '@medplum/fhirtypes';
 import bcrypt from 'bcrypt';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
-import { invalidRequest, repo, sendOutcome } from '../fhir';
+import { invalidRequest, systemRepo, sendOutcome } from '../fhir';
 import { authenticateToken } from '../oauth';
 
 export const changePasswordValidators = [
@@ -18,7 +18,7 @@ export async function changePasswordHandler(req: Request, res: Response) {
       return sendOutcome(res, invalidRequest(errors));
     }
 
-    const [userOutcome, user] = await repo.readResource<User>('User', res.locals.user);
+    const [userOutcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
     assertOk(userOutcome);
 
     const outcome = await changePassword({
@@ -45,7 +45,7 @@ export async function changePassword(request: ChangePasswordRequest): Promise<Op
   }
 
   const newPasswordHash = await bcrypt.hash(request.newPassword, 10);
-  const [outcome] = await repo.updateResource<User>({
+  const [outcome] = await systemRepo.updateResource<User>({
     ...request.user,
     passwordHash: newPasswordHash,
   });

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -7,7 +7,7 @@ import { inviteUser } from '../admin/invite';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
 import { registerNew } from './register';
@@ -93,9 +93,9 @@ describe('Profile', () => {
     expect(res1.status).toBe(200);
     expect(res1.body.login).toBeDefined();
 
-    const [readOutcome, login] = await repo.readResource<Login>('Login', res1.body.login);
+    const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
     assertOk(readOutcome);
-    await repo.updateResource({
+    await systemRepo.updateResource({
       ...(login as Login),
       revoked: true,
     });
@@ -121,9 +121,9 @@ describe('Profile', () => {
     expect(res1.status).toBe(200);
     expect(res1.body.login).toBeDefined();
 
-    const [readOutcome, login] = await repo.readResource<Login>('Login', res1.body.login);
+    const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
     assertOk(readOutcome);
-    await repo.updateResource({
+    await systemRepo.updateResource({
       ...(login as Login),
       granted: true,
     });
@@ -149,9 +149,9 @@ describe('Profile', () => {
     expect(res1.status).toBe(200);
     expect(res1.body.login).toBeDefined();
 
-    const [readOutcome, login] = await repo.readResource<Login>('Login', res1.body.login);
+    const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
     assertOk(readOutcome);
-    await repo.updateResource({
+    await systemRepo.updateResource({
       ...(login as Login),
       project: {
         reference: `Project/${randomUUID()}`,

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -2,7 +2,7 @@ import { assertOk, badRequest, createReference, ProfileResource } from '@medplum
 import { Login, Project, Reference, User } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
-import { invalidRequest, repo, sendOutcome } from '../fhir';
+import { invalidRequest, systemRepo, sendOutcome } from '../fhir';
 import { getUserMemberships } from '../oauth';
 
 export const profileValidators = [
@@ -16,7 +16,7 @@ export async function profileHandler(req: Request, res: Response) {
     return sendOutcome(res, invalidRequest(errors));
   }
 
-  const [loginOutcome, login] = await repo.readResource<Login>('Login', req.body.login);
+  const [loginOutcome, login] = await systemRepo.readResource<Login>('Login', req.body.login);
   assertOk(loginOutcome);
 
   if (login?.revoked) {
@@ -39,16 +39,16 @@ export async function profileHandler(req: Request, res: Response) {
   }
 
   // Get up-to-date project and profile
-  const [projectOutcome, project] = await repo.readReference<Project>(membership.project as Reference<Project>);
+  const [projectOutcome, project] = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
   assertOk(projectOutcome);
 
-  const [profileOutcome, profile] = await repo.readReference<ProfileResource>(
+  const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>(
     membership.profile as Reference<ProfileResource>
   );
   assertOk(profileOutcome);
 
   // Update the login
-  const [updateOutcome] = await repo.updateResource({
+  const [updateOutcome] = await systemRepo.updateResource({
     ...(login as Login),
     project: createReference(project as Project),
     profile: createReference(profile as ProfileResource),

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -4,7 +4,7 @@ import bcrypt from 'bcrypt';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
-import { invalidRequest, repo, sendOutcome } from '../fhir';
+import { invalidRequest, systemRepo, sendOutcome } from '../fhir';
 import { logger } from '../logger';
 import { generateSecret, getAuthTokens, tryLogin } from '../oauth';
 import { createPractitioner, createProjectMembership } from './utils';
@@ -84,7 +84,7 @@ export async function registerNew(request: RegisterRequest): Promise<RegisterRes
 }
 
 async function searchForExisting(email: string): Promise<boolean> {
-  const [outcome, bundle] = await repo.search<User>({
+  const [outcome, bundle] = await systemRepo.search<User>({
     resourceType: 'User',
     filters: [
       {
@@ -103,7 +103,7 @@ async function createUser(request: RegisterRequest): Promise<User> {
   const { email, password, admin } = request;
   logger.info('Create user ' + email);
   const passwordHash = await bcrypt.hash(password, 10);
-  const [outcome, result] = await repo.createResource<User>({
+  const [outcome, result] = await systemRepo.createResource<User>({
     resourceType: 'User',
     email,
     passwordHash,
@@ -116,7 +116,7 @@ async function createUser(request: RegisterRequest): Promise<User> {
 
 async function createProject(request: RegisterRequest, user: User): Promise<Project> {
   logger.info('Create project ' + request.projectName);
-  const [outcome, result] = await repo.createResource<Project>({
+  const [outcome, result] = await systemRepo.createResource<Project>({
     resourceType: 'Project',
     name: request.projectName,
     owner: createReference(user),
@@ -128,7 +128,7 @@ async function createProject(request: RegisterRequest, user: User): Promise<Proj
 
 async function createClientApplication(project: Project): Promise<ClientApplication> {
   logger.info('Create default client ' + project.name);
-  const [outcome, result] = await repo.createResource<ClientApplication>({
+  const [outcome, result] = await systemRepo.createResource<ClientApplication>({
     resourceType: 'ClientApplication',
     name: project.name + ' Default Client',
     description: 'Default client for ' + project.name,

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -4,7 +4,7 @@ import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { getConfig } from '../config';
 import { sendEmail } from '../email';
-import { invalidRequest, repo, sendOutcome } from '../fhir';
+import { invalidRequest, systemRepo, sendOutcome } from '../fhir';
 import { generateSecret } from '../oauth';
 
 export const resetPasswordValidators = [body('email').isEmail().withMessage('Valid email address is required')];
@@ -15,7 +15,7 @@ export async function resetPasswordHandler(req: Request, res: Response) {
     return sendOutcome(res, invalidRequest(errors));
   }
 
-  const [existingOutcome, existingBundle] = await repo.search<User>({
+  const [existingOutcome, existingBundle] = await systemRepo.search<User>({
     resourceType: 'User',
     filters: [
       {
@@ -64,7 +64,7 @@ export async function resetPasswordHandler(req: Request, res: Response) {
  */
 export async function resetPassword(user: User): Promise<string> {
   // Create the password change request
-  const [createOutcome, pcr] = await repo.createResource<PasswordChangeRequest>({
+  const [createOutcome, pcr] = await systemRepo.createResource<PasswordChangeRequest>({
     resourceType: 'PasswordChangeRequest',
     user: createReference(user),
     secret: generateSecret(16),

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -1,7 +1,7 @@
 import { assertOk, createReference } from '@medplum/core';
 import { Login, Practitioner, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import { Response } from 'express';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 import { logger } from '../logger';
 import { getUserMemberships } from '../oauth';
@@ -14,7 +14,7 @@ export interface NewAccountRequest {
 
 export async function createPractitioner(request: NewAccountRequest, project: Project): Promise<Practitioner> {
   logger.info(`Create practitioner: ${request.firstName} ${request.lastName}`);
-  const [outcome, result] = await repo.createResource<Practitioner>({
+  const [outcome, result] = await systemRepo.createResource<Practitioner>({
     resourceType: 'Practitioner',
     meta: {
       project: project.id,
@@ -45,7 +45,7 @@ export async function createProjectMembership(
   admin: boolean
 ): Promise<ProjectMembership> {
   logger.info('Create project membership: ' + project.name);
-  const [outcome, result] = await repo.createResource<ProjectMembership>({
+  const [outcome, result] = await systemRepo.createResource<ProjectMembership>({
     resourceType: 'ProjectMembership',
     project: createReference(project),
     user: createReference(user),
@@ -77,7 +77,7 @@ export async function sendLoginResult(res: Response, login: Login): Promise<void
       profile: m.profile,
     }));
     res.status(200).json(
-      await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, {
+      await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, {
         login: login?.id,
         memberships: redactedMemberships,
       })

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -5,13 +5,22 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { seedDatabase } from '../seed';
 import { processBatch } from './batch';
-import { repo, Repository } from './repo';
+import { Repository } from './repo';
+
+let repo: Repository;
 
 describe('Batch', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initDatabase(config.database);
     await seedDatabase();
+
+    repo = new Repository({
+      project: randomUUID(),
+      author: {
+        reference: 'ClientApplication/' + randomUUID(),
+      },
+    });
   });
 
   afterAll(async () => {

--- a/packages/server/src/fhir/graphql.test.ts
+++ b/packages/server/src/fhir/graphql.test.ts
@@ -6,7 +6,7 @@ import { closeDatabase, initDatabase } from '../database';
 import { initTestAuth } from '../jest.setup';
 import { initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
-import { repo } from './repo';
+import { systemRepo } from './repo';
 
 const app = express();
 let accessToken: string;
@@ -21,7 +21,7 @@ describe('GraphQL', () => {
     accessToken = await initTestAuth();
 
     // Creat a simple patient
-    await repo.updateResource({
+    await systemRepo.updateResource({
       resourceType: 'Patient',
       id: '8a54c7db-654b-4c3d-ba85-e0909f51c12b',
       name: [
@@ -33,7 +33,7 @@ describe('GraphQL', () => {
     });
 
     // Create an encounter referring to the patient
-    await repo.updateResource({
+    await systemRepo.updateResource({
       resourceType: 'Encounter',
       id: '1ef2b1fc-74d9-491c-8e5e-595a9d460043',
       class: {
@@ -45,7 +45,7 @@ describe('GraphQL', () => {
     });
 
     // Create an encounter referring to missing patient
-    await repo.updateResource({
+    await systemRepo.updateResource({
       resourceType: 'Encounter',
       id: '1ef2b1fc-74d9-491c-8e5e-595a9d460044',
       class: {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1033,7 +1033,7 @@ export class Repository {
       const patientId = getPatientId(updated);
       if (patientId) {
         // If the resource is in a patient compartment, then lookup the patient.
-        const [patientOutcome, patient] = await repo.readResource('Patient', patientId);
+        const [patientOutcome, patient] = await systemRepo.readResource('Patient', patientId);
         if (isOk(patientOutcome) && patient?.meta?.account) {
           // If the patient has an account, then use it as the resource account.
           return patient.meta.account;
@@ -1189,7 +1189,7 @@ export async function getRepoForLogin(login: Login): Promise<Repository> {
   }
 
   if (login.accessPolicy) {
-    const [accessPolicyOutcome, accessPolicyResource] = await repo.readReference(login.accessPolicy);
+    const [accessPolicyOutcome, accessPolicyResource] = await systemRepo.readReference(login.accessPolicy);
     assertOk(accessPolicyOutcome);
     accessPolicy = accessPolicyResource as AccessPolicy;
   }
@@ -1209,7 +1209,7 @@ export async function getRepoForLogin(login: Login): Promise<Repository> {
         profileType.startsWith('ClientApplication') ||
         profileType.startsWith('Subscription'))
     ) {
-      const [profileOutcome, profileResource] = await repo.readReference(login.profile);
+      const [profileOutcome, profileResource] = await systemRepo.readReference(login.profile);
       assertOk(profileOutcome);
       if (profileResource?.meta?.account) {
         accessPolicy = buildSyntheticAccessPolicy(profileResource.meta.account);
@@ -1250,7 +1250,7 @@ function buildSyntheticAccessPolicy(compartment: Reference): AccessPolicy {
   };
 }
 
-export const repo = new Repository({
+export const systemRepo = new Repository({
   author: {
     reference: 'system',
   },

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -3,7 +3,7 @@ import { Binary, Practitioner } from '@medplum/fhirtypes';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { seedDatabase } from '../seed';
-import { repo } from './repo';
+import { systemRepo } from './repo';
 import { rewriteAttachments, RewriteMode } from './rewrite';
 
 describe('URL rewrite', () => {
@@ -15,7 +15,7 @@ describe('URL rewrite', () => {
     await initDatabase(config.database);
     await seedDatabase();
 
-    const [outcome, resource] = await repo.createResource({
+    const [outcome, resource] = await systemRepo.createResource({
       resourceType: 'Binary',
     });
     assertOk(outcome);
@@ -27,12 +27,12 @@ describe('URL rewrite', () => {
   });
 
   test('Null', async () => {
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, null);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, null);
     expect(result).toBeNull();
   });
 
   test('Undefined', async () => {
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, undefined);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, undefined);
     expect(result).toBeUndefined();
   });
 
@@ -47,7 +47,7 @@ describe('URL rewrite', () => {
       ],
     };
 
-    const output = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, input);
+    const output = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, input);
     expect(output).toMatchObject(input);
   });
 
@@ -62,7 +62,7 @@ describe('URL rewrite', () => {
       ],
     };
 
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, practitioner);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, practitioner);
     expect(result).toMatchObject(practitioner);
   });
 
@@ -77,7 +77,7 @@ describe('URL rewrite', () => {
       ],
     };
 
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, practitioner);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, practitioner);
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('Practitioner');
     expect(result.photo).toBeDefined();
@@ -98,7 +98,7 @@ describe('URL rewrite', () => {
       ],
     };
 
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, practitioner);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, practitioner);
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('Practitioner');
     expect(result.photo).toBeDefined();
@@ -119,7 +119,7 @@ describe('URL rewrite', () => {
       ],
     };
 
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, practitioner);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, practitioner);
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('Practitioner');
     expect(result.photo).toBeDefined();
@@ -140,7 +140,7 @@ describe('URL rewrite', () => {
       ],
     };
 
-    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, practitioner);
+    const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, practitioner);
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('Practitioner');
     expect(result.photo).toBeDefined();

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -9,7 +9,7 @@ import { closeDatabase, initDatabase } from '../database';
 import { initTestAuth } from '../jest.setup';
 import { initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
-import { repo } from './repo';
+import { systemRepo } from './repo';
 
 const app = express();
 let accessToken: string;
@@ -26,7 +26,7 @@ describe('FHIR Routes', () => {
     await initKeys(config);
     accessToken = await initTestAuth();
 
-    const [outcome, patient] = await repo.createResource({
+    const [outcome, patient] = await systemRepo.createResource({
       resourceType: 'Patient',
       name: [
         {

--- a/packages/server/src/jest.setup.ts
+++ b/packages/server/src/jest.setup.ts
@@ -1,11 +1,11 @@
 import { assertOk, createReference, isOk } from '@medplum/core';
 import { ClientApplication, Login, Project } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
-import { repo } from './fhir';
+import { systemRepo } from './fhir';
 import { generateAccessToken } from './oauth';
 
 export async function createTestClient(): Promise<ClientApplication> {
-  const [projectOutcome, project] = await repo.createResource<Project>({
+  const [projectOutcome, project] = await systemRepo.createResource<Project>({
     resourceType: 'Project',
     name: 'Test Project',
     owner: {
@@ -14,7 +14,7 @@ export async function createTestClient(): Promise<ClientApplication> {
   });
   assertOk(projectOutcome);
 
-  const [clientOutcome, client] = await repo.createResource<ClientApplication>({
+  const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
     resourceType: 'ClientApplication',
     secret: randomUUID(),
     redirectUri: 'https://example.com/',
@@ -30,7 +30,7 @@ export async function initTestAuth() {
   const client = await createTestClient();
   const scope = 'openid';
 
-  const [loginOutcome, login] = await repo.createResource<Login>({
+  const [loginOutcome, login] = await systemRepo.createResource<Login>({
     resourceType: 'Login',
     client: createReference(client),
     profile: createReference(client),

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -2,7 +2,7 @@ import { getDateProperty, isOk, Operator } from '@medplum/core';
 import { ClientApplication, Login, OperationOutcome } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { asyncWrap } from '../async';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { logger } from '../logger';
 import { renderTemplate } from '../templates';
 import { MedplumIdTokenClaims, verifyJwt } from './keys';
@@ -71,7 +71,7 @@ export const authorizePostHandler = asyncWrap(async (req: Request, res: Response
 async function validateAuthorizeRequest(req: Request, res: Response): Promise<boolean> {
   // First validate the client and the redirect URI.
   // If these are invalid, then show an error page.
-  const [clientOutcome, client] = await repo.readResource<ClientApplication>(
+  const [clientOutcome, client] = await systemRepo.readResource<ClientApplication>(
     'ClientApplication',
     req.query.client_id as string
   );
@@ -125,7 +125,7 @@ async function validateAuthorizeRequest(req: Request, res: Response): Promise<bo
   }
 
   if (prompt !== 'login' && existingLogin) {
-    await repo.updateResource<Login>({
+    await systemRepo.updateResource<Login>({
       ...existingLogin,
       nonce: req.query.nonce as string,
       granted: false,
@@ -190,7 +190,7 @@ async function getExistingLoginFromIdTokenHint(req: Request): Promise<Login | un
     return undefined;
   }
 
-  const [existingOutcome, existing] = await repo.readResource<Login>('Login', existingLoginId);
+  const [existingOutcome, existing] = await systemRepo.readResource<Login>('Login', existingLoginId);
   if (!isOk(existingOutcome) || !existing) {
     return undefined;
   }
@@ -211,7 +211,7 @@ async function getExistingLoginFromCookie(req: Request, client: ClientApplicatio
     return undefined;
   }
 
-  const [outcome, bundle] = await repo.search({
+  const [outcome, bundle] = await systemRepo.search({
     resourceType: 'Login',
     filters: [
       {

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -14,7 +14,7 @@ import {
   SignJWT,
 } from 'jose';
 import { MedplumServerConfig } from '../config';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { logger } from '../logger';
 
 export interface MedplumBaseClaims extends JWTPayload {
@@ -94,7 +94,7 @@ export async function initKeys(config: MedplumServerConfig) {
     throw new Error('Missing issuer');
   }
 
-  const [searchOutcome, searchResult] = await repo.search({
+  const [searchOutcome, searchResult] = await systemRepo.search({
     resourceType: 'JsonWebKey',
     filters: [{ code: 'active', operator: Operator.EQUALS, value: 'true' }],
   });
@@ -114,7 +114,7 @@ export async function initKeys(config: MedplumServerConfig) {
     logger.info('No keys found.  Creating new key...');
     const keyResult = await generateKeyPair(ALG);
     const jwk = await exportJWK(keyResult.privateKey);
-    const [createOutcome, createResult] = await repo.createResource<JsonWebKey>({
+    const [createOutcome, createResult] = await systemRepo.createResource<JsonWebKey>({
       resourceType: 'JsonWebKey',
       active: true,
       ...jwk,

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { createTestClient } from '../jest.setup';
 import { initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
@@ -32,7 +32,7 @@ describe('Auth middleware', () => {
   test('Success', async () => {
     const scope = 'openid';
 
-    const [loginOutcome, login] = await repo.createResource<Login>({
+    const [loginOutcome, login] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       profile: createReference(client),
@@ -76,7 +76,7 @@ describe('Auth middleware', () => {
   test('Login revoked', async () => {
     const scope = 'openid';
 
-    const [loginOutcome, login] = await repo.createResource<Login>({
+    const [loginOutcome, login] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       profile: createReference(client),

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -1,7 +1,7 @@
 import { createReference, getReferenceString, isOk } from '@medplum/core';
 import { ClientApplication, Login } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response } from 'express';
-import { getRepoForLogin, repo } from '../fhir';
+import { getRepoForLogin, systemRepo } from '../fhir';
 import { logger } from '../logger';
 import { MedplumAccessTokenClaims, verifyJwt } from './keys';
 
@@ -26,7 +26,7 @@ async function authenticateBearerToken(req: Request, res: Response, next: NextFu
   try {
     const verifyResult = await verifyJwt(token);
     const claims = verifyResult.payload as MedplumAccessTokenClaims;
-    const [loginOutcome, login] = await repo.readResource<Login>('Login', claims.login_id);
+    const [loginOutcome, login] = await systemRepo.readResource<Login>('Login', claims.login_id);
     if (!isOk(loginOutcome) || !login || login.revoked) {
       res.sendStatus(401);
       return;
@@ -52,7 +52,7 @@ async function authenticateBasicAuth(req: Request, res: Response, next: NextFunc
     return;
   }
 
-  const [outcome, client] = await repo.readResource<ClientApplication>('ClientApplication', username);
+  const [outcome, client] = await systemRepo.readResource<ClientApplication>('ClientApplication', username);
   if (!isOk(outcome) || !client) {
     res.sendStatus(401);
     return;

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 import { initApp } from '../app';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { seedDatabase } from '../seed';
 import { initKeys } from './keys';
 import { hashCode } from './token';
@@ -23,7 +23,7 @@ describe('OAuth2 Token', () => {
     await initApp(app);
     await initKeys(config);
 
-    const [outcome, resource] = await repo.createResource<ClientApplication>({
+    const [outcome, resource] = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       secret: randomUUID(),
       redirectUri: 'https://example.com/',
@@ -121,7 +121,7 @@ describe('OAuth2 Token', () => {
 
   test('Token for client empty secret', async () => {
     // Create a client without an secret
-    const [outcome, badClient] = await repo.createResource<ClientApplication>({
+    const [outcome, badClient] = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       name: 'Bad Client',
       description: 'Bad Client',

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -3,7 +3,7 @@ import { ClientApplication, Login } from '@medplum/fhirtypes';
 import { createHash } from 'crypto';
 import { Request, RequestHandler, Response } from 'express';
 import { asyncWrap } from '../async';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { generateAccessToken, MedplumRefreshTokenClaims, verifyJwt } from './keys';
 import { getAuthTokens, getReferenceIdPart, revokeLogin } from './utils';
 
@@ -57,7 +57,7 @@ async function handleClientCredentials(req: Request, res: Response): Promise<Res
     return sendTokenError(res, 'invalid_request', 'Missing client_secret');
   }
 
-  const [readOutcome, client] = await repo.readResource<ClientApplication>('ClientApplication', clientId);
+  const [readOutcome, client] = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
   if (!isOk(readOutcome) || !client) {
     return sendTokenError(res, 'invalid_request', 'Invalid client');
   }
@@ -72,7 +72,7 @@ async function handleClientCredentials(req: Request, res: Response): Promise<Res
 
   const scope = req.body.scope as string;
 
-  const [loginOutcome, login] = await repo.createResource<Login>({
+  const [loginOutcome, login] = await systemRepo.createResource<Login>({
     resourceType: 'Login',
     client: createReference(client),
     profile: createReference(client),
@@ -115,7 +115,7 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<Res
     return sendTokenError(res, 'invalid_request', 'Missing code');
   }
 
-  const [searchOutcome, searchResult] = await repo.search({
+  const [searchOutcome, searchResult] = await systemRepo.search({
     resourceType: 'Login',
     filters: [
       {
@@ -201,7 +201,7 @@ async function handleRefreshToken(req: Request, res: Response): Promise<Response
     return sendTokenError(res, 'invalid_request', 'Invalid refresh token');
   }
 
-  const [loginOutcome, login] = await repo.readResource<Login>('Login', claims.login_id);
+  const [loginOutcome, login] = await systemRepo.readResource<Login>('Login', claims.login_id);
   if (!isOk(loginOutcome) || !login) {
     return sendTokenError(res, 'invalid_request', 'Invalid token');
   }

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -10,7 +10,7 @@ import {
 } from '@medplum/core';
 import { Request, RequestHandler, Response } from 'express';
 import { asyncWrap } from '../async';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 
 /**
  * Handles the OAuth/OpenID UserInfo Endpoint.
@@ -21,7 +21,7 @@ export const userInfoHandler: RequestHandler = asyncWrap(async (req: Request, re
     sub: res.locals.user,
   };
 
-  const [outcome, resource] = await repo.readReference({
+  const [outcome, resource] = await systemRepo.readReference({
     reference: res.locals.profile,
   });
   if (!isOk(outcome) || !resource) {

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -3,7 +3,7 @@ import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Project, SearchParameter, User } from '@medplum/fhirtypes';
 import { registerNew } from './auth/register';
 import { getConfig } from './config';
-import { repo } from './fhir';
+import { systemRepo } from './fhir';
 import { logger } from './logger';
 import { createStructureDefinitions } from './seeds/structuredefinitions';
 import { createValueSetElements } from './seeds/valuesets';
@@ -23,7 +23,7 @@ export async function seedDatabase(): Promise<void> {
     password: 'admin',
   });
 
-  await repo.updateResource({
+  await systemRepo.updateResource({
     ...registerResponse.client,
     redirectUri: getConfig().appBaseUrl,
   });
@@ -39,7 +39,7 @@ export async function seedDatabase(): Promise<void> {
  * @returns True if already seeded.
  */
 async function isSeeded(): Promise<boolean> {
-  const [outcome, bundle] = await repo.search({
+  const [outcome, bundle] = await systemRepo.search({
     resourceType: 'User',
     count: 1,
   });
@@ -54,7 +54,7 @@ async function isSeeded(): Promise<boolean> {
  */
 async function createPublicProject(owner: User): Promise<void> {
   logger.info('Create Public project...');
-  const [outcome, result] = await repo.createResource<Project>({
+  const [outcome, result] = await systemRepo.createResource<Project>({
     resourceType: 'Project',
     name: 'Public',
     owner: createReference(owner),
@@ -73,7 +73,7 @@ async function createSearchParameters(): Promise<void> {
     const searchParam = entry.resource as SearchParameter;
 
     logger.debug('SearchParameter: ' + searchParam.name);
-    const [outcome, result] = await repo.createResource<SearchParameter>({
+    const [outcome, result] = await systemRepo.createResource<SearchParameter>({
       ...searchParam,
       text: undefined,
     });

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -2,7 +2,7 @@ import { isOk, OperationOutcomeError } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
 import { getClient } from '../database';
-import { repo } from '../fhir';
+import { systemRepo } from '../fhir';
 import { logger } from '../logger';
 
 /**
@@ -21,7 +21,7 @@ async function createStructureDefinitionsForBundle(structureDefinitions: Bundle)
 
     if (resource.resourceType === 'StructureDefinition' && resource.name) {
       logger.debug('StructureDefinition: ' + resource.name);
-      const [outcome, result] = await repo.createResource<StructureDefinition>({
+      const [outcome, result] = await systemRepo.createResource<StructureDefinition>({
         ...resource,
         text: undefined,
       });

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -7,7 +7,7 @@ import request from 'supertest';
 import { initApp } from './app';
 import { loadTestConfig } from './config';
 import { closeDatabase, initDatabase } from './database';
-import { getBinaryStorage, initBinaryStorage, repo } from './fhir';
+import { getBinaryStorage, initBinaryStorage, systemRepo } from './fhir';
 import { seedDatabase } from './seed';
 
 const app = express();
@@ -22,7 +22,7 @@ describe('Storage Routes', () => {
     await initApp(app);
     await initBinaryStorage('file:' + binaryDir);
 
-    const [outcome, resource] = await repo.createResource<Binary>({
+    const [outcome, resource] = await systemRepo.createResource<Binary>({
       resourceType: 'Binary',
       contentType: 'text/plain',
     });

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -2,11 +2,13 @@ import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from './async';
-import { repo } from './fhir/repo';
+import { systemRepo } from './fhir/repo';
 import { getBinaryStorage } from './fhir/storage';
 
 export const storageRouter = Router();
 
+// This endpoint emulates CloudFront storage for localhost development.
+// It is not intended for production use.
 storageRouter.get(
   '/:id/:versionId?',
   asyncWrap(async (req: Request, res: Response) => {
@@ -16,7 +18,7 @@ storageRouter.get(
     }
 
     const { id } = req.params;
-    const [outcome, resource] = await repo.readResource('Binary', id);
+    const [outcome, resource] = await systemRepo.readResource('Binary', id);
     assertOk(outcome);
 
     const binary = resource as Binary;


### PR DESCRIPTION
Renamed the global `repo` to `systemRepo`.

The `systemRepo` global is a `Repository` instance, which allows access as the `system` identity.  This is often necessary for touching system primitives such as `User`, `Project`, etc.

On any HTTP request, the authentication middleware creates a `Repository` configured for the user, and sets it on `res.locals.repo`:

https://github.com/medplum/medplum/blob/main/packages/server/src/oauth/middleware.ts#L38

Why rename this? Two reasons:
1. Psychological.  If using `systemRepo`, we want it to be very clear to the developer that they're doing something potentially risky.
2. Practical.  In some tests, we used `repo` as the system repo, and in other tests, we used `repo` as an instance scoped to a `User` or `ClienitApplication`.  Now that `systemRepo` is renamed, we can more easily clean up that ambiguity.