### PR TITLE
Disable composite search parameter indexing

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -838,7 +838,7 @@ export class Repository {
    * @param searchParam The search parameter definition.
    */
   #buildColumn(resource: Resource, columns: Record<string, any>, searchParam: SearchParameter): void {
-    if (searchParam.code?.startsWith('_') || this.#isIndexTable(searchParam)) {
+    if (searchParam.code?.startsWith('_') || searchParam.type === 'composite' || this.#isIndexTable(searchParam)) {
       return;
     }
 


### PR DESCRIPTION
[Composite search](https://www.hl7.org/fhir/search.html#composite) is an advanced FHIR search feature:

> When searching using multiple query parameters, there are cases where individual search parameters combined with AND would match unintended results. Composite search parameters are a special type of search parameter that address this issue.
> 
> For example, the Observation resource may contain multiple values in the component field, each of which contains a pair of code and value. A search for Observation?component-code=8867-4&component-value-quantity=lt50 would match a resource that had one component containing a code of 8867-4 and a different component containing a value less than 50. This search cannot be used to restrict to a match of these two values within the same component.

Composite search is already on the backlog.  This PR explicitly ignores `composite` search parameters during the indexing phase, because some of the FHIRPath expressions resolve to the entire FHIR resource, which leads to excessive data duplication.

Consider the FHIRPath expression for `Observation-code-value-concept`:

```json
      "code" : "code-value-concept",
      "base" : ["Observation"],
      "type" : "composite",
      "expression" : "Observation",
      "component" : [{
        "definition" : "http://hl7.org/fhir/SearchParameter/clinical-code",
        "expression" : "code"
      },
      {
        "definition" : "http://hl7.org/fhir/SearchParameter/Observation-value-concept",
        "expression" : "value.as(CodeableConcept)"
      }]
```

The full composite implementation will require either multiple columns or separate lookup tables.  For the current search indexer, evaluating the FHIRPath expression `Observation` simply returns the full resource, which is obviously incorrect.