### PR TITLE
Fixed lighthouse warning about google dependencies

### DIFF
--- a/packages/app/index.html.ejs
+++ b/packages/app/index.html.ejs
@@ -13,8 +13,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="theme-color" content="#5b2876" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
-    <script src="https://www.google.com/recaptcha/api.js?render=<%= RECAPTCHA_SITE_KEY %>"></script>
   </head>
 
   <body>

--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -28,6 +28,16 @@ describe('RegisterPage', () => {
     Object.defineProperty(global, 'crypto', {
       value: crypto.webcrypto,
     });
+  });
+
+  test('Renders', () => {
+    setup();
+    const input = screen.getByTestId('submit') as HTMLButtonElement;
+    expect(input.innerHTML).toBe('Create account');
+  });
+
+  test('Submit success', async () => {
+    setup();
 
     Object.defineProperty(global, 'grecaptcha', {
       value: {
@@ -39,16 +49,6 @@ describe('RegisterPage', () => {
         },
       },
     });
-  });
-
-  test('Renders', () => {
-    setup();
-    const input = screen.getByTestId('submit') as HTMLButtonElement;
-    expect(input.innerHTML).toBe('Create account');
-  });
-
-  test('Submit success', async () => {
-    setup();
 
     await act(async () => {
       fireEvent.change(screen.getByTestId('firstName'), {

--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -1,13 +1,17 @@
 import { RegisterRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Button, Document, Form, FormSection, Logo, TextField, useMedplum } from '@medplum/ui';
-import React, { useState } from 'react';
-import { getRecaptcha } from './utils';
+import React, { useEffect, useState } from 'react';
+import { getRecaptcha, initRecaptcha } from './utils';
 
 export function RegisterPage(): JSX.Element {
   const medplum = useMedplum();
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    initRecaptcha();
+  }, []);
 
   return (
     <Document width={450}>

--- a/packages/app/src/ResetPasswordPage.tsx
+++ b/packages/app/src/ResetPasswordPage.tsx
@@ -1,12 +1,16 @@
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Button, Document, Form, FormSection, Logo, MedplumLink, TextField, useMedplum } from '@medplum/ui';
-import React, { useState } from 'react';
-import { getRecaptcha } from './utils';
+import React, { useEffect, useState } from 'react';
+import { getRecaptcha, initRecaptcha } from './utils';
 
 export function ResetPasswordPage(): JSX.Element {
   const medplum = useMedplum();
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    initRecaptcha();
+  }, []);
 
   return (
     <Document width={450}>

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -1,9 +1,15 @@
 import { SignInForm } from '@medplum/ui';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { initGoogleAuth } from './utils';
 
 export function SignInPage(): JSX.Element {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    initGoogleAuth();
+  }, []);
+
   return (
     <SignInForm
       onSuccess={() => navigate('/')}

--- a/packages/app/src/utils.test.ts
+++ b/packages/app/src/utils.test.ts
@@ -1,0 +1,40 @@
+import { initGoogleAuth, initRecaptcha } from './utils';
+
+describe('Utils', () => {
+  beforeEach(() => {
+    // Reset the DOM
+    document.getElementsByTagName('html')[0].innerHTML = '';
+  });
+
+  test('initGoogleAuth', () => {
+    expect(document.getElementsByTagName('script').length).toBe(0);
+
+    // Init Google Auth
+    // Should create a <script> tag for the Google Auth script.
+    initGoogleAuth();
+    expect(document.getElementsByTagName('script').length).toBe(1);
+
+    // Simulate loading the script
+    Object.defineProperty(global, 'google', { value: {} });
+
+    // Initializing again should not create more <script> tags
+    initGoogleAuth();
+    expect(document.getElementsByTagName('script').length).toBe(1);
+  });
+
+  test('initRecaptcha', () => {
+    expect(document.getElementsByTagName('script').length).toBe(0);
+
+    // Init Recaptcha
+    // Should create a <script> tag for the Recaptcha script.
+    initRecaptcha();
+    expect(document.getElementsByTagName('script').length).toBe(1);
+
+    // Simulate loading the script
+    Object.defineProperty(global, 'grecaptcha', { value: {} });
+
+    // Initializing again should not create more <script> tags
+    initRecaptcha();
+    expect(document.getElementsByTagName('script').length).toBe(1);
+  });
+});

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -1,5 +1,7 @@
 import { Patient, Reference, Resource } from '@medplum/fhirtypes';
 
+declare const google: unknown;
+
 export function getPatient(resource: Resource): Patient | Reference<Patient> | undefined {
   if (resource.resourceType === 'Patient') {
     return resource;
@@ -15,6 +17,42 @@ export function getPatient(resource: Resource): Patient | Reference<Patient> | u
   return undefined;
 }
 
+/**
+ * Dynamically loads the Google Auth script.
+ * We do not want to load the script on page load unless the user needs it.
+ */
+export function initGoogleAuth(): void {
+  if (typeof google === 'undefined') {
+    createScriptTag('https://accounts.google.com/gsi/client');
+  }
+}
+
+/**
+ * Dynamically loads the recaptcha script.
+ * We do not want to load the script on page load unless the user needs it.
+ */
+export function initRecaptcha(): void {
+  if (typeof grecaptcha === 'undefined') {
+    createScriptTag('https://www.google.com/recaptcha/api.js?render=' + process.env.RECAPTCHA_SITE_KEY);
+  }
+}
+
+/**
+ * Dynamically creates a script tag for the specified JavaScript file.
+ * @param src The JavaScript file URL.
+ */
+function createScriptTag(src: string): void {
+  const head = document.getElementsByTagName('head')[0];
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = src;
+  head.appendChild(script);
+}
+
+/**
+ * Starts a request to generate a recapcha token.
+ * @returns Promise to a recaptcha token for the current user.
+ */
 export function getRecaptcha(): Promise<string> {
   return new Promise((resolve) => {
     grecaptcha.ready(() => {

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -32,9 +32,6 @@ module.exports = (env, argv) => ({
     new HtmlWebpackPlugin({
       template: 'index.html.ejs',
       favicon: 'favicon.ico',
-      templateParameters: {
-        RECAPTCHA_SITE_KEY: process.env.RECAPTCHA_SITE_KEY,
-      },
     }),
     new MiniCssExtractPlugin({
       filename: 'css/[name].[contenthash].css',


### PR DESCRIPTION
Before:  `<script>` tags for Google Auth and Google Recaptcha were on every page.  That actually represented more content than all of the medplum assets combined (lol), which negatively impacted page load times.

After: We dynamically add the `<script>` tags when on a page that requires them.

This issue was identified by Lighthouse: https://developers.google.com/web/tools/lighthouse