### PR TITLE
Draft of streaming uploads to S3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,22 +2064,22 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.44.0.tgz",
-      "integrity": "sha512-vv3w5RhAZnT/LfiV0SICvvzv5SAeH61erbwm6FpKC9W7lGdcA6o7F2/Bls44fyMW41awYIRZKoPGZApYCrFR6A==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.45.0.tgz",
+      "integrity": "sha512-9JMAdLNWKlqKb3k2mtI0LRrzrfLfqnbShG5e6Im8+Rj+Br5QhtrJ5WIwvT953S+GGumvBzWE28kQcN1/Ve0flw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/eventstream-serde-browser": "3.40.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.40.0",
         "@aws-sdk/eventstream-serde-node": "3.40.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-blob-browser": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/hash-stream-node": "3.40.0",
+        "@aws-sdk/hash-stream-node": "3.45.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
         "@aws-sdk/md5-js": "3.40.0",
         "@aws-sdk/middleware-apply-body-checksum": "3.40.0",
@@ -2090,9 +2090,9 @@
         "@aws-sdk/middleware-location-constraint": "3.40.0",
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-s3": "3.41.0",
+        "@aws-sdk/middleware-sdk-s3": "3.45.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-ssec": "3.40.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
@@ -2126,15 +2126,15 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.43.0.tgz",
-      "integrity": "sha512-0EHsbZqLziWmZ75PyNh92+SX+7a+h/spOWlS9vmpRrqbHASAPbij8HcPf2ITw7woivgKD2dqh42+nMhutsLmlg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.45.0.tgz",
+      "integrity": "sha512-fwNZa98sbSAJDJSEbGZ0MqevgdgHrGtbu6KWCLuTueiHlkrhejTiOno8A0JiQFz0nYRR7lYTX51YZz+BjWhJjQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -2143,7 +2143,7 @@
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -2173,15 +2173,15 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.43.0.tgz",
-      "integrity": "sha512-sbRJ5ZXF3M8Ch4OzPPxSfqADVeR5suiJvRKS9AE0oO0s0P2P2qG94yBFVd9GR7Hx27lw11S0+npDl3sf9J9t8g==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.45.0.tgz",
+      "integrity": "sha512-bFRU+HTa2Akar5crYydWy3CLhv5uaxvuseIE8ifScA34+CBzIDj6x4pK8qhvq+pB2/4qzlLLX8/GX8yyKjGnww==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -2190,7 +2190,7 @@
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -2219,15 +2219,15 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.44.0.tgz",
-      "integrity": "sha512-85+D0KTGlkN/cu+qEGZLXylHs1KT1qxayxXgJdQWXlq93rdAH4R0W2HcfUclbc4ZKpW9u85cCcl4UnBk3/DLiA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.45.0.tgz",
+      "integrity": "sha512-5Yr5ipb9VxgpbJy666KzEfpd4fsZ3V9EutMtR3jnVGRDb4foVzybBBoD7sU4EI9wBDusV0uGnlMwXVMI4tCVCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -2236,7 +2236,7 @@
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -2267,13 +2267,13 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
-      "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.45.0.tgz",
+      "integrity": "sha512-MfsKg4Wq5KvuGEg+M7kYfl6B3TRhxKeL01+5wtxhYbiLqxzr18mfO8PnBAasXMmYCmEQsSGmFepD7GLOld9uHA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
+        "@aws-sdk/config-resolver": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -2310,14 +2310,14 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
-      "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.45.0.tgz",
+      "integrity": "sha512-D+VGhAg+1i7/WQhfkLn7nWHR+Uyp7FPVAQ/N2MBQvZxGbSSb2agU9DN2FnxeFljOEcGJ7NdJ9YSZCFlJo0bLWA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -2325,9 +2325,9 @@
         "@aws-sdk/middleware-host-header": "3.40.0",
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-sts": "3.40.0",
+        "@aws-sdk/middleware-sdk-sts": "3.45.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -2358,11 +2358,11 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
-      "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.45.0.tgz",
+      "integrity": "sha512-pk+9jWQGvga2jr4aiB/KR1vAI0vPngvo9HqBbKebbJzaBhpA/RwGVWB1ZJch93oG8DBeyKZ0md9eOJRU1BkTIQ==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "@aws-sdk/util-config-provider": "3.40.0",
         "tslib": "^2.3.0"
@@ -2415,13 +2415,13 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
-      "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.45.0.tgz",
+      "integrity": "sha512-lfYh8LVW33de01zzfqs6H+4xr20l+++QtvWG8PwKzEAY/71s344ybrOw7KiVUkCDLLbj3SWEmsMJFvBcrvifbA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.40.0",
         "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
+        "@aws-sdk/credential-provider-sso": "3.45.0",
         "@aws-sdk/credential-provider-web-identity": "3.41.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
@@ -2439,15 +2439,15 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
-      "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.45.0.tgz",
+      "integrity": "sha512-ZNqo0JlA7S4k1bAB+Xb8A3KsmNPWVFMmoY3NC25dgXU4xQLVxy0MucQggnfCqRjvshwI4OEdDQsRgl69n/XErQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.40.0",
         "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-ini": "3.41.0",
+        "@aws-sdk/credential-provider-ini": "3.45.0",
         "@aws-sdk/credential-provider-process": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
+        "@aws-sdk/credential-provider-sso": "3.45.0",
         "@aws-sdk/credential-provider-web-identity": "3.41.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
@@ -2485,11 +2485,11 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
-      "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.45.0.tgz",
+      "integrity": "sha512-FBMn+QA6rI74A90ieQtCJckbKPBxNn4mgR9rzWyi/R6o5gVuu99yJGL03NXtWtm5N4x/1SygBtezY/XL5UU0Mg==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.41.0",
+        "@aws-sdk/client-sso": "3.45.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
         "@aws-sdk/types": "3.40.0",
@@ -2664,9 +2664,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.40.0.tgz",
-      "integrity": "sha512-4yvRwODMGYtj6qrt+fyydV5MwVwPPoyoeqDoXdLo9x75vRY71DT1pMRt8PDOoY/ZwWbIdEt4+V7x0sLt2uy9WA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.45.0.tgz",
+      "integrity": "sha512-gZiH4wgYvsLxyMnMvuF3UmOl9KkFTrixIatlFdYG6eLCDgP2oOkXeW007Yu6BQxchsTUC7WUZ971R3T1DtpJlQ==",
       "dependencies": {
         "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
@@ -2706,6 +2706,47 @@
       }
     },
     "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.45.0.tgz",
+      "integrity": "sha512-DmDjrLnyk+zo19beQTMJ/RtZdIkF6N3kPHpFopWVVxJW8lVU3nLf5XrKjFpuuOD5Cgg4gVDeTKQX8DGd0Jof+w==",
+      "dependencies": {
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/abort-controller": "^3.0.0",
+        "@aws-sdk/client-s3": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-storage/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
@@ -2893,12 +2934,12 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.41.0.tgz",
-      "integrity": "sha512-B7JOpmIpm1zxERQEMwZCWj3FisTvwfUgpfQglYdqrB6VpIoCM8fk2pmi5KzU/JDeNBlhTouj6mwnhJL/z5jopA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.45.0.tgz",
+      "integrity": "sha512-V4rnR4pnCxbZOMIFLkIEejmvrW3cujB1OECsK4/fmIlxpgImwYhHbCvFRG/upe92oltehqddGtkCxglmHNMs3g==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "@aws-sdk/util-arn-parser": "3.37.0",
         "tslib": "^2.3.0"
@@ -2916,14 +2957,14 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
-      "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.45.0.tgz",
+      "integrity": "sha512-nvvzoKItzyZF44+0/VdygbUDgBG8wxYqDK0i+aPYLmmTu2NTBcREeMDiYO/aHZIzMNemyJqSdB3p8sdf2BYTAA==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       },
@@ -2954,13 +2995,13 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
-      "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.45.0.tgz",
+      "integrity": "sha512-MUtKe0mRWgWimGlbDX9KWHnxcQz8g1N+gEjfkcxzw+HMIxxQIKYFgUyllhFZ3HvYIje/wLlFYuDKXRBrJjUxYQ==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       },
@@ -3157,9 +3198,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
-      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.45.0.tgz",
+      "integrity": "sha512-73dwNe4R4Ytgn82gV8B99tE6UqrWjHE1JIAXpEZeXsBPJtg+8wpgd9sujs6JH9JW2cvnSnIsCXs1gQGD9+bZ0A==",
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.37.0",
         "@aws-sdk/types": "3.40.0",
@@ -21700,7 +21741,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -28459,7 +28499,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -42521,10 +42560,11 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.44.0",
-        "@aws-sdk/client-secrets-manager": "3.43.0",
-        "@aws-sdk/client-sesv2": "3.43.0",
-        "@aws-sdk/client-ssm": "3.44.0",
+        "@aws-sdk/client-s3": "3.45.0",
+        "@aws-sdk/client-secrets-manager": "3.45.0",
+        "@aws-sdk/client-sesv2": "3.45.0",
+        "@aws-sdk/client-ssm": "3.45.0",
+        "@aws-sdk/lib-storage": "3.45.0",
         "@medplum/core": "0.3.0",
         "@medplum/definitions": "0.3.0",
         "@medplum/fhirpath": "0.3.0",
@@ -44216,22 +44256,22 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.44.0.tgz",
-      "integrity": "sha512-vv3w5RhAZnT/LfiV0SICvvzv5SAeH61erbwm6FpKC9W7lGdcA6o7F2/Bls44fyMW41awYIRZKoPGZApYCrFR6A==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.45.0.tgz",
+      "integrity": "sha512-9JMAdLNWKlqKb3k2mtI0LRrzrfLfqnbShG5e6Im8+Rj+Br5QhtrJ5WIwvT953S+GGumvBzWE28kQcN1/Ve0flw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/eventstream-serde-browser": "3.40.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.40.0",
         "@aws-sdk/eventstream-serde-node": "3.40.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-blob-browser": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
-        "@aws-sdk/hash-stream-node": "3.40.0",
+        "@aws-sdk/hash-stream-node": "3.45.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
         "@aws-sdk/md5-js": "3.40.0",
         "@aws-sdk/middleware-apply-body-checksum": "3.40.0",
@@ -44242,9 +44282,9 @@
         "@aws-sdk/middleware-location-constraint": "3.40.0",
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-s3": "3.41.0",
+        "@aws-sdk/middleware-sdk-s3": "3.45.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-ssec": "3.40.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
@@ -44277,15 +44317,15 @@
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.43.0.tgz",
-      "integrity": "sha512-0EHsbZqLziWmZ75PyNh92+SX+7a+h/spOWlS9vmpRrqbHASAPbij8HcPf2ITw7woivgKD2dqh42+nMhutsLmlg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.45.0.tgz",
+      "integrity": "sha512-fwNZa98sbSAJDJSEbGZ0MqevgdgHrGtbu6KWCLuTueiHlkrhejTiOno8A0JiQFz0nYRR7lYTX51YZz+BjWhJjQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -44294,7 +44334,7 @@
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -44323,15 +44363,15 @@
       }
     },
     "@aws-sdk/client-sesv2": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.43.0.tgz",
-      "integrity": "sha512-sbRJ5ZXF3M8Ch4OzPPxSfqADVeR5suiJvRKS9AE0oO0s0P2P2qG94yBFVd9GR7Hx27lw11S0+npDl3sf9J9t8g==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.45.0.tgz",
+      "integrity": "sha512-bFRU+HTa2Akar5crYydWy3CLhv5uaxvuseIE8ifScA34+CBzIDj6x4pK8qhvq+pB2/4qzlLLX8/GX8yyKjGnww==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -44340,7 +44380,7 @@
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -44368,15 +44408,15 @@
       }
     },
     "@aws-sdk/client-ssm": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.44.0.tgz",
-      "integrity": "sha512-85+D0KTGlkN/cu+qEGZLXylHs1KT1qxayxXgJdQWXlq93rdAH4R0W2HcfUclbc4ZKpW9u85cCcl4UnBk3/DLiA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.45.0.tgz",
+      "integrity": "sha512-5Yr5ipb9VxgpbJy666KzEfpd4fsZ3V9EutMtR3jnVGRDb4foVzybBBoD7sU4EI9wBDusV0uGnlMwXVMI4tCVCQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.43.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/client-sts": "3.45.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -44385,7 +44425,7 @@
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -44415,13 +44455,13 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.41.0.tgz",
-      "integrity": "sha512-xDvcy7wv3KdHhOpl5fZN+Ydw+dHBmsCZwMFI1ZdJVCSGO+ZKgl5KVWi1LCif6vjZP1pUuGl44oDOZz1ACqOzTg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.45.0.tgz",
+      "integrity": "sha512-MfsKg4Wq5KvuGEg+M7kYfl6B3TRhxKeL01+5wtxhYbiLqxzr18mfO8PnBAasXMmYCmEQsSGmFepD7GLOld9uHA==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
+        "@aws-sdk/config-resolver": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -44457,14 +44497,14 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.43.0.tgz",
-      "integrity": "sha512-4CKYimjhIEixVtJH0Y8FR5FXc7zIepZtfScy8QHgH+DERXm/YL5cuUbkJiL6ZRTpek0vztVvE+mNSQU0z1eXag==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.45.0.tgz",
+      "integrity": "sha512-D+VGhAg+1i7/WQhfkLn7nWHR+Uyp7FPVAQ/N2MBQvZxGbSSb2agU9DN2FnxeFljOEcGJ7NdJ9YSZCFlJo0bLWA==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.40.0",
-        "@aws-sdk/credential-provider-node": "3.41.0",
+        "@aws-sdk/config-resolver": "3.45.0",
+        "@aws-sdk/credential-provider-node": "3.45.0",
         "@aws-sdk/fetch-http-handler": "3.40.0",
         "@aws-sdk/hash-node": "3.40.0",
         "@aws-sdk/invalid-dependency": "3.40.0",
@@ -44472,9 +44512,9 @@
         "@aws-sdk/middleware-host-header": "3.40.0",
         "@aws-sdk/middleware-logger": "3.40.0",
         "@aws-sdk/middleware-retry": "3.40.0",
-        "@aws-sdk/middleware-sdk-sts": "3.40.0",
+        "@aws-sdk/middleware-sdk-sts": "3.45.0",
         "@aws-sdk/middleware-serde": "3.40.0",
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/middleware-stack": "3.40.0",
         "@aws-sdk/middleware-user-agent": "3.40.0",
         "@aws-sdk/node-config-provider": "3.40.0",
@@ -44504,11 +44544,11 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.40.0.tgz",
-      "integrity": "sha512-QYy6J2k31QL6J74hPBfptnLW1kQYdN+xjwH4UQ1mv7EUhRoJN9ZY2soStJowFy4at6IIOOVWbyG5dyqvrbEovg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.45.0.tgz",
+      "integrity": "sha512-pk+9jWQGvga2jr4aiB/KR1vAI0vPngvo9HqBbKebbJzaBhpA/RwGVWB1ZJch93oG8DBeyKZ0md9eOJRU1BkTIQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "@aws-sdk/util-config-provider": "3.40.0",
         "tslib": "^2.3.0"
@@ -44558,13 +44598,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.41.0.tgz",
-      "integrity": "sha512-98CGEHg7Tb6HxK5ZIdbAcijvD3IpLe0ddse1xMe/Ilhjz770FS/L2UNprOP6PZTqrSfBffiMrvfThUSuUaTlIQ==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.45.0.tgz",
+      "integrity": "sha512-lfYh8LVW33de01zzfqs6H+4xr20l+++QtvWG8PwKzEAY/71s344ybrOw7KiVUkCDLLbj3SWEmsMJFvBcrvifbA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.40.0",
         "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
+        "@aws-sdk/credential-provider-sso": "3.45.0",
         "@aws-sdk/credential-provider-web-identity": "3.41.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
@@ -44581,15 +44621,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.41.0.tgz",
-      "integrity": "sha512-5FW6+wNJgyDCsbAd+mLm/1DBTDkyIYOMVzcxbr6Vi3pM4UrMFdeLdAP62edYW8usg78Xg+c6vaAoEv/M3zkS0Q==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.45.0.tgz",
+      "integrity": "sha512-ZNqo0JlA7S4k1bAB+Xb8A3KsmNPWVFMmoY3NC25dgXU4xQLVxy0MucQggnfCqRjvshwI4OEdDQsRgl69n/XErQ==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.40.0",
         "@aws-sdk/credential-provider-imds": "3.40.0",
-        "@aws-sdk/credential-provider-ini": "3.41.0",
+        "@aws-sdk/credential-provider-ini": "3.45.0",
         "@aws-sdk/credential-provider-process": "3.40.0",
-        "@aws-sdk/credential-provider-sso": "3.41.0",
+        "@aws-sdk/credential-provider-sso": "3.45.0",
         "@aws-sdk/credential-provider-web-identity": "3.41.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
@@ -44625,11 +44665,11 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.41.0.tgz",
-      "integrity": "sha512-9s7SWu3RVIQ/MTcBCt35EMzxNQm3avivrbpSOKfJwxR5L+oNKPsV+gSqMlkNZGwOVJyUicIsZGcq/4ON6CjrOg==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.45.0.tgz",
+      "integrity": "sha512-FBMn+QA6rI74A90ieQtCJckbKPBxNn4mgR9rzWyi/R6o5gVuu99yJGL03NXtWtm5N4x/1SygBtezY/XL5UU0Mg==",
       "requires": {
-        "@aws-sdk/client-sso": "3.41.0",
+        "@aws-sdk/client-sso": "3.45.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/shared-ini-file-loader": "3.37.0",
         "@aws-sdk/types": "3.40.0",
@@ -44803,9 +44843,9 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.40.0.tgz",
-      "integrity": "sha512-4yvRwODMGYtj6qrt+fyydV5MwVwPPoyoeqDoXdLo9x75vRY71DT1pMRt8PDOoY/ZwWbIdEt4+V7x0sLt2uy9WA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.45.0.tgz",
+      "integrity": "sha512-gZiH4wgYvsLxyMnMvuF3UmOl9KkFTrixIatlFdYG6eLCDgP2oOkXeW007Yu6BQxchsTUC7WUZ971R3T1DtpJlQ==",
       "requires": {
         "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
@@ -44842,6 +44882,42 @@
         "tslib": "^2.3.0"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
+    "@aws-sdk/lib-storage": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.45.0.tgz",
+      "integrity": "sha512-DmDjrLnyk+zo19beQTMJ/RtZdIkF6N3kPHpFopWVVxJW8lVU3nLf5XrKjFpuuOD5Cgg4gVDeTKQX8DGd0Jof+w==",
+      "requires": {
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "stream-browserify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+          "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+          "requires": {
+            "inherits": "~2.0.4",
+            "readable-stream": "^3.5.0"
+          }
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -45025,12 +45101,12 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.41.0.tgz",
-      "integrity": "sha512-B7JOpmIpm1zxERQEMwZCWj3FisTvwfUgpfQglYdqrB6VpIoCM8fk2pmi5KzU/JDeNBlhTouj6mwnhJL/z5jopA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.45.0.tgz",
+      "integrity": "sha512-V4rnR4pnCxbZOMIFLkIEejmvrW3cujB1OECsK4/fmIlxpgImwYhHbCvFRG/upe92oltehqddGtkCxglmHNMs3g==",
       "requires": {
         "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "@aws-sdk/util-arn-parser": "3.37.0",
         "tslib": "^2.3.0"
@@ -45044,14 +45120,14 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.40.0.tgz",
-      "integrity": "sha512-TcrbCvj1PkabFZiNczT3yePZtuEm2fAIw1OVnQyLcF2KW+p62Hv5YkK4MPOfx3LA/0lzjOUO1RNl2x7gzV443Q==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.45.0.tgz",
+      "integrity": "sha512-nvvzoKItzyZF44+0/VdygbUDgBG8wxYqDK0i+aPYLmmTu2NTBcREeMDiYO/aHZIzMNemyJqSdB3p8sdf2BYTAA==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.40.0",
+        "@aws-sdk/middleware-signing": "3.45.0",
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       },
@@ -45080,13 +45156,13 @@
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.40.0.tgz",
-      "integrity": "sha512-RqK5nPbfma0qInMvjtpVkDYY/KkFS6EKlOv3DWTdxbXJ4YuOxgKiuUromhmBUoyjFag0JO7LUWod07H+/DawoA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.45.0.tgz",
+      "integrity": "sha512-MUtKe0mRWgWimGlbDX9KWHnxcQz8g1N+gEjfkcxzw+HMIxxQIKYFgUyllhFZ3HvYIje/wLlFYuDKXRBrJjUxYQ==",
       "requires": {
         "@aws-sdk/property-provider": "3.40.0",
         "@aws-sdk/protocol-http": "3.40.0",
-        "@aws-sdk/signature-v4": "3.40.0",
+        "@aws-sdk/signature-v4": "3.45.0",
         "@aws-sdk/types": "3.40.0",
         "tslib": "^2.3.0"
       },
@@ -45269,9 +45345,9 @@
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.40.0.tgz",
-      "integrity": "sha512-Q1GNZJRCS3W2qsRtDsX/b6EOSfMXfr6TW46N3LnLTGYZ3KAN2SOSJ1DsW59AuGpEZyRmOhJ9L/Q5U403+bZMXQ==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.45.0.tgz",
+      "integrity": "sha512-73dwNe4R4Ytgn82gV8B99tE6UqrWjHE1JIAXpEZeXsBPJtg+8wpgd9sujs6JH9JW2cvnSnIsCXs1gQGD9+bZ0A==",
       "requires": {
         "@aws-sdk/is-array-buffer": "3.37.0",
         "@aws-sdk/types": "3.40.0",
@@ -49207,10 +49283,11 @@
     "@medplum/server": {
       "version": "file:packages/server",
       "requires": {
-        "@aws-sdk/client-s3": "3.44.0",
-        "@aws-sdk/client-secrets-manager": "3.43.0",
-        "@aws-sdk/client-sesv2": "3.43.0",
-        "@aws-sdk/client-ssm": "3.44.0",
+        "@aws-sdk/client-s3": "3.45.0",
+        "@aws-sdk/client-secrets-manager": "3.45.0",
+        "@aws-sdk/client-sesv2": "3.45.0",
+        "@aws-sdk/client-ssm": "3.45.0",
+        "@aws-sdk/lib-storage": "3.45.0",
         "@jest/test-sequencer": "27.4.5",
         "@medplum/core": "0.3.0",
         "@medplum/definitions": "0.3.0",
@@ -60285,8 +60362,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "batch": {
       "version": "0.6.1",
@@ -65593,8 +65669,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,10 +19,11 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "3.44.0",
-    "@aws-sdk/client-sesv2": "3.43.0",
-    "@aws-sdk/client-ssm": "3.44.0",
-    "@aws-sdk/client-secrets-manager": "3.43.0",
+    "@aws-sdk/client-s3": "3.45.0",
+    "@aws-sdk/client-sesv2": "3.45.0",
+    "@aws-sdk/client-ssm": "3.45.0",
+    "@aws-sdk/client-secrets-manager": "3.45.0",
+    "@aws-sdk/lib-storage": "3.45.0",
     "@medplum/core": "0.3.0",
     "@medplum/definitions": "0.3.0",
     "@medplum/fhirpath": "0.3.0",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,17 +1,16 @@
 import { badRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import { json, raw, urlencoded } from 'body-parser';
 import cors from 'cors';
-import { Express, NextFunction, Request, Response } from 'express';
+import { Express, json, NextFunction, Request, Response, urlencoded } from 'express';
 import { adminRouter } from './admin';
 import { asyncWrap } from './async';
 import { authRouter } from './auth';
 import { getConfig } from './config';
 import { dicomRouter } from './dicom/routes';
-import { fhirRouter, sendOutcome } from './fhir';
+import { binaryRouter, fhirRouter, sendOutcome } from './fhir';
 import { healthcheckHandler } from './healthcheck';
 import { logger } from './logger';
-import { oauthRouter } from './oauth';
+import { authenticateToken, oauthRouter } from './oauth';
 import { openApiHandler } from './openapi';
 import { scimRouter } from './scim';
 import { storageRouter } from './storage';
@@ -70,6 +69,7 @@ export async function initApp(app: Express): Promise<Express> {
   const config = getConfig();
   app.set('trust proxy', true);
   app.set('x-powered-by', false);
+  app.use('/fhir/R4/Binary', [authenticateToken], binaryRouter);
   app.set('json spaces', 2);
   app.use(cacheHandler);
   app.use(cors(corsOptions));
@@ -82,12 +82,6 @@ export async function initApp(app: Express): Promise<Express> {
     json({
       type: ['application/json', 'application/fhir+json', 'application/json-patch+json'],
       limit: config.maxJsonSize,
-    })
-  );
-  app.use(
-    raw({
-      type: '*/*',
-      limit: config.maxUploadSize,
     })
   );
   app.get('/', (req: Request, res: Response) => res.sendStatus(200));

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -69,10 +69,9 @@ export async function initApp(app: Express): Promise<Express> {
   const config = getConfig();
   app.set('trust proxy', true);
   app.set('x-powered-by', false);
-  app.use('/fhir/R4/Binary', [authenticateToken], binaryRouter);
-  app.set('json spaces', 2);
   app.use(cacheHandler);
   app.use(cors(corsOptions));
+  app.use('/fhir/R4/Binary', [authenticateToken], binaryRouter);
   app.use(
     urlencoded({
       extended: false,

--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -30,7 +30,7 @@ describe('Binary', () => {
     rmSync(binaryDir, { recursive: true, force: true });
   });
 
-  test('Payload too large', async () => {
+  test.skip('Payload too large', async () => {
     const res = await request(app)
       .post(`/fhir/R4/Binary`)
       .set('Authorization', 'Bearer ' + accessToken)

--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -82,4 +82,15 @@ describe('Binary', () => {
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res3.status).toBe(200);
   });
+
+  test('Binary CORS', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/Binary')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'text/plain')
+      .set('Origin', 'https://www.example.com')
+      .send('Hello world');
+    expect(res.status).toBe(201);
+    expect(res.headers['access-control-allow-origin']).toBe('https://www.example.com');
+  });
 });

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -7,7 +7,6 @@ import { asyncWrap } from '../async';
 import { getConfig } from '../config';
 import { authenticateToken } from '../oauth';
 import { processBatch } from './batch';
-import { binaryRouter } from './binary';
 import { expandOperator } from './expand';
 import { getRootSchema } from './graphql';
 import { getCapabilityStatement } from './metadata';
@@ -92,9 +91,6 @@ publicRoutes.get('/.well-known/smart-configuration', (req: Request, res: Respons
 const protectedRoutes = Router();
 fhirRouter.use(authenticateToken);
 fhirRouter.use(protectedRoutes);
-
-// Binary routes
-protectedRoutes.use('/Binary/', binaryRouter);
 
 // ValueSet $expand operation
 protectedRoutes.get('/ValueSet/([$]|%24)expand', expandOperator);

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -3,6 +3,7 @@ import { Binary } from '@medplum/fhirtypes';
 import express, { Request } from 'express';
 import { mkdtempSync, rmSync } from 'fs';
 import { sep } from 'path';
+import { Readable } from 'stream';
 import request from 'supertest';
 import { initApp } from './app';
 import { loadTestConfig } from './config';
@@ -29,7 +30,11 @@ describe('Storage Routes', () => {
     assertOk(outcome);
     binary = resource;
 
-    await getBinaryStorage().writeBinary(binary as Binary, { body: 'hello world' } as Request);
+    const req = new Readable();
+    req.push('hello world');
+    req.push(null);
+    (req as any).headers = {};
+    await getBinaryStorage().writeBinary(binary as Binary, req as Request);
   });
 
   afterAll(async () => {


### PR DESCRIPTION
In order to support more video files that can be 1+ GB, this implements streaming uploads to S3.

Before:  We used `body-parser` and `PutObjectCommand`.  That is the straightforward simple implementation of file upload.  `body-parser` is by far the most common way to parse an HTTP request content.  `PutObjectCommand` is by far the most common way to upload a file to S3.

Unfortunately, `body-parser` will always create a temporary file on the server disk.  To make matters worse, it fully uploads the temp file before the "max file size" check is performed, because it has to decompress the file to know the file size 🤦‍♂️

`PutObjectCommand` works great for small files, but is inefficient for large files.  AWS released [lib-storage](https://github.com/aws/aws-sdk-js-v3/tree/v3.44.0/lib/lib-storage) to address these performance concerns.  It is a wrapper around the normal S3 library.

Now: 
1. We explicitly do *not* use `body-parser` on the `/fhir/R4/Binary` routes.  That means there is no pre-processing of the request content body.
2. We construct a nodejs `Stream` from the content.
3. We pass the stream to `lib-storage` to upload to S3

As a result, temp files should never touch disk.  Uploads are faster, because they are routed directly to S3.  With this, we can remove the 1 GB cap on file uploads.