### PR TITLE
Synchronize active login using storage events

### DIFF
--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -22,6 +22,10 @@ function setup(url = '/Patient'): void {
 }
 
 describe('HomePage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   test('Renders default page', async () => {
     setup('/');
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -525,7 +525,17 @@ describe('Client', () => {
     expect(mockAddEventListener.mock.calls[0][0]).toBe('storage');
 
     const callback = mockAddEventListener.mock.calls[0][1];
+
+    mockReload.mockReset();
+    callback({ key: 'randomKey' });
+    expect(mockReload).not.toHaveBeenCalled();
+
+    mockReload.mockReset();
     callback({ key: 'activeLogin' });
+    expect(mockReload).toHaveBeenCalled();
+
+    mockReload.mockReset();
+    callback({ key: null });
     expect(mockReload).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -505,4 +505,27 @@ describe('Client', () => {
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('ValueSet');
   });
+
+  test('Storage events', async () => {
+    // Make window.location writeable
+    Object.defineProperty(window, 'location', {
+      value: { assign: {} },
+      writable: true,
+    });
+
+    const mockAddEventListener = jest.fn();
+    const mockReload = jest.fn();
+
+    window.addEventListener = mockAddEventListener;
+    window.location.reload = mockReload;
+
+    const client = new MedplumClient(defaultOptions);
+    expect(client).toBeDefined();
+    expect(mockAddEventListener).toHaveBeenCalled();
+    expect(mockAddEventListener.mock.calls[0][0]).toBe('storage');
+
+    const callback = mockAddEventListener.mock.calls[0][1];
+    callback({ key: 'activeLogin' });
+    expect(mockReload).toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -182,11 +182,21 @@ export class MedplumClient extends EventTarget {
     this.tokenUrl = options?.tokenUrl || this.baseUrl + 'oauth2/token';
     this.logoutUrl = options?.logoutUrl || this.baseUrl + 'oauth2/logout';
     this.onUnauthenticated = options?.onUnauthenticated;
-    if (!this.getActiveLogin()?.profile?.reference) {
-      this.clear();
-    }
     this.loading = false;
     this.refreshProfile().catch(console.log);
+
+    try {
+      window.addEventListener('storage', (e: StorageEvent) => {
+        if (e.key === null || e.key === 'activeLogin') {
+          // Storage events fire when different tabs make changes.
+          // On storage clear (key === null) or activeLogin change (key === 'activeLogin')
+          // Refresh the page to ensure the active login is up to date.
+          window.location.reload();
+        }
+      });
+    } catch (err) {
+      // Silently ignore if this environment does not support storage events
+    }
   }
 
   /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -184,19 +184,7 @@ export class MedplumClient extends EventTarget {
     this.onUnauthenticated = options?.onUnauthenticated;
     this.loading = false;
     this.refreshProfile().catch(console.log);
-
-    try {
-      window.addEventListener('storage', (e: StorageEvent) => {
-        if (e.key === null || e.key === 'activeLogin') {
-          // Storage events fire when different tabs make changes.
-          // On storage clear (key === null) or activeLogin change (key === 'activeLogin')
-          // Refresh the page to ensure the active login is up to date.
-          window.location.reload();
-        }
-      });
-    } catch (err) {
-      // Silently ignore if this environment does not support storage events
-    }
+    this.setupStorageListener();
   }
 
   /**
@@ -774,6 +762,25 @@ export class MedplumClient extends EventTarget {
       project: tokens.project,
       profile: tokens.profile,
     });
+  }
+
+  /**
+   * Sets up a listener for window storage events.
+   * This synchronizes state across browser windows and browser tabs.
+   */
+  private setupStorageListener(): void {
+    try {
+      window.addEventListener('storage', (e: StorageEvent) => {
+        if (e.key === null || e.key === 'activeLogin') {
+          // Storage events fire when different tabs make changes.
+          // On storage clear (key === null) or activeLogin change (key === 'activeLogin')
+          // Refresh the page to ensure the active login is up to date.
+          window.location.reload();
+        }
+      });
+    } catch (err) {
+      // Silently ignore if this environment does not support storage events
+    }
   }
 }
 


### PR DESCRIPTION
Consider a user with 2 browser tabs open.  If the user (a) changes active profile or (b) signs out, those events should be synchronized across both tabs.

Here we use [Window storage events](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) to support that.