### PR TITLE
Finished migrating 'page' to 'offset'

### DIFF
--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -78,7 +78,7 @@ function addDefaultSearchValues(search: SearchRequest, config: UserConfiguration
   const fields = search.fields ?? getDefaultFields(resourceType);
   const filters = search.filters ?? (!search.resourceType ? getDefaultFilters(resourceType) : undefined);
   const sortRules = search.sortRules ?? getDefaultSortRules(resourceType);
-  const page = search.page ?? 0;
+  const offset = search.offset ?? 0;
   const count = search.count ?? 20;
 
   return {
@@ -87,7 +87,7 @@ function addDefaultSearchValues(search: SearchRequest, config: UserConfiguration
     fields,
     filters,
     sortRules,
-    page,
+    offset,
     count,
   };
 }

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -1,4 +1,11 @@
-import { Filter, formatSearchQuery, parseSearchDefinition, SearchRequest, SortRule } from '@medplum/core';
+import {
+  DEFAULT_SEARCH_COUNT,
+  Filter,
+  formatSearchQuery,
+  parseSearchDefinition,
+  SearchRequest,
+  SortRule,
+} from '@medplum/core';
 import { UserConfiguration } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
@@ -79,7 +86,7 @@ function addDefaultSearchValues(search: SearchRequest, config: UserConfiguration
   const filters = search.filters ?? (!search.resourceType ? getDefaultFilters(resourceType) : undefined);
   const sortRules = search.sortRules ?? getDefaultSortRules(resourceType);
   const offset = search.offset ?? 0;
-  const count = search.count ?? 20;
+  const count = search.count ?? DEFAULT_SEARCH_COUNT;
 
   return {
     ...search,

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -102,10 +102,10 @@ describe('Search Utils', () => {
           value: 'alice',
         },
       ],
-      page: 2,
+      offset: 10,
       count: 5,
     });
-    expect(result).toEqual('?_count=5&_fields=id,name&_page=2&name=alice');
+    expect(result).toEqual('?_count=5&_fields=id,name&_offset=10&name=alice');
   });
 
   test('Format Patient search sort', () => {

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -104,8 +104,9 @@ describe('Search Utils', () => {
       ],
       offset: 10,
       count: 5,
+      total: 'accurate',
     });
-    expect(result).toEqual('?_count=5&_fields=id,name&_offset=10&name=alice');
+    expect(result).toEqual('?_count=5&_fields=id,name&_offset=10&_total=accurate&name=alice');
   });
 
   test('Format Patient search sort', () => {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -2,7 +2,7 @@ export interface SearchRequest {
   readonly resourceType: string;
   filters?: Filter[];
   sortRules?: SortRule[];
-  page?: number;
+  offset?: number;
   count?: number;
   fields?: string[];
   name?: string;
@@ -95,15 +95,15 @@ export function parseSearchDefinition(url: string): SearchRequest {
   let filters: Filter[] | undefined = undefined;
   let sortRules: SortRule[] | undefined = undefined;
   let fields: string[] | undefined = undefined;
-  let page = undefined;
+  let offset = undefined;
   let count = undefined;
   let total = undefined;
 
   params.forEach((value, key) => {
     if (key === '_fields') {
       fields = value.split(',');
-    } else if (key === '_page') {
-      page = parseInt(value);
+    } else if (key === '_offset') {
+      offset = parseInt(value);
     } else if (key === '_count') {
       count = parseInt(value);
     } else if (key === '_total') {
@@ -121,7 +121,7 @@ export function parseSearchDefinition(url: string): SearchRequest {
     resourceType,
     filters,
     fields,
-    page,
+    offset,
     count,
     total,
     sortRules,
@@ -206,15 +206,15 @@ export function formatSearchQuery(definition: SearchRequest): string {
     params.push(formatSortRules(definition.sortRules));
   }
 
-  if (definition.page && definition.page > 0) {
-    params.push('_page=' + definition.page);
+  if (definition.offset !== undefined) {
+    params.push('_offset=' + definition.offset);
   }
 
-  if (definition.count && definition.count > 0) {
+  if (definition.count !== undefined) {
     params.push('_count=' + definition.count);
   }
 
-  if (definition.total) {
+  if (definition.total !== undefined) {
     params.push('_total=' + encodeURIComponent(definition.total));
   }
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_SEARCH_COUNT = 20;
+
 export interface SearchRequest {
   readonly resourceType: string;
   filters?: Filter[];

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -59,6 +59,7 @@ describe('FHIR Repo', () => {
     });
     assertOk(outcome1, result1);
     expect(result1.total).toBeUndefined();
+    expect(result1.link?.length).toBe(3);
 
     const [outcome2, result2] = await systemRepo.search({
       resourceType: 'Patient',
@@ -91,6 +92,8 @@ describe('FHIR Repo', () => {
     });
     assertOk(outcome1, result1);
     expect(result1.entry).toBeUndefined();
+    expect(result1.link).toBeDefined();
+    expect(result1.link?.length).toBe(1);
   });
 
   test('Repo read malformed reference', async () => {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -84,6 +84,15 @@ describe('FHIR Repo', () => {
     expect(typeof result4.total).toBe('number');
   });
 
+  test('Search count=0', async () => {
+    const [outcome1, result1] = await systemRepo.search({
+      resourceType: 'Patient',
+      count: 0,
+    });
+    assertOk(outcome1, result1);
+    expect(result1.entry).toBeUndefined();
+  });
+
   test('Repo read malformed reference', async () => {
     const [outcome1, resource1] = await systemRepo.readReference({
       reference: undefined,

--- a/packages/server/src/fhir/search/parse.test.ts
+++ b/packages/server/src/fhir/search/parse.test.ts
@@ -36,19 +36,11 @@ describe('FHIR Search Utils', () => {
     });
   });
 
-  test('Parse page and count', () => {
-    expect(parseSearchRequest('Patient', { _page: '3', _count: '7' })).toMatchObject({
-      resourceType: 'Patient',
-      page: 3,
-      count: 7,
-    });
-  });
-
   test('Parse count and offset', () => {
     expect(parseSearchRequest('Patient', { _count: '5', _offset: '10' })).toMatchObject({
       resourceType: 'Patient',
-      page: 2,
       count: 5,
+      offset: 10,
     });
   });
 
@@ -64,6 +56,14 @@ describe('FHIR Search Utils', () => {
     expect(parseSearchRequest('Patient', { _total: 'estimate' })).toMatchObject({
       resourceType: 'Patient',
       total: 'estimate',
+    });
+  });
+
+  test('Parse summary', () => {
+    expect(parseSearchRequest('Patient', { _summary: 'true' })).toMatchObject({
+      resourceType: 'Patient',
+      total: 'estimate',
+      count: 0,
     });
   });
 

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -73,18 +73,14 @@ class SearchParser implements SearchRequest {
   readonly resourceType: string;
   readonly filters: Filter[];
   readonly sortRules: SortRule[];
-  page: number;
-  count: number;
-  offset: number;
+  count?: number;
+  offset?: number;
   total?: 'none' | 'estimate' | 'accurate';
 
   constructor(resourceType: string, query: Record<string, string[] | string | undefined>) {
     this.resourceType = resourceType;
     this.filters = [];
     this.sortRules = [];
-    this.page = 0;
-    this.count = 0;
-    this.offset = 0;
 
     for (const [key, value] of Object.entries(query)) {
       if (Array.isArray(value)) {
@@ -92,17 +88,6 @@ class SearchParser implements SearchRequest {
       } else {
         this.#parseKeyValue(key, value ?? '');
       }
-    }
-
-    if (this.offset > 0) {
-      // TODO: Reconcile "page" and "offset"
-      // In normal FHIR search, the notion of "page" and "offset" is unspecified:
-      // https://www.hl7.org/fhir/search.html
-      // In the absence of a spec, we used "page"
-      // In GraphQL, "offset" is specified:
-      // https://www.hl7.org/fhir/graphql.html
-      // It would be nice to migrate everything to the specified behavior.
-      this.page = Math.floor(this.offset / this.count);
     }
   }
 
@@ -154,9 +139,9 @@ class SearchParser implements SearchRequest {
         this.#parseSortRule(value);
         break;
 
-      case '_page':
-        this.page = parseInt(value);
-        break;
+      // case '_page':
+      //   this.page = parseInt(value);
+      //   break;
 
       case '_count':
         this.count = parseInt(value);
@@ -168,6 +153,11 @@ class SearchParser implements SearchRequest {
 
       case '_total':
         this.total = value as 'none' | 'estimate' | 'accurate';
+        break;
+
+      case '_summary':
+        this.total = 'estimate';
+        this.count = 0;
         break;
 
       default: {

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -139,10 +139,6 @@ class SearchParser implements SearchRequest {
         this.#parseSortRule(value);
         break;
 
-      // case '_page':
-      //   this.page = parseInt(value);
-      //   break;
-
       case '_count':
         this.count = parseInt(value);
         break;

--- a/packages/ui/src/DefaultResourceTimeline.tsx
+++ b/packages/ui/src/DefaultResourceTimeline.tsx
@@ -24,7 +24,7 @@ export function DefaultResourceTimeline(props: DefaultResourceTimelineProps): JS
           {
             request: {
               method: 'GET',
-              url: `AuditEvent?entity=${getReferenceString(resource)}&_count=20&_sort=-_lastUpdated`,
+              url: `AuditEvent?entity=${getReferenceString(resource)}&_sort=-_lastUpdated`,
             },
           },
         ],

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -525,5 +525,5 @@ function getStart(search: SearchRequest, total: number): number {
 }
 
 function getEnd(search: SearchRequest, total: number): number {
-  return Math.min(total, ((search.offset ?? 0) + 1) * (search.count ?? 10));
+  return Math.min(total, ((search.offset ?? 0) + 1) * (search.count ?? DEFAULT_SEARCH_COUNT));
 }

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -521,9 +521,9 @@ function FilterIcon(): JSX.Element {
 }
 
 function getStart(search: SearchRequest, total: number): number {
-  return Math.min(total, (search.page ?? 0) * (search.count ?? 10) + 1);
+  return Math.min(total, (search.offset ?? 0) + 1);
 }
 
 function getEnd(search: SearchRequest, total: number): number {
-  return Math.min(total, ((search.page ?? 0) + 1) * (search.count ?? 10));
+  return Math.min(total, ((search.offset ?? 0) + 1) * (search.count ?? 10));
 }

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -1,4 +1,10 @@
-import { Filter, IndexedStructureDefinition, parseSearchDefinition, SearchRequest } from '@medplum/core';
+import {
+  DEFAULT_SEARCH_COUNT,
+  Filter,
+  IndexedStructureDefinition,
+  parseSearchDefinition,
+  SearchRequest,
+} from '@medplum/core';
 import { Bundle, OperationOutcome, Resource, SearchParameter, UserConfiguration } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';

--- a/packages/ui/src/SearchUtils.test.tsx
+++ b/packages/ui/src/SearchUtils.test.tsx
@@ -16,7 +16,7 @@ import {
   getSortField,
   isSortDescending,
   setFilters,
-  setPage,
+  setOffset,
   setSort,
   toggleSort,
 } from './SearchUtils';
@@ -25,7 +25,7 @@ describe('SearchUtils', () => {
   test('Set filters', () => {
     const original: SearchRequest = {
       resourceType: 'Patient',
-      page: 2,
+      offset: 10,
       filters: [
         {
           code: 'name',
@@ -44,7 +44,7 @@ describe('SearchUtils', () => {
     const result = setFilters(original, filters);
     expect(result.filters?.length).toBe(1);
     expect(result.filters?.[0].value).toBe('alice');
-    expect(result.page).toBe(0);
+    expect(result.offset).toBe(0);
   });
 
   test('Clear filters', () => {
@@ -267,18 +267,18 @@ describe('SearchUtils', () => {
     });
   });
 
-  test('Set page', () => {
-    expect(setPage({ resourceType: 'Patient' }, 1)).toMatchObject({
+  test('Set offset', () => {
+    expect(setOffset({ resourceType: 'Patient' }, 1)).toMatchObject({
       resourceType: 'Patient',
-      page: 1,
+      offset: 1,
     });
-    expect(setPage({ resourceType: 'Patient', page: 2 }, 2)).toMatchObject({
+    expect(setOffset({ resourceType: 'Patient', offset: 10 }, 10)).toMatchObject({
       resourceType: 'Patient',
-      page: 2,
+      offset: 10,
     });
-    expect(setPage({ resourceType: 'Patient', page: 3 }, 4)).toMatchObject({
+    expect(setOffset({ resourceType: 'Patient', offset: 15 }, 20)).toMatchObject({
       resourceType: 'Patient',
-      page: 4,
+      offset: 20,
     });
   });
 

--- a/packages/ui/src/SearchUtils.tsx
+++ b/packages/ui/src/SearchUtils.tsx
@@ -72,7 +72,7 @@ export function setFilters(definition: SearchRequest, filters: Filter[]): Search
   return {
     ...definition,
     filters: filters,
-    page: 0,
+    offset: 0,
     name: undefined,
   };
 }
@@ -352,17 +352,17 @@ export function hasFilterOnField(definition: SearchRequest, code: string): boole
 }
 
 /**
- * Sets the page number (starting at zero).
+ * Sets the offset (starting at zero).
  *
- * @param {number} page The page number.
+ * @param {number} offset The offset number.
  */
-export function setPage(definition: SearchRequest, page: number): SearchRequest {
-  if (definition.page === page) {
+export function setOffset(definition: SearchRequest, offset: number): SearchRequest {
+  if (definition.offset === offset) {
     return definition;
   }
   return {
     ...definition,
-    page: page,
+    offset,
     name: undefined,
   };
 }
@@ -374,7 +374,10 @@ export function setPage(definition: SearchRequest, page: number): SearchRequest 
  * @return {boolean} True if the page actually moved; false otherwise.
  */
 export function movePage(definition: SearchRequest, delta: number): SearchRequest {
-  return setPage(definition, Math.max((definition.page || 0) + (delta || 0), 0));
+  const count = definition.count ?? 20;
+  const currOffset = definition.offset ?? 0;
+  const newOffset = currOffset + delta * count;
+  return setOffset(definition, Math.max(newOffset, 0));
 }
 
 /**


### PR DESCRIPTION
In normal FHIR search, the notion of "page" and "offset" is unspecified: https://www.hl7.org/fhir/search.html

In the absence of a spec, we used "page" as our parameter name.

In GraphQL, "offset" is specified: https://www.hl7.org/fhir/graphql.html

So then we implemented "offset", but kept "page" support.

This PR cleans all of that up, removes "page", and moves everything to "offset".

This PR also includes:
* Support for the `_count=0` special case
* Minimal support for the `_summary=true` special case
* `Bundle.link` URL's for "self", "first", "next", and "previous"
* Centralized constant for "default search page size"