### PR TITLE
Resolve font paths

### DIFF
--- a/packages/server/src/util/pdf.ts
+++ b/packages/server/src/util/pdf.ts
@@ -1,5 +1,6 @@
 import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
+import { resolve } from 'path';
 import PdfPrinter from 'pdfmake';
 import { TDocumentDefinitions } from 'pdfmake/interfaces';
 import { PassThrough } from 'stream';
@@ -32,7 +33,7 @@ export async function createPdf(
       bolditalics: 'Helvetica-BoldOblique',
     },
     Avenir: {
-      normal: 'fonts/avenir.ttf',
+      normal: resolve(__dirname, '../../fonts/avenir.ttf'),
     },
   };
 


### PR DESCRIPTION
The server looked for custom fonts in the "./fonts" directory, relative to the current working directory.

That worked fine on localhost and the dev Docker.

On prod, we run the server relative to the root directory of the project, not the root of the server package, so the relative file path was incorrect.