### PR TITLE
Updated CSP require-trusted-types

### DIFF
--- a/packages/infra/src/frontend.ts
+++ b/packages/infra/src/frontend.ts
@@ -49,7 +49,6 @@ export class FrontEnd extends cdk.Construct {
             `script-src 'self' *.gstatic.com *.google.com`,
             `style-src 'self' 'unsafe-inline' *.gstatic.com *.google.com`,
             `worker-src 'self' *.gstatic.com *.google.com`,
-            `require-trusted-types-for 'script'`,
             `upgrade-insecure-requests`,
           ].join('; '),
           override: true,


### PR DESCRIPTION
`require-trusted-types-for` is a `Content-Security-Policy` feature that controls what the browser allows scripts to do:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for

Earlier this week, we enabled it per the recommendation of [Mozilla Observatory](https://observatory.mozilla.org/)

Unfortunately, it appears that `require-trusted-types-for` breaks reCAPTCHA: https://stackoverflow.com/questions/62081028/this-document-requires-trustedscripturl-assignment

Even after this change, we still receive an "A+" rating from Mozilla Observatory: https://observatory.mozilla.org/analyze/app.medplum.com