### PR TITLE
MedplumClient improvements

### DIFF
--- a/packages/app/src/PatientHeader.tsx
+++ b/packages/app/src/PatientHeader.tsx
@@ -1,3 +1,4 @@
+import { calculateAgeString } from '@medplum/core';
 import { Patient, Reference } from '@medplum/fhirtypes';
 import { Avatar, HumanNameDisplay, MedplumLink, Scrollable, useResource } from '@medplum/ui';
 import React from 'react';
@@ -32,7 +33,7 @@ export function PatientHeader(props: PatientHeaderProps): JSX.Element | null {
             </dl>
             <dl>
               <dt>Age</dt>
-              <dd>{getAge(patient)}</dd>
+              <dd>{calculateAgeString(patient.birthDate)}</dd>
             </dl>
           </>
         )}
@@ -69,43 +70,4 @@ function getDefaultColor(patient: Patient): string {
     return '#c58686'; // pink
   }
   return '#6cb578'; // green
-}
-
-function getAge(patient: Patient): string | undefined {
-  if (!patient.birthDate) {
-    return undefined;
-  }
-
-  const birthDate = new Date(patient.birthDate);
-  const years = getAgeInYears(birthDate);
-  const months = getAgeInMonths(birthDate);
-  if (years >= 2) {
-    return years.toString().padStart(3, '0') + 'Y';
-  } else {
-    return months.toString().padStart(3, '0') + 'M';
-  }
-}
-
-function getAgeInYears(birthDate: Date): number {
-  const today = new Date();
-  today.setUTCHours(0, 0, 0, 0);
-  let years = today.getUTCFullYear() - birthDate.getUTCFullYear();
-  if (
-    today.getUTCMonth() < birthDate.getUTCMonth() ||
-    (today.getUTCMonth() === birthDate.getUTCMonth() && today.getUTCDate() < birthDate.getUTCDate())
-  ) {
-    years--;
-  }
-  return years;
-}
-
-function getAgeInMonths(birthDate: Date): number {
-  const today = new Date();
-  today.setUTCHours(0, 0, 0, 0);
-  let months =
-    today.getUTCFullYear() * 12 + today.getUTCMonth() - (birthDate.getUTCFullYear() * 12 + birthDate.getUTCMonth());
-  if (today.getUTCDate() < birthDate.getUTCDate()) {
-    months--;
-  }
-  return months;
 }

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -5,13 +5,23 @@
  */
 function decodePayload(payload: string): Record<string, number | string> {
   const cleanedPayload = payload.replace(/-/g, '+').replace(/_/g, '/');
-  const decodedPayload = window.atob(cleanedPayload);
+  const decodedPayload = decodeBase64(cleanedPayload);
   const uriEncodedPayload = Array.from(decodedPayload).reduce((acc, char) => {
     const uriEncodedChar = ('00' + char.charCodeAt(0).toString(16)).slice(-2);
     return `${acc}%${uriEncodedChar}`;
   }, '');
   const jsonPayload = decodeURIComponent(uriEncodedPayload);
   return JSON.parse(jsonPayload);
+}
+
+function decodeBase64(data: string): string {
+  if (typeof window !== 'undefined') {
+    return window.atob(data);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(data, 'base64').toString('binary');
+  }
+  throw new Error('Unable to decode base64');
 }
 
 /**

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,6 +1,8 @@
 import {
   arrayBufferToBase64,
   arrayBufferToHex,
+  calculateAge,
+  calculateAgeString,
   capitalize,
   createReference,
   deepEquals,
@@ -152,6 +154,40 @@ describe('Core Utils', () => {
     expect(getDateProperty(undefined)).toBeUndefined();
     expect(getDateProperty('')).toBeUndefined();
     expect(getDateProperty('2020-01-01')).toEqual(new Date('2020-01-01'));
+  });
+
+  test('Calculate age', () => {
+    expect(calculateAge(new Date().toISOString().substring(0, 10))).toMatchObject({ years: 0, months: 0, days: 0 });
+    expect(calculateAge('2020-01-01', '2020-01-01')).toMatchObject({ years: 0, months: 0, days: 0 });
+    expect(calculateAge('2020-01-01', '2020-01-02')).toMatchObject({ years: 0, months: 0, days: 1 });
+    expect(calculateAge('2020-01-01', '2020-02-01')).toMatchObject({ years: 0, months: 1 });
+    expect(calculateAge('2020-01-01', '2020-02-02')).toMatchObject({ years: 0, months: 1 });
+    expect(calculateAge('2020-01-01', '2020-03-01')).toMatchObject({ years: 0, months: 2 });
+    expect(calculateAge('2020-01-01', '2020-03-02')).toMatchObject({ years: 0, months: 2 });
+    expect(calculateAge('2020-01-01', '2021-01-01')).toMatchObject({ years: 1, months: 12 });
+    expect(calculateAge('2020-01-01', '2021-01-02')).toMatchObject({ years: 1, months: 12 });
+    expect(calculateAge('2020-01-01', '2021-02-01')).toMatchObject({ years: 1, months: 13 });
+    expect(calculateAge('2020-01-01', '2021-02-02')).toMatchObject({ years: 1, months: 13 });
+
+    // End month < start month
+    expect(calculateAge('2020-06-01', '2022-05-01')).toMatchObject({ years: 1, months: 23 });
+
+    // End day < start day
+    expect(calculateAge('2020-06-30', '2022-06-29')).toMatchObject({ years: 1, months: 23 });
+  });
+
+  test('Calculate age string', () => {
+    expect(calculateAgeString('2020-01-01', '2020-01-01')).toEqual('000D');
+    expect(calculateAgeString('2020-01-01', '2020-01-02')).toEqual('001D');
+    expect(calculateAgeString('2020-01-01', '2020-02-01')).toEqual('001M');
+    expect(calculateAgeString('2020-01-01', '2020-02-02')).toEqual('001M');
+    expect(calculateAgeString('2020-01-01', '2020-03-01')).toEqual('002M');
+    expect(calculateAgeString('2020-01-01', '2020-03-02')).toEqual('002M');
+    expect(calculateAgeString('2020-01-01', '2021-01-01')).toEqual('012M');
+    expect(calculateAgeString('2020-01-01', '2021-01-02')).toEqual('012M');
+    expect(calculateAgeString('2020-01-01', '2021-02-01')).toEqual('013M');
+    expect(calculateAgeString('2020-01-01', '2021-02-02')).toEqual('013M');
+    expect(calculateAgeString('2020-01-01', '2022-01-01')).toEqual('002Y');
   });
 
   test('Stringify', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -174,7 +174,7 @@ export function calculateAge(
   }
 
   let months = endYear * 12 + endMonth - (startYear * 12 + startMonth);
-  if (endMonth === startMonth && endDay < startDay) {
+  if (endDay < startDay) {
     months--;
   }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -145,6 +145,43 @@ export function getDateProperty(date: string | undefined): Date | undefined {
 }
 
 /**
+ *
+ * @param birthDate The birth date.
+ * @returns
+ */
+export function calculateAgeInYears(birthDateStr: string, startDateStr?: string): number {
+  const birthDate = new Date(birthDateStr);
+  birthDate.setUTCHours(0, 0, 0, 0);
+
+  const today = startDateStr ? new Date(startDateStr) : new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  let years = today.getUTCFullYear() - birthDate.getUTCFullYear();
+  if (
+    today.getUTCMonth() < birthDate.getUTCMonth() ||
+    (today.getUTCMonth() === birthDate.getUTCMonth() && today.getUTCDate() < birthDate.getUTCDate())
+  ) {
+    years--;
+  }
+  return years;
+}
+
+export function calculateAgeInMonths(birthDateStr: string, startDateStr?: string): number {
+  const birthDate = new Date(birthDateStr);
+  birthDate.setUTCHours(0, 0, 0, 0);
+
+  const today = startDateStr ? new Date(startDateStr) : new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  let months =
+    today.getUTCFullYear() * 12 + today.getUTCMonth() - (birthDate.getUTCFullYear() * 12 + birthDate.getUTCMonth());
+  if (today.getUTCDate() < birthDate.getUTCDate()) {
+    months--;
+  }
+  return months;
+}
+
+/**
  * FHIR JSON stringify.
  * Removes properties with empty string values.
  * Removes objects with zero properties.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -145,40 +145,62 @@ export function getDateProperty(date: string | undefined): Date | undefined {
 }
 
 /**
- *
- * @param birthDate The birth date.
- * @returns
+ * Calculates the age in years from the birth date.
+ * @param birthDateStr The birth date or start date in ISO-8601 format YYYY-MM-DD.
+ * @param endDateStr Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
+ * @returns The age in years, months, and days.
  */
-export function calculateAgeInYears(birthDateStr: string, startDateStr?: string): number {
-  const birthDate = new Date(birthDateStr);
-  birthDate.setUTCHours(0, 0, 0, 0);
+export function calculateAge(
+  birthDateStr: string,
+  endDateStr?: string
+): { years: number; months: number; days: number } {
+  const startDate = new Date(birthDateStr);
+  startDate.setUTCHours(0, 0, 0, 0);
 
-  const today = startDateStr ? new Date(startDateStr) : new Date();
-  today.setUTCHours(0, 0, 0, 0);
+  const endDate = endDateStr ? new Date(endDateStr) : new Date();
+  endDate.setUTCHours(0, 0, 0, 0);
 
-  let years = today.getUTCFullYear() - birthDate.getUTCFullYear();
-  if (
-    today.getUTCMonth() < birthDate.getUTCMonth() ||
-    (today.getUTCMonth() === birthDate.getUTCMonth() && today.getUTCDate() < birthDate.getUTCDate())
-  ) {
+  const startYear = startDate.getUTCFullYear();
+  const startMonth = startDate.getUTCMonth();
+  const startDay = startDate.getUTCDate();
+
+  const endYear = endDate.getUTCFullYear();
+  const endMonth = endDate.getUTCMonth();
+  const endDay = endDate.getUTCDate();
+
+  let years = endYear - startYear;
+  if (endMonth < startMonth || (endMonth === startMonth && endDay < startDay)) {
     years--;
   }
-  return years;
-}
 
-export function calculateAgeInMonths(birthDateStr: string, startDateStr?: string): number {
-  const birthDate = new Date(birthDateStr);
-  birthDate.setUTCHours(0, 0, 0, 0);
-
-  const today = startDateStr ? new Date(startDateStr) : new Date();
-  today.setUTCHours(0, 0, 0, 0);
-
-  let months =
-    today.getUTCFullYear() * 12 + today.getUTCMonth() - (birthDate.getUTCFullYear() * 12 + birthDate.getUTCMonth());
-  if (today.getUTCDate() < birthDate.getUTCDate()) {
+  let months = endYear * 12 + endMonth - (startYear * 12 + startMonth);
+  if (endMonth === startMonth && endDay < startDay) {
     months--;
   }
-  return months;
+
+  const days = Math.floor((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  return { years, months, days };
+}
+
+/**
+ * Calculates the age string for display using the age appropriate units.
+ * If the age is greater than or equal to 2 years, then the age is displayed in years.
+ * If the age is greater than or equal to 1 month, then the age is displayed in months.
+ * Otherwise, the age is displayed in days.
+ * @param birthDateStr The birth date or start date in ISO-8601 format YYYY-MM-DD.
+ * @param endDateStr Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
+ * @returns The age string.
+ */
+export function calculateAgeString(birthDateStr: string, endDateStr?: string): string | undefined {
+  const { years, months, days } = calculateAge(birthDateStr, endDateStr);
+  if (years >= 2) {
+    return years.toString().padStart(3, '0') + 'Y';
+  } else if (months >= 1) {
+    return months.toString().padStart(3, '0') + 'M';
+  } else {
+    return days.toString().padStart(3, '0') + 'D';
+  }
 }
 
 /**


### PR DESCRIPTION
* Modified `client.search()` to accept either a `SearchRequest` or a `string`
  * If the arg is a `string`, then parses it into a `SearchRequest`
* Added `client.searchResources()`
  * Wraps `client.search()` but returns an array of resources rather than `Bundle<T>`
* Added `client.searchOne()`, which is a convenience method for searching for only one result.
  * Automatically adds `_count=1`
  * Returns either the resource if found or `undefined` if not found
* Updated `MedplumClient` to work without `window`
  * This mostly worked before, because we already had an option to pass in `fetch` from `node-fetch`
  * Some of the JWT handshake did not work, because the base64 decoding assumed `window.atob` is available
* Added `calculateAge()` utility, which returns the age in years, months, and days
  * We were previously doing this in `app` for the patient header
  * We've seen a few use cases in bots / other projects (i.e., to calculate the age of a specimen)
* Added `calculateAgeString()` utility, which takes the ages and returns an age string

These all came directly from some custom app development exercises.