### PR TITLE
Use Observation.code in getDisplayString(resource)

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -68,6 +68,10 @@ describe('Core Utils', () => {
     expect(getDisplayString({ resourceType: 'Patient', name: [{ family: 'Smith' }] })).toEqual('Smith');
     expect(getDisplayString({ resourceType: 'Patient', id: '123', name: [] })).toEqual('Patient/123');
     expect(getDisplayString({ resourceType: 'Observation', id: '123' })).toEqual('Observation/123');
+    expect(getDisplayString({ resourceType: 'Observation', id: '123', code: {} })).toEqual('Observation/123');
+    expect(getDisplayString({ resourceType: 'Observation', id: '123', code: { text: 'TESTOSTERONE' } })).toEqual(
+      'TESTOSTERONE'
+    );
     expect(getDisplayString({ resourceType: 'ClientApplication', id: '123' })).toEqual('ClientApplication/123');
     expect(
       getDisplayString({

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -71,6 +71,9 @@ export function getDisplayString(resource: Resource): string {
   if ('name' in resource && resource.name && typeof resource.name === 'string') {
     return resource.name;
   }
+  if ('code' in resource && (resource.code as any)?.text) {
+    return (resource.code as any)?.text;
+  }
   return getReferenceString(resource);
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -63,6 +63,11 @@ export function getDisplayString(resource: Resource): string {
       return deviceName;
     }
   }
+  if (resource.resourceType === 'Observation') {
+    if ('code' in resource && (resource.code as any)?.text) {
+      return (resource.code as any)?.text;
+    }
+  }
   if (resource.resourceType === 'User') {
     if (resource.email) {
       return resource.email;
@@ -70,9 +75,6 @@ export function getDisplayString(resource: Resource): string {
   }
   if ('name' in resource && resource.name && typeof resource.name === 'string') {
     return resource.name;
-  }
-  if ('code' in resource && (resource.code as any)?.text) {
-    return (resource.code as any)?.text;
   }
   return getReferenceString(resource);
 }


### PR DESCRIPTION
Before: Observations were displayed as `Observation/{id}`
Now: If available, observations will be displayed as the code.text

<img width="662" alt="image" src="https://user-images.githubusercontent.com/749094/164334230-929a358c-44a1-4e04-9181-da6a60a8a139.png">
