### PR TITLE
fix: accept trailing slashes in search locations

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -7,6 +7,12 @@ describe('Search Utils', () => {
     expect(result.filters).toEqual([]);
   });
 
+  test('Parse Patient search with trailing slash', () => {
+    const result = parseSearchDefinition({ pathname: '/Patient/' });
+    expect(result.resourceType).toBe('Patient');
+    expect(result.filters).toEqual([]);
+  });
+
   test('Parse Patient search name', () => {
     const result = parseSearchDefinition({
       pathname: 'Patient',

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -86,7 +86,10 @@ const PREFIX_OPERATORS: Operator[] = [
  * @returns Parsed search definition.
  */
 export function parseSearchDefinition(location: { pathname: string; search?: string }): SearchRequest {
-  const resourceType = location.pathname.split('/').pop() as string;
+  const resourceType = location.pathname
+    .replace(/^\/|\/$/g, '')
+    .split('/')
+    .pop() as string;
   const params = new URLSearchParams(location.search);
   const filters: Filter[] = [];
   const sortRules: SortRule[] = [];


### PR DESCRIPTION
this handles the case where `/foo/` would be parsed as the
resource type `""` instead of `"foo"`

In particular, I was running into issues getting to `/Bot/`.

The routing allows this but it fails when run through this parser.