### PR TITLE
Add AuditEvents for Bot execute operations

### DIFF
--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -1,0 +1,10 @@
+/**
+ * AuditEvent outcome code.
+ * See: https://www.hl7.org/fhir/valueset-audit-event-outcome.html
+ */
+export enum AuditEventOutcome {
+  Success = '0',
+  MinorFailure = '4',
+  SeriousFailure = '8',
+  MajorFailure = '12',
+}

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -9,6 +9,7 @@ import { Repository, systemRepo } from '../fhir';
 import { executeBot } from '../fhir/operations/execute';
 import { matchesSearchRequest, parseSearchUrl } from '../fhir/search';
 import { logger } from '../logger';
+import { AuditEventOutcome } from '../util/auditevent';
 import { MockConsole } from '../util/console';
 
 /*
@@ -24,17 +25,6 @@ export interface SubscriptionJobData {
   readonly resourceType: string;
   readonly id: string;
   readonly versionId: string;
-}
-
-/**
- * AuditEvent outcome code.
- * See: https://www.hl7.org/fhir/valueset-audit-event-outcome.html
- */
-enum AuditEventOutcome {
-  Success = '0',
-  MinorFailure = '4',
-  SeriousFailure = '8',
-  MajorFailure = '12',
 }
 
 const queueName = 'SubscriptionQueue';


### PR DESCRIPTION
Before:  No user-facing logs or events when a Bot `$execute` operation

After:  Create a FHIR `AuditEvent` in the Bot timeline with the contents of all console.log() values.