### PR TITLE
Handle human name search with spaces

### DIFF
--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -41,6 +41,32 @@ describe('HumanName Lookup Table', () => {
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient?.id);
   });
 
+  test('Search with spaces', async () => {
+    const name1 = randomUUID();
+    const name2 = randomUUID();
+    const name3 = randomUUID();
+
+    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ given: [name1, name2], family: name3 }],
+    });
+    assertOk(createOutcome, patient);
+
+    const [searchOutcome, searchResult] = await systemRepo.search({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.EQUALS,
+          value: `${name1} ${name3}`,
+        },
+      ],
+    });
+    assertOk(searchOutcome, searchResult);
+    expect(searchResult.entry?.length).toEqual(1);
+    expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient?.id);
+  });
+
   test('Multiple names', async () => {
     const name = randomUUID();
     const other = randomUUID();

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -47,8 +47,10 @@ export abstract class LookupTable<T> {
     const columnName = this.getColumnName(filter.code);
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
-      .where({ tableName, columnName }, Operator.LIKE, '%' + filter.value + '%')
       .orderBy('resourceId');
+    for (const chunk of filter.value.split(/\s+/)) {
+      subQuery.where({ tableName, columnName }, Operator.LIKE, `%${chunk}%`);
+    }
     selectQuery.join(joinName, 'id', 'resourceId', subQuery);
   }
 


### PR DESCRIPTION
If a search string did not perfectly match the whitespace of the stored name, then it would not match the search.

This PR splits the input string, and adds separate clauses to the search.