### PR TITLE
Improved getSchema/requestSchema

### DIFF
--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -29,7 +29,7 @@ export function HomePage(): JSX.Element {
     }
   }, [location]);
 
-  if (!search.resourceType) {
+  if (!search.resourceType || !search.fields || search.fields.length === 0) {
     return <Loading />;
   }
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -439,6 +439,8 @@ describe('Client', () => {
 
   test('Request schema', async () => {
     const client = new MedplumClient(defaultOptions);
+    expect(client.getSchema()).toBeDefined();
+    expect(client.getSchema().types['Patient']).toBeUndefined();
     const schema = await client.requestSchema('Patient');
     expect(schema).toBeDefined();
     expect(schema.types['Patient']).toBeDefined();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -27,11 +27,6 @@ const patientStructureDefinition: StructureDefinition = {
   },
 };
 
-const patientStructureDefinitionBundle: Bundle<StructureDefinition> = {
-  resourceType: 'Bundle',
-  entry: [{ resource: patientStructureDefinition }],
-};
-
 const patientSearchParameter: SearchParameter = {
   resourceType: 'SearchParameter',
   id: 'Patient-name',
@@ -41,9 +36,11 @@ const patientSearchParameter: SearchParameter = {
   expression: 'Patient.name',
 };
 
-const patientSearchParameterBundle: Bundle<SearchParameter> = {
-  resourceType: 'Bundle',
-  entry: [{ resource: patientSearchParameter }],
+const schemaResponse = {
+  data: {
+    StructureDefinitionList: [patientStructureDefinition],
+    SearchParameterList: [patientSearchParameter],
+  },
 };
 
 const emptyBundle: Bundle = {
@@ -118,10 +115,6 @@ function mockFetch(url: string, options: any): Promise<any> {
     result = emptyBundle;
   } else if (method === 'GET' && url.endsWith('/fhir/R4/StructureDefinition?_count=1&name:exact=DoesNotExist')) {
     result = emptyBundle;
-  } else if (method === 'GET' && url.endsWith('/fhir/R4/StructureDefinition?_count=1&name:exact=Patient')) {
-    result = patientStructureDefinitionBundle;
-  } else if (method === 'GET' && url.endsWith('/fhir/R4/SearchParameter?_count=100&base=Patient')) {
-    result = patientSearchParameterBundle;
   } else if (method === 'PUT' && url.endsWith('Patient/777')) {
     result = {
       status: 304, // Not modified
@@ -136,6 +129,8 @@ function mockFetch(url: string, options: any): Promise<any> {
     result = {
       resourceType: 'ValueSet',
     };
+  } else if (method === 'POST' && url.endsWith('fhir/R4/%24graphql')) {
+    result = schemaResponse;
   }
 
   const response: any = {
@@ -458,16 +453,6 @@ describe('Client', () => {
 
     const schema2 = await client.requestSchema('Patient');
     expect(schema2).toEqual(schema);
-  });
-
-  test('Request schema for missing resource type', async () => {
-    const client = new MedplumClient(defaultOptions);
-    expect(client.requestSchema('')).rejects.toEqual('StructureDefinition not found');
-  });
-
-  test('Request schema for bad resource type', async () => {
-    const client = new MedplumClient(defaultOptions);
-    expect(client.requestSchema('DoesNotExist')).rejects.toEqual('StructureDefinition not found');
   });
 
   test('Search ValueSet', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -13,15 +13,14 @@ import {
   Subscription,
   ValueSet,
 } from '@medplum/fhirtypes';
-import { createSchema, indexSearchParameters } from '.';
 import { LRUCache } from './cache';
 import { encryptSHA256, getRandomString } from './crypto';
 import { EventTarget } from './eventtarget';
 import { parseJWTPayload } from './jwt';
 import { isOk } from './outcomes';
-import { formatSearchQuery, Operator, SearchRequest } from './search';
+import { formatSearchQuery, SearchRequest } from './search';
 import { ClientStorage } from './storage';
-import { IndexedStructureDefinition, indexStructureDefinition } from './types';
+import { createSchema, IndexedStructureDefinition, indexSearchParameter, indexStructureDefinition } from './types';
 import { arrayBufferToBase64, ProfileResource, stringify } from './utils';
 
 const DEFAULT_BASE_URL = 'https://api.medplum.com/';
@@ -141,10 +140,17 @@ export interface TokenResponse {
   readonly profile: Reference<ProfileResource>;
 }
 
+interface SchemaGraphQLResponse {
+  readonly data: {
+    readonly StructureDefinitionList: StructureDefinition[];
+    readonly SearchParameterList: SearchParameter[];
+  };
+}
+
 export class MedplumClient extends EventTarget {
   private readonly fetch: FetchLike;
   private readonly storage: ClientStorage;
-  private readonly schema: Map<string, IndexedStructureDefinition>;
+  private readonly schema: IndexedStructureDefinition;
   private readonly resourceCache: LRUCache<Resource | Promise<Resource>>;
   private readonly baseUrl: string;
   private readonly clientId: string;
@@ -169,7 +175,7 @@ export class MedplumClient extends EventTarget {
 
     this.fetch = options.fetch || window.fetch.bind(window);
     this.storage = new ClientStorage();
-    this.schema = new Map();
+    this.schema = createSchema();
     this.resourceCache = new LRUCache(options.resourceCacheSize ?? DEFAULT_RESOURCE_CACHE_SIZE);
     this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
     this.clientId = options.clientId || '';
@@ -189,7 +195,6 @@ export class MedplumClient extends EventTarget {
    */
   clear(): void {
     this.storage.clear();
-    this.schema.clear();
     this.resourceCache.clear();
     this.dispatchEvent({ type: 'change' });
   }
@@ -382,8 +387,8 @@ export class MedplumClient extends EventTarget {
    * @param resourceType The FHIR resource type.
    * @returns The schema if immediately available, undefined otherwise.
    */
-  getSchema(resourceType: string): IndexedStructureDefinition | undefined {
-    return this.schema.get(resourceType);
+  getSchema(): IndexedStructureDefinition {
+    return this.schema;
   }
 
   /**
@@ -393,43 +398,46 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to a schema with the requested resource type.
    */
   async requestSchema(resourceType: string): Promise<IndexedStructureDefinition> {
-    const cached = this.schema.get(resourceType);
-    if (cached) {
-      return Promise.resolve(cached);
+    if (resourceType in this.schema.types) {
+      return Promise.resolve(this.schema);
     }
 
-    const schema: IndexedStructureDefinition = createSchema();
-    const structureDefinitionBundle = await this.search<StructureDefinition>({
-      resourceType: 'StructureDefinition',
-      count: 1,
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.EXACT,
-          value: resourceType,
-        },
-      ],
-    });
-    const structureDefinition = structureDefinitionBundle?.entry?.[0]?.resource;
-    if (!structureDefinition) {
-      return Promise.reject('StructureDefinition not found');
-    }
-    indexStructureDefinition(schema, structureDefinition);
+    const query = `{
+      StructureDefinitionList(name: "${encodeURIComponent(resourceType)}") {
+        name,
+        description,
+        snapshot {
+          element {
+            id,
+            path,
+            min,
+            max,
+            type {
+              code,
+              targetProfile
+            },
+            definition
+          }
+        }
+      }
+      SearchParameterList(base: "${encodeURIComponent(resourceType)}") {
+        base,
+        code,
+        type
+      }
+    }`.replace(/\s+/g, ' ');
 
-    const searchParamBundle = await this.search<SearchParameter>({
-      resourceType: 'SearchParameter',
-      count: 100,
-      filters: [
-        {
-          code: 'base',
-          operator: Operator.EQUALS,
-          value: resourceType,
-        },
-      ],
-    });
-    indexSearchParameters(schema, searchParamBundle);
-    this.schema.set(resourceType, schema);
-    return schema;
+    const response = (await this.graphql(query)) as SchemaGraphQLResponse;
+
+    for (const structureDefinition of response.data.StructureDefinitionList) {
+      indexStructureDefinition(this.schema, structureDefinition);
+    }
+
+    for (const searchParameter of response.data.SearchParameterList) {
+      indexSearchParameter(this.schema, searchParameter);
+    }
+
+    return this.schema;
   }
 
   readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
@@ -469,8 +477,8 @@ export class MedplumClient extends EventTarget {
     return this.delete(this.fhirUrl(resourceType, id));
   }
 
-  graphql(gql: any): Promise<any> {
-    return this.post(this.fhirUrl('$graphql'), gql, JSON_CONTENT_TYPE);
+  graphql(query: string): Promise<any> {
+    return this.post(this.fhirUrl('$graphql'), { query }, JSON_CONTENT_TYPE);
   }
 
   subscribe(criteria: string, handler: (e: Resource) => void): Promise<EventSource> {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -10,7 +10,6 @@ import {
   Resource,
   SearchParameter,
   StructureDefinition,
-  Subscription,
   ValueSet,
 } from '@medplum/fhirtypes';
 import { LRUCache } from './cache';
@@ -479,27 +478,6 @@ export class MedplumClient extends EventTarget {
 
   graphql(query: string): Promise<any> {
     return this.post(this.fhirUrl('$graphql'), { query }, JSON_CONTENT_TYPE);
-  }
-
-  subscribe(criteria: string, handler: (e: Resource) => void): Promise<EventSource> {
-    return this.create({
-      resourceType: 'Subscription',
-      status: 'active',
-      criteria: criteria,
-      channel: {
-        type: 'sse',
-      },
-    }).then((sub: Subscription) => {
-      const eventSource = new EventSource(this.baseUrl + 'sse?subscription=' + encodeURIComponent(sub.id as string), {
-        withCredentials: true,
-      });
-
-      eventSource.onmessage = (e: MessageEvent) => {
-        handler(JSON.parse(e.data) as Resource);
-      };
-
-      return eventSource;
-    });
   }
 
   getActiveLogin(): LoginState | undefined {

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,6 +1,77 @@
-import { getPropertyDisplayName } from './types';
+import { indexSearchParameter, indexStructureDefinition } from '.';
+import { createSchema, getPropertyDisplayName } from './types';
 
 describe('Type Utils', () => {
+  test('indexStructureDefinition', () => {
+    const schema = createSchema();
+    expect(schema.types).toBeDefined();
+
+    // Silently ignore empty structure definitions
+    indexStructureDefinition(schema, { resourceType: 'StructureDefinition' });
+
+    // Silently ignore structure definitions without any elements
+    indexStructureDefinition(schema, {
+      resourceType: 'StructureDefinition',
+      name: 'EmptyStructureDefinition',
+      snapshot: {},
+    });
+
+    // Index a patient definition
+    indexStructureDefinition(schema, {
+      resourceType: 'StructureDefinition',
+      id: '123',
+      name: 'Patient',
+      snapshot: {
+        element: [
+          {
+            id: 'Patient.name',
+            path: 'Patient.name',
+            type: [
+              {
+                code: 'HumanName',
+              },
+            ],
+            max: '*',
+          },
+        ],
+      },
+    });
+    expect(schema.types['Patient']).toBeDefined();
+    expect(schema.types['Patient'].properties).toBeDefined();
+    expect(schema.types['Patient'].properties['name']).toBeDefined();
+
+    // Silently ignore search parameters without base
+    indexSearchParameter(schema, { resourceType: 'SearchParameter' });
+
+    // Silently ignore search parameters for types without a StructureDefinition
+    indexSearchParameter(schema, { resourceType: 'SearchParameter', base: ['XYZ'] });
+    expect(schema.types['XYZ']).toBeUndefined();
+
+    // Index a patient search parameter
+    indexSearchParameter(schema, {
+      resourceType: 'SearchParameter',
+      id: 'Patient-name',
+      base: ['Patient'],
+      code: 'name',
+      name: 'name',
+      type: 'string',
+      expression: 'Patient.name',
+    });
+    expect(schema.types['Patient'].searchParams?.['name']).toBeDefined();
+
+    // Index again and silently ignore
+    indexSearchParameter(schema, {
+      resourceType: 'SearchParameter',
+      id: 'Patient-name',
+      base: ['Patient'],
+      code: 'name',
+      name: 'name',
+      type: 'string',
+      expression: 'Patient.name',
+    });
+    expect(schema.types['Patient'].searchParams?.['name']).toBeDefined();
+  });
+
   test('getPropertyDisplayName', () => {
     expect(getPropertyDisplayName({ path: 'Patient.name' })).toEqual('Name');
     expect(getPropertyDisplayName({ path: 'Patient.birthDate' })).toEqual('Birth Date');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,7 +134,7 @@ export function indexStructureDefinition(
 ): void {
   const typeName = structureDefinition.name;
   if (!typeName) {
-    throw new Error('Invalid StructureDefinition');
+    return;
   }
 
   schema.types[typeName] = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import { Bundle, ElementDefinition, SearchParameter, StructureDefinition } from '@medplum/fhirtypes';
+import { ElementDefinition, SearchParameter, StructureDefinition } from '@medplum/fhirtypes';
 import { capitalize } from './utils';
 
 /**
@@ -199,38 +199,20 @@ function indexProperty(schema: IndexedStructureDefinition, element: ElementDefin
 }
 
 /**
- * Indexes a bundle of SearchParameter resources.
- * See indexSearchParameter for more details.
- * @param schema The output IndexedStructureDefinition.
- * @param searchParamBundle The Bundle of SearchParameter resources.
- */
-export function indexSearchParameters(
-  schema: IndexedStructureDefinition,
-  searchParamBundle: Bundle<SearchParameter>
-): void {
-  if (searchParamBundle.entry) {
-    for (const entry of searchParamBundle.entry) {
-      indexSearchParameter(schema, entry.resource as SearchParameter);
-    }
-  }
-}
-
-/**
  * Indexes a SearchParameter resource for fast lookup.
  * Indexes by SearchParameter.code, which is the query string parameter name.
  * @param schema The output IndexedStructureDefinition.
  * @param searchParam The SearchParameter resource.
  */
-function indexSearchParameter(schema: IndexedStructureDefinition, searchParam: SearchParameter): void {
+export function indexSearchParameter(schema: IndexedStructureDefinition, searchParam: SearchParameter): void {
   if (!searchParam.base) {
     return;
   }
 
   for (const resourceType of searchParam.base) {
-    let typeSchema = schema.types[resourceType];
-
+    const typeSchema = schema.types[resourceType];
     if (!typeSchema) {
-      schema.types[resourceType] = typeSchema = {} as TypeSchema;
+      continue;
     }
 
     if (!typeSchema.searchParams) {

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -1,5 +1,5 @@
 import { MedplumClient } from '@medplum/core';
-import { Document, MedplumProvider, SignInForm, useMedplumProfile } from '@medplum/ui';
+import { MedplumProvider, SignInForm, useMedplumProfile } from '@medplum/ui';
 import GraphiQL from 'graphiql';
 import React from 'react';
 import { render } from 'react-dom';
@@ -42,9 +42,7 @@ function App(): JSX.Element {
   return profile ? (
     <GraphiQL fetcher={async (graphQLParams) => medplum.graphql(graphQLParams)} defaultQuery={HELP_TEXT} />
   ) : (
-    <Document width={450}>
-      <SignInForm onSuccess={() => undefined} />
-    </Document>
+    <SignInForm onSuccess={() => undefined} />
   );
 }
 

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -108,6 +108,24 @@ describe('MockClient', () => {
     });
   });
 
+  test('Request schema', async () => {
+    const client = new MockClient();
+    const schema = await client.requestSchema('Patient');
+    expect(schema).toBeDefined();
+    expect(schema.types['Patient']).toBeDefined();
+    expect(schema.types['Patient'].searchParams).toBeDefined();
+  });
+
+  test('Get cached schema', async () => {
+    const client = new MockClient();
+    const schema = await client.requestSchema('Patient');
+    expect(schema).toBeDefined();
+    expect(schema.types['Patient']).toBeDefined();
+
+    const schema2 = await client.requestSchema('Patient');
+    expect(schema2).toEqual(schema);
+  });
+
   test('Debug mode', async () => {
     console.log = jest.fn();
     const client = new MockClient({ debug: true });

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -14,6 +14,7 @@ import {
   ExampleSubscription,
   ExampleSubscriptionHistory,
   exampleValueSet,
+  GraphQLSchemaResponse,
   HomerCommunications,
   HomerDiagnosticReport,
   HomerDiagnosticReportBundle,
@@ -32,16 +33,7 @@ import {
   HomerServiceRequestSearchBundle,
   HomerSimpson,
   HomerSimpsonHistory,
-  ObservationSearchParameterBundle,
-  ObservationStructureBundle,
   OrganizationSearchBundle,
-  PatientSearchParameterBundle,
-  PatientStructureBundle,
-  PractitionerStructureBundle,
-  QuestionnaireResponseStructureDefinitionBundle,
-  QuestionnaireSearchParameterBundle,
-  QuestionnaireStructureDefinitionBundle,
-  ServiceRequestStructureDefinitionBundle,
   SimpsonSearchBundle,
   TestOrganization,
 } from './mocks';
@@ -306,15 +298,6 @@ const routes: Record<string, Record<string, any>> = {
   'fhir/R4/QuestionnaireResponse/123': {
     GET: ExampleQuestionnaireResponse,
   },
-  'fhir/R4/SearchParameter?_count=100&base=Observation': {
-    GET: ObservationSearchParameterBundle,
-  },
-  'fhir/R4/SearchParameter?_count=100&base=Patient': {
-    GET: PatientSearchParameterBundle,
-  },
-  'fhir/R4/SearchParameter?_count=100&base=Questionnaire': {
-    GET: QuestionnaireSearchParameterBundle,
-  },
   'fhir/R4/ServiceRequest/123': {
     GET: HomerServiceRequest,
   },
@@ -324,24 +307,6 @@ const routes: Record<string, Record<string, any>> = {
   'fhir/R4/ServiceRequest?subject=Patient/123': {
     GET: HomerServiceRequestSearchBundle,
   },
-  'fhir/R4/StructureDefinition?_count=1&name:exact=Observation': {
-    GET: ObservationStructureBundle,
-  },
-  'fhir/R4/StructureDefinition?_count=1&name:exact=Patient': {
-    GET: PatientStructureBundle,
-  },
-  'fhir/R4/StructureDefinition?_count=1&name:exact=Practitioner': {
-    GET: PractitionerStructureBundle,
-  },
-  'fhir/R4/StructureDefinition?_count=1&name:exact=Questionnaire': {
-    GET: QuestionnaireStructureDefinitionBundle,
-  },
-  'fhir/R4/StructureDefinition?_count=1&name:exact=QuestionnaireResponse': {
-    GET: QuestionnaireResponseStructureDefinitionBundle,
-  },
-  'fhir/R4/StructureDefinition?_count=1&name:exact=ServiceRequest': {
-    GET: ServiceRequestStructureDefinitionBundle,
-  },
   'fhir/R4/Subscription/123': {
     GET: ExampleSubscription,
   },
@@ -350,6 +315,9 @@ const routes: Record<string, Record<string, any>> = {
   },
   'fhir/R4/ValueSet/%24expand?url=https%3A%2F%2Fexample.com%2Ftest&filter=xyz': {
     GET: exampleValueSet,
+  },
+  'fhir/R4/%24graphql': {
+    POST: GraphQLSchemaResponse,
   },
   'fhir/R4': {
     POST: (body: string) => {

--- a/packages/mock/src/mocks/types.ts
+++ b/packages/mock/src/mocks/types.ts
@@ -7,74 +7,61 @@ export const EmptySearchBundle: Bundle = {
   entry: [],
 };
 
-export const ObservationStructureBundle: Bundle = {
-  resourceType: 'Bundle',
-  entry: [
-    {
-      resource: {
-        resourceType: 'StructureDefinition',
-        name: 'Observation',
-        snapshot: {
-          element: [
-            {
-              path: 'Observation.id',
-              type: [
-                {
-                  code: 'code',
-                },
-              ],
-            },
-            {
-              path: 'Observation.value[x]',
-              min: 0,
-              max: '1',
-              type: [
-                {
-                  code: 'Quantity',
-                },
-                {
-                  code: 'CodeableConcept',
-                },
-                {
-                  code: 'string',
-                },
-                {
-                  code: 'boolean',
-                },
-                {
-                  code: 'integer',
-                },
-                {
-                  code: 'Range',
-                },
-                {
-                  code: 'Ratio',
-                },
-                {
-                  code: 'SampledData',
-                },
-                {
-                  code: 'time',
-                },
-                {
-                  code: 'dateTime',
-                },
-                {
-                  code: 'Period',
-                },
-              ],
-            },
-          ],
-        },
+export const ObservationStructureDefinition: StructureDefinition = {
+  resourceType: 'StructureDefinition',
+  name: 'Observation',
+  snapshot: {
+    element: [
+      {
+        path: 'Observation.id',
+        type: [
+          {
+            code: 'code',
+          },
+        ],
       },
-    },
-  ],
-};
-
-export const ObservationSearchParameterBundle: Bundle = {
-  resourceType: 'Bundle',
-  type: 'searchset',
-  entry: [],
+      {
+        path: 'Observation.value[x]',
+        min: 0,
+        max: '1',
+        type: [
+          {
+            code: 'Quantity',
+          },
+          {
+            code: 'CodeableConcept',
+          },
+          {
+            code: 'string',
+          },
+          {
+            code: 'boolean',
+          },
+          {
+            code: 'integer',
+          },
+          {
+            code: 'Range',
+          },
+          {
+            code: 'Ratio',
+          },
+          {
+            code: 'SampledData',
+          },
+          {
+            code: 'time',
+          },
+          {
+            code: 'dateTime',
+          },
+          {
+            code: 'Period',
+          },
+        ],
+      },
+    ],
+  },
 };
 
 export const PatientStructureDefinition: StructureDefinition = {
@@ -97,205 +84,159 @@ export const PatientStructureDefinition: StructureDefinition = {
   },
 };
 
-export const PatientStructureBundle: Bundle<StructureDefinition> = {
-  resourceType: 'Bundle',
-  entry: [
-    {
-      resource: PatientStructureDefinition,
-    },
-  ],
+export const PatientSearchParameters: SearchParameter[] = [
+  {
+    resourceType: 'SearchParameter',
+    id: 'Patient-name',
+    base: ['Patient'],
+    code: 'name',
+    name: 'name',
+    type: 'string',
+    expression: 'Patient.name',
+  },
+  {
+    resourceType: 'SearchParameter',
+    id: 'Patient-birthdate',
+    base: ['Patient'],
+    code: 'birthdate',
+    name: 'birthdate',
+    type: 'date',
+    expression: 'Patient.birthdate',
+  },
+  {
+    resourceType: 'SearchParameter',
+    id: 'Patient-organization',
+    base: ['Patient'],
+    code: 'organization',
+    name: 'organization',
+    type: 'reference',
+    expression: 'Patient.organization',
+    target: ['Organization'],
+  },
+];
+
+export const PractitionerStructureDefinition: StructureDefinition = {
+  resourceType: 'StructureDefinition',
+  name: 'Practitioner',
+  snapshot: {
+    element: [
+      {
+        path: 'Practitioner.id',
+        type: [
+          {
+            code: 'code',
+          },
+        ],
+      },
+      {
+        path: 'Practitioner.name',
+        type: [
+          {
+            code: 'HumanName',
+          },
+        ],
+        max: '*',
+      },
+      {
+        path: 'Practitioner.gender',
+        type: [
+          {
+            code: 'code',
+          },
+        ],
+      },
+    ],
+  },
 };
 
-export const PatientSearchParameterBundle: Bundle<SearchParameter> = {
-  resourceType: 'Bundle',
-  entry: [
-    {
-      resource: {
-        resourceType: 'SearchParameter',
-        id: 'Patient-name',
-        base: ['Patient'],
-        code: 'name',
-        name: 'name',
-        type: 'string',
-        expression: 'Patient.name',
+export const QuestionnaireStructureDefinition: StructureDefinition = {
+  resourceType: 'StructureDefinition',
+  name: 'Questionnaire',
+  snapshot: {
+    element: [
+      {
+        id: 'Questionnaire.item',
+        path: 'Questionnaire.item',
+        type: [
+          {
+            code: 'BackboneElement',
+          },
+        ],
       },
-    },
-    {
-      resource: {
-        resourceType: 'SearchParameter',
-        id: 'Patient-birthdate',
-        base: ['Patient'],
-        code: 'birthdate',
-        name: 'birthdate',
-        type: 'date',
-        expression: 'Patient.birthdate',
+      {
+        id: 'Questionnaire.item.answerOption',
+        path: 'Questionnaire.item.answerOption',
+        type: [
+          {
+            code: 'BackboneElement',
+          },
+        ],
       },
-    },
-    {
-      resource: {
-        resourceType: 'SearchParameter',
-        id: 'Patient-organization',
-        base: ['Patient'],
-        code: 'organization',
-        name: 'organization',
-        type: 'reference',
-        expression: 'Patient.organization',
-        target: ['Organization'],
+      {
+        id: 'Questionnaire.item.answerOption.value[x]',
+        path: 'Questionnaire.item.answerOption.value[x]',
+        min: 1,
+        max: '1',
+        type: [
+          {
+            code: 'integer',
+          },
+          {
+            code: 'date',
+          },
+          {
+            code: 'time',
+          },
+          {
+            code: 'string',
+          },
+          {
+            code: 'Coding',
+          },
+          {
+            code: 'Reference',
+            targetProfile: ['http://hl7.org/fhir/StructureDefinition/Resource'],
+          },
+        ],
       },
-    },
-  ],
+    ],
+  },
 };
 
-export const PractitionerStructureBundle: Bundle<StructureDefinition> = {
-  resourceType: 'Bundle',
-  entry: [
-    {
-      resource: {
-        resourceType: 'StructureDefinition',
-        name: 'Practitioner',
-        snapshot: {
-          element: [
-            {
-              path: 'Practitioner.id',
-              type: [
-                {
-                  code: 'code',
-                },
-              ],
-            },
-            {
-              path: 'Practitioner.name',
-              type: [
-                {
-                  code: 'HumanName',
-                },
-              ],
-              max: '*',
-            },
-            {
-              path: 'Practitioner.gender',
-              type: [
-                {
-                  code: 'code',
-                },
-              ],
-            },
-          ],
-        },
+export const ServiceRequestServiceDefinition: StructureDefinition = {
+  resourceType: 'StructureDefinition',
+  name: 'ServiceRequest',
+  snapshot: {
+    element: [
+      {
+        path: 'ServiceRequest.id',
+        type: [
+          {
+            code: 'code',
+          },
+        ],
       },
-    },
-  ],
+      {
+        path: 'ServiceRequest.code',
+        type: [
+          {
+            code: 'CodeableConcept',
+          },
+        ],
+      },
+    ],
+  },
 };
 
-export const QuestionnaireStructureDefinitionBundle: Bundle<StructureDefinition> = {
-  resourceType: 'Bundle',
-  type: 'searchset',
-  entry: [
-    {
-      resource: {
-        resourceType: 'StructureDefinition',
-        name: 'Questionnaire',
-        snapshot: {
-          element: [
-            {
-              id: 'Questionnaire.item',
-              path: 'Questionnaire.item',
-              type: [
-                {
-                  code: 'BackboneElement',
-                },
-              ],
-            },
-            {
-              id: 'Questionnaire.item.answerOption',
-              path: 'Questionnaire.item.answerOption',
-              type: [
-                {
-                  code: 'BackboneElement',
-                },
-              ],
-            },
-            {
-              id: 'Questionnaire.item.answerOption.value[x]',
-              path: 'Questionnaire.item.answerOption.value[x]',
-              min: 1,
-              max: '1',
-              type: [
-                {
-                  code: 'integer',
-                },
-                {
-                  code: 'date',
-                },
-                {
-                  code: 'time',
-                },
-                {
-                  code: 'string',
-                },
-                {
-                  code: 'Coding',
-                },
-                {
-                  code: 'Reference',
-                  targetProfile: ['http://hl7.org/fhir/StructureDefinition/Resource'],
-                },
-              ],
-            },
-          ],
-        },
-      },
-    },
-  ],
-};
-
-export const QuestionnaireSearchParameterBundle: Bundle<SearchParameter> = {
-  resourceType: 'Bundle',
-  type: 'searchset',
-  entry: [],
-};
-
-export const QuestionnaireResponseStructureDefinitionBundle: Bundle<StructureDefinition> = {
-  resourceType: 'Bundle',
-  type: 'searchset',
-  entry: [
-    {
-      resource: {
-        resourceType: 'StructureDefinition',
-        name: 'QuestionnaireResponse',
-      },
-    },
-  ],
-};
-
-export const ServiceRequestStructureDefinitionBundle: Bundle<StructureDefinition> = {
-  resourceType: 'Bundle',
-  entry: [
-    {
-      resource: {
-        resourceType: 'StructureDefinition',
-        name: 'ServiceRequest',
-        snapshot: {
-          element: [
-            {
-              path: 'ServiceRequest.id',
-              type: [
-                {
-                  code: 'code',
-                },
-              ],
-            },
-            {
-              path: 'ServiceRequest.code',
-              type: [
-                {
-                  code: 'CodeableConcept',
-                },
-              ],
-            },
-          ],
-        },
-      },
-    },
-  ],
+export const GraphQLSchemaResponse = {
+  data: {
+    StructureDefinitionList: [
+      ObservationStructureDefinition,
+      PatientStructureDefinition,
+      PractitionerStructureDefinition,
+      QuestionnaireStructureDefinition,
+      ServiceRequestServiceDefinition,
+    ],
+    SearchParameterList: [...PatientSearchParameters],
+  },
 };

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -197,7 +197,11 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   }
 
   useEffect(() => {
-    medplum.requestSchema(props.search.resourceType).then(setSchema);
+    medplum.requestSchema(props.search.resourceType).then((newSchema) => {
+      // The schema could have the same object identity,
+      // so need to use the spread operator to kick React re-render.
+      setSchema({ ...newSchema });
+    });
   }, [props.search.resourceType]);
 
   useEffect(() => requestResources(), [props.search]);

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -202,7 +202,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
 
   useEffect(() => requestResources(), [props.search]);
 
-  if (!schema) {
+  if (!schema?.types?.[props.search.resourceType]) {
     return <Loading />;
   }
 

--- a/packages/ui/src/SearchFilterEditor.tsx
+++ b/packages/ui/src/SearchFilterEditor.tsx
@@ -113,10 +113,7 @@ interface FilterRowDisplayProps {
 function FilterRowDisplay(props: FilterRowDisplayProps): JSX.Element | null {
   const { resourceType, filter } = props;
   const medplum = useMedplum();
-  const schema = medplum.getSchema(resourceType);
-  if (!schema) {
-    return null;
-  }
+  const schema = medplum.getSchema();
   return (
     <tr>
       <td>{buildFieldNameString(schema, resourceType, filter.code)}</td>

--- a/packages/ui/src/SearchFilterValueDisplay.tsx
+++ b/packages/ui/src/SearchFilterValueDisplay.tsx
@@ -11,12 +11,8 @@ export interface SearchFilterValueDisplayProps {
 
 export function SearchFilterValueDisplay(props: SearchFilterValueDisplayProps): JSX.Element | null {
   const medplum = useMedplum();
-  const schema = medplum.getSchema(props.resourceType);
-  if (!schema) {
-    return null;
-  }
-
-  const searchParam = schema.types[props.resourceType].searchParams?.[props.filter.code];
+  const schema = medplum.getSchema();
+  const searchParam = schema.types[props.resourceType]?.searchParams?.[props.filter.code];
 
   const filter = props.filter;
   if (searchParam?.type === 'reference') {


### PR DESCRIPTION
This is a collection of performance improvements to the search page.

Before:  A fresh page load to the search page will generate the following HTTP requests:
![image](https://user-images.githubusercontent.com/749094/149210927-4edb1ae5-6bf0-44d0-ad1c-00afc4733bad.png)

Notably:
* The search itself (`HTTP GET /fhir/R4/Patient...`) and its preflight check
* The `StructureDefintion` search and its preflight check
* The `SearchParameter` search and its preflight check

These queries were run in serial, meaning that the results were blocked on a series of 6 HTTP round trips.

The `StructureDefinition` and `SearchParameter` queries returned full results, which are full of unneeded data.  Note that the `StructureDefinition` for `Patient` is almost 100kb.

After:
![image](https://user-images.githubusercontent.com/749094/149211975-d9ddb574-3d66-4ac5-b456-f46380a4e143.png)

* The search itself (`HTTP GET /fhir/R4/Patient...`) and its preflight check
* One GraphQL request for both `StructureDefinition` and `SearchParameter`
  * Executes in parallel to the patient search
  * Only requests the fields that are needed
  * From 4 requests to 2 requests
  * From 120kb content to 18kb content
  * GraphQL endpoint more likely to have cached CORS headers