### PR TITLE
Reset the page number after changing search filters

### DIFF
--- a/packages/ui/src/SearchUtils.test.tsx
+++ b/packages/ui/src/SearchUtils.test.tsx
@@ -25,6 +25,7 @@ describe('SearchUtils', () => {
   test('Set filters', () => {
     const original: SearchRequest = {
       resourceType: 'Patient',
+      page: 2,
       filters: [
         {
           code: 'name',
@@ -43,6 +44,7 @@ describe('SearchUtils', () => {
     const result = setFilters(original, filters);
     expect(result.filters?.length).toBe(1);
     expect(result.filters?.[0].value).toBe('alice');
+    expect(result.page).toBe(0);
   });
 
   test('Clear filters', () => {

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -79,6 +79,7 @@ export function setFilters(definition: SearchRequest, filters: Filter[]): Search
   return {
     ...definition,
     filters: filters,
+    page: 0,
     name: undefined,
   };
 }


### PR DESCRIPTION
Before:  If you were looking at page 2 or higher in search results, and you added a filter, you would stay on page 2, even though the results changed.  Worse, if there was only 1 page of results, the user interface would incorrectly look like there were no results.

After:  If the user changes the search filters, the page is always reset to the first page.

