### PR TITLE
Login/ProjectMembership refactor

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,47 +40,7 @@ export function App(): JSX.Element {
             medplum.signOut();
             navigate('/signin');
           }}
-          sidebarLinks={[
-            {
-              title: 'Favorites',
-              links: [
-                { label: 'Patients', href: '/Patient' },
-                { label: 'Practitioners', href: '/Practitioner' },
-                { label: 'Observations', href: '/Observation' },
-                { label: 'Organizations', href: '/Organization' },
-                { label: 'Service Requests', href: '/ServiceRequest' },
-                { label: 'Encounters', href: '/Encounter' },
-                { label: 'Diagnostic Reports', href: '/DiagnosticReport' },
-                { label: 'Questionnaires', href: '/Questionnaire' },
-              ],
-            },
-            {
-              title: 'Admin',
-              links: [
-                { label: 'Project', href: '/admin/project' },
-                { label: 'AccessPolicy', href: '/AccessPolicy' },
-              ],
-            },
-            {
-              title: 'Developer',
-              links: [
-                { label: 'Client Applications', href: '/ClientApplication' },
-                { label: 'Subscriptions', href: '/Subscription' },
-                { label: 'Bots', href: '/Bot' },
-                { label: 'Batch', href: '/batch' },
-              ],
-            },
-            {
-              title: 'Settings',
-              links: [
-                {
-                  label: 'Profile',
-                  href: `/${profile.resourceType}/${profile.id}`,
-                },
-                { label: 'Change Password', href: '/changepassword' },
-              ],
-            },
-          ]}
+          config={medplum.getUserConfiguration()}
         />
       )}
       <Routes>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -2,6 +2,7 @@ import { getReferenceString } from '@medplum/core';
 import { FooterLinks, Header, Loading, useMedplum, useMedplumProfile } from '@medplum/ui';
 import React from 'react';
 import { Route, Routes, useNavigate } from 'react-router-dom';
+import { CreateClientPage } from './admin/CreateClientPage';
 import { EditMembershipPage } from './admin/EditMembershipPage';
 import { InvitePage } from './admin/InvitePage';
 import { ProjectPage } from './admin/ProjectPage';
@@ -52,7 +53,8 @@ export function App(): JSX.Element {
         <Route path="/batch" element={<BatchPage />} />
         <Route path="/forms/:id" element={<FormPage />} />
         <Route path="/admin/project" element={<ProjectPage />} />
-        <Route path="/admin/projects/:id/invite" element={<InvitePage />} />
+        <Route path="/admin/projects/:projectId/client" element={<CreateClientPage />} />
+        <Route path="/admin/projects/:projectId/invite" element={<InvitePage />} />
         <Route path="/admin/projects/:projectId/members/:membershipId" element={<EditMembershipPage />} />
         <Route path="/admin/super" element={<SuperAdminPage />} />
         <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />

--- a/packages/app/src/admin/CreateClientPage.test.tsx
+++ b/packages/app/src/admin/CreateClientPage.test.tsx
@@ -3,7 +3,7 @@ import { MedplumProvider } from '@medplum/ui';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { InvitePage } from './InvitePage';
+import { CreateClientPage } from './CreateClientPage';
 
 const medplum = new MockClient();
 
@@ -12,14 +12,14 @@ function setup(url: string): void {
     <MedplumProvider medplum={medplum}>
       <MemoryRouter initialEntries={[url]} initialIndex={0}>
         <Routes>
-          <Route path="/admin/projects/:projectId/invite" element={<InvitePage />} />
+          <Route path="/admin/projects/:projectId/client" element={<CreateClientPage />} />
         </Routes>
       </MemoryRouter>
     </MedplumProvider>
   );
 }
 
-describe('InvitePage', () => {
+describe('CreateClientPage', () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -32,61 +32,61 @@ describe('InvitePage', () => {
   });
 
   test('Renders', async () => {
-    setup('/admin/projects/123/invite');
+    setup('/admin/projects/123/client');
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Invite'));
+      await waitFor(() => screen.getByText('Create Client'));
     });
 
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(screen.getByText('Create Client')).toBeInTheDocument();
   });
 
   test('Submit success', async () => {
-    setup('/admin/projects/123/invite');
+    setup('/admin/projects/123/client');
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Invite'));
+      await waitFor(() => screen.getByText('Create Client'));
     });
 
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(screen.getByText('Create Client')).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('firstName'), {
-        target: { value: 'George' },
+      fireEvent.change(screen.getByTestId('name'), {
+        target: { value: 'Test Client' },
       });
-      fireEvent.change(screen.getByTestId('lastName'), {
-        target: { value: 'Washington' },
+      fireEvent.change(screen.getByTestId('description'), {
+        target: { value: 'Test Description' },
       });
-      fireEvent.change(screen.getByTestId('email'), {
-        target: { value: 'george@example.com' },
+      fireEvent.change(screen.getByTestId('redirectUri'), {
+        target: { value: 'https://example.com/' },
       });
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
+      fireEvent.click(screen.getByText('Create Client'));
     });
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
   });
 
   test('Submit with access policy', async () => {
-    setup('/admin/projects/123/invite');
+    setup('/admin/projects/123/client');
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Invite'));
+      await waitFor(() => screen.getByText('Create Client'));
     });
 
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(screen.getByText('Create Client')).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('firstName'), {
-        target: { value: 'George' },
+      fireEvent.change(screen.getByTestId('name'), {
+        target: { value: 'Test Client' },
       });
-      fireEvent.change(screen.getByTestId('lastName'), {
-        target: { value: 'Washington' },
+      fireEvent.change(screen.getByTestId('description'), {
+        target: { value: 'Test Description' },
       });
-      fireEvent.change(screen.getByTestId('email'), {
-        target: { value: 'george@example.com' },
+      fireEvent.change(screen.getByTestId('redirectUri'), {
+        target: { value: 'https://example.com/' },
       });
     });
 
@@ -109,7 +109,7 @@ describe('InvitePage', () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Invite'));
+      fireEvent.click(screen.getByText('Create Client'));
     });
 
     expect(screen.getByTestId('success')).toBeInTheDocument();

--- a/packages/app/src/admin/CreateClientPage.tsx
+++ b/packages/app/src/admin/CreateClientPage.tsx
@@ -1,17 +1,17 @@
 import { AccessPolicy, OperationOutcome, Reference } from '@medplum/fhirtypes';
-import { Button, Document, Form, FormSection, Loading, MedplumLink, Input, useMedplum } from '@medplum/ui';
+import { Button, Document, Form, FormSection, Loading, MedplumLink, TextField, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AccessPolicyInput } from './AccessPolicyInput';
 
-export function InvitePage(): JSX.Element {
+export function CreateClientPage(): JSX.Element {
   const { projectId } = useParams() as { projectId: string };
   const medplum = useMedplum();
   const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<any>();
-  const [firstName, setFirstName] = useState<string>('');
-  const [lastName, setLastName] = useState<string>('');
-  const [email, setEmail] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const [description, setDescription] = useState<string>('');
+  const [redirectUri, setRedirectUri] = useState<string>('');
   const [accessPolicy, setAccessPolicy] = useState<Reference<AccessPolicy>>();
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const [success, setSuccess] = useState(false);
@@ -33,55 +33,57 @@ export function InvitePage(): JSX.Element {
   return (
     <Document width={600}>
       <h1>Admin / Projects / {result.project.name}</h1>
-      <h3>Invite new member</h3>
+      <h3>Create new Client</h3>
       <Form
         onSubmit={() => {
           const body = {
-            firstName,
-            lastName,
-            email,
+            name,
+            description,
+            redirectUri,
             accessPolicy,
           };
           medplum
-            .post('admin/projects/' + projectId + '/invite', body)
+            .post('admin/projects/' + projectId + '/client', body)
             .then(() => setSuccess(true))
             .catch(setOutcome);
         }}
       >
         {!success && (
           <>
-            <FormSection title="First Name" htmlFor="firstName" outcome={outcome}>
-              <Input
-                name="firstName"
-                type="text"
-                testid="firstName"
+            <FormSection title="Name" htmlFor="name" outcome={outcome}>
+              <TextField
+                name="name"
+                testid="name"
                 required={true}
                 autoFocus={true}
-                onChange={setFirstName}
+                onChange={(e) => setName(e.target.value)}
                 outcome={outcome}
               />
             </FormSection>
-            <FormSection title="Last Name" htmlFor="lastName" outcome={outcome}>
-              <Input
-                name="lastName"
-                type="text"
-                testid="lastName"
-                required={true}
-                onChange={setLastName}
+            <FormSection title="Description" htmlFor="description" outcome={outcome}>
+              <TextField
+                name="description"
+                testid="description"
+                onChange={(e) => setDescription(e.target.value)}
                 outcome={outcome}
               />
             </FormSection>
-            <FormSection title="Email" htmlFor="email" outcome={outcome}>
-              <Input name="email" type="email" testid="email" required={true} onChange={setEmail} outcome={outcome} />
+            <FormSection title="Redirect URI" htmlFor="redirectUri" outcome={outcome}>
+              <TextField
+                name="redirectUri"
+                testid="redirectUri"
+                onChange={(e) => setRedirectUri(e.target.value)}
+                outcome={outcome}
+              />
             </FormSection>
             <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
               <AccessPolicyInput name="accessPolicy" onChange={setAccessPolicy} />
             </FormSection>
-            <div className="medplum-signin-buttons">
+            <div className="right">
               <div></div>
               <div>
                 <Button type="submit" testid="submit">
-                  Invite
+                  Create Client
                 </Button>
               </div>
             </div>
@@ -89,8 +91,7 @@ export function InvitePage(): JSX.Element {
         )}
         {success && (
           <div data-testid="success">
-            <p>User created</p>
-            <p>Email sent</p>
+            <p>Client created</p>
             <p>
               Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
             </p>

--- a/packages/app/src/admin/CreateClientPage.tsx
+++ b/packages/app/src/admin/CreateClientPage.tsx
@@ -7,7 +7,6 @@ import { AccessPolicyInput } from './AccessPolicyInput';
 export function CreateClientPage(): JSX.Element {
   const { projectId } = useParams() as { projectId: string };
   const medplum = useMedplum();
-  const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<any>();
   const [name, setName] = useState<string>('');
   const [description, setDescription] = useState<string>('');
@@ -21,12 +20,11 @@ export function CreateClientPage(): JSX.Element {
       .get('admin/projects/' + projectId)
       .then((response) => {
         setResult(response);
-        setLoading(false);
       })
       .catch(setOutcome);
   }, [projectId]);
 
-  if (loading || !result) {
+  if (!result) {
     return <Loading />;
   }
 

--- a/packages/app/src/admin/CreateClientPage.tsx
+++ b/packages/app/src/admin/CreateClientPage.tsx
@@ -1,5 +1,5 @@
 import { AccessPolicy, OperationOutcome, Reference } from '@medplum/fhirtypes';
-import { Button, Document, Form, FormSection, Loading, MedplumLink, TextField, useMedplum } from '@medplum/ui';
+import { Button, Document, Form, FormSection, Input, Loading, MedplumLink, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { AccessPolicyInput } from './AccessPolicyInput';
@@ -49,30 +49,13 @@ export function CreateClientPage(): JSX.Element {
         {!success && (
           <>
             <FormSection title="Name" htmlFor="name" outcome={outcome}>
-              <TextField
-                name="name"
-                testid="name"
-                required={true}
-                autoFocus={true}
-                onChange={(e) => setName(e.target.value)}
-                outcome={outcome}
-              />
+              <Input name="name" testid="name" required={true} autoFocus={true} onChange={setName} outcome={outcome} />
             </FormSection>
             <FormSection title="Description" htmlFor="description" outcome={outcome}>
-              <TextField
-                name="description"
-                testid="description"
-                onChange={(e) => setDescription(e.target.value)}
-                outcome={outcome}
-              />
+              <Input name="description" testid="description" onChange={setDescription} outcome={outcome} />
             </FormSection>
             <FormSection title="Redirect URI" htmlFor="redirectUri" outcome={outcome}>
-              <TextField
-                name="redirectUri"
-                testid="redirectUri"
-                onChange={(e) => setRedirectUri(e.target.value)}
-                outcome={outcome}
-              />
+              <Input name="redirectUri" testid="redirectUri" onChange={setRedirectUri} outcome={outcome} />
             </FormSection>
             <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
               <AccessPolicyInput name="accessPolicy" onChange={setAccessPolicy} />

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -7,7 +7,6 @@ import { AccessPolicyInput } from './AccessPolicyInput';
 export function InvitePage(): JSX.Element {
   const { projectId } = useParams() as { projectId: string };
   const medplum = useMedplum();
-  const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<any>();
   const [firstName, setFirstName] = useState<string>('');
   const [lastName, setLastName] = useState<string>('');
@@ -21,12 +20,11 @@ export function InvitePage(): JSX.Element {
       .get('admin/projects/' + projectId)
       .then((response) => {
         setResult(response);
-        setLoading(false);
       })
       .catch(setOutcome);
   }, [projectId]);
 
-  if (loading || !result) {
+  if (!result) {
     return <Loading />;
   }
 

--- a/packages/app/src/admin/ProjectPage.tsx
+++ b/packages/app/src/admin/ProjectPage.tsx
@@ -36,29 +36,68 @@ export function ProjectPage(): JSX.Element {
       <h1>Admin / Projects / {result.project.name}</h1>
       <h3>Members</h3>
       <table className="medplum-table">
+        <colgroup>
+          <col style={{ width: '60%' }} />
+          <col style={{ width: '20%' }} />
+          <col style={{ width: '20%' }} />
+        </colgroup>
         <thead>
           <tr>
             <th>Name</th>
-            <th>Role</th>
-            <th>Actions</th>
+            <th className="center">Role</th>
+            <th className="center">Actions</th>
           </tr>
         </thead>
         <tbody>
-          {result.members.map((member: any) => (
-            <tr key={member.profile}>
-              <td>
-                <ResourceBadge value={{ reference: member.profile }} link={true} />
-              </td>
-              <td>{member.role}</td>
-              <td>
-                <MedplumLink to={`/admin/projects/${id}/members/${member.membershipId}`}>Edit</MedplumLink>
-              </td>
-            </tr>
-          ))}
+          {result.members
+            .filter((member: any) => member.role !== 'client')
+            .map((member: any) => (
+              <tr key={member.profile.reference}>
+                <td>
+                  <ResourceBadge value={member.profile} link={true} />
+                </td>
+                <td className="center">{member.role}</td>
+                <td className="center">
+                  <MedplumLink to={`/admin/projects/${id}/members/${member.id}`}>Access</MedplumLink>
+                </td>
+              </tr>
+            ))}
         </tbody>
       </table>
-      <hr />
-      <MedplumLink to={`/admin/projects/${result.project.id}/invite`}>Invite</MedplumLink>
+      <div className="p2 right">
+        <MedplumLink to={`/admin/projects/${result.project.id}/invite`}>Invite new user</MedplumLink>
+      </div>
+      <h3>Clients</h3>
+      <table className="table">
+        <colgroup>
+          <col style={{ width: '80%' }} />
+          <col style={{ width: '20%' }} />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th className="center">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {result.members
+            .filter((member: any) => member.role === 'client')
+            .map((member: any) => (
+              <tr key={member.profile.reference}>
+                <td>
+                  <ResourceBadge value={member.profile} link={true} />
+                </td>
+                <td className="center">
+                  <MedplumLink to={`/admin/projects/${id}/client/${resolveId(member.profile)}`}>Edit</MedplumLink>
+                  <MedplumLink to={`/admin/projects/${id}/members/${member.id}`}>Access</MedplumLink>
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+      <div className="p2 right">
+        <MedplumLink to={`/admin/projects/${result.project.id}/client`}>Create new client</MedplumLink>
+      </div>
     </Document>
   );
 }

--- a/packages/app/src/admin/ProjectPage.tsx
+++ b/packages/app/src/admin/ProjectPage.tsx
@@ -1,9 +1,10 @@
+import { resolveId } from '@medplum/core';
 import { Document, Loading, MedplumLink, ResourceBadge, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
 
 export function ProjectPage(): JSX.Element {
   const medplum = useMedplum();
-  const id = medplum.getActiveLogin()?.project?.reference?.split('/')?.[1] as string;
+  const id = resolveId(medplum.getActiveLogin()?.project) as string;
   const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<any>();
   const [error, setError] = useState();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -3,7 +3,7 @@ import crypto, { randomUUID } from 'crypto';
 import { TextEncoder } from 'util';
 import { MedplumClient } from './client';
 import { Operator } from './search';
-import { stringify } from './utils';
+import { ProfileResource, stringify } from './utils';
 
 const defaultOptions = {
   clientId: 'xyz',
@@ -77,6 +77,28 @@ function mockFetch(url: string, options: any): Promise<any> {
       },
       profile: {
         reference: 'Practitioner/123',
+      },
+    };
+  } else if (method === 'GET' && url.endsWith('auth/me')) {
+    result = {
+      profile: {
+        resourceType: 'Practitioner',
+        id: '123',
+      },
+      config: {
+        resourceType: 'UserConfiguration',
+        id: '123',
+        menu: [
+          {
+            title: 'My Menu',
+            link: [
+              {
+                name: 'My Link',
+                target: '/my-target',
+              },
+            ],
+          },
+        ],
       },
     };
   } else if (method === 'GET' && url.endsWith('Practitioner/123')) {
@@ -210,6 +232,32 @@ describe('Client', () => {
 
     window.fetch = jest.fn();
     expect(() => new MedplumClient()).not.toThrow();
+  });
+
+  test('Restore from localStorage', async () => {
+    window.localStorage.setItem(
+      'activeLogin',
+      JSON.stringify({
+        accessToken: '123',
+        refreshToken: '456',
+        project: {
+          reference: 'Project/123',
+        },
+        profile: {
+          reference: 'Practitioner/123',
+        },
+      })
+    );
+
+    const client = new MedplumClient(defaultOptions);
+    expect(client.isLoading()).toBe(true);
+    expect(client.getProfile()).toBeUndefined();
+    expect(client.getUserConfiguration()).toBeUndefined();
+
+    const profile = (await client.getProfileAsync()) as ProfileResource;
+    expect(client.isLoading()).toBe(false);
+    expect(profile.id).toBe('123');
+    expect(client.getUserConfiguration()).toBeDefined();
   });
 
   test('Clear', () => {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -252,11 +252,13 @@ describe('Client', () => {
     const client = new MedplumClient(defaultOptions);
     expect(client.isLoading()).toBe(true);
     expect(client.getProfile()).toBeUndefined();
+    expect(client.getProfileAsync()).toBeDefined();
     expect(client.getUserConfiguration()).toBeUndefined();
 
     const profile = (await client.getProfileAsync()) as ProfileResource;
     expect(client.isLoading()).toBe(false);
     expect(profile.id).toBe('123');
+    expect(client.getProfileAsync()).toBeDefined();
     expect(client.getUserConfiguration()).toBeDefined();
   });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -10,6 +10,7 @@ import {
   Resource,
   SearchParameter,
   StructureDefinition,
+  UserConfiguration,
   ValueSet,
 } from '@medplum/fhirtypes';
 import { LRUCache } from './cache';
@@ -527,6 +528,54 @@ export class MedplumClient extends EventTarget {
 
   isLoading(): boolean {
     return this.#loading;
+  }
+
+  getUserConfiguration(): UserConfiguration {
+    const profile = this.getProfile();
+    return {
+      resourceType: 'UserConfiguration',
+      menu: [
+        {
+          title: 'Favorites',
+          link: [
+            { name: 'Patients', target: '/Patient' },
+            { name: 'Practitioners', target: '/Practitioner' },
+            { name: 'Observations', target: '/Observation' },
+            { name: 'Organizations', target: '/Organization' },
+            { name: 'Service Requests', target: '/ServiceRequest' },
+            { name: 'Encounters', target: '/Encounter' },
+            { name: 'Diagnostic Reports', target: '/DiagnosticReport' },
+            { name: 'Questionnaires', target: '/Questionnaire' },
+          ],
+        },
+        {
+          title: 'Admin',
+          link: [
+            { name: 'Project', target: '/admin/project' },
+            { name: 'AccessPolicy', target: '/AccessPolicy' },
+          ],
+        },
+        {
+          title: 'Developer',
+          link: [
+            { name: 'Client Applications', target: '/ClientApplication' },
+            { name: 'Subscriptions', target: '/Subscription' },
+            { name: 'Bots', target: '/Bot' },
+            { name: 'Batch', target: '/batch' },
+          ],
+        },
+        {
+          title: 'Settings',
+          link: [
+            {
+              name: 'Profile',
+              target: `/${profile?.resourceType}/${profile?.id}`,
+            },
+            { name: 'Change Password', target: '/changepassword' },
+          ],
+        },
+      ],
+    };
   }
 
   /**

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,3 +1,4 @@
+import { resolveId } from '.';
 import {
   arrayBufferToBase64,
   arrayBufferToHex,
@@ -44,6 +45,14 @@ describe('Core Utils', () => {
     ).toMatchObject({
       reference: 'Device/123',
     });
+  });
+
+  test('resolveId', () => {
+    expect(resolveId(undefined)).toBeUndefined();
+    expect(resolveId({})).toBeUndefined();
+    expect(resolveId({ id: '123' })).toBeUndefined();
+    expect(resolveId({ reference: 'Patient' })).toBeUndefined();
+    expect(resolveId({ reference: 'Patient/123' })).toBe('123');
   });
 
   test('isProfileResource', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -24,6 +24,15 @@ export function getReferenceString(resource: Resource): string {
 }
 
 /**
+ * Returns the ID portion of a reference.
+ * @param reference A FHIR reference.
+ * @returns The ID portion of a reference.
+ */
+export function resolveId(reference: Reference | undefined): string | undefined {
+  return reference?.reference?.split('/')[1];
+}
+
+/**
  * Returns true if the resource is a "ProfileResource".
  * @param resource The FHIR resource.
  * @returns True if the resource is a "ProfileResource".

--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61096,6 +61096,10 @@
           "description": "User that is granted access to the project.",
           "$ref": "#/definitions/Reference"
         },
+        "userConfiguration": {
+          "description": "The user configuration for the user within the project memebership such as menu links, saved searches, and features.",
+          "$ref": "#/definitions/Reference"
+        },
         "admin": {
           "description": "Whether this user is a project administrator.",
           "$ref": "#/definitions/boolean"
@@ -61249,8 +61253,8 @@
           "description": "The user requesting the code.",
           "$ref": "#/definitions/Reference"
         },
-        "profile": {
-          "description": "Reference to the user's FHIR identity for this login (patient, practitioner, etc).",
+        "membership": {
+          "description": "Reference to the project membership which includes FHIR identity (patient, practitioner, etc), access policy, and user configuration.",
           "$ref": "#/definitions/Reference"
         },
         "scope": {
@@ -61299,14 +61303,6 @@
             "$ref": "#/definitions/Reference"
           },
           "type": "array"
-        },
-        "project": {
-          "description": "Reference to the default project for the duration of the login.",
-          "$ref": "#/definitions/Reference"
-        },
-        "accessPolicy": {
-          "description": "Collection of compartments that the user has been granted access.  This is a flattened collection of all ProjectMembership compartments at the time of login.",
-          "$ref": "#/definitions/Reference"
         },
         "admin": {
           "description": "Whether this login has system administrator privileges.",

--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61161,8 +61161,7 @@
       },
       "required": [
         "resourceType",
-        "secret",
-        "redirectUri"
+        "secret"
       ]
     },
     "User": {

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -357,9 +357,10 @@
             "max" : "1",
             "type" : [{
               "code" : "Reference",
-              "targetProfile" : ["http://hl7.org/fhir/StructureDefinition/Patient",
-              "http://hl7.org/fhir/StructureDefinition/Practitioner",
-              "http://hl7.org/fhir/StructureDefinition/RelatedPerson"]
+              "targetProfile" : ["http://hl7.org/fhir/StructureDefinition/ClientApplication",
+                "http://hl7.org/fhir/StructureDefinition/Patient",
+                "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                "http://hl7.org/fhir/StructureDefinition/RelatedPerson"]
             }]
           },
           {
@@ -381,6 +382,17 @@
             "type" : [{
               "code" : "Reference",
               "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/AccessPolicy"]
+            }]
+          },
+          {
+            "id" : "ProjectMembership.userConfiguration",
+            "path" : "ProjectMembership.userConfiguration",
+            "definition" : "The user configuration for the user within the project memebership such as menu links, saved searches, and features.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "Reference",
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/UserConfiguration"]
             }]
           },
           {
@@ -561,21 +573,19 @@
             "max" : "1",
             "type" : [{
               "code" : "Reference",
-              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/User"]
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/ClientApplication",
+                "https://medplum.com/fhir/StructureDefinition/User"]
             }]
           },
           {
-            "id" : "Login.profile",
-            "path" : "Login.profile",
-            "definition" : "Reference to the user's FHIR identity for this login (patient, practitioner, etc).",
+            "id" : "Login.membership",
+            "path" : "Login.membership",
+            "definition" : "Reference to the project membership which includes FHIR identity (patient, practitioner, etc), access policy, and user configuration.",
             "min" : 1,
             "max" : "1",
             "type" : [{
               "code" : "Reference",
-              "targetProfile" : ["http://hl7.org/fhir/StructureDefinition/Patient",
-              "http://hl7.org/fhir/StructureDefinition/Practitioner",
-              "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-              "https://medplum.com/fhir/StructureDefinition/ClientApplication"]
+              "targetProfile" : ["http://hl7.org/fhir/StructureDefinition/ProjectMembership"]
             }]
           },
           {
@@ -676,28 +686,6 @@
             "max" : "1",
             "type" : [{
               "code" : "boolean"
-            }]
-          },
-          {
-            "id" : "Login.accessPolicy",
-            "path" : "Login.accessPolicy",
-            "definition" : "Collection of compartments that the user has been granted access.  This is a flattened collection of all ProjectMembership compartments at the time of login.",
-            "min" : 0,
-            "max" : "1",
-            "type" : [{
-              "code" : "Reference",
-              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/AccessPolicy"]
-            }]
-          },
-          {
-            "id" : "Login.project",
-            "path" : "Login.project",
-            "definition" : "Reference to the default project for the duration of the login.",
-            "min" : 0,
-            "max" : "1",
-            "type" : [{
-              "code" : "Reference",
-              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/Project"]
             }]
           },
           {

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -346,7 +346,8 @@
             "max" : "1",
             "type" : [{
               "code" : "Reference",
-              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/User"]
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/ClientApplication",
+                "https://medplum.com/fhir/StructureDefinition/User"]
             }]
           },
           {

--- a/packages/definitions/dist/fhir/r4/search-parameters.json
+++ b/packages/definitions/dist/fhir/r4/search-parameters.json
@@ -65473,7 +65473,7 @@
       "expression" : "ProjectMembership.user",
       "xpath" : "f:ProjectMembership/f:user",
       "xpathUsage" : "normal",
-      "target" : ["User"]
+      "target" : ["ClientApplication", "User"]
     }
   },
   {

--- a/packages/fhirtypes/dist/Login.d.ts
+++ b/packages/fhirtypes/dist/Login.d.ts
@@ -3,14 +3,10 @@
  * Do not edit manually.
  */
 
-import { AccessPolicy } from './AccessPolicy';
 import { ClientApplication } from './ClientApplication';
 import { Meta } from './Meta';
-import { Patient } from './Patient';
-import { Practitioner } from './Practitioner';
-import { Project } from './Project';
+import { ProjectMembership } from './ProjectMembership';
 import { Reference } from './Reference';
-import { RelatedPerson } from './RelatedPerson';
 import { User } from './User';
 
 /**
@@ -57,13 +53,13 @@ export interface Login {
   /**
    * The user requesting the code.
    */
-  readonly user?: Reference<User>;
+  readonly user?: Reference<ClientApplication | User>;
 
   /**
-   * Reference to the user's FHIR identity for this login (patient,
-   * practitioner, etc).
+   * Reference to the project membership which includes FHIR identity
+   * (patient, practitioner, etc), access policy, and user configuration.
    */
-  readonly profile?: Reference<Patient | Practitioner | RelatedPerson | ClientApplication>;
+  readonly membership?: Reference<ProjectMembership>;
 
   /**
    * OAuth scope or scopes.
@@ -126,18 +122,6 @@ export interface Login {
    * Whether this login has been revoked or invalidated.
    */
   readonly revoked?: boolean;
-
-  /**
-   * Collection of compartments that the user has been granted access.
-   * This is a flattened collection of all ProjectMembership compartments
-   * at the time of login.
-   */
-  readonly accessPolicy?: Reference<AccessPolicy>;
-
-  /**
-   * Reference to the default project for the duration of the login.
-   */
-  readonly project?: Reference<Project>;
 
   /**
    * Whether this login has system administrator privileges.

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -4,6 +4,7 @@
  */
 
 import { AccessPolicy } from './AccessPolicy';
+import { ClientApplication } from './ClientApplication';
 import { Meta } from './Meta';
 import { Patient } from './Patient';
 import { Practitioner } from './Practitioner';
@@ -11,6 +12,7 @@ import { Project } from './Project';
 import { Reference } from './Reference';
 import { RelatedPerson } from './RelatedPerson';
 import { User } from './User';
+import { UserConfiguration } from './UserConfiguration';
 
 /**
  * Medplum project membership. A project membership grants a user access
@@ -63,7 +65,7 @@ export interface ProjectMembership {
    * Reference to the resource that represents the user profile within the
    * project.
    */
-  readonly profile?: Reference<Patient | Practitioner | RelatedPerson>;
+  readonly profile?: Reference<ClientApplication | Patient | Practitioner | RelatedPerson>;
 
   /**
    * Optional account reference that can be used for sub-project
@@ -75,6 +77,12 @@ export interface ProjectMembership {
    * The access policy for the user within the project memebership.
    */
   readonly accessPolicy?: Reference<AccessPolicy>;
+
+  /**
+   * The user configuration for the user within the project memebership
+   * such as menu links, saved searches, and features.
+   */
+  readonly userConfiguration?: Reference<UserConfiguration>;
 
   /**
    * Whether this user is a project administrator.

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -59,7 +59,7 @@ export interface ProjectMembership {
   /**
    * User that is granted access to the project.
    */
-  readonly user?: Reference<User>;
+  readonly user?: Reference<ClientApplication | User>;
 
   /**
    * Reference to the resource that represents the user profile within the

--- a/packages/fhirtypes/dist/UserConfiguration.d.ts
+++ b/packages/fhirtypes/dist/UserConfiguration.d.ts
@@ -4,9 +4,6 @@
  */
 
 import { Meta } from './Meta';
-import { Project } from './Project';
-import { Reference } from './Reference';
-import { User } from './User';
 
 /**
  * User specific configuration for the Medplum application.
@@ -45,22 +42,12 @@ export interface UserConfiguration {
   readonly language?: string;
 
   /**
-   * Reference to the user for which this configuration applies.
-   */
-  readonly user?: Reference<User>;
-
-  /**
-   * Reference to the project for which this configuration applies.
-   */
-  readonly project?: Reference<Project>;
-
-  /**
-   * Optional menu of shortcuts to URLs
+   * Optional menu of shortcuts to URLs.
    */
   readonly menu?: UserConfigurationMenu[];
 
   /**
-   * Shortcut links to URLs
+   * Shortcut links to URLs.
    */
   readonly search?: UserConfigurationSearch[];
 
@@ -71,7 +58,7 @@ export interface UserConfiguration {
 }
 
 /**
- * Optional menu of shortcuts to URLs
+ * Optional menu of shortcuts to URLs.
  */
 export interface UserConfigurationMenu {
 
@@ -81,13 +68,13 @@ export interface UserConfigurationMenu {
   readonly title?: string;
 
   /**
-   * Shortcut links to URLs
+   * Shortcut links to URLs.
    */
   readonly link?: UserConfigurationMenuLink[];
 }
 
 /**
- * Shortcut links to URLs
+ * Shortcut links to URLs.
  */
 export interface UserConfigurationMenuLink {
 
@@ -97,7 +84,7 @@ export interface UserConfigurationMenuLink {
   readonly name?: string;
 
   /**
-   * The URL target of the link
+   * The URL target of the link.
    */
   readonly target?: string;
 }
@@ -144,7 +131,7 @@ export interface UserConfigurationOption {
 }
 
 /**
- * Shortcut links to URLs
+ * Shortcut links to URLs.
  */
 export interface UserConfigurationSearch {
 
@@ -154,7 +141,8 @@ export interface UserConfigurationSearch {
   readonly name?: string;
 
   /**
-   * The rules that the server should use to determine which resources to return.
+   * The rules that the server should use to determine which resources to
+   * return.
    */
   readonly criteria?: string;
 }

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -61,7 +61,7 @@ const routes: Record<string, Record<string, any>> = {
   'admin/projects/123': {
     GET: {
       project: { id: '123', name: 'Project 123' },
-      members: [{ profile: 'Practitioner/123', name: 'Alice Smith' }],
+      members: [{ id: '123', profile: { reference: 'Practitioner/123', display: 'Alice Smith' } }],
     },
   },
   'admin/super/structuredefinitions': {

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -61,7 +61,10 @@ const routes: Record<string, Record<string, any>> = {
   'admin/projects/123': {
     GET: {
       project: { id: '123', name: 'Project 123' },
-      members: [{ id: '123', profile: { reference: 'Practitioner/123', display: 'Alice Smith' } }],
+      members: [
+        { id: '123', profile: { reference: 'Practitioner/123', display: 'Alice Smith' }, role: 'owner' },
+        { id: '888', profile: { reference: 'ClientApplication/123', display: 'Test Client' }, role: 'client' },
+      ],
     },
   },
   'admin/super/structuredefinitions': {

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -60,6 +60,7 @@ describe('Client admin', () => {
     const res2 = await request(app)
       .post('/admin/projects/' + resolveId(res.body.project) + '/client')
       .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .type('json')
       .send({
         name: 'Alice personal client',
         description: 'Alice client description',
@@ -77,5 +78,13 @@ describe('Client admin', () => {
     expect(res3.status).toBe(200);
     expect(res3.body.resourceType).toBe('ClientApplication');
     expect(res3.body.id).toBe(res2.body.id);
+
+    // Invalid clients should fail
+    const res4 = await request(app)
+      .post('/admin/projects/' + resolveId(res.body.project) + '/client')
+      .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .type('json')
+      .send({});
+    expect(res4.status).toBe(400);
   });
 });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -73,18 +73,10 @@ describe('Client admin', () => {
 
     // Read the client
     const res3 = await request(app)
-      .get('/admin/projects/' + resolveId(res.body.project) + '/client/' + res2.body.id)
+      .get('/fhir/R4/ClientApplication/' + res2.body.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
     expect(res3.status).toBe(200);
     expect(res3.body.resourceType).toBe('ClientApplication');
     expect(res3.body.id).toBe(res2.body.id);
-
-    // Invalid clients should fail
-    const res4 = await request(app)
-      .post('/admin/projects/' + resolveId(res.body.project) + '/client')
-      .set('Authorization', 'Bearer ' + res.body.accessToken)
-      .type('json')
-      .send({});
-    expect(res4.status).toBe(400);
   });
 });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -78,5 +78,13 @@ describe('Client admin', () => {
     expect(res3.status).toBe(200);
     expect(res3.body.resourceType).toBe('ClientApplication');
     expect(res3.body.id).toBe(res2.body.id);
+
+    // Create client with invalid name (should fail)
+    const res4 = await request(app)
+      .post('/admin/projects/' + resolveId(res.body.project) + '/client')
+      .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .type('json')
+      .send({ foo: 'bar' });
+    expect(res4.status).toBe(400);
   });
 });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -1,0 +1,81 @@
+import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
+import { resolveId } from '@medplum/core';
+import { randomUUID } from 'crypto';
+import express from 'express';
+import { pwnedPassword } from 'hibp';
+import fetch from 'node-fetch';
+import request from 'supertest';
+import { initApp } from '../app';
+import { loadTestConfig } from '../config';
+import { closeDatabase, initDatabase } from '../database';
+import { setupPwnedPasswordMock, setupRecaptchaMock } from '../jest.setup';
+import { initKeys } from '../oauth';
+import { seedDatabase } from '../seed';
+
+jest.mock('@aws-sdk/client-sesv2');
+jest.mock('hibp');
+jest.mock('node-fetch');
+
+const app = express();
+
+describe('Client admin', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config.database);
+    await seedDatabase();
+    await initApp(app);
+    await initKeys(config);
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  beforeEach(() => {
+    (SESv2Client as unknown as jest.Mock).mockClear();
+    (SendEmailCommand as unknown as jest.Mock).mockClear();
+    (fetch as unknown as jest.Mock).mockClear();
+    (pwnedPassword as unknown as jest.Mock).mockClear();
+    setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
+    setupRecaptchaMock(fetch as unknown as jest.Mock, true);
+  });
+
+  test('Create new client', async () => {
+    // First, Alice creates a project
+    const res = await request(app)
+      .post('/auth/register')
+      .type('json')
+      .send({
+        firstName: 'Alice',
+        lastName: 'Smith',
+        projectName: 'Alice Project',
+        email: `alice${randomUUID()}@example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.project).toBeDefined();
+
+    // Next, Alice creates a client
+    const res2 = await request(app)
+      .post('/admin/projects/' + resolveId(res.body.project) + '/client')
+      .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .send({
+        name: 'Alice personal client',
+        description: 'Alice client description',
+      });
+    expect(res2.status).toBe(201);
+    expect(res2.body.resourceType).toBe('ClientApplication');
+    expect(res2.body.id).toBeDefined();
+    expect(res2.body.secret).toBeDefined();
+    expect(res2.body.secret).toHaveLength(96);
+
+    // Read the client
+    const res3 = await request(app)
+      .get('/admin/projects/' + resolveId(res.body.project) + '/client/' + res2.body.id)
+      .set('Authorization', 'Bearer ' + res.body.accessToken);
+    expect(res3.status).toBe(200);
+    expect(res3.body.resourceType).toBe('ClientApplication');
+    expect(res3.body.id).toBe(res2.body.id);
+  });
+});

--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -64,16 +64,3 @@ export async function createClient(request: CreateClientRequest): Promise<Client
   assertOk(membershipOutcome, membership);
   return client;
 }
-
-export async function readClientHandler(req: Request, res: Response): Promise<void> {
-  const projectDetails = await verifyProjectAdmin(req, res);
-  if (!projectDetails) {
-    res.sendStatus(404);
-    return;
-  }
-
-  const { clientId } = req.params;
-  const [clientOutcome, client] = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
-  assertOk(clientOutcome, client);
-  res.json(client);
-}

--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -1,0 +1,79 @@
+import { assertOk, createReference } from '@medplum/core';
+import { AccessPolicy, ClientApplication, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import { invalidRequest, sendOutcome, systemRepo } from '../fhir';
+import { generateSecret } from '../oauth';
+import { verifyProjectAdmin } from './utils';
+
+export const createClientValidators = [body('name').notEmpty().withMessage('Client name is required')];
+
+export async function createClientHandler(req: Request, res: Response): Promise<void> {
+  const projectDetails = await verifyProjectAdmin(req, res);
+  if (!projectDetails) {
+    res.sendStatus(404);
+    return;
+  }
+
+  const { project } = projectDetails;
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    sendOutcome(res, invalidRequest(errors));
+    return;
+  }
+
+  const client = await createClient({
+    ...req.body,
+    project: project,
+  });
+
+  res.status(201).json(client);
+}
+
+export interface CreateClientRequest {
+  readonly project: Project;
+  readonly name: string;
+  readonly description?: string;
+  readonly redirectUri?: string;
+  readonly accessPolicy?: Reference<AccessPolicy>;
+}
+
+export async function createClient(request: CreateClientRequest): Promise<ClientApplication> {
+  const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
+    meta: {
+      project: request.project.id,
+    },
+    resourceType: 'ClientApplication',
+    name: request.name,
+    secret: generateSecret(48),
+    description: request.description,
+    redirectUri: request.redirectUri,
+  });
+  assertOk(clientOutcome, client);
+
+  const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
+    meta: {
+      project: request.project.id,
+    },
+    resourceType: 'ProjectMembership',
+    project: createReference(request.project),
+    user: createReference(client),
+    profile: createReference(client),
+    accessPolicy: request.accessPolicy,
+  });
+  assertOk(membershipOutcome, membership);
+  return client;
+}
+
+export async function readClientHandler(req: Request, res: Response): Promise<void> {
+  const projectDetails = await verifyProjectAdmin(req, res);
+  if (!projectDetails) {
+    res.sendStatus(404);
+    return;
+  }
+
+  const { clientId } = req.params;
+  const [clientOutcome, client] = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+  assertOk(clientOutcome, client);
+  res.json(client);
+}

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -1,4 +1,5 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
+import { resolveId } from '@medplum/core';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
@@ -59,7 +60,7 @@ describe('Admin Invite', () => {
     // Second, Alice invites Bob to the project
     const bobEmail = `bob${randomUUID()}@example.com`;
     const res2 = await request(app)
-      .post('/admin/projects/' + res.body.project.reference.replace('Project/', '') + '/invite')
+      .post('/admin/projects/' + resolveId(res.body.project) + '/invite')
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .send({
         firstName: 'Bob',
@@ -120,7 +121,7 @@ describe('Admin Invite', () => {
     // Third, Alice invites Bob to the project
     // Because Bob already has an account, no emails should be sent
     const res3 = await request(app)
-      .post('/admin/projects/' + res.body.project.reference.replace('Project/', '') + '/invite')
+      .post('/admin/projects/' + resolveId(res.body.project) + '/invite')
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .send({
         firstName: 'Bob',
@@ -184,7 +185,7 @@ describe('Admin Invite', () => {
     // In this example, Bob is not an admin of Alice's project
     // So access is denied
     const res3 = await request(app)
-      .post('/admin/projects/' + res.body.project.reference.replace('Project/', '') + '/invite')
+      .post('/admin/projects/' + resolveId(res.body.project) + '/invite')
       .set('Authorization', 'Bearer ' + res2.body.accessToken)
       .send({
         firstName: 'Carol',
@@ -218,7 +219,7 @@ describe('Admin Invite', () => {
     // But she forgets his email address
     // So the request should fail
     const res2 = await request(app)
-      .post('/admin/projects/' + res.body.project.reference.replace('Project/', '') + '/invite')
+      .post('/admin/projects/' + resolveId(res.body.project) + '/invite')
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .send({
         firstName: 'Bob',

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -90,13 +90,13 @@ describe('Project Admin routes', () => {
 
     // Get the new membership details
     const res4 = await request(app)
-      .get('/admin/projects/' + projectId + '/members/' + member.membershipId)
+      .get('/admin/projects/' + projectId + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
     expect(res4.status).toBe(200);
 
     // Try a naughty request using a different resource type
     const res5 = await request(app)
-      .post('/admin/projects/' + projectId + '/members/' + member.membershipId)
+      .post('/admin/projects/' + projectId + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .type('json')
       .send({
@@ -106,7 +106,7 @@ describe('Project Admin routes', () => {
 
     // Try a naughty request using a different membership
     const res6 = await request(app)
-      .post('/admin/projects/' + projectId + '/members/' + member.membershipId)
+      .post('/admin/projects/' + projectId + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .type('json')
       .send({
@@ -117,7 +117,7 @@ describe('Project Admin routes', () => {
 
     // Promote the new member to admin
     const res7 = await request(app)
-      .post('/admin/projects/' + projectId + '/members/' + member.membershipId)
+      .post('/admin/projects/' + projectId + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .type('json')
       .send({
@@ -183,6 +183,10 @@ describe('Project Admin routes', () => {
       .set('Authorization', 'Bearer ' + res.body.accessToken);
 
     expect(res3.status).toBe(200);
+    expect(res3.body.members).toBeDefined();
+    expect(res3.body.members.length).toEqual(2);
+    expect(res3.body.members[0].id).toBeDefined();
+    expect(res3.body.members[1].id).toBeDefined();
 
     // Try to access Alice's project using Bob's access token
     // Should fail
@@ -195,7 +199,7 @@ describe('Project Admin routes', () => {
     // Try to access Alice's project members using Bob's access token
     // Should fail
     const res5 = await request(app)
-      .get('/admin/projects/' + projectId + '/members/' + res3.body.members[0].membershipId)
+      .get('/admin/projects/' + projectId + '/members/' + res3.body.members[0].id)
       .set('Authorization', 'Bearer ' + res2.body.accessToken);
 
     expect(res5.status).toBe(404);
@@ -203,7 +207,7 @@ describe('Project Admin routes', () => {
     // Try to edit Alice's project members using Bob's access token
     // Should fail
     const res6 = await request(app)
-      .post('/admin/projects/' + projectId + '/members/' + res3.body.members[0].membershipId)
+      .post('/admin/projects/' + projectId + '/members/' + res3.body.members[0].id)
       .set('Authorization', 'Bearer ' + res2.body.accessToken)
       .type('json')
       .send({ resourceType: 'ProjectMembership' });
@@ -213,7 +217,7 @@ describe('Project Admin routes', () => {
     // Try to read Alice's client using Alices's access token
     // Should succeed
     const res7 = await request(app)
-      .get('/admin/projects/' + projectId + '/client/' + clientId)
+      .get('/fhir/R4/ClientApplication/' + clientId)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
 
     expect(res7.status).toBe(200);
@@ -221,7 +225,7 @@ describe('Project Admin routes', () => {
     // Try to read Alice's client using Bob's access token
     // Should fail
     const res8 = await request(app)
-      .get('/admin/projects/' + projectId + '/client/' + clientId)
+      .get('/fhir/R4/ClientApplication/' + clientId)
       .set('Authorization', 'Bearer ' + res2.body.accessToken);
 
     expect(res8.status).toBe(404);

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -73,13 +73,14 @@ describe('Project Admin routes', () => {
     // Get the project details
     // Make sure the new member is in the members list
     // Get the project details and members
+    // 3 members total (1 admin, 1 client, 1 invited)
     const res3 = await request(app)
       .get('/admin/projects/' + projectId)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
     expect(res3.status).toBe(200);
     expect(res3.body.project).toBeDefined();
     expect(res3.body.members).toBeDefined();
-    expect(res3.body.members.length).toEqual(2);
+    expect(res3.body.members.length).toEqual(3);
 
     const owner = res3.body.members.find((m: any) => m.role === 'owner');
     expect(owner).toBeDefined();
@@ -126,14 +127,14 @@ describe('Project Admin routes', () => {
 
     // Get the project details
     // Make sure the new member is an admin
+    // 3 members total (1 admin, 1 client, 1 invited)
     const res8 = await request(app)
       .get('/admin/projects/' + projectId)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
-
     expect(res8.status).toBe(200);
     expect(res8.body.project).toBeDefined();
     expect(res8.body.members).toBeDefined();
-    expect(res8.body.members.length).toEqual(2);
+    expect(res8.body.members.length).toEqual(3);
 
     const admin = res8.body.members.find((m: any) => m.role === 'admin');
     expect(admin).toBeDefined();

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -171,8 +171,10 @@ describe('Project Admin routes', () => {
 
     expect(res2.status).toBe(200);
     expect(res2.body.project).toBeDefined();
+    expect(res2.body.client).toBeDefined();
 
     const projectId = resolveId(res.body.project);
+    const clientId = resolveId(res.body.client);
 
     // Try to access Alice's project using Alices's access token
     // Should succeed
@@ -207,5 +209,42 @@ describe('Project Admin routes', () => {
       .send({ resourceType: 'ProjectMembership' });
 
     expect(res6.status).toBe(404);
+
+    // Try to read Alice's client using Alices's access token
+    // Should succeed
+    const res7 = await request(app)
+      .get('/admin/projects/' + projectId + '/client/' + clientId)
+      .set('Authorization', 'Bearer ' + res.body.accessToken);
+
+    expect(res7.status).toBe(200);
+
+    // Try to read Alice's client using Bob's access token
+    // Should fail
+    const res8 = await request(app)
+      .get('/admin/projects/' + projectId + '/client/' + clientId)
+      .set('Authorization', 'Bearer ' + res2.body.accessToken);
+
+    expect(res8.status).toBe(404);
+
+    // Try to create a new client in Alice's project using Alices's access token
+    // Should succeed
+    const res9 = await request(app)
+      .post('/admin/projects/' + projectId + '/client')
+      .set('Authorization', 'Bearer ' + res.body.accessToken)
+      .type('json')
+      .send({
+        resourceType: 'ClientApplication',
+        name: 'Test client',
+      });
+
+    expect(res9.status).toBe(201);
+
+    // Try to create a new client in Alice's project using Bob's access token
+    // Should fail
+    const res10 = await request(app)
+      .post('/admin/projects/' + projectId + '/client')
+      .set('Authorization', 'Bearer ' + res2.body.accessToken);
+
+    expect(res10.status).toBe(404);
   });
 });

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -1,4 +1,5 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
+import { resolveId } from '@medplum/core';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
@@ -56,7 +57,7 @@ describe('Project Admin routes', () => {
     expect(res.status).toBe(200);
     expect(res.body.project).toBeDefined();
 
-    const projectId = res.body.project.reference.replace('Project/', '');
+    const projectId = resolveId(res.body.project);
 
     // Invite a new member
     const res2 = await request(app)
@@ -171,7 +172,7 @@ describe('Project Admin routes', () => {
     expect(res2.status).toBe(200);
     expect(res2.body.project).toBeDefined();
 
-    const projectId = res.body.project.reference.replace('Project/', '');
+    const projectId = resolveId(res.body.project);
 
     // Try to access Alice's project using Alices's access token
     // Should succeed

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -4,11 +4,14 @@ import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
 import { systemRepo } from '../fhir';
 import { authenticateToken } from '../oauth';
+import { createClientHandler, createClientValidators, readClientHandler } from './client';
 import { inviteHandler, inviteValidators } from './invite';
 import { verifyProjectAdmin } from './utils';
 
 export const projectAdminRouter = Router();
 projectAdminRouter.use(authenticateToken);
+projectAdminRouter.post('/:projectId/client', createClientValidators, asyncWrap(createClientHandler));
+projectAdminRouter.get('/:projectId/client/:clientId', asyncWrap(readClientHandler));
 projectAdminRouter.post('/:projectId/invite', inviteValidators, asyncWrap(inviteHandler));
 
 /**

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -94,6 +94,9 @@ projectAdminRouter.post(
  * @returns A string representing the role of the user in the project.
  */
 function getRole(project: Project, membership: ProjectMembership): string {
+  if (membership.user?.reference?.startsWith('ClientApplication/')) {
+    return 'client';
+  }
   if (membership.user?.reference === project.owner?.reference) {
     return 'owner';
   }

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -4,14 +4,13 @@ import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
 import { systemRepo } from '../fhir';
 import { authenticateToken } from '../oauth';
-import { createClientHandler, createClientValidators, readClientHandler } from './client';
+import { createClientHandler, createClientValidators } from './client';
 import { inviteHandler, inviteValidators } from './invite';
 import { verifyProjectAdmin } from './utils';
 
 export const projectAdminRouter = Router();
 projectAdminRouter.use(authenticateToken);
 projectAdminRouter.post('/:projectId/client', createClientValidators, asyncWrap(createClientHandler));
-projectAdminRouter.get('/:projectId/client/:clientId', asyncWrap(readClientHandler));
 projectAdminRouter.post('/:projectId/invite', inviteValidators, asyncWrap(inviteHandler));
 
 /**
@@ -30,10 +29,9 @@ projectAdminRouter.get(
     const members = [];
     for (const membership of memberships) {
       members.push({
-        membershipId: membership.id,
-        profile: membership.profile?.reference,
-        user: membership.user?.reference,
-        name: membership.profile?.display,
+        id: membership.id,
+        user: membership.user,
+        profile: membership.profile,
         accessPolicy: membership.accessPolicy,
         role: getRole(project, membership),
       });

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -1,5 +1,5 @@
 import { assertOk, createReference, getReferenceString } from '@medplum/core';
-import { ClientApplication, Login, Practitioner, User } from '@medplum/fhirtypes';
+import { ClientApplication, Login, Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -7,11 +7,12 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
-import { createTestClient } from '../jest.setup';
+import { createTestProject } from '../jest.setup';
 import { generateAccessToken, initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
 
 const app = express();
+let project: Project;
 let client: ClientApplication;
 let adminAccessToken: string;
 let nonAdminAccessToken: string;
@@ -24,7 +25,7 @@ describe('Super Admin routes', () => {
     await initApp(app);
     await initKeys(config);
 
-    client = await createTestClient();
+    ({ project, client } = await createTestProject());
 
     const [outcome1, practitioner1] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
     assertOk(outcome1, practitioner1);
@@ -48,19 +49,41 @@ describe('Super Admin routes', () => {
     });
     assertOk(outcome4, user2);
 
+    const [membershipOutcome1, membership1] = await systemRepo.createResource<ProjectMembership>({
+      resourceType: 'ProjectMembership',
+      project: createReference(project),
+      user: createReference(user1),
+      profile: createReference(practitioner1),
+    });
+    assertOk(membershipOutcome1, membership1);
+
+    const [membershipOutcome2, membership2] = await systemRepo.createResource<ProjectMembership>({
+      resourceType: 'ProjectMembership',
+      project: createReference(project),
+      user: createReference(user2),
+      profile: createReference(practitioner2),
+    });
+    assertOk(membershipOutcome2, membership2);
+
     const [outcome5, login1] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
+      user: createReference(user1),
+      membership: createReference(membership1),
       authTime: new Date().toISOString(),
       scope: 'openid',
+      admin: true,
     });
     assertOk(outcome5, login1);
 
     const [outcome6, login2] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
+      user: createReference(user2),
+      membership: createReference(membership2),
       authTime: new Date().toISOString(),
       scope: 'openid',
+      admin: false,
     });
     assertOk(outcome6, login2);
 

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -51,7 +51,6 @@ describe('Super Admin routes', () => {
     const [outcome5, login1] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
-      profile: createReference(practitioner1 as Practitioner),
       authTime: new Date().toISOString(),
       scope: 'openid',
     });
@@ -60,7 +59,6 @@ describe('Super Admin routes', () => {
     const [outcome6, login2] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
-      profile: createReference(practitioner2 as Practitioner),
       authTime: new Date().toISOString(),
       scope: 'openid',
     });

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -215,13 +215,13 @@ describe('Login', () => {
 
     // Get the new membership details
     const res4 = await request(app)
-      .get('/admin/projects/' + projectId + '/members/' + member.membershipId)
+      .get('/admin/projects/' + projectId + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
     expect(res4.status).toBe(200);
 
     // Set the new member's access policy
     const res5 = await request(app)
-      .post('/admin/projects/' + projectId + '/members/' + member.membershipId)
+      .post('/admin/projects/' + projectId + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + res.body.accessToken)
       .type('json')
       .send({

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -199,13 +199,14 @@ describe('Login', () => {
     // Get the project details
     // Make sure the new member is in the members list
     // Get the project details and members
+    // 3 members total (1 admin, 1 client, 1 invited)
     const res3 = await request(app)
       .get('/admin/projects/' + projectId)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
     expect(res3.status).toBe(200);
     expect(res3.body.project).toBeDefined();
     expect(res3.body.members).toBeDefined();
-    expect(res3.body.members.length).toEqual(2);
+    expect(res3.body.members.length).toEqual(3);
 
     const owner = res3.body.members.find((m: any) => m.role === 'owner');
     expect(owner).toBeDefined();
@@ -231,14 +232,14 @@ describe('Login', () => {
 
     // Get the project details
     // Make sure the access policy is set
+    // 3 members total (1 admin, 1 client, 1 invited)
     const res6 = await request(app)
       .get('/admin/projects/' + projectId)
       .set('Authorization', 'Bearer ' + res.body.accessToken);
-
     expect(res6.status).toBe(200);
     expect(res6.body.project).toBeDefined();
     expect(res6.body.members).toBeDefined();
-    expect(res6.body.members.length).toEqual(2);
+    expect(res6.body.members.length).toEqual(3);
 
     const member2 = res6.body.members.find((m: any) => m.role === 'member');
     expect(member2).toBeDefined();

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -1,5 +1,5 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
-import { createReference } from '@medplum/core';
+import { createReference, resolveId } from '@medplum/core';
 import { ClientApplication } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -153,7 +153,7 @@ describe('Login', () => {
     expect(res.status).toBe(200);
     expect(res.body.project).toBeDefined();
 
-    const projectId = res.body.project.reference.replace('Project/', '');
+    const projectId = resolveId(res.body.project);
 
     // Create an access policy
     const resX = await request(app)

--- a/packages/server/src/auth/me.test.ts
+++ b/packages/server/src/auth/me.test.ts
@@ -1,3 +1,5 @@
+import { createReference, resolveId } from '@medplum/core';
+import { UserConfiguration } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
@@ -40,7 +42,7 @@ describe('Me', () => {
     expect(res.status).toBe(401);
   });
 
-  test('Get default user configuration', async () => {
+  test('User configuration', async () => {
     const res1 = await request(app)
       .post('/auth/register')
       .type('json')
@@ -55,7 +57,9 @@ describe('Me', () => {
 
     expect(res1.status).toBe(200);
     expect(res1.body.accessToken).toBeDefined();
+    expect(res1.body.membership).toBeDefined();
 
+    // Get the user profile with default user configuration
     const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${res1.body.accessToken}`);
     expect(res2.status).toBe(200);
     expect(res2.body).toBeDefined();
@@ -63,5 +67,49 @@ describe('Me', () => {
     expect(res2.body.profile.resourceType).toBe('Practitioner');
     expect(res2.body.config).toBeDefined();
     expect(res2.body.config.resourceType).toBe('UserConfiguration');
+
+    // Create a new user configuration
+    const config: UserConfiguration = {
+      resourceType: 'UserConfiguration',
+      menu: [
+        {
+          title: 'My Menu',
+          link: [{ name: 'My Link', target: '/my-target' }],
+        },
+      ],
+    };
+    const res3 = await request(app)
+      .post('/fhir/R4/UserConfiguration')
+      .set('Authorization', `Bearer ${res1.body.accessToken}`)
+      .type('json')
+      .send(config);
+    expect(res3.status).toBe(201);
+    expect(res3.body.resourceType).toBe('UserConfiguration');
+    expect(res3.body.id).toBeDefined();
+    expect(res3.body).toMatchObject(config);
+
+    // Read the project membership
+    const res4 = await request(app)
+      .get(`/admin/projects/${resolveId(res1.body.project)}/members/${resolveId(res1.body.membership)}`)
+      .set('Authorization', 'Bearer ' + res1.body.accessToken);
+    expect(res4.status).toBe(200);
+    expect(res4.body.resourceType).toBe('ProjectMembership');
+
+    // Update the project membership
+    const res5 = await request(app)
+      .post(`/admin/projects/${resolveId(res1.body.project)}/members/${resolveId(res1.body.membership)}`)
+      .set('Authorization', 'Bearer ' + res1.body.accessToken)
+      .type('json')
+      .send({
+        ...res4.body,
+        userConfiguration: createReference(res3.body),
+      });
+    expect(res5.status).toBe(200);
+
+    // Reload the user profile with the new user configuration
+    const res6 = await request(app).get('/auth/me').set('Authorization', `Bearer ${res1.body.accessToken}`);
+    expect(res6.status).toBe(200);
+    expect(res6.body).toBeDefined();
+    expect(res6.body.config).toMatchObject(config);
   });
 });

--- a/packages/server/src/auth/me.test.ts
+++ b/packages/server/src/auth/me.test.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'crypto';
+import express from 'express';
+import { pwnedPassword } from 'hibp';
+import fetch from 'node-fetch';
+import request from 'supertest';
+import { initApp } from '../app';
+import { loadTestConfig } from '../config';
+import { closeDatabase, initDatabase } from '../database';
+import { setupPwnedPasswordMock, setupRecaptchaMock } from '../jest.setup';
+import { initKeys } from '../oauth';
+import { seedDatabase } from '../seed';
+
+jest.mock('hibp');
+jest.mock('node-fetch');
+
+const app = express();
+
+describe('Me', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config.database);
+    await seedDatabase();
+    await initApp(app);
+    await initKeys(config);
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    (fetch as unknown as jest.Mock).mockClear();
+    (pwnedPassword as unknown as jest.Mock).mockClear();
+    setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
+    setupRecaptchaMock(fetch as unknown as jest.Mock, true);
+  });
+
+  test('Unauthenticated', async () => {
+    const res = await request(app).get('/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  test('Get default user configuration', async () => {
+    const res1 = await request(app)
+      .post('/auth/register')
+      .type('json')
+      .send({
+        firstName: 'Alexander',
+        lastName: 'Hamilton',
+        projectName: 'Hamilton Project',
+        email: `alex${randomUUID()}@example.com`,
+        password: 'password!@#',
+        recaptchaToken: 'xyz',
+      });
+
+    expect(res1.status).toBe(200);
+    expect(res1.body.accessToken).toBeDefined();
+
+    const res2 = await request(app).get('/auth/me').set('Authorization', `Bearer ${res1.body.accessToken}`);
+    expect(res2.status).toBe(200);
+    expect(res2.body).toBeDefined();
+    expect(res2.body.profile).toBeDefined();
+    expect(res2.body.profile.resourceType).toBe('Practitioner');
+    expect(res2.body.config).toBeDefined();
+    expect(res2.body.config.resourceType).toBe('UserConfiguration');
+  });
+});

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -29,46 +29,22 @@ async function getUserConfiguration(membership: ProjectMembership): Promise<User
     return config;
   }
 
+  const favorites = ['Patient', 'Practitioner', 'Organization', 'ServiceRequest', 'DiagnosticReport', 'Questionnaire'];
+
   return {
     resourceType: 'UserConfiguration',
     menu: [
       {
         title: 'Favorites',
-        link: [
-          { name: 'Patients', target: '/Patient' },
-          { name: 'Practitioners', target: '/Practitioner' },
-          { name: 'Observations', target: '/Observation' },
-          { name: 'Organizations', target: '/Organization' },
-          { name: 'Service Requests', target: '/ServiceRequest' },
-          { name: 'Encounters', target: '/Encounter' },
-          { name: 'Diagnostic Reports', target: '/DiagnosticReport' },
-          { name: 'Questionnaires', target: '/Questionnaire' },
-        ],
+        link: favorites.map((resourceType) => ({ name: resourceType, target: '/' + resourceType })),
       },
       {
         title: 'Admin',
         link: [
           { name: 'Project', target: '/admin/project' },
           { name: 'AccessPolicy', target: '/AccessPolicy' },
-        ],
-      },
-      {
-        title: 'Developer',
-        link: [
-          { name: 'Client Applications', target: '/ClientApplication' },
           { name: 'Subscriptions', target: '/Subscription' },
-          { name: 'Bots', target: '/Bot' },
           { name: 'Batch', target: '/batch' },
-        ],
-      },
-      {
-        title: 'Settings',
-        link: [
-          {
-            name: 'Profile',
-            target: `/${membership.profile?.reference}`,
-          },
-          { name: 'Change Password', target: '/changepassword' },
         ],
       },
     ],

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -1,0 +1,86 @@
+import { assertOk, ProfileResource } from '@medplum/core';
+import { ProjectMembership, Reference, UserConfiguration } from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import { systemRepo } from '../fhir';
+import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
+
+export async function meHandler(req: Request, res: Response): Promise<void> {
+  const membership = res.locals.membership as ProjectMembership;
+  if (!membership) {
+    res.status(401);
+    return;
+  }
+
+  const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>(
+    membership.profile as Reference<ProfileResource>
+  );
+  assertOk(profileOutcome, profile);
+
+  // const [configOutcome, config] = await systemRepo.readReference<UserConfiguration>(
+  //   membership.userConfiguration as Reference<UserConfiguration>
+  // );
+  // assertOk(configOutcome, config);
+  const config = await getUserConfiguration(membership);
+
+  const result = {
+    profile,
+    config,
+  };
+
+  res.status(200).json(await rewriteAttachments(RewriteMode.PRESIGNED_URL, systemRepo, result));
+}
+
+async function getUserConfiguration(membership: ProjectMembership): Promise<UserConfiguration> {
+  if (membership.userConfiguration) {
+    const [configOutcome, config] = await systemRepo.readReference<UserConfiguration>(
+      membership.userConfiguration as Reference<UserConfiguration>
+    );
+    assertOk(configOutcome, config);
+    return config;
+  }
+
+  return {
+    resourceType: 'UserConfiguration',
+    menu: [
+      {
+        title: 'Favorites',
+        link: [
+          { name: 'Patients', target: '/Patient' },
+          { name: 'Practitioners', target: '/Practitioner' },
+          { name: 'Observations', target: '/Observation' },
+          { name: 'Organizations', target: '/Organization' },
+          { name: 'Service Requests', target: '/ServiceRequest' },
+          { name: 'Encounters', target: '/Encounter' },
+          { name: 'Diagnostic Reports', target: '/DiagnosticReport' },
+          { name: 'Questionnaires', target: '/Questionnaire' },
+        ],
+      },
+      {
+        title: 'Admin',
+        link: [
+          { name: 'Project', target: '/admin/project' },
+          { name: 'AccessPolicy', target: '/AccessPolicy' },
+        ],
+      },
+      {
+        title: 'Developer',
+        link: [
+          { name: 'Client Applications', target: '/ClientApplication' },
+          { name: 'Subscriptions', target: '/Subscription' },
+          { name: 'Bots', target: '/Bot' },
+          { name: 'Batch', target: '/batch' },
+        ],
+      },
+      {
+        title: 'Settings',
+        link: [
+          {
+            name: 'Profile',
+            target: `/${membership.profile?.reference}`,
+          },
+          { name: 'Change Password', target: '/changepassword' },
+        ],
+      },
+    ],
+  };
+}

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -6,20 +6,12 @@ import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 
 export async function meHandler(req: Request, res: Response): Promise<void> {
   const membership = res.locals.membership as ProjectMembership;
-  if (!membership) {
-    res.status(401);
-    return;
-  }
 
   const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>(
     membership.profile as Reference<ProfileResource>
   );
   assertOk(profileOutcome, profile);
 
-  // const [configOutcome, config] = await systemRepo.readReference<UserConfiguration>(
-  //   membership.userConfiguration as Reference<UserConfiguration>
-  // );
-  // assertOk(configOutcome, config);
   const config = await getUserConfiguration(membership);
 
   const result = {
@@ -32,9 +24,7 @@ export async function meHandler(req: Request, res: Response): Promise<void> {
 
 async function getUserConfiguration(membership: ProjectMembership): Promise<UserConfiguration> {
   if (membership.userConfiguration) {
-    const [configOutcome, config] = await systemRepo.readReference<UserConfiguration>(
-      membership.userConfiguration as Reference<UserConfiguration>
-    );
+    const [configOutcome, config] = await systemRepo.readReference<UserConfiguration>(membership.userConfiguration);
     assertOk(configOutcome, config);
     return config;
   }

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -153,11 +153,8 @@ describe('Profile', () => {
     assertOk(readOutcome, login);
     await systemRepo.updateResource({
       ...login,
-      project: {
-        reference: `Project/${randomUUID()}`,
-      },
-      profile: {
-        reference: `Practitioner/${randomUUID()}`,
+      membership: {
+        reference: `ProjectMembership/${randomUUID()}`,
       },
     });
 

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest } from '@medplum/core';
+import { assertOk, badRequest, createReference } from '@medplum/core';
 import { Login, Reference, User } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -51,7 +51,7 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
   // Update the login
   const [updateOutcome, updated] = await systemRepo.updateResource<Login>({
     ...login,
-    membership,
+    membership: createReference(membership),
   });
   assertOk(updateOutcome, updated);
 

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -1,9 +1,14 @@
-import { assertOk, badRequest, createReference, ProfileResource } from '@medplum/core';
-import { Login, Project, Reference, User } from '@medplum/fhirtypes';
+import { assertOk, badRequest } from '@medplum/core';
+import { Login, Reference, User } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { invalidRequest, sendOutcome, systemRepo } from '../fhir';
 import { getUserMemberships } from '../oauth';
+
+/*
+ * The profile handler is used during login when a user has multiple profiles.
+ * The client will submit the profile id and the server will update the login.
+ */
 
 export const profileValidators = [
   body('login').exists().withMessage('Missing login'),
@@ -30,7 +35,7 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
     return;
   }
 
-  if (login.project || login.profile) {
+  if (login.membership) {
     sendOutcome(res, badRequest('Login profile already set'));
     return;
   }
@@ -43,21 +48,10 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
     return;
   }
 
-  // Get up-to-date project and profile
-  const [projectOutcome, project] = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
-  assertOk(projectOutcome, project);
-
-  const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>(
-    membership.profile as Reference<ProfileResource>
-  );
-  assertOk(profileOutcome, profile);
-
   // Update the login
-  const [updateOutcome, updated] = await systemRepo.updateResource({
+  const [updateOutcome, updated] = await systemRepo.updateResource<Login>({
     ...login,
-    project: createReference(project),
-    profile: createReference(profile),
-    accessPolicy: membership.accessPolicy,
+    membership,
   });
   assertOk(updateOutcome, updated);
 

--- a/packages/server/src/auth/register.test.ts
+++ b/packages/server/src/auth/register.test.ts
@@ -340,6 +340,7 @@ describe('Register', () => {
 
     expect(res3.status).toBe(200);
     expect(res3.body.profile).toBeDefined();
+    expect(res3.body.client).toBeDefined();
 
     // Try to access User1 patient using User2 directly
     // This should fail
@@ -348,21 +349,11 @@ describe('Register', () => {
       .set('Authorization', 'Bearer ' + res3.body.accessToken);
     expect(res4.status).toBe(404);
 
-    // Create a client application
-    const client: ClientApplication = {
-      resourceType: 'ClientApplication',
-      name: 'User2 Client',
-      secret: generateSecret(48),
-      redirectUri: 'https://example.com',
-    };
-
+    // Get the client
     const res5 = await request(app)
-      .post(`/fhir/R4/ClientApplication`)
-      .set('Authorization', 'Bearer ' + res3.body.accessToken)
-      .type('json')
-      .send(client);
-
-    expect(res5.status).toBe(201);
+      .get(`/fhir/R4/${res3.body.client.reference}`)
+      .set('Authorization', 'Bearer ' + res3.body.accessToken);
+    expect(res5.status).toBe(200);
 
     // Get a token using the client
     const res6 = await request(app).post('/oauth2/token').type('form').send({

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -79,6 +79,7 @@ export async function registerHandler(req: Request, res: Response): Promise<void
   res.status(200).json({
     ...token,
     project: result.project && createReference(result.project),
+    membership: result.membership && createReference(result.membership),
     profile: result.profile && createReference(result.profile),
     client: result.client && createReference(result.client),
   });

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -80,6 +80,7 @@ export async function registerHandler(req: Request, res: Response): Promise<void
     ...token,
     project: result.project && createReference(result.project),
     profile: result.profile && createReference(result.profile),
+    client: result.client && createReference(result.client),
   });
 }
 
@@ -155,5 +156,16 @@ async function createClientApplication(project: Project): Promise<ClientApplicat
   });
   assertOk(outcome, result);
   logger.info('Created: ' + result.id);
+
+  logger.info('Create client project membership');
+  const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
+    resourceType: 'ProjectMembership',
+    project: createReference(project),
+    user: createReference(result),
+    profile: createReference(result),
+  });
+  assertOk(membershipOutcome, membership);
+  logger.info('Created: ' + membership.id);
+
   return result;
 }

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -1,14 +1,17 @@
 import { Router } from 'express';
 import { asyncWrap } from '../async';
+import { authenticateToken } from '../oauth';
 import { changePasswordHandler, changePasswordValidators } from './changepassword';
 import { googleHandler, googleValidators } from './google';
 import { loginHandler, loginValidators } from './login';
+import { meHandler } from './me';
 import { profileHandler, profileValidators } from './profile';
 import { registerHandler, registerValidators } from './register';
 import { resetPasswordHandler, resetPasswordValidators } from './resetpassword';
 import { setPasswordHandler, setPasswordValidators } from './setpassword';
 
 export const authRouter = Router();
+authRouter.get('/me', authenticateToken, asyncWrap(meHandler));
 authRouter.post('/register', registerValidators, asyncWrap(registerHandler));
 authRouter.post('/login', loginValidators, asyncWrap(loginHandler));
 authRouter.post('/profile', profileValidators, asyncWrap(profileHandler));

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -69,7 +69,7 @@ export async function createProjectMembership(
  * @param login The login details.
  */
 export async function sendLoginResult(res: Response, login: Login): Promise<void> {
-  if (!login?.profile) {
+  if (!login?.membership) {
     // User has multiple profiles, so the user needs to select
     // Safe to rewrite attachments,
     // because we know that these are all resources that the user has access to

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -344,13 +344,18 @@ describe('AccessPolicy', () => {
 
     // Create a repo for the ClientApplication
     // Use getRepoForLogin to generate the synthetic access policy
-    const clientRepo = await getRepoForLogin({
-      resourceType: 'ProjectMembership',
-      project: {
-        reference: 'Project/' + project,
+    const clientRepo = await getRepoForLogin(
+      {
+        resourceType: 'Login',
       },
-      profile: createReference(clientApplication as ClientApplication),
-    });
+      {
+        resourceType: 'ProjectMembership',
+        project: {
+          reference: 'Project/' + project,
+        },
+        profile: createReference(clientApplication as ClientApplication),
+      }
+    );
 
     // Create a Patient using the ClientApplication
     const [outcome2, patient] = await clientRepo.createResource<Patient>({

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -342,10 +342,10 @@ describe('AccessPolicy', () => {
     assertOk(outcome1, clientApplication);
     expect(clientApplication).toBeDefined();
 
-    // Create a systemRepo for the ClientApplication
+    // Create a repo for the ClientApplication
     // Use getRepoForLogin to generate the synthetic access policy
     const clientRepo = await getRepoForLogin({
-      resourceType: 'Login',
+      resourceType: 'ProjectMembership',
       project: {
         reference: 'Project/' + project,
       },

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -414,6 +414,74 @@ describe('AccessPolicy', () => {
     expect(outcome7.id).toEqual('not-found');
   });
 
+  test('ClientApplication with access policy', async () => {
+    const project = randomUUID();
+    const account = 'Organization/' + randomUUID();
+
+    // Create the access policy
+    const [accessPolicyOutcome, accessPolicy] = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Patient',
+        },
+      ],
+    });
+    assertOk(accessPolicyOutcome, accessPolicy);
+
+    // Create a ClientApplication with an account value
+    const [outcome1, clientApplication] = await systemRepo.createResource<ClientApplication>({
+      resourceType: 'ClientApplication',
+      secret: 'foo',
+      redirectUri: 'https://example.com/',
+      meta: {
+        account: {
+          reference: account,
+        },
+      },
+    });
+    assertOk(outcome1, clientApplication);
+    expect(clientApplication).toBeDefined();
+
+    // Create a repo for the ClientApplication
+    const clientRepo = await getRepoForLogin(
+      {
+        resourceType: 'Login',
+      },
+      {
+        resourceType: 'ProjectMembership',
+        project: {
+          reference: 'Project/' + project,
+        },
+        profile: createReference(clientApplication as ClientApplication),
+        accessPolicy: createReference(accessPolicy),
+      }
+    );
+
+    // Create a Patient using the ClientApplication
+    const [outcome2, patient] = await clientRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Al'], family: 'Bundy' }],
+      birthDate: '1975-12-12',
+    });
+    assertOk(outcome2, patient);
+    expect(patient).toBeDefined();
+
+    // Create an Observation using the ClientApplication
+    // Observation is not in the AccessPolicy
+    // So this should fail
+    const [outcome3, observation] = await clientRepo.createResource<Observation>({
+      resourceType: 'Observation',
+      subject: createReference(patient as Patient),
+      code: {
+        text: 'test',
+      },
+      valueString: 'positive',
+    });
+    expect(outcome3.id).toEqual('access-denied');
+    expect(observation).toBeUndefined();
+  });
+
   test('Readonly fields on write', async () => {
     const [createOutcome, patient] = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',

--- a/packages/server/src/fhir/patient.ts
+++ b/packages/server/src/fhir/patient.ts
@@ -1,3 +1,4 @@
+import { resolveId } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { CompartmentDefinition, CompartmentDefinitionResource, Reference, Resource } from '@medplum/fhirtypes';
 
@@ -123,15 +124,4 @@ function getPatientIdFromReference(reference: Reference): string | undefined {
     return resolveId(reference);
   }
   return undefined;
-}
-
-/**
- * Returns the ID portion of a reference.
- * For now, assumes the common convention of resourceType/id.
- * In the future, detect and handle searches (i.e., "Patient?identifier=123").
- * @param reference A FHIR reference.
- * @returns The ID portion of a reference.
- */
-function resolveId(reference: Reference | undefined): string | undefined {
-  return reference?.reference?.split('/')[1];
 }

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -3,7 +3,6 @@ import {
   Bundle,
   Communication,
   Encounter,
-  Login,
   Patient,
   Resource,
   SearchParameter,
@@ -14,7 +13,6 @@ import { randomUUID } from 'crypto';
 import { registerNew, RegisterRequest } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { tryLogin } from '../oauth';
 import { seedDatabase } from '../seed';
 import { processBatch } from './batch';
 import { getRepoForLogin, Repository, systemRepo } from './repo';
@@ -847,19 +845,7 @@ describe('FHIR Repo', () => {
     const result1 = await registerNew(registration1);
     expect(result1.profile).toBeDefined();
 
-    const [loginOutcome1, login1] = await tryLogin({
-      authMethod: 'password',
-      email: registration1.email,
-      password: registration1.password,
-      scope: 'openid',
-      nonce: randomUUID(),
-      remember: true,
-    });
-
-    assertOk(loginOutcome1, login1);
-    expect(login1).toBeDefined();
-
-    const repo1 = await getRepoForLogin(login1 as Login);
+    const repo1 = await getRepoForLogin(result1.membership);
     const [patientOutcome1, patient1] = await repo1.createResource<Patient>({
       resourceType: 'Patient',
     });
@@ -884,19 +870,7 @@ describe('FHIR Repo', () => {
     const result2 = await registerNew(registration2);
     expect(result2.profile).toBeDefined();
 
-    const [loginOutcome2, login2] = await tryLogin({
-      authMethod: 'password',
-      email: registration2.email,
-      password: registration2.password,
-      scope: 'openid',
-      nonce: randomUUID(),
-      remember: true,
-    });
-
-    assertOk(loginOutcome2, login2);
-    expect(login2).toBeDefined();
-
-    const repo2 = await getRepoForLogin(login2 as Login);
+    const repo2 = await getRepoForLogin(result2.membership);
     const [patientOutcome3, patient3] = await repo2.readResource('Patient', patient1?.id as string);
     expect(patientOutcome3.id).toEqual('not-found');
     expect(patient3).toBeUndefined();

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -28,6 +28,12 @@ describe('FHIR Repo', () => {
     await closeDatabase();
   });
 
+  test('getRepoForLogin', async () => {
+    await expect(() =>
+      getRepoForLogin({ resourceType: 'Login' }, { resourceType: 'ProjectMembership' })
+    ).rejects.toEqual('Cannot create repo for login without profile');
+  });
+
   test('Read resource with undefined id', async () => {
     const [outcome] = await systemRepo.readResource('Patient', undefined as unknown as string);
     expect(isOk(outcome)).toBe(false);

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -845,7 +845,7 @@ describe('FHIR Repo', () => {
     const result1 = await registerNew(registration1);
     expect(result1.profile).toBeDefined();
 
-    const repo1 = await getRepoForLogin(result1.membership);
+    const repo1 = await getRepoForLogin({ resourceType: 'Login' }, result1.membership);
     const [patientOutcome1, patient1] = await repo1.createResource<Patient>({
       resourceType: 'Patient',
     });
@@ -870,7 +870,7 @@ describe('FHIR Repo', () => {
     const result2 = await registerNew(registration2);
     expect(result2.profile).toBeDefined();
 
-    const repo2 = await getRepoForLogin(result2.membership);
+    const repo2 = await getRepoForLogin({ resourceType: 'Login' }, result2.membership);
     const [patientOutcome3, patient3] = await repo2.readResource('Patient', patient1?.id as string);
     expect(patientOutcome3.id).toEqual('not-found');
     expect(patient3).toBeUndefined();

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -103,6 +103,7 @@ const publicResourceTypes = [
  * Reading and writing is limited to the system account.
  */
 const protectedResourceTypes = [
+  'ClientApplication',
   'JsonWebKey',
   'Login',
   'PasswordChangeRequest',

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -25,9 +25,9 @@ import {
   AccessPolicy,
   AccessPolicyResource,
   Bundle,
-  Login,
   Meta,
   OperationOutcome,
+  ProjectMembership,
   Reference,
   Resource,
   SearchParameter,
@@ -394,7 +394,7 @@ export class Repository {
       id,
       lastUpdated,
       deleted: true,
-      compartments: [],
+      compartments: this.#getCompartments(resource as Resource),
       content,
     };
 
@@ -1239,7 +1239,7 @@ function fhirOperatorToSqlOperator(fhirOperator: FhirOperator): Operator {
  * @param login The user login.
  * @returns A repository configured for the login details.
  */
-export async function getRepoForLogin(login: Login): Promise<Repository> {
+export async function getRepoForLogin(login: ProjectMembership): Promise<Repository> {
   let accessPolicy: AccessPolicy | undefined = undefined;
 
   if (!login.profile?.reference) {
@@ -1278,7 +1278,6 @@ export async function getRepoForLogin(login: Login): Promise<Repository> {
   return new Repository({
     project: resolveId(login.project) as string,
     author: login.profile as Reference,
-    admin: login.admin,
     accessPolicy,
   });
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -103,7 +103,6 @@ const publicResourceTypes = [
  * Reading and writing is limited to the system account.
  */
 const protectedResourceTypes = [
-  'ClientApplication',
   'JsonWebKey',
   'Login',
   'PasswordChangeRequest',

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -14,6 +14,7 @@ import {
   notFound,
   notModified,
   Operator as FhirOperator,
+  resolveId,
   SearchParameterDetails,
   SearchParameterType,
   SearchRequest,
@@ -1193,17 +1194,6 @@ export class Repository {
     const { adminClientId } = getConfig();
     return !!adminClientId && this.#context.author.reference === 'ClientApplication/' + adminClientId;
   }
-}
-
-/**
- * Returns the ID portion of a reference.
- * For now, assumes the common convention of resourceType/id.
- * In the future, detect and handle searches (i.e., "Patient?identifier=123").
- * @param reference A FHIR reference.
- * @returns The ID portion of a reference.
- */
-export function resolveId(reference: Reference | undefined): string | undefined {
-  return reference?.reference?.split('/')[1];
 }
 
 /**

--- a/packages/server/src/jest.setup.ts
+++ b/packages/server/src/jest.setup.ts
@@ -1,10 +1,14 @@
 import { assertOk, createReference, isOk } from '@medplum/core';
-import { ClientApplication, Login, Project } from '@medplum/fhirtypes';
+import { ClientApplication, Login, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { systemRepo } from './fhir';
 import { generateAccessToken } from './oauth';
 
-export async function createTestClient(): Promise<ClientApplication> {
+export async function createTestProject(): Promise<{
+  project: Project;
+  client: ClientApplication;
+  membership: ProjectMembership;
+}> {
   const [projectOutcome, project] = await systemRepo.createResource<Project>({
     resourceType: 'Project',
     name: 'Test Project',
@@ -23,17 +27,34 @@ export async function createTestClient(): Promise<ClientApplication> {
     },
   });
   assertOk(clientOutcome, client);
-  return client;
+
+  const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
+    resourceType: 'ProjectMembership',
+    user: { reference: 'User/' + randomUUID() },
+    project: createReference(project),
+    profile: createReference(client),
+  });
+  assertOk(membershipOutcome, membership);
+
+  return {
+    project,
+    client,
+    membership,
+  };
+}
+
+export async function createTestClient(): Promise<ClientApplication> {
+  return (await createTestProject()).client;
 }
 
 export async function initTestAuth(): Promise<string> {
-  const client = await createTestClient();
+  const { client, membership } = await createTestProject();
   const scope = 'openid';
 
   const [loginOutcome, login] = await systemRepo.createResource<Login>({
     resourceType: 'Login',
     client: createReference(client),
-    profile: createReference(client),
+    membership: createReference(membership),
     authTime: new Date().toISOString(),
     scope,
   });

--- a/packages/server/src/jest.setup.ts
+++ b/packages/server/src/jest.setup.ts
@@ -30,9 +30,9 @@ export async function createTestProject(): Promise<{
 
   const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
     resourceType: 'ProjectMembership',
-    user: { reference: 'User/' + randomUUID() },
-    project: createReference(project),
+    user: createReference(client),
     profile: createReference(client),
+    project: createReference(project),
   });
   assertOk(membershipOutcome, membership);
 

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -35,7 +35,6 @@ describe('Auth middleware', () => {
     const [loginOutcome, login] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
-      profile: createReference(client),
       authTime: new Date().toISOString(),
       scope,
     });
@@ -79,7 +78,6 @@ describe('Auth middleware', () => {
     const [loginOutcome, login] = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
-      profile: createReference(client),
       authTime: new Date().toISOString(),
       revoked: true,
       scope,

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -29,33 +29,6 @@ describe('Auth middleware', () => {
     await closeDatabase();
   });
 
-  test('Success', async () => {
-    const scope = 'openid';
-
-    const [loginOutcome, login] = await systemRepo.createResource<Login>({
-      resourceType: 'Login',
-      client: createReference(client),
-      authTime: new Date().toISOString(),
-      scope,
-    });
-
-    assertOk(loginOutcome, login);
-
-    const accessToken = await generateAccessToken({
-      login_id: login?.id as string,
-      sub: client.id as string,
-      username: client.id as string,
-      client_id: client.id as string,
-      profile: client.resourceType + '/' + client.id,
-      scope,
-    });
-
-    const res = await request(app)
-      .get('/fhir/R4/Patient')
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
-  });
-
   test('Login not found', async () => {
     const accessToken = await generateAccessToken({
       login_id: randomUUID(),

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -1,5 +1,5 @@
-import { assertOk, createReference, getReferenceString, isOk, ProfileResource } from '@medplum/core';
-import { ClientApplication, Login, ProjectMembership, Reference } from '@medplum/fhirtypes';
+import { assertOk, createReference, getReferenceString, isOk } from '@medplum/core';
+import { ClientApplication, Login, ProjectMembership } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response } from 'express';
 import { getRepoForLogin, systemRepo } from '../fhir';
 import { logger } from '../logger';
@@ -27,44 +27,20 @@ async function authenticateBearerToken(req: Request, res: Response, next: NextFu
     const verifyResult = await verifyJwt(token);
     const claims = verifyResult.payload as MedplumAccessTokenClaims;
     const [loginOutcome, login] = await systemRepo.readResource<Login>('Login', claims.login_id);
-    if (!isOk(loginOutcome) || !login || login.revoked) {
+    if (!isOk(loginOutcome) || !login || !login.membership || login.revoked) {
       res.sendStatus(401);
       return;
     }
 
-    let membership: ProjectMembership | undefined = undefined;
-
-    // TODO: Make login.membership a required field
-    if (login.membership) {
-      const [membershipOutcome, membership2] = await systemRepo.readReference<ProjectMembership>(
-        login.membership as Reference<ProjectMembership>
-      );
-      assertOk(membershipOutcome, membership2);
-      membership = membership2;
-    } else {
-      const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>({
-        reference: claims.profile,
-      } as Reference<ProfileResource>);
-      assertOk(profileOutcome, profile);
-      membership = {
-        resourceType: 'ProjectMembership',
-        project: {
-          reference: 'Project/' + profile.meta?.project,
-        },
-        profile: createReference(profile),
-      };
-    }
-
-    if (!membership) {
-      res.sendStatus(500);
-      return;
-    }
+    const [membershipOutcome, membership] = await systemRepo.readReference<ProjectMembership>(login.membership);
+    assertOk(membershipOutcome, membership);
 
     res.locals.login = login;
     res.locals.user = claims.username;
     res.locals.profile = claims.profile;
     res.locals.scope = claims.scope;
-    res.locals.repo = await getRepoForLogin(membership);
+    res.locals.repo = await getRepoForLogin(login, membership);
+
     next();
   } catch (err) {
     logger.error('verify error', err);
@@ -92,6 +68,10 @@ async function authenticateBasicAuth(req: Request, res: Response, next: NextFunc
     return;
   }
 
+  const login: Login = {
+    resourceType: 'Login',
+  };
+
   // TODO: Lookup project membership for client.
   const membership: ProjectMembership = {
     resourceType: 'ProjectMembership',
@@ -104,6 +84,6 @@ async function authenticateBasicAuth(req: Request, res: Response, next: NextFunc
   res.locals.user = client.id;
   res.locals.profile = getReferenceString(client);
   res.locals.scope = 'openid';
-  res.locals.repo = await getRepoForLogin(membership);
+  res.locals.repo = await getRepoForLogin(login, membership);
   next();
 }

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -36,6 +36,7 @@ async function authenticateBearerToken(req: Request, res: Response, next: NextFu
     assertOk(membershipOutcome, membership);
 
     res.locals.login = login;
+    res.locals.membership = membership;
     res.locals.user = claims.username;
     res.locals.profile = claims.profile;
     res.locals.scope = claims.scope;
@@ -81,6 +82,8 @@ async function authenticateBasicAuth(req: Request, res: Response, next: NextFunc
     profile: createReference(client),
   };
 
+  res.locals.login = login;
+  res.locals.membership = membership;
   res.locals.user = client.id;
   res.locals.profile = getReferenceString(client);
   res.locals.scope = 'openid';

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -10,7 +10,7 @@ import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
 import { createTestClient } from '../jest.setup';
 import { seedDatabase } from '../seed';
-import { initKeys } from './keys';
+import { generateSecret, initKeys } from './keys';
 import { hashCode } from './token';
 
 const app = express();
@@ -129,6 +129,24 @@ describe('OAuth2 Token', () => {
       grant_type: 'client_credentials',
       client_id: badClient.id,
       client_secret: 'wrong-client-secret',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.error_description).toBe('Invalid client');
+  });
+
+  test('Token for client without project membership', async () => {
+    const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
+      resourceType: 'ClientApplication',
+      name: 'Client without project membership',
+      secret: generateSecret(48),
+    });
+    assertOk(clientOutcome, client);
+
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'client_credentials',
+      client_id: client.id,
+      client_secret: client.secret,
     });
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('invalid_request');

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -8,6 +8,7 @@ import { initApp } from '../app';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
+import { createTestClient } from '../jest.setup';
 import { seedDatabase } from '../seed';
 import { initKeys } from './keys';
 import { hashCode } from './token';
@@ -23,14 +24,7 @@ describe('OAuth2 Token', () => {
     await seedDatabase();
     await initApp(app);
     await initKeys(config);
-
-    const [outcome, resource] = await systemRepo.createResource<ClientApplication>({
-      resourceType: 'ClientApplication',
-      secret: randomUUID(),
-      redirectUri: 'https://example.com/',
-    });
-    assertOk(outcome, resource);
-    client = resource;
+    client = await createTestClient();
   });
 
   afterAll(async () => {

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -88,13 +88,15 @@ async function handleClientCredentials(req: Request, res: Response): Promise<Res
     return sendTokenError(res, 'invalid_request', 'Invalid client');
   }
 
+  const membership = membershipBundle.entry[0].resource as ProjectMembership;
+
   const scope = req.body.scope as string;
 
   const [loginOutcome, login] = await systemRepo.createResource<Login>({
     resourceType: 'Login',
     user: createReference(client),
     client: createReference(client),
-    membership: createReference(membershipBundle.entry[0].resource as ProjectMembership),
+    membership: createReference(membership),
     authTime: new Date().toISOString(),
     granted: true,
     scope,
@@ -114,6 +116,8 @@ async function handleClientCredentials(req: Request, res: Response): Promise<Res
     token_type: 'Bearer',
     access_token: accessToken,
     expires_in: 3600,
+    project: membership.project,
+    profile: membership.profile,
     scope,
   });
 }
@@ -191,6 +195,8 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<Res
     id_token: token.idToken,
     access_token: token.accessToken,
     refresh_token: token.refreshToken,
+    project: membership.project,
+    profile: membership.profile,
   });
 }
 
@@ -275,6 +281,8 @@ async function handleRefreshToken(req: Request, res: Response): Promise<Response
     id_token: token.idToken,
     access_token: token.accessToken,
     refresh_token: token.refreshToken,
+    project: membership.project,
+    profile: membership.profile,
   });
 }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -1,11 +1,19 @@
-import { assertOk, createReference, getReferenceString, isOk, Operator, ProfileResource } from '@medplum/core';
+import {
+  assertOk,
+  createReference,
+  getReferenceString,
+  isOk,
+  Operator,
+  ProfileResource,
+  resolveId,
+} from '@medplum/core';
 import { ClientApplication, Login, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { createHash, timingSafeEqual } from 'crypto';
 import { Request, RequestHandler, Response } from 'express';
 import { asyncWrap } from '../async';
 import { systemRepo } from '../fhir';
 import { generateAccessToken, generateSecret, MedplumRefreshTokenClaims, verifyJwt } from './keys';
-import { getAuthTokens, getReferenceIdPart, revokeLogin } from './utils';
+import { getAuthTokens, revokeLogin } from './utils';
 
 /**
  * Handles the OAuth/OpenID Token Endpoint.
@@ -244,7 +252,7 @@ async function handleRefreshToken(req: Request, res: Response): Promise<Response
     const base64Credentials = authHeader.split(' ')[1];
     const credentials = Buffer.from(base64Credentials, 'base64').toString('ascii');
     const [clientId, clientSecret] = credentials.split(':');
-    if (clientId !== getReferenceIdPart(login.client)) {
+    if (clientId !== resolveId(login.client)) {
       return sendTokenError(res, 'invalid_grant', 'Incorrect client');
     }
     if (!clientSecret) {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -9,6 +9,7 @@ import {
   notFound,
   Operator,
   ProfileResource,
+  resolveId,
 } from '@medplum/core';
 import {
   BundleEntry,
@@ -217,8 +218,8 @@ export async function getAuthTokens(
   login: Login,
   profile: Reference<ProfileResource>
 ): Promise<[OperationOutcome, TokenResult | undefined]> {
-  const clientId = login.client && getReferenceIdPart(login.client);
-  const userId = getReferenceIdPart(login.user);
+  const clientId = login.client && resolveId(login.client);
+  const userId = resolveId(login.user);
   if (!userId) {
     return [badRequest('Login missing user'), undefined];
   }
@@ -271,19 +272,6 @@ export async function revokeLogin(login: Login): Promise<void> {
     ...login,
     revoked: true,
   });
-}
-
-/**
- * Returns the ID portion of a FHIR reference.
- * @param reference A reference object.
- * @returns The resource ID portion of the reference.
- */
-export function getReferenceIdPart(reference: Reference | undefined): string | undefined {
-  const str = reference?.reference;
-  if (!str) {
-    return undefined;
-  }
-  return str.split('/')[1];
 }
 
 /**

--- a/packages/ui/src/Header.test.tsx
+++ b/packages/ui/src/Header.test.tsx
@@ -44,10 +44,13 @@ describe('Header', () => {
 
   test('Renders sidebar links', async () => {
     setup({
-      sidebarLinks: [
-        { title: 'section 1', links: [{ label: 'label 1', href: 'href1' }] },
-        { title: 'section 2', links: [{ label: 'label 2', href: 'href2' }] },
-      ],
+      config: {
+        resourceType: 'UserConfiguration',
+        menu: [
+          { title: 'section 1', link: [{ name: 'label 1', target: 'href1' }] },
+          { title: 'section 2', link: [{ name: 'label 2', target: 'href2' }] },
+        ],
+      },
     });
 
     await act(async () => {

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -179,6 +179,15 @@ export function Header(props: HeaderProps): JSX.Element {
                 </li>
               ))}
             </ul>
+            <h5>Settings</h5>
+            <ul>
+              <li>
+                <MedplumLink to={context.profile}>Profile</MedplumLink>
+              </li>
+              <li>
+                <MedplumLink to="/changepassword">Change password</MedplumLink>
+              </li>
+            </ul>
           </React.Fragment>
         ))}
       </Popup>

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -1,5 +1,5 @@
 import { getReferenceString, ProfileResource } from '@medplum/core';
-import { HumanName, Patient } from '@medplum/fhirtypes';
+import { HumanName, Patient, UserConfiguration } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Avatar } from './Avatar';
@@ -15,17 +15,7 @@ export interface HeaderProps {
   onLogo?: () => void;
   onProfile?: () => void;
   onSignOut?: () => void;
-  sidebarLinks?: SidebarLinkGroup[];
-}
-
-export interface SidebarLinkGroup {
-  title: string;
-  links: SidebarLink[];
-}
-
-export interface SidebarLink {
-  label: string;
-  href: string;
+  config?: UserConfiguration;
 }
 
 export function Header(props: HeaderProps): JSX.Element {
@@ -179,13 +169,13 @@ export function Header(props: HeaderProps): JSX.Element {
         inactiveClassName="medplum-sidebar"
         onClose={() => setSidebarVisible(false)}
       >
-        {props.sidebarLinks?.map((group) => (
-          <React.Fragment key={group.title}>
-            <h5>{group.title}</h5>
+        {props.config?.menu?.map((menu) => (
+          <React.Fragment key={menu.title}>
+            <h5>{menu.title}</h5>
             <ul>
-              {group.links.map((link) => (
-                <li key={link.href}>
-                  <MedplumLink to={link.href}>{link.label}</MedplumLink>
+              {menu.link?.map((link) => (
+                <li key={link.target}>
+                  <MedplumLink to={link.target}>{link.name}</MedplumLink>
                 </li>
               ))}
             </ul>

--- a/packages/ui/src/MedplumLink.tsx
+++ b/packages/ui/src/MedplumLink.tsx
@@ -7,6 +7,7 @@ export interface MedplumLinkProps {
   to?: Resource | Reference | string;
   label?: string;
   testid?: string;
+  className?: string;
   onClick?: () => void;
   children: React.ReactNode;
 }
@@ -30,6 +31,7 @@ export function MedplumLink(props: MedplumLinkProps): JSX.Element {
       href={href}
       aria-label={props.label}
       data-testid={props.testid || 'link'}
+      className={props.className}
       onClick={(e: React.SyntheticEvent) => {
         killEvent(e);
         if (props.onClick) {

--- a/packages/ui/src/SignInForm.test.tsx
+++ b/packages/ui/src/SignInForm.test.tsx
@@ -83,6 +83,15 @@ function mockFetch(url: string, options: any): Promise<any> {
       project: { reference: 'Project/123' },
       profile: { reference: 'Practitioner/123' },
     };
+  } else if (options.method === 'GET' && url.endsWith('auth/me')) {
+    status = 200;
+    result = {
+      profile: {
+        resourceType: 'Practitioner',
+        id: '123',
+        name: [{ given: ['Medplum'], family: ['Admin'] }],
+      },
+    };
   } else {
     console.log(options.method, url);
   }

--- a/packages/ui/src/stories/Header.stories.tsx
+++ b/packages/ui/src/stories/Header.stories.tsx
@@ -1,6 +1,7 @@
+import { UserConfigurationMenuLink } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import React from 'react';
-import { Header, HeaderProps, SidebarLink } from '../Header';
+import { Header, HeaderProps } from '../Header';
 import { useMedplumContext } from '../MedplumProvider';
 
 export default {
@@ -8,9 +9,9 @@ export default {
   component: Header,
 } as Meta;
 
-const manyLinks: SidebarLink[] = new Array(50).fill(0).map((el, index) => ({
-  label: 'Link ' + (index + 1),
-  href: '/link/' + index,
+const manyLinks: UserConfigurationMenuLink[] = new Array(50).fill(0).map((el, index) => ({
+  name: 'Link ' + (index + 1),
+  target: '/link/' + index,
 }));
 
 export const Basic = (args: HeaderProps): JSX.Element => {
@@ -23,20 +24,23 @@ export const Basic = (args: HeaderProps): JSX.Element => {
         alert('Sign out!');
         ctx.medplum.signOut();
       }}
-      sidebarLinks={[
-        {
-          title: 'Favorites',
-          links: [
-            { label: 'Patient', href: '/Patient' },
-            { label: 'Observation', href: '/Observation' },
-            { label: 'Practitioner', href: '/Practitioner' },
-          ],
-        },
-        {
-          title: 'More',
-          links: manyLinks,
-        },
-      ]}
+      config={{
+        resourceType: 'UserConfiguration',
+        menu: [
+          {
+            title: 'Favorites',
+            link: [
+              { name: 'Patient', target: '/Patient' },
+              { name: 'Observation', target: '/Observation' },
+              { name: 'Practitioner', target: '/Practitioner' },
+            ],
+          },
+          {
+            title: 'More',
+            link: manyLinks,
+          },
+        ],
+      }}
       {...args}
     />
   );


### PR DESCRIPTION
Changes:

* Refactor `Login` to reference `ProjectMembership` rather than `profile` and `project`
  * There was already too much duplication between `Login` and `ProjectMembership`
  * Duplicated fields included `profile`, `project`, and `accessPolicy`
  * Introducing `userConfiguration` was going to be yet another duplicated field
  * Allowing `ClientApplication` to be a `profile` and `user` was going to be yet another duplicated edge case
* Added `userConfiguration` to `ProjectMembership`
  * This enables project admins to customize sidebar links, pre-configured searches, and feature toggles (i.e., JSON view, and History view)
* Added `ClientApplication` as option for `ProjectMembership.user` and `ProjectMembership.profile`
  * This is incremental work to enabling  https://github.com/medplum/medplum/issues/327