### PR TITLE
Fixed disconnected FormSection errors

### DIFF
--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -2,6 +2,7 @@ import { RegisterRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Button, Document, Form, FormSection, Logo, TextField, useMedplum } from '@medplum/ui';
 import React, { useState } from 'react';
+import { getRecaptcha } from './utils';
 
 export function RegisterPage(): JSX.Element {
   const medplum = useMedplum();
@@ -13,20 +14,14 @@ export function RegisterPage(): JSX.Element {
       <Form
         style={{ maxWidth: 400 }}
         onSubmit={(formData: Record<string, string>) => {
-          grecaptcha.ready(() => {
-            grecaptcha.execute(process.env.RECAPTCHA_SITE_KEY as string, { action: 'submit' }).then((token: string) => {
-              medplum
-                .register({
-                  ...formData,
-                  recaptchaToken: token,
-                } as unknown as RegisterRequest)
-                .then(() => setSuccess(true))
-                .catch((err) => {
-                  if (err.outcome) {
-                    setOutcome(err.outcome);
-                  }
-                });
-            });
+          getRecaptcha().then((recaptchaToken: string) => {
+            medplum
+              .register({
+                ...formData,
+                recaptchaToken,
+              } as unknown as RegisterRequest)
+              .then(() => setSuccess(true))
+              .catch(setOutcome);
           });
         }}
       >
@@ -36,7 +31,7 @@ export function RegisterPage(): JSX.Element {
         </div>
         {!success && (
           <>
-            <FormSection title="First Name">
+            <FormSection title="First Name" htmlFor="firstName" outcome={outcome}>
               <TextField
                 name="firstName"
                 type="text"
@@ -46,16 +41,16 @@ export function RegisterPage(): JSX.Element {
                 outcome={outcome}
               />
             </FormSection>
-            <FormSection title="Last Name">
+            <FormSection title="Last Name" htmlFor="lastName" outcome={outcome}>
               <TextField name="lastName" type="text" testid="lastName" required={true} outcome={outcome} />
             </FormSection>
-            <FormSection title="Project Name">
+            <FormSection title="Project Name" htmlFor="projectName" outcome={outcome}>
               <TextField name="projectName" type="text" testid="projectName" required={true} outcome={outcome} />
             </FormSection>
-            <FormSection title="Email">
+            <FormSection title="Email" htmlFor="email" outcome={outcome}>
               <TextField name="email" type="email" testid="email" required={true} outcome={outcome} />
             </FormSection>
-            <FormSection title="Password">
+            <FormSection title="Password" htmlFor="password" outcome={outcome}>
               <TextField name="password" type="password" testid="password" required={true} outcome={outcome} />
             </FormSection>
             <p style={{ fontSize: '12px', color: '#888' }}>

--- a/packages/app/src/ResetPasswordPage.tsx
+++ b/packages/app/src/ResetPasswordPage.tsx
@@ -1,6 +1,7 @@
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Button, Document, Form, FormSection, Logo, MedplumLink, TextField, useMedplum } from '@medplum/ui';
 import React, { useState } from 'react';
+import { getRecaptcha } from './utils';
 
 export function ResetPasswordPage(): JSX.Element {
   const medplum = useMedplum();
@@ -12,13 +13,11 @@ export function ResetPasswordPage(): JSX.Element {
       <Form
         style={{ maxWidth: 400 }}
         onSubmit={(formData: Record<string, string>) => {
-          grecaptcha.ready(() => {
-            grecaptcha.execute(process.env.RECAPTCHA_SITE_KEY as string, { action: 'submit' }).then((token: string) => {
-              medplum
-                .post('auth/resetpassword', { ...formData, recaptchaToken: token })
-                .then(() => setSuccess(true))
-                .catch(setOutcome);
-            });
+          getRecaptcha().then((recaptchaToken: string) => {
+            medplum
+              .post('auth/resetpassword', { ...formData, recaptchaToken })
+              .then(() => setSuccess(true))
+              .catch(setOutcome);
           });
         }}
       >
@@ -28,7 +27,7 @@ export function ResetPasswordPage(): JSX.Element {
         </div>
         {!success && (
           <>
-            <FormSection title="Email">
+            <FormSection title="Email" htmlFor="email" outcome={outcome}>
               <TextField name="email" type="email" testid="email" required={true} autoFocus={true} outcome={outcome} />
             </FormSection>
             <div className="medplum-signin-buttons">

--- a/packages/app/src/admin/EditMembershipPage.tsx
+++ b/packages/app/src/admin/EditMembershipPage.tsx
@@ -9,7 +9,6 @@ export function EditMembershipPage(): JSX.Element {
   const medplum = useMedplum();
   const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<ProjectMembership>();
-  const [error, setError] = useState();
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const [success, setSuccess] = useState(false);
 
@@ -20,16 +19,8 @@ export function EditMembershipPage(): JSX.Element {
         setResult(response);
         setLoading(false);
       })
-      .catch((reason) => setError(reason));
+      .catch(setOutcome);
   }, [projectId, membershipId]);
-
-  if (error) {
-    return (
-      <Document>
-        <pre data-testid="error">{JSON.stringify(error, undefined, 2)}</pre>
-      </Document>
-    );
-  }
 
   if (loading || !result) {
     return <Loading />;
@@ -56,19 +47,15 @@ export function EditMembershipPage(): JSX.Element {
           medplum
             .post(`admin/projects/${projectId}/members/${membershipId}`, updated)
             .then(() => setSuccess(true))
-            .catch((err) => {
-              if (err.outcome) {
-                setOutcome(err.outcome);
-              }
-            });
+            .catch(setOutcome);
         }}
       >
         {!success && (
           <>
-            <FormSection title="Access Policy">
+            <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
               <AccessPolicyInput name="accessPolicy" defaultValue={result.accessPolicy} />
             </FormSection>
-            <FormSection title="Admin">
+            <FormSection title="Admin" htmlFor="admin" outcome={outcome}>
               <input type="checkbox" name="admin" defaultChecked={!!result.admin} value="true" />
             </FormSection>
             <div className="medplum-signin-buttons">

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -9,7 +9,6 @@ export function InvitePage(): JSX.Element {
   const medplum = useMedplum();
   const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<any>();
-  const [error, setError] = useState();
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const [success, setSuccess] = useState(false);
 
@@ -20,16 +19,8 @@ export function InvitePage(): JSX.Element {
         setResult(response);
         setLoading(false);
       })
-      .catch((reason) => setError(reason));
+      .catch(setOutcome);
   }, [id]);
-
-  if (error) {
-    return (
-      <Document>
-        <pre data-testid="error">{JSON.stringify(error, undefined, 2)}</pre>
-      </Document>
-    );
-  }
 
   if (loading || !result) {
     return <Loading />;
@@ -56,7 +47,7 @@ export function InvitePage(): JSX.Element {
       >
         {!success && (
           <>
-            <FormSection title="First Name">
+            <FormSection title="First Name" htmlFor="firstName" outcome={outcome}>
               <TextField
                 name="firstName"
                 type="text"
@@ -66,13 +57,13 @@ export function InvitePage(): JSX.Element {
                 outcome={outcome}
               />
             </FormSection>
-            <FormSection title="Last Name">
+            <FormSection title="Last Name" htmlFor="lastName" outcome={outcome}>
               <TextField name="lastName" type="text" testid="lastName" required={true} outcome={outcome} />
             </FormSection>
-            <FormSection title="Email">
+            <FormSection title="Email" htmlFor="email" outcome={outcome}>
               <TextField name="email" type="email" testid="email" required={true} outcome={outcome} />
             </FormSection>
-            <FormSection title="Access Policy">
+            <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
               <AccessPolicyInput name="accessPolicy" />
             </FormSection>
             <div className="medplum-signin-buttons">

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -14,3 +14,11 @@ export function getPatient(resource: Resource): Patient | Reference<Patient> | u
   }
   return undefined;
 }
+
+export function getRecaptcha(): Promise<string> {
+  return new Promise((resolve) => {
+    grecaptcha.ready(() => {
+      grecaptcha.execute(process.env.RECAPTCHA_SITE_KEY as string, { action: 'submit' }).then(resolve);
+    });
+  });
+}

--- a/packages/ui/src/BackboneElementInput.tsx
+++ b/packages/ui/src/BackboneElementInput.tsx
@@ -42,12 +42,19 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
         if (!property.type) {
           return null;
         }
+        const name = props.name + '.' + key;
         return (
-          <FormSection key={key} title={getPropertyDisplayName(property)} description={property.definition}>
+          <FormSection
+            key={key}
+            title={getPropertyDisplayName(property)}
+            description={property.definition}
+            htmlFor={name}
+            outcome={props.outcome}
+          >
             <ResourcePropertyInput
               schema={props.schema}
               property={property}
-              name={props.name + '.' + key}
+              name={name}
               defaultValue={getDefaultValue(value, key, entry[1])}
               outcome={props.outcome}
               onChange={(newValue: any, propName?: string) => {


### PR DESCRIPTION
On most of our form pages, there is a common pattern:

```tsx
<Form ...>
  <FormSection title="X" htmlFor="x" outcome={outcome}>
    <TextField name="x" defaultValue="..." outcome={outcome} />
  </FormSection>
</Form>
```

A little redundant, but it is explicit and it works.

The `outcome` parameter is an optional `OperationOutcome` from the server.  An `OperationOutcome` can represent success or failure.  On a failure outcome, we try to populate `expression` so the client can show the error at the right place.

For example, here's an `OperationOutcome` of a user trying to register with an email address that already exists:

```json
{
  "resourceType":"OperationOutcome",
  "issue":[
    {
      "severity":"error",
      "code":"invalid",
      "details":{
        "text":"Email already registered"
      },
      "expression":[
        "email"
      ]
    }
  ]
}
```

Note that `outcome.issue[0].expression[0]` is "email", corresponding to the "email" input field.

So, the bug... In a few of our forms, the `outcome` parameter was only passed to the `<TextField>` component, and not the `<FormSection>` component.  If it's not in both places, then it doesn't work correctly, and we don't show the error.

This PR adds `outcome` to all instances of `<FormSection>` that were missing.

In the future, the `<FormSection>` component could be refactored to reduce the verbosity and reduce the risk of mistake.  Something like:

```tsx
<Form ...>
  <FormSection name="x" title="X" defaultValue="..." component={TextField} outcome={outcome} />
</Form>
```


