### PR TITLE
Remove unused ProjectMembership.account

### DIFF
--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -365,16 +365,6 @@
             }]
           },
           {
-            "id" : "ProjectMembership.account",
-            "path" : "ProjectMembership.account",
-            "definition" : "Optional account reference that can be used for sub-project compartments.",
-            "min" : 0,
-            "max" : "1",
-            "type" : [{
-              "code" : "Reference"
-            }]
-          },
-          {
             "id" : "ProjectMembership.accessPolicy",
             "path" : "ProjectMembership.accessPolicy",
             "definition" : "The access policy for the user within the project memebership.",

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -68,12 +68,6 @@ export interface ProjectMembership {
   readonly profile?: Reference<ClientApplication | Patient | Practitioner | RelatedPerson>;
 
   /**
-   * Optional account reference that can be used for sub-project
-   * compartments.
-   */
-  readonly account?: Reference;
-
-  /**
    * The access policy for the user within the project memebership.
    */
   readonly accessPolicy?: Reference<AccessPolicy>;


### PR DESCRIPTION
This was replaced by ProjectMembership.accessPolicy.