### PR TITLE
Hide underscore properties in OpenAPI definition

### DIFF
--- a/packages/server/src/openapi.test.ts
+++ b/packages/server/src/openapi.test.ts
@@ -24,5 +24,11 @@ describe('OpenAPI', () => {
     expect(res.status).toBe(200);
     expect(res.body.openapi).toBeDefined();
     expect(res.body.info).toBeDefined();
+
+    const patient = res.body.components.schemas.Patient;
+    expect(patient).toBeDefined();
+    expect(patient.properties.id).toBeDefined();
+    expect(patient.properties.language).toBeDefined();
+    expect(patient.properties._language).toBeUndefined();
   });
 });

--- a/packages/server/src/openapi.ts
+++ b/packages/server/src/openapi.ts
@@ -158,7 +158,7 @@ function refReplacer(key: string, value: any): any {
   if (key === '$ref') {
     return (value as string).replace('#/definitions/', '#/components/schemas/');
   }
-  if (key === 'oneOf' || key === 'extension' || key === '_extension') {
+  if (key === 'oneOf' || key.startsWith('_')) {
     return undefined;
   }
   return value;


### PR DESCRIPTION
When generating test clients with [OpenAPI Generator](https://openapi-generator.tech/), the clients often had errors because they normalized underscore `_` properties, which then led to property name collisions and compile errors.

For example, any FHIR resource that extends from `DomainResource` has both `language` and `_language`, both `extension` and `_extension`, etc, etc.

For now, just hiding all `_` properties from the OpenAPI definition.