### PR TITLE
Account for scrollbar width in popup position

### DIFF
--- a/packages/ui/src/Popup.test.tsx
+++ b/packages/ui/src/Popup.test.tsx
@@ -69,8 +69,13 @@ describe('Popup', () => {
   });
 
   test('Anchor happy path', () => {
-    window.innerWidth = 1600;
-    window.innerHeight = 900;
+    // window.innerWidth and window.innerHeight include scrollbars
+    window.innerWidth = 1650;
+    window.innerHeight = 950;
+
+    // document.body.clientWidth and document.body.clientHeight do not include scrollbars
+    Object.defineProperty(document.body, 'clientWidth', { value: 1600 });
+    Object.defineProperty(document.body, 'clientHeight', { value: 900 });
 
     const anchor = { left: 10, right: 20, top: 10, bottom: 20 } as DOMRectReadOnly;
 
@@ -87,8 +92,13 @@ describe('Popup', () => {
   });
 
   test('Anchor flip horizontal', () => {
-    window.innerWidth = 1600;
-    window.innerHeight = 900;
+    // window.innerWidth and window.innerHeight include scrollbars
+    window.innerWidth = 1650;
+    window.innerHeight = 950;
+
+    // document.body.clientWidth and document.body.clientHeight do not include scrollbars
+    Object.defineProperty(document.body, 'clientWidth', { value: 1600 });
+    Object.defineProperty(document.body, 'clientHeight', { value: 900 });
 
     const anchor = { left: 1400, right: 1500, top: 10, bottom: 20 } as DOMRectReadOnly;
 

--- a/packages/ui/src/Popup.tsx
+++ b/packages/ui/src/Popup.tsx
@@ -61,16 +61,16 @@ export function Popup(props: PopupProps) {
   };
 
   if (props.anchor) {
-    if (props.anchor.right + 250 < window.innerWidth) {
+    if (props.anchor.right + 250 < document.body.clientWidth) {
       style.left = props.anchor.right + 'px';
     } else {
-      style.right = window.innerWidth - props.anchor.left + 'px';
+      style.right = document.body.clientWidth - props.anchor.left + 'px';
     }
 
-    if (props.anchor.top + 300 < window.innerHeight) {
+    if (props.anchor.top + 300 < document.body.clientHeight) {
       style.top = props.anchor.top + 'px';
     } else {
-      style.bottom = window.innerHeight - props.anchor.top + 'px';
+      style.bottom = document.body.clientHeight - props.anchor.top + 'px';
     }
   }
 


### PR DESCRIPTION
Consider a popup menu, which doesn't fit to the right, so it wraps around to the left:

![image](https://user-images.githubusercontent.com/749094/147793649-3855f560-50b7-44a1-b0cb-6f7a3b0221ab.png)

We use simple math to determine the desired position.  Sub menu X = window width - parent window width - sub menu width.

The bug:  For "window width" we used `window.innerWidth`, which also includes the width of the scrollbar.  That resulted in sub menus being too far left:

![image](https://user-images.githubusercontent.com/749094/147793709-dd8336c8-5645-4909-9616-8b5a93ce6746.png)

The fix:  Use `document.body.clientWidth` instead of `window.innerWidth`, which does not include the width of the scrollbar.