### PR TITLE
Removed synthetic access policies

### DIFF
--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -328,6 +328,29 @@ describe('AccessPolicy', () => {
     const project = randomUUID();
     const account = 'Organization/' + randomUUID();
 
+    // Create the access policy
+    const [accessPolicyOutcome, accessPolicy] = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      compartment: {
+        reference: account,
+      },
+      resource: [
+        {
+          resourceType: 'Observation',
+          compartment: {
+            reference: account,
+          },
+        },
+        {
+          resourceType: 'Patient',
+          compartment: {
+            reference: account,
+          },
+        },
+      ],
+    });
+    assertOk(accessPolicyOutcome, accessPolicy);
+
     // Create a ClientApplication with an account value
     const [outcome1, clientApplication] = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
@@ -354,6 +377,7 @@ describe('AccessPolicy', () => {
           reference: 'Project/' + project,
         },
         profile: createReference(clientApplication as ClientApplication),
+        accessPolicy: createReference(accessPolicy),
       }
     );
 
@@ -416,7 +440,6 @@ describe('AccessPolicy', () => {
 
   test('ClientApplication with access policy', async () => {
     const project = randomUUID();
-    const account = 'Organization/' + randomUUID();
 
     // Create the access policy
     const [accessPolicyOutcome, accessPolicy] = await systemRepo.createResource<AccessPolicy>({
@@ -429,16 +452,11 @@ describe('AccessPolicy', () => {
     });
     assertOk(accessPolicyOutcome, accessPolicy);
 
-    // Create a ClientApplication with an account value
+    // Create a ClientApplication
     const [outcome1, clientApplication] = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       secret: 'foo',
       redirectUri: 'https://example.com/',
-      meta: {
-        account: {
-          reference: account,
-        },
-      },
     });
     assertOk(outcome1, clientApplication);
     expect(clientApplication).toBeDefined();

--- a/packages/server/src/fhir/patient.test.ts
+++ b/packages/server/src/fhir/patient.test.ts
@@ -1,16 +1,10 @@
 import { Account, Observation, Patient, Reference } from '@medplum/fhirtypes';
-import { getPatientCompartmentProperties, getPatientCompartmentResourceTypes, getPatientId } from './patient';
+import { getPatientCompartmentProperties, getPatientId } from './patient';
 
 describe('FHIR Patient utils', () => {
   test('getPatientCompartmentProperties', () => {
     expect(getPatientCompartmentProperties('Observation')).toEqual(['subject', 'performer']);
     expect(getPatientCompartmentProperties('xxx')).toBeUndefined();
-  });
-
-  test('getPatientCompartmentResourceTypes', () => {
-    const resourceTypes = getPatientCompartmentResourceTypes();
-    expect(resourceTypes).toContain('Patient');
-    expect(resourceTypes).toContain('Observation');
   });
 
   test('getPatientId', () => {

--- a/packages/server/src/fhir/patient.ts
+++ b/packages/server/src/fhir/patient.ts
@@ -37,25 +37,6 @@ export function getPatientCompartmentProperties(resourceType: string): string[] 
 }
 
 /**
- * Returns the list of patient resource types.
- * See: https://www.hl7.org/fhir/compartmentdefinition-patient.html
- * @returns List of resource types in the patient compartment.
- */
-export function getPatientCompartmentResourceTypes(): string[] {
-  const result = ['Patient'];
-  const resourceList = getPatientCompartments().resource as CompartmentDefinitionResource[];
-  for (const resource of resourceList) {
-    if (resource.code && resource.param) {
-      // Only add resource definitions with a 'param' value
-      // The param value defines the eligible properties
-      // If param is missing, it means the resource type is not in the compartment
-      result.push(resource.code);
-    }
-  }
-  return result;
-}
-
-/**
  * Returns the patient compartment ID for a resource.
  * If the resource is in a patient compartment (i.e., an Observation about the patient),
  * then return the patient ID.


### PR DESCRIPTION
What is a "synthetic access policy"?

Before https://github.com/medplum/medplum/pull/336 it was not possible to assign an `AccessPolicy` to a `ClientApplication`, but we still wanted some of the access policy features.  So we had a temporary solution called "synthetic access policy".  Here's how it worked:
* If a `ClientApplication` has `meta.account`
* Then dynamically create an AccessPolicy restricting everything in "patient compartments" to that account value

It worked great.  However, now that we have proper AccessPolicies for ClientApplications, the temporary solution is no longer required.

All ClientApplications with synthetic access policies have already been migrated.