### PR TITLE
Fixed date/time values in SearchControl

### DIFF
--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -316,6 +316,7 @@ export const HomerServiceRequest: ServiceRequest = {
     },
   ],
   specimen: [createReference(HomerSimpsonSpecimen)],
+  authoredOn: '2020-01-01T12:00:00Z',
 };
 
 export const BartSimpson: Patient = {

--- a/packages/mock/src/mocks/types.ts
+++ b/packages/mock/src/mocks/types.ts
@@ -95,6 +95,14 @@ export const PatientSearchParameters: SearchParameter[] = [
   },
   {
     resourceType: 'SearchParameter',
+    id: 'ServiceRequest-authored',
+    code: 'authored',
+    base: ['ServiceRequest'],
+    type: 'date',
+    expression: 'ServiceRequest.authoredOn',
+  },
+  {
+    resourceType: 'SearchParameter',
     id: 'Observation-value-quantity',
     code: 'value-quantity',
     base: ['Observation'],

--- a/packages/ui/src/ResourcePropertyDisplay.tsx
+++ b/packages/ui/src/ResourcePropertyDisplay.tsx
@@ -8,6 +8,7 @@ import { BackboneElementDisplay } from './BackboneElementDisplay';
 import { CodeableConceptDisplay } from './CodeableConceptDisplay';
 import { CodingDisplay } from './CodingDisplay';
 import { ContactPointDisplay } from './ContactPointDisplay';
+import { DateTimeDisplay } from './DateTimeDisplay';
 import { HumanNameDisplay } from './HumanNameDisplay';
 import { IdentifierDisplay } from './IdentifierDisplay';
 import { PeriodDisplay } from './PeriodDisplay';
@@ -53,8 +54,6 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     case PropertyType.canonical:
     case PropertyType.code:
     case PropertyType.date:
-    case PropertyType.dateTime:
-    case PropertyType.instant:
     case PropertyType.integer:
     case PropertyType.positiveInt:
     case PropertyType.string:
@@ -62,6 +61,9 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     case PropertyType.uri:
     case PropertyType.url:
       return <div>{value}</div>;
+    case PropertyType.dateTime:
+    case PropertyType.instant:
+      return <DateTimeDisplay value={value} />;
     case PropertyType.markdown:
       return <pre>{value}</pre>;
     case PropertyType.Address:

--- a/packages/ui/src/SearchControlField.ts
+++ b/packages/ui/src/SearchControlField.ts
@@ -104,9 +104,6 @@ function getFieldDefinition(
   if (elementDefinition && !searchParam && typeSchema.searchParams) {
     // Try to find a search parameter based on the property
     // For example, name="birthDate", try to find searchParam="birthdate"
-    // const path = `${resourceType}.${name}`;
-    // searchParam = Object.values(typeSchema.searchParams).find((p) => p.expression?.includes(path));
-    // searchParam = getSearchParamForElement(typeSchema, resourceType, name);
     const path = `${resourceType}.${name}`;
     searchParam = Object.values(typeSchema.searchParams).find((p) => p.expression?.includes(path));
   }

--- a/packages/ui/src/stories/SearchControl.stories.tsx
+++ b/packages/ui/src/stories/SearchControl.stories.tsx
@@ -69,7 +69,7 @@ export const ExtraFields = (): JSX.Element => {
 export const ServiceRequests = (): JSX.Element => {
   const [search, setSearch] = useState<SearchRequest>({
     resourceType: 'ServiceRequest',
-    fields: ['id', '_lastUpdated', 'subject', 'code', 'status', 'orderDetail'],
+    fields: ['id', '_lastUpdated', 'subject', 'code', 'status', 'orderDetail', 'authoredOn'],
   });
 
   return (


### PR DESCRIPTION
Before: Simply displayed the unformatted ISO-8601 string

After: Uses `<DateTimeDisplay>` component to nicely format the string