### PR TITLE
Support embedded urn:uuid strings in transaction bundles

### DIFF
--- a/packages/server/src/fhir/batch.ts
+++ b/packages/server/src/fhir/batch.ts
@@ -314,8 +314,15 @@ class BatchProcessor {
   }
 
   private rewriteIdsInString(input: string): string {
-    const resource = this.ids[input];
-    return resource ? getReferenceString(resource) : input;
+    const matches = input.match(/urn:uuid:\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/);
+    if (matches) {
+      const fullUrl = matches[0];
+      const resource = this.ids[fullUrl];
+      if (resource) {
+        return input.replaceAll(fullUrl, getReferenceString(resource));
+      }
+    }
+    return input;
   }
 }
 


### PR DESCRIPTION
Setup: Creating a batch of resources using the batch API.  Want to reference one resource from another, but embedded within another string.

For example:
* Create a `Questionnaire`
* Create a `Subscription`  with criteria "QuestionnaireResponse?questionnaire=____"

How do you connect the subscription?

Before:  You could not.

Now: You can use the "urn:uuid:" syntax within a string, like so:

```typescript
{
  resourceType: 'Subscription',
  criteria: 'QuestionnaireResponse?questionnaire=urn:uuid:e95d01cf-60ae-43f7-a8fc-0500a8b045bb',
}
```