### PR TITLE
DRAFT: Add 'input' and 'resource' as input variables to AWS lambda

### DIFF
--- a/packages/server/src/fhir/operations/publish.ts
+++ b/packages/server/src/fhir/operations/publish.ts
@@ -65,6 +65,8 @@ async function createZipFile(code: string): Promise<Uint8Array> {
     import { assertOk, createReference, LegacyRepositoryClient, MedplumClient } from './medplum.mjs';
     export async function handler(event, context) {
       const accessToken = event.accessToken;
+      const input = event.input;
+      const resource = event.input;
       const medplum = new MedplumClient({ fetch });
       medplum.setAccessToken(accessToken);
       const repo = new LegacyRepositoryClient(medplum);


### PR DESCRIPTION
This is intended to start a conversation regarding how "input" is passed into a Bot.

With the legacy "vm context" bots:
* For `Subscription` events, the resource that triggered the subscription was passed as `resource` 
  * The value is always present
  * The value is always a FHIR resource
* For `$execute` events, the HTTP content body was passed as `input`
  * If the content type is `x-application/hl7-v2+er7`, the value is parsed as an HL7 message
  * If the content type is compatible with `application/json`, the value is a JSON object (this includes FHIR resources)
  * If the content type is `text/plain`, the value is a text string
  * Otherwise `input` is undefined

For the new "AWS lambda" bots:
* We can pass in any valid JSON value (see [Payload](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestSyntax))
* That would support plain text strings and JSON objects such as FHIR resources
* That does not support HL7 messages, because it would not have our HL7 classes

The 2 line change in this PR would allow us to switch over the majority of Bots exactly as written from VM context to AWS lambda.  The only exception is bots that depend on the HL7 parsing.  For those bots, we would need to update the code to explicitly call a `parseHl7()` function.

Alternatively, in the preamble code, we could detect that the input is HL7, and replicate the current HL7 parsing behavior.  This would be more convenient, but it might also increase the feeling of confusing magic.

While we're here, and while the total number of bots is still manageable, some other design considerations:
* Should we continue to use the magic globals such as `resource` and/or `input`?
* Should we consolidate the magic globals into a single parent to help control the chaos?
* Should we instead require bots to `export` a function?  I.e., `export function handler(medplum, input) { ... }`