### PR TITLE
Fixed remove property bug

### DIFF
--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference } from '@medplum/core';
+import { assertOk, createReference, Operator } from '@medplum/core';
 import { AccessPolicy, ClientApplication, Observation, Patient, ServiceRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../config';
@@ -546,6 +546,78 @@ describe('AccessPolicy', () => {
       birthDate: '1970-01-01',
       active: true,
     });
+  });
+
+  test('Try to remove readonly property', async () => {
+    const value = randomUUID();
+
+    // Create a patient with an identifier
+    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Identifier'], family: 'Test' }],
+      identifier: [{ system: 'https://example.com/', value }],
+    });
+    assertOk(outcome1, patient1);
+
+    // Search for patient by identifier
+    // This should succeed
+    const [outcome2, bundle1] = await systemRepo.search<Patient>({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'identifier',
+          operator: Operator.EQUALS,
+          value,
+        },
+      ],
+    });
+    assertOk(outcome2, bundle1);
+    expect(bundle1.entry?.length).toEqual(1);
+
+    // Create AccessPolicy with Patient.identifier readonly
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Patient',
+          readonlyFields: ['identifier'],
+        },
+      ],
+    };
+
+    const repo2 = new Repository({
+      author: {
+        reference: 'Practitioner/123',
+      },
+      accessPolicy,
+    });
+
+    const { identifier, ...rest } = patient1;
+    expect(identifier).toBeDefined();
+    expect((rest as Patient).identifier).toBeUndefined();
+
+    // Try to update the patient without the identifier
+    // Effectively, try to remove the identifier
+    // This returns success, but the identifier should still be there
+    const [outcome3, patient2] = await repo2.updateResource<Patient>(rest);
+    assertOk(outcome3, patient2);
+    expect(patient2.identifier).toBeDefined();
+    expect(patient2.identifier?.[0]?.value).toEqual(value);
+
+    // Try to search for the identifier
+    // This should still return the result succeed
+    const [outcome4, bundle2] = await repo2.search<Patient>({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'identifier',
+          operator: Operator.EQUALS,
+          value,
+        },
+      ],
+    });
+    assertOk(outcome4, bundle2);
+    expect(bundle2.entry?.length).toEqual(1);
   });
 
   test('Hidden fields on read', async () => {

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -548,6 +548,90 @@ describe('AccessPolicy', () => {
     });
   });
 
+  test('Try to create with readonly property', async () => {
+    const value = randomUUID();
+
+    // AccessPolicy with Patient.identifier readonly
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Patient',
+          readonlyFields: ['identifier'],
+        },
+      ],
+    };
+
+    const repo = new Repository({
+      author: {
+        reference: 'Practitioner/123',
+      },
+      accessPolicy,
+    });
+
+    // Create a patient with an identifier
+    const [outcome, patient] = await repo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Identifier'], family: 'Test' }],
+      identifier: [{ system: 'https://example.com/', value }],
+    });
+    assertOk(outcome, patient);
+    expect(patient.identifier).toBeUndefined();
+  });
+
+  test('Try to add readonly property', async () => {
+    const value = randomUUID();
+
+    // Create a patient
+    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: ['Identifier'], family: 'Test' }],
+    });
+    assertOk(outcome1, patient1);
+
+    // AccessPolicy with Patient.identifier readonly
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Patient',
+          readonlyFields: ['identifier'],
+        },
+      ],
+    };
+
+    const repo = new Repository({
+      author: {
+        reference: 'Practitioner/123',
+      },
+      accessPolicy,
+    });
+
+    // Try to add an identifier
+    // This returns success, but the result should not have an identifier
+    const [outcome3, patient2] = await repo.updateResource<Patient>({
+      ...patient1,
+      identifier: [{ system: 'https://example.com/', value }],
+    });
+    assertOk(outcome3, patient2);
+    expect(patient2.identifier).toBeUndefined();
+
+    // Try to search for the identifier
+    // This should still return the result succeed
+    const [outcome4, bundle2] = await repo.search<Patient>({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'identifier',
+          operator: Operator.EQUALS,
+          value,
+        },
+      ],
+    });
+    assertOk(outcome4, bundle2);
+    expect(bundle2.entry?.length).toEqual(0);
+  });
+
   test('Try to remove readonly property', async () => {
     const value = randomUUID();
 
@@ -574,7 +658,7 @@ describe('AccessPolicy', () => {
     assertOk(outcome2, bundle1);
     expect(bundle1.entry?.length).toEqual(1);
 
-    // Create AccessPolicy with Patient.identifier readonly
+    // AccessPolicy with Patient.identifier readonly
     const accessPolicy: AccessPolicy = {
       resourceType: 'AccessPolicy',
       resource: [
@@ -585,7 +669,7 @@ describe('AccessPolicy', () => {
       ],
     };
 
-    const repo2 = new Repository({
+    const repo = new Repository({
       author: {
         reference: 'Practitioner/123',
       },
@@ -599,14 +683,14 @@ describe('AccessPolicy', () => {
     // Try to update the patient without the identifier
     // Effectively, try to remove the identifier
     // This returns success, but the identifier should still be there
-    const [outcome3, patient2] = await repo2.updateResource<Patient>(rest);
+    const [outcome3, patient2] = await repo.updateResource<Patient>(rest);
     assertOk(outcome3, patient2);
     expect(patient2.identifier).toBeDefined();
     expect(patient2.identifier?.[0]?.value).toEqual(value);
 
     // Try to search for the identifier
     // This should still return the result succeed
-    const [outcome4, bundle2] = await repo2.search<Patient>({
+    const [outcome4, bundle2] = await repo.search<Patient>({
       resourceType: 'Patient',
       filters: [
         {

--- a/packages/server/src/fhir/lookups/identifier.ts
+++ b/packages/server/src/fhir/lookups/identifier.ts
@@ -43,11 +43,7 @@ export class IdentifierTable extends LookupTable<Identifier> {
    * @returns Promise on completion.
    */
   async indexResource(resource: Resource): Promise<void> {
-    if (!('identifier' in resource)) {
-      return;
-    }
-
-    const identifiers = resource.identifier as Identifier[];
+    const identifiers = (resource as any).identifier ?? [];
     const resourceId = resource.id as string;
     const existing = await this.getExistingValues(resourceId);
 


### PR DESCRIPTION
Before: An HTTP PUT operation would attempt a "merge" operation rather than an "overwrite" operation.

https://www.hl7.org/fhir/http.html#update

> Note that update generally updates the whole content of the resource. For partial updates, see [patch](https://www.hl7.org/fhir/http.html#patch) below.

After:  An HTTP PUT operation updates the entire content (aside from meta).

That change by itself would be simple, but it created some complexity with regards to how we handle access controls for "readonly" properties.

To be clear, this is a possibly breaking change.  To the best of my knowledge, no current consumers rely on this behavior.