### PR TITLE
UI perf optimizations using React.memo

### DIFF
--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -1,5 +1,5 @@
 import { formatSearchQuery, parseSearchDefinition, SearchRequest } from '@medplum/core';
-import { Loading, SearchControl, useMedplum } from '@medplum/ui';
+import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -34,7 +34,7 @@ export function HomePage(): JSX.Element {
   }
 
   return (
-    <SearchControl
+    <MemoizedSearchControl
       checkboxesEnabled={true}
       search={search}
       onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -353,22 +353,29 @@ describe('Client', () => {
 
   test('Read cached resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.readCached('Patient', '123');
+    expect(client.getCached('Patient', '123')).toBeUndefined(); // Nothing in the cache
+    const readPromise = client.readCached('Patient', '123');
+    expect(client.getCached('Patient', '123')).toBeUndefined(); // Promise in the cache
+    const result = await readPromise;
     expect(result).toBeDefined();
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');
     expect(result.resourceType).toBe('Patient');
     expect(result.id).toBe('123');
+    expect(client.getCached('Patient', '123')).toBe(result); // Value in the cache
   });
 
   test('Read cached reference', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.readCachedReference({
-      reference: 'Patient/123',
-    });
+    const reference = { reference: 'Patient/123' };
+    expect(client.getCachedReference(reference)).toBeUndefined();
+    const readPromise = client.readCachedReference(reference);
+    expect(client.getCachedReference(reference)).toBeUndefined(); // Promise in the cache
+    const result = await readPromise;
     expect(result).toBeDefined();
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');
     expect(result.resourceType).toBe('Patient');
     expect(result.id).toBe('123');
+    expect(client.getCachedReference(reference)).toBe(result);
   });
 
   test('Read cached empty reference', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -319,6 +319,34 @@ export class MedplumClient extends EventTarget {
     );
   }
 
+  /**
+   * Returns a cached resource if it is available.
+   * @param resourceType The FHIR resource type.
+   * @param id The FHIR resource ID.
+   * @returns The resource if it is available in the cache; undefined otherwise.
+   */
+  getCached<T extends Resource>(resourceType: string, id: string): T | undefined {
+    const cached = this.resourceCache.get(resourceType + '/' + id) as T | undefined;
+    if (cached && !('then' in cached)) {
+      return cached;
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns a cached resource if it is available.
+   * @param resourceType The FHIR resource type.
+   * @param id The FHIR resource ID.
+   * @returns The resource if it is available in the cache; undefined otherwise.
+   */
+  getCachedReference<T extends Resource>(reference: Reference<T>): T | undefined {
+    const cached = this.resourceCache.get(reference.reference as string) as T | undefined;
+    if (cached && !('then' in cached)) {
+      return cached;
+    }
+    return undefined;
+  }
+
   read<T extends Resource>(resourceType: string, id: string): Promise<T> {
     const cacheKey = resourceType + '/' + id;
     const promise = this.get(this.fhirUrl(resourceType, id)).then((resource: T) => {

--- a/packages/ui/src/Document.css
+++ b/packages/ui/src/Document.css
@@ -14,6 +14,7 @@ article {
   border: 0.1px solid var(--medplum-gray-300);
   border-radius: 8px;
   box-shadow: 0 1px 3px 0 var(--medplum-gray-300);
+  overflow: auto;
 }
 
 article h1,

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -403,6 +403,8 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   );
 }
 
+export const MemoizedSearchControl = React.memo(SearchControl);
+
 interface FilterDescriptionProps {
   readonly resourceType: string;
   readonly field: string;

--- a/packages/ui/src/useResource.ts
+++ b/packages/ui/src/useResource.ts
@@ -59,7 +59,7 @@ function getInitialResource<T extends Resource>(
   }
 
   if ('resourceType' in value) {
-    return value as T;
+    return value;
   }
 
   if ('reference' in value) {
@@ -67,7 +67,7 @@ function getInitialResource<T extends Resource>(
       return system as T;
     }
 
-    return medplum.getCachedReference(value as Reference<T>);
+    return medplum.getCachedReference(value);
   }
 
   return undefined;

--- a/packages/ui/src/useResource.ts
+++ b/packages/ui/src/useResource.ts
@@ -1,3 +1,4 @@
+import { MedplumClient } from '@medplum/core';
 import { Device, Reference, Resource } from '@medplum/fhirtypes';
 import { useEffect, useState } from 'react';
 import { useMedplum } from './MedplumProvider';
@@ -20,17 +21,12 @@ const system: Device = {
  */
 export function useResource<T extends Resource>(value: Reference<T> | T | undefined): T | undefined {
   const medplum = useMedplum();
-  const [resource, setResource] = useState<T | undefined>(value && 'resourceType' in value ? value : undefined);
+  const [resource, setResource] = useState<T | undefined>(getInitialResource(medplum, value));
 
   useEffect(() => {
     let subscribed = true;
 
-    if (value && 'reference' in value) {
-      if (value.reference === 'system') {
-        setResource(system as T);
-        return;
-      }
-
+    if (!resource && value && 'reference' in value) {
       medplum.readCachedReference(value as Reference<T>).then((r) => {
         if (subscribed) {
           setResource(r);
@@ -42,4 +38,37 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
   }, [value]);
 
   return resource;
+}
+
+/**
+ * Returns the initial resource value based on the input value.
+ * If the input value is a resource, returns the resource.
+ * If the input value is a reference to system, returns the system resource.
+ * If the input value is a reference to a resource available in the cache, returns the resource.
+ * Otherwise, returns undefined.
+ * @param medplum The medplum client.
+ * @param value The resource or reference to resource.
+ * @returns An initial resource if available; undefined otherwise.
+ */
+function getInitialResource<T extends Resource>(
+  medplum: MedplumClient,
+  value: Reference<T> | T | undefined
+): T | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if ('resourceType' in value) {
+    return value as T;
+  }
+
+  if ('reference' in value) {
+    if (value.reference === 'system') {
+      return system as T;
+    }
+
+    return medplum.getCachedReference(value as Reference<T>);
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
2 minor perf tweaks that make everything feel much snappier:

1. Use [`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) for the `<SearchControl>` component.  This dramatically improves the "click on logo, go back to home page" performance.  It prevents multiple HTTP requests, and a whole bunch of compute.
2. Updated the cache logic in `useResource`.  `useResource` is a killer React hook.  You can give it a `Resource`, a `Reference<T>` to a resource, or `undefined`.  The hook will ✨figure it out✨ and return a `Resource`.  It already had some awareness of our internal resource cache, but it still used a `Promise` to return the cached resource.  That means it would almost always require a repaint.  Now, if the resource is in the cache, it returns instantly, avoiding repaints entirely.