### PR TITLE
Improved graphql schema build performance

### DIFF
--- a/packages/server/src/fhir/structure.ts
+++ b/packages/server/src/fhir/structure.ts
@@ -8,13 +8,15 @@ import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, SearchParameter } from '@medplum/fhirtypes';
 
 const schema = createSchema();
+let loaded = false;
 
 export function getStructureDefinitions(): IndexedStructureDefinition {
-  if (Object.keys(schema.types).length === 0) {
+  if (!loaded) {
     buildStructureDefinitions('profiles-types.json');
     buildStructureDefinitions('profiles-resources.json');
     buildStructureDefinitions('profiles-medplum.json');
     buildSearchParameters();
+    loaded = true;
   }
 
   return schema;


### PR DESCRIPTION
This improves GraphQL schema generation from 3 seconds to 0.1 seconds on my laptop.

To be candid, I don't know why.  In my experiments, the call to `Object.keys` was always nearly instant.

We lazy generate the GraphQL schema on the first GraphQL request, so this really only matters at startup.  It was bugging me though.