### PR TITLE
Fixed an assortment of bugs in search parameter columns

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -445,7 +445,8 @@ export class MedplumClient extends EventTarget {
       SearchParameterList(base: "${encodeURIComponent(resourceType)}") {
         base,
         code,
-        type
+        type,
+        expression
       }
     }`.replace(/\s+/g, ' ');
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -241,6 +241,8 @@ describe('Core Utils', () => {
     expect(capitalize('Id')).toEqual('ID');
     expect(capitalize('foo')).toEqual('Foo');
     expect(capitalize('FOO')).toEqual('FOO');
+    expect(capitalize('你好')).toEqual('你好');
+    expect(capitalize('dinç')).toEqual('Dinç');
   });
 
   test('isLowerCase', () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -237,8 +237,8 @@ describe('Core Utils', () => {
   });
 
   test('Capitalize', () => {
-    expect(capitalize('id')).toEqual('ID');
-    expect(capitalize('Id')).toEqual('ID');
+    expect(capitalize('id')).toEqual('Id');
+    expect(capitalize('Id')).toEqual('Id');
     expect(capitalize('foo')).toEqual('Foo');
     expect(capitalize('FOO')).toEqual('FOO');
     expect(capitalize('你好')).toEqual('你好');

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -237,7 +237,10 @@ describe('Core Utils', () => {
   });
 
   test('Capitalize', () => {
+    expect(capitalize('id')).toEqual('ID');
+    expect(capitalize('Id')).toEqual('ID');
     expect(capitalize('foo')).toEqual('Foo');
+    expect(capitalize('FOO')).toEqual('FOO');
   });
 
   test('isLowerCase', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -242,9 +242,6 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
 }
 
 export function capitalize(word: string): string {
-  if (word.toLowerCase() === 'id') {
-    return 'ID';
-  }
   return word.charAt(0).toUpperCase() + word.substr(1);
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -242,6 +242,9 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
 }
 
 export function capitalize(word: string): string {
+  if (word.toLowerCase() === 'id') {
+    return 'ID';
+  }
   return word.charAt(0).toUpperCase() + word.substr(1);
 }
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -291,6 +291,9 @@ const routes: Record<string, Record<string, any>> = {
   'fhir/R4/Patient?_fields=id,_lastUpdated,name,birthDate,active,telecom,email,phone&_total=accurate': {
     GET: SimpsonSearchBundle,
   },
+  'fhir/R4/Patient?_fields=id,_lastUpdated,name,address-city,address-state&_total=accurate': {
+    GET: SimpsonSearchBundle,
+  },
   'fhir/R4/Patient?_fields=id,_lastUpdated,name&name=Simpson': {
     GET: SimpsonSearchBundle,
   },

--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -49,6 +49,15 @@ export const HomerSimpson: Patient = {
       value: 'chunkylover53@aol.com',
     },
   ],
+  address: [
+    {
+      use: 'home',
+      line: ['742 Evergreen Terrace'],
+      city: 'Springfield',
+      state: 'IL',
+      postalCode: '12345',
+    },
+  ],
 };
 
 export const HomerSimpsonHistory: Bundle<Patient> = {

--- a/packages/mock/src/mocks/types.ts
+++ b/packages/mock/src/mocks/types.ts
@@ -73,6 +73,24 @@ export const PatientSearchParameters: SearchParameter[] = [
     type: 'token',
     expression: "Patient.telecom.where(system='phone') | Practitioner.telecom.where(system='phone')",
   },
+  {
+    resourceType: 'SearchParameter',
+    id: 'individual-address-city',
+    base: ['Patient', 'Practitioner'],
+    code: 'address-city',
+    name: 'address-city',
+    type: 'token',
+    expression: 'Patient.address.city | Practitioner.address.city',
+  },
+  {
+    resourceType: 'SearchParameter',
+    id: 'individual-address-state',
+    base: ['Patient', 'Practitioner'],
+    code: 'address-state',
+    name: 'address-state',
+    type: 'token',
+    expression: 'Patient.address.state | Practitioner.address.state',
+  },
 ];
 
 export const GraphQLSchemaResponse = {

--- a/packages/server/src/fhir/graphql.ts
+++ b/packages/server/src/fhir/graphql.ts
@@ -229,6 +229,7 @@ async function resolveBySearch(
   const repo = ctx.res.locals.repo as Repository;
   const [outcome, bundle] = await repo.search({
     resourceType,
+    count: 100,
     filters: Object.entries(args).map(
       (e) =>
         ({

--- a/packages/ui/src/SearchControl.test.tsx
+++ b/packages/ui/src/SearchControl.test.tsx
@@ -197,6 +197,29 @@ describe('SearchControl', () => {
     expect(screen.getByText('555-7334 [home phone]')).toBeInTheDocument();
   });
 
+  test('Renders nested properties', async () => {
+    const props = {
+      search: {
+        resourceType: 'Patient',
+        fields: ['id', '_lastUpdated', 'name', 'address-city', 'address-state'],
+      },
+      onLoad: jest.fn(),
+    };
+
+    setup(props);
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('search-control'));
+    });
+
+    const control = screen.getByTestId('search-control');
+    expect(control).toBeDefined();
+    expect(props.onLoad).toBeCalled();
+
+    expect(screen.getByText('Springfield')).toBeInTheDocument();
+    expect(screen.getByText('IL')).toBeInTheDocument();
+  });
+
   test('Renders filters', async () => {
     const props = {
       search: {

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -301,7 +301,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
             )}
             {fields.map((field) => (
               <th key={field.name} onClick={(e) => handleSortClick(e, field.searchParam)}>
-                {buildFieldNameString(schema, resourceType, field.name)}
+                {buildFieldNameString(field.name)}
               </th>
             ))}
           </tr>

--- a/packages/ui/src/SearchControlField.ts
+++ b/packages/ui/src/SearchControlField.ts
@@ -111,7 +111,7 @@ function getFieldDefinition(
     searchParam = Object.values(typeSchema.searchParams).find((p) => p.expression?.includes(path));
   }
 
-  if (!elementDefinition && searchParam) {
+  if (!elementDefinition && searchParam?.expression) {
     // Try to find an element definition based on the search parameter
     // For example, name="email", try to find elementDefinition="telecom"
     const details = getSearchParameterDetails(schema, resourceType, searchParam);

--- a/packages/ui/src/SearchFilterEditor.test.tsx
+++ b/packages/ui/src/SearchFilterEditor.test.tsx
@@ -308,7 +308,7 @@ describe('SearchFilterEditor', () => {
       />
     );
 
-    expect(screen.getByText('not-a-code')).toBeInTheDocument();
+    expect(screen.getByText('Not A Code')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Edit'));

--- a/packages/ui/src/SearchFilterEditor.tsx
+++ b/packages/ui/src/SearchFilterEditor.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Dialog } from './Dialog';
 import { Input } from './Input';
-import { useMedplum } from './MedplumProvider';
 import { ReferenceInput } from './ReferenceInput';
 import { SearchFilterValueDisplay } from './SearchFilterValueDisplay';
 import {
@@ -114,12 +113,10 @@ interface FilterRowDisplayProps {
 }
 
 function FilterRowDisplay(props: FilterRowDisplayProps): JSX.Element | null {
-  const { resourceType, filter } = props;
-  const medplum = useMedplum();
-  const schema = medplum.getSchema();
+  const { filter } = props;
   return (
     <tr>
-      <td>{buildFieldNameString(schema, resourceType, filter.code)}</td>
+      <td>{buildFieldNameString(filter.code)}</td>
       <td>{getOpString(filter.operator)}</td>
       <td>
         <SearchFilterValueDisplay resourceType={props.resourceType} filter={filter} />
@@ -171,7 +168,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
           <option value=""></option>
           {Object.keys(props.searchParams).map((param) => (
             <option key={param} value={param}>
-              {param}
+              {buildFieldNameString(param)}
             </option>
           ))}
         </Select>

--- a/packages/ui/src/SearchPopupMenu.tsx
+++ b/packages/ui/src/SearchPopupMenu.tsx
@@ -144,8 +144,7 @@ export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null
    * @param {Operator} op The filter operation.
    */
   function prompt(op: Operator): void {
-    const caption = buildFieldNameString(props.schema, props.search.resourceType, code) + ' ' + getOpString(op) + '...';
-
+    const caption = buildFieldNameString(code) + ' ' + getOpString(op) + '...';
     const retVal = window.prompt(caption, '');
     if (retVal !== null) {
       onChange(addFilter(props.search, code, op, retVal, true));
@@ -170,12 +169,8 @@ export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null
       <MenuSeparator />
       <MenuItem onClick={() => clearFilters()}>Clear filters</MenuItem>
       {renderSubMenu()}
-      {paramType === 'string' && (
-        <>
-          <MenuSeparator />
-          <MenuItem onClick={() => prompt(Operator.CONTAINS)}>Search</MenuItem>
-        </>
-      )}
+      <MenuSeparator />
+      <MenuItem onClick={() => prompt(Operator.CONTAINS)}>Search</MenuItem>
     </Popup>
   );
 }

--- a/packages/ui/src/SearchUtils.test.tsx
+++ b/packages/ui/src/SearchUtils.test.tsx
@@ -1,4 +1,4 @@
-import { Filter, Operator, SearchRequest, TypeSchema } from '@medplum/core';
+import { Filter, Operator, SearchRequest } from '@medplum/core';
 import {
   addField,
   addFilter,
@@ -478,21 +478,11 @@ describe('SearchUtils', () => {
   });
 
   test('buildFieldName', () => {
-    expect(buildFieldNameString(undefined, 'Patient', 'id')).toBe('ID');
-    expect(buildFieldNameString(undefined, 'Patient', 'meta.versionId')).toBe('Version ID');
-    expect(buildFieldNameString(undefined, 'Patient', '_lastUpdated')).toBe('Last Updated');
-    expect(buildFieldNameString(undefined, 'Patient', 'name')).toBe('name');
-    expect(buildFieldNameString({ types: {} }, 'Patient', 'name')).toBe('name');
-    expect(buildFieldNameString({ types: { Patient: {} as TypeSchema } }, 'Patient', 'name')).toBe('name');
-    expect(
-      buildFieldNameString({ types: { Patient: { display: 'Patient', properties: {} } } }, 'Patient', 'name')
-    ).toBe('name');
-    expect(
-      buildFieldNameString(
-        { types: { Patient: { display: 'Patient', properties: { name: { path: 'Patient.name' } } } } },
-        'Patient',
-        'name'
-      )
-    ).toBe('Name');
+    expect(buildFieldNameString('id')).toBe('ID');
+    expect(buildFieldNameString('meta.versionId')).toBe('Version ID');
+    expect(buildFieldNameString('_lastUpdated')).toBe('Last Updated');
+    expect(buildFieldNameString('name')).toBe('Name');
+    expect(buildFieldNameString('birthDate')).toBe('Birth Date');
+    expect(buildFieldNameString('order-detail')).toBe('Order Detail');
   });
 });

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -462,6 +462,16 @@ export function buildFieldNameString(key: string): string {
     tmp = tmp.split('.').pop() as string;
   }
 
+  // Special case for ID
+  if (tmp === 'id') {
+    return 'ID';
+  }
+
+  // Special case for Version ID
+  if (tmp === 'versionId') {
+    return 'Version ID';
+  }
+
   // Remove choice of type
   tmp = tmp.replace('[x]', '');
 


### PR DESCRIPTION
This is a fast follow to the features implemented in https://github.com/medplum/medplum/pull/405

Bugs fixed:


* When using `<SearchControl>` with GraphQL, make sure that `SearchParameter.expression` is included in the GraphQL query
* Before, search parameters were displayed as the code (i.e., "name", "birthDate", "status", "order-detail").  Now there is unified logic for making column identifiers human readable ("name"->"Name", "birthDate"->"Birth Date", "order-detail"->"Order Detail").  This logic handles camelCase, dash-case, choice of type (i.e. "value[x]"), nested types (i.e., "Patient.address.city"), etc.
* Added search parameters to the list of available fields in the Field editor
* De-duped items in the Field editor, both by key and display title (i.e., "generalPractitioner" and "general-practitioner" are detected as being the same thing)

