### PR TITLE
Header bar search for Patient or ServiceRequest

### DIFF
--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -278,6 +278,12 @@ export const HomerServiceRequest: ServiceRequest = {
       reference: 'Practitioner/123',
     },
   },
+  identifier: [
+    {
+      system: 'https://example.com',
+      value: '9001',
+    },
+  ],
   code: {
     coding: [
       {

--- a/packages/ui/src/Autocomplete.css
+++ b/packages/ui/src/Autocomplete.css
@@ -80,7 +80,7 @@
   position: absolute;
   background: var(--medplum-surface);
   width: 300px;
-  z-index: 1;
+  z-index: 5;
   cursor: pointer;
   border: 0.1px solid var(--medplum-gray-300);
   border-radius: 2px;
@@ -96,6 +96,8 @@
   margin: 0;
   padding: 0;
   cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .medplum-autocomplete-active {
@@ -115,10 +117,14 @@
   padding: 0 0 0 8px;
   cursor: pointer;
   user-select: none;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .medplum-autocomplete-label div {
   line-height: 18px;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .medplum-autocomplete-label .medplum-autocomplete-help-text {

--- a/packages/ui/src/Header.test.tsx
+++ b/packages/ui/src/Header.test.tsx
@@ -1,4 +1,4 @@
-import { MockClient } from '@medplum/mock';
+import { HomerSimpson, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -13,6 +13,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const medplum = new MockClient();
+medplum.graphql = jest.fn(() => Promise.resolve({ data: { Patients1: [HomerSimpson] } }));
 
 function setup(props?: HeaderProps): void {
   render(

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -58,11 +58,7 @@ export function Header(props: HeaderProps): JSX.Element {
               name="search"
               className="medplum-nav-search-container"
               placeholder="Search"
-              onChange={(resource: HeaderSearchTypes | undefined) => {
-                if (resource) {
-                  navigate(`/${resource.resourceType}/${resource.id}`);
-                }
-              }}
+              onChange={(resource: HeaderSearchTypes) => navigate(`/${resource.resourceType}/${resource.id}`)}
             />
           )}
         </div>

--- a/packages/ui/src/Header.tsx
+++ b/packages/ui/src/Header.tsx
@@ -1,14 +1,14 @@
 import { getReferenceString, ProfileResource } from '@medplum/core';
-import { HumanName, Patient, UserConfiguration } from '@medplum/fhirtypes';
+import { HumanName, UserConfiguration } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Avatar } from './Avatar';
 import { Button } from './Button';
+import { HeaderSearchInput, HeaderSearchTypes } from './HeaderSearchInput';
 import { HumanNameDisplay } from './HumanNameDisplay';
 import { MedplumLink } from './MedplumLink';
 import { useMedplumContext } from './MedplumProvider';
 import { Popup } from './Popup';
-import { ResourceInput } from './ResourceInput';
 import './Header.css';
 
 export interface HeaderProps {
@@ -53,15 +53,14 @@ export function Header(props: HeaderProps): JSX.Element {
             Medplum
           </MedplumLink>
           {context.profile && (
-            <ResourceInput
+            <HeaderSearchInput
               key={`header-input-${location.pathname}`}
-              resourceType="Patient"
               name="search"
               className="medplum-nav-search-container"
               placeholder="Search"
-              onChange={(patient: Patient | undefined) => {
-                if (patient) {
-                  navigate(`/${patient.resourceType}/${patient.id}`);
+              onChange={(resource: HeaderSearchTypes | undefined) => {
+                if (resource) {
+                  navigate(`/${resource.resourceType}/${resource.id}`);
                 }
               }}
             />

--- a/packages/ui/src/HeaderSearchInput.test.tsx
+++ b/packages/ui/src/HeaderSearchInput.test.tsx
@@ -40,6 +40,32 @@ medplum.graphql = jest.fn((query: string) => {
       ],
     }));
   }
+  if (query.includes('"empty"')) {
+    data.Patients1 = [
+      {
+        resourceType: 'Patient',
+        id: 'emptyPatient',
+        identifier: [
+          {
+            system: '',
+            value: '',
+          },
+        ],
+      },
+    ];
+    data.ServiceRequestList = [
+      {
+        resourceType: 'ServiceRequest',
+        id: 'emptyServiceRequest',
+        identifier: [
+          {
+            system: '',
+            value: '',
+          },
+        ],
+      },
+    ];
+  }
   return Promise.resolve({ data });
 });
 
@@ -174,5 +200,28 @@ describe('HeaderSearchInput', () => {
     // There should only be 5 results displayed
     const elements = screen.getAllByText('__Many__');
     expect(elements.length).toBe(5);
+  });
+
+  test('Empty strings', async () => {
+    setup({
+      name: 'foo',
+      onChange: jest.fn(),
+    });
+
+    const input = screen.getByTestId('input-element') as HTMLInputElement;
+
+    // Enter "empty"
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'empty' } });
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await waitFor(() => screen.getByTestId('dropdown'));
+    });
+
+    expect(screen.getByText('Patient/emptyPatient')).toBeInTheDocument();
+    expect(screen.getByText('ServiceRequest/emptyServiceRequest')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/HeaderSearchInput.test.tsx
+++ b/packages/ui/src/HeaderSearchInput.test.tsx
@@ -1,0 +1,94 @@
+import { HomerSimpson, MockClient } from '@medplum/mock';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { HeaderSearchInput, HeaderSearchInputProps } from './HeaderSearchInput';
+import { MedplumProvider } from './MedplumProvider';
+
+const medplum = new MockClient();
+medplum.graphql = jest.fn(() => Promise.resolve({ data: { Patients1: [HomerSimpson] } }));
+
+function setup(args: HeaderSearchInputProps): void {
+  render(
+    <MedplumProvider medplum={medplum}>
+      <HeaderSearchInput {...args} />
+    </MedplumProvider>
+  );
+}
+
+describe('HeaderSearchInput', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test('Renders empty', () => {
+    setup({
+      name: 'foo',
+      onChange: jest.fn(),
+    });
+    expect(screen.getByTestId('autocomplete')).toBeInTheDocument();
+  });
+
+  test('Use autocomplete', async () => {
+    setup({
+      name: 'foo',
+      onChange: jest.fn(),
+    });
+
+    const input = screen.getByTestId('input-element') as HTMLInputElement;
+
+    // Enter "Simpson"
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Simpson' } });
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await waitFor(() => screen.getByTestId('dropdown'));
+    });
+
+    // Press "Enter"
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    expect(screen.getByText('Homer Simpson')).toBeDefined();
+  });
+
+  test('Call onChange', async () => {
+    const onChange = jest.fn();
+
+    setup({
+      name: 'foo',
+      onChange,
+    });
+
+    const input = screen.getByTestId('input-element') as HTMLInputElement;
+
+    // Enter "Simpson"
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Simpson' } });
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await waitFor(() => screen.getByTestId('dropdown'));
+    });
+
+    // Press "Enter"
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    expect(screen.getByText('Homer Simpson')).toBeDefined();
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/HeaderSearchInput.tsx
+++ b/packages/ui/src/HeaderSearchInput.tsx
@@ -11,7 +11,7 @@ export interface HeaderSearchInputProps {
   readonly name: string;
   readonly className?: string;
   readonly placeholder?: string;
-  readonly onChange: (value: HeaderSearchTypes | undefined) => void;
+  readonly onChange: (value: HeaderSearchTypes) => void;
 }
 
 interface SearchGraphQLResponse {
@@ -49,13 +49,18 @@ export function HeaderSearchInput(props: HeaderSearchInputProps): JSX.Element {
         if (item.resourceType === 'Patient' && item.birthDate) {
           return 'DoB: ' + item.birthDate;
         }
+        if (item.resourceType === 'ServiceRequest' && item.subject) {
+          return item.subject.display;
+        }
         return undefined;
       }}
       name={props.name}
       className={props.className}
       placeholder={props.placeholder}
       onChange={(items: HeaderSearchTypes[]) => {
-        props.onChange(items.length > 0 ? items[0] : undefined);
+        if (items.length > 0) {
+          props.onChange(items[0]);
+        }
       }}
     />
   );

--- a/packages/ui/src/HeaderSearchInput.tsx
+++ b/packages/ui/src/HeaderSearchInput.tsx
@@ -1,0 +1,104 @@
+import { Patient, ServiceRequest } from '@medplum/fhirtypes';
+import React from 'react';
+import { Autocomplete } from './Autocomplete';
+import { Avatar } from './Avatar';
+import { useMedplum } from './MedplumProvider';
+import { ResourceName } from './ResourceName';
+
+export type HeaderSearchTypes = Patient | ServiceRequest;
+
+export interface HeaderSearchInputProps {
+  readonly name: string;
+  readonly className?: string;
+  readonly placeholder?: string;
+  readonly onChange: (value: HeaderSearchTypes | undefined) => void;
+}
+
+interface SearchGraphQLResponse {
+  readonly data: {
+    readonly Patients1: Patient[];
+    readonly Patients2: Patient[];
+    readonly ServiceRequestList: ServiceRequest[];
+  };
+}
+
+export function HeaderSearchInput(props: HeaderSearchInputProps): JSX.Element {
+  const medplum = useMedplum();
+  return (
+    <Autocomplete
+      loadOptions={async (input: string): Promise<HeaderSearchTypes[]> => {
+        const response = (await medplum.graphql(buildGraphQLQuery(input))) as SearchGraphQLResponse;
+        const resources = [];
+        if (response.data.Patients1) {
+          resources.push(...response.data.Patients1);
+        }
+        if (response.data.Patients2) {
+          resources.push(...response.data.Patients2);
+        }
+        if (response.data.ServiceRequestList) {
+          resources.push(...response.data.ServiceRequestList);
+        }
+        return resources;
+      }}
+      getId={(item: HeaderSearchTypes) => {
+        return item.id as string;
+      }}
+      getIcon={(item: HeaderSearchTypes) => <Avatar value={item} />}
+      getDisplay={(item: HeaderSearchTypes) => <ResourceName value={item} />}
+      getHelpText={(item: HeaderSearchTypes) => {
+        if (item.resourceType === 'Patient' && item.birthDate) {
+          return 'DoB: ' + item.birthDate;
+        }
+        return undefined;
+      }}
+      name={props.name}
+      className={props.className}
+      placeholder={props.placeholder}
+      onChange={(items: HeaderSearchTypes[]) => {
+        props.onChange(items.length > 0 ? items[0] : undefined);
+      }}
+    />
+  );
+}
+
+function buildGraphQLQuery(input: string): string {
+  return `{
+    Patients1: PatientList(name: "${encodeURIComponent(input)}") {
+      resourceType
+      id
+      identifier {
+        system
+        value
+      }
+      name {
+        given
+        family
+      }
+      birthDate
+    }
+    Patients2: PatientList(identifier: "${encodeURIComponent(input)}") {
+      resourceType
+      id
+      identifier {
+        system
+        value
+      }
+      name {
+        given
+        family
+      }
+      birthDate
+    }
+    ServiceRequestList(identifier: "${encodeURIComponent(input)}") {
+      resourceType
+      id
+      identifier {
+        system
+        value
+      }
+      subject {
+        display
+      }
+    }
+  }`.replace(/\s+/g, ' ');
+}

--- a/packages/ui/src/stories/Header.stories.tsx
+++ b/packages/ui/src/stories/Header.stories.tsx
@@ -16,6 +16,38 @@ const manyLinks: UserConfigurationMenuLink[] = new Array(50).fill(0).map((el, in
 
 export const Basic = (args: HeaderProps): JSX.Element => {
   const ctx = useMedplumContext();
+  const medplum = ctx.medplum;
+
+  medplum.graphql = async () => {
+    return {
+      data: {
+        Patients1: [
+          {
+            resourceType: 'Patient',
+            id: '1',
+            name: [{ given: ['Homer'], family: 'Simpson' }],
+            birthDate: '1950-01-01',
+          },
+        ],
+        ServiceRequestList: [
+          {
+            resourceType: 'ServiceRequest',
+            id: '000000-0000-0000-0000-000000000000',
+            identifier: [
+              {
+                system: 'barcode',
+                value: '9001',
+              },
+            ],
+            subject: {
+              display: 'Patient 1',
+            },
+          },
+        ],
+      },
+    };
+  };
+
   return (
     <Header
       onLogo={() => alert('Logo!')}


### PR DESCRIPTION
Before:  The header search only searched for Patient by name

Now: The header search tries 3 different searches:

1) Patient by name
2) Patient by identifier
3) ServiceRequest by identifier

While assisting with customer workflows, I found myself very frequently searching for ServiceRequest by identifier, so I think this will be popular.

Additional fixes:
* Cap to 5 results, across both Patients and ServiceRequests
* Sort by "relevance" (rough approximation based on string distance)
* Fixed z-index bug, where the search dropdown was hidden behind other page elements

Most of this PR is tests.  The meat is in `HeaderSearchInput.tsx`: https://github.com/medplum/medplum/pull/431/files#diff-038c8d422ecc0cbda1a87c318de82254ae5ed45024d19c1a44ea3a8c9acef404