### PR TITLE
Bulk app action

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -9,6 +9,7 @@ import { InvitePage } from './admin/InvitePage';
 import { ProjectPage } from './admin/ProjectPage';
 import { SuperAdminPage } from './admin/SuperAdminPage';
 import { BatchPage } from './BatchPage';
+import { BulkAppPage } from './BulkAppPage';
 import { ChangePasswordPage } from './ChangePasswordPage';
 import { CreateResourcePage } from './CreateResourcePage';
 import { FormPage } from './FormPage';
@@ -53,6 +54,7 @@ export function App(): JSX.Element {
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/changepassword" element={<ChangePasswordPage />} />
           <Route path="/batch" element={<BatchPage />} />
+          <Route path="/bulk/:resourceType" element={<BulkAppPage />} />
           <Route path="/forms/:id" element={<FormPage />} />
           <Route path="/admin/project" element={<ProjectPage />} />
           <Route path="/admin/projects/:projectId/bot" element={<CreateBotPage />} />

--- a/packages/app/src/BulkAppPage.test.tsx
+++ b/packages/app/src/BulkAppPage.test.tsx
@@ -1,0 +1,55 @@
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/ui';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { BulkAppPage } from './BulkAppPage';
+
+const medplum = new MockClient();
+
+describe('ResourcePage', () => {
+  async function setup(url: string): Promise<void> {
+    const urlObj = new URL(url, 'http://localhost');
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: urlObj.href,
+        search: urlObj.search,
+      },
+    });
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <MemoryRouter initialEntries={[url]} initialIndex={0}>
+            <Routes>
+              <Route path="/bulk/:resourceType" element={<BulkAppPage />} />
+            </Routes>
+          </MemoryRouter>
+        </MedplumProvider>
+      );
+    });
+  }
+
+  test('Patient apps', async () => {
+    await setup('/bulk/Patient?ids=123,456');
+    await waitFor(() => screen.getByText('Vitals'));
+    expect(screen.getByText('Vitals')).toBeInTheDocument();
+  });
+
+  test('No apps for resource type', async () => {
+    await setup('/bulk/DeviceDefinition?ids=123');
+    await waitFor(() => screen.getByText('No apps for DeviceDefinition'));
+    expect(screen.getByText('No apps for DeviceDefinition')).toBeInTheDocument();
+  });
+
+  test('No query params', async () => {
+    await setup('/bulk/Patient');
+    await waitFor(() => screen.getByText('Vitals'));
+    expect(screen.getByText('Vitals')).toBeInTheDocument();
+  });
+
+  test('Empty IDs', async () => {
+    await setup('/bulk/Patient?ids=123,,,');
+    await waitFor(() => screen.getByText('Vitals'));
+    expect(screen.getByText('Vitals')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/BulkAppPage.tsx
+++ b/packages/app/src/BulkAppPage.tsx
@@ -1,0 +1,55 @@
+import { Questionnaire } from '@medplum/fhirtypes';
+import { Document, Loading, MedplumLink, useMedplum } from '@medplum/ui';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+export function BulkAppPage(): JSX.Element {
+  const { resourceType } = useParams() as {
+    resourceType: string;
+    id: string;
+  };
+  const queryParams = Object.fromEntries(new URLSearchParams(location.search).entries()) as Record<string, string>;
+  const ids = (queryParams.ids || '').split(',').filter((e) => !!e);
+  const medplum = useMedplum();
+  const [questionnaires, setQuestionnaires] = useState<Questionnaire[]>();
+
+  useEffect(() => {
+    medplum
+      .searchResources<Questionnaire>(`Questionnaire?subject-type=${encodeURIComponent(resourceType)}`)
+      .then(setQuestionnaires);
+  }, [resourceType]);
+
+  if (!questionnaires) {
+    return <Loading />;
+  }
+
+  if (questionnaires.length === 0) {
+    return (
+      <Document>
+        <h1>No apps for {resourceType}</h1>
+        <MedplumLink to={`/${resourceType}`}>Return to search page</MedplumLink>
+      </Document>
+    );
+  }
+
+  return (
+    <Document>
+      <div>
+        {questionnaires.map((questionnaire) => (
+          <div key={questionnaire.id}>
+            <h3>
+              <MedplumLink
+                to={`/forms/${questionnaire?.id}?subject=${encodeURIComponent(
+                  ids.map((id) => `${resourceType}/${id}`).join(',')
+                )}`}
+              >
+                {questionnaire.name}
+              </MedplumLink>
+            </h3>
+            <p>{questionnaire?.description}</p>
+          </div>
+        ))}
+      </div>
+    </Document>
+  );
+}

--- a/packages/app/src/FormPage.test.tsx
+++ b/packages/app/src/FormPage.test.tsx
@@ -65,4 +65,13 @@ describe('FormPage', () => {
     expect(screen.getByText('First question')).toBeInTheDocument();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
   });
+
+  test('Multiple subjects', async () => {
+    await setup('/forms/123?subject=ServiceRequest/123,ServiceRequest/456');
+    await waitFor(() => screen.getByText('First question'));
+
+    expect(screen.getByText('First question')).toBeInTheDocument();
+    expect(screen.getByText('Submit for 2 resources')).toBeInTheDocument();
+    expect(screen.queryByText('Homer Simpson')).not.toBeInTheDocument();
+  });
 });

--- a/packages/app/src/FormPage.test.tsx
+++ b/packages/app/src/FormPage.test.tsx
@@ -71,7 +71,7 @@ describe('FormPage', () => {
     await waitFor(() => screen.getByText('First question'));
 
     expect(screen.getByText('First question')).toBeInTheDocument();
-    expect(screen.getByText('Submit for 2 resources')).toBeInTheDocument();
+    expect(screen.getByText('Vitals (for 2 resources)')).toBeInTheDocument();
     expect(screen.queryByText('Homer Simpson')).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/FormPage.tsx
+++ b/packages/app/src/FormPage.tsx
@@ -7,23 +7,24 @@ import {
   QuestionnaireResponse,
   Resource,
 } from '@medplum/fhirtypes';
-import { Document, Loading, QuestionnaireForm, TitleBar, useMedplum } from '@medplum/ui';
+import { Document, Loading, MedplumLink, QuestionnaireForm, TitleBar, useMedplum } from '@medplum/ui';
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { PatientHeader } from './PatientHeader';
 import { ResourceHeader } from './ResourceHeader';
 import { getPatient } from './utils';
 
 export function FormPage(): JSX.Element {
-  const navigate = useNavigate();
   const { id } = useParams() as { id: string };
   const location = useLocation();
   const queryParams = Object.fromEntries(new URLSearchParams(location.search).entries()) as Record<string, string>;
   const medplum = useMedplum();
   const [loading, setLoading] = useState<boolean>(true);
   const [questionnaire, setQuestionnaire] = useState<Questionnaire | undefined>();
+  const [subjectList, setSubjectList] = useState<string[] | undefined>();
   const [subject, setSubject] = useState<Resource | undefined>();
   const [error, setError] = useState<OperationOutcome>();
+  const [result, setResult] = useState<QuestionnaireResponse[] | undefined>();
 
   useEffect(() => {
     const requestBundle: Bundle = {
@@ -40,12 +41,16 @@ export function FormPage(): JSX.Element {
     };
 
     if ('subject' in queryParams) {
-      (requestBundle.entry as BundleEntry[]).push({
-        request: {
-          method: 'GET',
-          url: queryParams['subject'],
-        },
-      });
+      const subjectIds = queryParams.subject.split(',').filter((e) => !!e);
+      if (subjectIds.length === 1) {
+        (requestBundle.entry as BundleEntry[]).push({
+          request: {
+            method: 'GET',
+            url: subjectIds[0],
+          },
+        });
+      }
+      setSubjectList(subjectIds);
     }
 
     medplum
@@ -73,6 +78,42 @@ export function FormPage(): JSX.Element {
     );
   }
 
+  if (result) {
+    return (
+      <Document>
+        <h1>{questionnaire?.title}</h1>
+        <p>Your response has been recorded.</p>
+        <ul>
+          {result.length === 1 && (
+            <li>
+              <MedplumLink to={result[0]}>Review your answers</MedplumLink>
+            </li>
+          )}
+          {result.length > 1 && (
+            <li>
+              Review your answers:
+              <ul>
+                {result.map((response) => (
+                  <li>
+                    <MedplumLink to={response}>{getReferenceString(response)}</MedplumLink>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          )}
+          {subject && (
+            <li>
+              <MedplumLink to={subject}>Back to&nbsp;{getDisplayString(subject)}</MedplumLink>
+            </li>
+          )}
+          <li>
+            <MedplumLink to="/">Go back home</MedplumLink>
+          </li>
+        </ul>
+      </Document>
+    );
+  }
+
   if (loading || !questionnaire) {
     return <Loading />;
   }
@@ -84,19 +125,39 @@ export function FormPage(): JSX.Element {
       {patient && <PatientHeader patient={patient} />}
       {subject && subject.resourceType !== 'Patient' && <ResourceHeader resource={subject} />}
       <TitleBar>
-        <h1>{getDisplayString(questionnaire)}</h1>
+        <h1>
+          {getDisplayString(questionnaire)}
+          {subjectList && subjectList.length > 1 && <>&nbsp;(for {subjectList.length} resources)</>}
+        </h1>
       </TitleBar>
       <Document>
         <QuestionnaireForm
           questionnaire={questionnaire}
           subject={subject && createReference(subject)}
-          onSubmit={(questionnaireResponse: QuestionnaireResponse) => {
-            medplum.createResource(questionnaireResponse).then((result) => {
-              navigate(`/${getReferenceString(result)}`);
-            });
-          }}
+          onSubmit={handleSubmit}
         />
       </Document>
     </>
   );
+
+  async function handleSubmit(questionnaireResponse: QuestionnaireResponse): Promise<void> {
+    const result = [] as QuestionnaireResponse[];
+
+    if (!subjectList || subjectList.length === 0) {
+      // If there is no subject, then simply submit the questionnaire response.
+      result.push(await medplum.createResource(questionnaireResponse));
+    } else {
+      // Otherwise submit one questionnaire response for each subject ID.
+      for (const subjectId of subjectList) {
+        result.push(
+          await medplum.createResource({
+            ...questionnaireResponse,
+            subject: { reference: subjectId },
+          })
+        );
+      }
+    }
+
+    setResult(result);
+  }
 }

--- a/packages/app/src/FormPage.tsx
+++ b/packages/app/src/FormPage.tsx
@@ -141,15 +141,15 @@ export function FormPage(): JSX.Element {
   );
 
   async function handleSubmit(questionnaireResponse: QuestionnaireResponse): Promise<void> {
-    const result = [] as QuestionnaireResponse[];
+    const responses = [] as QuestionnaireResponse[];
 
     if (!subjectList || subjectList.length === 0) {
       // If there is no subject, then simply submit the questionnaire response.
-      result.push(await medplum.createResource(questionnaireResponse));
+      responses.push(await medplum.createResource(questionnaireResponse));
     } else {
       // Otherwise submit one questionnaire response for each subject ID.
       for (const subjectId of subjectList) {
-        result.push(
+        responses.push(
           await medplum.createResource({
             ...questionnaireResponse,
             subject: { reference: subjectId },
@@ -158,6 +158,6 @@ export function FormPage(): JSX.Element {
       }
     }
 
-    setResult(result);
+    setResult(responses);
   }
 }

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -76,6 +76,9 @@ export function HomePage(): JSX.Element {
             .then(() => setSearch({ ...search }));
         }
       }}
+      onBulk={(ids: string[]) => {
+        navigate(`/bulk/${search.resourceType}?ids=${ids.join(',')}`);
+      }}
     />
   );
 }

--- a/packages/ui/src/SearchControl.test.tsx
+++ b/packages/ui/src/SearchControl.test.tsx
@@ -391,6 +391,27 @@ describe('SearchControl', () => {
     expect(onDelete).toBeCalled();
   });
 
+  test('Bulk button', async () => {
+    const onBulk = jest.fn();
+
+    await setup({
+      search: {
+        resourceType: 'Patient',
+      },
+      onBulk,
+    });
+
+    await act(async () => {
+      await waitFor(() => screen.getByText('Bulk...'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Bulk...'));
+    });
+
+    expect(onBulk).toBeCalled();
+  });
+
   test('Click on row', async () => {
     const props = {
       search: {

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -63,6 +63,7 @@ export interface SearchControlProps {
   onExport?: () => void;
   onDelete?: (ids: string[]) => void;
   onPatch?: (ids: string[]) => void;
+  onBulk?: (ids: string[]) => void;
 }
 
 interface SearchControlState {
@@ -289,6 +290,11 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               onClick={() => (props.onDelete as (ids: string[]) => any)(Object.keys(state.selected))}
             >
               Delete...
+            </Button>
+          )}
+          {props.onBulk && (
+            <Button size="small" onClick={() => (props.onBulk as (ids: string[]) => any)(Object.keys(state.selected))}>
+              Bulk...
             </Button>
           )}
         </div>


### PR DESCRIPTION
Here's how it works:

Select multiple checkboxes on the home page / search page:

![image](https://user-images.githubusercontent.com/749094/166858834-72527601-16fd-46dc-a0a5-83201250e6ac.png)

Choose the app to run.  This is the same logic as the "Apps" tab on a resource page -- It searches for `Questionnaire` resources with matching `subject-type`.

![image](https://user-images.githubusercontent.com/749094/166858955-803b6769-8d80-4843-81d8-a0b5bc8aa269.png)

Submit the questionnaire form like normal.

![image](https://user-images.githubusercontent.com/749094/166859011-960bf701-990b-4af6-97e3-f45f7141c478.png)

Then, the app submits one `QuestionnaireResponse` for each selected resource.

![image](https://user-images.githubusercontent.com/749094/166859079-56cdca2a-65a8-4906-b039-16a6dca98b1e.png)
