### PR TITLE
UI improvements when fields are hidden

### DIFF
--- a/packages/app/src/PatientHeader.test.tsx
+++ b/packages/app/src/PatientHeader.test.tsx
@@ -184,4 +184,12 @@ describe('PatientHeader', () => {
 
     expect(screen.getByText('019M')).toBeInTheDocument();
   });
+
+  test('Handles blank name', async () => {
+    setup({
+      resourceType: 'Patient',
+    });
+
+    expect(screen.getByText('[blank]')).toBeInTheDocument();
+  });
 });

--- a/packages/app/src/PatientHeader.tsx
+++ b/packages/app/src/PatientHeader.tsx
@@ -20,7 +20,7 @@ export function PatientHeader(props: PatientHeaderProps): JSX.Element | null {
           <dt>Name</dt>
           <dd>
             <MedplumLink to={patient}>
-              <HumanNameDisplay value={patient.name?.[0]} options={{ use: false }} />
+              {patient.name ? <HumanNameDisplay value={patient.name?.[0]} options={{ use: false }} /> : '[blank]'}
             </MedplumLink>
           </dd>
         </dl>

--- a/packages/ui/src/ResourceTimeline.tsx
+++ b/packages/ui/src/ResourceTimeline.tsx
@@ -54,12 +54,16 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
       return;
     }
 
-    const bathRequest = props.buildSearchRequests(resource);
-    medplum.post('fhir/R4', bathRequest).then((batchResponse) => {
+    const batchRequest = props.buildSearchRequests(resource);
+    medplum.post('fhir/R4', batchRequest).then((batchResponse) => {
       const newItems = [];
 
       for (const batchEntry of batchResponse.entry) {
         const bundle = batchEntry.resource as Bundle;
+        if (!bundle) {
+          // User may not have access to all resource types
+          continue;
+        }
 
         if (bundle.type === 'history') {
           setHistory(bundle);


### PR DESCRIPTION
Now that more users have access policies with hidden fields, improving some of the UI rough edges.

* Use "[blank]" placeholder in `<PatientHeader>` if patient name is blank or hidden
* Gracefully ignore 403 resource types in patient timeline (for example, if user does not have access to "Communication" or "Media", silently ignore)