### PR TITLE
HL7 and ASTM bots

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -13,6 +13,7 @@ import { dicomRouter } from './dicom/routes';
 import { binaryRouter, fhirRouter, sendOutcome } from './fhir';
 import { healthcheckHandler } from './healthcheck';
 import { hl7Router } from './hl7';
+import { hl7BodyParser } from './hl7/parser';
 import { logger } from './logger';
 import { authenticateToken, oauthRouter } from './oauth';
 import { openApiHandler } from './openapi';
@@ -110,6 +111,11 @@ export async function initApp(app: Express): Promise<Express> {
     json({
       type: ['application/json', 'application/fhir+json', 'application/json-patch+json'],
       limit: config.maxJsonSize,
+    })
+  );
+  app.use(
+    hl7BodyParser({
+      type: ['x-application/hl7-v2+er7'],
     })
   );
   app.get('/', (req: Request, res: Response) => res.sendStatus(200));

--- a/packages/server/src/fhir/operations/README.md
+++ b/packages/server/src/fhir/operations/README.md
@@ -1,0 +1,5 @@
+# FHIR Operations
+
+This folder contains implementations of [FHIR Operations](https://hl7.org/fhir/operations.html)
+
+See [this list of defined operations](https://hl7.org/fhir/operationslist.html)

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -1,0 +1,90 @@
+import { Bot } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp } from '../../app';
+import { loadTestConfig } from '../../config';
+import { closeDatabase, initDatabase } from '../../database';
+import { initTestAuth } from '../../jest.setup';
+import { initKeys } from '../../oauth';
+import { seedDatabase } from '../../seed';
+
+const app = express();
+let accessToken: string;
+let bot: Bot;
+
+describe('Execute', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config.database);
+    await seedDatabase();
+    await initApp(app);
+    await initKeys(config);
+    accessToken = await initTestAuth();
+
+    const res = await request(app)
+      .post(`/fhir/R4/Bot`)
+      .set('Content-Type', 'application/fhir+json')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Bot',
+        name: 'Test Bot',
+        code: `console.log('input', input); return input;`,
+      });
+    expect(res.status).toBe(201);
+    bot = res.body as Bot;
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  test('Submit plain text', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Content-Type', 'text/plain')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send('input');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
+    expect(res.text).toEqual('input');
+  });
+
+  test('Submit FHIR with content type', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Content-Type', 'application/fhir+json')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Patient',
+        name: [{ given: ['John'], family: ['Doe'] }],
+      });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
+  });
+
+  test('Submit FHIR without content type', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Patient',
+        name: [{ given: ['John'], family: ['Doe'] }],
+      });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+  });
+
+  test('Submit HL7', async () => {
+    const text =
+      'MSH|^~\\&|Main_HIS|XYZ_HOSPITAL|iFW|ABC_Lab|20160915003015||ACK|9B38584D|P|2.6.1|\r' +
+      'MSA|AA|9B38584D|Everything was okay dokay!|';
+
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute`)
+      .set('Content-Type', 'x-application/hl7-v2+er7')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send(text);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('x-application/hl7-v2+er7; charset=utf-8');
+  });
+});

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -1,0 +1,92 @@
+import { assertOk, createReference } from '@medplum/core';
+import { Bot, Project } from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import vm from 'vm';
+import { asyncWrap } from '../../async';
+import { logger } from '../../logger';
+import { Repository, systemRepo } from '../repo';
+
+export const EXECUTE_CONTENT_TYPES = [
+  'application/json',
+  'application/fhir+json',
+  'text/plain',
+  'x-application/hl7-v2+er7',
+];
+
+/**
+ * Handles HTTP requests for the execute operation.
+ * First reads the bot and makes sure it is valid and the user has access to it.
+ * Then executes the bot.
+ * Returns the outcome of the bot execution.
+ * Assumes that input content-type is output content-type.
+ */
+export const executeHandler = asyncWrap(async (req: Request, res: Response) => {
+  const { id } = req.params;
+  const repo = res.locals.repo as Repository;
+  const [outcome, bot] = await repo.readResource<Bot>('Bot', id);
+  assertOk(outcome, bot);
+
+  const body = req.body;
+  const context = {
+    body,
+    repo,
+  };
+
+  try {
+    const result = await executeBot(bot, context);
+    res.status(200).type(getResponseContentType(req)).send(result);
+  } catch (err) {
+    res.status(400).send(err);
+  }
+});
+
+/**
+ * Executes a Bot in a VM sandbox.
+ * @param bot The bot resource.
+ * @param context The global variables to expose in the VM sandbox.
+ * @returns
+ */
+export async function executeBot(bot: Bot, context: any): Promise<any> {
+  const code = bot.code;
+  if (!code) {
+    logger.info('Ignore bots with no code');
+    return undefined;
+  }
+
+  if (!(await isBotEnabled(bot))) {
+    logger.info('Ignore bots if not enabled');
+    return undefined;
+  }
+
+  const sandbox = {
+    ...context,
+    assertOk,
+    createReference,
+  };
+
+  const options: vm.RunningScriptOptions = {
+    timeout: 100,
+  };
+
+  // Wrap code in an async block for top-level await support
+  const wrappedCode = '(async () => {' + code + '})();';
+
+  // Return the result of the code execution
+  return (await vm.runInNewContext(wrappedCode, sandbox, options)) as any;
+}
+
+async function isBotEnabled(bot: Bot): Promise<boolean> {
+  const [projectOutcome, project] = await systemRepo.readResource<Project>('Project', bot.meta?.project as string);
+  assertOk(projectOutcome, project);
+  return !!project.features?.includes('bots');
+}
+
+function getResponseContentType(req: Request): string {
+  const requestContentType = req.get('Content-Type');
+  if (requestContentType && EXECUTE_CONTENT_TYPES.includes(requestContentType)) {
+    return requestContentType;
+  }
+
+  // Default to FHIR
+  return 'application/fhir+json';
+}

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -4,6 +4,7 @@ import { Request, Response } from 'express';
 import vm from 'vm';
 import { asyncWrap } from '../../async';
 import { logger } from '../../logger';
+import { MockConsole } from '../../util/console';
 import { Repository, systemRepo } from '../repo';
 
 export const EXECUTE_CONTENT_TYPES = [
@@ -26,9 +27,9 @@ export const executeHandler = asyncWrap(async (req: Request, res: Response) => {
   const [outcome, bot] = await repo.readResource<Bot>('Bot', id);
   assertOk(outcome, bot);
 
-  const body = req.body;
   const context = {
-    body,
+    input: req.body,
+    console: new MockConsole(),
     repo,
   };
 

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -1,6 +1,7 @@
 import { assertOk, createReference } from '@medplum/core';
 import { Bot, Project } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
+import fetch from 'node-fetch';
 import vm from 'vm';
 import { asyncWrap } from '../../async';
 import { logger } from '../../logger';
@@ -30,6 +31,7 @@ export const executeHandler = asyncWrap(async (req: Request, res: Response) => {
   const context = {
     input: req.body,
     console: new MockConsole(),
+    fetch,
     repo,
   };
 

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -11,6 +11,7 @@ import { csvHandler } from './csv';
 import { expandOperator } from './expand';
 import { getRootSchema } from './graphql';
 import { getCapabilityStatement } from './metadata';
+import { executeHandler } from './operations/execute';
 import { sendOutcome } from './outcomes';
 import { Repository } from './repo';
 import { rewriteAttachments, RewriteMode } from './rewrite';
@@ -98,6 +99,9 @@ protectedRoutes.get('/ValueSet/([$]|%24)expand', expandOperator);
 
 // CSV Export
 protectedRoutes.get('/:resourceType/([$])csv', asyncWrap(csvHandler));
+
+// Bot $execute operation
+protectedRoutes.post('/Bot/:id/([$]|%24)execute', executeHandler);
 
 // GraphQL
 protectedRoutes.use(

--- a/packages/server/src/hl7/routes.test.ts
+++ b/packages/server/src/hl7/routes.test.ts
@@ -81,6 +81,6 @@ describe('HL7 Routes', () => {
       .set('Content-Type', HL7_V2_ER7_CONTENT_TYPE)
       .send(msg);
     expect(res.status).toBe(400);
-    expect(res.text).toBe('Invalid message');
+    expect(res.text).toMatch(/Content could not be parsed/);
   });
 });

--- a/packages/server/src/hl7/routes.ts
+++ b/packages/server/src/hl7/routes.ts
@@ -9,10 +9,11 @@ export const hl7Router = Router();
 hl7Router.use(authenticateToken);
 
 hl7Router.post('/', (req: Request, res: Response) => {
-  logger.info('Received HL7: ' + req.body);
+  logger.info('Received HL7: ' + req.body.toString());
   try {
-    const input = Message.parse(req.body);
-    const result = input.buildAck();
+    const body = req.body as Message | string;
+    const message = typeof body === 'string' ? Message.parse(body) : body;
+    const result = message.buildAck();
     res.status(200).contentType(HL7_V2_ER7_CONTENT_TYPE).send(result.toString());
   } catch (err) {
     res.status(400).send((err as Error).message);

--- a/packages/server/src/jest.setup.ts
+++ b/packages/server/src/jest.setup.ts
@@ -15,6 +15,7 @@ export async function createTestProject(): Promise<{
     owner: {
       reference: 'User/' + randomUUID(),
     },
+    features: ['bots'],
   });
   assertOk(projectOutcome, project);
 

--- a/packages/server/src/util/console.ts
+++ b/packages/server/src/util/console.ts
@@ -1,0 +1,11 @@
+export class MockConsole {
+  readonly messages: string[] = [];
+
+  log(...params: any[]): void {
+    this.messages.push(params.join(' '));
+  }
+
+  toString(): string {
+    return this.messages.join('\n');
+  }
+}

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -539,9 +539,7 @@ describe('Subscription Worker', () => {
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
     });
-
-    expect(patientOutcome.id).toEqual('created');
-    expect(patient).toBeDefined();
+    assertOk(patientOutcome, patient);
     expect(queue.add).toHaveBeenCalled();
 
     (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
@@ -561,7 +559,10 @@ describe('Subscription Worker', () => {
       ],
     });
     assertOk(searchOutcome, bundle);
-    expect(bundle.entry?.length).toEqual(0);
+    expect(bundle.entry?.length).toEqual(1);
+
+    const auditEvent = bundle.entry?.[0]?.resource as AuditEvent;
+    expect(auditEvent.outcomeDesc).toEqual('Success');
   });
 
   test('Execute bot subscriptions', async () => {

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -1,12 +1,12 @@
 import { assertOk, createReference, isGone, Operator, stringify } from '@medplum/core';
-import { AuditEvent, Bot, BundleEntry, Extension, Project, Resource, Subscription } from '@medplum/fhirtypes';
+import { AuditEvent, Bot, BundleEntry, Extension, Resource, Subscription } from '@medplum/fhirtypes';
 import { Job, Queue, QueueBaseOptions, QueueScheduler, Worker } from 'bullmq';
 import { createHmac } from 'crypto';
 import fetch, { HeadersInit } from 'node-fetch';
 import { URL } from 'url';
-import vm from 'vm';
 import { MedplumRedisConfig } from '../config';
 import { Repository, systemRepo } from '../fhir';
+import { executeBot } from '../fhir/operations/execute';
 import { matchesSearchRequest, parseSearchUrl } from '../fhir/search';
 import { logger } from '../logger';
 
@@ -364,22 +364,6 @@ export async function execBot(
   const [botOutcome, bot] = await systemRepo.readReference<Bot>({ reference: url });
   assertOk(botOutcome, bot);
 
-  const code = bot.code;
-  if (!code) {
-    logger.debug('Ignore action subscription missing code');
-    return;
-  }
-
-  // Get the bot project
-  const [projectOutcome, project] = await systemRepo.readResource<Project>('Project', bot.meta?.project as string);
-  assertOk(projectOutcome, project);
-
-  // Make sure that the "bots" feature is enabled
-  if (!project.features?.includes('bots')) {
-    logger.debug('Ignore action subscription missing code');
-    return;
-  }
-
   const botLog = [];
 
   const botConsole = {
@@ -396,25 +380,22 @@ export async function execBot(
     resource,
     console: botConsole,
     repo: botRepo,
-    assertOk,
-    createReference,
-  };
-
-  const options: vm.RunningScriptOptions = {
-    timeout: 100,
   };
 
   let outcome: AuditEventOutcome = AuditEventOutcome.Success;
 
   try {
-    const result = (await vm.runInNewContext('(async () => {' + code + '})();', sandbox, options)) as Promise<any>;
-    botLog.push('Success:', result);
+    const result = await executeBot(bot, sandbox);
+    botLog.push('Success');
+    if (result !== undefined) {
+      botLog.push(JSON.stringify(result, undefined, 2));
+    }
   } catch (error) {
     outcome = AuditEventOutcome.MinorFailure;
     botLog.push('Error:', (error as Error).message);
   }
 
-  await createSubscriptionEvent(subscription, resource, outcome, JSON.stringify(botLog, undefined, 2));
+  await createSubscriptionEvent(subscription, resource, outcome, botLog.join('\n'));
 }
 
 /**

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -365,13 +365,6 @@ export async function execBot(
   const [botOutcome, bot] = await systemRepo.readReference<Bot>({ reference: url });
   assertOk(botOutcome, bot);
 
-  // const botLog = [];
-
-  // const botConsole = {
-  //   ...console,
-  //   log: (...params: any[]) => botLog.push(params),
-  // };
-
   const botConsole = new MockConsole();
 
   const botRepo = new Repository({


### PR DESCRIPTION
We introduced new HTTP endpoints in the server project:

* `/Bot/{id}/$execute` to trigger bot by HTTP
* `/hl7/` for HL7 v2 over HTTP
* `/astm/` for ASTM messages

The initial implementation parsed the input and logged the values.

This PR adds support to execute bots configured for the endpoints.

