### PR TITLE
HL7 endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ packages/definitions/dist/**/*.d.ts
 packages/fhirpath/dist/
 packages/generator/dist/
 packages/graphiql/dist/
-packages/hl7/dist/
 packages/infra/dist/
 packages/mock/dist/
 packages/seeder/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ packages/definitions/dist/**/*.d.ts
 packages/fhirpath/dist/
 packages/generator/dist/
 packages/graphiql/dist/
+packages/hl7/dist/
 packages/infra/dist/
 packages/mock/dist/
 packages/seeder/dist/

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -2,7 +2,7 @@ import { badRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import compression from 'compression';
 import cors from 'cors';
-import { Express, json, NextFunction, Request, Response, urlencoded } from 'express';
+import { Express, json, NextFunction, Request, Response, urlencoded, text } from 'express';
 import { adminRouter } from './admin';
 import { asyncWrap } from './async';
 import { authRouter } from './auth';
@@ -11,6 +11,7 @@ import { corsOptions } from './cors';
 import { dicomRouter } from './dicom/routes';
 import { binaryRouter, fhirRouter, sendOutcome } from './fhir';
 import { healthcheckHandler } from './healthcheck';
+import { hl7Router } from './hl7';
 import { logger } from './logger';
 import { authenticateToken, oauthRouter } from './oauth';
 import { openApiHandler } from './openapi';
@@ -99,6 +100,7 @@ export async function initApp(app: Express): Promise<Express> {
       extended: false,
     })
   );
+  app.use(text());
   app.use(
     json({
       type: ['application/json', 'application/fhir+json', 'application/json-patch+json'],
@@ -113,6 +115,7 @@ export async function initApp(app: Express): Promise<Express> {
   app.use('/auth/', authRouter);
   app.use('/dicom/PS3/', dicomRouter);
   app.use('/fhir/R4/', fhirRouter);
+  app.use('/hl7/v2/', hl7Router);
   app.use('/oauth2/', oauthRouter);
   app.use('/scim/v2/', scimRouter);
   app.use('/storage/', storageRouter);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -100,7 +100,11 @@ export async function initApp(app: Express): Promise<Express> {
       extended: false,
     })
   );
-  app.use(text());
+  app.use(
+    text({
+      type: ['text/plain', 'x-application/hl7-v2+er7'],
+    })
+  );
   app.use(
     json({
       type: ['application/json', 'application/fhir+json', 'application/json-patch+json'],

--- a/packages/server/src/hl7/README.md
+++ b/packages/server/src/hl7/README.md
@@ -1,0 +1,36 @@
+# Medplum HL7
+
+This implements "HL7 over HTTP" as described here: https://hapifhir.github.io/hapi-hl7v2/hapi-hl7overhttp/specification.html
+
+## Implementation Notes
+
+HL7 v2.x in ER7 (pipe delimited) format is the only supported encoding.
+
+HL7 parsing is not "strict", similar to Mirth in non-strict mode.
+* One HTTP request represents one HL7 message
+* A `Message` is represented as an array of `Segment` objects
+* Each `Segment` is represented as an array of `Field` objects
+* Each `Field` is an array of components
+* All components are naively represented as strings
+
+### Content Type
+
+Request Content-Type is not validated. "x-application/hl7-v2+er7" is recommended.
+
+Response Content-Type will always be "x-application/hl7-v2+er7"
+
+### Character Set
+
+All requests and responses are handled as UTF8.
+
+### Line Endings
+
+Request line endings can be CR (\r), LF (\n), or CRLF (\r\n). CR is recommended.
+
+Response line endings will always be CR.
+
+## Security Profile
+
+We use Security Profile Level 2:
+* HTTPS/TLS only
+* Client authentication is required using standard Medplum authentication (Basic or Bearer)

--- a/packages/server/src/hl7/index.ts
+++ b/packages/server/src/hl7/index.ts
@@ -1,0 +1,1 @@
+export * from './routes';

--- a/packages/server/src/hl7/parser.test.ts
+++ b/packages/server/src/hl7/parser.test.ts
@@ -1,0 +1,122 @@
+import { Message } from './parser';
+
+describe('HL7', () => {
+  test('Unsupported encoding', () => {
+    expect(() => Message.parse('MSH_^~\\&|')).toThrow();
+  });
+
+  test('ACK', () => {
+    const text =
+      'MSH|^~\\&|Main_HIS|XYZ_HOSPITAL|iFW|ABC_Lab|20160915003015||ACK|9B38584D|P|2.6.1|\r' +
+      'MSA|AA|9B38584D|Everything was okay dokay!|';
+
+    const msg = Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(2);
+    expect(msg.toString()).toBe(text);
+  });
+
+  test('ADT', () => {
+    const text = `MSH|^~\\&|EPIC|EPICADT|SMS|SMSADT|199912271408|CHARRIS|ADT^A04|1817457|D|2.5|
+PID||0493575^^^2^ID 1|454721||DOE^JOHN^^^^|DOE^JOHN^^^^|19480203|M||B|254 MYSTREET AVE^^MYTOWN^OH^44123^USA||(216)123-4567|||M|NON|400003403~1129086|
+NK1||ROE^MARIE^^^^|SPO||(216)123-4567||EC|||||||||||||||||||||||||||
+PV1||O|168 ~219~C~PMA^^^^^^^^^||||277^ALLEN MYLASTNAME^BONNIE^^^^|||||||||| ||2688684|||||||||||||||||||||||||199912271408||||||002376853`;
+
+    const msg = Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(4);
+    expect(msg.segments[0].name).toBe('MSH');
+    expect(msg.segments[1].name).toBe('PID');
+    expect(msg.segments[2].name).toBe('NK1');
+    expect(msg.segments[3].name).toBe('PV1');
+
+    const msh = msg.get('MSH');
+    expect(msh).toBeDefined();
+    expect(msh?.get(2).toString()).toBe('EPIC');
+    expect(msh?.get(3).toString()).toBe('EPICADT');
+
+    const pid = msg.get('PID');
+    expect(pid).toBeDefined();
+    expect(pid?.get(2).get(0)).toBe('0493575');
+    expect(pid?.get(2).toString()).toBe('0493575^^^2^ID 1');
+
+    const nk1 = msg.get('NK1');
+    expect(nk1).toBeDefined();
+    expect(nk1?.get(2).get(0)).toBe('ROE');
+    expect(nk1?.get(2).get(1)).toBe('MARIE');
+    expect(nk1?.get(2).toString()).toBe('ROE^MARIE^^^^');
+
+    const pv1 = msg.get('PV1');
+    expect(pv1).toBeDefined();
+    expect(pv1?.get(2).get(0)).toBe('O');
+    expect(pv1?.get(2).toString()).toBe('O');
+  });
+
+  test('QBP_Q11', () => {
+    const text = `MSH|^~\\&|cobas® pro||host||20160724080600+0200||QBP^Q11^QBP_Q11|1233|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-27R^ROCHE
+QPD|INISEQ^^99ROC|query1233|123|50001|1|||||SERPLAS^^99ROC|SC^^99ROC|R
+RCP|I|1|R^^HL70394`;
+
+    const msg = Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(3);
+    expect(msg.segments[0].name).toBe('MSH');
+    expect(msg.segments[1].name).toBe('QPD');
+    expect(msg.segments[2].name).toBe('RCP');
+
+    const msh = msg.get('MSH');
+    expect(msh).toBeDefined();
+    expect(msh?.get(2).toString()).toBe('cobas® pro');
+    expect(msh?.get(4).toString()).toBe('host');
+  });
+
+  test('OUL_R22', () => {
+    const text = `MSH|^~\\&|cobas pro||host||20180222150842+0100||OUL^R22^OUL_R22|97|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-29^IHE
+PID|||||^^^^^^U|||U
+SPM|1|022&BARCODE||SERPLAS^^99ROC|||||||P^^HL70369|||~~~~||||||||||PSCO^^99ROC|||SC^^99ROC
+SAC|||022^BARCODE|||||||50120|2||||||||||||||||||^1^:^1
+OBR|1|""||20490^^99ROC|||||||
+ORC|SC||||CM
+TQ1|||||||||R^^HL70485
+OBX|1|NM|20490^20490^99ROC^^^IHELAW|1|32.2|mg/L^^99ROC||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|2|CE|20490^20490^99ROC^^^IHELAW|1|^^99ROC|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+TCD|20490^^99ROC|^1^:^1
+INV|2049001|OK^^HL70383~CURRENT^^99ROC|R1|514|1|8||||||20181030||||256616
+INV|2049001|OK^^HL70383~CURRENT^^99ROC|R3|514|1|8||||||20181030||||256616
+OBX|3|DTM|PT^Pipetting_Time^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|20180222145824|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|4|EI|CalibrationID^CalibrationID^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|23|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|5|EI|QCTID^QC·Test·ID^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|62~67|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|6|CE|QCSTATE^QC·Status^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|2^^99ROC|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|7|ST|TR_TECHNICALLIMIT^TR_TECHNICALLIMIT^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|0.300·-·350|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|8|ST|TR_REPEATLIMIT^TR_REPEATLIMIT^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|-99999·-·999999|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|-99999·-·999999|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT`;
+
+    const msg = Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(19);
+    expect(msg.segments[0].name).toBe('MSH');
+    expect(msg.segments[1].name).toBe('PID');
+    expect(msg.segments[2].name).toBe('SPM');
+    expect(msg.get(0)).toEqual(msg.get('MSH'));
+
+    const pid = msg.get('PID');
+    expect(pid).toBeDefined();
+    expect(pid?.toString()).toBe('PID|||||^^^^^^U|||U');
+
+    const msh = msg.get('MSH');
+    expect(msh).toBeDefined();
+    expect(msh?.get(2).toString()).toBe('cobas pro');
+    expect(msh?.get(4).toString()).toBe('host');
+
+    const obxs = msg.getAll('OBX');
+    expect(obxs).toBeDefined();
+    expect(obxs.length).toBe(9);
+
+    let i = 1;
+    for (const obx of obxs) {
+      expect(obx.name).toBe('OBX');
+      expect(obx.get(1).toString()).toBe(i.toString());
+      i++;
+    }
+  });
+});

--- a/packages/server/src/hl7/parser.test.ts
+++ b/packages/server/src/hl7/parser.test.ts
@@ -5,6 +5,20 @@ describe('HL7', () => {
     expect(() => Message.parse('MSH_^~\\&|')).toThrow();
   });
 
+  test('Minimal', () => {
+    const text = 'MSH|^~\\&';
+    const msg = Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(1);
+    expect(msg.toString()).toBe(text);
+
+    const ack = msg.buildAck();
+    expect(ack).toBeDefined();
+    expect(ack.segments.length).toBe(2);
+    expect(ack.segments[0].name).toBe('MSH');
+    expect(ack.segments[1].name).toBe('MSA');
+  });
+
   test('ACK', () => {
     const text =
       'MSH|^~\\&|Main_HIS|XYZ_HOSPITAL|iFW|ABC_Lab|20160915003015||ACK|9B38584D|P|2.6.1|\r' +

--- a/packages/server/src/hl7/parser.ts
+++ b/packages/server/src/hl7/parser.ts
@@ -2,61 +2,16 @@ export const SEGMENT_SEPARATOR = '\r';
 export const FIELD_SEPARATOR = '|';
 export const COMPONENT_SEPARATOR = '^';
 
-export class Field {
-  readonly components: string[];
-
-  constructor(components?: string[]) {
-    this.components = components || [];
-  }
-
-  get(index: number): string {
-    return this.components[index];
-  }
-
-  toString(): string {
-    return this.components.join(COMPONENT_SEPARATOR);
-  }
-
-  static parse(text: string): Field {
-    return new Field(text.split(COMPONENT_SEPARATOR));
-  }
-}
-
-export class Segment {
-  readonly name: string;
-  readonly fields: Field[];
-
-  constructor(fields?: Field[] | string[]) {
-    if (fields) {
-      if (isStringArray(fields)) {
-        this.fields = fields.map((f) => Field.parse(f));
-      } else {
-        this.fields = fields;
-      }
-    } else {
-      this.fields = [];
-    }
-    this.name = this.fields[0].components[0];
-  }
-
-  get(index: number): Field {
-    return this.fields[index];
-  }
-
-  toString(): string {
-    return this.fields.map((f) => f.toString()).join(FIELD_SEPARATOR);
-  }
-
-  static parse(text: string): Segment {
-    return new Segment(text.split(FIELD_SEPARATOR).map((f) => Field.parse(f)));
-  }
-}
-
+/**
+ * The Message class represents one HL7 message.
+ * A message is a collection of segments.
+ * Note that we do not strictly parse messages, and only use default delimeters.
+ */
 export class Message {
   readonly segments: Segment[];
 
-  constructor(segments?: Segment[]) {
-    this.segments = segments || [];
+  constructor(segments: Segment[]) {
+    this.segments = segments;
   }
 
   get(index: number | string): Segment | undefined {
@@ -104,13 +59,75 @@ export class Message {
   }
 
   static parse(text: string): Message {
-    if (!text.startsWith('MSH|^~\\&|')) {
+    if (!text.startsWith('MSH|^~\\&')) {
       throw new Error('Invalid input');
     }
     return new Message(text.split(/[\r\n]+/).map((line) => Segment.parse(line)));
   }
 }
 
+/**
+ * The Segment class represents one HL7 segment.
+ * A segment is a collection of fields.
+ * The name field is the first field.
+ * Note that we do not strictly parse messages, and only use default delimeters.
+ */
+export class Segment {
+  readonly name: string;
+  readonly fields: Field[];
+
+  constructor(fields: Field[] | string[]) {
+    if (isStringArray(fields)) {
+      this.fields = fields.map((f) => Field.parse(f));
+    } else {
+      this.fields = fields;
+    }
+    this.name = this.fields[0].components[0];
+  }
+
+  get(index: number): Field {
+    return this.fields[index];
+  }
+
+  toString(): string {
+    return this.fields.map((f) => f.toString()).join(FIELD_SEPARATOR);
+  }
+
+  static parse(text: string): Segment {
+    return new Segment(text.split(FIELD_SEPARATOR).map((f) => Field.parse(f)));
+  }
+}
+
+/**
+ * The Field class represents one HL7 field.
+ * A field is a collection of components.
+ * Note that we do not strictly parse messages, and only use default delimeters.
+ */
+export class Field {
+  readonly components: string[];
+
+  constructor(components: string[]) {
+    this.components = components;
+  }
+
+  get(index: number): string {
+    return this.components[index];
+  }
+
+  toString(): string {
+    return this.components.join(COMPONENT_SEPARATOR);
+  }
+
+  static parse(text: string): Field {
+    return new Field(text.split(COMPONENT_SEPARATOR));
+  }
+}
+
+/**
+ * Returns true if the input array is an array of strings.
+ * @param arr Input array.
+ * @returns True if the input array is an array of strings.
+ */
 function isStringArray(arr: any[]): arr is string[] {
   return arr.every((e) => typeof e === 'string');
 }

--- a/packages/server/src/hl7/parser.ts
+++ b/packages/server/src/hl7/parser.ts
@@ -60,7 +60,7 @@ export class Message {
 
   static parse(text: string): Message {
     if (!text.startsWith('MSH|^~\\&')) {
-      throw new Error('Invalid input');
+      throw new Error('Invalid message');
     }
     return new Message(text.split(/[\r\n]+/).map((line) => Segment.parse(line)));
   }

--- a/packages/server/src/hl7/parser.ts
+++ b/packages/server/src/hl7/parser.ts
@@ -1,0 +1,116 @@
+export const SEGMENT_SEPARATOR = '\r';
+export const FIELD_SEPARATOR = '|';
+export const COMPONENT_SEPARATOR = '^';
+
+export class Field {
+  readonly components: string[];
+
+  constructor(components?: string[]) {
+    this.components = components || [];
+  }
+
+  get(index: number): string {
+    return this.components[index];
+  }
+
+  toString(): string {
+    return this.components.join(COMPONENT_SEPARATOR);
+  }
+
+  static parse(text: string): Field {
+    return new Field(text.split(COMPONENT_SEPARATOR));
+  }
+}
+
+export class Segment {
+  readonly name: string;
+  readonly fields: Field[];
+
+  constructor(fields?: Field[] | string[]) {
+    if (fields) {
+      if (isStringArray(fields)) {
+        this.fields = fields.map((f) => Field.parse(f));
+      } else {
+        this.fields = fields;
+      }
+    } else {
+      this.fields = [];
+    }
+    this.name = this.fields[0].components[0];
+  }
+
+  get(index: number): Field {
+    return this.fields[index];
+  }
+
+  toString(): string {
+    return this.fields.map((f) => f.toString()).join(FIELD_SEPARATOR);
+  }
+
+  static parse(text: string): Segment {
+    return new Segment(text.split(FIELD_SEPARATOR).map((f) => Field.parse(f)));
+  }
+}
+
+export class Message {
+  readonly segments: Segment[];
+
+  constructor(segments?: Segment[]) {
+    this.segments = segments || [];
+  }
+
+  get(index: number | string): Segment | undefined {
+    if (typeof index === 'number') {
+      return this.segments[index];
+    }
+    return this.segments.find((s) => s.name === index);
+  }
+
+  getAll(name: string): Segment[] {
+    return this.segments.filter((s) => s.name === name);
+  }
+
+  toString(): string {
+    return this.segments.map((s) => s.toString()).join(SEGMENT_SEPARATOR);
+  }
+
+  buildAck(): Message {
+    const now = new Date();
+    const msh = this.get('MSH');
+    const sendingApp = msh?.get(2)?.toString() || '';
+    const sendingFacility = msh?.get(3)?.toString() || '';
+    const receivingApp = msh?.get(4)?.toString() || '';
+    const receivingFacility = msh?.get(5)?.toString() || '';
+    const controlId = msh?.get(9)?.toString() || '';
+    const versionId = msh?.get(12)?.toString() || '2.5.1';
+
+    return new Message([
+      new Segment([
+        'MSH',
+        '^~\\&',
+        receivingApp,
+        receivingFacility,
+        sendingApp,
+        sendingFacility,
+        now.toISOString(),
+        '',
+        'ACK',
+        now.getTime().toString(),
+        'P',
+        versionId,
+      ]),
+      new Segment(['MSA', 'AA', controlId, 'OK']),
+    ]);
+  }
+
+  static parse(text: string): Message {
+    if (!text.startsWith('MSH|^~\\&|')) {
+      throw new Error('Invalid input');
+    }
+    return new Message(text.split(/[\r\n]+/).map((line) => Segment.parse(line)));
+  }
+}
+
+function isStringArray(arr: any[]): arr is string[] {
+  return arr.every((e) => typeof e === 'string');
+}

--- a/packages/server/src/hl7/routes.test.ts
+++ b/packages/server/src/hl7/routes.test.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import request from 'supertest';
+import { initApp } from '../app';
+import { loadTestConfig } from '../config';
+import { closeDatabase, initDatabase } from '../database';
+import { initTestAuth } from '../jest.setup';
+import { initKeys } from '../oauth';
+import { seedDatabase } from '../seed';
+import { Message } from './parser';
+
+const app = express();
+let accessToken: string;
+
+describe('HL7 Routes', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config.database);
+    await seedDatabase();
+    await initApp(app);
+    await initKeys(config);
+    accessToken = await initTestAuth();
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  test('Send message', async () => {
+    const msg =
+      'MSH|^~\\&|device||host||20180222150842+0100||OUL^R22^OUL_R22|97|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-29^IHE\r\n' +
+      'PID|||||^^^^^^U|||U\r\n' +
+      'SPM|1|022&BARCODE||SERPLAS^^99ROC|||||||P^^HL70369|||~~~~||||||||||PSCO^^99ROC|||SC^^99ROC\r\n' +
+      'SAC|||022^BARCODE|||||||50120|2||||||||||||||||||^1^:^1\r\n' +
+      'OBR|1|""||20490^^99ROC|||||||\r\n' +
+      'ORC|SC||||CM\r\n' +
+      'TQ1|||||||||R^^HL70485\r\n' +
+      'OBX|1|NM|20490^20490^99ROC^^^IHELAW|1|32.2|mg/L^^99ROC||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT\r\n';
+
+    const res = await request(app)
+      .post(`/hl7/v2`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'text/plain')
+      .send(msg);
+    expect(res.status).toBe(200);
+
+    const ack = Message.parse(res.text);
+    expect(ack.get('MSH')).toBeDefined();
+    expect(ack.get('MSA')).toBeDefined();
+  });
+});

--- a/packages/server/src/hl7/routes.test.ts
+++ b/packages/server/src/hl7/routes.test.ts
@@ -7,6 +7,7 @@ import { initTestAuth } from '../jest.setup';
 import { initKeys } from '../oauth';
 import { seedDatabase } from '../seed';
 import { Message } from './parser';
+import { HL7_V2_ER7_CONTENT_TYPE } from './routes';
 
 const app = express();
 let accessToken: string;
@@ -46,5 +47,40 @@ describe('HL7 Routes', () => {
     const ack = Message.parse(res.text);
     expect(ack.get('MSH')).toBeDefined();
     expect(ack.get('MSA')).toBeDefined();
+  });
+
+  test('Send message with content type', async () => {
+    const msg =
+      'MSH|^~\\&|device||host||20180222150842+0100||OUL^R22^OUL_R22|97|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-29^IHE\r\n' +
+      'PID|||||^^^^^^U|||U\r\n' +
+      'SPM|1|022&BARCODE||SERPLAS^^99ROC|||||||P^^HL70369|||~~~~||||||||||PSCO^^99ROC|||SC^^99ROC\r\n' +
+      'SAC|||022^BARCODE|||||||50120|2||||||||||||||||||^1^:^1\r\n' +
+      'OBR|1|""||20490^^99ROC|||||||\r\n' +
+      'ORC|SC||||CM\r\n' +
+      'TQ1|||||||||R^^HL70485\r\n' +
+      'OBX|1|NM|20490^20490^99ROC^^^IHELAW|1|32.2|mg/L^^99ROC||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT\r\n';
+
+    const res = await request(app)
+      .post(`/hl7/v2`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', HL7_V2_ER7_CONTENT_TYPE)
+      .send(msg);
+    expect(res.status).toBe(200);
+
+    const ack = Message.parse(res.text);
+    expect(ack.get('MSH')).toBeDefined();
+    expect(ack.get('MSA')).toBeDefined();
+  });
+
+  test('Send invalid message', async () => {
+    const msg = '';
+
+    const res = await request(app)
+      .post(`/hl7/v2`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', HL7_V2_ER7_CONTENT_TYPE)
+      .send(msg);
+    expect(res.status).toBe(400);
+    expect(res.text).toBe('Invalid message');
   });
 });

--- a/packages/server/src/hl7/routes.ts
+++ b/packages/server/src/hl7/routes.ts
@@ -1,0 +1,14 @@
+import { Request, Response, Router } from 'express';
+import { authenticateToken } from '../oauth';
+import { Message } from './parser';
+
+const HL7_V2_ER7_CONTENT_TYPE = 'x-application/hl7-v2+er7';
+
+export const hl7Router = Router();
+hl7Router.use(authenticateToken);
+
+hl7Router.post('/', (req: Request, res: Response) => {
+  const input = Message.parse(req.body);
+  const result = input.buildAck();
+  res.status(200).contentType(HL7_V2_ER7_CONTENT_TYPE).send(result.toString());
+});

--- a/packages/server/src/hl7/routes.ts
+++ b/packages/server/src/hl7/routes.ts
@@ -2,13 +2,17 @@ import { Request, Response, Router } from 'express';
 import { authenticateToken } from '../oauth';
 import { Message } from './parser';
 
-const HL7_V2_ER7_CONTENT_TYPE = 'x-application/hl7-v2+er7';
+export const HL7_V2_ER7_CONTENT_TYPE = 'x-application/hl7-v2+er7';
 
 export const hl7Router = Router();
 hl7Router.use(authenticateToken);
 
 hl7Router.post('/', (req: Request, res: Response) => {
-  const input = Message.parse(req.body);
-  const result = input.buildAck();
-  res.status(200).contentType(HL7_V2_ER7_CONTENT_TYPE).send(result.toString());
+  try {
+    const input = Message.parse(req.body);
+    const result = input.buildAck();
+    res.status(200).contentType(HL7_V2_ER7_CONTENT_TYPE).send(result.toString());
+  } catch (err) {
+    res.status(400).send((err as Error).message);
+  }
 });


### PR DESCRIPTION
This PR adds a basic `/hl7` endpoint.  It accepts HL7 messages as POST body, and responds with an HL7 ACK.

It is not connected to a Bot for execution yet.  That will come in a future PR.  Every HL7 is effectively a no-op for now.

The HL7 implementation is "HL7 over HTTP" as described here: https://hapifhir.github.io/hapi-hl7v2/hapi-hl7overhttp/specification.html

For more details, refer to the readme in the PR: https://github.com/medplum/medplum/blob/4493fb3dbc4b34823083a56e7485822a12d3be40/packages/server/src/hl7/README.md