### PR TITLE
Fixes #355 - Update Github Actions to use workflow_run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: Build
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -50,31 +49,13 @@ jobs:
           RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
           POSTGRES_HOST: localhost
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@1.1.3
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Configure AWS Credentials
-        if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
-        uses: aws-actions/configure-aws-credentials@v1
+          name: medplum-dist
+          path: packages/**/dist/*
+      - name: Upload code coverage
+        uses: actions/upload-artifact@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Login to Amazon ECR
-        if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
-        uses: aws-actions/amazon-ecr-login@v1
-      - name: Deploy
-        if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
-        run: ./scripts/cicd-deploy.sh
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
-          DOCKER_SERVER: ${{ secrets.DOCKER_SERVER }}
-          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
-          ECS_SERVICE: ${{ secrets.ECS_SERVICE }}
+          name: medplum-code-coverage
+          path: coverage/lcov.info

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,22 @@
+name: Coveralls
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+jobs:
+  coveralls:
+    name: Coveralls
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: medplum-code-coverage
+          path: coverage
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    branches: [main]
+jobs:
+  build:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v2
+        with:
+          name: medplum-dist
+          path: packages
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Deploy
+        if: ${{ false }}
+        run: ./scripts/cicd-deploy.sh
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
+          DOCKER_SERVER: ${{ secrets.DOCKER_SERVER }}
+          ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          ECS_SERVICE: ${{ secrets.ECS_SERVICE }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,26 @@
+name: Sonar
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+jobs:
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: medplum-code-coverage
+          path: coverage
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          sonar.pullrequest.key: ${{ github.event.workflow_run.pull_requests.number }}
+          sonar.pullrequest.branch: ${{ github.event.workflow_run.pull_requests.head.ref }}
+          sonar.pullrequest.base: ${{ github.event.workflow_run.pull_requests.base.ref }}


### PR DESCRIPTION
I expect this to require some trial-and-error, but here's the general idea.  We will have 5 Github Actions Workflows:

1. Build (build.yml) - Runs on `push` and `pull_request`.  The main build script which builds all projects and runs all tests.
2. Sonar (sonar.yml) - Runs on `workflow_run` after Build.  Runs the SonarCloud analysis.
3. Coveralls (coveralls.yml) - Runs on `workflow_run` after Build.  Runs the Coveralls.io analysis.
4. CodeQL (codeql.yml) - Runs on `workflow_run` after Build.  Runs the [CodeQL](https://codeql.github.com/) analysis.
5. Deploy (deploy.yml) - Runs on `workflow_run` after Build only on the `main` branch.  Starts the deploy process.

Actions 1-4 should therefore run on every `push` and `pull_request`.

This configuration should fix the permissions issues with sharing Github secrets with the jobs.  The "Build" step does not need any secrets to run.  Actions 2-5 use `workflow_run`,  so they should have access to Github secrets.  Actions 2-5 will use the workflows defined on the `main` branch, not the PR branch, but that should be ok.

This should actually be a performance boost, because steps 2-5 can now run in parallel, versus before when they ran in sequence.
