### PR TITLE
Added UserConfiguration option for default resource type on login

### DIFF
--- a/packages/ui/src/BackboneElementInput.tsx
+++ b/packages/ui/src/BackboneElementInput.tsx
@@ -3,7 +3,8 @@ import { ElementDefinition, OperationOutcome } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { DEFAULT_IGNORED_PROPERTIES } from './constants';
 import { FormSection } from './FormSection';
-import { getDefaultValue, setPropertyValue } from './ResourceForm';
+import { setPropertyValue } from './ResourceForm';
+import { getValueAndType } from './ResourcePropertyDisplay';
 import { ResourcePropertyInput } from './ResourcePropertyInput';
 
 export interface BackboneElementInputProps {
@@ -43,6 +44,7 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
           return null;
         }
         const name = props.name + '.' + key;
+        const [propertyValue, propertyType] = getValueAndType(value, property);
         return (
           <FormSection
             key={key}
@@ -55,7 +57,8 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
               schema={props.schema}
               property={property}
               name={name}
-              defaultValue={getDefaultValue(value, key, entry[1])}
+              defaultValue={propertyValue}
+              defaultPropertyType={propertyType}
               outcome={props.outcome}
               onChange={(newValue: any, propName?: string) => {
                 setValueWrapper(setPropertyValue(value, key, propName ?? key, entry[1], newValue));

--- a/packages/ui/src/QuestionnaireBuilder.test.tsx
+++ b/packages/ui/src/QuestionnaireBuilder.test.tsx
@@ -494,6 +494,11 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Add choice'));
     });
 
+    // Change the question type from "integer" (default) to "string"
+    fireEvent.change(screen.getByDisplayValue('integer'), {
+      target: { value: 'string' },
+    });
+
     // Change the text for the choice
     fireEvent.change(screen.getByTestId('value[x]'), {
       target: { value: 'foo bar' },

--- a/packages/ui/src/ResourceForm.tsx
+++ b/packages/ui/src/ResourceForm.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_IGNORED_PROPERTIES } from './constants';
 import { FormSection } from './FormSection';
 import { Input } from './Input';
 import { useMedplum } from './MedplumProvider';
+import { getValueAndType } from './ResourcePropertyDisplay';
 import { ResourcePropertyInput } from './ResourcePropertyInput';
 import { useResource } from './useResource';
 
@@ -57,6 +58,7 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
           return null;
         }
         const property = entry[1];
+        const [propertyValue, propertyType] = getValueAndType(value, property);
         return (
           <FormSection
             key={key}
@@ -69,7 +71,8 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
               schema={schema}
               property={property}
               name={key}
-              defaultValue={getDefaultValue(value, key, entry[1])}
+              defaultValue={propertyValue}
+              defaultPropertyType={propertyType}
               outcome={props.outcome}
               onChange={(newValue: any, propName?: string) => {
                 setValue(setPropertyValue(value, key, propName ?? key, entry[1], newValue));
@@ -94,20 +97,6 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
       )}
     </form>
   );
-}
-
-export function getDefaultValue(obj: any, key: string, elementDefinition: ElementDefinition): any {
-  const types = elementDefinition.type as ElementDefinitionType[];
-  if (types.length === 1) {
-    return obj[key];
-  }
-  for (const type of types) {
-    const compoundKey = key.replace('[x]', capitalize(type.code as string));
-    if (compoundKey in obj) {
-      return obj[compoundKey];
-    }
-  }
-  return undefined;
 }
 
 export function setPropertyValue(

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -137,5 +137,5 @@ export function getValueAndType(context: any, property: ElementDefinition): [any
     }
   }
 
-  return [undefined, PropertyType.string];
+  return [undefined, types[0].code as PropertyType];
 }


### PR DESCRIPTION
To use, add an "option" with id="defaultResourceType" and valueString="ServiceRequest" or whatever resource type you want.

Plus a few drive by fixes:
* App home page was double requesting search results
* App home page did not remember filters if you visited a different page and came back
* `ResourceForm` did not correctly setup `defaultPropertyType` on "choice of type" properties such as `value[x]`