### PR TITLE
Added graphql special fields: _count, _offset, etc

### DIFF
--- a/packages/server/src/fhir/graphql.test.ts
+++ b/packages/server/src/fhir/graphql.test.ts
@@ -178,6 +178,9 @@ describe('GraphQL', () => {
     `,
       });
     expect(res.status).toBe(200);
+    expect(res.text).toMatch(/_count/);
+    expect(res.text).toMatch(/_sort/);
+    expect(res.text).toMatch(/_lastUpdated/);
   });
 
   test('Read by ID', async () => {
@@ -236,6 +239,25 @@ describe('GraphQL', () => {
       });
     expect(res.status).toBe(200);
     expect(res.body.data.PatientList).toBeDefined();
+  });
+
+  test('Search with _count', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/$graphql')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        query: `
+      {
+        EncounterList(_count: 1) {
+          id
+        }
+      }
+    `,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.data.EncounterList).toBeDefined();
+    expect(res.body.data.EncounterList.length).toBe(1);
   });
 
   test('Read resource by reference', async () => {

--- a/packages/server/src/fhir/graphql.test.ts
+++ b/packages/server/src/fhir/graphql.test.ts
@@ -260,6 +260,54 @@ describe('GraphQL', () => {
     expect(res.body.data.EncounterList.length).toBe(1);
   });
 
+  test('Sort by _lastUpdated asc', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/$graphql')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        query: `
+      {
+        EncounterList(_sort: "_lastUpdated") {
+          id
+          meta { lastUpdated }
+        }
+      }
+    `,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.data.EncounterList).toBeDefined();
+    expect(res.body.data.EncounterList.length >= 2).toBe(true);
+
+    const e1 = res.body.data.EncounterList[0];
+    const e2 = res.body.data.EncounterList[1];
+    expect(e1.meta.lastUpdated.localeCompare(e2.meta.lastUpdated)).toBeLessThanOrEqual(0);
+  });
+
+  test('Sort by _lastUpdated desc', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/$graphql')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        query: `
+      {
+        EncounterList(_sort: "-_lastUpdated") {
+          id
+          meta { lastUpdated }
+        }
+      }
+    `,
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.data.EncounterList).toBeDefined();
+    expect(res.body.data.EncounterList.length >= 2).toBe(true);
+
+    const e1 = res.body.data.EncounterList[0];
+    const e2 = res.body.data.EncounterList[1];
+    expect(e1.meta.lastUpdated.localeCompare(e2.meta.lastUpdated)).toBeGreaterThanOrEqual(0);
+  });
+
   test('Read resource by reference', async () => {
     const res = await request(app)
       .post('/fhir/R4/$graphql')

--- a/packages/server/src/fhir/graphql.ts
+++ b/packages/server/src/fhir/graphql.ts
@@ -78,7 +78,7 @@ function buildRootSchema(): GraphQLSchema {
     const args: GraphQLFieldConfigArgumentMap = {
       _count: {
         type: GraphQLInt,
-        description: 'Specify how many to elements to return from a repeating list.',
+        description: 'Specify how many elements to return from a repeating list.',
       },
       _offset: {
         type: GraphQLInt,

--- a/packages/server/src/fhir/graphql.ts
+++ b/packages/server/src/fhir/graphql.ts
@@ -239,29 +239,14 @@ function getRefString(property: any): string | undefined {
  */
 async function resolveBySearch(
   source: any,
-  args: any,
+  args: Record<string, string>,
   ctx: any,
   info: GraphQLResolveInfo
 ): Promise<Resource[] | undefined> {
   const fieldName = info.fieldName;
-  const resourceType = fieldName.substr(0, fieldName.length - 4);
+  const resourceType = fieldName.substring(0, fieldName.length - 4); // Remove "List"
   const repo = ctx.res.locals.repo as Repository;
-
-  const entries: Record<string, string[]> = {};
-  Object.entries(args).forEach(([key, value]) => {
-    let values = entries[key];
-    if (!values) {
-      values = [];
-      entries[key] = values;
-    }
-    if (typeof value === 'string') {
-      values.push(value);
-    } else if (typeof value === 'number') {
-      values.push(value.toString());
-    }
-  });
-
-  const [outcome, bundle] = await repo.search(parseSearchRequest(resourceType, entries));
+  const [outcome, bundle] = await repo.search(parseSearchRequest(resourceType, args));
   assertOk(outcome, bundle);
   return bundle.entry?.map((e) => e.resource as Resource);
 }

--- a/packages/server/src/fhir/graphql.ts
+++ b/packages/server/src/fhir/graphql.ts
@@ -1,4 +1,4 @@
-import { assertOk, Filter, Operator } from '@medplum/core';
+import { assertOk } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import {
   GraphQLBoolean,
@@ -7,6 +7,7 @@ import {
   GraphQLFieldConfigMap,
   GraphQLFloat,
   GraphQLID,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -19,6 +20,7 @@ import {
 import { JSONSchema4 } from 'json-schema';
 import { Repository } from './repo';
 import { getResourceTypes, getSchemaDefinition } from './schema';
+import { parseSearchRequest } from './search';
 import { getSearchParameters } from './structure';
 
 const typeCache: Record<string, GraphQLOutputType> = {
@@ -73,7 +75,24 @@ function buildRootSchema(): GraphQLSchema {
     };
 
     // Search resource by search parameters
-    const args: GraphQLFieldConfigArgumentMap = {};
+    const args: GraphQLFieldConfigArgumentMap = {
+      _count: {
+        type: GraphQLInt,
+        description: 'Specify how many to elements to return from a repeating list.',
+      },
+      _offset: {
+        type: GraphQLInt,
+        description: 'Specify the offset to start at for a repeating element.',
+      },
+      _sort: {
+        type: GraphQLString,
+        description: 'Specify the sort order by comma-separated list of sort rules in priority order.',
+      },
+      _lastUpdated: {
+        type: GraphQLString,
+        description: 'Select resources based on the last time they were changed.',
+      },
+    };
     const searchParams = getSearchParameters(resourceType);
     if (searchParams) {
       for (const [name, searchParam] of Object.entries(searchParams)) {
@@ -227,18 +246,22 @@ async function resolveBySearch(
   const fieldName = info.fieldName;
   const resourceType = fieldName.substr(0, fieldName.length - 4);
   const repo = ctx.res.locals.repo as Repository;
-  const [outcome, bundle] = await repo.search({
-    resourceType,
-    count: 100,
-    filters: Object.entries(args).map(
-      (e) =>
-        ({
-          code: e[0],
-          operator: Operator.EQUALS,
-          value: e[1] as string,
-        } as Filter)
-    ),
+
+  const entries: Record<string, string[]> = {};
+  Object.entries(args).forEach(([key, value]) => {
+    let values = entries[key];
+    if (!values) {
+      values = [];
+      entries[key] = values;
+    }
+    if (typeof value === 'string') {
+      values.push(value);
+    } else if (typeof value === 'number') {
+      values.push(value.toString());
+    }
   });
+
+  const [outcome, bundle] = await repo.search(parseSearchRequest(resourceType, entries));
   assertOk(outcome, bundle);
   return bundle.entry?.map((e) => e.resource as Resource);
 }

--- a/packages/server/src/fhir/search/parse.test.ts
+++ b/packages/server/src/fhir/search/parse.test.ts
@@ -44,6 +44,14 @@ describe('FHIR Search Utils', () => {
     });
   });
 
+  test('Parse count and offset', () => {
+    expect(parseSearchRequest('Patient', { _count: '5', _offset: '10' })).toMatchObject({
+      resourceType: 'Patient',
+      page: 2,
+      count: 5,
+    });
+  });
+
   test('Parse total', () => {
     expect(parseSearchRequest('Patient', { _total: 'none' })).toMatchObject({
       resourceType: 'Patient',


### PR DESCRIPTION
Added the following GraphQL special fields:

```ts
      _count: {
        type: GraphQLInt,
        description: 'Specify how many elements to return from a repeating list.',
      },
      _offset: {
        type: GraphQLInt,
        description: 'Specify the offset to start at for a repeating element.',
      },
      _sort: {
        type: GraphQLString,
        description: 'Specify the sort order by comma-separated list of sort rules in priority order.',
      },
      _lastUpdated: {
        type: GraphQLString,
        description: 'Select resources based on the last time they were changed.',
      },
```

One interesting note here:

```ts
      // TODO: Reconcile "page" and "offset"
      // In normal FHIR search, the notion of "page" and "offset" is unspecified:
      // https://www.hl7.org/fhir/search.html
      // In the absence of a spec, we used "page"
      // In GraphQL, "offset" is specified:
      // https://www.hl7.org/fhir/graphql.html
      // It would be nice to migrate everything to the specified behavior.
      this.page = Math.floor(this.offset / this.count);
```

If we do that, we should do it *everywhere*, including deprecating `_page`, updating clients, updating the front end app, etc.