### PR TITLE
AccessPolicy criteria field

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61590,8 +61590,12 @@
           "$ref": "#/definitions/string"
         },
         "compartment": {
-          "description": "Optional compartment restriction for the resource type.",
+          "description": "DEPRECATED Optional compartment restriction for the resource type.",
           "$ref": "#/definitions/Reference"
+        },
+        "criteria": {
+          "description": "The rules that the server should use to determine which resources to allow.",
+          "$ref": "#/definitions/string"
         },
         "readonly": {
           "description": "Optional flag to indicate that the resource type is read-only.",

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -1190,11 +1190,22 @@
           {
             "id" : "AccessPolicy.resource.compartment",
             "path" : "AccessPolicy.resource.compartment",
-            "definition" : "Optional compartment restriction for the resource type.",
+            "definition" : "DEPRECATED Optional compartment restriction for the resource type.",
             "min" : 0,
             "max" : "1",
             "type" : [{
               "code" : "Reference"
+            }]
+          },
+          {
+            "id" : "AccessPolicy.resource.criteria",
+            "path" : "AccessPolicy.resource.criteria",
+            "definition" : "The rules that the server should use to determine which resources to allow.",
+            "comment" : "The rules are search criteria (without the [base] part). Like Bundle.entry.request.url, it has no leading \"/\".",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
             }]
           },
           {

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -72,9 +72,15 @@ export interface AccessPolicyResource {
   resourceType?: string;
 
   /**
-   * Optional compartment restriction for the resource type.
+   * DEPRECATED Optional compartment restriction for the resource type.
    */
   compartment?: Reference;
+
+  /**
+   * The rules that the server should use to determine which resources to
+   * allow.
+   */
+  readonly criteria?: string;
 
   /**
    * Optional flag to indicate that the resource type is read-only.

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -175,12 +175,12 @@ describe('AccessPolicy', () => {
     });
     assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
-    expect(patient?.meta?.account).toBeDefined();
+    expect(patient?.meta?.account?.reference).toEqual('Organization/' + orgId);
 
     const [readOutcome, readPatient] = await repo.readResource('Patient', patient?.id as string);
     assertOk(readOutcome, readPatient);
     expect(readPatient).toBeDefined();
-    expect(readPatient?.meta?.account).toBeDefined();
+    expect(readPatient?.meta?.account?.reference).toEqual('Organization/' + orgId);
   });
 
   test('Access policy blocks account override', async () => {
@@ -263,6 +263,93 @@ describe('AccessPolicy', () => {
           compartment: {
             reference: 'Organization/' + org2,
           },
+        },
+      ],
+    };
+
+    const repo1 = new Repository({
+      author: {
+        reference: 'Practitioner/123',
+      },
+      accessPolicy: accessPolicy1,
+    });
+
+    const repo2 = new Repository({
+      author: {
+        reference: 'Practitioner/123',
+      },
+      accessPolicy: accessPolicy2,
+    });
+
+    const [createOutcome1, patient1] = await repo1.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Alice'], family: 'Smith' }],
+      birthDate: '1970-01-01',
+    });
+    assertOk(createOutcome1, patient1);
+    expect(patient1).toBeDefined();
+    expect(patient1?.meta?.account).toBeDefined();
+    expect(patient1?.meta?.account?.reference).toEqual('Organization/' + org1);
+
+    const [readOutcome1, readPatient1] = await repo1.readResource('Patient', patient1?.id as string);
+    assertOk(readOutcome1, readPatient1);
+    expect(readPatient1).toBeDefined();
+    expect(readPatient1?.meta?.account).toBeDefined();
+
+    const [createOutcome2, patient2] = await repo2.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Alice'], family: 'Smith' }],
+      birthDate: '1970-01-01',
+    });
+    assertOk(createOutcome2, patient2);
+    expect(patient2).toBeDefined();
+    expect(patient2?.meta?.account).toBeDefined();
+    expect(patient2?.meta?.account?.reference).toEqual('Organization/' + org2);
+
+    const [readOutcome2, readPatient2] = await repo2.readResource('Patient', patient2?.id as string);
+    assertOk(readOutcome2, readPatient2);
+    expect(readPatient2).toBeDefined();
+    expect(readPatient2?.meta?.account).toBeDefined();
+
+    // Try to read patient1 with repo2
+    // This should fail
+    const [readOutcome3, readPatient3] = await repo2.readResource('Patient', patient1?.id as string);
+    expect(readOutcome3.id).toEqual('not-found');
+    expect(readPatient3).toBeUndefined();
+
+    // Try to read patient2 with repo1
+    // This should fail
+    const [readOutcome4, readPatient4] = await repo1.readResource('Patient', patient2?.id as string);
+    expect(readOutcome4.id).toEqual('not-found');
+    expect(readPatient4).toBeUndefined();
+  });
+
+  test('Access policy restrict criteria', async () => {
+    const org1 = randomUUID();
+    const org2 = randomUUID();
+
+    const accessPolicy1: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      compartment: {
+        reference: 'Organization/' + org1,
+      },
+      resource: [
+        {
+          resourceType: 'Patient',
+          criteria: `Patient?_compartment=Organization/${org1}`,
+        },
+      ],
+    };
+
+    const accessPolicy2: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      compartment: {
+        reference: 'Organization/' + org2,
+      },
+      resource: [
+        {
+          resourceType: 'Patient',
+          criteria: `Patient?_compartment=Organization/${org1}`,
         },
       ],
     };

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -336,7 +336,7 @@ describe('AccessPolicy', () => {
       resource: [
         {
           resourceType: 'Patient',
-          criteria: `Patient?_compartment=Organization/${org1}`,
+          criteria: `Patient?_compartment=${org1}`,
         },
       ],
     };
@@ -349,7 +349,7 @@ describe('AccessPolicy', () => {
       resource: [
         {
           resourceType: 'Patient',
-          criteria: `Patient?_compartment=Organization/${org1}`,
+          criteria: `Patient?_compartment=${org2}`,
         },
       ],
     };

--- a/packages/server/src/fhir/lookups/contactpoint.ts
+++ b/packages/server/src/fhir/lookups/contactpoint.ts
@@ -97,7 +97,7 @@ export class ContactPointTable extends LookupTable<ContactPoint> {
    */
   addWhere(selectQuery: SelectQuery, predicate: Conjunction, filter: Filter): void {
     const tableName = this.getTableName();
-    const joinName = 'T' + (selectQuery.joins.length + 1);
+    const joinName = selectQuery.getNextJoinAlias();
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
       .where({ tableName, columnName: 'value' }, Operator.EQUALS, filter.value)

--- a/packages/server/src/fhir/lookups/contactpoint.ts
+++ b/packages/server/src/fhir/lookups/contactpoint.ts
@@ -2,7 +2,7 @@ import { Filter, stringify } from '@medplum/core';
 import { ContactPoint, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { getClient } from '../../database';
-import { InsertQuery, Operator, SelectQuery } from '../sql';
+import { Column, Condition, Conjunction, InsertQuery, Operator, SelectQuery } from '../sql';
 import { LookupTable } from './lookuptable';
 import { compareArrays } from './util';
 
@@ -92,11 +92,12 @@ export class ContactPointTable extends LookupTable<ContactPoint> {
   /**
    * Adds "where" conditions to the select query builder.
    * @param selectQuery The select query builder.
+   * @param predicate The conjunction where conditions should be added.
    * @param filter The search filter details.
    */
-  addWhere(selectQuery: SelectQuery, filter: Filter): void {
+  addWhere(selectQuery: SelectQuery, predicate: Conjunction, filter: Filter): void {
     const tableName = this.getTableName();
-    const joinName = tableName + '_' + filter.code + '_search';
+    const joinName = 'T' + (selectQuery.joins.length + 1);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
       .where({ tableName, columnName: 'value' }, Operator.EQUALS, filter.value)
@@ -108,5 +109,6 @@ export class ContactPointTable extends LookupTable<ContactPoint> {
     }
 
     selectQuery.join(joinName, 'id', 'resourceId', subQuery);
+    predicate.expressions.push(new Condition(new Column(joinName, 'id'), Operator.NOT_EQUALS, null));
   }
 }

--- a/packages/server/src/fhir/lookups/identifier.ts
+++ b/packages/server/src/fhir/lookups/identifier.ts
@@ -78,7 +78,7 @@ export class IdentifierTable extends LookupTable<Identifier> {
    */
   addWhere(selectQuery: SelectQuery, predicate: Conjunction, filter: Filter): void {
     const tableName = this.getTableName();
-    const joinName = 'T' + (selectQuery.joins.length + 1);
+    const joinName = selectQuery.getNextJoinAlias();
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
       .orderBy('resourceId');

--- a/packages/server/src/fhir/lookups/identifier.ts
+++ b/packages/server/src/fhir/lookups/identifier.ts
@@ -73,11 +73,12 @@ export class IdentifierTable extends LookupTable<Identifier> {
   /**
    * Adds "where" conditions to the select query builder.
    * @param selectQuery The select query builder.
+   * @param predicate The conjunction where conditions should be added.
    * @param filter The search filter details.
    */
-  addWhere(selectQuery: SelectQuery, filter: Filter): void {
+  addWhere(selectQuery: SelectQuery, predicate: Conjunction, filter: Filter): void {
     const tableName = this.getTableName();
-    const joinName = tableName + '_' + filter.code + '_search';
+    const joinName = 'T' + (selectQuery.joins.length + 1);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
       .orderBy('resourceId');
@@ -87,6 +88,7 @@ export class IdentifierTable extends LookupTable<Identifier> {
     }
     subQuery.whereExpr(disjunction);
     selectQuery.join(joinName, 'id', 'resourceId', subQuery);
+    predicate.expressions.push(new Condition(new Column(joinName, 'id'), Operator.NOT_EQUALS, null));
   }
 
   #buildWhereCondition(operator: FhirOperator, query: string): Expression {

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -44,7 +44,7 @@ export abstract class LookupTable<T> {
    */
   addWhere(selectQuery: SelectQuery, predicate: Conjunction, filter: Filter): void {
     const tableName = this.getTableName();
-    const joinName = 'T' + (selectQuery.joins.length + 1);
+    const joinName = selectQuery.getNextJoinAlias();
     const columnName = this.getColumnName(filter.code);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
@@ -75,13 +75,13 @@ export abstract class LookupTable<T> {
    */
   addOrderBy(selectQuery: SelectQuery, sortRule: SortRule): void {
     const tableName = this.getTableName();
-    const joinName = 'T' + (selectQuery.joins.length + 1);
+    const joinName = selectQuery.getNextJoinAlias();
     const columnName = this.getColumnName(sortRule.code);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
       .orderBy('resourceId');
     selectQuery.join(joinName, 'id', 'resourceId', subQuery);
-    selectQuery.orderBy({ tableName: joinName, columnName }, sortRule.descending);
+    selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending);
   }
 
   /**

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -39,11 +39,12 @@ export abstract class LookupTable<T> {
   /**
    * Adds "where" conditions to the select query builder.
    * @param selectQuery The select query builder.
+   * @param predicate The conjunction where conditions should be added.
    * @param filter The search filter details.
    */
-  addWhere(selectQuery: SelectQuery, filter: Filter): void {
+  addWhere(selectQuery: SelectQuery, predicate: Conjunction, filter: Filter): void {
     const tableName = this.getTableName();
-    const joinName = tableName + '_' + filter.code + '_search';
+    const joinName = 'T' + (selectQuery.joins.length + 1);
     const columnName = this.getColumnName(filter.code);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
@@ -64,6 +65,7 @@ export abstract class LookupTable<T> {
     }
     subQuery.whereExpr(disjunction);
     selectQuery.join(joinName, 'id', 'resourceId', subQuery);
+    predicate.expressions.push(new Condition(new Column(joinName, columnName), Operator.NOT_EQUALS, null));
   }
 
   /**
@@ -73,7 +75,7 @@ export abstract class LookupTable<T> {
    */
   addOrderBy(selectQuery: SelectQuery, sortRule: SortRule): void {
     const tableName = this.getTableName();
-    const joinName = tableName + '_' + sortRule.code + '_sort';
+    const joinName = 'T' + (selectQuery.joins.length + 1);
     const columnName = this.getColumnName(sortRule.code);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -568,7 +568,6 @@ export class Repository {
         if (policy.criteria) {
           // Add subquery for access policy criteria.
           const searchRequest = parseSearchUrl(new URL(policy.criteria, 'https://api.medplum.com/'));
-          console.log('parsed search', JSON.stringify(searchRequest, null, 2));
           const accessPolicyConjunction = new Conjunction([]);
           this.#addSearchFilters(builder, accessPolicyConjunction, searchRequest);
           expressions.push(accessPolicyConjunction);

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -129,6 +129,16 @@ class SearchParser implements SearchRequest {
         });
         break;
 
+      case '_account':
+      case '_compartment':
+      case '_project':
+        this.filters.push({
+          code: code,
+          operator: Operator.EQUALS,
+          value,
+        });
+        break;
+
       case '_lastUpdated':
       case 'meta.lastUpdated':
         {

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -1,0 +1,54 @@
+import { Condition, Negation, Operator, SelectQuery, SqlBuilder } from './sql';
+
+describe('SqlBuilder', () => {
+  test('Select', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').column('name').buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id", "name" FROM "MyTable"');
+  });
+
+  test('Select where', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').where('name', Operator.EQUALS, 'x').buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE "name"=$1');
+  });
+
+  test('Select where expression', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').whereExpr(new Condition('name', Operator.EQUALS, 'x')).buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE "name"=$1');
+  });
+
+  test('Select where negation', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable')
+      .column('id')
+      .whereExpr(new Negation(new Condition('name', Operator.EQUALS, 'x')))
+      .buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE NOT ("name"=$1)');
+  });
+
+  test('Select where array contains', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').where('name', Operator.ARRAY_CONTAINS, 'x').buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE $1=ANY("name")');
+  });
+
+  test('Select where array contains array', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').where('name', Operator.ARRAY_CONTAINS, ['x', 'y']).buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE "name"&&ARRAY[$1,$2]');
+  });
+
+  test('Select where is null', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').where('name', Operator.EQUALS, null).buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE "name" IS NULL');
+  });
+
+  test('Select where is not null', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').where('name', Operator.NOT_EQUALS, null).buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "id" FROM "MyTable" WHERE "name" IS NOT NULL');
+  });
+});

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -98,6 +98,12 @@ export class Condition implements Expression {
       sql.append(')');
       sql.append(this.operator);
       sql.param((this.parameter as string).toLowerCase());
+    } else if (this.operator === Operator.EQUALS && this.parameter === null) {
+      sql.appendColumn(this.column);
+      sql.append(' IS NULL');
+    } else if (this.operator === Operator.NOT_EQUALS && this.parameter === null) {
+      sql.appendColumn(this.column);
+      sql.append(' IS NOT NULL');
     } else {
       sql.appendColumn(this.column);
       sql.append(this.operator);
@@ -131,6 +137,15 @@ export class Conjunction extends Connective {
   constructor(expressions: Expression[]) {
     super(' AND ', expressions);
   }
+
+  whereExpr(expression: Expression): this {
+    this.expressions.push(expression);
+    return this;
+  }
+
+  where(column: Column | string, operator?: Operator, value?: any, type?: string): this {
+    return this.whereExpr(new Condition(column, operator as Operator, value, type));
+  }
 }
 
 export class Disjunction extends Connective {
@@ -145,6 +160,10 @@ export class Join {
 
 export class OrderBy {
   constructor(readonly column: Column, readonly descending?: boolean) {}
+}
+
+export interface Expression {
+  buildSql(sql: SqlBuilder): void;
 }
 
 export class SqlBuilder {
@@ -198,31 +217,27 @@ export class SqlBuilder {
 
 export abstract class BaseQuery {
   readonly tableName: string;
-  condition: Expression | undefined;
+  readonly predicate: Conjunction;
 
   constructor(tableName: string) {
     this.tableName = tableName;
+    this.predicate = new Conjunction([]);
   }
 
   whereExpr(expression: Expression): this {
-    if (this.condition && this.condition instanceof Conjunction) {
-      this.condition.expressions.push(expression);
-    } else if (this.condition) {
-      this.condition = new Conjunction([this.condition, expression]);
-    } else {
-      this.condition = expression;
-    }
+    this.predicate.whereExpr(expression);
     return this;
   }
 
   where(column: Column | string, operator?: Operator, value?: any, type?: string): this {
-    return this.whereExpr(new Condition(column, operator as Operator, value, type));
+    this.predicate.where(column, operator, value, type);
+    return this;
   }
 
   protected buildConditions(sql: SqlBuilder): void {
-    if (this.condition) {
+    if (this.predicate.expressions.length > 0) {
       sql.append(' WHERE ');
-      this.condition.buildSql(sql);
+      this.predicate.buildSql(sql);
     }
   }
 }
@@ -316,7 +331,7 @@ export class SelectQuery extends BaseQuery {
     sql.appendIdentifier(this.tableName);
 
     for (const join of this.joins) {
-      sql.append(' JOIN ');
+      sql.append(' LEFT JOIN ');
       if (join.subQuery) {
         sql.append(' ( ');
         join.subQuery.buildSql(sql);

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -32,7 +32,7 @@ export class Negation implements Expression {
   constructor(readonly expression: Expression) {}
 
   buildSql(sql: SqlBuilder): void {
-    sql.append(' NOT (');
+    sql.append('NOT (');
     this.expression.buildSql(sql);
     sql.append(')');
   }
@@ -204,8 +204,12 @@ export class SqlBuilder {
     return this;
   }
 
+  toString(): string {
+    return this.#sql.join('');
+  }
+
   async execute(conn: Client | Pool): Promise<any[]> {
-    const sql = this.#sql.join('');
+    const sql = this.toString();
     if (DEBUG) {
       console.log('sql', sql);
       console.log('values', this.#values);

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -268,6 +268,10 @@ export class SelectQuery extends BaseQuery {
     return this;
   }
 
+  getNextJoinAlias(): string {
+    return `T${this.joins.length + 1}`;
+  }
+
   join(rightTableName: string, leftColumnName: string, rightColumnName: string, subQuery?: SelectQuery): this {
     this.joins.push(
       new Join(new Column(this.tableName, leftColumnName), new Column(rightTableName, rightColumnName), subQuery)


### PR DESCRIPTION
This is a work-in-progress on a new proposal for `AccessPolicy`.

Context:
* A user or client can optionally have an `AccessPolicy` that defines access to resources
* An `AccessPolicy` can grant access to a resource type
* Access to a resource type can be scoped to a FHIR compartment (i.e., patient compartment, account compartment, etc)

Limitations:
* Compartments are pretty powerful, but we want to be more expressive
* The current version does not handle multiple compartments (i.e., patient A and patient B)
* The current version does not handle non-compartment restrictions (i.e., observations by code, reports by status, etc)

New model:
* Deprecate `AccessPolicy.resource.compartment`
* Add `AccessPolicy.resource.criteria`
  * The `criteria` property follows the same pattern as [`Subscription.criteria`](http://hl7.org/fhir/r4/subscription-definitions.html#Subscription.criteria)
  * A FHIR search string
  * This enables restricting access by any FHIR search parameter
* Document the exact behavior of "and" vs "or", and the behavior of multiple resource types
* Legacy behavior can be achieved with `?_compartment=xyz`

For discussion:
* FHIR v5 changes `Subscription.criteria` to `Subscription.filterBy` - should we jump ahead to this model?