### PR TITLE
Use @medplum/fhirtypes in codegen

### DIFF
--- a/packages/generator/src/docs.ts
+++ b/packages/generator/src/docs.ts
@@ -1,16 +1,12 @@
 import {
-  Bundle,
-  BundleEntry,
-  ElementDefinition,
   getExpressionForResourceType,
   IndexedStructureDefinition,
   indexStructureDefinition,
   isLowerCase,
-  Resource,
-  SearchParameter,
   TypeSchema,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
+import { Bundle, BundleEntry, ElementDefinition, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { writeFileSync } from 'fs';
 import { resolve } from 'path/posix';
 import { FileBuilder } from './filebuilder';

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -1,15 +1,6 @@
-import {
-  Bundle,
-  BundleEntry,
-  capitalize,
-  ElementDefinition,
-  ElementDefinitionType,
-  IndexedStructureDefinition,
-  indexStructureDefinition,
-  Resource,
-  TypeSchema,
-} from '@medplum/core';
+import { capitalize, IndexedStructureDefinition, indexStructureDefinition, TypeSchema } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
+import { Bundle, BundleEntry, ElementDefinition, ElementDefinitionType, Resource } from '@medplum/fhirtypes';
 import { mkdirSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { FileBuilder, wordWrap } from './filebuilder';

--- a/packages/generator/src/migrate.ts
+++ b/packages/generator/src/migrate.ts
@@ -1,16 +1,14 @@
 import {
-  Bundle,
-  BundleEntry,
   getSearchParameterDetails,
   IndexedStructureDefinition,
   indexStructureDefinition,
   isLowerCase,
-  Resource,
   SearchParameterDetails,
   SearchParameterType,
   TypeSchema,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
+import { Bundle, BundleEntry, Resource } from '@medplum/fhirtypes';
 import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { FileBuilder } from './filebuilder';


### PR DESCRIPTION
No production impact.  The `generator` project is used during development to generate code from FHIR spec files.