### PR TITLE
Autocomplete sequencing and auto submit

### DIFF
--- a/packages/ui/jest.config.json
+++ b/packages/ui/jest.config.json
@@ -12,7 +12,7 @@
   "setupFilesAfterEnv": ["./src/jest.setup.ts"],
   "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": [
     "**/src/**/*",
     "!**/stories/**"

--- a/packages/ui/src/Autocomplete.test.tsx
+++ b/packages/ui/src/Autocomplete.test.tsx
@@ -559,4 +559,38 @@ describe('Autocomplete', () => {
     expect(option).toBeDefined();
     expect(option?.innerHTML).toMatch(/Carol Brown/);
   });
+
+  test('Auto submit', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <Autocomplete
+        name="foo"
+        loadOptions={async () => ['Homer Simpson', 'Bob Jones', 'Carol Brown']}
+        getId={(item: string) => item}
+        getDisplay={(item: string) => <span>{item}</span>}
+        onChange={onChange}
+      />
+    );
+
+    const input = screen.getByTestId('input-element') as HTMLInputElement;
+
+    // Enter "Simpson"
+    await act(async () => {
+      fireEvent.input(input, { target: { value: 'Simpson' } });
+    });
+
+    // Press "Enter" (without waiting for the dropdown)
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await waitFor(() => expect(onChange).toHaveBeenCalledWith(['Homer Simpson']));
+    });
+
+    expect(onChange).toHaveBeenCalledWith(['Homer Simpson']);
+  });
 });


### PR DESCRIPTION
Before:
* Continuous timer that ticked every 50 ms
* The tick handler looked at the input value, and started a search if the value had changed
* The enter key would submit based on the current dropdown
* The enter key did nothing if no results were ready yet

Now:
* No continuous timer
* On input, a timer is created for 100 ms in the future
* If there is another input event, it cancels the existing timer and creates a new on for 100 ms in the futre
* The timer handler looks at the input value, and started a search if the value had changed
* The enter key still submits based on the current dropdown, but the dropdown should change less now
* If no results are available yet, the enter key is now remembered, and will "auto submit" on the next result load

For most human data entry, there will be no perceivable changes in behavior.

For barcode scanners, this should now match the expected behavior.

Consider a barcode scanner entering the string "123456" + the enter key with a 20 ms delay between characters

Before:
* t=0, Barcode scanner enters "1"
* t=20, Barcode scanner enters "2"
* t=40, Barcode scanner enters "3"
* t=50, Timer event ticks, and initiates a search for "123"
* t=60, Barcode scanner enters "4"
* t=80, Barcode scanner enters "5"
* t=90, Search results for "123" arrive, and the drop down is displayed
* t=100, Barcode scanner enters "6"
* t=120, Barcode scanner sends the "Enter" key, which selects the first result from the "123" search

Now:
* t=0, Barcode scanner enters "1", creates a timer for t=100
* t=20, Barcode scanner enters "2", cancels the previous timer, creates a timer for t=120
* t=40, Barcode scanner enters "3", cancels the previous timer, creates a timer for t=140
* t=60, Barcode scanner enters "4", cancels the previous timer, creates a timer for t=160
* t=80, Barcode scanner enters "5", cancels the previous timer, creates a timer for t=180
* t=100, Barcode scanner enters "6", cancels the previous timer, creates a timer for t=200
* t=120, Barcode scanner sends the "Enter" key, no results are available, so "auto submit" is flagged
* t=200, Timer event ticks, and initiates a search for "123456"
* t=240, Search results for "123" arrive, and the "auto submit" submits the first result

I tested this with [AutoHotKey](https://www.autohotkey.com/) macros, and it worked as expected:

0 ms delay:

```
^j::
Send, 137205{Enter}
return
```

10 ms delay:

```
^j::
Send, 1
Sleep 10
Send, 3
Sleep 10
Send, 7
Sleep 10
Send, 2
Sleep 10
Send, 0
Sleep 10
Send, 5
Sleep 10
Send, {Enter}
return
```

100 ms delay:

```
^j::
Send, 1
Sleep 100
Send, 3
Sleep 100
Send, 7
Sleep 100
Send, 2
Sleep 100
Send, 0
Sleep 100
Send, 5
Sleep 100
Send, {Enter}
return
```

It appears that the keypress delay is configurable in popular barcode scanners:
https://techdocs.zebra.com/datawedge/latest/guide/output/keystroke/

