### PR TITLE
Assorted fixes to the search page

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -49,6 +49,57 @@ describe('Search Utils', () => {
     expect(result.sortRules).toEqual([{ code: 'birthDate', descending: true }]);
   });
 
+  test('Parse modifier operator', () => {
+    const result = parseSearchDefinition({
+      pathname: 'Patient',
+      search: 'name:contains=alice',
+    });
+    expect(result).toMatchObject({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.CONTAINS,
+          value: 'alice',
+        },
+      ],
+    });
+  });
+
+  test('Parse prefix operator', () => {
+    const result = parseSearchDefinition({
+      pathname: 'Patient',
+      search: 'birthdate=gt2000-01-01',
+    });
+    expect(result).toMatchObject({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'birthdate',
+          operator: Operator.GREATER_THAN,
+          value: '2000-01-01',
+        },
+      ],
+    });
+  });
+
+  test('Parse prefix operator does not work on string', () => {
+    const result = parseSearchDefinition({
+      pathname: 'Patient',
+      search: 'name=leslie',
+    });
+    expect(result).toMatchObject({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.EQUALS,
+          value: 'leslie',
+        },
+      ],
+    });
+  });
+
   test('Format Patient search', () => {
     const result = formatSearchQuery({
       resourceType: 'Patient',

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -78,6 +78,9 @@ const PREFIX_OPERATORS: Operator[] = [
 
 /**
  * Parses a URL into a SearchRequest.
+ *
+ * See the FHIR search spec: http://hl7.org/fhir/r4/search.html
+ *
  * @param location The URL to parse.
  * @returns Parsed search definition.
  */
@@ -93,36 +96,14 @@ export function parseSearchDefinition(location: { pathname: string; search?: str
   params.forEach((value, key) => {
     if (key === '_fields') {
       fields = value.split(',');
-    } else if (key === '_sort') {
-      if (value.startsWith('-')) {
-        sortRules.push({ code: value.substr(1), descending: true });
-      } else {
-        sortRules.push({ code: value });
-      }
     } else if (key === '_page') {
       page = parseInt(value);
     } else if (key === '_count') {
       count = parseInt(value);
+    } else if (key === '_sort') {
+      sortRules.push(parseSortRule(value));
     } else {
-      let code = key;
-      let operator = Operator.EQUALS;
-
-      for (const modifier of MODIFIER_OPERATORS) {
-        const modifierIndex = code.indexOf(':' + modifier);
-        if (modifierIndex !== -1) {
-          operator = modifier as Operator;
-          code = code.substring(0, modifierIndex);
-        }
-      }
-
-      for (const prefix of PREFIX_OPERATORS) {
-        if (value.match(new RegExp('^' + prefix + '\\d'))) {
-          operator = prefix as Operator;
-          value = value.substring(prefix.length);
-        }
-      }
-
-      filters.push({ code, operator, value });
+      filters.push(parseSearchFilter(key, value));
     }
   });
 
@@ -134,6 +115,63 @@ export function parseSearchDefinition(location: { pathname: string; search?: str
     count,
     sortRules,
   };
+}
+
+/**
+ * Parses a URL query parameter into a sort rule.
+ *
+ * By default, the sort rule is the field name.
+ *
+ * Sort rules can be reversed into descending order by prefixing the field name with a minus sign.
+ *
+ * See sorting: http://hl7.org/fhir/r4/search.html#_sort
+ *
+ * @param value The URL parameter value.
+ * @returns The parsed sort rule.
+ */
+function parseSortRule(value: string): SortRule {
+  if (value.startsWith('-')) {
+    return { code: value.substring(1), descending: true };
+  } else {
+    return { code: value };
+  }
+}
+
+/**
+ * Parses a URL query parameter into a search filter.
+ *
+ * FHIR search filters can be specified as modifiers or prefixes.
+ *
+ * For string properties, modifiers are appended to the key, e.g. "name:contains=eve".
+ *
+ * For date and numeric properties, prefixes are prepended to the value, e.g. "birthdate=gt2000".
+ *
+ * See the FHIR search spec: http://hl7.org/fhir/r4/search.html
+ *
+ * @param key The URL parameter key.
+ * @param value The URL parameter value.
+ * @returns The parsed search filter.
+ */
+function parseSearchFilter(key: string, value: string): Filter {
+  let code = key;
+  let operator = Operator.EQUALS;
+
+  for (const modifier of MODIFIER_OPERATORS) {
+    const modifierIndex = code.indexOf(':' + modifier);
+    if (modifierIndex !== -1) {
+      operator = modifier;
+      code = code.substring(0, modifierIndex);
+    }
+  }
+
+  for (const prefix of PREFIX_OPERATORS) {
+    if (value.match(new RegExp('^' + prefix + '\\d'))) {
+      operator = prefix;
+      value = value.substring(prefix.length);
+    }
+  }
+
+  return { code, operator, value };
 }
 
 /**

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -104,11 +104,25 @@ export function parseSearchDefinition(location: { pathname: string; search?: str
     } else if (key === '_count') {
       count = parseInt(value);
     } else {
-      filters.push({
-        code: key,
-        operator: Operator.EQUALS,
-        value: value,
-      });
+      let code = key;
+      let operator = Operator.EQUALS;
+
+      for (const modifier of MODIFIER_OPERATORS) {
+        const modifierIndex = code.indexOf(':' + modifier);
+        if (modifierIndex !== -1) {
+          operator = modifier as Operator;
+          code = code.substring(0, modifierIndex);
+        }
+      }
+
+      for (const prefix of PREFIX_OPERATORS) {
+        if (value.match(new RegExp('^' + prefix + '\\d'))) {
+          operator = prefix as Operator;
+          value = value.substring(prefix.length);
+        }
+      }
+
+      filters.push({ code, operator, value });
     }
   });
 

--- a/packages/ui/src/CssBaseline.css
+++ b/packages/ui/src/CssBaseline.css
@@ -9,10 +9,11 @@
 
 html {
   position: relative;
-  min-height: 100%;
+  height: 100%;
 }
 
 body {
+  min-height: 100%;
   margin: 0 0 40px 0;
   font-size: var(--medplum-font-normal);
   font-style: normal;

--- a/packages/ui/src/TextField.css
+++ b/packages/ui/src/TextField.css
@@ -7,7 +7,7 @@ input[type='tel'],
 input[type='text'],
 input[type='time'],
 input[type='url'],
-select,
+select:not([size]),
 textarea {
   border: 0.1px solid var(--medplum-gray-300);
   border-radius: 3px;
@@ -26,7 +26,7 @@ input[type='tel'],
 input[type='text'],
 input[type='time'],
 input[type='url'],
-select {
+select:not([size]) {
   width: 100%;
   max-width: 400px;
   height: 34px;
@@ -100,18 +100,6 @@ select {
   margin: 1px;
   line-height: 28px;
   border-radius: 3px;
-}
-
-select:not([size]) {
-  height: 34px;
-}
-
-select.small:not([size]) {
-  height: 28px;
-}
-
-select.large:not([size]) {
-  height: 36px;
 }
 
 .medplum-input-error {


### PR DESCRIPTION
Fixing a handful of minor UI regressions...

* We changed the `<Popup>` position logic to use `document.body.clientHeight` rather than `window.innerHeight` to account for scrollbars.  Unfortunately we did not have a CSS rule for `body { height: 100%; }`, so the height calculations would put the popup at the bottom of the screen.
* We changed the default height of `<select>` controls to match `<input>` controls.  Unfortunately I did not add the `:not([size])` filter, so it also applied to multi-line select controls such as the one inside `<SearchFieldEditor>`
* Finally fixed the missing search filter display for non-equals search.  For example, a search for "name:contains=alice" would not show the filter on the "Name" column.