### PR TITLE
Let project admins set account compartment

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1046,7 +1046,7 @@ export class Repository {
     }
 
     // Otherwise, default to the existing value.
-    return existing?.meta?.account;
+    return existing?.meta?.account ?? updated.meta?.account;
   }
 
   /**
@@ -1063,7 +1063,7 @@ export class Repository {
    * @returns True if the current user can manually set meta fields.
    */
   private canWriteMeta(): boolean {
-    return this.isSystem() || this.isAdmin() || this.isClientApplication();
+    return this.isSystem() || this.isAdmin();
   }
 
   /**
@@ -1169,10 +1169,6 @@ export class Repository {
 
   private isAdmin(): boolean {
     return !!this.context.admin || this.isAdminClient();
-  }
-
-  private isClientApplication(): boolean {
-    return !!this.context.author.reference?.startsWith('ClientApplication/');
   }
 
   private isAdminClient(): boolean {

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -373,14 +373,9 @@ describe('Subscription Worker', () => {
   });
 
   test('Ignore resource changes in different project', async () => {
-    const project1 = randomUUID();
-    const project2 = randomUUID();
-
+    // Create a subscription in project 1
     const [subscriptionOutcome, subscription] = await repo.createResource<Subscription>({
       resourceType: 'Subscription',
-      meta: {
-        project: project1,
-      },
       status: 'active',
       criteria: 'Patient',
       channel: {
@@ -394,11 +389,9 @@ describe('Subscription Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [patientOutcome, patient] = await repo.createResource<Patient>({
+    // Create a patient in project 2
+    const [patientOutcome, patient] = await botRepo.createResource<Patient>({
       resourceType: 'Patient',
-      meta: {
-        project: project2,
-      },
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
 


### PR DESCRIPTION
Background:
* All resources can have an optional `meta.account` property
* Access policies can optionally restrict access to resources using that `meta.account` value
* The `meta.account` value is automatically set when a resource is created/updated by an identity with an Access Policy with an account value

Before:
* Project administrators could not set the account value manually

After:
* Project administrators can set an account if one is not set already

Added a bunch of tests for restricted users trying to do naughty things.