### PR TITLE
Handle canonical reference params in criteria matching

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -854,18 +854,18 @@ export class Repository {
    * @param value The property value of the reference.
    */
   #buildReferenceColumns(searchParam: SearchParameter, value: any): string | undefined {
-    // Handle "canonical"
-    if (typeof value === 'string') {
-      return value;
+    if (value) {
+      if (typeof value === 'string') {
+        // Handle "canonical" properties such as QuestionnaireResponse.questionnaire
+        // This is a reference string that is not a FHIR reference
+        return value;
+      }
+      if (typeof value === 'object') {
+        // Handle normal "reference" properties
+        return (value as Reference).reference;
+      }
     }
-
-    const refStr = (value as Reference).reference;
-    if (!refStr) {
-      return undefined;
-    }
-
-    // TODO: Consider normalizing reference string when known (searchParam.target.length === 1)
-    return refStr;
+    return undefined;
   }
 
   /**

--- a/packages/server/src/fhir/search/match.test.ts
+++ b/packages/server/src/fhir/search/match.test.ts
@@ -102,6 +102,63 @@ describe('Search matching', () => {
     ).toBe(true);
   });
 
+  test('Canonical reference filter', () => {
+    expect(
+      matchesSearchRequest(
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        {
+          resourceType: 'QuestionnaireResponse',
+          filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/123' }],
+        }
+      )
+    ).toBe(true);
+    expect(
+      matchesSearchRequest(
+        { resourceType: 'QuestionnaireResponse' },
+        {
+          resourceType: 'QuestionnaireResponse',
+          filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/123' }],
+        }
+      )
+    ).toBe(false);
+    expect(
+      matchesSearchRequest(
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        {
+          resourceType: 'QuestionnaireResponse',
+          filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/456' }],
+        }
+      )
+    ).toBe(false);
+    expect(
+      matchesSearchRequest(
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        {
+          resourceType: 'QuestionnaireResponse',
+          filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/123' }],
+        }
+      )
+    ).toBe(false);
+    expect(
+      matchesSearchRequest(
+        { resourceType: 'QuestionnaireResponse' },
+        {
+          resourceType: 'QuestionnaireResponse',
+          filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/123' }],
+        }
+      )
+    ).toBe(true);
+    expect(
+      matchesSearchRequest(
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        {
+          resourceType: 'QuestionnaireResponse',
+          filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/456' }],
+        }
+      )
+    ).toBe(true);
+  });
+
   test('String equals', () => {
     expect(
       matchesSearchRequest(


### PR DESCRIPTION
This is similar to https://github.com/medplum/medplum/pull/343

For context:  We have two different modes of evaluating search criteria.

1. In SQL.  We precompute search parameter values and store them in database columns.  This is the most common case, and what we use for all searching.
2. In memory.  We evaluate search parameters directly against search criteria.  This is a somewhat rare case for evaluating one-off criteria, such as when evaluating `Subscription.criteria` against resource changes.

In https://github.com/medplum/medplum/pull/343 we fixed the database/SQL model.

In this PR, we fix the in-memory criteria matching.