### PR TITLE
Use 'import type' for json patch

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -13,7 +13,7 @@ import {
   UserConfiguration,
   ValueSet,
 } from '@medplum/fhirtypes';
-import { Operation } from 'fast-json-patch';
+import type { Operation } from 'fast-json-patch';
 import { LRUCache } from './cache';
 import { encryptSHA256, getRandomString } from './crypto';
 import { EventTarget } from './eventtarget';


### PR DESCRIPTION
In `@medplum/core`, we import `Operation` from `fast-json-patch` just for the type definitions.

Unfortunately this causes npm dependency errors :'(

TIL you can use the syntax `import type` to avoid that.