### PR TITLE
Changed webhook retry logic

### DIFF
--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -445,7 +445,7 @@ describe('Subscription Worker', () => {
     expect(queue.add).not.toHaveBeenCalled();
   });
 
-  test('Retry on 400', async () => {
+  test('Retry on 429', async () => {
     const url = 'https://example.com/subscription';
 
     const [subscriptionOutcome, subscription] = await repo.createResource<Subscription>({
@@ -472,7 +472,7 @@ describe('Subscription Worker', () => {
     expect(patient).toBeDefined();
     expect(queue.add).toHaveBeenCalled();
 
-    (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 400 }));
+    (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 429 }));
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -333,7 +333,7 @@ export async function sendRestHook(
       `Attempt ${job.attemptsMade} received status ${response.status}`
     );
 
-    if (response.status >= 400) {
+    if (response.status > 410) {
       error = new Error('Received status ' + response.status);
     }
   } catch (ex) {


### PR DESCRIPTION
Before:  Webhook subscriptions retried on HTTP status codes >= 400

Now:  Webhook subscriptions retry on HTTP status codes > 410

This is probably a relatively minor point, but it has been extensively discussed with current customers.  This applies to:

- 400 Bad Request
- 401 Unauthorized
- 403 Forbidden
- 404 Not Found
- 405 Method Not Allowed
- 409 Conflict
- 410 Gone

The reasoning is that for these status codes, the server successfully received and acknowledged the request.