### PR TITLE
Added DCO to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ That being said, this codebase isn't your typical open source project because it
 
 #### Contributions and discussion guidelines
 
+By making a contribution to this project, you are deemed to have accepted the [Developer Certificate of Origin](https://developercertificate.org/) (DCO).
+
 All conversations and communities on Medplum agree to GitHub's [Community Guidelines](https://help.github.com/en/github/site-policy/github-community-guidelines) and [Acceptable Use Policies](https://help.github.com/en/github/site-policy/github-acceptable-use-policies). This code of conduct also applies to all conversations that happen within our contributor community here on GitHub. We expect discussions in issues and pull requests to stay positive, productive, and respectful. Remember: there are real people on the other side of that screen!
 
 #### Reporting a bug or discussing a feature idea


### PR DESCRIPTION
Language based on [GitLab's contributing docs](https://about.gitlab.com/community/contribute/dco-cla/)

Alternatively, we could put the contents of the DCO directly into the document like [how Linux does it](https://github.com/torvalds/linux/blob/6f38be8f2ccd9babf04b9b23539108542a59fcb8/Documentation/process/submitting-patches.rst#developers-certificate-of-origin-11)