### PR TITLE
Fixes #413 - Replaced window.prompt with dialog

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -446,7 +446,8 @@ export class MedplumClient extends EventTarget {
         base,
         code,
         type,
-        expression
+        expression,
+        target
       }
     }`.replace(/\s+/g, ' ');
 

--- a/packages/mock/src/mocks/types.ts
+++ b/packages/mock/src/mocks/types.ts
@@ -84,6 +84,15 @@ export const PatientSearchParameters: SearchParameter[] = [
     type: 'token',
     expression: 'Patient.address.state | Practitioner.address.state',
   },
+  {
+    resourceType: 'SearchParameter',
+    id: 'ServiceRequest-subject',
+    code: 'subject',
+    base: ['ServiceRequest'],
+    type: 'reference',
+    expression: 'ServiceRequest.subject',
+    target: ['Group', 'Device', 'Patient', 'Location'],
+  },
 ];
 
 export const GraphQLSchemaResponse = {

--- a/packages/mock/src/repo.ts
+++ b/packages/mock/src/repo.ts
@@ -112,6 +112,6 @@ export function matchesSearchRequest(resource: Resource, searchRequest: SearchRe
 function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, filter: Filter): boolean {
   const expression = filter.code.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
   const values = evalFhirPath(expression as string, resource);
-  const result = values.some((value) => JSON.stringify(value).includes(filter.value));
+  const result = values.some((value) => JSON.stringify(value).toLowerCase().includes(filter.value.toLowerCase()));
   return filter.operator === Operator.NOT_EQUALS ? !result : result;
 }

--- a/packages/ui/src/Autocomplete.css
+++ b/packages/ui/src/Autocomplete.css
@@ -10,6 +10,7 @@
   line-height: 28px;
   width: 100%;
   max-width: 400px;
+  text-align: left;
 }
 
 .medplum-autocomplete-container.focused {

--- a/packages/ui/src/Popup.css
+++ b/packages/ui/src/Popup.css
@@ -4,7 +4,7 @@
   cursor: default;
   margin: 0;
   outline: none;
-  z-index: 20000;
+  z-index: 11;
   border-radius: 0;
   box-shadow: 0 2px 4px var(--medplum-shadow);
   transition: opacity 0.2s;
@@ -14,7 +14,7 @@
 .medplum-backdrop {
   position: absolute;
   overflow: hidden;
-  z-index: 30;
+  z-index: 10;
   top: 50px;
   left: 0;
   bottom: 0;

--- a/packages/ui/src/QuestionnaireForm.tsx
+++ b/packages/ui/src/QuestionnaireForm.tsx
@@ -6,7 +6,6 @@ import {
   ProfileResource,
 } from '@medplum/core';
 import {
-  ElementDefinition,
   Questionnaire,
   QuestionnaireItem,
   QuestionnaireItemAnswerOption,
@@ -151,8 +150,6 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
   }
 
   const initial = item.initial && item.initial.length > 0 ? item.initial[0] : undefined;
-
-  const property: ElementDefinition = {} as ElementDefinition;
 
   function onChangeItem(newResponseItems: QuestionnaireResponseItem[]): void {
     props.onChange({
@@ -308,7 +305,6 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
     case QuestionnaireItemType.reference:
       return (
         <ReferenceInput
-          property={property}
           name={name}
           defaultValue={initial?.valueReference}
           onChange={(newValue) => onChangeAnswer({ valueReference: newValue })}

--- a/packages/ui/src/ReferenceInput.test.tsx
+++ b/packages/ui/src/ReferenceInput.test.tsx
@@ -29,7 +29,6 @@ describe('ReferenceInput', () => {
   test('Renders empty property', () => {
     setup({
       name: 'foo',
-      property: {},
     });
     expect(screen.getByTestId('reference-input-resource-type-input')).toBeInTheDocument();
   });
@@ -38,7 +37,6 @@ describe('ReferenceInput', () => {
     await act(async () => {
       setup({
         name: 'foo',
-        property: {},
         defaultValue: {
           reference: 'Patient/123',
         },
@@ -51,13 +49,6 @@ describe('ReferenceInput', () => {
   test('Change resource type without target types', async () => {
     setup({
       name: 'foo',
-      property: {
-        type: [
-          {
-            code: 'subject',
-          },
-        ],
-      },
     });
 
     await act(async () => {
@@ -72,14 +63,7 @@ describe('ReferenceInput', () => {
   test('Renders property with target types', () => {
     setup({
       name: 'foo',
-      property: {
-        type: [
-          {
-            code: 'subject',
-            targetProfile: ['Patient', 'Practitioner'],
-          },
-        ],
-      },
+      targetTypes: ['Patient', 'Practitioner'],
     });
     expect(screen.getByTestId('reference-input-resource-type-select')).toBeInTheDocument();
   });
@@ -87,14 +71,7 @@ describe('ReferenceInput', () => {
   test('Change resource type with target types', async () => {
     setup({
       name: 'foo',
-      property: {
-        type: [
-          {
-            code: 'subject',
-            targetProfile: ['Patient', 'Practitioner'],
-          },
-        ],
-      },
+      targetTypes: ['Patient', 'Practitioner'],
     });
 
     await act(async () => {
@@ -109,14 +86,7 @@ describe('ReferenceInput', () => {
   test('Use autocomplete', async () => {
     setup({
       name: 'foo',
-      property: {
-        type: [
-          {
-            code: 'subject',
-            targetProfile: ['Patient', 'Practitioner'],
-          },
-        ],
-      },
+      targetTypes: ['Patient', 'Practitioner'],
     });
 
     // Select "Patient" resource type
@@ -150,14 +120,7 @@ describe('ReferenceInput', () => {
 
     setup({
       name: 'foo',
-      property: {
-        type: [
-          {
-            code: 'subject',
-            targetProfile: ['Patient', 'Practitioner'],
-          },
-        ],
-      },
+      targetTypes: ['Patient', 'Practitioner'],
       onChange,
     });
 

--- a/packages/ui/src/ReferenceInput.tsx
+++ b/packages/ui/src/ReferenceInput.tsx
@@ -1,5 +1,5 @@
 import { createReference } from '@medplum/core';
-import { ElementDefinition, Reference, Resource } from '@medplum/fhirtypes';
+import { Reference, Resource } from '@medplum/fhirtypes';
 import React, { useRef, useState } from 'react';
 import { Input } from './Input';
 import { InputRow } from './InputRow';
@@ -7,14 +7,14 @@ import { ResourceInput } from './ResourceInput';
 import { Select } from './Select';
 
 export interface ReferenceInputProps {
-  property?: ElementDefinition;
   name: string;
   defaultValue?: Reference;
+  targetTypes?: string[];
   onChange?: (value: Reference | undefined) => void;
 }
 
 export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
-  const targetTypes = getTargetTypes(props.property);
+  const targetTypes = props.targetTypes;
   const initialResourceType = getInitialResourceType(props.defaultValue, targetTypes);
   const [value, setValue] = useState<Reference | undefined>(props.defaultValue);
   const [resourceType, setResourceType] = useState<string | undefined>(initialResourceType);
@@ -45,22 +45,16 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
       ) : (
         <Input testid="reference-input-resource-type-input" defaultValue={resourceType} onChange={setResourceType} />
       )}
-      {resourceType && (
-        <ResourceInput
-          resourceType={resourceType}
-          name={props.name + '-id'}
-          defaultValue={value}
-          onChange={(item: Resource | undefined) => {
-            setValueHelper(item ? createReference(item) : undefined);
-          }}
-        />
-      )}
+      <ResourceInput
+        resourceType={resourceType as string}
+        name={props.name + '-id'}
+        defaultValue={value}
+        onChange={(item: Resource | undefined) => {
+          setValueHelper(item ? createReference(item) : undefined);
+        }}
+      />
     </InputRow>
   );
-}
-
-function getTargetTypes(property?: ElementDefinition): string[] | undefined {
-  return property?.type?.[0]?.targetProfile?.map((p) => p.split('/').pop() as string);
 }
 
 function getInitialResourceType(

--- a/packages/ui/src/ResourcePropertyInput.tsx
+++ b/packages/ui/src/ResourcePropertyInput.tsx
@@ -227,7 +227,14 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
     case PropertyType.Ratio:
       return <RatioInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Reference:
-      return <ReferenceInput property={property} name={name} defaultValue={value} onChange={props.onChange} />;
+      return (
+        <ReferenceInput
+          name={name}
+          defaultValue={value}
+          targetTypes={getTargetTypes(property)}
+          onChange={props.onChange}
+        />
+      );
     default:
       return (
         <BackboneElementInput
@@ -240,4 +247,8 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
         />
       );
   }
+}
+
+function getTargetTypes(property?: ElementDefinition): string[] | undefined {
+  return property?.type?.[0]?.targetProfile?.map((p) => p.split('/').pop() as string);
 }

--- a/packages/ui/src/SearchControl.test.tsx
+++ b/packages/ui/src/SearchControl.test.tsx
@@ -459,36 +459,6 @@ describe('SearchControl', () => {
     expect(props.onAuxClick).toBeCalled();
   });
 
-  test('Open field editor', async () => {
-    const props = {
-      search: {
-        resourceType: 'Patient',
-        filters: [
-          {
-            code: 'name',
-            operator: Operator.EQUALS,
-            value: 'Simpson',
-          },
-        ],
-      },
-      onLoad: jest.fn(),
-    };
-
-    setup(props);
-
-    await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('fields-button'));
-    });
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
-  });
-
   test('Field editor onOk', async () => {
     const props = {
       search: {
@@ -557,7 +527,7 @@ describe('SearchControl', () => {
     });
   });
 
-  test('Open filter editor', async () => {
+  test('Filter editor onOk', async () => {
     const props = {
       search: {
         resourceType: 'Patient',
@@ -582,9 +552,88 @@ describe('SearchControl', () => {
       fireEvent.click(screen.getByTestId('filters-button'));
     });
 
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('dialog-ok'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('dialog-ok'));
+    });
+  });
+
+  test('Filter editor onCancel', async () => {
+    const props = {
+      search: {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: 'Simpson',
+          },
+        ],
+      },
+      onLoad: jest.fn(),
+    };
+
+    setup(props);
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('search-control'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('filters-button'));
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('dialog-cancel'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('dialog-cancel'));
+    });
+  });
+
+  test('Popup menu and prompt', async () => {
+    const props = {
+      search: {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: 'Simpson',
+          },
+        ],
+        fields: ['id', 'name'],
+      },
+      onLoad: jest.fn(),
+    };
+
+    setup(props);
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('search-control'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Name'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Search'));
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('filter-value'), {
+        target: { value: 'Washington' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('dialog-ok'));
+    });
   });
 
   test('Click all checkbox', async () => {

--- a/packages/ui/src/SearchFilterEditor.tsx
+++ b/packages/ui/src/SearchFilterEditor.tsx
@@ -1,11 +1,10 @@
 import { Filter, IndexedStructureDefinition, Operator, SearchRequest, stringify } from '@medplum/core';
-import { Reference, SearchParameter } from '@medplum/fhirtypes';
+import { SearchParameter } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Dialog } from './Dialog';
-import { Input } from './Input';
-import { ReferenceInput } from './ReferenceInput';
 import { SearchFilterValueDisplay } from './SearchFilterValueDisplay';
+import { SearchFilterValueInput } from './SearchFilterValueInput';
 import {
   addFilter,
   buildFieldNameString,
@@ -191,7 +190,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       </td>
       <td>
         {searchParam && value.operator && (
-          <FilterValueInput searchParam={searchParam} defaultValue={value.value} onChange={setFilterValue} />
+          <SearchFilterValueInput searchParam={searchParam} defaultValue={value.value} onChange={setFilterValue} />
         )}
       </td>
       <td>
@@ -214,37 +213,4 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       </td>
     </tr>
   );
-}
-
-interface FilterValueInputProps {
-  searchParam: SearchParameter;
-  defaultValue: string;
-  onChange: (value: string) => void;
-}
-
-function FilterValueInput(props: FilterValueInputProps): JSX.Element | null {
-  if (props.searchParam.type === 'reference') {
-    return (
-      <ReferenceInput
-        name="reference"
-        defaultValue={{ reference: props.defaultValue }}
-        onChange={(newReference: Reference | undefined) => {
-          if (newReference) {
-            props.onChange(newReference.reference as string);
-          } else {
-            props.onChange('');
-          }
-        }}
-      />
-    );
-  }
-
-  const inputTypes: Record<string, React.HTMLInputTypeAttribute> = {
-    numeric: 'number',
-    date: 'date',
-    datetime: 'datetime-local',
-  };
-
-  const inputType = inputTypes[props.searchParam.type as string] ?? 'text';
-  return <Input testid="filter-value" type={inputType} defaultValue={props.defaultValue} onChange={props.onChange} />;
 }

--- a/packages/ui/src/SearchFilterValueDialog.tsx
+++ b/packages/ui/src/SearchFilterValueDialog.tsx
@@ -1,0 +1,36 @@
+import { Filter } from '@medplum/core';
+import { SearchParameter } from '@medplum/fhirtypes';
+import React, { useState } from 'react';
+import { Dialog } from './Dialog';
+import { SearchFilterValueInput } from './SearchFilterValueInput';
+
+export interface SearchFilterValueDialogProps {
+  title: string;
+  visible: boolean;
+  searchParam?: SearchParameter;
+  filter?: Filter;
+  defaultValue?: string;
+  onOk: (filter: Filter) => void;
+  onCancel: () => void;
+}
+
+export function SearchFilterValueDialog(props: SearchFilterValueDialogProps): JSX.Element | null {
+  const [value, setValue] = useState<string>(props.defaultValue ?? '');
+
+  if (!props.visible || !props.searchParam || !props.filter) {
+    return null;
+  }
+
+  return (
+    <Dialog
+      title={props.title}
+      visible={props.visible}
+      onOk={() => props.onOk({ ...(props.filter as Filter), value })}
+      onCancel={props.onCancel}
+    >
+      <div style={{ width: 500 }}>
+        <SearchFilterValueInput searchParam={props.searchParam} defaultValue={value} onChange={setValue} />
+      </div>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/SearchFilterValueDisplay.tsx
+++ b/packages/ui/src/SearchFilterValueDisplay.tsx
@@ -2,7 +2,7 @@ import { Filter } from '@medplum/core';
 import React from 'react';
 import { DateTimeDisplay } from './DateTimeDisplay';
 import { useMedplum } from './MedplumProvider';
-import { ResourceBadge } from './ResourceBadge';
+import { ResourceName } from './ResourceName';
 
 export interface SearchFilterValueDisplayProps {
   readonly resourceType: string;
@@ -16,7 +16,7 @@ export function SearchFilterValueDisplay(props: SearchFilterValueDisplayProps): 
 
   const filter = props.filter;
   if (searchParam?.type === 'reference') {
-    return <ResourceBadge value={{ reference: filter.value }} />;
+    return <ResourceName value={{ reference: filter.value }} />;
   }
 
   if (props.filter.code === '_lastUpdated' || searchParam?.type === 'datetime') {

--- a/packages/ui/src/SearchFilterValueInput.tsx
+++ b/packages/ui/src/SearchFilterValueInput.tsx
@@ -1,0 +1,38 @@
+import { Reference, SearchParameter } from '@medplum/fhirtypes';
+import React from 'react';
+import { Input } from './Input';
+import { ReferenceInput } from './ReferenceInput';
+
+export interface SearchFilterValueInputProps {
+  searchParam: SearchParameter;
+  defaultValue?: string;
+  onChange: (value: string) => void;
+}
+
+export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.Element | null {
+  if (props.searchParam.type === 'reference') {
+    return (
+      <ReferenceInput
+        name="reference"
+        defaultValue={{ reference: props.defaultValue }}
+        targetTypes={props.searchParam?.target}
+        onChange={(newReference: Reference | undefined) => {
+          if (newReference) {
+            props.onChange(newReference.reference as string);
+          } else {
+            props.onChange('');
+          }
+        }}
+      />
+    );
+  }
+
+  const inputTypes: Record<string, React.HTMLInputTypeAttribute> = {
+    numeric: 'number',
+    date: 'date',
+    datetime: 'datetime-local',
+  };
+
+  const inputType = inputTypes[props.searchParam.type as string] ?? 'text';
+  return <Input testid="filter-value" type={inputType} defaultValue={props.defaultValue} onChange={props.onChange} />;
+}

--- a/packages/ui/src/SearchPopupMenu.test.tsx
+++ b/packages/ui/src/SearchPopupMenu.test.tsx
@@ -60,7 +60,18 @@ const schema: IndexedStructureDefinition = {
 const medplum = new MockClient();
 
 describe('SearchPopupMenu', () => {
-  function setup(props: SearchPopupMenuProps): void {
+  function setup(partialProps: Partial<SearchPopupMenuProps>): void {
+    const props = {
+      schema,
+      visible: true,
+      x: 0,
+      y: 0,
+      onPrompt: jest.fn(),
+      onChange: jest.fn(),
+      onClose: jest.fn(),
+      ...partialProps,
+    } as SearchPopupMenuProps;
+
     render(
       <MemoryRouter>
         <MedplumProvider medplum={medplum}>
@@ -72,37 +83,22 @@ describe('SearchPopupMenu', () => {
 
   test('Invalid resource', () => {
     setup({
-      schema,
       search: { resourceType: 'xyz' },
-      visible: true,
-      x: 0,
-      y: 0,
-      onClose: jest.fn(),
     });
   });
 
   test('Invalid property', () => {
     setup({
-      schema,
       search: { resourceType: 'Patient' },
-      visible: true,
-      x: 0,
-      y: 0,
-      onClose: jest.fn(),
     });
   });
 
   test('Renders name field', () => {
     setup({
-      schema,
       search: {
         resourceType: 'Patient',
       },
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Patient']?.searchParams?.['name'],
-      onClose: jest.fn(),
     });
 
     expect(screen.getByText('Equals...')).toBeDefined();
@@ -110,15 +106,10 @@ describe('SearchPopupMenu', () => {
 
   test('Renders date field', () => {
     setup({
-      schema,
       search: {
         resourceType: 'Patient',
       },
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
-      onClose: jest.fn(),
     });
 
     expect(screen.getByText('Before...')).toBeDefined();
@@ -127,15 +118,10 @@ describe('SearchPopupMenu', () => {
 
   test('Renders date field submenu', async () => {
     setup({
-      schema,
       search: {
         resourceType: 'Patient',
       },
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
-      onClose: jest.fn(),
     });
 
     expect(screen.getByText('Before...')).toBeDefined();
@@ -154,15 +140,10 @@ describe('SearchPopupMenu', () => {
 
   test('Renders numeric field', () => {
     setup({
-      schema,
       search: {
         resourceType: 'Observation',
       },
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Observation']?.searchParams?.['value-quantity'],
-      onClose: jest.fn(),
     });
 
     expect(screen.getByText('Sort Largest to Smallest')).toBeDefined();
@@ -175,14 +156,9 @@ describe('SearchPopupMenu', () => {
     };
 
     setup({
-      schema,
       search: currSearch,
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
       onChange: (e) => (currSearch = e),
-      onClose: jest.fn(),
     });
 
     await act(async () => {
@@ -217,14 +193,9 @@ describe('SearchPopupMenu', () => {
     };
 
     setup({
-      schema,
       search: currSearch,
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Patient']?.searchParams?.['name'],
       onChange: (e) => (currSearch = e),
-      onClose: jest.fn(),
     });
 
     await act(async () => {
@@ -235,21 +206,14 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Text submenu prompt', async () => {
-    window.prompt = jest.fn().mockImplementation(() => 'xyz');
-
-    let currSearch: SearchRequest = {
-      resourceType: 'Patient',
-    };
+    const onPrompt = jest.fn();
 
     setup({
-      schema,
-      search: currSearch,
-      visible: true,
-      x: 0,
-      y: 0,
+      search: {
+        resourceType: 'Patient',
+      },
       searchParam: schema.types['Patient']?.searchParams?.['name'],
-      onChange: (e) => (currSearch = e),
-      onClose: jest.fn(),
+      onPrompt,
     });
 
     const options = [
@@ -260,67 +224,51 @@ describe('SearchPopupMenu', () => {
     ];
 
     for (const option of options) {
+      onPrompt.mockClear();
+
       await act(async () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(currSearch.filters).toBeDefined();
-      expect(currSearch.filters?.length).toEqual(1);
-      expect(currSearch.filters?.[0]).toMatchObject({
+      expect(onPrompt).toBeCalledWith({
         code: 'name',
         operator: option.operator,
-        value: 'xyz',
+        value: '',
       } as Filter);
     }
   });
 
   test('Text search prompt', async () => {
-    window.prompt = jest.fn().mockImplementation(() => 'xyz');
-
-    let currSearch: SearchRequest = {
-      resourceType: 'Patient',
-    };
+    const onPrompt = jest.fn();
 
     setup({
-      schema,
-      search: currSearch,
-      visible: true,
-      x: 0,
-      y: 0,
+      search: {
+        resourceType: 'Patient',
+      },
       searchParam: schema.types['Patient']?.searchParams?.['name'],
-      onChange: (e) => (currSearch = e),
-      onClose: jest.fn(),
+      onPrompt,
     });
 
     await act(async () => {
       fireEvent.click(screen.getByText('Search'));
     });
 
-    expect(currSearch.filters).toBeDefined();
-    expect(currSearch.filters?.length).toEqual(1);
-    expect(currSearch.filters?.[0]).toMatchObject({
+    expect(onPrompt).toBeCalledWith({
       code: 'name',
       operator: Operator.CONTAINS,
-      value: 'xyz',
+      value: '',
     } as Filter);
   });
 
   test('Date submenu prompt', async () => {
-    window.prompt = jest.fn().mockImplementation(() => 'xyz');
-
-    let currSearch: SearchRequest = {
-      resourceType: 'Patient',
-    };
+    const onPrompt = jest.fn();
 
     setup({
-      schema,
-      search: currSearch,
-      visible: true,
-      x: 0,
-      y: 0,
+      search: {
+        resourceType: 'Patient',
+      },
       searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
-      onChange: (e) => (currSearch = e),
-      onClose: jest.fn(),
+      onPrompt,
     });
 
     const options = [
@@ -334,36 +282,29 @@ describe('SearchPopupMenu', () => {
     ];
 
     for (const option of options) {
+      onPrompt.mockClear();
+
       await act(async () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(currSearch.filters).toBeDefined();
-      expect(currSearch.filters?.length).toEqual(1);
-      expect(currSearch.filters?.[0]).toMatchObject({
+      expect(onPrompt).toBeCalledWith({
         code: 'birthdate',
         operator: option.operator,
-        value: 'xyz',
+        value: '',
       } as Filter);
     }
   });
 
   test('Date shortcuts', async () => {
-    window.prompt = jest.fn().mockImplementation(() => 'xyz');
-
     let currSearch: SearchRequest = {
       resourceType: 'Patient',
     };
 
     setup({
-      schema,
       search: currSearch,
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
       onChange: (e) => (currSearch = e),
-      onClose: jest.fn(),
     });
 
     const options = ['Tomorrow', 'Today', 'Yesterday', 'Next Month', 'This Month', 'Last Month', 'Year to date'];
@@ -396,13 +337,8 @@ describe('SearchPopupMenu', () => {
     const fields = getFieldDefinitions(schema, search);
 
     setup({
-      schema,
       search,
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: fields[0].searchParam,
-      onClose: jest.fn(),
     });
 
     expect(screen.getByText('Equals...')).toBeDefined();
@@ -417,15 +353,10 @@ describe('SearchPopupMenu', () => {
     const fields = getFieldDefinitions(schema, search);
 
     setup({
-      schema,
       search: {
         resourceType: 'Patient',
       },
-      visible: true,
-      x: 0,
-      y: 0,
       searchParam: fields[0].searchParam,
-      onClose: jest.fn(),
     });
 
     expect(screen.getByText('Before...')).toBeDefined();

--- a/packages/ui/src/SearchPopupMenu.tsx
+++ b/packages/ui/src/SearchPopupMenu.tsx
@@ -1,11 +1,10 @@
-import { IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
+import { Filter, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import React from 'react';
 import { MenuItem } from './MenuItem';
 import { MenuSeparator } from './MenuSeparator';
 import { Popup } from './Popup';
 import {
-  addFilter,
   addLastMonthFilter,
   addNextMonthFilter,
   addThisMonthFilter,
@@ -13,9 +12,7 @@ import {
   addTomorrowFilter,
   addYearToDateFilter,
   addYesterdayFilter,
-  buildFieldNameString,
   clearFiltersOnField,
-  getOpString,
   setSort,
 } from './SearchUtils';
 import { SubMenu } from './SubMenu';
@@ -27,7 +24,8 @@ export interface SearchPopupMenuProps {
   x: number;
   y: number;
   searchParam?: SearchParameter;
-  onChange?: (definition: SearchRequest) => void;
+  onPrompt: (filter: Filter) => void;
+  onChange: (definition: SearchRequest) => void;
   onClose: () => void;
 }
 
@@ -143,12 +141,8 @@ export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null
    *
    * @param {Operator} op The filter operation.
    */
-  function prompt(op: Operator): void {
-    const caption = buildFieldNameString(code) + ' ' + getOpString(op) + '...';
-    const retVal = window.prompt(caption, '');
-    if (retVal !== null) {
-      onChange(addFilter(props.search, code, op, retVal, true));
-    }
+  function prompt(operator: Operator): void {
+    props.onPrompt({ code, operator, value: '' });
   }
 
   function onChange(definition: SearchRequest): void {
@@ -170,7 +164,9 @@ export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null
       <MenuItem onClick={() => clearFilters()}>Clear filters</MenuItem>
       {renderSubMenu()}
       <MenuSeparator />
-      <MenuItem onClick={() => prompt(Operator.CONTAINS)}>Search</MenuItem>
+      <MenuItem onClick={() => prompt(props.searchParam?.type === 'reference' ? Operator.EQUALS : Operator.CONTAINS)}>
+        Search
+      </MenuItem>
     </Popup>
   );
 }

--- a/packages/ui/src/stories/ReferenceInput.stories.tsx
+++ b/packages/ui/src/stories/ReferenceInput.stories.tsx
@@ -10,31 +10,12 @@ export default {
 
 export const TargetProfile = (): JSX.Element => (
   <Document>
-    <ReferenceInput
-      name="foo"
-      property={{
-        type: [
-          {
-            code: 'reference',
-            targetProfile: ['Practitioner', 'Patient'],
-          },
-        ],
-      }}
-    />
+    <ReferenceInput name="foo" targetTypes={['Practitioner', 'Patient']} />
   </Document>
 );
 
 export const FreeText = (): JSX.Element => (
   <Document>
-    <ReferenceInput
-      name="foo"
-      property={{
-        type: [
-          {
-            code: 'reference',
-          },
-        ],
-      }}
-    />
+    <ReferenceInput name="foo" />
   </Document>
 );

--- a/packages/ui/src/useResource.ts
+++ b/packages/ui/src/useResource.ts
@@ -26,7 +26,7 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
   useEffect(() => {
     let subscribed = true;
 
-    if (!resource && value && 'reference' in value) {
+    if (!resource && value && 'reference' in value && value.reference) {
       medplum.readCachedReference(value as Reference<T>).then((r) => {
         if (subscribed) {
           setResource(r);


### PR DESCRIPTION
Before:  When prompting the user for a search value, we used `windows.prompt`, which is an extremely simplistic way to capture input.  It was broken for structured input, such as references to other entities.

https://user-images.githubusercontent.com/749094/158935941-9b2ae5be-07a6-4532-a758-a58087d23763.mp4

After:  We use an in-app dialog which uses our React components to capture input.  It uses the same React component as the Filter dialog, so it is aware of the filter type.  For example, if it is a string column, it will prompt for text; if it is a date column, it will prompt for a date, etc.

https://user-images.githubusercontent.com/749094/158936281-ae24b28f-54ee-4da3-b664-5a5724ba3e4f.mp4


