### PR TITLE
Use ECMAScript hash private fields

### DIFF
--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -3,38 +3,38 @@
  * Source: https://stackoverflow.com/a/46432113
  */
 export class LRUCache<T> {
-  private readonly max: number;
-  private readonly cache: Map<string, T>;
+  readonly #max: number;
+  readonly #cache: Map<string, T>;
 
   constructor(max = 10) {
-    this.max = max;
-    this.cache = new Map();
+    this.#max = max;
+    this.#cache = new Map();
   }
 
   clear(): void {
-    this.cache.clear();
+    this.#cache.clear();
   }
 
   get(key: string): T | undefined {
-    const item = this.cache.get(key);
+    const item = this.#cache.get(key);
     if (item) {
-      this.cache.delete(key);
-      this.cache.set(key, item);
+      this.#cache.delete(key);
+      this.#cache.set(key, item);
     }
     return item;
   }
 
   set(key: string, val: T): void {
-    if (this.cache.has(key)) {
-      this.cache.delete(key);
-    } else if (this.cache.size >= this.max) {
-      this.cache.delete(this.first());
+    if (this.#cache.has(key)) {
+      this.#cache.delete(key);
+    } else if (this.#cache.size >= this.#max) {
+      this.#cache.delete(this.#first());
     }
-    this.cache.set(key, val);
+    this.#cache.set(key, val);
   }
 
-  private first(): string {
+  #first(): string {
     // This works because the Map class maintains ordered keys.
-    return this.cache.keys().next().value;
+    return this.#cache.keys().next().value;
   }
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -147,18 +147,18 @@ interface SchemaGraphQLResponse {
 }
 
 export class MedplumClient extends EventTarget {
-  private readonly fetch: FetchLike;
-  private readonly storage: ClientStorage;
-  private readonly schema: IndexedStructureDefinition;
-  private readonly resourceCache: LRUCache<Resource | Promise<Resource>>;
-  private readonly baseUrl: string;
-  private readonly clientId: string;
-  private readonly authorizeUrl: string;
-  private readonly tokenUrl: string;
-  private readonly logoutUrl: string;
-  private readonly onUnauthenticated?: () => void;
-  private refreshPromise?: Promise<any>;
-  private loading: boolean;
+  readonly #fetch: FetchLike;
+  readonly #storage: ClientStorage;
+  readonly #schema: IndexedStructureDefinition;
+  readonly #resourceCache: LRUCache<Resource | Promise<Resource>>;
+  readonly #baseUrl: string;
+  readonly #clientId: string;
+  readonly #authorizeUrl: string;
+  readonly #tokenUrl: string;
+  readonly #logoutUrl: string;
+  readonly #onUnauthenticated?: () => void;
+  #refreshPromise?: Promise<any>;
+  #loading: boolean;
 
   constructor(options?: MedplumClientOptions) {
     super();
@@ -172,44 +172,44 @@ export class MedplumClient extends EventTarget {
       }
     }
 
-    this.fetch = options?.fetch || window.fetch.bind(window);
-    this.storage = new ClientStorage();
-    this.schema = createSchema();
-    this.resourceCache = new LRUCache(options?.resourceCacheSize ?? DEFAULT_RESOURCE_CACHE_SIZE);
-    this.baseUrl = options?.baseUrl || DEFAULT_BASE_URL;
-    this.clientId = options?.clientId || '';
-    this.authorizeUrl = options?.authorizeUrl || this.baseUrl + 'oauth2/authorize';
-    this.tokenUrl = options?.tokenUrl || this.baseUrl + 'oauth2/token';
-    this.logoutUrl = options?.logoutUrl || this.baseUrl + 'oauth2/logout';
-    this.onUnauthenticated = options?.onUnauthenticated;
-    this.loading = false;
-    this.refreshProfile().catch(console.log);
-    this.setupStorageListener();
+    this.#fetch = options?.fetch || window.fetch.bind(window);
+    this.#storage = new ClientStorage();
+    this.#schema = createSchema();
+    this.#resourceCache = new LRUCache(options?.resourceCacheSize ?? DEFAULT_RESOURCE_CACHE_SIZE);
+    this.#baseUrl = options?.baseUrl || DEFAULT_BASE_URL;
+    this.#clientId = options?.clientId || '';
+    this.#authorizeUrl = options?.authorizeUrl || this.#baseUrl + 'oauth2/authorize';
+    this.#tokenUrl = options?.tokenUrl || this.#baseUrl + 'oauth2/token';
+    this.#logoutUrl = options?.logoutUrl || this.#baseUrl + 'oauth2/logout';
+    this.#onUnauthenticated = options?.onUnauthenticated;
+    this.#loading = false;
+    this.#refreshProfile().catch(console.log);
+    this.#setupStorageListener();
   }
 
   /**
    * Clears all auth state including local storage and session storage.
    */
   clear(): void {
-    this.storage.clear();
-    this.resourceCache.clear();
+    this.#storage.clear();
+    this.#resourceCache.clear();
     this.dispatchEvent({ type: 'change' });
   }
 
   get(url: string): Promise<any> {
-    return this.request('GET', url);
+    return this.#request('GET', url);
   }
 
   post(url: string, body: any, contentType?: string): Promise<any> {
-    return this.request('POST', url, contentType, body);
+    return this.#request('POST', url, contentType, body);
   }
 
   put(url: string, body: any, contentType?: string): Promise<any> {
-    return this.request('PUT', url, contentType, body);
+    return this.#request('PUT', url, contentType, body);
   }
 
   delete(url: string): Promise<any> {
-    return this.request('DELETE', url);
+    return this.#request('DELETE', url);
   }
 
   /**
@@ -230,12 +230,12 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to the authentication response.
    */
   async startLogin(email: string, password: string, remember?: boolean): Promise<LoginAuthenticationResponse> {
-    await this.startPkce();
+    await this.#startPkce();
     return this.post('auth/login', {
-      clientId: this.clientId,
+      clientId: this.#clientId,
       scope: DEFAULT_SCOPE,
       codeChallengeMethod: 'S256',
-      codeChallenge: this.storage.getString('codeChallenge') as string,
+      codeChallenge: this.#storage.getString('codeChallenge') as string,
       email,
       password,
       remember: !!remember,
@@ -250,7 +250,7 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to the authentication response.
    */
   async startGoogleLogin(googleResponse: GoogleCredentialResponse): Promise<LoginAuthenticationResponse> {
-    await this.startPkce();
+    await this.#startPkce();
     return this.post('auth/google', googleResponse) as Promise<LoginAuthenticationResponse>;
   }
 
@@ -272,7 +272,7 @@ export class MedplumClient extends EventTarget {
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get('code');
     if (!code) {
-      this.requestAuthorization();
+      this.#requestAuthorization();
       return undefined;
     } else {
       return this.processCode(code);
@@ -284,7 +284,7 @@ export class MedplumClient extends EventTarget {
    * See: https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html
    */
   signOutWithRedirect(): void {
-    window.location.assign(this.logoutUrl);
+    window.location.assign(this.#logoutUrl);
   }
 
   /**
@@ -294,7 +294,7 @@ export class MedplumClient extends EventTarget {
    * @returns The well-formed FHIR URL.
    */
   fhirUrl(...path: string[]): string {
-    const builder = [this.baseUrl, 'fhir/R4'];
+    const builder = [this.#baseUrl, 'fhir/R4'];
     path.forEach((p) => builder.push('/', encodeURIComponent(p)));
     return builder.join('');
   }
@@ -330,7 +330,7 @@ export class MedplumClient extends EventTarget {
    * @returns The resource if it is available in the cache; undefined otherwise.
    */
   getCached<T extends Resource>(resourceType: string, id: string): T | undefined {
-    const cached = this.resourceCache.get(resourceType + '/' + id) as T | undefined;
+    const cached = this.#resourceCache.get(resourceType + '/' + id) as T | undefined;
     if (cached && !('then' in cached)) {
       return cached;
     }
@@ -344,7 +344,7 @@ export class MedplumClient extends EventTarget {
    * @returns The resource if it is available in the cache; undefined otherwise.
    */
   getCachedReference<T extends Resource>(reference: Reference<T>): T | undefined {
-    const cached = this.resourceCache.get(reference.reference as string) as T | undefined;
+    const cached = this.#resourceCache.get(reference.reference as string) as T | undefined;
     if (cached && !('then' in cached)) {
       return cached;
     }
@@ -354,15 +354,15 @@ export class MedplumClient extends EventTarget {
   read<T extends Resource>(resourceType: string, id: string): Promise<T> {
     const cacheKey = resourceType + '/' + id;
     const promise = this.get(this.fhirUrl(resourceType, id)).then((resource: T) => {
-      this.resourceCache.set(cacheKey, resource);
+      this.#resourceCache.set(cacheKey, resource);
       return resource;
     });
-    this.resourceCache.set(cacheKey, promise);
+    this.#resourceCache.set(cacheKey, promise);
     return promise;
   }
 
   readCached<T extends Resource>(resourceType: string, id: string): Promise<T> {
-    const cached = this.resourceCache.get(resourceType + '/' + id) as T | Promise<T> | undefined;
+    const cached = this.#resourceCache.get(resourceType + '/' + id) as T | Promise<T> | undefined;
     return cached ? Promise.resolve(cached) : this.read(resourceType, id);
   }
 
@@ -392,7 +392,7 @@ export class MedplumClient extends EventTarget {
    * @returns The schema if immediately available, undefined otherwise.
    */
   getSchema(): IndexedStructureDefinition {
-    return this.schema;
+    return this.#schema;
   }
 
   /**
@@ -402,8 +402,8 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to a schema with the requested resource type.
    */
   async requestSchema(resourceType: string): Promise<IndexedStructureDefinition> {
-    if (resourceType in this.schema.types) {
-      return Promise.resolve(this.schema);
+    if (resourceType in this.#schema.types) {
+      return Promise.resolve(this.#schema);
     }
 
     const query = `{
@@ -437,14 +437,14 @@ export class MedplumClient extends EventTarget {
     const response = (await this.graphql(query)) as SchemaGraphQLResponse;
 
     for (const structureDefinition of response.data.StructureDefinitionList) {
-      indexStructureDefinition(this.schema, structureDefinition);
+      indexStructureDefinition(this.#schema, structureDefinition);
     }
 
     for (const searchParameter of response.data.SearchParameterList) {
-      indexSearchParameter(this.schema, searchParameter);
+      indexSearchParameter(this.#schema, searchParameter);
     }
 
-    return this.schema;
+    return this.#schema;
   }
 
   readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
@@ -477,7 +477,7 @@ export class MedplumClient extends EventTarget {
   }
 
   patch(resourceType: string, id: string, operations: any): Promise<any> {
-    return this.request('PATCH', this.fhirUrl(resourceType, id), PATCH_CONTENT_TYPE, operations);
+    return this.#request('PATCH', this.fhirUrl(resourceType, id), PATCH_CONTENT_TYPE, operations);
   }
 
   deleteResource(resourceType: string, id: string): Promise<any> {
@@ -489,44 +489,44 @@ export class MedplumClient extends EventTarget {
   }
 
   getActiveLogin(): LoginState | undefined {
-    return this.storage.getObject('activeLogin');
+    return this.#storage.getObject('activeLogin');
   }
 
   async setActiveLogin(login: LoginState): Promise<void> {
-    this.storage.setObject('activeLogin', login);
-    this.addLogin(login);
-    this.resourceCache.clear();
-    this.refreshPromise = undefined;
-    await this.refreshProfile();
+    this.#storage.setObject('activeLogin', login);
+    this.#addLogin(login);
+    this.#resourceCache.clear();
+    this.#refreshPromise = undefined;
+    await this.#refreshProfile();
   }
 
   getLogins(): LoginState[] {
-    return this.storage.getObject<LoginState[]>('logins') ?? [];
+    return this.#storage.getObject<LoginState[]>('logins') ?? [];
   }
 
-  private addLogin(newLogin: LoginState): void {
+  #addLogin(newLogin: LoginState): void {
     const logins = this.getLogins().filter((login) => login.profile?.reference !== newLogin.profile?.reference);
     logins.push(newLogin);
-    this.storage.setObject('logins', logins);
+    this.#storage.setObject('logins', logins);
   }
 
-  private async refreshProfile(): Promise<ProfileResource | undefined> {
+  async #refreshProfile(): Promise<ProfileResource | undefined> {
     const reference = this.getActiveLogin()?.profile;
     if (reference?.reference) {
-      this.loading = true;
-      this.storage.setObject('profile', await this.readCachedReference(reference));
-      this.loading = false;
+      this.#loading = true;
+      this.#storage.setObject('profile', await this.readCachedReference(reference));
+      this.#loading = false;
       this.dispatchEvent({ type: 'change' });
     }
     return this.getProfile();
   }
 
   getProfile(): ProfileResource | undefined {
-    return this.storage.getObject('profile');
+    return this.#storage.getObject('profile');
   }
 
   isLoading(): boolean {
-    return this.loading;
+    return this.#loading;
   }
 
   /**
@@ -536,13 +536,13 @@ export class MedplumClient extends EventTarget {
    * @param {string=} contentType
    * @param {Object=} body
    */
-  private async request(method: string, url: string, contentType?: string, body?: any): Promise<any> {
-    if (this.refreshPromise) {
-      await this.refreshPromise;
+  async #request(method: string, url: string, contentType?: string, body?: any): Promise<any> {
+    if (this.#refreshPromise) {
+      await this.#refreshPromise;
     }
 
     if (!url.startsWith('http')) {
-      url = this.baseUrl + url;
+      url = this.#baseUrl + url;
     }
 
     const headers: Record<string, string> = {
@@ -569,10 +569,10 @@ export class MedplumClient extends EventTarget {
       }
     }
 
-    const response = await this.fetch(url, options);
+    const response = await this.#fetch(url, options);
     if (response.status === 401) {
       // Refresh and try again
-      return this.handleUnauthenticated(method, url, contentType, body);
+      return this.#handleUnauthenticated(method, url, contentType, body);
     }
 
     if (response.status === 204 || response.status === 304) {
@@ -596,13 +596,13 @@ export class MedplumClient extends EventTarget {
    * @param contentType The content type of the original request.
    * @param body The body of the original request.
    */
-  private async handleUnauthenticated(method: string, url: string, contentType?: string, body?: any): Promise<any> {
-    return this.refresh()
-      .then(() => this.request(method, url, contentType, body))
+  async #handleUnauthenticated(method: string, url: string, contentType?: string, body?: any): Promise<any> {
+    return this.#refresh()
+      .then(() => this.#request(method, url, contentType, body))
       .catch((error) => {
         this.clear();
-        if (this.onUnauthenticated) {
-          this.onUnauthenticated();
+        if (this.#onUnauthenticated) {
+          this.#onUnauthenticated();
         }
         return Promise.reject(error);
       });
@@ -612,16 +612,16 @@ export class MedplumClient extends EventTarget {
    * Starts a new PKCE flow.
    * These PKCE values are stateful, and must survive redirects and page refreshes.
    */
-  private async startPkce(): Promise<void> {
+  async #startPkce(): Promise<void> {
     const pkceState = getRandomString();
-    this.storage.setString('pkceState', pkceState);
+    this.#storage.setString('pkceState', pkceState);
 
     const codeVerifier = getRandomString();
-    this.storage.setString('codeVerifier', codeVerifier);
+    this.#storage.setString('codeVerifier', codeVerifier);
 
     const arrayHash = await encryptSHA256(codeVerifier);
     const codeChallenge = arrayBufferToBase64(arrayHash).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-    this.storage.setString('codeChallenge', codeChallenge);
+    this.#storage.setString('codeChallenge', codeChallenge);
   }
 
   /**
@@ -629,27 +629,27 @@ export class MedplumClient extends EventTarget {
    * Clears all auth state including local storage and session storage.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
    */
-  private async requestAuthorization(): Promise<void> {
-    if (!this.authorizeUrl) {
+  async #requestAuthorization(): Promise<void> {
+    if (!this.#authorizeUrl) {
       throw new Error('Missing authorize URL');
     }
 
-    this.startPkce();
+    this.#startPkce();
 
     window.location.assign(
-      this.authorizeUrl +
+      this.#authorizeUrl +
         '?response_type=code' +
         '&state=' +
-        encodeURIComponent(this.storage.getString('pkceState') as string) +
+        encodeURIComponent(this.#storage.getString('pkceState') as string) +
         '&client_id=' +
-        encodeURIComponent(this.clientId) +
+        encodeURIComponent(this.#clientId) +
         '&redirect_uri=' +
         encodeURIComponent(getBaseUrl()) +
         '&scope=' +
         encodeURIComponent(DEFAULT_SCOPE) +
         '&code_challenge_method=S256' +
         '&code_challenge=' +
-        encodeURIComponent(this.storage.getString('codeChallenge') as string)
+        encodeURIComponent(this.#storage.getString('codeChallenge') as string)
     );
   }
 
@@ -659,21 +659,21 @@ export class MedplumClient extends EventTarget {
    * @param code The authorization code received by URL parameter.
    */
   processCode(code: string): Promise<ProfileResource> {
-    const pkceState = this.storage.getString('pkceState');
+    const pkceState = this.#storage.getString('pkceState');
     if (!pkceState) {
       this.clear();
       throw new Error('Invalid PCKE state');
     }
 
-    const codeVerifier = this.storage.getString('codeVerifier');
+    const codeVerifier = this.#storage.getString('codeVerifier');
     if (!codeVerifier) {
       this.clear();
       throw new Error('Invalid PCKE code verifier');
     }
 
-    return this.fetchTokens(
+    return this.#fetchTokens(
       'grant_type=authorization_code' +
-        (this.clientId ? '&client_id=' + encodeURIComponent(this.clientId) : '') +
+        (this.#clientId ? '&client_id=' + encodeURIComponent(this.#clientId) : '') +
         '&code_verifier=' +
         encodeURIComponent(codeVerifier) +
         '&redirect_uri=' +
@@ -687,9 +687,9 @@ export class MedplumClient extends EventTarget {
    * Tries to refresh the auth tokens.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens
    */
-  private async refresh(): Promise<void> {
-    if (this.refreshPromise) {
-      return this.refreshPromise;
+  async #refresh(): Promise<void> {
+    if (this.#refreshPromise) {
+      return this.#refreshPromise;
     }
 
     const refreshToken = this.getActiveLogin()?.refreshToken;
@@ -698,15 +698,15 @@ export class MedplumClient extends EventTarget {
       return Promise.reject('Invalid refresh token');
     }
 
-    this.refreshPromise = this.fetchTokens(
+    this.#refreshPromise = this.#fetchTokens(
       'grant_type=refresh_token' +
         '&client_id=' +
-        encodeURIComponent(this.clientId) +
+        encodeURIComponent(this.#clientId) +
         '&refresh_token=' +
         encodeURIComponent(refreshToken)
     );
 
-    await this.refreshPromise;
+    await this.#refreshPromise;
   }
 
   /**
@@ -714,12 +714,12 @@ export class MedplumClient extends EventTarget {
    * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
    * @param formBody Token parameters in URL encoded format.
    */
-  private async fetchTokens(formBody: string): Promise<ProfileResource> {
-    if (!this.tokenUrl) {
+  async #fetchTokens(formBody: string): Promise<ProfileResource> {
+    if (!this.#tokenUrl) {
       return Promise.reject('Missing token URL');
     }
 
-    return this.fetch(this.tokenUrl, {
+    return this.#fetch(this.#tokenUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: formBody,
@@ -730,7 +730,7 @@ export class MedplumClient extends EventTarget {
         }
         return response.json();
       })
-      .then((tokens) => this.verifyTokens(tokens))
+      .then((tokens) => this.#verifyTokens(tokens))
       .then(() => this.getProfile() as ProfileResource);
   }
 
@@ -740,7 +740,7 @@ export class MedplumClient extends EventTarget {
    * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
    * @param tokens
    */
-  private async verifyTokens(tokens: TokenResponse): Promise<void> {
+  async #verifyTokens(tokens: TokenResponse): Promise<void> {
     const token = tokens.access_token;
 
     // Verify token has not expired
@@ -751,7 +751,7 @@ export class MedplumClient extends EventTarget {
     }
 
     // Verify app_client_id
-    if (this.clientId && tokenPayload.client_id !== this.clientId) {
+    if (this.#clientId && tokenPayload.client_id !== this.#clientId) {
       this.clear();
       return Promise.reject('Token was not issued for this audience');
     }
@@ -768,7 +768,7 @@ export class MedplumClient extends EventTarget {
    * Sets up a listener for window storage events.
    * This synchronizes state across browser windows and browser tabs.
    */
-  private setupStorageListener(): void {
+  #setupStorageListener(): void {
     try {
       window.addEventListener('storage', (e: StorageEvent) => {
         if (e.key === null || e.key === 'activeLogin') {

--- a/packages/core/src/eventtarget.ts
+++ b/packages/core/src/eventtarget.ts
@@ -3,28 +3,28 @@
  */
 
 interface Event {
-  type: string;
-  defaultPrevented?: boolean;
+  readonly type: string;
+  readonly defaultPrevented?: boolean;
 }
 
 type EventListener = (e: Event) => void;
 
 export class EventTarget {
-  private readonly listeners: Record<string, EventListener[]>;
+  readonly #listeners: Record<string, EventListener[]>;
 
   constructor() {
-    this.listeners = {};
+    this.#listeners = {};
   }
 
   addEventListener(type: string, callback: EventListener): void {
-    if (!this.listeners[type]) {
-      this.listeners[type] = [];
+    if (!this.#listeners[type]) {
+      this.#listeners[type] = [];
     }
-    this.listeners[type].push(callback);
+    this.#listeners[type].push(callback);
   }
 
   removeEventListeneer(type: string, callback: EventListener): void {
-    const array = this.listeners[type];
+    const array = this.#listeners[type];
     if (!array) {
       return;
     }
@@ -37,7 +37,7 @@ export class EventTarget {
   }
 
   dispatchEvent(event: Event): boolean {
-    const array = this.listeners[event.type];
+    const array = this.#listeners[event.type];
     if (array) {
       array.forEach((listener) => listener.call(this, event));
     }

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -8,25 +8,25 @@ import { stringify } from './utils';
  * When Using MedplumClient in the server, it will be backed by the MemoryStorage class.
  */
 export class ClientStorage {
-  private readonly storage: Storage;
+  readonly #storage: Storage;
 
   constructor() {
-    this.storage = typeof localStorage !== 'undefined' ? localStorage : new MemoryStorage();
+    this.#storage = typeof localStorage !== 'undefined' ? localStorage : new MemoryStorage();
   }
 
   clear(): void {
-    this.storage.clear();
+    this.#storage.clear();
   }
 
   getString(key: string): string | undefined {
-    return this.storage.getItem(key) || undefined;
+    return this.#storage.getItem(key) || undefined;
   }
 
   setString(key: string, value: string | undefined): void {
     if (value) {
-      this.storage.setItem(key, value);
+      this.#storage.setItem(key, value);
     } else {
-      this.storage.removeItem(key);
+      this.#storage.removeItem(key);
     }
   }
 
@@ -44,31 +44,31 @@ export class ClientStorage {
  * The MemoryStorage class is a minimal in-memory implementation of the Storage interface.
  */
 export class MemoryStorage implements Storage {
-  private data: Map<string, string>;
+  #data: Map<string, string>;
 
   constructor() {
-    this.data = new Map<string, string>();
+    this.#data = new Map<string, string>();
   }
 
   /**
    * Returns the number of key/value pairs.
    */
   get length(): number {
-    return this.data.size;
+    return this.#data.size;
   }
 
   /**
    * Removes all key/value pairs, if there are any.
    */
   clear(): void {
-    this.data.clear();
+    this.#data.clear();
   }
 
   /**
    * Returns the current value associated with the given key, or null if the given key does not exist.
    */
   getItem(key: string): string | null {
-    return this.data.get(key) ?? null;
+    return this.#data.get(key) ?? null;
   }
 
   /**
@@ -76,9 +76,9 @@ export class MemoryStorage implements Storage {
    */
   setItem(key: string, value: string | null): void {
     if (value) {
-      this.data.set(key, value);
+      this.#data.set(key, value);
     } else {
-      this.data.delete(key);
+      this.#data.delete(key);
     }
   }
 
@@ -86,13 +86,13 @@ export class MemoryStorage implements Storage {
    * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
    */
   removeItem(key: string): void {
-    this.data.delete(key);
+    this.#data.delete(key);
   }
 
   /**
    * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
    */
   key(index: number): string | null {
-    return Array.from(this.data.keys())[index];
+    return Array.from(this.#data.keys())[index];
   }
 }

--- a/packages/fhirpath/src/tokenize.ts
+++ b/packages/fhirpath/src/tokenize.ts
@@ -29,19 +29,19 @@ const STANDARD_UNITS = [
 const TWO_CHAR_OPERATORS = ['!=', '!~', '<=', '>=', '{}'];
 
 class Tokenizer {
-  private readonly str: string;
-  private pos: number;
+  readonly #str: string;
+  #pos: number;
 
   constructor(str: string) {
-    this.str = str;
-    this.pos = 0;
+    this.#str = str;
+    this.#pos = 0;
   }
 
   tokenize(): Token[] {
     const result: Token[] = [];
 
-    while (this.pos < this.str.length) {
-      const token = this.consumeToken();
+    while (this.#pos < this.#str.length) {
+      const token = this.#consumeToken();
       if (token) {
         result.push(token);
       }
@@ -50,186 +50,186 @@ class Tokenizer {
     return result;
   }
 
-  private peekToken(): Token | undefined {
-    const start = this.pos;
-    const token = this.consumeToken();
-    this.pos = start;
+  #peekToken(): Token | undefined {
+    const start = this.#pos;
+    const token = this.#consumeToken();
+    this.#pos = start;
     return token;
   }
 
-  private consumeToken(): Token | undefined {
-    this.consumeWhitespace();
+  #consumeToken(): Token | undefined {
+    this.#consumeWhitespace();
 
-    const c = this.curr();
+    const c = this.#curr();
     if (!c) {
       return undefined;
     }
 
-    const next = this.peek();
+    const next = this.#peek();
 
     if (c === '/' && next === '*') {
-      return this.consumeMultiLineComment();
+      return this.#consumeMultiLineComment();
     }
 
     if (c === '/' && next === '/') {
-      return this.consumeSingleLineComment();
+      return this.#consumeSingleLineComment();
     }
 
     if (c === "'") {
-      return this.consumeString();
+      return this.#consumeString();
     }
 
     if (c === '`') {
-      return this.consumeBacktickSymbol();
+      return this.#consumeBacktickSymbol();
     }
 
     if (c === '@') {
-      return this.consumeDateTime();
+      return this.#consumeDateTime();
     }
 
     if (c.match(/\d/)) {
-      return this.consumeNumber();
+      return this.#consumeNumber();
     }
 
     if (c.match(/\w/)) {
-      return this.consumeSymbol();
+      return this.#consumeSymbol();
     }
 
     if (c === '$' && next.match(/\w/)) {
-      return this.consumeSymbol();
+      return this.#consumeSymbol();
     }
 
-    return this.consumeOperator();
+    return this.#consumeOperator();
   }
 
-  private consumeWhitespace(): Token {
+  #consumeWhitespace(): Token {
     return buildToken(
       'Whitespace',
-      this.consumeWhile(() => this.curr().match(/\s/))
+      this.#consumeWhile(() => this.#curr().match(/\s/))
     );
   }
 
-  private consumeMultiLineComment(): Token {
-    const start = this.pos;
-    this.consumeWhile(() => this.curr() !== '*' || this.peek() !== '/');
-    this.pos += 2;
-    return buildToken('Comment', this.str.substring(start, this.pos));
+  #consumeMultiLineComment(): Token {
+    const start = this.#pos;
+    this.#consumeWhile(() => this.#curr() !== '*' || this.#peek() !== '/');
+    this.#pos += 2;
+    return buildToken('Comment', this.#str.substring(start, this.#pos));
   }
 
-  private consumeSingleLineComment(): Token {
+  #consumeSingleLineComment(): Token {
     return buildToken(
       'Comment',
-      this.consumeWhile(() => this.curr() !== '\n')
+      this.#consumeWhile(() => this.#curr() !== '\n')
     );
   }
 
-  private consumeString(): Token {
-    this.pos++;
+  #consumeString(): Token {
+    this.#pos++;
     const result = buildToken(
       'String',
-      this.consumeWhile(() => this.prev() === '\\' || this.curr() !== "'")
+      this.#consumeWhile(() => this.#prev() === '\\' || this.#curr() !== "'")
     );
-    this.pos++;
+    this.#pos++;
     return result;
   }
 
-  private consumeBacktickSymbol(): Token {
-    this.pos++;
+  #consumeBacktickSymbol(): Token {
+    this.#pos++;
     const result = buildToken(
       'Symbol',
-      this.consumeWhile(() => this.curr() !== '`')
+      this.#consumeWhile(() => this.#curr() !== '`')
     );
-    this.pos++;
+    this.#pos++;
     return result;
   }
 
-  private consumeDateTime(): Token {
-    const start = this.pos;
-    this.pos++;
-    this.consumeWhile(() => this.curr().match(/[\d-]/));
+  #consumeDateTime(): Token {
+    const start = this.#pos;
+    this.#pos++;
+    this.#consumeWhile(() => this.#curr().match(/[\d-]/));
 
-    if (this.curr() === 'T') {
-      this.pos++;
-      this.consumeWhile(() => this.curr().match(/[\d:]/));
+    if (this.#curr() === 'T') {
+      this.#pos++;
+      this.#consumeWhile(() => this.#curr().match(/[\d:]/));
 
-      if (this.curr() === '.' && this.peek().match(/\d/)) {
-        this.pos++;
-        this.consumeWhile(() => this.curr().match(/[\d]/));
+      if (this.#curr() === '.' && this.#peek().match(/\d/)) {
+        this.#pos++;
+        this.#consumeWhile(() => this.#curr().match(/[\d]/));
       }
 
-      if (this.curr() === 'Z') {
-        this.pos++;
-      } else if (this.curr() === '+' || this.curr() === '-') {
-        this.pos++;
-        this.consumeWhile(() => this.curr().match(/[\d:]/));
+      if (this.#curr() === 'Z') {
+        this.#pos++;
+      } else if (this.#curr() === '+' || this.#curr() === '-') {
+        this.#pos++;
+        this.#consumeWhile(() => this.#curr().match(/[\d:]/));
       }
     }
 
-    return buildToken('DateTime', this.str.substring(start + 1, this.pos));
+    return buildToken('DateTime', this.#str.substring(start + 1, this.#pos));
   }
 
-  private consumeNumber(): Token {
-    const start = this.pos;
+  #consumeNumber(): Token {
+    const start = this.#pos;
     let id = 'Number';
 
-    this.consumeWhile(() => this.curr().match(/\d/));
+    this.#consumeWhile(() => this.#curr().match(/\d/));
 
-    if (this.curr() === '.' && this.peek().match(/\d/)) {
-      this.pos++;
-      this.consumeWhile(() => this.curr().match(/\d/));
+    if (this.#curr() === '.' && this.#peek().match(/\d/)) {
+      this.#pos++;
+      this.#consumeWhile(() => this.#curr().match(/\d/));
     }
 
-    if (this.curr() === ' ') {
-      if (isUnitToken(this.peekToken())) {
+    if (this.#curr() === ' ') {
+      if (isUnitToken(this.#peekToken())) {
         id = 'Quantity';
-        this.consumeToken();
+        this.#consumeToken();
       }
     }
 
-    return buildToken(id, this.str.substring(start, this.pos));
+    return buildToken(id, this.#str.substring(start, this.#pos));
   }
 
-  private consumeSymbol(): Token {
+  #consumeSymbol(): Token {
     return buildToken(
       'Symbol',
-      this.consumeWhile(() => this.curr().match(/[$\w]/))
+      this.#consumeWhile(() => this.#curr().match(/[$\w]/))
     );
   }
 
-  private consumeOperator(): Token {
-    const c = this.curr();
-    const next = this.peek();
+  #consumeOperator(): Token {
+    const c = this.#curr();
+    const next = this.#peek();
     const twoCharOp = c + next;
 
     if (TWO_CHAR_OPERATORS.includes(twoCharOp)) {
-      this.pos += 2;
+      this.#pos += 2;
       return buildToken(twoCharOp, twoCharOp);
     }
 
-    this.pos++;
+    this.#pos++;
     return buildToken(c, c);
   }
 
-  private consumeWhile(condition: () => unknown): string {
-    const start = this.pos;
+  #consumeWhile(condition: () => unknown): string {
+    const start = this.#pos;
 
-    while (this.pos < this.str.length && condition()) {
-      this.pos++;
+    while (this.#pos < this.#str.length && condition()) {
+      this.#pos++;
     }
 
-    return this.str.substring(start, this.pos);
+    return this.#str.substring(start, this.#pos);
   }
 
-  private curr(): string {
-    return this.str[this.pos];
+  #curr(): string {
+    return this.#str[this.#pos];
   }
 
-  private prev(): string {
-    return this.str[this.pos - 1] ?? '';
+  #prev(): string {
+    return this.#str[this.#pos - 1] ?? '';
   }
 
-  private peek(): string {
-    return this.str[this.pos + 1] ?? '';
+  #peek(): string {
+    return this.#str[this.#pos + 1] ?? '';
   }
 }
 

--- a/packages/generator/src/filebuilder.ts
+++ b/packages/generator/src/filebuilder.ts
@@ -1,13 +1,13 @@
 const DEFAULT_INDENT = ' '.repeat(2);
 
 export class FileBuilder {
-  private readonly indent: string;
-  private readonly b: string[];
+  readonly #indent: string;
+  readonly #b: string[];
   indentCount: number;
 
   constructor(indent = DEFAULT_INDENT, header = true) {
-    this.indent = indent;
-    this.b = [];
+    this.#indent = indent;
+    this.#b = [];
     this.indentCount = 0;
 
     if (header) {
@@ -20,37 +20,37 @@ export class FileBuilder {
   }
 
   newLine(): void {
-    this.b.push('\n');
+    this.#b.push('\n');
   }
 
   appendNoWrap(line: string): void {
-    this.b.push(this.indent.repeat(this.indentCount));
-    this.b.push(line);
-    this.b.push('\n');
+    this.#b.push(this.#indent.repeat(this.indentCount));
+    this.#b.push(line);
+    this.#b.push('\n');
   }
 
   append(line: string): void {
-    const nowrap = this.indent.repeat(this.indentCount) + line;
+    const nowrap = this.#indent.repeat(this.indentCount) + line;
     if (nowrap.length < 160) {
-      this.b.push(nowrap);
-      this.b.push('\n');
+      this.#b.push(nowrap);
+      this.#b.push('\n');
     } else {
       let first = true;
-      for (const wrappedLine of wordWrap(nowrap, 120 - this.indent.length * this.indentCount)) {
+      for (const wrappedLine of wordWrap(nowrap, 120 - this.#indent.length * this.indentCount)) {
         if (first) {
-          this.b.push(this.indent.repeat(this.indentCount));
+          this.#b.push(this.#indent.repeat(this.indentCount));
         } else {
-          this.b.push(this.indent.repeat(this.indentCount + 2));
+          this.#b.push(this.#indent.repeat(this.indentCount + 2));
         }
-        this.b.push(wrappedLine.trim());
-        this.b.push('\n');
+        this.#b.push(wrappedLine.trim());
+        this.#b.push('\n');
         first = false;
       }
     }
   }
 
   toString(): string {
-    return this.b.join('').replaceAll('\n\n\n', '\n\n');
+    return this.#b.join('').replaceAll('\n\n\n', '\n\n');
   }
 }
 

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -11,7 +11,7 @@ import { compareArrays } from './util';
  * Each name is represented as a separate row in the "Address" table.
  */
 export class AddressTable implements LookupTable {
-  private static readonly knownParams: Set<string> = new Set<string>([
+  static readonly #knownParams: Set<string> = new Set<string>([
     'individual-address',
     'individual-address-city',
     'individual-address-country',
@@ -52,7 +52,7 @@ export class AddressTable implements LookupTable {
    * @returns True if the search parameter is an "identifier" parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
-    return AddressTable.knownParams.has(searchParam.id as string);
+    return AddressTable.#knownParams.has(searchParam.id as string);
   }
 
   /**
@@ -72,13 +72,13 @@ export class AddressTable implements LookupTable {
    * @returns Promise on completion.
    */
   async indexResource(resource: Resource): Promise<void> {
-    const addresses = this.getIncomingAddresses(resource);
+    const addresses = this.#getIncomingAddresses(resource);
     if (!addresses || !Array.isArray(addresses)) {
       return;
     }
 
     const resourceId = resource.id as string;
-    const existing = await this.getExistingAddresses(resourceId);
+    const existing = await this.#getExistingAddresses(resourceId);
 
     if (!compareArrays(addresses, existing)) {
       const client = getClient();
@@ -120,7 +120,7 @@ export class AddressTable implements LookupTable {
    */
   addWhere(selectQuery: SelectQuery, filter: Filter): void {
     selectQuery.where(
-      { tableName: 'Address', columnName: this.getColumnName(filter.code) },
+      { tableName: 'Address', columnName: this.#getColumnName(filter.code) },
       Operator.LIKE,
       '%' + filter.value + '%'
     );
@@ -132,7 +132,7 @@ export class AddressTable implements LookupTable {
    * @param sortRule The sort rule details.
    */
   addOrderBy(selectQuery: SelectQuery, sortRule: SortRule): void {
-    selectQuery.orderBy({ tableName: 'Address', columnName: this.getColumnName(sortRule.code) }, sortRule.descending);
+    selectQuery.orderBy({ tableName: 'Address', columnName: this.#getColumnName(sortRule.code) }, sortRule.descending);
   }
 
   /**
@@ -150,11 +150,11 @@ export class AddressTable implements LookupTable {
    * @param code The search parameter code.
    * @returns The column name.
    */
-  private getColumnName(code: string): string {
+  #getColumnName(code: string): string {
     return code === 'address' ? 'address' : code.replace('address-', '');
   }
 
-  private getIncomingAddresses(resource: Resource): Address[] | undefined {
+  #getIncomingAddresses(resource: Resource): Address[] | undefined {
     if (
       resource.resourceType === 'Patient' ||
       resource.resourceType === 'Person' ||
@@ -187,7 +187,7 @@ export class AddressTable implements LookupTable {
    * @param resourceId The FHIR resource ID.
    * @returns Promise for the list of indexed addresses.
    */
-  private async getExistingAddresses(resourceId: string): Promise<Address[]> {
+  async #getExistingAddresses(resourceId: string): Promise<Address[]> {
     return new SelectQuery('Address')
       .column('content')
       .where('resourceId', Operator.EQUALS, resourceId)

--- a/packages/server/src/fhir/lookups/contactpoint.ts
+++ b/packages/server/src/fhir/lookups/contactpoint.ts
@@ -11,7 +11,7 @@ import { compareArrays } from './util';
  * Each name is represented as a separate row in the "ContactPoint" table.
  */
 export class ContactPointTable implements LookupTable {
-  private static readonly knownParams: Set<string> = new Set<string>([
+  static readonly #knownParams: Set<string> = new Set<string>([
     'individual-telecom',
     'individual-email',
     'individual-phone',
@@ -34,7 +34,7 @@ export class ContactPointTable implements LookupTable {
    * @returns True if the search parameter is an "identifier" parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
-    return ContactPointTable.knownParams.has(searchParam.id as string);
+    return ContactPointTable.#knownParams.has(searchParam.id as string);
   }
 
   /**
@@ -69,7 +69,7 @@ export class ContactPointTable implements LookupTable {
     }
 
     const resourceId = resource.id as string;
-    const existing = await this.getExisting(resourceId);
+    const existing = await this.#getExisting(resourceId);
 
     if (!compareArrays(contactPoints, existing)) {
       const client = getClient();
@@ -127,7 +127,7 @@ export class ContactPointTable implements LookupTable {
    * @param resourceId The FHIR resource ID.
    * @returns Promise for the list of indexed names.
    */
-  private async getExisting(resourceId: string): Promise<ContactPoint[]> {
+  async #getExisting(resourceId: string): Promise<ContactPoint[]> {
     return new SelectQuery('ContactPoint')
       .column('content')
       .where('resourceId', Operator.EQUALS, resourceId)

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -11,7 +11,7 @@ import { compareArrays } from './util';
  * Each name is represented as a separate row in the "HumanName" table.
  */
 export class HumanNameTable implements LookupTable {
-  private static readonly knownParams: Set<string> = new Set<string>([
+  static readonly #knownParams: Set<string> = new Set<string>([
     'individual-given',
     'individual-family',
     'Patient-name',
@@ -34,7 +34,7 @@ export class HumanNameTable implements LookupTable {
    * @returns True if the search parameter is an "identifier" parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
-    return HumanNameTable.knownParams.has(searchParam.id as string);
+    return HumanNameTable.#knownParams.has(searchParam.id as string);
   }
 
   /**
@@ -69,7 +69,7 @@ export class HumanNameTable implements LookupTable {
     }
 
     const resourceId = resource.id as string;
-    const existing = await this.getNames(resourceId);
+    const existing = await this.#getNames(resourceId);
 
     if (!compareArrays(names, existing)) {
       const client = getClient();
@@ -124,7 +124,7 @@ export class HumanNameTable implements LookupTable {
    * @param resourceId The FHIR resource ID.
    * @returns Promise for the list of indexed names.
    */
-  private async getNames(resourceId: string): Promise<HumanName[]> {
+  async #getNames(resourceId: string): Promise<HumanName[]> {
     return new SelectQuery('HumanName')
       .column('content')
       .where('resourceId', Operator.EQUALS, resourceId)

--- a/packages/server/src/fhir/lookups/identifier.ts
+++ b/packages/server/src/fhir/lookups/identifier.ts
@@ -56,7 +56,7 @@ export class IdentifierTable implements LookupTable {
     }
 
     const resourceId = resource.id as string;
-    const existing = await this.getIdentifiers(resourceId);
+    const existing = await this.#getIdentifiers(resourceId);
 
     if (!compareArrays(identifiers, existing)) {
       const client = getClient();
@@ -110,7 +110,7 @@ export class IdentifierTable implements LookupTable {
    * @param resourceId The FHIR resource ID.
    * @returns Promise for the list of indexed identifiers.
    */
-  private async getIdentifiers(resourceId: string): Promise<Identifier[]> {
+  async #getIdentifiers(resourceId: string): Promise<Identifier[]> {
     return new SelectQuery('Identifier')
       .column('content')
       .where('resourceId', Operator.EQUALS, resourceId)

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -85,14 +85,14 @@ class SearchParser {
 
     for (const [key, value] of Object.entries(query)) {
       if (Array.isArray(value)) {
-        value.forEach((element) => this.parseKeyValue(key, element));
+        value.forEach((element) => this.#parseKeyValue(key, element));
       } else {
-        this.parseKeyValue(key, value ?? '');
+        this.#parseKeyValue(key, value ?? '');
       }
     }
   }
 
-  private parseKeyValue(key: string, value: string): void {
+  #parseKeyValue(key: string, value: string): void {
     let code;
     let modifier;
 
@@ -127,7 +127,7 @@ class SearchParser {
         break;
 
       case '_sort':
-        this.parseSortRule(value);
+        this.#parseSortRule(value);
         break;
 
       case '_page':
@@ -141,13 +141,13 @@ class SearchParser {
       default: {
         const param = getSearchParameter(this.resourceType, code);
         if (param) {
-          this.parseParameter(param, modifier, value);
+          this.#parseParameter(param, modifier, value);
         }
       }
     }
   }
 
-  private parseSortRule(value: string): void {
+  #parseSortRule(value: string): void {
     for (const field of value.split(',')) {
       let code;
       let descending = false;
@@ -161,27 +161,27 @@ class SearchParser {
     }
   }
 
-  private parseParameter(searchParam: SearchParameter, modifier: string, value: string): void {
+  #parseParameter(searchParam: SearchParameter, modifier: string, value: string): void {
     switch (searchParam.type) {
       case 'number':
       case 'date':
-        this.parsePrefixType(searchParam, value);
+        this.#parsePrefixType(searchParam, value);
         break;
       case 'string':
       case 'token':
       case 'uri':
-        this.parseModifierType(searchParam, modifier, value);
+        this.#parseModifierType(searchParam, modifier, value);
         break;
       case 'reference':
-        this.parseReference(searchParam, value);
+        this.#parseReference(searchParam, value);
         break;
       case 'quantity':
-        this.parseQuantity(searchParam, value);
+        this.#parseQuantity(searchParam, value);
         break;
     }
   }
 
-  private parsePrefixType(param: SearchParameter, input: string): void {
+  #parsePrefixType(param: SearchParameter, input: string): void {
     const { operator, value } = parsePrefix(input);
     this.filters.push({
       code: param.code as string,
@@ -190,7 +190,7 @@ class SearchParser {
     });
   }
 
-  private parseModifierType(param: SearchParameter, modifier: string, value: string): void {
+  #parseModifierType(param: SearchParameter, modifier: string, value: string): void {
     this.filters.push({
       code: param.code as string,
       operator: parseModifier(modifier),
@@ -198,7 +198,7 @@ class SearchParser {
     });
   }
 
-  private parseReference(param: SearchParameter, value: string): void {
+  #parseReference(param: SearchParameter, value: string): void {
     this.filters.push({
       code: param.code as string,
       operator: Operator.EQUALS,
@@ -206,7 +206,7 @@ class SearchParser {
     });
   }
 
-  private parseQuantity(param: SearchParameter, input: string): void {
+  #parseQuantity(param: SearchParameter, input: string): void {
     const [prefixNumber, unitSystem, unitCode] = input.split('|');
     const { operator, value } = parsePrefix(prefixNumber);
     this.filters.push({

--- a/packages/server/src/fhir/signer.ts
+++ b/packages/server/src/fhir/signer.ts
@@ -13,11 +13,15 @@ import { getConfig } from '../config';
  * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
  */
 export class Signer {
-  constructor(
-    private readonly keyPairId: string,
-    private readonly privateKey: string,
-    private readonly passphrase: string
-  ) {}
+  readonly #keyPairId: string;
+  readonly #privateKey: string;
+  readonly #passphrase: string;
+
+  constructor(keyPairId: string, privateKey: string, passphrase: string) {
+    this.#keyPairId = keyPairId;
+    this.#privateKey = privateKey;
+    this.#passphrase = passphrase;
+  }
 
   /**
    * Creates a signed URL.
@@ -46,15 +50,15 @@ export class Signer {
 
     const result = new URL(url);
     result.searchParams.set('Expires', expires.toString());
-    result.searchParams.set('Key-Pair-Id', this.keyPairId);
-    result.searchParams.set('Signature', this.signPolicy(policy));
+    result.searchParams.set('Key-Pair-Id', this.#keyPairId);
+    result.searchParams.set('Signature', this.#signPolicy(policy));
     return result.toString();
   }
 
-  private signPolicy(policy: any): string {
+  #signPolicy(policy: any): string {
     const sign = crypto.createSign('RSA-SHA1');
     sign.write(JSON.stringify(policy));
-    return this.queryEncode(sign.sign({ key: this.privateKey, passphrase: this.passphrase }, 'base64'));
+    return this.#queryEncode(sign.sign({ key: this.#privateKey, passphrase: this.#passphrase }, 'base64'));
   }
 
   /**
@@ -67,7 +71,7 @@ export class Signer {
    * For more information, see
    * http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-canned-policy.html
    */
-  private queryEncode(str: string): string {
+  #queryEncode(str: string): string {
     return str.replace(/\+/g, '-').replace(/=/g, '_').replace(/\//g, '~');
   }
 }


### PR DESCRIPTION
Before:  We used TypeScript `private` for private fields:

```ts
class Example {
  private foo: string;
}
```

After: We use ECMAScript `#` for private fields:

```ts
class Example {
  #foo: string;
}
```

Why?  This is considered best practice, because ECMAScript private fields are actually enforced at runtime, whereas TypeScript private fields are only enforced at build time.

Learn more:
* https://www.amitmerchant.com/typescript-private-modifier-vs-ecmascript-hash-private-fields/
* https://www.executeprogram.com/blog/typescript-features-to-avoid
