### PR TITLE
Fixed header search bar string escaping

### DIFF
--- a/packages/ui/src/HeaderSearchInput.test.tsx
+++ b/packages/ui/src/HeaderSearchInput.test.tsx
@@ -11,6 +11,9 @@ medplum.graphql = jest.fn((query: string) => {
   if (query.includes('"Simpson"')) {
     data.Patients1 = [HomerSimpson];
   }
+  if (query.includes('"hom sim"')) {
+    data.Patients1 = [HomerSimpson];
+  }
   if (query.includes('"abc"')) {
     data.Patients2 = [HomerSimpson];
   }
@@ -124,7 +127,7 @@ describe('HeaderSearchInput', () => {
     expect(screen.getByText('Homer Simpson')).toBeDefined();
   });
 
-  test.each(['Simpson', 'abc', '9001'])('onChange with %s', async (query) => {
+  test.each(['Simpson', 'hom sim', 'abc', '9001'])('onChange with %s', async (query) => {
     const onChange = jest.fn();
 
     setup({

--- a/packages/ui/src/HeaderSearchInput.tsx
+++ b/packages/ui/src/HeaderSearchInput.tsx
@@ -53,8 +53,9 @@ export function HeaderSearchInput(props: HeaderSearchInputProps): JSX.Element {
 }
 
 function buildGraphQLQuery(input: string): string {
+  const escaped = JSON.stringify(input);
   return `{
-    Patients1: PatientList(name: "${encodeURIComponent(input)}", _count: 5) {
+    Patients1: PatientList(name: ${escaped}, _count: 5) {
       resourceType
       id
       identifier {
@@ -67,7 +68,7 @@ function buildGraphQLQuery(input: string): string {
       }
       birthDate
     }
-    Patients2: PatientList(identifier: "${encodeURIComponent(input)}", _count: 5) {
+    Patients2: PatientList(identifier: ${escaped}, _count: 5) {
       resourceType
       id
       identifier {
@@ -80,7 +81,7 @@ function buildGraphQLQuery(input: string): string {
       }
       birthDate
     }
-    ServiceRequestList(identifier: "${encodeURIComponent(input)}", _count: 5) {
+    ServiceRequestList(identifier: ${escaped}, _count: 5) {
       resourceType
       id
       identifier {


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/445 we fixed searching for human names with space characters.

But the header bar search still did not work with spaces.  It turns out that we were using `encodeUriComponent` for string escaping.  That was good for escaping double quotes and backslashes, but it also replaced whitespace with URL escape codes such as "%20".

By using `JSON.stringify` we only escape double quotes and back slashes.