### PR TITLE
Search total

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -49,6 +49,15 @@ describe('Search Utils', () => {
     expect(result.sortRules).toEqual([{ code: 'birthDate', descending: true }]);
   });
 
+  test('Parse Patient search total', () => {
+    const result = parseSearchDefinition({
+      pathname: 'Patient',
+      search: '_total=accurate',
+    });
+    expect(result.resourceType).toBe('Patient');
+    expect(result.total).toBe('accurate');
+  });
+
   test('Parse modifier operator', () => {
     const result = parseSearchDefinition({
       pathname: 'Patient',
@@ -144,6 +153,14 @@ describe('Search Utils', () => {
       ],
     });
     expect(result).toEqual('?_fields=id,name&_sort=-name');
+  });
+
+  test('Format Patient search total', () => {
+    const result = formatSearchQuery({
+      resourceType: 'Patient',
+      total: 'accurate',
+    });
+    expect(result).toEqual('?_total=accurate');
   });
 
   test('Format number not equals', () => {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -6,6 +6,7 @@ export interface SearchRequest {
   readonly count?: number;
   readonly fields?: string[];
   readonly name?: string;
+  readonly total?: 'none' | 'estimate' | 'accurate';
 }
 
 export interface Filter {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -93,6 +93,7 @@ export function parseSearchDefinition(location: { pathname: string; search?: str
   let fields;
   let page = 0;
   let count = 10;
+  let total = undefined;
 
   params.forEach((value, key) => {
     if (key === '_fields') {
@@ -101,6 +102,8 @@ export function parseSearchDefinition(location: { pathname: string; search?: str
       page = parseInt(value);
     } else if (key === '_count') {
       count = parseInt(value);
+    } else if (key === '_total') {
+      total = value;
     } else if (key === '_sort') {
       sortRules.push(parseSortRule(value));
     } else {
@@ -114,6 +117,7 @@ export function parseSearchDefinition(location: { pathname: string; search?: str
     fields,
     page,
     count,
+    total,
     sortRules,
   };
 }
@@ -206,6 +210,10 @@ export function formatSearchQuery(definition: SearchRequest): string {
 
   if (definition.count && definition.count > 0) {
     params.push('_count=' + definition.count);
+  }
+
+  if (definition.total) {
+    params.push('_total=' + encodeURIComponent(definition.total));
   }
 
   if (params.length === 0) {

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -229,6 +229,9 @@ const routes: Record<string, Record<string, any>> = {
   'fhir/R4/Observation?_fields=value[x]': {
     GET: HomerObservationSearchBundle,
   },
+  'fhir/R4/Observation?_fields=value[x]&_total=accurate': {
+    GET: HomerObservationSearchBundle,
+  },
   'fhir/R4/Observation/1': {
     GET: HomerObservation1,
   },
@@ -256,25 +259,55 @@ const routes: Record<string, Record<string, any>> = {
   'fhir/R4/Organization/456': {
     GET: DifferentOrganization,
   },
+  'fhir/R4/Patient?_total=accurate': {
+    GET: SimpsonSearchBundle,
+  },
   'fhir/R4/Patient?name=Simpson': {
+    GET: SimpsonSearchBundle,
+  },
+  'fhir/R4/Patient?_total=accurate&name=Simpson': {
+    GET: SimpsonSearchBundle,
+  },
+  'fhir/R4/Patient?_fields=id,name&_total=accurate': {
+    GET: SimpsonSearchBundle,
+  },
+  'fhir/R4/Patient?_fields=id,name&_total=accurate&name=Simpson': {
     GET: SimpsonSearchBundle,
   },
   'fhir/R4/Patient?_fields=id,_lastUpdated,name': {
     GET: SimpsonSearchBundle,
   },
+  'fhir/R4/Patient?_fields=id,_lastUpdated,name&_total=accurate': {
+    GET: SimpsonSearchBundle,
+  },
   'fhir/R4/Patient?_fields=id,_lastUpdated,name,birthDate': {
+    GET: SimpsonSearchBundle,
+  },
+  'fhir/R4/Patient?_fields=id,_lastUpdated,name,birthDate&_total=accurate': {
     GET: SimpsonSearchBundle,
   },
   'fhir/R4/Patient?_fields=id,_lastUpdated,name&name=Simpson': {
     GET: SimpsonSearchBundle,
   },
+  'fhir/R4/Patient?_fields=id,_lastUpdated,name&_total=accurate&name=Simpson': {
+    GET: SimpsonSearchBundle,
+  },
   'fhir/R4/Patient?_count=20&_fields=id,_lastUpdated,name,birthDate,gender&_sort=-_lastUpdated': {
+    GET: SimpsonSearchBundle,
+  },
+  'fhir/R4/Patient?_count=20&_fields=id,_lastUpdated,name,birthDate,gender&_sort=-_lastUpdated&_total=accurate': {
     GET: SimpsonSearchBundle,
   },
   'fhir/R4/Patient?_fields=id,_lastUpdated,name&_lastUpdated=ge2021-12-01T00%3A00%3A00.000Z': {
     GET: SimpsonSearchBundle,
   },
+  'fhir/R4/Patient?_fields=id,_lastUpdated,name&_lastUpdated=ge2021-12-01T00%3A00%3A00.000Z&_total=accurate': {
+    GET: SimpsonSearchBundle,
+  },
   'fhir/R4/Patient?name=Bob': {
+    GET: EmptySearchBundle,
+  },
+  'fhir/R4/Patient?_total=accurate&name=Bob': {
     GET: EmptySearchBundle,
   },
   'fhir/R4/Patient/123': {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -203,6 +203,35 @@ describe('FHIR Repo', () => {
     expect(searchResult2?.entry?.[0]?.resource?.id).toEqual(patient?.id);
   });
 
+  test('Search total', async () => {
+    const [outcome1, result1] = await systemRepo.search({
+      resourceType: 'Patient',
+    });
+    assertOk(outcome1, result1);
+    expect(result1.total).toBeUndefined();
+
+    const [outcome2, result2] = await systemRepo.search({
+      resourceType: 'Patient',
+      total: 'none',
+    });
+    assertOk(outcome2, result2);
+    expect(result2.total).toBeUndefined();
+
+    const [outcome3, result3] = await systemRepo.search({
+      resourceType: 'Patient',
+      total: 'accurate',
+    });
+    assertOk(outcome3, result3);
+    expect(result3.total).toBeDefined();
+
+    const [outcome4, result4] = await systemRepo.search({
+      resourceType: 'Patient',
+      total: 'estimate',
+    });
+    assertOk(outcome4, result4);
+    expect(result4.total).toBeDefined();
+  });
+
   test('Repo read malformed reference', async () => {
     const [outcome1, resource1] = await systemRepo.readReference({
       reference: undefined,

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -450,8 +450,12 @@ export class Repository {
     builder.limit(count);
     builder.offset(count * page);
 
-    const total = await this.#getTotalCount(searchRequest);
     const rows = await builder.execute(client);
+
+    let total = undefined;
+    if (searchRequest.total === 'estimate' || searchRequest.total === 'accurate') {
+      total = await this.#getTotalCount(searchRequest);
+    }
 
     return [
       allOk,

--- a/packages/server/src/fhir/search/parse.test.ts
+++ b/packages/server/src/fhir/search/parse.test.ts
@@ -44,6 +44,21 @@ describe('FHIR Search Utils', () => {
     });
   });
 
+  test('Parse total', () => {
+    expect(parseSearchRequest('Patient', { _total: 'none' })).toMatchObject({
+      resourceType: 'Patient',
+      total: 'none',
+    });
+    expect(parseSearchRequest('Patient', { _total: 'accurate' })).toMatchObject({
+      resourceType: 'Patient',
+      total: 'accurate',
+    });
+    expect(parseSearchRequest('Patient', { _total: 'estimate' })).toMatchObject({
+      resourceType: 'Patient',
+      total: 'estimate',
+    });
+  });
+
   test('Patient has birthdate param', () => {
     const params = getSearchParameters('Patient');
     expect(params?.['birthdate']).toBeDefined();

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -69,12 +69,13 @@ export function parseSearchUrl(url: URL): SearchRequest {
   return new SearchParser(resourceType, Object.fromEntries(url.searchParams.entries()));
 }
 
-class SearchParser {
+class SearchParser implements SearchRequest {
   readonly resourceType: string;
   readonly filters: Filter[];
   readonly sortRules: SortRule[];
   page: number;
   count: number;
+  total?: 'none' | 'estimate' | 'accurate';
 
   constructor(resourceType: string, query: Record<string, string[] | string | undefined>) {
     this.resourceType = resourceType;
@@ -136,6 +137,10 @@ class SearchParser {
 
       case '_count':
         this.count = parseInt(value);
+        break;
+
+      case '_total':
+        this.total = value as 'none' | 'estimate' | 'accurate';
         break;
 
       default: {

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -91,7 +91,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   function requestResources(): void {
     setOutcome(undefined);
     medplum
-      .search(props.search)
+      .search({ ...props.search, total: 'accurate' })
       .then((response) => {
         setState({ ...stateRef.current, searchResponse: response });
         if (props.onLoad) {


### PR DESCRIPTION
See the FHIR spec for `_total`: http://www.hl7.org/fhir/search.html#total

Before: We calculated and returned `total` for every search, whether it was requested or not.

After: We only calculate and return `total` for searches when the search request includes `_total=estimate` or `_total=accurate`

This reduces the total number of SQL queries executed during unit tests by about 2,000.