### PR TITLE
Fixed storybook deploy

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,7 +16,7 @@
     "build": "npm run clean && tsc && npm run copyfiles",
     "test": "jest",
     "copyfiles": "copyfiles -u 1 \"./src/**/*.css\" dist",
-    "storybook": "build-storybook -s public"
+    "storybook": "build-storybook"
   },
   "devDependencies": {
     "@medplum/core": "0.3.0",


### PR DESCRIPTION
See broken build: https://github.com/medplum/medplum/runs/4643889199?check_suite_focus=true

```
ERR! Error: Conflict when trying to read staticDirs:
ERR! * Storybook's configuration option: 'staticDirs'
ERR! * Storybook's CLI flag: '--staticDir' or '-s'
ERR! 
ERR! Choose one of them, but not both.
ERR!     at buildStaticStandalone (/home/runner/work/medplum/medplum/node_modules/@storybook/core-server/dist/cjs/build-static.js:104:11)
ERR!     at async buildStatic (/home/runner/work/medplum/medplum/node_modules/@storybook/core-server/dist/cjs/build-static.js:195:5)
ERR!  Error: Conflict when trying to read staticDirs:
ERR! * Storybook's configuration option: 'staticDirs'
ERR! * Storybook's CLI flag: '--staticDir' or '-s'
ERR! 
ERR! Choose one of them, but not both.
ERR!     at buildStaticStandalone (/home/runner/work/medplum/medplum/node_modules/@storybook/core-server/dist/cjs/build-static.js:104:11)
ERR!     at async buildStatic (/home/runner/work/medplum/medplum/node_modules/@storybook/core-server/dist/cjs/build-static.js:195:5)
Error: Process completed with exit code 1.
```