### PR TITLE
Added LegacyRepositoryClient

### DIFF
--- a/packages/app/src/CreateResourcePage.tsx
+++ b/packages/app/src/CreateResourcePage.tsx
@@ -20,7 +20,7 @@ export function CreateResourcePage(): JSX.Element {
           onSubmit={(formData: Resource) => {
             setError(undefined);
             medplum
-              .create(formData)
+              .createResource(formData)
               .then((result) => navigate('/' + result.resourceType + '/' + result.id))
               .catch(setError);
           }}

--- a/packages/app/src/FormPage.tsx
+++ b/packages/app/src/FormPage.tsx
@@ -91,7 +91,7 @@ export function FormPage(): JSX.Element {
           questionnaire={questionnaire}
           subject={subject && createReference(subject)}
           onSubmit={(questionnaireResponse: QuestionnaireResponse) => {
-            medplum.create(questionnaireResponse).then((result) => {
+            medplum.createResource(questionnaireResponse).then((result) => {
               navigate(`/${getReferenceString(result)}`);
             });
           }}

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -12,7 +12,7 @@ export function HomePage(): JSX.Element {
 
   useEffect(() => {
     // Parse the search from the URL
-    const parsedSearch = parseSearchDefinition(location);
+    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
 
     // Fill in the search with default values
     const populatedSearch = addDefaultSearchValues(parsedSearch, medplum.getUserConfiguration());

--- a/packages/app/src/ResourcePage.tsx
+++ b/packages/app/src/ResourcePage.tsx
@@ -158,7 +158,7 @@ export function ResourcePage(): JSX.Element {
   }
 
   function onSubmit(newResource: Resource): void {
-    medplum.update(cleanResource(newResource)).then(loadResource).catch(setError);
+    medplum.updateResource(cleanResource(newResource)).then(loadResource).catch(setError);
   }
 
   function onStatusChange(status: string): void {

--- a/packages/core/jest.config.json
+++ b/packages/core/jest.config.json
@@ -8,6 +8,6 @@
   "testMatch": ["**/src/**/*.test.ts"],
   "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,8 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@medplum/fhirtypes": "0.5.2"
+    "@medplum/fhirtypes": "0.5.2",
+    "fast-json-patch": "3.1.1"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -378,7 +378,7 @@ describe('Client', () => {
 
   test('Read resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.read('Patient', '123');
+    const result = await client.readResource('Patient', '123');
     expect(result).toBeDefined();
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');
     expect(result.resourceType).toBe('Patient');
@@ -449,7 +449,7 @@ describe('Client', () => {
 
   test('Create resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.create({ resourceType: 'Patient' });
+    const result = await client.createResource({ resourceType: 'Patient' });
     expect(result).toBeDefined();
     expect((result as any).request.options.method).toBe('POST');
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient');
@@ -457,7 +457,7 @@ describe('Client', () => {
 
   test('Update resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.update({ resourceType: 'Patient', id: '123' });
+    const result = await client.updateResource({ resourceType: 'Patient', id: '123' });
     expect(result).toBeDefined();
     expect((result as any).request.options.method).toBe('PUT');
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');
@@ -465,20 +465,20 @@ describe('Client', () => {
 
   test('Not modified', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.update({ resourceType: 'Patient', id: '777' });
+    const result = await client.updateResource({ resourceType: 'Patient', id: '777' });
     expect(result).toBeUndefined();
   });
 
   test('Bad Request', async () => {
     const client = new MedplumClient(defaultOptions);
-    const promise = client.update({ resourceType: 'Patient', id: '888' });
+    const promise = client.updateResource({ resourceType: 'Patient', id: '888' });
     expect(promise).rejects.toMatchObject({});
   });
 
   test('Create resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    expect(() => client.create({} as Patient)).toThrowError('Missing resourceType');
-    const result = await client.create({ resourceType: 'Patient', name: [{ family: 'Smith' }] });
+    expect(() => client.createResource({} as Patient)).toThrowError('Missing resourceType');
+    const result = await client.createResource({ resourceType: 'Patient', name: [{ family: 'Smith' }] });
     expect(result).toBeDefined();
     expect((result as any).request.options.method).toBe('POST');
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient');
@@ -494,9 +494,9 @@ describe('Client', () => {
 
   test('Update resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    expect(() => client.update({} as Patient)).toThrowError('Missing resourceType');
-    expect(() => client.update({ resourceType: 'Patient' })).toThrowError('Missing id');
-    const result = await client.update({ resourceType: 'Patient', id: '123', name: [{ family: 'Smith' }] });
+    expect(() => client.updateResource({} as Patient)).toThrowError('Missing resourceType');
+    expect(() => client.updateResource({ resourceType: 'Patient' })).toThrowError('Missing id');
+    const result = await client.updateResource({ resourceType: 'Patient', id: '123', name: [{ family: 'Smith' }] });
     expect(result).toBeDefined();
     expect((result as any).request.options.method).toBe('PUT');
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');
@@ -504,7 +504,7 @@ describe('Client', () => {
 
   test('Patch resource', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.patch('Patient', '123', []);
+    const result = await client.patchResource('Patient', '123', []);
     expect(result).toBeDefined();
     expect((result as any).request.options.method).toBe('PATCH');
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');

--- a/packages/core/src/repo.test.ts
+++ b/packages/core/src/repo.test.ts
@@ -1,0 +1,177 @@
+import { MedplumClient } from './client';
+import { allOk, assertOk, badRequest } from './outcomes';
+import { LegacyRepositoryClient } from './repo';
+import { Operator } from './search';
+
+describe('LegacyRepositoryClient', () => {
+  test('Create success', async () => {
+    const client = new LegacyRepositoryClient({
+      createResource: async (resource: any) => resource,
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.createResource({ resourceType: 'Patient' });
+    assertOk(outcome, result);
+  });
+
+  test('Create failure', async () => {
+    const client = new LegacyRepositoryClient({
+      createResource: () => Promise.reject(badRequest('Resource already exists')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.createResource({ resourceType: 'Patient' });
+    expect(outcome).toMatchObject(badRequest('Resource already exists'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Read success', async () => {
+    const client = new LegacyRepositoryClient({
+      readResource: () => Promise.resolve({ resourceType: 'Patient' }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readResource('Patient', '123');
+    assertOk(outcome, result);
+  });
+
+  test('Read failure', async () => {
+    const client = new LegacyRepositoryClient({
+      readResource: () => Promise.reject(badRequest('Resource not found')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readResource('Patient', '123');
+    expect(outcome).toMatchObject(badRequest('Resource not found'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Read reference success', async () => {
+    const client = new LegacyRepositoryClient({
+      readReference: () => Promise.resolve({ resourceType: 'Patient' }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readReference({ reference: 'Patient/123' });
+    assertOk(outcome, result);
+  });
+
+  test('Read reference failure', async () => {
+    const client = new LegacyRepositoryClient({
+      readReference: () => Promise.reject(badRequest('Resource not found')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readReference({ reference: 'Patient/123' });
+    expect(outcome).toMatchObject(badRequest('Resource not found'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Read history success', async () => {
+    const client = new LegacyRepositoryClient({
+      readHistory: () =>
+        Promise.resolve({ resourceType: 'Bundle', entry: [{ resource: { resourceType: 'Patient' } }] }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readHistory('Patient', '123');
+    assertOk(outcome, result);
+  });
+
+  test('Read history failure', async () => {
+    const client = new LegacyRepositoryClient({
+      readHistory: () => Promise.reject(badRequest('Resource not found')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readHistory('Patient', '123');
+    expect(outcome).toMatchObject(badRequest('Resource not found'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Read version success', async () => {
+    const client = new LegacyRepositoryClient({
+      readVersion: () => Promise.resolve({ resourceType: 'Patient' }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readVersion('Patient', '123', '456');
+    assertOk(outcome, result);
+  });
+
+  test('Read version failure', async () => {
+    const client = new LegacyRepositoryClient({
+      readVersion: () => Promise.reject(badRequest('Resource not found')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.readVersion('Patient', '123', '456');
+    expect(outcome).toMatchObject(badRequest('Resource not found'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Update success', async () => {
+    const client = new LegacyRepositoryClient({
+      updateResource: async (resource: any) => resource,
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.updateResource({ resourceType: 'Patient' });
+    assertOk(outcome, result);
+  });
+
+  test('Update failure', async () => {
+    const client = new LegacyRepositoryClient({
+      updateResource: () => Promise.reject(badRequest('Bad request')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.updateResource({ resourceType: 'Patient' });
+    expect(outcome).toMatchObject(badRequest('Bad request'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Delete success', async () => {
+    const client = new LegacyRepositoryClient({
+      deleteResource: () => Promise.resolve(allOk),
+    } as unknown as MedplumClient);
+    const [outcome] = await client.deleteResource('Patient', '123');
+    assertOk(outcome, {});
+  });
+
+  test('Delete failure', async () => {
+    const client = new LegacyRepositoryClient({
+      deleteResource: () => Promise.reject(badRequest('Resource not found')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.deleteResource('Patient', '123');
+    expect(outcome).toMatchObject(badRequest('Resource not found'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Patch success', async () => {
+    const client = new LegacyRepositoryClient({
+      patchResource: () => Promise.resolve({ resourceType: 'Patient' }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.patchResource('Patient', '123', []);
+    assertOk(outcome, result);
+  });
+
+  test('Patch failure', async () => {
+    const client = new LegacyRepositoryClient({
+      patchResource: () => Promise.reject(badRequest('Resource not found')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.patchResource('Patient', '123', []);
+    expect(outcome).toMatchObject(badRequest('Resource not found'));
+    expect(result).toBeUndefined();
+  });
+
+  test('Search success', async () => {
+    const client = new LegacyRepositoryClient({
+      search: () => Promise.resolve({ resourceType: 'Bundle', entry: [{ resource: { resourceType: 'Patient' } }] }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.search('Patient?name=eve');
+    assertOk(outcome, result);
+  });
+
+  test('Search by request object success', async () => {
+    const client = new LegacyRepositoryClient({
+      search: () => Promise.resolve({ resourceType: 'Bundle', entry: [{ resource: { resourceType: 'Patient' } }] }),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.search({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.EQUALS,
+          value: 'eve',
+        },
+      ],
+    });
+    assertOk(outcome, result);
+  });
+
+  test('Search failure', async () => {
+    const client = new LegacyRepositoryClient({
+      search: () => Promise.reject(badRequest('Invalid search')),
+    } as unknown as MedplumClient);
+    const [outcome, result] = await client.search('Patient?name=eve');
+    expect(outcome).toMatchObject(badRequest('Invalid search'));
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/core/src/repo.ts
+++ b/packages/core/src/repo.ts
@@ -1,0 +1,195 @@
+import { Bundle, OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
+import { Operation } from 'fast-json-patch';
+import { MedplumClient } from './client';
+import { allOk, created } from './outcomes';
+import { parseSearchDefinition, SearchRequest } from './search';
+
+/**
+ * The LegacyRepositoryResult type is a tuple of operation outcome and optional resource.
+ * @deprecated
+ */
+export type LegacyRepositoryResult<T extends Resource | undefined> = Promise<[OperationOutcome, T | undefined]>;
+
+/**
+ * The LegacyRepositoryClient is a supplementary API client that matches the legacy "Repository" API.
+ * The "Repository" API is deprecated and will be removed in a future release.
+ * This LegacyRepositoryClient is also deprecated and will be removed in a future release.
+ * @deprecated
+ */
+export class LegacyRepositoryClient {
+  readonly #client: MedplumClient;
+
+  constructor(client: MedplumClient) {
+    this.#client = client;
+  }
+
+  /**
+   * Creates a resource.
+   *
+   * See: https://www.hl7.org/fhir/http.html#create
+   *
+   * @param resource The resource to create.
+   * @returns Operation outcome and the new resource.
+   * @deprecated
+   */
+  async createResource<T extends Resource>(resource: T): LegacyRepositoryResult<T> {
+    try {
+      const result = await this.#client.createResource<T>(resource);
+      return [created, result];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Returns a resource.
+   *
+   * See: https://www.hl7.org/fhir/http.html#read
+   *
+   * @param resourceType The FHIR resource type.
+   * @param id The FHIR resource ID.
+   * @returns Operation outcome and a resource.
+   * @deprecated
+   */
+  async readResource<T extends Resource>(resourceType: string, id: string): LegacyRepositoryResult<T> {
+    try {
+      const resource = await this.#client.readResource<T>(resourceType, id);
+      return [allOk, resource];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Returns a resource by FHIR reference.
+   *
+   * See: https://www.hl7.org/fhir/http.html#read
+   *
+   * @param reference The FHIR reference.
+   * @returns Operation outcome and a resource.
+   * @deprecated
+   */
+  async readReference<T extends Resource>(reference: Reference<T>): LegacyRepositoryResult<T> {
+    try {
+      const resource = await this.#client.readReference<T>(reference);
+      return [allOk, resource];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Returns resource history.
+   *
+   * See: https://www.hl7.org/fhir/http.html#history
+   *
+   * @param resourceType The FHIR resource type.
+   * @param id The FHIR resource ID.
+   * @returns Operation outcome and a history bundle.
+   * @deprecated
+   */
+  async readHistory<T extends Resource>(resourceType: string, id: string): LegacyRepositoryResult<Bundle<T>> {
+    try {
+      const resource = await this.#client.readHistory<T>(resourceType, id);
+      return [allOk, resource];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Returns a resource version.
+   *
+   * See: https://www.hl7.org/fhir/http.html#vread
+   *
+   * @param resourceType The FHIR resource type.
+   * @param id The FHIR resource ID.
+   * @param vid The version ID.
+   * @returns Operation outcome and a resource.
+   * @deprecated
+   */
+  async readVersion<T extends Resource>(resourceType: string, id: string, vid: string): LegacyRepositoryResult<T> {
+    try {
+      const resource = await this.#client.readVersion<T>(resourceType, id, vid);
+      return [allOk, resource];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Updates a resource.
+   *
+   * See: https://www.hl7.org/fhir/http.html#update
+   *
+   * @param resource The resource to update.
+   * @returns Operation outcome and the updated resource.
+   * @deprecated
+   */
+  async updateResource<T extends Resource>(resource: T): LegacyRepositoryResult<T> {
+    try {
+      const updated = await this.#client.updateResource<T>(resource);
+      return [allOk, updated];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Deletes a resource.
+   *
+   * See: https://www.hl7.org/fhir/http.html#delete
+   *
+   * @param resourceType The FHIR resource type.
+   * @param id The resource ID.
+   * @returns Operation outcome.
+   * @deprecated
+   */
+  async deleteResource(resourceType: string, id: string): LegacyRepositoryResult<undefined> {
+    try {
+      await this.#client.deleteResource(resourceType, id);
+      return [allOk, undefined];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Patches a resource.
+   *
+   * See: https://www.hl7.org/fhir/http.html#patch
+   *
+   * @param resourceType The FHIR resource type.
+   * @param id The resource ID.
+   * @param patch Array of JSONPatch operations.
+   * @returns Operation outcome and the resource.
+   * @deprecated
+   */
+  async patchResource(resourceType: string, id: string, patch: Operation[]): LegacyRepositoryResult<Resource> {
+    try {
+      const resource = await this.#client.patchResource(resourceType, id, patch);
+      return [allOk, resource];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+
+  /**
+   * Searches for resources.
+   *
+   * See: https://www.hl7.org/fhir/http.html#search
+   *
+   * @param searchRequest The search request.
+   * @returns The search result bundle.
+   * @deprecated
+   */
+  async search<T extends Resource>(query: SearchRequest | string): LegacyRepositoryResult<Bundle<T>> {
+    const searchRequest = typeof query === 'string' ? parseSearchDefinition(query) : query;
+    try {
+      const bundle = await this.#client.search<T>(searchRequest);
+      return [allOk, bundle];
+    } catch (error) {
+      return [error as OperationOutcome, undefined];
+    }
+  }
+}

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -2,22 +2,19 @@ import { formatSearchQuery, Operator, parseSearchDefinition } from './search';
 
 describe('Search Utils', () => {
   test('Parse Patient search', () => {
-    const result = parseSearchDefinition({ pathname: '/x/y/z/Patient' });
+    const result = parseSearchDefinition('/x/y/z/Patient');
     expect(result.resourceType).toBe('Patient');
     expect(result.filters).toBeUndefined();
   });
 
   test('Parse Patient search with trailing slash', () => {
-    const result = parseSearchDefinition({ pathname: '/Patient/' });
+    const result = parseSearchDefinition('/Patient/');
     expect(result.resourceType).toBe('Patient');
     expect(result.filters).toBeUndefined();
   });
 
   test('Parse Patient search name', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: 'name=alice',
-    });
+    const result = parseSearchDefinition('Patient?name=alice');
     expect(result.resourceType).toBe('Patient');
     expect(result.filters).toEqual([
       {
@@ -29,46 +26,31 @@ describe('Search Utils', () => {
   });
 
   test('Parse Patient search fields', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: '_fields=id,name,birthDate',
-    });
+    const result = parseSearchDefinition('Patient?_fields=id,name,birthDate');
     expect(result.resourceType).toBe('Patient');
     expect(result.fields).toEqual(['id', 'name', 'birthDate']);
   });
 
   test('Parse Patient search sort', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: '_sort=birthDate',
-    });
+    const result = parseSearchDefinition('Patient?_sort=birthDate');
     expect(result.resourceType).toBe('Patient');
     expect(result.sortRules).toEqual([{ code: 'birthDate' }]);
   });
 
   test('Parse Patient search sort descending', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: '_sort=-birthDate',
-    });
+    const result = parseSearchDefinition('Patient?_sort=-birthDate');
     expect(result.resourceType).toBe('Patient');
     expect(result.sortRules).toEqual([{ code: 'birthDate', descending: true }]);
   });
 
   test('Parse Patient search total', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: '_total=accurate',
-    });
+    const result = parseSearchDefinition('Patient?_total=accurate');
     expect(result.resourceType).toBe('Patient');
     expect(result.total).toBe('accurate');
   });
 
   test('Parse modifier operator', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: 'name:contains=alice',
-    });
+    const result = parseSearchDefinition('Patient?name:contains=alice');
     expect(result).toMatchObject({
       resourceType: 'Patient',
       filters: [
@@ -82,10 +64,7 @@ describe('Search Utils', () => {
   });
 
   test('Parse prefix operator', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: 'birthdate=gt2000-01-01',
-    });
+    const result = parseSearchDefinition('Patient?birthdate=gt2000-01-01');
     expect(result).toMatchObject({
       resourceType: 'Patient',
       filters: [
@@ -99,10 +78,7 @@ describe('Search Utils', () => {
   });
 
   test('Parse prefix operator does not work on string', () => {
-    const result = parseSearchDefinition({
-      pathname: 'Patient',
-      search: 'name=leslie',
-    });
+    const result = parseSearchDefinition('Patient?name=leslie');
     expect(result).toMatchObject({
       resourceType: 'Patient',
       filters: [

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -82,10 +82,11 @@ const PREFIX_OPERATORS: Operator[] = [
  *
  * See the FHIR search spec: http://hl7.org/fhir/r4/search.html
  *
- * @param location The URL to parse.
+ * @param url The URL to parse.
  * @returns Parsed search definition.
  */
-export function parseSearchDefinition(location: { pathname: string; search?: string }): SearchRequest {
+export function parseSearchDefinition(url: string): SearchRequest {
+  const location = new URL(url, 'https://example.com/');
   const resourceType = location.pathname
     .replace(/(^\/)|(\/$)/g, '') // Remove leading and trailing slashes
     .split('/')

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -336,7 +336,7 @@ function mockFhirHandler(method: string, url: string, options: any): any {
     } else if (resourceType && id) {
       return mockRepo.readResource(resourceType, id);
     } else if (resourceType) {
-      return mockRepo.search(parseSearchDefinition(new URL(url, 'https://example.com/')));
+      return mockRepo.search(parseSearchDefinition(url));
     }
   } else if (method === 'PUT') {
     return mockRepo.createResource(JSON.parse(options.body));

--- a/packages/mock/src/repo.test.ts
+++ b/packages/mock/src/repo.test.ts
@@ -8,7 +8,7 @@ describe('Mock Repo', () => {
   test('Create resource with ID', async () => {
     const client = new MockClient();
     const id = randomUUID();
-    const result = await client.create({
+    const result = await client.createResource({
       resourceType: 'Patient',
       id,
     });
@@ -17,7 +17,7 @@ describe('Mock Repo', () => {
 
   test('Create resource without ID', async () => {
     const client = new MockClient();
-    const result = await client.create<Patient>({
+    const result = await client.createResource<Patient>({
       resourceType: 'Patient',
     });
     expect(result.id).toBeDefined();
@@ -27,7 +27,7 @@ describe('Mock Repo', () => {
     const client = new MockClient();
     const id = randomUUID();
     const versionId = randomUUID();
-    const result = await client.create({
+    const result = await client.createResource({
       resourceType: 'Patient',
       id,
       meta: {
@@ -40,7 +40,7 @@ describe('Mock Repo', () => {
 
   test('Create resource without ID', async () => {
     const client = new MockClient();
-    const result = await client.create<Patient>({
+    const result = await client.createResource<Patient>({
       resourceType: 'Patient',
     });
     expect(result.id).toBeDefined();

--- a/packages/ui/src/ResourceTimeline.tsx
+++ b/packages/ui/src/ResourceTimeline.tsx
@@ -111,7 +111,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
       // Encounter not loaded yet
       return;
     }
-    medplum.create(props.createCommunication(resource, sender, contentString)).then((result) => {
+    medplum.createResource(props.createCommunication(resource, sender, contentString)).then((result) => {
       addResources([result]);
     });
   }
@@ -125,7 +125,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
       // Encounter not loaded yet
       return;
     }
-    medplum.create(props.createMedia(resource, sender, attachment)).then((result) => {
+    medplum.createResource(props.createMedia(resource, sender, attachment)).then((result) => {
       addResources([result]);
     });
   }

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -242,7 +242,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               testid="saved-search-select"
               style={{ width: 80 }}
               onChange={(newValue) => {
-                emitSearchChange(parseSearchDefinition(new URL(newValue, 'https://example.com')));
+                emitSearchChange(parseSearchDefinition(newValue));
               }}
             >
               <option></option>

--- a/packages/ui/src/SearchFilterValueInput.test.tsx
+++ b/packages/ui/src/SearchFilterValueInput.test.tsx
@@ -139,7 +139,7 @@ describe('SearchFilterValueInput', () => {
 
   test('Reference input', async () => {
     // Warm up the default value
-    await medplum.read('Organization', '123');
+    await medplum.readResource('Organization', '123');
 
     const onChange = jest.fn();
 


### PR DESCRIPTION
I found that I needed this for local development of a Bot, so I went ahead and polished it up.

This introduces `LegacyRepositoryClient` -- an API client with the JavaScript interface of the original Bot `repo`.

Use cases:
1) Local development of bots
2) Migration pathway away from original Bot `repo` to API clients

Along the way, I tweaked some of the `MedplumClient` API to align with the upcoming API review:
1) `create` -> `createResource`
2) `read` -> `readResource`
3) `update` -> `updateResource`
4) `patch` -> `patchResource`