### PR TITLE
fix(app): handle admin checkbox change event in membership page

### DIFF
--- a/packages/app/src/admin/EditMembershipPage.test.tsx
+++ b/packages/app/src/admin/EditMembershipPage.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { EditMembershipPage } from './EditMembershipPage';
 
-const medplum = new MockClient();
+let medplum = new MockClient();
 
 function setup(url: string): void {
   render(
@@ -21,6 +21,8 @@ function setup(url: string): void {
 
 describe('EditMembershipPage', () => {
   beforeEach(() => {
+    medplum = new MockClient();
+
     jest.useFakeTimers();
   });
 
@@ -89,5 +91,42 @@ describe('EditMembershipPage', () => {
     });
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
+  });
+
+  test('Submit with admin', async () => {
+    const medplumPostSpy = jest.spyOn(medplum, 'post');
+
+    setup('/admin/projects/123/members/456');
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Save'));
+    });
+
+    expect(screen.getByText('Save')).toBeInTheDocument();
+
+    const input = screen.getByTestId('admin-checkbox') as HTMLInputElement;
+
+    // Enter "Example Access Policy"
+    await act(async () => {
+      fireEvent.click(input);
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    expect(screen.getByTestId('success')).toBeInTheDocument();
+
+    expect(medplumPostSpy).toHaveBeenCalledWith(
+      `admin/projects/123/members/456`,
+      expect.objectContaining({
+        admin: true,
+      })
+    );
   });
 });

--- a/packages/app/src/admin/EditMembershipPage.tsx
+++ b/packages/app/src/admin/EditMembershipPage.tsx
@@ -56,7 +56,14 @@ export function EditMembershipPage(): JSX.Element {
               <AccessPolicyInput name="accessPolicy" defaultValue={accessPolicy} onChange={setAccessPolicy} />
             </FormSection>
             <FormSection title="Admin" htmlFor="admin" outcome={outcome}>
-              <input type="checkbox" name="admin" defaultChecked={admin} value="true" />
+              <input
+                data-testid="admin-checkbox"
+                type="checkbox"
+                name="admin"
+                defaultChecked={admin}
+                value="true"
+                onChange={(event) => setAdmin(event.currentTarget.value === 'true')}
+              />
             </FormSection>
             <div className="medplum-signin-buttons">
               <div></div>


### PR DESCRIPTION
the admin checkbox was not wired up to the state changes so clicking it
did nothing in the project UI