### PR TITLE
Handle middle click on search control

### DIFF
--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -38,6 +38,7 @@ export function HomePage() {
       checkboxesEnabled={true}
       search={search}
       onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
+      onAuxClick={(e) => window.open(`/${e.resource.resourceType}/${e.resource.id}`, '_blank')}
       onChange={(e) => {
         if (e.definition.resourceType && e.definition.fields && e.definition.fields.length > 0) {
           navigate(`/${search.resourceType}${formatSearchQuery(e.definition)}`);

--- a/packages/ui/src/SearchControl.test.tsx
+++ b/packages/ui/src/SearchControl.test.tsx
@@ -337,6 +337,7 @@ describe('SearchControl', () => {
         ],
       },
       onClick: jest.fn(),
+      onAuxClick: jest.fn(),
     };
 
     setup(props);
@@ -355,6 +356,42 @@ describe('SearchControl', () => {
     });
 
     expect(props.onClick).toBeCalled();
+    expect(props.onAuxClick).not.toBeCalled();
+  });
+
+  test('Aux click on row', async () => {
+    const props = {
+      search: {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: 'Simpson',
+          },
+        ],
+      },
+      onClick: jest.fn(),
+      onAuxClick: jest.fn(),
+    };
+
+    setup(props);
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('search-control'));
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getAllByTestId('search-control-row'));
+    });
+
+    await act(async () => {
+      const rows = screen.getAllByTestId('search-control-row');
+      fireEvent.click(rows[0], { button: 1 });
+    });
+
+    expect(props.onClick).not.toBeCalled();
+    expect(props.onAuxClick).toBeCalled();
   });
 
   test('Open field editor', async () => {

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -104,24 +104,21 @@ export function SearchControl(props: SearchControlProps) {
       });
   }
 
-  function handleSingleCheckboxClick(e: React.ChangeEvent) {
+  function handleSingleCheckboxClick(e: React.ChangeEvent, id: string): void {
     e.stopPropagation();
 
     const el = e.target as HTMLInputElement;
     const checked = el.checked;
-    const id = el.dataset['id'];
-    if (id) {
-      const newSelected = { ...stateRef.current.selected };
-      if (checked) {
-        newSelected[id] = true;
-      } else {
-        delete newSelected[id];
-      }
-      setState({ ...stateRef.current, selected: newSelected });
+    const newSelected = { ...stateRef.current.selected };
+    if (checked) {
+      newSelected[id] = true;
+    } else {
+      delete newSelected[id];
     }
+    setState({ ...stateRef.current, selected: newSelected });
   }
 
-  function handleAllCheckboxClick(e: React.ChangeEvent) {
+  function handleAllCheckboxClick(e: React.ChangeEvent): void {
     e.stopPropagation();
 
     const el = e.target as HTMLInputElement;
@@ -136,10 +133,9 @@ export function SearchControl(props: SearchControlProps) {
       });
     }
     setState({ ...stateRef.current, selected: newSelected });
-    return true;
   }
 
-  function isAllSelected() {
+  function isAllSelected(): boolean {
     const state = stateRef.current;
     if (!state.searchResponse?.entry || state.searchResponse.entry.length === 0) {
       return false;
@@ -154,21 +150,17 @@ export function SearchControl(props: SearchControlProps) {
 
   /**
    * Handles a click on a column header cell.
-   *
-   * @param {MouseEvent} e The click event.
+   * @param e The click event.
+   * @param key The field key.
    */
-  function handleSortClick(e: React.MouseEvent) {
-    const el = e.currentTarget as HTMLElement;
-    const key = el.dataset['key'];
-    if (key) {
-      setState({
-        ...stateRef.current,
-        popupVisible: true,
-        popupX: e.clientX,
-        popupY: e.clientY,
-        popupField: key,
-      });
-    }
+  function handleSortClick(e: React.MouseEvent, key: string): void {
+    setState({
+      ...stateRef.current,
+      popupVisible: true,
+      popupX: e.clientX,
+      popupY: e.clientY,
+      popupField: key,
+    });
   }
 
   /**
@@ -184,10 +176,10 @@ export function SearchControl(props: SearchControlProps) {
   /**
    * Handles a click on a order row.
    *
-   * @param {MouseEvent} e The click event.
-   * @param {Element} el The click target element.
+   * @param e The click event.
+   * @param resource The FHIR resource.
    */
-  function handleRowClick(e: React.MouseEvent) {
+  function handleRowClick(e: React.MouseEvent, resource: Resource): void {
     if (e.target instanceof HTMLInputElement && e.target.type === 'checkbox') {
       // Ignore clicks on checkboxes
       return;
@@ -195,31 +187,12 @@ export function SearchControl(props: SearchControlProps) {
 
     killEvent(e);
 
-    const el = e.currentTarget as HTMLElement;
-    const id = el.dataset['id'];
-    if (!id) {
-      // Ignore clicks on rows without resource IDs
-      return;
-    }
-
-    const entries = state.searchResponse?.entry;
-    if (!entries) {
-      // Ignore clicks when search results not loaded
-      return;
-    }
-
-    const entry = entries.find((e) => e.resource?.id === id);
-    if (!entry?.resource) {
-      // Ignore clicks if resource not found (?)
-      return;
-    }
-
     if (e.button !== 1 && props.onClick) {
-      props.onClick(new SearchClickEvent(entry.resource, e));
+      props.onClick(new SearchClickEvent(resource, e));
     }
 
     if (e.button === 1 && props.onAuxClick) {
-      props.onAuxClick(new SearchClickEvent(entry.resource, e));
+      props.onAuxClick(new SearchClickEvent(resource, e));
     }
   }
 
@@ -314,7 +287,7 @@ export function SearchControl(props: SearchControlProps) {
               </th>
             )}
             {fields.map((field) => (
-              <th key={field} data-key={field} onClick={(e) => handleSortClick(e)}>
+              <th key={field} onClick={(e) => handleSortClick(e, field)}>
                 {buildFieldNameString(schema, resourceType, field)}
               </th>
             ))}
@@ -322,7 +295,7 @@ export function SearchControl(props: SearchControlProps) {
           <tr>
             {checkboxColumn && <th className="filters medplum-search-icon-cell" />}
             {fields.map((field) => (
-              <th key={field} data-key={field} className="filters">
+              <th key={field} className="filters">
                 <FilterDescription resourceType={resourceType} field={field} filters={props.search.filters} />
               </th>
             ))}
@@ -334,20 +307,18 @@ export function SearchControl(props: SearchControlProps) {
               resource && (
                 <tr
                   key={resource.id}
-                  data-id={resource.id}
                   data-testid="search-control-row"
-                  onClick={handleRowClick}
-                  onAuxClick={handleRowClick}
+                  onClick={(e) => handleRowClick(e, resource)}
+                  onAuxClick={(e) => handleRowClick(e, resource)}
                 >
                   {checkboxColumn && (
                     <td className="medplum-search-icon-cell">
                       <input
                         type="checkbox"
                         value="checked"
-                        data-id={resource.id}
                         data-testid="row-checkbox"
-                        checked={!!(resource.id && state.selected[resource.id])}
-                        onChange={(e) => handleSingleCheckboxClick(e)}
+                        checked={!!state.selected[resource.id as string]}
+                        onChange={(e) => handleSingleCheckboxClick(e, resource.id as string)}
                       />
                     </td>
                   )}


### PR DESCRIPTION
Before: Middle click on a row in `<SearchControl>` (for example, on the app default page) would silently ignore

Now: Middle click opens the resource in a new tab