### PR TITLE
InputRow and PeriodInput

### DIFF
--- a/packages/ui/src/AddressInput.tsx
+++ b/packages/ui/src/AddressInput.tsx
@@ -1,5 +1,6 @@
 import { Address } from '@medplum/fhirtypes';
 import React, { useRef, useState } from 'react';
+import { InputRow } from './InputRow';
 
 function getLine(address: Address, index: number): string {
   return address && address.line && address.line.length > index ? address.line[index] : '';
@@ -62,73 +63,51 @@ export function AddressInput(props: AddressInputProps): JSX.Element {
   }
 
   return (
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <select data-testid="address-use" defaultValue={value?.use} onChange={(e) => setUse(e.currentTarget.value)}>
-              <option></option>
-              <option>home</option>
-              <option>mobile</option>
-              <option>old</option>
-              <option>temp</option>
-              <option>work</option>
-            </select>
-          </td>
-          <td>
-            <select
-              data-testid="address-type"
-              defaultValue={value?.type}
-              onChange={(e) => setType(e.currentTarget.value)}
-            >
-              <option></option>
-              <option>postal</option>
-              <option>physical</option>
-              <option>both</option>
-            </select>
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Line 1"
-              defaultValue={getLine(value, 0)}
-              onChange={(e) => setLine1(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Line 2"
-              defaultValue={getLine(value, 1)}
-              onChange={(e) => setLine2(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="City"
-              defaultValue={value.city}
-              onChange={(e) => setCity(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="State"
-              defaultValue={value.state}
-              onChange={(e) => setState(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Postal Code"
-              defaultValue={value.postalCode}
-              onChange={(e) => setPostalCode(e.currentTarget.value)}
-            />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <InputRow>
+      <select data-testid="address-use" defaultValue={value?.use} onChange={(e) => setUse(e.currentTarget.value)}>
+        <option></option>
+        <option>home</option>
+        <option>mobile</option>
+        <option>old</option>
+        <option>temp</option>
+        <option>work</option>
+      </select>
+      <select data-testid="address-type" defaultValue={value?.type} onChange={(e) => setType(e.currentTarget.value)}>
+        <option></option>
+        <option>postal</option>
+        <option>physical</option>
+        <option>both</option>
+      </select>
+      <input
+        type="text"
+        placeholder="Line 1"
+        defaultValue={getLine(value, 0)}
+        onChange={(e) => setLine1(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="Line 2"
+        defaultValue={getLine(value, 1)}
+        onChange={(e) => setLine2(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="City"
+        defaultValue={value.city}
+        onChange={(e) => setCity(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="State"
+        defaultValue={value.state}
+        onChange={(e) => setState(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="Postal Code"
+        defaultValue={value.postalCode}
+        onChange={(e) => setPostalCode(e.currentTarget.value)}
+      />
+    </InputRow>
   );
 }

--- a/packages/ui/src/AttachmentArrayInput.tsx
+++ b/packages/ui/src/AttachmentArrayInput.tsx
@@ -12,7 +12,7 @@ export interface AttachmentArrayInputProps {
 }
 
 export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Element {
-  const [values, setValues] = useState(props.defaultValue ?? []);
+  const [values, setValues] = useState<Attachment[]>(props.defaultValue ?? []);
 
   const valuesRef = useRef<Attachment[]>();
   valuesRef.current = values;
@@ -25,48 +25,43 @@ export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Elem
   }
 
   return (
-    <div>
-      <table>
-        <colgroup>
-          <col width="90%" />
-          <col width="10%" />
-        </colgroup>
-        <tbody>
-          {values.map(
-            (v: any, index: number) =>
-              !v.__removed && (
-                <tr key={`${index}-${values.length}`}>
-                  <td>
-                    <AttachmentDisplay value={v} maxWidth={200} />
-                  </td>
-                  <td>
-                    <button
-                      className="btn"
-                      onClick={(e) => {
-                        killEvent(e);
-                        const copy = values.slice();
-                        copy.splice(index, 1);
-                        setValuesWrapper(copy);
-                      }}
-                    >
-                      Remove
-                    </button>
-                  </td>
-                </tr>
-              )
-          )}
-          <tr>
-            <td></td>
+    <table>
+      <colgroup>
+        <col width="90%" />
+        <col width="10%" />
+      </colgroup>
+      <tbody>
+        {values.map((v: Attachment, index: number) => (
+          <tr key={`${index}-${values.length}`}>
             <td>
-              <UploadButton
-                onUpload={(attachment: Attachment) => {
-                  setValuesWrapper([...(valuesRef.current as Attachment[]), attachment]);
+              <AttachmentDisplay value={v} maxWidth={200} />
+            </td>
+            <td className="right">
+              <button
+                className="btn"
+                onClick={(e) => {
+                  killEvent(e);
+                  const copy = values.slice();
+                  copy.splice(index, 1);
+                  setValuesWrapper(copy);
                 }}
-              />
+              >
+                Remove
+              </button>
             </td>
           </tr>
-        </tbody>
-      </table>
-    </div>
+        ))}
+        <tr>
+          <td></td>
+          <td className="right">
+            <UploadButton
+              onUpload={(attachment: Attachment) => {
+                setValuesWrapper([...(valuesRef.current as Attachment[]), attachment]);
+              }}
+            />
+          </td>
+        </tr>
+      </tbody>
+    </table>
   );
 }

--- a/packages/ui/src/Autocomplete.css
+++ b/packages/ui/src/Autocomplete.css
@@ -5,10 +5,11 @@
   box-shadow: 0 1px 1px 0 var(--medplum-gray-200);
   outline: 2px var(--medplum-surface);
   position: relative;
-  margin: 0;
   cursor: text;
-  height: 32px;
+  height: 34px;
   line-height: 28px;
+  width: 100%;
+  max-width: 400px;
 }
 
 .medplum-autocomplete-container.focused {
@@ -23,7 +24,7 @@
   list-style-type: none;
   overflow: hidden;
   cursor: text;
-  height: 32px;
+  height: 34px;
 }
 
 .medplum-autocomplete-container > ul > li {
@@ -52,9 +53,10 @@
 .medplum-autocomplete-container > ul > li > input {
   display: inline-block;
   width: 80px;
+  height: 28px;
   line-height: 26px;
   padding: 0 0 0 6px;
-  margin: 2px 0 0 2px;
+  margin: 3px 0 0 2px;
   outline: none;
   border: none;
   box-shadow: none;

--- a/packages/ui/src/BackboneElementDisplay.test.tsx
+++ b/packages/ui/src/BackboneElementDisplay.test.tsx
@@ -1,11 +1,11 @@
 import { IndexedStructureDefinition } from '@medplum/core';
 import { ElementDefinition } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { BackboneElementDisplay, BackboneElementDisplayProps } from './BackboneElementDisplay';
 import { MedplumProvider } from './MedplumProvider';
-import { MockClient } from '@medplum/mock';
 
 const contactProperty: ElementDefinition = {
   id: 'Patient.contact',
@@ -43,6 +43,18 @@ const nameProperty: ElementDefinition = {
   max: '1',
 };
 
+const deviceNameNameProperty: ElementDefinition = {
+  id: 'Device.deviceName.name',
+  path: 'Device.deviceName.name',
+  type: [
+    {
+      code: 'string',
+    },
+  ],
+  min: 0,
+  max: '1',
+};
+
 const schema: IndexedStructureDefinition = {
   types: {
     Patient: {
@@ -56,6 +68,12 @@ const schema: IndexedStructureDefinition = {
       properties: {
         id: idProperty,
         name: nameProperty,
+      },
+    },
+    DeviceDeviceName: {
+      display: 'Device Device Name',
+      properties: {
+        name: deviceNameNameProperty,
       },
     },
   },
@@ -94,6 +112,40 @@ describe('BackboneElementDisplay', () => {
         },
       },
     });
-    expect(screen.getByText('Name')).toBeDefined();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+
+  test('Ignore missing properties', () => {
+    setup({
+      schema,
+      typeName: 'PatientContact',
+      value: {
+        id: '123',
+      },
+      ignoreMissingValues: true,
+    });
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
+  });
+
+  test('Renders simple name', () => {
+    setup({
+      schema,
+      typeName: 'DeviceDeviceName',
+      value: {
+        name: 'Simple Name',
+      },
+    });
+    expect(screen.getByText('Simple Name')).toBeInTheDocument();
+  });
+
+  test('Not implemented', () => {
+    setup({
+      schema,
+      typeName: 'Foo',
+      value: {
+        foo: 'bar',
+      },
+    });
+    expect(screen.getByText('Foo not implemented')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/BackboneElementDisplay.tsx
+++ b/packages/ui/src/BackboneElementDisplay.tsx
@@ -21,7 +21,7 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
   const typeName = props.typeName;
   const typeSchema = props.schema.types[typeName];
   if (!typeSchema) {
-    return <div>Schema not found</div>;
+    return <div>{typeName}&nbsp;not implemented</div>;
   }
 
   if (typeof value === 'object' && 'name' in value && Object.keys(value).length === 1) {

--- a/packages/ui/src/BackboneElementInput.test.tsx
+++ b/packages/ui/src/BackboneElementInput.test.tsx
@@ -1,11 +1,11 @@
 import { IndexedStructureDefinition } from '@medplum/core';
 import { ElementDefinition } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { BackboneElementInput, BackboneElementInputProps } from './BackboneElementInput';
 import { MedplumProvider } from './MedplumProvider';
-import { MockClient } from '@medplum/mock';
 
 const contactProperty: ElementDefinition = {
   id: 'Patient.contact',
@@ -148,5 +148,16 @@ describe('BackboneElementInput', () => {
     });
     expect(screen.getByText('Locked Date')).toBeInTheDocument();
     expect(screen.queryByText('Exclude')).toBeNull();
+  });
+
+  test('Not implemented', () => {
+    setup({
+      schema,
+      property: {
+        path: 'foo',
+      },
+      name: 'foo',
+    });
+    expect(screen.getByText('Foo not implemented')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/BackboneElementInput.tsx
+++ b/packages/ui/src/BackboneElementInput.tsx
@@ -28,7 +28,7 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
   const typeName = buildTypeName(props.property.path?.split('.') as string[]);
   const typeSchema = props.schema.types[typeName];
   if (!typeSchema) {
-    return <div>Schema not found</div>;
+    return <div>{typeName}&nbsp;not implemented</div>;
   }
 
   return (

--- a/packages/ui/src/ContactPointInput.tsx
+++ b/packages/ui/src/ContactPointInput.tsx
@@ -1,5 +1,6 @@
 import { ContactPoint } from '@medplum/fhirtypes';
 import React, { useRef, useState } from 'react';
+import { InputRow } from './InputRow';
 
 export interface ContactPointInputProps {
   name: string;
@@ -39,45 +40,35 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
   }
 
   return (
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <select
-              defaultValue={contactPoint?.system}
-              onChange={(e) => setSystem(e.currentTarget.value)}
-              data-testid="system"
-            >
-              <option></option>
-              <option>email</option>
-              <option>fax</option>
-              <option>pager</option>
-              <option>phone</option>
-              <option>other</option>
-              <option>sms</option>
-              <option>sms</option>
-            </select>
-          </td>
-          <td>
-            <select defaultValue={contactPoint?.use} onChange={(e) => setUse(e.currentTarget.value)} data-testid="use">
-              <option></option>
-              <option>home</option>
-              <option>mobile</option>
-              <option>old</option>
-              <option>temp</option>
-              <option>work</option>
-            </select>
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Value"
-              defaultValue={contactPoint?.value}
-              onChange={(e) => setValue(e.currentTarget.value)}
-            />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <InputRow>
+      <select
+        defaultValue={contactPoint?.system}
+        onChange={(e) => setSystem(e.currentTarget.value)}
+        data-testid="system"
+      >
+        <option></option>
+        <option>email</option>
+        <option>fax</option>
+        <option>pager</option>
+        <option>phone</option>
+        <option>other</option>
+        <option>sms</option>
+        <option>sms</option>
+      </select>
+      <select defaultValue={contactPoint?.use} onChange={(e) => setUse(e.currentTarget.value)} data-testid="use">
+        <option></option>
+        <option>home</option>
+        <option>mobile</option>
+        <option>old</option>
+        <option>temp</option>
+        <option>work</option>
+      </select>
+      <input
+        type="text"
+        placeholder="Value"
+        defaultValue={contactPoint?.value}
+        onChange={(e) => setValue(e.currentTarget.value)}
+      />
+    </InputRow>
   );
 }

--- a/packages/ui/src/CssBaseline.css
+++ b/packages/ui/src/CssBaseline.css
@@ -94,9 +94,12 @@ hr {
   text-align: center;
 }
 
+table {
+  width: 100%;
+}
+
 table.table {
   border-collapse: collapse;
-  width: 100%;
 }
 
 table.table th,

--- a/packages/ui/src/DateTimeDisplay.test.tsx
+++ b/packages/ui/src/DateTimeDisplay.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { CodingDisplay } from './CodingDisplay';
+
+describe('CodingDisplay', () => {
+  test('Renders display', () => {
+    render(<CodingDisplay value={{ display: 'Display Text', code: '123' }} />);
+    expect(screen.getByText('Display Text')).toBeInTheDocument();
+    expect(screen.queryByText('123')).not.toBeInTheDocument();
+  });
+
+  test('Renders code', () => {
+    render(<CodingDisplay value={{ code: '123' }} />);
+    expect(screen.getByText('123')).toBeInTheDocument();
+  });
+
+  test('Renders undefined value', () => {
+    render(<CodingDisplay />);
+  });
+});

--- a/packages/ui/src/DateTimeDisplay.test.tsx
+++ b/packages/ui/src/DateTimeDisplay.test.tsx
@@ -1,20 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { CodingDisplay } from './CodingDisplay';
+import { DateTimeDisplay } from './DateTimeDisplay';
 
-describe('CodingDisplay', () => {
-  test('Renders display', () => {
-    render(<CodingDisplay value={{ display: 'Display Text', code: '123' }} />);
-    expect(screen.getByText('Display Text')).toBeInTheDocument();
-    expect(screen.queryByText('123')).not.toBeInTheDocument();
+describe('DateTimeDisplay', () => {
+  test('Handles undefined value', () => {
+    render(<DateTimeDisplay />);
   });
 
-  test('Renders code', () => {
-    render(<CodingDisplay value={{ code: '123' }} />);
-    expect(screen.getByText('123')).toBeInTheDocument();
+  test('Handles malformed value', () => {
+    render(<DateTimeDisplay value="xyz" />);
   });
 
-  test('Renders undefined value', () => {
-    render(<CodingDisplay />);
+  test('Renders dateTime', () => {
+    render(<DateTimeDisplay value="2021-06-01T12:00:00Z" />);
+    expect(screen.getByText('2021', { exact: false })).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/DateTimeDisplay.tsx
+++ b/packages/ui/src/DateTimeDisplay.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export interface DateTimeDisplayProps {
+  value?: string;
+}
+
+export function DateTimeDisplay(props: DateTimeDisplayProps): JSX.Element | null {
+  if (!props.value) {
+    return null;
+  }
+  return <>{new Date(props.value).toLocaleString()}</>;
+}

--- a/packages/ui/src/FormSection.css
+++ b/packages/ui/src/FormSection.css
@@ -23,21 +23,3 @@ fieldset small {
   margin: 2px 0 4px 0;
   padding: 2px 0 4px 0;
 }
-
-fieldset input[type='date'],
-fieldset input[type='datetime-local'],
-fieldset input[type='email'],
-fieldset input[type='number'],
-fieldset input[type='password'],
-fieldset input[type='tel'],
-fieldset input[type='text'],
-fieldset input[type='time'],
-fieldset input[type='url'] {
-  width: 100%;
-  max-width: 400px;
-}
-
-fieldset select,
-fieldset table {
-  width: 100%;
-}

--- a/packages/ui/src/HumanNameInput.tsx
+++ b/packages/ui/src/HumanNameInput.tsx
@@ -1,5 +1,6 @@
 import { HumanName } from '@medplum/fhirtypes';
 import React, { useRef, useState } from 'react';
+import { InputRow } from './InputRow';
 
 export interface HumanNameInputProps {
   name: string;
@@ -53,55 +54,41 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
   }
 
   return (
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <select defaultValue={value?.use} onChange={(e) => setUse(e.currentTarget.value)} data-testid="use">
-              <option></option>
-              <option>usual</option>
-              <option>official</option>
-              <option>temp</option>
-              <option>nickname</option>
-              <option>anonymous</option>
-              <option>old</option>
-              <option>maiden</option>
-            </select>
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Prefix"
-              defaultValue={value?.prefix?.join(' ')}
-              onChange={(e) => setPrefix(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Given"
-              defaultValue={value?.given?.join(' ')}
-              onChange={(e) => setGiven(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Family"
-              defaultValue={value?.family}
-              onChange={(e) => setFamily(e.currentTarget.value)}
-            />
-          </td>
-          <td>
-            <input
-              type="text"
-              placeholder="Suffix"
-              defaultValue={value?.suffix?.join(' ')}
-              onChange={(e) => setSuffix(e.currentTarget.value)}
-            />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <InputRow>
+      <select defaultValue={value?.use} onChange={(e) => setUse(e.currentTarget.value)} data-testid="use">
+        <option></option>
+        <option>usual</option>
+        <option>official</option>
+        <option>temp</option>
+        <option>nickname</option>
+        <option>anonymous</option>
+        <option>old</option>
+        <option>maiden</option>
+      </select>
+      <input
+        type="text"
+        placeholder="Prefix"
+        defaultValue={value?.prefix?.join(' ')}
+        onChange={(e) => setPrefix(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="Given"
+        defaultValue={value?.given?.join(' ')}
+        onChange={(e) => setGiven(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="Family"
+        defaultValue={value?.family}
+        onChange={(e) => setFamily(e.currentTarget.value)}
+      />
+      <input
+        type="text"
+        placeholder="Suffix"
+        defaultValue={value?.suffix?.join(' ')}
+        onChange={(e) => setSuffix(e.currentTarget.value)}
+      />
+    </InputRow>
   );
 }

--- a/packages/ui/src/InputRow.tsx
+++ b/packages/ui/src/InputRow.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export interface InputRowProps {
+  children: React.ReactNode;
+}
+
+export function InputRow(props: InputRowProps): JSX.Element {
+  return <div style={{ display: 'flex', width: '100%', gap: '3px', alignItems: 'center' }}>{props.children}</div>;
+}

--- a/packages/ui/src/PeriodDisplay.test.tsx
+++ b/packages/ui/src/PeriodDisplay.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { PeriodDisplay } from './PeriodDisplay';
+
+describe('PeriodDisplay', () => {
+  test('Renders', () => {
+    render(<PeriodDisplay value={{ start: '2021-01-01T12:00:00Z', end: '2021-01-02T12:00:00Z' }} />);
+    expect(screen.getByText('2021', { exact: false })).toBeInTheDocument();
+  });
+
+  test('Renders undefined value', () => {
+    render(<PeriodDisplay />);
+  });
+});

--- a/packages/ui/src/PeriodDisplay.test.tsx
+++ b/packages/ui/src/PeriodDisplay.test.tsx
@@ -3,12 +3,27 @@ import React from 'react';
 import { PeriodDisplay } from './PeriodDisplay';
 
 describe('PeriodDisplay', () => {
-  test('Renders', () => {
-    render(<PeriodDisplay value={{ start: '2021-01-01T12:00:00Z', end: '2021-01-02T12:00:00Z' }} />);
+  test('Handles undefined value', () => {
+    render(<PeriodDisplay />);
+  });
+
+  test('Ignores empty value', () => {
+    render(<PeriodDisplay value={{}} />);
+  });
+
+  test('Renders both start and end', () => {
+    render(<PeriodDisplay value={{ start: '2021-06-01T12:00:00Z', end: '2022-06-02T12:00:00Z' }} />);
+    expect(screen.getByText('2021', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('2022', { exact: false })).toBeInTheDocument();
+  });
+
+  test('Renders only start', () => {
+    render(<PeriodDisplay value={{ start: '2021-01-01T12:00:00Z' }} />);
     expect(screen.getByText('2021', { exact: false })).toBeInTheDocument();
   });
 
-  test('Renders undefined value', () => {
-    render(<PeriodDisplay />);
+  test('Renders only end', () => {
+    render(<PeriodDisplay value={{ end: '2022-06-02T12:00:00Z' }} />);
+    expect(screen.getByText('2022', { exact: false })).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/PeriodDisplay.tsx
+++ b/packages/ui/src/PeriodDisplay.tsx
@@ -1,0 +1,22 @@
+import { Period } from '@medplum/fhirtypes';
+import React from 'react';
+import { DateTimeDisplay } from './DateTimeDisplay';
+
+export interface PeriodDisplayProps {
+  value?: Period;
+}
+
+export function PeriodDisplay(props: PeriodDisplayProps): JSX.Element | null {
+  const value = props.value;
+  if (!value || (!value.start && !value.end)) {
+    return null;
+  }
+
+  return (
+    <span>
+      <DateTimeDisplay value={value.start} />
+      -
+      <DateTimeDisplay value={value.end} />
+    </span>
+  );
+}

--- a/packages/ui/src/PeriodInput.test.tsx
+++ b/packages/ui/src/PeriodInput.test.tsx
@@ -1,0 +1,42 @@
+import { Period } from '@medplum/fhirtypes';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { PeriodInput } from './PeriodInput';
+
+const startDateTime = '2021-01-01T00:00:00Z';
+const endDateTime = '2021-01-02T00:00:00Z';
+
+describe('PeriodInput', () => {
+  test('Renders undefined value', () => {
+    render(<PeriodInput name="a" />);
+    expect(screen.getByPlaceholderText('Start')).toBeDefined();
+    expect(screen.getByPlaceholderText('End')).toBeDefined();
+  });
+
+  test('Renders', () => {
+    render(<PeriodInput name="a" defaultValue={{ start: startDateTime, end: endDateTime }} />);
+    expect(screen.getByPlaceholderText('Start')).toBeDefined();
+    expect(screen.getByPlaceholderText('End')).toBeDefined();
+  });
+
+  test('Set value', async () => {
+    let lastValue: Period | undefined = undefined;
+
+    render(<PeriodInput name="a" onChange={(value) => (lastValue = value)} />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('Start'), {
+        target: { value: startDateTime },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('End'), {
+        target: { value: endDateTime },
+      });
+    });
+
+    expect(lastValue).toBeDefined();
+    expect(lastValue).toMatchObject({ start: startDateTime, end: endDateTime });
+  });
+});

--- a/packages/ui/src/PeriodInput.test.tsx
+++ b/packages/ui/src/PeriodInput.test.tsx
@@ -20,6 +20,25 @@ describe('PeriodInput', () => {
   });
 
   test('Set value', async () => {
+    render(<PeriodInput name="a" />);
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('Start'), {
+        target: { value: startDateTime },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('End'), {
+        target: { value: endDateTime },
+      });
+    });
+
+    expect(screen.getByDisplayValue(startDateTime)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(endDateTime)).toBeInTheDocument();
+  });
+
+  test('Change event', async () => {
     let lastValue: Period | undefined = undefined;
 
     render(<PeriodInput name="a" onChange={(value) => (lastValue = value)} />);

--- a/packages/ui/src/PeriodInput.tsx
+++ b/packages/ui/src/PeriodInput.tsx
@@ -1,18 +1,18 @@
-import { Identifier } from '@medplum/fhirtypes';
+import { Period } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { InputRow } from './InputRow';
 import { TextField } from './TextField';
 
-export interface IdentifierInputProps {
+export interface PeriodInputProps {
   name: string;
-  defaultValue?: Identifier;
-  onChange?: (value: Identifier) => void;
+  defaultValue?: Period;
+  onChange?: (value: Period) => void;
 }
 
-export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
+export function PeriodInput(props: PeriodInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
 
-  function setValueWrapper(newValue: Identifier): void {
+  function setValueWrapper(newValue: Period): void {
     setValue(newValue);
     if (props.onChange) {
       props.onChange(newValue);
@@ -22,22 +22,24 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
   return (
     <InputRow>
       <TextField
-        placeholder="System"
-        defaultValue={value?.system}
+        type="datetime-local"
+        placeholder="Start"
+        defaultValue={value?.start}
         onChange={(e) =>
           setValueWrapper({
             ...value,
-            system: (e.currentTarget as HTMLInputElement).value,
+            start: (e.currentTarget as HTMLInputElement).value,
           })
         }
       />
       <TextField
-        placeholder="Value"
-        defaultValue={value?.value}
+        type="datetime-local"
+        placeholder="End"
+        defaultValue={value?.end}
         onChange={(e) =>
           setValueWrapper({
             ...value,
-            value: (e.currentTarget as HTMLInputElement).value,
+            end: (e.currentTarget as HTMLInputElement).value,
           })
         }
       />

--- a/packages/ui/src/QuantityInput.tsx
+++ b/packages/ui/src/QuantityInput.tsx
@@ -1,5 +1,6 @@
 import { Quantity } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
+import { InputRow } from './InputRow';
 import { TextField } from './TextField';
 
 export interface QuantityInputProps {
@@ -19,39 +20,31 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
   }
 
   return (
-    <table>
-      <tbody>
-        <tr>
-          <td>
-            <TextField
-              name={props.name}
-              type="number"
-              step={0.01}
-              placeholder="Value"
-              defaultValue={value?.value?.toString()}
-              onChange={(e) =>
-                setValueWrapper({
-                  ...value,
-                  value: tryParseNumber((e.currentTarget as HTMLInputElement).value),
-                })
-              }
-            />
-          </td>
-          <td>
-            <TextField
-              placeholder="Unit"
-              defaultValue={value?.unit}
-              onChange={(e) =>
-                setValueWrapper({
-                  ...value,
-                  unit: (e.currentTarget as HTMLInputElement).value,
-                })
-              }
-            />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <InputRow>
+      <TextField
+        name={props.name}
+        type="number"
+        step={0.01}
+        placeholder="Value"
+        defaultValue={value?.value?.toString()}
+        onChange={(e) =>
+          setValueWrapper({
+            ...value,
+            value: tryParseNumber((e.currentTarget as HTMLInputElement).value),
+          })
+        }
+      />
+      <TextField
+        placeholder="Unit"
+        defaultValue={value?.unit}
+        onChange={(e) =>
+          setValueWrapper({
+            ...value,
+            unit: (e.currentTarget as HTMLInputElement).value,
+          })
+        }
+      />
+    </InputRow>
   );
 }
 

--- a/packages/ui/src/ReferenceInput.tsx
+++ b/packages/ui/src/ReferenceInput.tsx
@@ -1,6 +1,7 @@
 import { createReference } from '@medplum/core';
 import { ElementDefinition, Reference, Resource } from '@medplum/fhirtypes';
 import React, { useRef, useState } from 'react';
+import { InputRow } from './InputRow';
 import { ResourceInput } from './ResourceInput';
 
 export interface ReferenceInputProps {
@@ -30,49 +31,40 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
   }
 
   return (
-    <table style={{ tableLayout: 'fixed' }}>
-      <tbody>
-        <tr>
-          <td>
-            <input name={props.name} type="hidden" value={JSON.stringify(value) || ''} readOnly={true} />
-            {targetTypes ? (
-              <select
-                data-testid="reference-input-resource-type-select"
-                defaultValue={resourceType}
-                onChange={(e) => setResourceType(e.currentTarget.value)}
-              >
-                {targetTypes.map((targetType) => (
-                  <option key={targetType} value={targetType}>
-                    {targetType}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <input
-                type="text"
-                data-testid="reference-input-resource-type-input"
-                defaultValue={resourceType}
-                onChange={(e) => {
-                  setResourceType(e.currentTarget.value);
-                }}
-              />
-            )}
-          </td>
-          <td>
-            {resourceType && (
-              <ResourceInput
-                resourceType={resourceType}
-                name={props.name + '-id'}
-                defaultValue={value}
-                onChange={(item: Resource | undefined) => {
-                  setValueHelper(item ? createReference(item) : undefined);
-                }}
-              />
-            )}
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <InputRow>
+      {targetTypes ? (
+        <select
+          data-testid="reference-input-resource-type-select"
+          defaultValue={resourceType}
+          onChange={(e) => setResourceType(e.currentTarget.value)}
+        >
+          {targetTypes.map((targetType) => (
+            <option key={targetType} value={targetType}>
+              {targetType}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type="text"
+          data-testid="reference-input-resource-type-input"
+          defaultValue={resourceType}
+          onChange={(e) => {
+            setResourceType(e.currentTarget.value);
+          }}
+        />
+      )}
+      {resourceType && (
+        <ResourceInput
+          resourceType={resourceType}
+          name={props.name + '-id'}
+          defaultValue={value}
+          onChange={(item: Resource | undefined) => {
+            setValueHelper(item ? createReference(item) : undefined);
+          }}
+        />
+      )}
+    </InputRow>
   );
 }
 

--- a/packages/ui/src/ResourceArrayInput.tsx
+++ b/packages/ui/src/ResourceArrayInput.tsx
@@ -29,7 +29,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
 
   return (
     <div>
-      <table>
+      <table style={{ width: '100%' }}>
         <colgroup>
           <col width="90%" />
           <col width="10%" />
@@ -51,7 +51,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
                   }}
                 />
               </td>
-              <td>
+              <td style={{ textAlign: 'right' }}>
                 <Button
                   onClick={(e) => {
                     killEvent(e);
@@ -67,7 +67,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
           ))}
           <tr>
             <td></td>
-            <td>
+            <td style={{ textAlign: 'right' }}>
               <Button
                 onClick={(e) => {
                   killEvent(e);

--- a/packages/ui/src/ResourceForm.tsx
+++ b/packages/ui/src/ResourceForm.tsx
@@ -33,10 +33,6 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
   }
 
   const typeSchema = schema.types[value.resourceType];
-  if (!typeSchema) {
-    return <div>{value.resourceType}&nbsp;not found</div>;
-  }
-
   return (
     <form
       noValidate

--- a/packages/ui/src/ResourceForm.tsx
+++ b/packages/ui/src/ResourceForm.tsx
@@ -34,7 +34,7 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
 
   const typeSchema = schema.types[value.resourceType];
   if (!typeSchema) {
-    return <div>Schema not found</div>;
+    return <div>{value.resourceType}&nbsp;not found</div>;
   }
 
   return (

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -9,6 +9,7 @@ import {
   ElementDefinition,
   HumanName,
   Identifier,
+  Period,
   Quantity,
   Reference,
   SubscriptionChannel,
@@ -1172,6 +1173,24 @@ describe('ResourcePropertyDisplay', () => {
     );
 
     expect(screen.getByText('xyz: xyz123')).toBeDefined();
+  });
+
+  test('Renders Period', () => {
+    const value: Period = {
+      start: '2021-06-01T12:00:00Z',
+      end: '2021-06-30T12:00:00Z',
+    };
+
+    render(
+      <ResourcePropertyDisplay
+        schema={schema}
+        property={{ type: [{ code: 'Period' }] }}
+        propertyType={PropertyType.Period}
+        value={value}
+      />
+    );
+
+    expect(screen.getByText('2021', { exact: false })).toBeInTheDocument();
   });
 
   test('Renders Quantity', () => {

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -10,6 +10,7 @@ import { CodingDisplay } from './CodingDisplay';
 import { ContactPointDisplay } from './ContactPointDisplay';
 import { HumanNameDisplay } from './HumanNameDisplay';
 import { IdentifierDisplay } from './IdentifierDisplay';
+import { PeriodDisplay } from './PeriodDisplay';
 import { QuantityDisplay } from './QuantityDisplay';
 import { ReferenceDisplay } from './ReferenceDisplay';
 import { ResourceArrayDisplay } from './ResourceArrayDisplay';
@@ -75,6 +76,8 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       return <HumanNameDisplay value={value} />;
     case PropertyType.Identifier:
       return <IdentifierDisplay value={value} />;
+    case PropertyType.Period:
+      return <PeriodDisplay value={value} />;
     case PropertyType.Quantity:
       return <QuantityDisplay value={value} />;
     case PropertyType.Reference:

--- a/packages/ui/src/ResourcePropertyInput.test.tsx
+++ b/packages/ui/src/ResourcePropertyInput.test.tsx
@@ -8,6 +8,7 @@ import {
   ElementDefinition,
   HumanName,
   Identifier,
+  Period,
 } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
@@ -189,6 +190,54 @@ describe('ResourcePropertyInput', () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
+  test('Date property', async () => {
+    const onChange = jest.fn();
+
+    setup({
+      schema,
+      property: {
+        type: [
+          {
+            code: 'date',
+          },
+        ],
+      },
+      name: 'date',
+      onChange,
+    });
+    expect(screen.getByTestId('date')).toBeDefined();
+
+    act(() => {
+      fireEvent.change(screen.getByTestId('date'), { target: { value: '2021-01-01' } });
+    });
+
+    expect(onChange).toHaveBeenCalledWith('2021-01-01');
+  });
+
+  test('Date/Time property', async () => {
+    const onChange = jest.fn();
+
+    setup({
+      schema,
+      property: {
+        type: [
+          {
+            code: 'dateTime',
+          },
+        ],
+      },
+      name: 'dateTime',
+      onChange,
+    });
+    expect(screen.getByTestId('dateTime')).toBeDefined();
+
+    act(() => {
+      fireEvent.change(screen.getByTestId('dateTime'), { target: { value: '2021-01-01T12:00:00Z' } });
+    });
+
+    expect(onChange).toHaveBeenCalledWith('2021-01-01T12:00:00Z');
+  });
+
   test('Renders Address property', () => {
     const address: Address[] = [
       {
@@ -353,6 +402,40 @@ describe('ResourcePropertyInput', () => {
     });
     expect(screen.getByDisplayValue('https://example.com')).toBeDefined();
     expect(screen.getByDisplayValue('123')).toBeDefined();
+  });
+
+  test('Renders Period property', async () => {
+    const period: Period = {
+      start: '2020-01-01T12:00:00Z',
+      end: '2021-01-02T12:00:00Z',
+    };
+
+    const onChange = jest.fn();
+
+    setup({
+      schema,
+      property: {
+        type: [
+          {
+            code: 'Period',
+          },
+        ],
+      },
+      name: 'period',
+      defaultValue: period,
+      onChange,
+    });
+
+    expect(screen.getByPlaceholderText('Start')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('End')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('End'), {
+        target: { value: '2021-01-03T12:00:00Z' },
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ start: '2020-01-01T12:00:00Z', end: '2021-01-03T12:00:00Z' });
   });
 
   test('Renders Reference property', () => {

--- a/packages/ui/src/ResourcePropertyInput.tsx
+++ b/packages/ui/src/ResourcePropertyInput.tsx
@@ -13,6 +13,8 @@ import { ContactPointInput } from './ContactPointInput';
 import { ExtensionInput } from './ExtensionInput';
 import { HumanNameInput } from './HumanNameInput';
 import { IdentifierInput } from './IdentifierInput';
+import { InputRow } from './InputRow';
+import { PeriodInput } from './PeriodInput';
 import { QuantityInput } from './QuantityInput';
 import { ReferenceInput } from './ReferenceInput';
 import { ResourceArrayInput } from './ResourceArrayInput';
@@ -72,41 +74,34 @@ export function ElementDefinitionInputSelector(props: ElementDefinitionSelectorP
   }
   const [selectedType, setSelectedType] = useState(initialPropertyType);
   return (
-    <table>
-      <tbody>
-        <tr>
-          <td style={{ width: '20%' }}>
-            <select
-              defaultValue={selectedType.code}
-              onChange={(e: React.ChangeEvent) => {
-                setSelectedType(
-                  propertyTypes.find(
-                    (type: ElementDefinitionType) => type.code === (e.target as HTMLSelectElement).value
-                  ) as ElementDefinitionType
-                );
-              }}
-            >
-              {propertyTypes.map((type: ElementDefinitionType) => (
-                <option key={type.code} value={type.code}>
-                  {type.code}
-                </option>
-              ))}
-            </select>
-          </td>
-          <td style={{ width: '80%' }}>
-            <ElementDefinitionTypeInput
-              {...props}
-              elementDefinitionType={selectedType}
-              onChange={(newValue: any) => {
-                if (props.onChange) {
-                  props.onChange(newValue, props.name.replace('[x]', capitalize(selectedType.code as string)));
-                }
-              }}
-            />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <InputRow>
+      <select
+        style={{ width: '200px' }}
+        defaultValue={selectedType.code}
+        onChange={(e: React.ChangeEvent) => {
+          setSelectedType(
+            propertyTypes.find(
+              (type: ElementDefinitionType) => type.code === (e.target as HTMLSelectElement).value
+            ) as ElementDefinitionType
+          );
+        }}
+      >
+        {propertyTypes.map((type: ElementDefinitionType) => (
+          <option key={type.code} value={type.code}>
+            {type.code}
+          </option>
+        ))}
+      </select>
+      <ElementDefinitionTypeInput
+        {...props}
+        elementDefinitionType={selectedType}
+        onChange={(newValue: any) => {
+          if (props.onChange) {
+            props.onChange(newValue, props.name.replace('[x]', capitalize(selectedType.code as string)));
+          }
+        }}
+      />
+    </InputRow>
   );
 }
 
@@ -123,15 +118,36 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
   switch (propertyType) {
     case PropertyType.SystemString:
     case PropertyType.canonical:
-    case PropertyType.date:
-    case PropertyType.dateTime:
-    case PropertyType.instant:
     case PropertyType.string:
+    case PropertyType.time:
     case PropertyType.uri:
     case PropertyType.url:
       return (
         <TextField
           type="text"
+          name={name}
+          testid={name}
+          defaultValue={value}
+          onChange={(e: React.ChangeEvent) => props.onChange && props.onChange((e.target as HTMLInputElement).value)}
+          outcome={props.outcome}
+        />
+      );
+    case PropertyType.date:
+      return (
+        <TextField
+          type="date"
+          name={name}
+          testid={name}
+          defaultValue={value}
+          onChange={(e: React.ChangeEvent) => props.onChange && props.onChange((e.target as HTMLInputElement).value)}
+          outcome={props.outcome}
+        />
+      );
+    case PropertyType.dateTime:
+    case PropertyType.instant:
+      return (
+        <TextField
+          type="datetime-local"
           name={name}
           testid={name}
           defaultValue={value}
@@ -197,6 +213,8 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
       return <HumanNameInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Identifier:
       return <IdentifierInput name={name} defaultValue={value} onChange={props.onChange} />;
+    case PropertyType.Period:
+      return <PeriodInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Quantity:
       return <QuantityInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Reference:

--- a/packages/ui/src/SearchFilterValueDisplay.tsx
+++ b/packages/ui/src/SearchFilterValueDisplay.tsx
@@ -1,5 +1,6 @@
 import { Filter } from '@medplum/core';
 import React from 'react';
+import { DateTimeDisplay } from './DateTimeDisplay';
 import { useMedplum } from './MedplumProvider';
 import { ResourceBadge } from './ResourceBadge';
 
@@ -23,7 +24,7 @@ export function SearchFilterValueDisplay(props: SearchFilterValueDisplayProps): 
   }
 
   if (props.filter.code === '_lastUpdated' || searchParam?.type === 'datetime') {
-    return <>{new Date(filter.value).toLocaleString()}</>;
+    return <DateTimeDisplay value={filter.value} />;
   }
 
   return <>{filter.value}</>;

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -1,6 +1,7 @@
 import { Filter, getPropertyDisplayName, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
 import { Resource, SearchParameter } from '@medplum/fhirtypes';
 import React from 'react';
+import { DateTimeDisplay } from './DateTimeDisplay';
 import { getValueAndType, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 const searchParamToOperators: Record<string, Operator[]> = {
@@ -493,7 +494,7 @@ export function renderValue(
   }
 
   if (key === '_lastUpdated') {
-    return new Date(resource.meta?.lastUpdated as string).toLocaleString('en-US');
+    return <DateTimeDisplay value={resource.meta?.lastUpdated} />;
   }
 
   const property = schema.types[resource.resourceType]?.properties?.[key];

--- a/packages/ui/src/TextField.css
+++ b/packages/ui/src/TextField.css
@@ -27,6 +27,9 @@ input[type='text'],
 input[type='time'],
 input[type='url'],
 select {
+  width: 100%;
+  max-width: 400px;
+  height: 34px;
   line-height: 28px;
 }
 
@@ -100,7 +103,7 @@ select {
 }
 
 select:not([size]) {
-  height: 32px;
+  height: 34px;
 }
 
 select.small:not([size]) {

--- a/packages/ui/src/TextField.tsx
+++ b/packages/ui/src/TextField.tsx
@@ -84,5 +84,5 @@ export function Select(props: SelectProps): JSX.Element {
  */
 function getInputType(requestedType: string | undefined): string {
   const result = requestedType || 'text';
-  return process.env.NODE_ENV === 'test' ? result.replace('datetime-local', 'text') : result;
+  return process.env.NODE_ENV === 'test' ? result.replace(/date|datetime-local/, 'text') : result;
 }

--- a/packages/ui/src/TextField.tsx
+++ b/packages/ui/src/TextField.tsx
@@ -26,7 +26,7 @@ export function TextField(props: TextFieldProps): JSX.Element {
     <input
       id={props.name}
       name={props.name}
-      type={props.type || 'text'}
+      type={getInputType(props.type)}
       step={props.step}
       className={className}
       defaultValue={props.defaultValue || ''}
@@ -74,4 +74,15 @@ export function Select(props: SelectProps): JSX.Element {
       {props.children}
     </select>
   );
+}
+
+/**
+ * Returns the input type for the requested type.
+ * JSDOM does not support many of the valid <input> type attributes.
+ * For example, it won't fire change events for <input type="datetime-local">.
+ * @param requestedType The optional type as requested by the parent component.
+ */
+function getInputType(requestedType: string | undefined): string {
+  const result = requestedType || 'text';
+  return process.env.NODE_ENV === 'test' ? result.replace('datetime-local', 'text') : result;
 }

--- a/packages/ui/src/utils/format.ts
+++ b/packages/ui/src/utils/format.ts
@@ -4,6 +4,7 @@ import { Bundle, BundleEntry, Resource } from '@medplum/fhirtypes';
  * Returns a formatted date string.
  * @param dateTime A date that can be either a ISO 8601 string or a Date object.
  * @returns A user-friendly formatted date string.
+ * @deprecated Use <DateTimeDisplay> component instead.
  */
 export function formatDateTime(dateTime: string | undefined): string {
   if (!dateTime) {


### PR DESCRIPTION
* Added `<PeriodInput>` for the [Period](http://www.hl7.org/fhir/datatypes.html#Period) data type
* Added `<PeriodDisplay>` for the [Period](http://www.hl7.org/fhir/datatypes.html#Period) data type
* Added `<InputRow>` to group a row of inputs
  * Before, we used a janky `<table>` setup with only one row.
  * Now, we use a simple `<div>` with appropriate flex styling

After this, here are the remaining unimplemented primitive types:
* [Ratio](http://www.hl7.org/fhir/datatypes.html#Ratio) - should be straightforward, although space will get tight in one row
* [Range](http://www.hl7.org/fhir/datatypes.html#Range) - should be straightforward, although space will get tight in one row
* [Timing](http://www.hl7.org/fhir/datatypes.html#Timing) - basically the full complexity of recurring calendar events