### PR TITLE
Updated assertOk utility

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -46,7 +46,7 @@ describe('Outcomes', () => {
   });
 
   test('Assert OK', () => {
-    expect(() => assertOk(allOk)).not.toThrow();
-    expect(() => assertOk(notFound)).toThrowError('Not found');
+    expect(() => assertOk(allOk, { resourceType: 'Patient' })).not.toThrow();
+    expect(() => assertOk(notFound, undefined)).toThrowError('Not found');
   });
 });

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -1,4 +1,4 @@
-import { OperationOutcome, Resource } from '@medplum/fhirtypes';
+import { OperationOutcome } from '@medplum/fhirtypes';
 
 const OK_ID = 'ok';
 const CREATED_ID = 'created';
@@ -142,8 +142,8 @@ export function getStatus(outcome: OperationOutcome): number {
  * @param outcome The operation outcome.
  * @param resource The resource that may or may not have been returned.
  */
-export function assertOk(outcome: OperationOutcome, resource: Resource | undefined): asserts resource is Resource {
-  if (!isOk(outcome) || !resource) {
+export function assertOk<T>(outcome: OperationOutcome, resource: T | undefined): asserts resource is T {
+  if (!isOk(outcome) || resource === undefined) {
     throw new OperationOutcomeError(outcome);
   }
 }

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -1,4 +1,4 @@
-import { OperationOutcome } from '@medplum/fhirtypes';
+import { OperationOutcome, Resource } from '@medplum/fhirtypes';
 
 const OK_ID = 'ok';
 const CREATED_ID = 'created';
@@ -137,8 +137,13 @@ export function getStatus(outcome: OperationOutcome): number {
   }
 }
 
-export function assertOk(outcome: OperationOutcome): void {
-  if (!isOk(outcome)) {
+/**
+ * Asserts that the operation completed successfully and that the resource is defined.
+ * @param outcome The operation outcome.
+ * @param resource The resource that may or may not have been returned.
+ */
+export function assertOk(outcome: OperationOutcome, resource: Resource | undefined): asserts resource is Resource {
+  if (!isOk(outcome) || !resource) {
     throw new OperationOutcomeError(outcome);
   }
 }

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -105,8 +105,8 @@ async function searchForExisting(email: string): Promise<User | undefined> {
       },
     ],
   });
-  assertOk(outcome);
-  if (bundle?.entry && bundle.entry.length > 0) {
+  assertOk(outcome, bundle);
+  if (bundle.entry && bundle.entry.length > 0) {
     return bundle.entry[0].resource as User;
   }
   return undefined;
@@ -122,7 +122,7 @@ async function createUser(request: InviteRequest): Promise<User> {
     email,
     passwordHash,
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as User).id);
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
   return result as User;
 }

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -124,5 +124,5 @@ async function createUser(request: InviteRequest): Promise<User> {
   });
   assertOk(outcome, result);
   logger.info('Created: ' + result.id);
-  return result as User;
+  return result;
 }

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -57,7 +57,7 @@ projectAdminRouter.get(
 
     const { membershipId } = req.params;
     const [outcome, membership] = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
-    assertOk(outcome);
+    assertOk(outcome, membership);
     res.status(getStatus(outcome)).json(membership);
   })
 );
@@ -78,7 +78,7 @@ projectAdminRouter.post(
     }
 
     const [outcome, result] = await systemRepo.updateResource(resource);
-    assertOk(outcome);
+    assertOk(outcome, result);
     res.status(getStatus(outcome)).json(result);
   })
 );

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -27,10 +27,10 @@ describe('Super Admin routes', () => {
     client = await createTestClient();
 
     const [outcome1, practitioner1] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
-    assertOk(outcome1);
+    assertOk(outcome1, practitioner1);
 
     const [outcome2, practitioner2] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
-    assertOk(outcome2);
+    assertOk(outcome2, practitioner2);
 
     const [outcome3, user1] = await systemRepo.createResource<User>({
       resourceType: 'User',
@@ -38,7 +38,7 @@ describe('Super Admin routes', () => {
       passwordHash: 'abc',
       admin: true,
     });
-    assertOk(outcome3);
+    assertOk(outcome3, user1);
 
     const [outcome4, user2] = await systemRepo.createResource<User>({
       resourceType: 'User',
@@ -46,7 +46,7 @@ describe('Super Admin routes', () => {
       passwordHash: 'abc',
       admin: false,
     });
-    assertOk(outcome4);
+    assertOk(outcome4, user2);
 
     const [outcome5, login1] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
@@ -55,7 +55,7 @@ describe('Super Admin routes', () => {
       authTime: new Date().toISOString(),
       scope: 'openid',
     });
-    assertOk(outcome5);
+    assertOk(outcome5, login1);
 
     const [outcome6, login2] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
@@ -64,7 +64,7 @@ describe('Super Admin routes', () => {
       authTime: new Date().toISOString(),
       scope: 'openid',
     });
-    assertOk(outcome6);
+    assertOk(outcome6, login2);
 
     adminAccessToken = await generateAccessToken({
       login_id: login1?.id as string,

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -2,7 +2,7 @@ import { accessDenied, allOk, assertOk, isOk } from '@medplum/core';
 import { User } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
-import { systemRepo, sendOutcome, validateResourceType } from '../fhir';
+import { sendOutcome, systemRepo, validateResourceType } from '../fhir';
 import { authenticateToken } from '../oauth';
 import { createStructureDefinitions } from '../seeds/structuredefinitions';
 import { createValueSetElements } from '../seeds/valuesets';
@@ -17,9 +17,9 @@ superAdminRouter.post(
   '/valuesets',
   asyncWrap(async (req: Request, res: Response) => {
     const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome);
+    assertOk(outcome, user);
 
-    if (!user?.admin) {
+    if (!user.admin) {
       sendOutcome(res, accessDenied);
       return;
     }
@@ -36,9 +36,9 @@ superAdminRouter.post(
   '/structuredefinitions',
   asyncWrap(async (req: Request, res: Response) => {
     const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome);
+    assertOk(outcome, user);
 
-    if (!user?.admin) {
+    if (!user.admin) {
       sendOutcome(res, accessDenied);
       return;
     }
@@ -55,9 +55,9 @@ superAdminRouter.post(
   '/reindex',
   asyncWrap(async (req: Request, res: Response) => {
     const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome);
+    assertOk(outcome, user);
 
-    if (!user?.admin) {
+    if (!user.admin) {
       sendOutcome(res, accessDenied);
       return;
     }

--- a/packages/server/src/admin/utils.ts
+++ b/packages/server/src/admin/utils.ts
@@ -1,5 +1,5 @@
 import { assertOk, Operator } from '@medplum/core';
-import { Bundle, BundleEntry, Project, ProjectMembership } from '@medplum/fhirtypes';
+import { BundleEntry, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { systemRepo } from '../fhir';
 
@@ -20,7 +20,7 @@ export async function verifyProjectAdmin(req: Request, res: Response): Promise<P
   const { projectId } = req.params;
 
   const [projectOutcome, project] = await systemRepo.readResource<Project>('Project', projectId);
-  assertOk(projectOutcome);
+  assertOk(projectOutcome, project);
 
   const [membershipOutcome, bundle] = await systemRepo.search<ProjectMembership>({
     resourceType: 'ProjectMembership',
@@ -32,9 +32,9 @@ export async function verifyProjectAdmin(req: Request, res: Response): Promise<P
       },
     ],
   });
-  assertOk(membershipOutcome);
+  assertOk(membershipOutcome, bundle);
 
-  const memberships = ((bundle as Bundle<ProjectMembership>).entry as BundleEntry<ProjectMembership>[]).map(
+  const memberships = (bundle.entry as BundleEntry<ProjectMembership>[]).map(
     (entry) => entry.resource as ProjectMembership
   );
 
@@ -43,7 +43,7 @@ export async function verifyProjectAdmin(req: Request, res: Response): Promise<P
   }
 
   return {
-    project: project as Project,
+    project,
     memberships,
   };
 }

--- a/packages/server/src/auth/changepassword.ts
+++ b/packages/server/src/auth/changepassword.ts
@@ -3,7 +3,7 @@ import { OperationOutcome, User } from '@medplum/fhirtypes';
 import bcrypt from 'bcrypt';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
-import { invalidRequest, systemRepo, sendOutcome } from '../fhir';
+import { invalidRequest, sendOutcome, systemRepo } from '../fhir';
 import { authenticateToken } from '../oauth';
 
 export const changePasswordValidators = [
@@ -20,10 +20,10 @@ export async function changePasswordHandler(req: Request, res: Response): Promis
     }
 
     const [userOutcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(userOutcome);
+    assertOk(userOutcome, user);
 
     const outcome = await changePassword({
-      user: user as User,
+      user,
       oldPassword: req.body.oldPassword,
       newPassword: req.body.newPassword,
     });

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -1,5 +1,4 @@
 import { assertOk, badRequest } from '@medplum/core';
-import { Login } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -73,6 +72,6 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
     nonce: randomUUID(),
     remember: true,
   });
-  assertOk(loginOutcome);
-  await sendLoginResult(res, login as Login);
+  assertOk(loginOutcome, login);
+  await sendLoginResult(res, login);
 }

--- a/packages/server/src/auth/login.ts
+++ b/packages/server/src/auth/login.ts
@@ -1,5 +1,4 @@
 import { assertOk } from '@medplum/core';
-import { Login } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -30,6 +29,6 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
     nonce: randomUUID(),
     remember: true,
   });
-  assertOk(loginOutcome);
-  await sendLoginResult(res, login as Login);
+  assertOk(loginOutcome, login);
+  await sendLoginResult(res, login);
 }

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -170,7 +170,7 @@ describe('Profile', () => {
       });
     expect(res2.status).toBe(400);
     expect(res2.body.issue).toBeDefined();
-    expect(res2.body.issue[0].details.text).toBe('Login profile set');
+    expect(res2.body.issue[0].details.text).toBe('Login profile already set');
   });
 
   test('Membership not found', async () => {

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -94,9 +94,9 @@ describe('Profile', () => {
     expect(res1.body.login).toBeDefined();
 
     const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
-    assertOk(readOutcome);
+    assertOk(readOutcome, login);
     await systemRepo.updateResource({
-      ...(login as Login),
+      ...login,
       revoked: true,
     });
 
@@ -122,9 +122,9 @@ describe('Profile', () => {
     expect(res1.body.login).toBeDefined();
 
     const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
-    assertOk(readOutcome);
+    assertOk(readOutcome, login);
     await systemRepo.updateResource({
-      ...(login as Login),
+      ...login,
       granted: true,
     });
 
@@ -150,9 +150,9 @@ describe('Profile', () => {
     expect(res1.body.login).toBeDefined();
 
     const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
-    assertOk(readOutcome);
+    assertOk(readOutcome, login);
     await systemRepo.updateResource({
-      ...(login as Login),
+      ...login,
       project: {
         reference: `Project/${randomUUID()}`,
       },

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -55,8 +55,8 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
   // Update the login
   const [updateOutcome, updated] = await systemRepo.updateResource({
     ...login,
-    project: createReference(project as Project),
-    profile: createReference(profile as ProfileResource),
+    project: createReference(project),
+    profile: createReference(profile),
     accessPolicy: membership.accessPolicy,
   });
   assertOk(updateOutcome, updated);

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -18,20 +18,20 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
   }
 
   const [loginOutcome, login] = await systemRepo.readResource<Login>('Login', req.body.login);
-  assertOk(loginOutcome);
+  assertOk(loginOutcome, login);
 
-  if (login?.revoked) {
+  if (login.revoked) {
     sendOutcome(res, badRequest('Login revoked'));
     return;
   }
 
-  if (login?.granted) {
+  if (login.granted) {
     sendOutcome(res, badRequest('Login granted'));
     return;
   }
 
-  if (login?.project || login?.profile) {
-    sendOutcome(res, badRequest('Login profile set'));
+  if (login.project || login.profile) {
+    sendOutcome(res, badRequest('Login profile already set'));
     return;
   }
 
@@ -45,21 +45,21 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
 
   // Get up-to-date project and profile
   const [projectOutcome, project] = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
-  assertOk(projectOutcome);
+  assertOk(projectOutcome, project);
 
   const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>(
     membership.profile as Reference<ProfileResource>
   );
-  assertOk(profileOutcome);
+  assertOk(profileOutcome, profile);
 
   // Update the login
-  const [updateOutcome] = await systemRepo.updateResource({
-    ...(login as Login),
+  const [updateOutcome, updated] = await systemRepo.updateResource({
+    ...login,
     project: createReference(project as Project),
     profile: createReference(profile as ProfileResource),
     accessPolicy: membership.accessPolicy,
   });
-  assertOk(updateOutcome);
+  assertOk(updateOutcome, updated);
 
   res.status(200).json({
     login: login?.id,

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -65,10 +65,10 @@ export async function registerHandler(req: Request, res: Response): Promise<void
     nonce: randomUUID(),
     remember: true,
   });
-  assertOk(loginOutcome);
+  assertOk(loginOutcome, login);
 
   const [tokenOutcome, token] = await getAuthTokens(login as Login);
-  assertOk(tokenOutcome);
+  assertOk(tokenOutcome, token);
 
   res.status(200).json({
     ...token,
@@ -103,8 +103,8 @@ async function searchForExisting(email: string): Promise<boolean> {
     ],
   });
 
-  assertOk(outcome);
-  return (bundle?.entry as BundleEntry<User>[]).length > 0;
+  assertOk(outcome, bundle);
+  return (bundle.entry as BundleEntry<User>[]).length > 0;
 }
 
 async function createUser(request: RegisterRequest): Promise<User> {
@@ -117,9 +117,9 @@ async function createUser(request: RegisterRequest): Promise<User> {
     passwordHash,
     admin,
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as User).id);
-  return result as User;
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
+  return result;
 }
 
 async function createProject(request: RegisterRequest, user: User): Promise<Project> {
@@ -129,9 +129,9 @@ async function createProject(request: RegisterRequest, user: User): Promise<Proj
     name: request.projectName,
     owner: createReference(user),
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as Project).id);
-  return result as Project;
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
+  return result;
 }
 
 async function createClientApplication(project: Project): Promise<ClientApplication> {
@@ -146,9 +146,9 @@ async function createClientApplication(project: Project): Promise<ClientApplicat
       project: project.id,
     },
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as ClientApplication).id);
-  return result as ClientApplication;
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
+  return result;
 }
 
 /**

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -1,5 +1,5 @@
 import { allOk, assertOk, badRequest, createReference, Operator } from '@medplum/core';
-import { Bundle, BundleEntry, PasswordChangeRequest, User } from '@medplum/fhirtypes';
+import { BundleEntry, PasswordChangeRequest, User } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { getConfig } from '../config';
@@ -26,9 +26,9 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
       },
     ],
   });
-  assertOk(existingOutcome);
+  assertOk(existingOutcome, existingBundle);
 
-  if (((existingBundle as Bundle).entry as BundleEntry[]).length === 0) {
+  if ((existingBundle.entry as BundleEntry[]).length === 0) {
     sendOutcome(res, badRequest('User not found', 'email'));
     return;
   }
@@ -71,8 +71,8 @@ export async function resetPassword(user: User): Promise<string> {
     user: createReference(user),
     secret: generateSecret(16),
   });
-  assertOk(createOutcome);
+  assertOk(createOutcome, pcr);
 
   // Build the reset URL
-  return `${getConfig().appBaseUrl}setpassword/${pcr?.id}/${pcr?.secret}`;
+  return `${getConfig().appBaseUrl}setpassword/${pcr.id}/${pcr.secret}`;
 }

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -7,10 +7,7 @@ import { sendEmail } from '../email';
 import { invalidRequest, sendOutcome, systemRepo } from '../fhir';
 import { generateSecret } from '../oauth';
 
-export const resetPasswordValidators = [
-  body('email').isEmail().withMessage('Valid email address is required'),
-  body('recaptchaToken').notEmpty().withMessage('Recaptcha token is required'),
-];
+export const resetPasswordValidators = [body('email').isEmail().withMessage('Valid email address is required')];
 
 export async function resetPasswordHandler(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -7,7 +7,10 @@ import { sendEmail } from '../email';
 import { invalidRequest, sendOutcome, systemRepo } from '../fhir';
 import { generateSecret } from '../oauth';
 
-export const resetPasswordValidators = [body('email').isEmail().withMessage('Valid email address is required')];
+export const resetPasswordValidators = [
+  body('email').isEmail().withMessage('Valid email address is required'),
+  body('recaptchaToken').notEmpty().withMessage('Recaptcha token is required'),
+];
 
 export async function resetPasswordHandler(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -21,28 +21,28 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
   const [pcrOutcome, pcr] = await systemRepo.readResource<PasswordChangeRequest>('PasswordChangeRequest', req.body.id);
   assertOk(pcrOutcome, pcr);
 
-  if (pcr?.used) {
+  if (pcr.used) {
     sendOutcome(res, badRequest('Already used'));
     return;
   }
 
-  if (pcr?.secret !== req.body.secret) {
+  if (pcr.secret !== req.body.secret) {
     sendOutcome(res, badRequest('Incorrect secret'));
     return;
   }
 
-  const [userOutcome, user] = await systemRepo.readReference(pcr?.user as Reference<User>);
+  const [userOutcome, user] = await systemRepo.readReference(pcr.user as Reference<User>);
   assertOk(userOutcome, user);
 
   const passwordHash = await bcrypt.hash(req.body.password, 10);
   const [updateUserOutcome, updatedUser] = await systemRepo.updateResource<User>({
-    ...(user as User),
+    ...user,
     passwordHash,
   });
   assertOk(updateUserOutcome, updatedUser);
 
   const [updatePcrOutcome, updatedPcr] = await systemRepo.updateResource<PasswordChangeRequest>({
-    ...(pcr as PasswordChangeRequest),
+    ...pcr,
     used: true,
   });
   assertOk(updatePcrOutcome, updatedPcr);

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -19,7 +19,7 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
   }
 
   const [pcrOutcome, pcr] = await systemRepo.readResource<PasswordChangeRequest>('PasswordChangeRequest', req.body.id);
-  assertOk(pcrOutcome);
+  assertOk(pcrOutcome, pcr);
 
   if (pcr?.used) {
     sendOutcome(res, badRequest('Already used'));
@@ -32,20 +32,20 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
   }
 
   const [userOutcome, user] = await systemRepo.readReference(pcr?.user as Reference<User>);
-  assertOk(userOutcome);
+  assertOk(userOutcome, user);
 
   const passwordHash = await bcrypt.hash(req.body.password, 10);
-  const [updateUserOutcome] = await systemRepo.updateResource<User>({
+  const [updateUserOutcome, updatedUser] = await systemRepo.updateResource<User>({
     ...(user as User),
     passwordHash,
   });
-  assertOk(updateUserOutcome);
+  assertOk(updateUserOutcome, updatedUser);
 
-  const [updatePcrOutcome] = await systemRepo.updateResource<PasswordChangeRequest>({
+  const [updatePcrOutcome, updatedPcr] = await systemRepo.updateResource<PasswordChangeRequest>({
     ...(pcr as PasswordChangeRequest),
     used: true,
   });
-  assertOk(updatePcrOutcome);
+  assertOk(updatePcrOutcome, updatedPcr);
 
   sendOutcome(res, allOk);
 }

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -1,6 +1,8 @@
 import { assertOk, createReference } from '@medplum/core';
 import { AccessPolicy, Login, Practitioner, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import { Response } from 'express';
+import fetch from 'node-fetch';
+import { getConfig } from '../config';
 import { systemRepo } from '../fhir';
 import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 import { logger } from '../logger';
@@ -90,4 +92,24 @@ export async function sendLoginResult(res: Response, login: Login): Promise<void
       code: login?.code,
     });
   }
+}
+
+/**
+ * Verifies the recaptcha response from the client.
+ * @param recaptchaToken The Recaptcha response from the client.
+ * @returns True on success, false on failure.
+ */
+export async function verifyRecaptcha(recaptchaToken: string): Promise<boolean> {
+  const secretKey = getConfig().recaptchaSecretKey as string;
+
+  const url =
+    'https://www.google.com/recaptcha/api/siteverify' +
+    '?secret=' +
+    encodeURIComponent(secretKey) +
+    '&response=' +
+    encodeURIComponent(recaptchaToken);
+
+  const response = await fetch(url, { method: 'POST' });
+  const json = await response.json();
+  return json.success;
 }

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -33,9 +33,9 @@ export async function createPractitioner(request: NewAccountRequest, project: Pr
       },
     ],
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as Practitioner).id);
-  return result as Practitioner;
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
+  return result;
 }
 
 export async function createProjectMembership(
@@ -54,9 +54,9 @@ export async function createProjectMembership(
     accessPolicy,
     admin,
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as ProjectMembership).id);
-  return result as ProjectMembership;
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
+  return result;
 }
 
 /**

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -489,7 +489,7 @@ describe('Batch', () => {
     const [patientOutcome, patient] = await repo.createResource<Patient>({
       resourceType: 'Patient',
     });
-    assertOk(patientOutcome);
+    assertOk(patientOutcome, patient);
 
     const [outcome, bundle] = await processBatch(repo, {
       resourceType: 'Bundle',
@@ -501,7 +501,7 @@ describe('Batch', () => {
             url: 'Patient/' + patient?.id,
           },
           resource: {
-            ...(patient as Patient),
+            ...patient,
             active: true,
           },
         },
@@ -567,7 +567,7 @@ describe('Batch', () => {
     const [patientOutcome, patient] = await repo.createResource<Patient>({
       resourceType: 'Patient',
     });
-    assertOk(patientOutcome);
+    assertOk(patientOutcome, patient);
 
     const [outcome, bundle] = await processBatch(repo, {
       resourceType: 'Bundle',
@@ -576,7 +576,7 @@ describe('Batch', () => {
         {
           request: {
             method: 'DELETE',
-            url: 'Patient/' + patient?.id,
+            url: 'Patient/' + patient.id,
           },
         },
       ],
@@ -741,7 +741,7 @@ describe('Batch', () => {
       resourceType: 'Patient',
       name: [{ family: 'Foo', given: ['Bar'] }],
     });
-    assertOk(createOutcome);
+    assertOk(createOutcome, patient);
 
     const [outcome, bundle] = await processBatch(repo, {
       resourceType: 'Bundle',
@@ -750,7 +750,7 @@ describe('Batch', () => {
         {
           request: {
             method: 'GET',
-            url: `Patient/${patient?.id}/_history`,
+            url: `Patient/${patient.id}/_history`,
           },
         },
       ],

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -23,7 +23,7 @@ binaryRouter.post(
         project: req.query['_project'] as string | undefined,
       },
     });
-    assertOk(outcome);
+    assertOk(outcome, resource);
 
     const stream = getContentStream(req);
     if (!stream) {
@@ -31,10 +31,10 @@ binaryRouter.post(
       return;
     }
 
-    await getBinaryStorage().writeBinary(resource as Binary, stream);
+    await getBinaryStorage().writeBinary(resource, stream);
     res.status(201).json({
       ...resource,
-      url: getPresignedUrl(resource as Binary),
+      url: getPresignedUrl(resource),
     });
   })
 );
@@ -53,7 +53,7 @@ binaryRouter.put(
         project: req.query['_project'] as string | undefined,
       },
     });
-    assertOk(outcome);
+    assertOk(outcome, resource);
 
     const stream = getContentStream(req);
     if (!stream) {
@@ -61,7 +61,7 @@ binaryRouter.put(
       return;
     }
 
-    await getBinaryStorage().writeBinary(resource as Binary, stream);
+    await getBinaryStorage().writeBinary(resource, stream);
     res.status(200).json(resource);
   })
 );
@@ -72,10 +72,9 @@ binaryRouter.get(
   asyncWrap(async (req: Request, res: Response) => {
     const { id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.readResource('Binary', id);
-    assertOk(outcome);
+    const [outcome, binary] = await repo.readResource<Binary>('Binary', id);
+    assertOk(outcome, binary);
 
-    const binary = resource as Binary;
     res.status(200).contentType(binary.contentType as string);
 
     const stream = await getBinaryStorage().readBinary(binary);

--- a/packages/server/src/fhir/graphql.ts
+++ b/packages/server/src/fhir/graphql.ts
@@ -238,8 +238,8 @@ async function resolveBySearch(
         } as Filter)
     ),
   });
-  assertOk(outcome);
-  return bundle?.entry?.map((e) => e.resource as Resource);
+  assertOk(outcome, bundle);
+  return bundle.entry?.map((e) => e.resource as Resource);
 }
 
 /**
@@ -256,7 +256,7 @@ async function resolveBySearch(
 async function resolveById(source: any, args: any, ctx: any, info: GraphQLResolveInfo): Promise<Resource | undefined> {
   const repo = ctx.res.locals.repo as Repository;
   const [outcome, resource] = await repo.readResource(info.fieldName, args.id);
-  assertOk(outcome);
+  assertOk(outcome, resource);
   return resource;
 }
 
@@ -273,7 +273,7 @@ async function resolveById(source: any, args: any, ctx: any, info: GraphQLResolv
 async function resolveByReference(source: any, args: any, ctx: any): Promise<Resource | undefined> {
   const repo = ctx.res.locals.repo as Repository;
   const [outcome, resource] = await repo.readReference(source as Reference);
-  assertOk(outcome);
+  assertOk(outcome, resource);
   return resource;
 }
 

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -827,7 +827,7 @@ describe('FHIR Repo', () => {
       remember: true,
     });
 
-    assertOk(loginOutcome1);
+    assertOk(loginOutcome1, login1);
     expect(login1).toBeDefined();
 
     const repo1 = await getRepoForLogin(login1 as Login);
@@ -835,12 +835,12 @@ describe('FHIR Repo', () => {
       resourceType: 'Patient',
     });
 
-    assertOk(patientOutcome1);
+    assertOk(patientOutcome1, patient1);
     expect(patient1).toBeDefined();
     expect(patient1?.id).toBeDefined();
 
     const [patientOutcome2, patient2] = await repo1.readResource('Patient', patient1?.id as string);
-    assertOk(patientOutcome2);
+    assertOk(patientOutcome2, patient2);
     expect(patient2).toBeDefined();
     expect(patient2?.id).toEqual(patient1?.id);
 
@@ -864,7 +864,7 @@ describe('FHIR Repo', () => {
       remember: true,
     });
 
-    assertOk(loginOutcome2);
+    assertOk(loginOutcome2, login2);
     expect(login2).toBeDefined();
 
     const repo2 = await getRepoForLogin(login2 as Login);
@@ -879,7 +879,7 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome);
+    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     // Empty access policy effectively blocks all reads and writes
@@ -939,7 +939,7 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome);
+    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     const accessPolicy: AccessPolicy = {
@@ -959,10 +959,10 @@ describe('FHIR Repo', () => {
       accessPolicy,
     });
 
-    const [readOutcome] = await repo2.readResource('Patient', patient?.id as string);
-    assertOk(readOutcome);
+    const [readOutcome, patient2] = await repo2.readResource('Patient', patient.id as string);
+    assertOk(readOutcome, patient2);
 
-    const [writeOutcome] = await repo2.updateResource(patient as Patient);
+    const [writeOutcome] = await repo2.updateResource(patient);
     expect(writeOutcome.id).toEqual('access-denied');
   });
 
@@ -972,7 +972,7 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome);
+    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     const accessPolicy: AccessPolicy = {
@@ -992,10 +992,10 @@ describe('FHIR Repo', () => {
       accessPolicy,
     });
 
-    const [readOutcome] = await repo2.readResource('Patient', patient?.id as string);
-    assertOk(readOutcome);
+    const [readOutcome, patient2] = await repo2.readResource('Patient', patient.id as string);
+    assertOk(readOutcome, patient2);
 
-    const [deleteOutcome] = await repo2.deleteResource('Patient', patient?.id as string);
+    const [deleteOutcome] = await repo2.deleteResource('Patient', patient.id as string);
     expect(deleteOutcome.id).toEqual('access-denied');
   });
 
@@ -1029,12 +1029,12 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome);
+    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
     expect(patient?.meta?.account).toBeDefined();
 
     const [readOutcome, readPatient] = await systemRepo.readResource('Patient', patient?.id as string);
-    assertOk(readOutcome);
+    assertOk(readOutcome, readPatient);
     expect(readPatient).toBeDefined();
     expect(readPatient?.meta?.account).toBeDefined();
   });
@@ -1092,13 +1092,13 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome1);
+    assertOk(createOutcome1, patient1);
     expect(patient1).toBeDefined();
     expect(patient1?.meta?.account).toBeDefined();
     expect(patient1?.meta?.account?.reference).toEqual('Organization/' + org1);
 
     const [readOutcome1, readPatient1] = await repo1.readResource('Patient', patient1?.id as string);
-    assertOk(readOutcome1);
+    assertOk(readOutcome1, readPatient1);
     expect(readPatient1).toBeDefined();
     expect(readPatient1?.meta?.account).toBeDefined();
 
@@ -1107,13 +1107,13 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome2);
+    assertOk(createOutcome2, patient2);
     expect(patient2).toBeDefined();
     expect(patient2?.meta?.account).toBeDefined();
     expect(patient2?.meta?.account?.reference).toEqual('Organization/' + org2);
 
     const [readOutcome2, readPatient2] = await repo2.readResource('Patient', patient2?.id as string);
-    assertOk(readOutcome2);
+    assertOk(readOutcome2, readPatient2);
     expect(readPatient2).toBeDefined();
     expect(readPatient2?.meta?.account).toBeDefined();
 
@@ -1145,7 +1145,7 @@ describe('FHIR Repo', () => {
         },
       },
     });
-    assertOk(outcome1);
+    assertOk(outcome1, clientApplication);
     expect(clientApplication).toBeDefined();
 
     // Create a systemRepo for the ClientApplication
@@ -1164,7 +1164,7 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Al'], family: 'Bundy' }],
       birthDate: '1975-12-12',
     });
-    assertOk(outcome2);
+    assertOk(outcome2, patient);
     expect(patient).toBeDefined();
 
     // The Patient should have the account value set
@@ -1179,7 +1179,7 @@ describe('FHIR Repo', () => {
       },
       valueString: 'positive',
     });
-    assertOk(outcome3);
+    assertOk(outcome3, observation);
     expect(observation).toBeDefined();
 
     // The Observation should have the account value set
@@ -1191,7 +1191,7 @@ describe('FHIR Repo', () => {
       name: [{ given: ['Peggy'], family: 'Bundy' }],
       birthDate: '1975-11-11',
     });
-    assertOk(outcome4);
+    assertOk(outcome4, patient2);
     expect(patient2).toBeDefined();
 
     // The ClientApplication should not be able to access it
@@ -1207,7 +1207,7 @@ describe('FHIR Repo', () => {
       },
       valueString: 'positive',
     });
-    assertOk(outcome6);
+    assertOk(outcome6, observation2);
     expect(observation2).toBeDefined();
 
     // The ClientApplication should not be able to access it
@@ -1318,7 +1318,7 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome1);
+    assertOk(outcome1, bundle1);
     expect(bundle1?.entry?.length).toEqual(2);
     expect((bundle1?.entry?.[0]?.resource as StructureDefinition).name).toEqual('Questionnaire');
     expect((bundle1?.entry?.[1]?.resource as StructureDefinition).name).toEqual('QuestionnaireResponse');
@@ -1333,7 +1333,7 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome2);
+    assertOk(outcome2, bundle2);
     expect(bundle2?.entry?.length).toEqual(1);
     expect((bundle2?.entry?.[0]?.resource as StructureDefinition).name).toEqual('Questionnaire');
   });
@@ -1346,7 +1346,7 @@ describe('FHIR Repo', () => {
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family }],
     });
-    assertOk(createOutcome);
+    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     const [searchOutcome1, searchResult1] = await systemRepo.search({
@@ -1395,7 +1395,7 @@ describe('FHIR Repo', () => {
         project: project1,
       },
     });
-    assertOk(outcome1);
+    assertOk(outcome1, patient1);
     expect(patient1).toBeDefined();
 
     const [outcome2, patient2] = await systemRepo.createResource<Patient>({
@@ -1405,7 +1405,7 @@ describe('FHIR Repo', () => {
         project: project2,
       },
     });
-    assertOk(outcome2);
+    assertOk(outcome2, patient2);
     expect(patient2).toBeDefined();
 
     const [outcome3, bundle] = await systemRepo.search({
@@ -1418,7 +1418,7 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome3);
+    assertOk(outcome3, bundle);
     expect(bundle?.entry?.length).toEqual(1);
     expect(bundleContains(bundle as Bundle, patient1 as Patient)).toEqual(true);
     expect(bundleContains(bundle as Bundle, patient2 as Patient)).toEqual(false);
@@ -1441,7 +1441,7 @@ describe('FHIR Repo', () => {
         lastUpdated: nowMinus1Second.toISOString(),
       },
     });
-    assertOk(outcome1);
+    assertOk(outcome1, patient1);
     expect(patient1).toBeDefined();
 
     const [outcome2, patient2] = await systemRepo.createResource<Patient>({
@@ -1451,7 +1451,7 @@ describe('FHIR Repo', () => {
         lastUpdated: nowMinus2Seconds.toISOString(),
       },
     });
-    assertOk(outcome2);
+    assertOk(outcome2, patient2);
     expect(patient2).toBeDefined();
 
     // Greater than (newer than) 2 seconds ago should only return patient 1
@@ -1560,7 +1560,7 @@ describe('FHIR Repo', () => {
         project,
       },
     });
-    assertOk(outcome1);
+    assertOk(outcome1, patient1);
     expect(patient1).toBeDefined();
 
     const [outcome2, patient2] = await systemRepo.createResource<Patient>({
@@ -1571,7 +1571,7 @@ describe('FHIR Repo', () => {
         project,
       },
     });
-    assertOk(outcome2);
+    assertOk(outcome2, patient2);
     expect(patient2).toBeDefined();
 
     const [outcome3, bundle3] = await systemRepo.search({
@@ -1590,7 +1590,7 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome3);
+    assertOk(outcome3, bundle3);
     expect(bundle3?.entry?.length).toEqual(2);
     expect(bundle3?.entry?.[0]?.resource?.id).toEqual(patient1?.id);
     expect(bundle3?.entry?.[1]?.resource?.id).toEqual(patient2?.id);
@@ -1611,7 +1611,7 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome4);
+    assertOk(outcome4, bundle4);
     expect(bundle4?.entry?.length).toEqual(2);
     expect(bundle4?.entry?.[0]?.resource?.id).toEqual(patient2?.id);
     expect(bundle4?.entry?.[1]?.resource?.id).toEqual(patient1?.id);
@@ -1645,7 +1645,7 @@ describe('FHIR Repo', () => {
       resourceType: 'Patient',
       name: [{ given: ['John'], family: 'CodeableConcept' }],
     });
-    assertOk(outcome0);
+    assertOk(outcome0, patient);
     expect(patient).toBeDefined();
 
     // Use code.coding[0].code
@@ -1660,7 +1660,7 @@ describe('FHIR Repo', () => {
         ],
       },
     });
-    assertOk(outcome1);
+    assertOk(outcome1, serviceRequest1);
     expect(serviceRequest1).toBeDefined();
 
     // Use code.coding[0].display
@@ -1675,7 +1675,7 @@ describe('FHIR Repo', () => {
         ],
       },
     });
-    assertOk(outcome2);
+    assertOk(outcome2, serviceRequest2);
     expect(serviceRequest2).toBeDefined();
 
     // Use code.text

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1646,12 +1646,11 @@ describe('FHIR Repo', () => {
       name: [{ given: ['John'], family: 'CodeableConcept' }],
     });
     assertOk(outcome0, patient);
-    expect(patient).toBeDefined();
 
     // Use code.coding[0].code
     const [outcome1, serviceRequest1] = await systemRepo.createResource<ServiceRequest>({
       resourceType: 'ServiceRequest',
-      subject: createReference(patient as Patient),
+      subject: createReference(patient),
       code: {
         coding: [
           {
@@ -1661,12 +1660,11 @@ describe('FHIR Repo', () => {
       },
     });
     assertOk(outcome1, serviceRequest1);
-    expect(serviceRequest1).toBeDefined();
 
     // Use code.coding[0].display
     const [outcome2, serviceRequest2] = await systemRepo.createResource<ServiceRequest>({
       resourceType: 'ServiceRequest',
-      subject: createReference(patient as Patient),
+      subject: createReference(patient),
       code: {
         coding: [
           {
@@ -1676,18 +1674,16 @@ describe('FHIR Repo', () => {
       },
     });
     assertOk(outcome2, serviceRequest2);
-    expect(serviceRequest2).toBeDefined();
 
     // Use code.text
     const [outcome3, serviceRequest3] = await systemRepo.createResource<ServiceRequest>({
       resourceType: 'ServiceRequest',
-      subject: createReference(patient as Patient),
+      subject: createReference(patient),
       code: {
         text: x3,
       },
     });
-    assertOk(outcome3);
-    expect(serviceRequest3).toBeDefined();
+    assertOk(outcome3, serviceRequest3);
 
     const [outcome4, bundle1] = await systemRepo.search({
       resourceType: 'ServiceRequest',
@@ -1699,11 +1695,11 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome4);
-    expect(bundle1?.entry?.length).toEqual(1);
-    expect(bundleContains(bundle1 as Bundle, serviceRequest1 as ServiceRequest)).toEqual(true);
-    expect(bundleContains(bundle1 as Bundle, serviceRequest2 as ServiceRequest)).toEqual(false);
-    expect(bundleContains(bundle1 as Bundle, serviceRequest3 as ServiceRequest)).toEqual(false);
+    assertOk(outcome4, bundle1);
+    expect(bundle1.entry?.length).toEqual(1);
+    expect(bundleContains(bundle1, serviceRequest1)).toEqual(true);
+    expect(bundleContains(bundle1, serviceRequest2)).toEqual(false);
+    expect(bundleContains(bundle1, serviceRequest3)).toEqual(false);
 
     const [outcome5, bundle2] = await systemRepo.search({
       resourceType: 'ServiceRequest',
@@ -1715,11 +1711,11 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome5);
-    expect(bundle2?.entry?.length).toEqual(1);
-    expect(bundleContains(bundle2 as Bundle, serviceRequest1 as ServiceRequest)).toEqual(false);
-    expect(bundleContains(bundle2 as Bundle, serviceRequest2 as ServiceRequest)).toEqual(true);
-    expect(bundleContains(bundle2 as Bundle, serviceRequest3 as ServiceRequest)).toEqual(false);
+    assertOk(outcome5, bundle2);
+    expect(bundle2.entry?.length).toEqual(1);
+    expect(bundleContains(bundle2, serviceRequest1)).toEqual(false);
+    expect(bundleContains(bundle2, serviceRequest2)).toEqual(true);
+    expect(bundleContains(bundle2, serviceRequest3)).toEqual(false);
 
     const [outcome6, bundle3] = await systemRepo.search({
       resourceType: 'ServiceRequest',
@@ -1731,11 +1727,11 @@ describe('FHIR Repo', () => {
         },
       ],
     });
-    assertOk(outcome6);
-    expect(bundle3?.entry?.length).toEqual(1);
-    expect(bundleContains(bundle3 as Bundle, serviceRequest1 as ServiceRequest)).toEqual(false);
-    expect(bundleContains(bundle3 as Bundle, serviceRequest2 as ServiceRequest)).toEqual(false);
-    expect(bundleContains(bundle3 as Bundle, serviceRequest3 as ServiceRequest)).toEqual(true);
+    assertOk(outcome6, bundle3);
+    expect(bundle3.entry?.length).toEqual(1);
+    expect(bundleContains(bundle3, serviceRequest1)).toEqual(false);
+    expect(bundleContains(bundle3, serviceRequest2)).toEqual(false);
+    expect(bundleContains(bundle3, serviceRequest3)).toEqual(true);
   });
 
   test('Reindex resource type as non-admin', async () => {
@@ -1769,7 +1765,7 @@ describe('FHIR Repo', () => {
 
   test('Reindex success', async () => {
     const [reindexOutcome] = await systemRepo.reindexResourceType('Practitioner');
-    assertOk(reindexOutcome);
+    expect(isOk(reindexOutcome)).toBe(true);
   });
 });
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1190,8 +1190,8 @@ export async function getRepoForLogin(login: Login): Promise<Repository> {
 
   if (login.accessPolicy) {
     const [accessPolicyOutcome, accessPolicyResource] = await systemRepo.readReference(login.accessPolicy);
-    assertOk(accessPolicyOutcome);
-    accessPolicy = accessPolicyResource as AccessPolicy;
+    assertOk(accessPolicyOutcome, accessPolicyResource);
+    accessPolicy = accessPolicyResource;
   }
 
   // If the resource is an "actor" resource,
@@ -1210,8 +1210,8 @@ export async function getRepoForLogin(login: Login): Promise<Repository> {
         profileType.startsWith('Subscription'))
     ) {
       const [profileOutcome, profileResource] = await systemRepo.readReference(login.profile);
-      assertOk(profileOutcome);
-      if (profileResource?.meta?.account) {
+      assertOk(profileOutcome, profileResource);
+      if (profileResource.meta?.account) {
         accessPolicy = buildSyntheticAccessPolicy(profileResource.meta.account);
       }
     }

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -19,8 +19,8 @@ describe('URL rewrite', () => {
     const [outcome, resource] = await systemRepo.createResource({
       resourceType: 'Binary',
     });
-    assertOk(outcome);
-    binary = resource as Binary;
+    assertOk(outcome, resource);
+    binary = resource;
   });
 
   afterAll(async () => {

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -118,7 +118,7 @@ protectedRoutes.post(
     }
     const repo = res.locals.repo as Repository;
     const [outcome, result] = await processBatch(repo, bundle);
-    assertOk(outcome);
+    assertOk(outcome, result);
     sendResponse(res, outcome, result);
   })
 );
@@ -131,7 +131,7 @@ protectedRoutes.get(
     const repo = res.locals.repo as Repository;
     const query = req.query as Record<string, string[] | string | undefined>;
     const [outcome, bundle] = await repo.search(parseSearchRequest(resourceType, query));
-    assertOk(outcome);
+    assertOk(outcome, bundle);
     sendResponse(res, outcome, bundle);
   })
 );
@@ -152,7 +152,7 @@ protectedRoutes.post(
     }
     const repo = res.locals.repo as Repository;
     const [outcome, result] = await repo.createResource(resource);
-    assertOk(outcome);
+    assertOk(outcome, result);
     sendResponse(res, outcome, result);
   })
 );
@@ -164,7 +164,7 @@ protectedRoutes.get(
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
     const [outcome, resource] = await repo.readResource(resourceType, id);
-    assertOk(outcome);
+    assertOk(outcome, resource);
     sendResponse(res, outcome, resource);
   })
 );
@@ -176,7 +176,7 @@ protectedRoutes.get(
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
     const [outcome, bundle] = await repo.readHistory(resourceType, id);
-    assertOk(outcome);
+    assertOk(outcome, bundle);
     res.status(getStatus(outcome)).json(bundle);
   })
 );
@@ -188,7 +188,7 @@ protectedRoutes.get(
     const { resourceType, id, vid } = req.params;
     const repo = res.locals.repo as Repository;
     const [outcome, resource] = await repo.readVersion(resourceType, id, vid);
-    assertOk(outcome);
+    assertOk(outcome, resource);
     res.status(getStatus(outcome)).json(resource);
   })
 );
@@ -213,7 +213,7 @@ protectedRoutes.put(
     }
     const repo = res.locals.repo as Repository;
     const [outcome, result] = await repo.updateResource(resource);
-    assertOk(outcome);
+    assertOk(outcome, result);
     sendResponse(res, outcome, result);
   })
 );
@@ -225,7 +225,7 @@ protectedRoutes.delete(
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
     const [outcome] = await repo.deleteResource(resourceType, id);
-    assertOk(outcome);
+    assertOk(outcome, { resourceType });
     sendOutcome(res, outcome);
   })
 );
@@ -242,7 +242,7 @@ protectedRoutes.patch(
     const patch = req.body as Operation[];
     const repo = res.locals.repo as Repository;
     const [outcome, resource] = await repo.patchResource(resourceType, id, patch);
-    assertOk(outcome);
+    assertOk(outcome, resource);
     sendResponse(res, outcome, resource);
   })
 );

--- a/packages/server/src/jest.setup.ts
+++ b/packages/server/src/jest.setup.ts
@@ -12,18 +12,18 @@ export async function createTestClient(): Promise<ClientApplication> {
       reference: 'User/' + randomUUID(),
     },
   });
-  assertOk(projectOutcome);
+  assertOk(projectOutcome, project);
 
   const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
     resourceType: 'ClientApplication',
     secret: randomUUID(),
     redirectUri: 'https://example.com/',
     meta: {
-      project: project?.id as string,
+      project: project.id as string,
     },
   });
-  assertOk(clientOutcome);
-  return client as ClientApplication;
+  assertOk(clientOutcome, client);
+  return client;
 }
 
 export async function initTestAuth(): Promise<string> {

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -40,7 +40,7 @@ describe('Auth middleware', () => {
       scope,
     });
 
-    assertOk(loginOutcome);
+    assertOk(loginOutcome, login);
 
     const accessToken = await generateAccessToken({
       login_id: login?.id as string,
@@ -85,7 +85,7 @@ describe('Auth middleware', () => {
       scope,
     });
 
-    assertOk(loginOutcome);
+    assertOk(loginOutcome, login);
 
     const accessToken = await generateAccessToken({
       login_id: login?.id as string,

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -29,8 +29,8 @@ describe('OAuth2 Token', () => {
       secret: randomUUID(),
       redirectUri: 'https://example.com/',
     });
-    assertOk(outcome);
-    client = resource as ClientApplication;
+    assertOk(outcome, resource);
+    client = resource;
   });
 
   afterAll(async () => {
@@ -129,11 +129,11 @@ describe('OAuth2 Token', () => {
       secret: '',
       redirectUri: 'https://example.com',
     });
-    assertOk(outcome);
+    assertOk(outcome, badClient);
 
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_id: badClient?.id,
+      client_id: badClient.id,
       client_secret: 'wrong-client-secret',
     });
     expect(res.status).toBe(400);

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -83,7 +83,7 @@ async function handleClientCredentials(req: Request, res: Response): Promise<Res
     },
     scope,
   });
-  assertOk(loginOutcome);
+  assertOk(loginOutcome, login);
 
   const accessToken = await generateAccessToken({
     login_id: login?.id as string,

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -226,8 +226,8 @@ export async function getUserMemberships(user: Reference<User>): Promise<Project
       },
     ],
   });
-  assertOk(membershipsOutcome);
-  return (memberships?.entry as BundleEntry<ProjectMembership>[]).map((entry) => entry.resource as ProjectMembership);
+  assertOk(membershipsOutcome, memberships);
+  return (memberships.entry as BundleEntry<ProjectMembership>[]).map((entry) => entry.resource as ProjectMembership);
 }
 
 export async function getAuthTokens(login: Login): Promise<[OperationOutcome, TokenResult | undefined]> {
@@ -316,9 +316,9 @@ async function getUserByEmail(email: string): RepositoryResult<User | undefined>
       },
     ],
   });
-  assertOk(outcome);
+  assertOk(outcome, bundle);
 
-  if (!bundle?.entry || bundle.entry.length === 0) {
+  if (!bundle.entry || bundle.entry.length === 0) {
     return [notFound, undefined];
   }
 

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -43,8 +43,8 @@ async function isSeeded(): Promise<boolean> {
     resourceType: 'User',
     count: 1,
   });
-  assertOk(outcome);
-  return !!bundle?.entry && bundle.entry.length > 0;
+  assertOk(outcome, bundle);
+  return !!bundle.entry && bundle.entry.length > 0;
 }
 
 /**
@@ -59,8 +59,8 @@ async function createPublicProject(owner: User): Promise<void> {
     name: 'Public',
     owner: createReference(owner),
   });
-  assertOk(outcome);
-  logger.info('Created: ' + (result as Project).id);
+  assertOk(outcome, result);
+  logger.info('Created: ' + result.id);
 }
 
 /**
@@ -77,7 +77,7 @@ async function createSearchParameters(): Promise<void> {
       ...searchParam,
       text: undefined,
     });
-    assertOk(outcome);
-    logger.debug('Created: ' + (result as SearchParameter).id);
+    assertOk(outcome, result);
+    logger.debug('Created: ' + result.id);
   }
 }

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -25,8 +25,8 @@ async function createStructureDefinitionsForBundle(structureDefinitions: Bundle)
         ...resource,
         text: undefined,
       });
-      assertOk(outcome);
-      logger.debug('Created: ' + (result as StructureDefinition).id);
+      assertOk(outcome, result);
+      logger.debug('Created: ' + result.id);
     }
   }
 }

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -13,7 +13,7 @@ import { seedDatabase } from './seed';
 
 const app = express();
 const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
-let binary: Binary | undefined = undefined;
+let binary: Binary;
 
 describe('Storage Routes', () => {
   beforeAll(async () => {
@@ -27,14 +27,14 @@ describe('Storage Routes', () => {
       resourceType: 'Binary',
       contentType: 'text/plain',
     });
-    assertOk(outcome);
+    assertOk(outcome, resource);
     binary = resource;
 
     const req = new Readable();
     req.push('hello world');
     req.push(null);
     (req as any).headers = {};
-    await getBinaryStorage().writeBinary(binary as Binary, req as Request);
+    await getBinaryStorage().writeBinary(binary, req as Request);
   });
 
   afterAll(async () => {
@@ -43,12 +43,12 @@ describe('Storage Routes', () => {
   });
 
   test('Missing signature', async () => {
-    const res = await request(app).get(`/storage/${binary?.id}`);
+    const res = await request(app).get(`/storage/${binary.id}`);
     expect(res.status).toBe(401);
   });
 
   test('Success', async () => {
-    const res = await request(app).get(`/storage/${binary?.id}?Signature=xyz&Expires=123`);
+    const res = await request(app).get(`/storage/${binary.id}?Signature=xyz&Expires=123`);
     expect(res.status).toBe(200);
   });
 });

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -18,10 +18,9 @@ storageRouter.get(
     }
 
     const { id } = req.params;
-    const [outcome, resource] = await systemRepo.readResource('Binary', id);
-    assertOk(outcome);
+    const [outcome, binary] = await systemRepo.readResource<Binary>('Binary', id);
+    assertOk(outcome, binary);
 
-    const binary = resource as Binary;
     res.status(200).contentType(binary.contentType as string);
 
     const stream = await getBinaryStorage().readBinary(binary);

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -164,14 +164,13 @@ describe('Download Worker', () => {
       },
     });
 
-    expect(mediaOutcome.id).toEqual('created');
-    expect(media).toBeDefined();
+    assertOk(mediaOutcome, media);
     expect(queue.add).toHaveBeenCalled();
 
     // At this point the job should be in the queue
     // But let's delete the resource
     const [deleteOutcome] = await repo.deleteResource('Media', media?.id as string);
-    assertOk(deleteOutcome);
+    assertOk(deleteOutcome, media);
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
     await execDownloadJob(job);
@@ -198,14 +197,14 @@ describe('Download Worker', () => {
 
     // At this point the job should be in the queue
     // But let's change the URL to an internal Binary resource
-    const [updateOutcome] = await repo.updateResource({
+    const [updateOutcome, updated] = await repo.updateResource({
       ...(media as Media),
       content: {
         contentType: 'text/plain',
         url: 'Binary/' + randomUUID(),
       },
     });
-    assertOk(updateOutcome);
+    assertOk(updateOutcome, updated);
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
     await execDownloadJob(job);

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -155,7 +155,7 @@ export async function execDownloadJob(job: Job<DownloadJobData>): Promise<void> 
     // If the resource was deleted, then stop processing it.
     return;
   }
-  assertOk(readOutcome);
+  assertOk(readOutcome, resource);
 
   if (!JSON.stringify(resource).includes(url)) {
     // If the resource no longer includes the URL, then stop processing it.
@@ -178,13 +178,13 @@ export async function execDownloadJob(job: Job<DownloadJobData>): Promise<void> 
         project: resource?.meta?.project,
       },
     });
-    assertOk(createBinaryOutcome);
-    await getBinaryStorage().writeBinary(binary as Binary, response.body);
+    assertOk(createBinaryOutcome, binary);
+    await getBinaryStorage().writeBinary(binary, response.body);
 
     const updated = JSON.parse(JSON.stringify(resource).replace(url, `Binary/${binary?.id}`)) as Resource;
     (updated.meta as any).author = { reference: 'system' };
-    const [updateOutcome] = await systemRepo.updateResource(updated);
-    assertOk(updateOutcome);
+    const [updateOutcome, updatedResource] = await systemRepo.updateResource(updated);
+    assertOk(updateOutcome, updatedResource);
     logger.info('Downloaded content successfully');
   } catch (ex) {
     logger.info('Download exception: ' + ex);

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -7,7 +7,7 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, getClient, initDatabase } from '../database';
 import { Repository, systemRepo } from '../fhir/repo';
 import { seedDatabase } from '../seed';
-import { closeSubscriptionWorker, initSubscriptionWorker, execSubscriptionJob } from './subscription';
+import { closeSubscriptionWorker, execSubscriptionJob, initSubscriptionWorker } from './subscription';
 
 jest.mock('bullmq');
 jest.mock('node-fetch');
@@ -540,12 +540,11 @@ describe('Subscription Worker', () => {
         },
       ],
     });
-    assertOk(searchOutcome);
-    expect(bundle).toBeDefined();
-    expect(bundle?.entry?.length).toEqual(1);
-    expect(bundle?.entry?.[0]?.resource?.outcome).toEqual('0');
-    expect(bundle?.entry?.[0]?.resource?.outcomeDesc).toContain('Success');
-    expect(bundle?.entry?.[0]?.resource?.outcomeDesc).toContain(nonce);
+    assertOk(searchOutcome, bundle);
+    expect(bundle.entry?.length).toEqual(1);
+    expect(bundle.entry?.[0]?.resource?.outcome).toEqual('0');
+    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain('Success');
+    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain(nonce);
   });
 
   test('Bot failure', async () => {
@@ -600,12 +599,11 @@ describe('Subscription Worker', () => {
         },
       ],
     });
-    assertOk(searchOutcome);
-    expect(bundle).toBeDefined();
-    expect(bundle?.entry?.length).toEqual(1);
-    expect(bundle?.entry?.[0]?.resource?.outcome).not.toEqual('0');
-    expect(bundle?.entry?.[0]?.resource?.outcomeDesc).toContain('Error');
-    expect(bundle?.entry?.[0]?.resource?.outcomeDesc).toContain(nonce);
+    assertOk(searchOutcome, bundle);
+    expect(bundle.entry?.length).toEqual(1);
+    expect(bundle.entry?.[0]?.resource?.outcome).not.toEqual('0');
+    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain('Error');
+    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain(nonce);
   });
 
   test('Stop retries if Subscription status not active', async () => {
@@ -658,9 +656,8 @@ describe('Subscription Worker', () => {
         },
       ],
     });
-    assertOk(searchOutcome);
-    expect(bundle).toBeDefined();
-    expect(bundle?.entry?.length).toEqual(0);
+    assertOk(searchOutcome, bundle);
+    expect(bundle.entry?.length).toEqual(0);
   });
 
   test('Stop retries if Subscription deleted', async () => {
@@ -684,14 +681,13 @@ describe('Subscription Worker', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
 
-    expect(patientOutcome.id).toEqual('created');
-    expect(patient).toBeDefined();
+    assertOk(patientOutcome, patient);
     expect(queue.add).toHaveBeenCalled();
 
     // At this point the job should be in the queue
     // But let's delete the subscription
     const [deleteOutcome] = await repo.deleteResource('Subscription', subscription?.id as string);
-    assertOk(deleteOutcome);
+    assertOk(deleteOutcome, subscription);
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
     await execSubscriptionJob(job);
@@ -710,9 +706,8 @@ describe('Subscription Worker', () => {
         },
       ],
     });
-    assertOk(searchOutcome);
-    expect(bundle).toBeDefined();
-    expect(bundle?.entry?.length).toEqual(0);
+    assertOk(searchOutcome, bundle);
+    expect(bundle.entry?.length).toEqual(0);
   });
 
   test('Stop retries if Resource deleted', async () => {
@@ -736,14 +731,13 @@ describe('Subscription Worker', () => {
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
 
-    expect(patientOutcome.id).toEqual('created');
-    expect(patient).toBeDefined();
+    assertOk(patientOutcome, patient);
     expect(queue.add).toHaveBeenCalled();
 
     // At this point the job should be in the queue
     // But let's delete the resource
-    const [deleteOutcome] = await repo.deleteResource('Patient', patient?.id as string);
-    assertOk(deleteOutcome);
+    const [deleteOutcome] = await repo.deleteResource('Patient', patient.id as string);
+    assertOk(deleteOutcome, patient);
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as any as Job;
     await execSubscriptionJob(job);
@@ -762,9 +756,8 @@ describe('Subscription Worker', () => {
         },
       ],
     });
-    assertOk(searchOutcome);
-    expect(bundle).toBeDefined();
-    expect(bundle?.entry?.length).toEqual(0);
+    assertOk(searchOutcome, bundle);
+    expect(bundle.entry?.length).toEqual(0);
   });
 
   test('AuditEvent has Subscription account details', async () => {
@@ -820,9 +813,8 @@ describe('Subscription Worker', () => {
         },
       ],
     });
-    assertOk(searchOutcome);
-    expect(bundle).toBeDefined();
-    expect(bundle?.entry?.length).toEqual(1);
+    assertOk(searchOutcome, bundle);
+    expect(bundle.entry?.length).toEqual(1);
 
     const auditEvent = bundle?.entry?.[0].resource as AuditEvent;
     expect(auditEvent.meta?.account).toBeDefined();

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -253,8 +253,8 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
       },
     ],
   });
-  assertOk(outcome);
-  return (bundle?.entry as BundleEntry<Subscription>[]).map((e) => e.resource as Subscription);
+  assertOk(outcome, bundle);
+  return (bundle.entry as BundleEntry<Subscription>[]).map((e) => e.resource as Subscription);
 }
 
 /**
@@ -272,22 +272,22 @@ export async function execSubscriptionJob(job: Job<SubscriptionJobData>): Promis
     // If the subscription was deleted, then stop processing it.
     return;
   }
-  assertOk(subscriptionOutcome);
+  assertOk(subscriptionOutcome, subscription);
 
-  if (subscription?.status !== 'active') {
+  if (subscription.status !== 'active') {
     // If the subscription has been disabled, then stop processing it.
     return;
   }
 
-  const [readOutcome] = await systemRepo.readResource(resourceType, id);
+  const [readOutcome, currentVersion] = await systemRepo.readResource(resourceType, id);
   if (isGone(readOutcome)) {
     // If the resource was deleted, then stop processing it.
     return;
   }
-  assertOk(readOutcome);
+  assertOk(readOutcome, currentVersion);
 
   const [versionOutcome, resourceVersion] = await systemRepo.readVersion(resourceType, id, versionId);
-  assertOk(versionOutcome);
+  assertOk(versionOutcome, resourceVersion);
 
   const channelType = subscription?.channel?.type;
   if (channelType === 'rest-hook') {
@@ -399,9 +399,9 @@ export async function execBot(
 
   // URL should be a Bot reference string
   const [botOutcome, bot] = await systemRepo.readReference<Bot>({ reference: url });
-  assertOk(botOutcome);
+  assertOk(botOutcome, bot);
 
-  const code = bot?.code;
+  const code = bot.code;
   if (!code) {
     logger.debug('Ignore action subscription missing code');
     return;

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -292,9 +292,9 @@ export async function execSubscriptionJob(job: Job<SubscriptionJobData>): Promis
   const channelType = subscription?.channel?.type;
   if (channelType === 'rest-hook') {
     if (subscription?.channel?.endpoint?.startsWith('Bot/')) {
-      await execBot(job, subscription, resourceVersion as Resource);
+      await execBot(job, subscription, resourceVersion);
     } else {
-      await sendRestHook(job, subscription, resourceVersion as Resource);
+      await sendRestHook(job, subscription, resourceVersion);
     }
   }
 }


### PR DESCRIPTION
The crux of the change is this:

Before:

```typescript
export function assertOk(outcome: OperationOutcome): void {
  if (!isOk(outcome)) {
    throw new OperationOutcomeError(outcome);
  }
}
```

After:

```typescript
export function assertOk<T>(outcome: OperationOutcome, resource: T | undefined): asserts resource is T {
  if (!isOk(outcome) || resource === undefined) {
    throw new OperationOutcomeError(outcome);
  }
}
```

See details here: https://stackoverflow.com/a/59017341/2051724