### PR TITLE
Endpoints for $reindex and $resend

### DIFF
--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -420,4 +420,20 @@ describe('FHIR Routes', () => {
       .send('hello');
     expect(res.status).toBe(400);
   });
+
+  test('Reindex resource access denied', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Patient/${patientId}/$reindex`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  test('Resend subscriptions access denied', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Patient/${patientId}/$resend`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res.status).toBe(403);
+  });
 });

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -268,6 +268,30 @@ protectedRoutes.post(
   })
 );
 
+// Reindex resource
+protectedRoutes.post(
+  '/:resourceType/:id/([$])reindex',
+  asyncWrap(async (req: Request, res: Response) => {
+    const { resourceType, id } = req.params;
+    const repo = res.locals.repo as Repository;
+    const [outcome, resource] = await repo.reindexResource(resourceType, id);
+    assertOk(outcome, resource);
+    sendResponse(res, outcome, resource);
+  })
+);
+
+// Resend subscriptions
+protectedRoutes.post(
+  '/:resourceType/:id/([$])resend',
+  asyncWrap(async (req: Request, res: Response) => {
+    const { resourceType, id } = req.params;
+    const repo = res.locals.repo as Repository;
+    const [outcome, resource] = await repo.resendSubscriptions(resourceType, id);
+    assertOk(outcome, resource);
+    sendResponse(res, outcome, resource);
+  })
+);
+
 function isFhirJsonContentType(req: Request): boolean {
   return !!(req.is('application/json') || req.is('application/fhir+json'));
 }


### PR DESCRIPTION
Two special endpoints, only available to super admins:
* `/fhir/R4/{resourceType}/{id}/$reindex` - forces a reindex of the resource, in case there were changes to indexing logic
* `/fhir/R4/{resourceType}/{id}/$resend` - resends all subscriptions for the resource