### PR TITLE
Removed references to RefreshToken

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -615,9 +615,6 @@
       "$ref": "#/definitions/Login"
     },
     {
-      "$ref": "#/definitions/RefreshToken"
-    },
-    {
       "$ref": "#/definitions/PasswordChangeRequest"
     },
     {
@@ -1085,9 +1082,6 @@
         },
         {
           "$ref": "#/definitions/Login"
-        },
-        {
-          "$ref": "#/definitions/RefreshToken"
         },
         {
           "$ref": "#/definitions/PasswordChangeRequest"

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -109,15 +109,7 @@ const publicResourceTypes = [
  * Protected resource types are in the "medplum" project.
  * Reading and writing is limited to the system account.
  */
-const protectedResourceTypes = [
-  'JsonWebKey',
-  'Login',
-  'PasswordChangeRequest',
-  'Project',
-  'ProjectMembership',
-  'RefreshToken',
-  'User',
-];
+const protectedResourceTypes = ['JsonWebKey', 'Login', 'PasswordChangeRequest', 'Project', 'ProjectMembership', 'User'];
 
 /**
  * The lookup tables array includes a list of special tables for search indexing.


### PR DESCRIPTION
A long time ago, we had separate types for `Login` and `RefreshToken`.  At some point, they were merged, and now `Login` maintains refresh state.  

This PR removes a few straggler references to the removed `RefreshToken` type.

This came up because we use fhir.schema.json to generate OpenAPI definitions, which led to an error in some tools.