### PR TITLE
Download external media content

### DIFF
--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import { mkdtempSync, rmSync } from 'fs';
 import { sep } from 'path';
+import { Duplex, Readable } from 'stream';
 import request from 'supertest';
+import zlib from 'zlib';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
@@ -28,15 +30,6 @@ describe('Binary', () => {
   afterAll(async () => {
     await closeDatabase();
     rmSync(binaryDir, { recursive: true, force: true });
-  });
-
-  test.skip('Payload too large', async () => {
-    const res = await request(app)
-      .post(`/fhir/R4/Binary`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/octet-stream')
-      .send('a'.repeat(11 * 1024 * 1024));
-    expect(res.status).toBe(400);
   });
 
   test('Create and read binary', async () => {
@@ -93,4 +86,63 @@ describe('Binary', () => {
     expect(res.status).toBe(201);
     expect(res.headers['access-control-allow-origin']).toBe('https://www.example.com');
   });
+
+  test('Unsupported content encoding', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/Binary')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'text/plain')
+      .set('Content-Encoding', 'fake')
+      .send('Hello world');
+    expect(res.status).toBe(400);
+  });
+
+  test('Deflate', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/Binary')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'text/plain')
+      .set('Content-Encoding', 'deflate')
+      .send(await createBufferForStream('Hello world', zlib.createDeflate()));
+    expect(res.status).toBe(201);
+
+    const binary = res.body;
+    const res2 = await request(app)
+      .get('/fhir/R4/Binary/' + binary.id)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toBe(200);
+    expect(res2.text).toEqual('Hello world');
+  });
+
+  test('GZIP', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/Binary')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'text/plain')
+      .set('Content-Encoding', 'gzip')
+      .send(await createBufferForStream('Hello world', zlib.createGzip()));
+    expect(res.status).toBe(201);
+
+    const binary = res.body;
+    const res2 = await request(app)
+      .get('/fhir/R4/Binary/' + binary.id)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toBe(200);
+    expect(res2.text).toEqual('Hello world');
+  });
 });
+
+async function createBufferForStream(message: string, stream: Duplex): Promise<Buffer> {
+  const input = new Readable();
+  input.push('Hello world');
+  input.push(null);
+
+  input.pipe(stream);
+
+  return new Promise<Buffer>((resolve, reject) => {
+    const _buf = Array<any>();
+    stream.on('data', (chunk) => _buf.push(chunk));
+    stream.on('end', () => resolve(Buffer.concat(_buf)));
+    stream.on('error', (err) => reject(`error converting stream - ${err}`));
+  });
+}

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -35,7 +35,7 @@ import { applyPatch, Operation } from 'fast-json-patch';
 import validator from 'validator';
 import { getConfig } from '../config';
 import { getClient } from '../database';
-import { addSubscriptionJobs } from '../workers/subscription';
+import { addBackgroundJobs } from '../workers';
 import { AddressTable, ContactPointTable, HumanNameTable, IdentifierTable, LookupTable } from './lookups';
 import { getPatientCompartmentResourceTypes, getPatientId } from './patient';
 import { rewriteAttachments, RewriteMode } from './rewrite';
@@ -316,7 +316,7 @@ export class Repository {
       await this.writeResource(result);
       await this.writeResourceVersion(result);
       await this.writeLookupTables(result);
-      await addSubscriptionJobs(result);
+      await addBackgroundJobs(result);
     } catch (error) {
       return [badRequest((error as Error).message), undefined];
     }

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -1,12 +1,9 @@
 import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { Binary } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
-import { createWriteStream, existsSync, mkdirSync } from 'fs';
-import { IncomingMessage } from 'http';
+import { createReadStream, createWriteStream, existsSync, mkdirSync } from 'fs';
 import path from 'path';
 import internal from 'stream';
-import zlib from 'zlib';
 
 let binaryStorage: BinaryStorage | undefined = undefined;
 
@@ -31,9 +28,9 @@ export function getBinaryStorage(): BinaryStorage {
  * The BinaryStorage interface represents a method of reading and writing binary blobs.
  */
 interface BinaryStorage {
-  writeBinary(binary: Binary, req: Request): Promise<void>;
+  writeBinary(binary: Binary, stream: internal.Readable | NodeJS.ReadableStream): Promise<void>;
 
-  readBinary(binary: Binary, res: Response): Promise<void>;
+  readBinary(binary: Binary): Promise<internal.Readable>;
 }
 
 /**
@@ -50,22 +47,24 @@ class FileSystemStorage implements BinaryStorage {
     }
   }
 
-  async writeBinary(binary: Binary, req: Request): Promise<void> {
+  async writeBinary(binary: Binary, stream: internal.Readable | NodeJS.ReadableStream): Promise<void> {
     const dir = this.getDir(binary);
     if (!existsSync(dir)) {
       mkdirSync(dir);
     }
-    const body = getContentStream(req);
     const writeStream = createWriteStream(this.getPath(binary), { flags: 'w' });
-    body.pipe(writeStream);
+    stream.pipe(writeStream);
     return new Promise((resolve, reject) => {
       writeStream.on('close', resolve);
       writeStream.on('error', reject);
     });
   }
 
-  async readBinary(binary: Binary, res: Response): Promise<void> {
-    res.sendFile(this.getPath(binary));
+  async readBinary(binary: Binary): Promise<internal.Readable> {
+    if (!existsSync(this.getPath(binary))) {
+      throw new Error('File not found');
+    }
+    return createReadStream(this.getPath(binary));
   }
 
   private getDir(binary: Binary): string {
@@ -105,14 +104,12 @@ class S3Storage implements BinaryStorage {
    * @param binary The binary resource destination.
    * @param req The HTTP request with the binary content.
    */
-  async writeBinary(binary: Binary, req: Request): Promise<void> {
-    const body = getContentStream(req);
-
+  async writeBinary(binary: Binary, stream: internal.Readable | NodeJS.ReadableStream): Promise<void> {
     const upload = new Upload({
       params: {
         Bucket: this.bucket,
         Key: this.getKey(binary),
-        Body: body,
+        Body: stream,
       },
       client: this.client,
       queueSize: 3,
@@ -121,53 +118,17 @@ class S3Storage implements BinaryStorage {
     await upload.done();
   }
 
-  async readBinary(binary: Binary, res: Response): Promise<void> {
+  async readBinary(binary: Binary): Promise<internal.Readable> {
     const output = await this.client.send(
       new GetObjectCommand({
         Bucket: this.bucket,
         Key: this.getKey(binary),
       })
     );
-    (output.Body as IncomingMessage).pipe(res);
+    return output.Body as internal.Readable;
   }
 
   private getKey(binary: Binary): string {
     return 'binary/' + binary.id + '/' + binary.meta?.versionId;
   }
-}
-
-/**
- * Get the content stream of the request.
- *
- * Based on body-parser implementation:
- * https://github.com/expressjs/body-parser/blob/master/lib/read.js
- *
- * Unfortunately body-parser will always write the content to a temporary file on local disk.
- * That is not acceptable for multi gigabyte files, which could easily fill up the disk.
- *
- * @param req The HTTP request.
- * @returns The content stream.
- */
-
-function getContentStream(req: Request): internal.Readable {
-  const encoding = (req.headers['content-encoding'] || 'identity').toLowerCase();
-  let stream;
-
-  switch (encoding) {
-    case 'deflate':
-      stream = zlib.createInflate();
-      req.pipe(stream);
-      break;
-    case 'gzip':
-      stream = zlib.createGunzip();
-      req.pipe(stream);
-      break;
-    case 'identity':
-      stream = req;
-      break;
-    default:
-      throw new Error('encoding.unsupoorted');
-  }
-
-  return stream;
 }

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -61,9 +61,6 @@ class FileSystemStorage implements BinaryStorage {
   }
 
   async readBinary(binary: Binary): Promise<internal.Readable> {
-    if (!existsSync(this.getPath(binary))) {
-      throw new Error('File not found');
-    }
     return createReadStream(this.getPath(binary));
   }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,7 +7,7 @@ import { logger } from './logger';
 import { initKeys } from './oauth';
 import { initRedis } from './redis';
 import { seedDatabase } from './seed';
-import { initSubscriptionWorker } from './workers/subscription';
+import { initWorkers } from './workers';
 
 async function main(): Promise<void> {
   logger.info('Starting Medplum Server...');
@@ -23,10 +23,7 @@ async function main(): Promise<void> {
   await initKeys(config);
   await seedDatabase();
   initBinaryStorage(config.binaryStorage);
-
-  logger.debug('Initializing workers...');
-  initSubscriptionWorker(config.redis);
-  logger.debug('Workers initialized');
+  initWorkers(config.redis);
 
   const app = await initApp(express());
   app.listen(5000);

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -14,7 +14,7 @@ export enum LogLevel {
 }
 
 export const logger = {
-  level: process.env.NODE_ENV === 'test' ? LogLevel.NONE : LogLevel.DEBUG,
+  level: process.env.NODE_ENV === 'test' ? LogLevel.NONE : LogLevel.INFO,
 
   error(...args: any[]): void {
     if (logger.level >= LogLevel.ERROR) {

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -14,7 +14,7 @@ export enum LogLevel {
 }
 
 export const logger = {
-  level: process.env.NODE_ENV === 'test' ? LogLevel.NONE : LogLevel.INFO,
+  level: process.env.NODE_ENV === 'test' ? LogLevel.NONE : LogLevel.DEBUG,
 
   error(...args: any[]): void {
     if (logger.level >= LogLevel.ERROR) {

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -23,6 +23,8 @@ storageRouter.get(
 
     const binary = resource as Binary;
     res.status(200).contentType(binary.contentType as string);
-    await getBinaryStorage().readBinary(binary, res);
+
+    const stream = await getBinaryStorage().readBinary(binary);
+    stream.pipe(res);
   })
 );

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -1,0 +1,182 @@
+import { assertOk } from '@medplum/core';
+import { Media } from '@medplum/fhirtypes';
+import { Job, Queue } from 'bullmq';
+import { randomUUID } from 'crypto';
+import { mkdtempSync } from 'fs';
+import fetch from 'node-fetch';
+import { sep } from 'path';
+import { Readable } from 'stream';
+import { loadTestConfig } from '../config';
+import { closeDatabase, initDatabase } from '../database';
+import { initBinaryStorage } from '../fhir';
+import { Repository } from '../fhir/repo';
+import { seedDatabase } from '../seed';
+import { closeDownloadWorker, execDownloadJob, initDownloadWorker } from './download';
+
+jest.mock('bullmq');
+jest.mock('node-fetch');
+
+const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
+let repo: Repository;
+
+describe('Download Worker', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config.database);
+    await seedDatabase();
+    await initBinaryStorage('file:' + binaryDir);
+    await initDownloadWorker(config.redis);
+
+    repo = new Repository({
+      project: randomUUID(),
+      author: {
+        reference: 'ClientApplication/' + randomUUID(),
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+    await closeDownloadWorker();
+    await closeDownloadWorker(); // Double close to ensure quite ignore
+  });
+
+  beforeEach(async () => {
+    (fetch as any).mockClear();
+  });
+
+  test('Download external URL', async () => {
+    const url = 'https://example.com/download';
+
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [mediaOutcome, media] = await repo.createResource<Media>({
+      resourceType: 'Media',
+      content: {
+        contentType: 'text/plain',
+        url,
+      },
+    });
+
+    expect(mediaOutcome.id).toEqual('created');
+    expect(media).toBeDefined();
+    expect(queue.add).toHaveBeenCalled();
+
+    const body = new Readable();
+    body.push('foo');
+    body.push(null);
+
+    (fetch as any).mockImplementation(() => ({
+      status: 200,
+      headers: {
+        get: jest.fn(),
+      },
+      body,
+    }));
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
+    await execDownloadJob(job);
+
+    expect(fetch).toHaveBeenCalledWith(url);
+  });
+
+  test('Ignore media missing URL', async () => {
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [mediaOutcome, media] = await repo.createResource<Media>({
+      resourceType: 'Media',
+      content: {
+        contentType: 'text/plain',
+        url: '',
+      },
+    });
+
+    expect(mediaOutcome.id).toEqual('created');
+    expect(media).toBeDefined();
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  test('Retry on 400', async () => {
+    const url = 'https://example.com/download';
+
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [mediaOutcome, media] = await repo.createResource<Media>({
+      resourceType: 'Media',
+      content: {
+        contentType: 'text/plain',
+        url,
+      },
+    });
+
+    expect(mediaOutcome.id).toEqual('created');
+    expect(media).toBeDefined();
+    expect(queue.add).toHaveBeenCalled();
+
+    (fetch as any).mockImplementation(() => ({ status: 400 }));
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
+
+    // If the job throws, then the QueueScheduler will retry
+    await expect(execDownloadJob(job)).rejects.toThrow();
+  });
+
+  test('Retry on exception', async () => {
+    const url = 'https://example.com/download';
+
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [mediaOutcome, media] = await repo.createResource<Media>({
+      resourceType: 'Media',
+      content: {
+        contentType: 'text/plain',
+        url,
+      },
+    });
+
+    expect(mediaOutcome.id).toEqual('created');
+    expect(media).toBeDefined();
+    expect(queue.add).toHaveBeenCalled();
+
+    (fetch as any).mockImplementation(() => {
+      throw new Error();
+    });
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
+
+    // If the job throws, then the QueueScheduler will retry
+    await expect(execDownloadJob(job)).rejects.toThrow();
+  });
+
+  test('Stop retries if Resource deleted', async () => {
+    const queue = (Queue as any).mock.instances[0];
+    queue.add.mockClear();
+
+    const [mediaOutcome, media] = await repo.createResource<Media>({
+      resourceType: 'Media',
+      content: {
+        contentType: 'text/plain',
+        url: 'https://example.com/download',
+      },
+    });
+
+    expect(mediaOutcome.id).toEqual('created');
+    expect(media).toBeDefined();
+    expect(queue.add).toHaveBeenCalled();
+
+    // At this point the job should be in the queue
+    // But let's delete the resource
+    const [deleteOutcome] = await repo.deleteResource('Media', media?.id as string);
+    assertOk(deleteOutcome);
+
+    const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
+    await execDownloadJob(job);
+
+    // Fetch should not have been called
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -6,13 +6,12 @@ import { mkdtempSync } from 'fs';
 import fetch from 'node-fetch';
 import { sep } from 'path';
 import { Readable } from 'stream';
-import { closeWorkers, initWorkers } from '.';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initBinaryStorage } from '../fhir';
 import { Repository } from '../fhir/repo';
 import { seedDatabase } from '../seed';
-import { closeDownloadWorker, execDownloadJob } from './download';
+import { closeDownloadWorker, execDownloadJob, initDownloadWorker } from './download';
 
 jest.mock('bullmq');
 jest.mock('node-fetch');
@@ -26,7 +25,7 @@ describe('Download Worker', () => {
     await initDatabase(config.database);
     await seedDatabase();
     await initBinaryStorage('file:' + binaryDir);
-    await initWorkers(config.redis);
+    await initDownloadWorker(config.redis);
 
     repo = new Repository({
       project: randomUUID(),
@@ -38,7 +37,6 @@ describe('Download Worker', () => {
 
   afterAll(async () => {
     await closeDatabase();
-    await closeWorkers();
     await closeDownloadWorker();
     await closeDownloadWorker(); // Double close to ensure quite ignore
   });

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -6,12 +6,13 @@ import { mkdtempSync } from 'fs';
 import fetch from 'node-fetch';
 import { sep } from 'path';
 import { Readable } from 'stream';
+import { closeWorkers, initWorkers } from '.';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initBinaryStorage } from '../fhir';
 import { Repository } from '../fhir/repo';
 import { seedDatabase } from '../seed';
-import { closeDownloadWorker, execDownloadJob, initDownloadWorker } from './download';
+import { closeDownloadWorker, execDownloadJob } from './download';
 
 jest.mock('bullmq');
 jest.mock('node-fetch');
@@ -25,7 +26,7 @@ describe('Download Worker', () => {
     await initDatabase(config.database);
     await seedDatabase();
     await initBinaryStorage('file:' + binaryDir);
-    await initDownloadWorker(config.redis);
+    await initWorkers(config.redis);
 
     repo = new Repository({
       project: randomUUID(),
@@ -37,6 +38,7 @@ describe('Download Worker', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    await closeWorkers();
     await closeDownloadWorker();
     await closeDownloadWorker(); // Double close to ensure quite ignore
   });

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -1,0 +1,193 @@
+import { assertOk, isGone } from '@medplum/core';
+import { Binary, Resource } from '@medplum/fhirtypes';
+import { Job, Queue, QueueBaseOptions, QueueScheduler, Worker } from 'bullmq';
+import fetch from 'node-fetch';
+import { getConfig, MedplumRedisConfig } from '../config';
+import { getBinaryStorage, systemRepo } from '../fhir';
+import { logger } from '../logger';
+
+/*
+ * The download worker inspects resources,
+ * looking for external URLs that need to be downloaded.
+ *
+ * If an external URL is found, the worker attempts to download the content,
+ * and use the Medplum server storage service.
+ *
+ * On successfully downloading the content, the worker updates the resource
+ * with the Binary resource.
+ */
+
+export interface DownloadJobData {
+  readonly resourceType: string;
+  readonly id: string;
+  readonly url: string;
+}
+
+const queueName = 'DownloadQueue';
+const jobName = 'DownloadJobData';
+let queueScheduler: QueueScheduler | undefined = undefined;
+let queue: Queue<DownloadJobData> | undefined = undefined;
+let worker: Worker<DownloadJobData> | undefined = undefined;
+
+/**
+ * Initializes the download worker.
+ * Sets up the BullMQ job queue.
+ * Sets up the BullMQ worker.
+ */
+export function initDownloadWorker(config: MedplumRedisConfig): void {
+  const defaultOptions: QueueBaseOptions = {
+    connection: config,
+  };
+
+  queueScheduler = new QueueScheduler(queueName, defaultOptions);
+
+  queue = new Queue<DownloadJobData>(queueName, {
+    ...defaultOptions,
+    defaultJobOptions: {
+      attempts: 3,
+      backoff: {
+        type: 'exponential',
+        delay: 1000,
+      },
+    },
+  });
+
+  worker = new Worker<DownloadJobData>(queueName, execDownloadJob, defaultOptions);
+  worker.on('completed', (job) => logger.info(`Completed job ${job.id} successfully`));
+  worker.on('failed', (job, err) => logger.info(`Failed job ${job.id} with ${err}`));
+}
+
+/**
+ * Shuts down the download worker.
+ * Closes the BullMQ scheduler.
+ * Closes the BullMQ job queue.
+ * Clsoes the BullMQ worker.
+ */
+export async function closeDownloadWorker(): Promise<void> {
+  if (queueScheduler) {
+    await queueScheduler.close();
+    queueScheduler = undefined;
+  }
+
+  if (queue) {
+    await queue.close();
+    queue = undefined;
+  }
+
+  if (worker) {
+    await worker.close();
+    worker = undefined;
+  }
+}
+
+/**
+ * Adds all download jobs for a given resource.
+ *
+ * There are a few important structural considerations:
+ * 1) One resource change can spawn multiple download jobs.
+ * 2) Download jobs can fail, and must be retried independently.
+ * 3) Downloads should be evaluated at the time of the resource change.
+ *
+ * So, when a resource changes (create or update), we evaluate all downloaders
+ * at that moment in time.  For each matching download, we enqueue the job.
+ * The only purpose of the job is to make the outbound HTTP request,
+ * not to re-evaluate the download.
+ *
+ * @param resource The resource that was created or updated.
+ */
+export async function addDownloadJobs(resource: Resource): Promise<void> {
+  if (resource.resourceType === 'AuditEvent') {
+    // Never send downloaders for audit events
+    return;
+  }
+
+  if (resource.resourceType === 'Media' && isExternalUrl(resource.content?.url)) {
+    addDownloadJobData({
+      resourceType: resource.resourceType,
+      id: resource.id as string,
+      url: resource.content?.url as string,
+    });
+  }
+}
+
+/**
+ * Determines if a content URL is an external URL.
+ *
+ * URL's are "internal" if:
+ *  1) They refer to a fully qualified fhir/R4/Binary/ endpoint.
+ *  2) They refer to the Medplum storage URL.
+ *  3) They refer to a Binary in canonical form (i.e., "Binary/123").
+ *
+ * @param url The Media content URL.
+ * @returns True if the URL is an external URL.
+ */
+function isExternalUrl(url: string | undefined): boolean {
+  return !!(
+    url &&
+    !url.startsWith(getConfig().baseUrl + 'fhir/R4/Binary/') &&
+    !url.startsWith(getConfig().storageBaseUrl) &&
+    !url.startsWith('Binary/')
+  );
+}
+
+/**
+ * Adds a download job to the queue.
+ * @param job The download job details.
+ */
+function addDownloadJobData(job: DownloadJobData): void {
+  logger.debug(`Adding Download job`);
+  if (queue) {
+    queue.add(jobName, job);
+  } else {
+    logger.debug(`Download queue not initialized`);
+  }
+}
+
+/**
+ * Executes a download job.
+ * @param job The download job details.
+ */
+export async function execDownloadJob(job: Job<DownloadJobData>): Promise<void> {
+  const { resourceType, id, url } = job.data;
+
+  const [readOutcome, resource] = await systemRepo.readResource(resourceType, id);
+  if (isGone(readOutcome)) {
+    // If the resource was deleted, then stop processing it.
+    return;
+  }
+  assertOk(readOutcome);
+
+  if (!JSON.stringify(resource).includes(url)) {
+    // If the resource no longer includes the URL, then stop processing it.
+    return;
+  }
+
+  try {
+    logger.info('Requesting content at: ' + url);
+    const response = await fetch(url);
+
+    logger.info('Received status: ' + response.status);
+    if (response.status >= 400) {
+      throw new Error('Received status ' + response.status);
+    }
+
+    const [createBinaryOutcome, binary] = await systemRepo.createResource<Binary>({
+      resourceType: 'Binary',
+      contentType: response.headers.get('content-type') as string,
+      meta: {
+        project: resource?.meta?.project,
+      },
+    });
+    assertOk(createBinaryOutcome);
+    await getBinaryStorage().writeBinary(binary as Binary, response.body);
+
+    const updated = JSON.parse(JSON.stringify(resource).replace(url, `Binary/${binary?.id}`)) as Resource;
+    (updated.meta as any).author = { reference: 'system' };
+    const [updateOutcome] = await systemRepo.updateResource(updated);
+    assertOk(updateOutcome);
+    logger.info('Downloaded content successfully');
+  } catch (ex) {
+    logger.info('Download exception: ' + ex);
+    throw ex;
+  }
+}

--- a/packages/server/src/workers/index.test.ts
+++ b/packages/server/src/workers/index.test.ts
@@ -1,0 +1,19 @@
+import { closeWorkers, initWorkers } from '.';
+import { loadTestConfig } from '../config';
+import { closeDatabase, initDatabase } from '../database';
+import { initBinaryStorage } from '../fhir';
+import { seedDatabase } from '../seed';
+
+jest.mock('bullmq');
+
+describe('Workers', () => {
+  test('Init and close', async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config.database);
+    await seedDatabase();
+    await initBinaryStorage('file:binary');
+    initWorkers(config.redis);
+    await closeWorkers();
+    await closeDatabase();
+  });
+});

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -5,9 +5,7 @@ import { addDownloadJobs, closeDownloadWorker, initDownloadWorker } from './down
 import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } from './subscription';
 
 /**
- * Initializes the subscription worker.
- * Sets up the BullMQ job queue.
- * Sets up the BullMQ worker.
+ * Initializes all background workers.
  */
 export function initWorkers(config: MedplumRedisConfig): void {
   logger.debug('Initializing workers...');
@@ -17,10 +15,7 @@ export function initWorkers(config: MedplumRedisConfig): void {
 }
 
 /**
- * Shuts down the subscription worker.
- * Closes the BullMQ scheduler.
- * Closes the BullMQ job queue.
- * Clsoes the BullMQ worker.
+ * Shuts down all background workers.
  */
 export async function closeWorkers(): Promise<void> {
   await closeSubscriptionWorker();
@@ -28,18 +23,7 @@ export async function closeWorkers(): Promise<void> {
 }
 
 /**
- * Adds all subscription jobs for a given resource.
- *
- * There are a few important structural considerations:
- * 1) One resource change can spawn multiple subscription jobs.
- * 2) Subscription jobs can fail, and must be retried independently.
- * 3) Subscriptions should be evaluated at the time of the resource change.
- *
- * So, when a resource changes (create or update), we evaluate all subscriptions
- * at that moment in time.  For each matching subscription, we enqueue the job.
- * The only purpose of the job is to make the outbound HTTP request,
- * not to re-evaluate the subscription.
- *
+ * Adds all background jobs for a given resource.
  * @param resource The resource that was created or updated.
  */
 export async function addBackgroundJobs(resource: Resource): Promise<void> {

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -1,0 +1,48 @@
+import { Resource } from '@medplum/fhirtypes';
+import { MedplumRedisConfig } from '../config';
+import { logger } from '../logger';
+import { addDownloadJobs, closeDownloadWorker, initDownloadWorker } from './download';
+import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } from './subscription';
+
+/**
+ * Initializes the subscription worker.
+ * Sets up the BullMQ job queue.
+ * Sets up the BullMQ worker.
+ */
+export function initWorkers(config: MedplumRedisConfig): void {
+  logger.debug('Initializing workers...');
+  initSubscriptionWorker(config);
+  initDownloadWorker(config);
+  logger.debug('Workers initialized');
+}
+
+/**
+ * Shuts down the subscription worker.
+ * Closes the BullMQ scheduler.
+ * Closes the BullMQ job queue.
+ * Clsoes the BullMQ worker.
+ */
+export async function closeWorkers(): Promise<void> {
+  await closeSubscriptionWorker();
+  await closeDownloadWorker();
+}
+
+/**
+ * Adds all subscription jobs for a given resource.
+ *
+ * There are a few important structural considerations:
+ * 1) One resource change can spawn multiple subscription jobs.
+ * 2) Subscription jobs can fail, and must be retried independently.
+ * 3) Subscriptions should be evaluated at the time of the resource change.
+ *
+ * So, when a resource changes (create or update), we evaluate all subscriptions
+ * at that moment in time.  For each matching subscription, we enqueue the job.
+ * The only purpose of the job is to make the outbound HTTP request,
+ * not to re-evaluate the subscription.
+ *
+ * @param resource The resource that was created or updated.
+ */
+export async function addBackgroundJobs(resource: Resource): Promise<void> {
+  await addSubscriptionJobs(resource);
+  await addDownloadJobs(resource);
+}

--- a/packages/ui/src/ResourcePropertyInput.tsx
+++ b/packages/ui/src/ResourcePropertyInput.tsx
@@ -186,7 +186,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
     case PropertyType.Annotation:
       return <AnnotationInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Attachment:
-      return <AttachmentInput name={name} defaultValue={value} />;
+      return <AttachmentInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.CodeableConcept:
       return <CodeableConceptInput property={property} name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Coding:

--- a/packages/ui/src/stories/ResourceForm.stories.tsx
+++ b/packages/ui/src/stories/ResourceForm.stories.tsx
@@ -164,3 +164,16 @@ export const Specimen = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Media = (): JSX.Element => (
+  <Document>
+    <ResourceForm
+      defaultValue={{
+        resourceType: 'Media',
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);


### PR DESCRIPTION
Use case:  When creating a `Media` resource, rather than manually creating a `Binary` and uploading content, the user instead wants to just submit a publicly accessible URL.  The server should recognize this external URL, and fetch the content.