### PR TITLE
Support Coding in ResourcePropertyDisplay

### DIFF
--- a/packages/ui/src/CodeableConceptDisplay.tsx
+++ b/packages/ui/src/CodeableConceptDisplay.tsx
@@ -1,5 +1,6 @@
 import { CodeableConcept } from '@medplum/fhirtypes';
 import React from 'react';
+import { CodingDisplay } from './CodingDisplay';
 
 export interface CodeableConceptInputProps {
   value?: CodeableConcept;
@@ -11,6 +12,13 @@ export function CodeableConceptDisplay(props: CodeableConceptInputProps) {
     return null;
   }
 
-  const text = value.text ?? value.coding?.[0]?.display ?? value.coding?.[0]?.code;
-  return <>{text}</>;
+  if (value.text) {
+    return <>{value.text}</>;
+  }
+
+  if (value.coding && value.coding.length > 0) {
+    return <CodingDisplay value={value.coding[0]} />;
+  }
+
+  return null;
 }

--- a/packages/ui/src/CodingDisplay.test.tsx
+++ b/packages/ui/src/CodingDisplay.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { CodingDisplay } from './CodingDisplay';
+
+describe('CodingDisplay', () => {
+  test('Renders display', () => {
+    render(<CodingDisplay value={{ display: 'Display Text', code: '123' }} />);
+    expect(screen.getByText('Display Text')).toBeInTheDocument();
+    expect(screen.queryByText('123')).not.toBeInTheDocument();
+  });
+
+  test('Renders code', () => {
+    render(<CodingDisplay value={{ code: '123' }} />);
+    expect(screen.getByText('123')).toBeInTheDocument();
+  });
+
+  test('Renders undefined value', () => {
+    render(<CodingDisplay />);
+  });
+});

--- a/packages/ui/src/CodingDisplay.tsx
+++ b/packages/ui/src/CodingDisplay.tsx
@@ -1,0 +1,10 @@
+import { Coding } from '@medplum/fhirtypes';
+import React from 'react';
+
+export interface CodingDisplayProps {
+  value?: Coding;
+}
+
+export function CodingDisplay(props: CodingDisplayProps) {
+  return <>{props.value?.display || props.value?.code}</>;
+}

--- a/packages/ui/src/CodingInput.tsx
+++ b/packages/ui/src/CodingInput.tsx
@@ -1,6 +1,7 @@
 import { Coding, ElementDefinition, ValueSet, ValueSetExpansion, ValueSetExpansionContains } from '@medplum/fhirtypes';
 import React from 'react';
 import { Autocomplete } from './Autocomplete';
+import { CodingDisplay } from './CodingDisplay';
 import { useMedplum } from './MedplumProvider';
 
 export interface CodingInputProps {
@@ -35,7 +36,7 @@ export function CodingInput(props: CodingInputProps) {
       }}
       buildUnstructured={(str: string) => ({ code: str })}
       getId={(item: Coding) => item.code as string}
-      getDisplay={(item: Coding) => <>{item.display || item.code}</>}
+      getDisplay={(item: Coding) => <CodingDisplay value={item} />}
       name={props.name}
       defaultValue={defaultValue}
       onChange={(values: Coding[]) => {

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -4,6 +4,7 @@ import {
   Annotation,
   Attachment,
   CodeableConcept,
+  Coding,
   ContactPoint,
   ElementDefinition,
   HumanName,
@@ -1100,6 +1101,24 @@ describe('ResourcePropertyDisplay', () => {
     );
 
     expect(screen.getByText('foo')).toBeDefined();
+  });
+
+  test('Renders Coding', () => {
+    const value: Coding = {
+      display: 'Test Coding',
+      code: 'test-coding',
+    };
+
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Coding' }] }}
+        propertyType={PropertyType.Coding}
+        value={value}
+      />
+    );
+
+    expect(screen.getByText('Test Coding')).toBeDefined();
   });
 
   test('Renders ContactPoint', () => {

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -6,6 +6,7 @@ import { AttachmentArrayDisplay } from './AttachmentArrayDisplay';
 import { AttachmentDisplay } from './AttachmentDisplay';
 import { BackboneElementDisplay } from './BackboneElementDisplay';
 import { CodeableConceptDisplay } from './CodeableConceptDisplay';
+import { CodingDisplay } from './CodingDisplay';
 import { ContactPointDisplay } from './ContactPointDisplay';
 import { HumanNameDisplay } from './HumanNameDisplay';
 import { IdentifierDisplay } from './IdentifierDisplay';
@@ -66,6 +67,8 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps) {
       return <AttachmentDisplay value={value} maxWidth={props.maxWidth} />;
     case PropertyType.CodeableConcept:
       return <CodeableConceptDisplay value={value} />;
+    case PropertyType.Coding:
+      return <CodingDisplay value={value} />;
     case PropertyType.ContactPoint:
       return <ContactPointDisplay value={value} />;
     case PropertyType.HumanName:


### PR DESCRIPTION
This fixes "Schema not found" in Questionnaires.  The reason is interesting.

There are 3 important distinct concepts when it comes to "coding":
* [code](https://www.hl7.org/fhir/datatypes.html#code) - a string value
* [Coding](https://www.hl7.org/fhir/datatypes.html#Coding) - an object that contains a `code` and optionally a `display`
* [CodeableConcept](https://www.hl7.org/fhir/datatypes.html#CodeableConcept) - an object that can contain multiple `Coding` objects and optional text description

Most FHIR properties are either `code` or `CodeableConcept`, but there are some `Coding` - 40 to be exact.  See below.

Before, when we rendered an object with a `Coding` property, we rendered a confusing "Schema not found" message.

Now, we render the value.

Fixed properties:

- AuditEvent type
- AuditEvent subtype
- AuditEventAgent media
- AuditEventSource type
- AuditEventEntity type
- AuditEventEntity role
- AuditEventEntity lifecycle
- AuditEventEntity securityLabel
- CapabilityStatementMessagingEndpoint protocol
- CodeSystemConceptDesignation use
- ConsentProvision securityLabel
- ConsentProvision purpose
- ConsentProvision class
- ContractTermSecurityLabel classification
- ContractTermSecurityLabel category
- ContractTermSecurityLabel control
- ContractTermAsset relationship
- ContractSigner type
- DocumentReferenceContent format
- Encounter class
- EncounterClassHistory class
- Endpoint connectionType
- ExplanationOfBenefitSupportingInfo reason
- ImagingStudy modality
- ImagingStudySeries modality
- ImagingStudySeries bodySite
- ImagingStudySeries laterality
- ImagingStudySeriesInstance sopClass
- Location operationalStatus
- MedicinalProduct domain
- MedicinalProductNameNamePart type
- MessageDefinition event[x]
- MessageHeader event[x]
- Questionnaire code
- QuestionnaireItem code
- StructureDefinition keyword
- TestScriptOrigin profile
- TestScriptDestination profile
- TestScriptSetupActionOperation type
- ValueSetComposeIncludeConceptDesignation use