### PR TITLE
Add rollup.config.js to .npmignore

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -5,4 +5,5 @@ dist/**/*.test.js.map
 src/
 babel.config.json
 jest.config.json
+rollup.config.js
 tsconfig.json

--- a/packages/fhirpath/.npmignore
+++ b/packages/fhirpath/.npmignore
@@ -5,4 +5,5 @@ dist/**/*.test.js.map
 src/
 babel.config.json
 jest.config.json
+rollup.config.js
 tsconfig.json

--- a/packages/mock/.npmignore
+++ b/packages/mock/.npmignore
@@ -5,4 +5,5 @@ dist/**/*.test.js.map
 src/
 babel.config.json
 jest.config.json
+rollup.config.js
 tsconfig.json

--- a/packages/ui/.npmignore
+++ b/packages/ui/.npmignore
@@ -10,4 +10,5 @@ storybook-static/
 .env.defaults
 babel.config.json
 jest.config.json
+rollup.config.js
 tsconfig.json


### PR DESCRIPTION
Minor cleanup:  Don't publish the rollup config files when publishing to npm central repos.