### PR TITLE
Enabled subresource integrity in app assets

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -36,7 +36,8 @@
     "mini-css-extract-plugin": "2.4.6",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-router-dom": "6.2.1"
+    "react-router-dom": "6.2.1",
+    "webpack-subresource-integrity": "5.1.0"
   },
   "browserslist": [
     "last 1 Chrome versions"

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["esnext", "dom", "dom.iterable"]
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "noEmit": true,
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "./jest.setup.ts"]
 }

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -3,6 +3,7 @@ const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPl
 const DotenvPlugin = require('dotenv-webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
 const dotenv = require('dotenv');
 
 dotenv.config();
@@ -14,6 +15,7 @@ module.exports = (env, argv) => ({
     path: path.resolve(__dirname, 'dist'),
     filename: 'js/[name].[contenthash].js',
     publicPath: '/',
+    crossOriginLoading: 'anonymous',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
@@ -37,6 +39,7 @@ module.exports = (env, argv) => ({
     new MiniCssExtractPlugin({
       filename: 'css/[name].[contenthash].css',
     }),
+    new SubresourceIntegrityPlugin(),
   ],
   module: {
     rules: [


### PR DESCRIPTION
Enabled [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for static assets such as .css and .js files.

Before:
```html
<script defer="defer" src="/js/runtime.6da4bbb98b56d6b221b3.js"></script>
```

After:
```html
<script defer="defer" src="/js/runtime.6da4bbb98b56d6b221b3.js" integrity="sha384-unScoHs/2aJUPMIC6ozpTTWRNfstx/zetF1AGCu1qCdtF0xM/N7paepndgKK9MVp" crossorigin="anonymous"></script>
```

Browsers recognize the `integrity` and `crossorigin` attributes, and perform extra validation to make sure we're loading the content that we think we are.

The [webpack-subresource-integrity](https://www.npmjs.com/package/webpack-subresource-integrity) plugin is really doing the hard work here.  The hash is automatically calculated and inserted into the HTML at build time.

This is a good security feature by itself.  Another motivation for this is that it incrementally helps clean up our `Content-Security-Policy` `script-src` configuration.

Current `script-src`:

```
script-src 'self' *.gstatic.com *.google.com;
```

[Mozilla Observatory](https://observatory.mozilla.org/analyze/app.medplum.com) gives this an A+ (yay!).  [Google CSP](https://csp-evaluator.withgoogle.com/) evaluator doesn't like it though:

![image](https://user-images.githubusercontent.com/749094/149672166-bab773c3-c8f6-410e-aa35-aafddc704aae.png)

(Let's take a moment to appreciate that Google is complaining about Google's own config).

The recommended best practice today is to use [`strict-dynamic`](https://content-security-policy.com/strict-dynamic/).  Unfortunately, that doesn't work out of the box with Google Auth or Google Recaptcha.  Google is really putting us in a bind here.