### PR TITLE
Index canonical properties for reference search params

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -854,6 +854,11 @@ export class Repository {
    * @param value The property value of the reference.
    */
   #buildReferenceColumns(searchParam: SearchParameter, value: any): string | undefined {
+    // Handle "canonical"
+    if (typeof value === 'string') {
+      return value;
+    }
+
     const refStr = (value as Reference).reference;
     if (!refStr) {
       return undefined;


### PR DESCRIPTION
Interesting edge case.  Consider `QuestionnaireResponse.questionnaire`

The property type is `canonical` (effectively a string): https://www.hl7.org/fhir/questionnaireresponse-definitions.html#QuestionnaireResponse.questionnaire

The search parameter type is `reference`: https://www.hl7.org/fhir/questionnaireresponse.html#search

Our search indexer did not correctly handle this type mismatch, so searching by QuestionnaireResponse.questionnaire failed.