### PR TITLE
Always use QuantityDisplay to display quantities

### DIFF
--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -214,6 +214,7 @@ export const HomerObservation4: Observation = {
   valueQuantity: {
     value: 50,
     unit: 'x',
+    comparator: '>',
   },
   referenceRange: [
     {

--- a/packages/ui/src/DiagnosticReportDisplay.test.tsx
+++ b/packages/ui/src/DiagnosticReportDisplay.test.tsx
@@ -79,16 +79,22 @@ describe('DiagnosticReportDisplay', () => {
     await act(async () => {
       setup({ value: HomerDiagnosticReport });
     });
+
+    // See packages/mock/src/mocks/simpsons.ts
     expect(screen.getByText('Diagnostic Report')).toBeDefined();
-    expect(screen.getByText('110/75')).toBeDefined();
+    expect(screen.getByText('110 mmHg / 75 mmHg')).toBeDefined();
+    expect(screen.getByText('> 50 x')).toBeDefined();
   });
 
   test('Renders by reference', async () => {
     await act(async () => {
       setup({ value: { reference: 'DiagnosticReport/123' } });
     });
+
+    // See packages/mock/src/mocks/simpsons.ts
     expect(screen.getByText('Diagnostic Report')).toBeDefined();
-    expect(screen.getByText('110/75')).toBeDefined();
+    expect(screen.getByText('110 mmHg / 75 mmHg')).toBeDefined();
+    expect(screen.getByText('> 50 x')).toBeDefined();
   });
 
   test('Renders presented form', async () => {

--- a/packages/ui/src/QuantityDisplay.tsx
+++ b/packages/ui/src/QuantityDisplay.tsx
@@ -11,9 +11,27 @@ export function QuantityDisplay(props: QuantityDisplayProps): JSX.Element | null
     return null;
   }
 
-  return (
-    <span>
-      {value.comparator} {value.value} {value.unit}
-    </span>
-  );
+  return <>{formatQuantityString(value)}</>;
+}
+
+export function formatQuantityString(quantity: Quantity): string {
+  const result = [];
+
+  if (quantity.comparator) {
+    result.push(quantity.comparator);
+    result.push(' ');
+  }
+
+  if (quantity.value !== undefined) {
+    result.push(quantity.value);
+  }
+
+  if (quantity.unit) {
+    if (quantity.unit !== '%') {
+      result.push(' ');
+    }
+    result.push(quantity.unit);
+  }
+
+  return result.join('');
 }

--- a/packages/ui/src/RangeDisplay.test.tsx
+++ b/packages/ui/src/RangeDisplay.test.tsx
@@ -5,20 +5,17 @@ import { RangeDisplay } from './RangeDisplay';
 describe('RangeDisplay', () => {
   test('Renders', () => {
     render(<RangeDisplay value={{ low: { value: 5, unit: 'mg' }, high: { value: 10, unit: 'mg' } }} />);
-    expect(screen.getByText('5 mg')).toBeInTheDocument();
-    expect(screen.getByText('10 mg')).toBeInTheDocument();
+    expect(screen.getByText('5 mg - 10 mg')).toBeInTheDocument();
   });
 
   test('Renders low only', () => {
     render(<RangeDisplay value={{ low: { value: 5, unit: 'mg' } }} />);
-    expect(screen.getByText('>=')).toBeInTheDocument();
-    expect(screen.getByText('5 mg')).toBeInTheDocument();
+    expect(screen.getByText('>= 5 mg')).toBeInTheDocument();
   });
 
   test('Renders high only', () => {
     render(<RangeDisplay value={{ high: { value: 10, unit: 'mg' } }} />);
-    expect(screen.getByText('<=')).toBeInTheDocument();
-    expect(screen.getByText('10 mg')).toBeInTheDocument();
+    expect(screen.getByText('<= 10 mg')).toBeInTheDocument();
   });
 
   test('Renders undefined value', () => {

--- a/packages/ui/src/RatioDisplay.test.tsx
+++ b/packages/ui/src/RatioDisplay.test.tsx
@@ -5,8 +5,7 @@ import { RatioDisplay } from './RatioDisplay';
 describe('RatioDisplay', () => {
   test('Renders', () => {
     render(<RatioDisplay value={{ numerator: { value: 5, unit: 'mg' }, denominator: { value: 10, unit: 'ml' } }} />);
-    expect(screen.getByText('5 mg')).toBeInTheDocument();
-    expect(screen.getByText('10 ml')).toBeInTheDocument();
+    expect(screen.getByText('5 mg / 10 ml')).toBeInTheDocument();
   });
 
   test('Renders undefined value', () => {

--- a/packages/ui/src/RatioDisplay.tsx
+++ b/packages/ui/src/RatioDisplay.tsx
@@ -13,10 +13,10 @@ export function RatioDisplay(props: RatioDisplayProps): JSX.Element | null {
   }
 
   return (
-    <span>
+    <>
       <QuantityDisplay value={value.numerator} />
       &nbsp;/&nbsp;
       <QuantityDisplay value={value.denominator} />
-    </span>
+    </>
   );
 }

--- a/packages/ui/src/ResourcePropertyDisplay.test.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.test.tsx
@@ -429,7 +429,7 @@ describe('ResourcePropertyDisplay', () => {
       />
     );
 
-    expect(screen.getByText('5 mg')).toBeInTheDocument();
+    expect(screen.getByText('5 mg - 10 mg')).toBeInTheDocument();
   });
 
   test('Renders Ratio', () => {
@@ -447,7 +447,7 @@ describe('ResourcePropertyDisplay', () => {
       />
     );
 
-    expect(screen.getByText('5 mg')).toBeInTheDocument();
+    expect(screen.getByText('5 mg / 10 ml')).toBeInTheDocument();
   });
 
   test('Renders Reference', () => {


### PR DESCRIPTION
Before: The `<DiagnosticReportDisplay>` component had its own logic for rendering `Quantity` values.  That did not include the `Quantity.comparator`

After:  The `<DiagnosticReportDisplay>` component uses the `<QuantityDisplay>` component, which centralizes the logic for rendering `Quantity` values.

Bonus fixes:
* Removed the space separator between the number and the "%" in percentage quantities (i.e., "10 %" to "10%")
* Removed unnecessary `<span>` elements in `<QuantityDisplay>`, `<RangeDisplay>`, and `<RatioDisplay>`