### PR TITLE
Show PDF preview in resource timeline

### DIFF
--- a/packages/ui/src/AttachmentDisplay.test.tsx
+++ b/packages/ui/src/AttachmentDisplay.test.tsx
@@ -68,6 +68,18 @@ describe('AttachmentDisplay', () => {
     });
   });
 
+  test('Renders PDF', async () => {
+    await act(async () => {
+      await setup({
+        value: {
+          contentType: 'application/pdf',
+          url: 'https://example.com/test.pdf',
+        },
+      });
+      await waitFor(() => screen.getByTestId('attachment-pdf'));
+    });
+  });
+
   test('Renders other file', async () => {
     await act(async () => {
       await setup({

--- a/packages/ui/src/AttachmentDisplay.tsx
+++ b/packages/ui/src/AttachmentDisplay.tsx
@@ -25,7 +25,7 @@ export function AttachmentDisplay(props: AttachmentDisplayProps): JSX.Element {
 
     if (contentType === 'application/pdf') {
       return (
-        <div style={{ maxWidth: props.maxWidth, minHeight: 400 }}>
+        <div data-testid="attachment-pdf" style={{ maxWidth: props.maxWidth, minHeight: 400 }}>
           <iframe width="100%" height="400" src={url} allowFullScreen={true} frameBorder={0} seamless={true} />
         </div>
       );

--- a/packages/ui/src/AttachmentDisplay.tsx
+++ b/packages/ui/src/AttachmentDisplay.tsx
@@ -10,16 +10,26 @@ export function AttachmentDisplay(props: AttachmentDisplayProps): JSX.Element {
   const value = props.value;
   const { contentType, url } = value ?? {};
 
-  if (contentType?.startsWith('image/') && url) {
-    return <img data-testid="attachment-image" style={{ maxWidth: props.maxWidth }} src={url} alt={value?.title} />;
-  }
+  if (contentType && url) {
+    if (contentType.startsWith('image/')) {
+      return <img data-testid="attachment-image" style={{ maxWidth: props.maxWidth }} src={url} alt={value?.title} />;
+    }
 
-  if (contentType?.startsWith('video/') && url) {
-    return (
-      <video data-testid="attachment-video" style={{ maxWidth: props.maxWidth }} controls={true}>
-        <source type={contentType} src={url} />
-      </video>
-    );
+    if (contentType.startsWith('video/')) {
+      return (
+        <video data-testid="attachment-video" style={{ maxWidth: props.maxWidth }} controls={true}>
+          <source type={contentType} src={url} />
+        </video>
+      );
+    }
+
+    if (contentType === 'application/pdf') {
+      return (
+        <div style={{ maxWidth: props.maxWidth, minHeight: 400 }}>
+          <iframe width="100%" height="400" src={url} allowFullScreen={true} frameBorder={0} seamless={true} />
+        </div>
+      );
+    }
   }
 
   return (

--- a/packages/ui/src/ResourceTimeline.tsx
+++ b/packages/ui/src/ResourceTimeline.tsx
@@ -238,7 +238,11 @@ interface MediaTimelineItemProps {
 
 function MediaTimelineItem(props: MediaTimelineItemProps): JSX.Element {
   const contentType = props.media.content?.contentType;
-  const padding = contentType && !contentType.startsWith('image/') && !contentType.startsWith('video/');
+  const padding =
+    contentType &&
+    !contentType.startsWith('image/') &&
+    !contentType.startsWith('video/') &&
+    contentType !== 'application/pdf';
   return (
     <TimelineItem resource={props.media} padding={!!padding}>
       <AttachmentDisplay value={props.media.content} />


### PR DESCRIPTION
Before:

<img width="546" alt="image" src="https://user-images.githubusercontent.com/749094/162266083-bb0b1ae3-f777-46f6-a523-d6fae2c82611.png">

After:

<img width="542" alt="image" src="https://user-images.githubusercontent.com/749094/162266123-67c4ebcc-85f1-4227-ae2f-662fd8fa67d3.png">

`allowFullScreen` is enabled, so you get nice preview and download links:

<img width="548" alt="image" src="https://user-images.githubusercontent.com/749094/162266205-57e7e615-1f44-4530-8842-999c07ed790d.png">
