### PR TITLE
Remove all references to __key

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -139,14 +139,11 @@ export function stringify(value: any, pretty?: boolean): string {
  * Evaluates JSON key/value pairs for FHIR JSON stringify.
  * Removes properties with empty string values.
  * Removes objects with zero properties.
- * Replaces any key/value pair of key "__key" with value undefined.
- * This function can be used as the 2nd argument to stringify to remove __key properties.
- * We add __key properties to array elements to improve React render performance.
  * @param {string} k Property key.
  * @param {*} v Property value.
  */
 function stringifyReplacer(k: string, v: any): any {
-  return k === '__key' || isEmpty(v) ? undefined : v;
+  return isEmpty(v) ? undefined : v;
 }
 
 /**


### PR DESCRIPTION
Once upon a time, we added lots of `"__key"` properties to in-memory objects.  There were two reasons:
1. We used it internally for "add", "remove", "move up", "move down" operations, where the notion of "identity" can be non-obvious.
2. We used it for React rendering.  If there are an array of objects, you need a `"key"` attribute on the component for the React runtime to understand which components changed vs stayed the same.

After littering objects with private `"__key"` properties, we then had to clean them out, using this `stringReplacer` method.

Since those times, we have moved to a model that doesn't rely on DOM state, and generally bypasses all of these concerns.

The last remaining vestiges were in `<QuestionnaireBuilder>`, which were cleaned out in https://github.com/medplum/medplum/commit/f61a056cfef2a2c765677b0aecde1844e2a05515

And now we can finally purge `__key` from the code base.