### PR TITLE
Added project features, and restricted bot execution

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61036,6 +61036,13 @@
         "owner": {
           "description": "Indicates the user with responsibility for managing the Project.",
           "$ref": "#/definitions/Reference"
+        },
+        "features": {
+          "description": "A list of optional features that are enabled for the project.",
+          "items": {
+            "$ref": "#/definitions/code"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -84,6 +84,16 @@
               "code" : "Reference",
               "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/User"]
             }]
+          },
+          {
+            "id" : "Project.features",
+            "path" : "Project.features",
+            "definition" : "A list of optional features that are enabled for the project.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "code"
+            }]
           }
         ]
       }

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -54,4 +54,9 @@ export interface Project {
    * The user who owns the project.
    */
   readonly owner?: Reference<User>;
+
+  /**
+   * A list of optional features that are enabled for the project.
+   */
+  readonly features?: string[];
 }


### PR DESCRIPTION
The `Project` resource now has a `features` property, which is an array of strings:
![image](https://user-images.githubusercontent.com/749094/148292039-e0c17496-5295-4dc4-ae83-61f88207937e.png)


Bot execution is disabled unless the project has the "bots" feature.