### PR TITLE
Make sure search bundle.total is a number

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -73,6 +73,7 @@ describe('FHIR Repo', () => {
     });
     assertOk(outcome3, result3);
     expect(result3.total).toBeDefined();
+    expect(typeof result3.total).toBe('number');
 
     const [outcome4, result4] = await systemRepo.search({
       resourceType: 'Patient',
@@ -80,6 +81,7 @@ describe('FHIR Repo', () => {
     });
     assertOk(outcome4, result4);
     expect(result4.total).toBeDefined();
+    expect(typeof result4.total).toBe('number');
   });
 
   test('Repo read malformed reference', async () => {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -477,7 +477,7 @@ export class Repository {
   async #getTotalCount(searchRequest: SearchRequest): Promise<number> {
     const client = getClient();
     const builder = new SelectQuery(searchRequest.resourceType).raw(
-      `COUNT (DISTINCT "${searchRequest.resourceType}"."id") AS "count"`
+      `COUNT (DISTINCT "${searchRequest.resourceType}"."id")::int AS "count"`
     );
 
     this.#addDeletedFilter(builder);


### PR DESCRIPTION
Postgres returns `COUNT(*)` as a bigint.

Node Postgres then returns the bigint as a JavaScript `string`

By casting to `::int`, everything falls into place, and we get a JavaScript `number` like we want.

That is, until we start returning 2,147,483,647 rows.