### PR TITLE
Use <MedplumLink> over <a href>

### DIFF
--- a/packages/app/src/SetPasswordPage.tsx
+++ b/packages/app/src/SetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import { OperationOutcome } from '@medplum/fhirtypes';
-import { Button, Document, Form, FormSection, Logo, TextField, useMedplum } from '@medplum/ui';
+import { Button, Document, Form, FormSection, Logo, MedplumLink, TextField, useMedplum } from '@medplum/ui';
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -55,7 +55,7 @@ export function SetPasswordPage() {
         )}
         {success && (
           <div data-testid="success">
-            Password set. You can now <a href="/signin">sign in</a>.
+            Password set. You can now&nbsp;<MedplumLink to="/signin">sign in</MedplumLink>.
           </div>
         )}
       </Form>

--- a/packages/app/src/admin/EditMembershipPage.tsx
+++ b/packages/app/src/admin/EditMembershipPage.tsx
@@ -1,5 +1,15 @@
 import { AccessPolicy, ElementDefinition, OperationOutcome, ProjectMembership, Reference } from '@medplum/fhirtypes';
-import { Button, Document, Form, FormSection, Loading, ReferenceInput, ResourceBadge, useMedplum } from '@medplum/ui';
+import {
+  Button,
+  Document,
+  Form,
+  FormSection,
+  Loading,
+  MedplumLink,
+  ReferenceInput,
+  ResourceBadge,
+  useMedplum,
+} from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -102,7 +112,7 @@ export function EditMembershipPage() {
             <p>User updated</p>
             <pre>{JSON.stringify(outcome, undefined, 2)}</pre>
             <p>
-              Click <a href={'/admin/project'}>here</a> to return to the project admin page
+              Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
             </p>
           </div>
         )}

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -1,5 +1,5 @@
 import { OperationOutcome } from '@medplum/fhirtypes';
-import { Button, Document, Form, FormSection, Loading, TextField, useMedplum } from '@medplum/ui';
+import { Button, Document, Form, FormSection, Loading, MedplumLink, TextField, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -83,7 +83,7 @@ export function InvitePage() {
             <p>User created</p>
             <p>Email sent</p>
             <p>
-              Click <a href={'/admin/project'}>here</a> to return to the project admin page
+              Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
             </p>
           </div>
         )}

--- a/packages/app/src/admin/ProjectPage.tsx
+++ b/packages/app/src/admin/ProjectPage.tsx
@@ -57,7 +57,7 @@ export function ProjectPage() {
         </tbody>
       </table>
       <hr />
-      <a href={`/admin/projects/${result.project.id}/invite`}>Invite</a>
+      <MedplumLink to={`/admin/projects/${result.project.id}/invite`}>Invite</MedplumLink>
     </Document>
   );
 }


### PR DESCRIPTION
Fixed a few cases of using `<a href="">...</a>` that should have been `<MedplumLink>`

There are a few reasons to prefer `<MedplumLink>`

1. First and foremost, `<Medplum>` link uses `react-router` `navigate()`, which will use intelligent partial rendering within React, so it will load as fast as possible.  Using `<a href="">` will perform a full page reload, re-request static resources, rebuild the React shell, flushes the medplum resource cache... about the worst case possible for performance.

2. `<MedplumLink>` supports linking to a resource rather than a URL.  It's conceptually cleaner.  It removes the burden of "what is the URL for this resource" from the developer.  It's more future-proof, in case the resource URL schema ever changes.

3. In the future, we intend to add hover cards for resource links, which will be done within `<MedplumLink>`.

There are cases where it is OK to use a normal `<a href="">` link.  Notably, it is a URL outside of the app, such as links to docs,  Terms of Service, Privacy Policy, etc.