### PR TITLE
Unify jest coverage for all packages

### DIFF
--- a/packages/app/jest.config.json
+++ b/packages/app/jest.config.json
@@ -9,8 +9,7 @@
   },
   "testMatch": ["**/src/**/*.test.ts", "**/src/**/*.test.tsx"],
   "setupFilesAfterEnv": ["./src/test.setup.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]
 }

--- a/packages/cli/jest.config.json
+++ b/packages/cli/jest.config.json
@@ -5,7 +5,6 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
   "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]

--- a/packages/core/jest.config.json
+++ b/packages/core/jest.config.json
@@ -5,7 +5,6 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
   "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]

--- a/packages/definitions/jest.config.json
+++ b/packages/definitions/jest.config.json
@@ -5,8 +5,7 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]
 }

--- a/packages/docs/docs/contributing/testing.md
+++ b/packages/docs/docs/contributing/testing.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 50
+---
+
+# Testing
+
+Medplum strongly believes in the importance of testing.
+
+We use the following tools for testing:
+- [Jest](https://jestjs.io/) as the primary test runner
+- [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) for React testing
+  - [@testing-library/dom](https://www.npmjs.com/package/@testing-library/dom) - DOM testing utilities
+  - [@testing-library/jest-dom](https://www.npmjs.com/package/@testing-library/jest-dom) - Jest matchers for DOM state
+  - [@testing-library/react](https://www.npmjs.com/package/@testing-library/react) - Ties it all together: Jest, React, and DOM
+
+Every pull request is analyzed by [Sonarcloud](https://sonarcloud.io/project/overview?id=medplum_medplum) and [Coveralls](https://coveralls.io/github/medplum/medplum?branch=main) for code coverage and other static analysis.
+
+## How to test
+
+To run all tests for all packages, use the build script:
+
+```bash
+./scripts/build.sh
+```
+
+To run all tests for a single package, use `npm t` inside the package folder:
+
+```bash
+cd packages/app
+npm t
+```
+
+To run tests for a single file, pass in the file name:
+
+```bash
+npm t -- src/App.test.tsx
+```
+
+To run a single test in a single file, pass the file name and the test name:
+
+```bash
+npm t -- src/App.test.tsx -t 'Click logo'
+```
+
+Any time you run `npm t`, you can optionally pass in `--coverage` to collect code coverage stats.  They will be printed in the terminal:
+
+```bash
+npm t -- --coverage
+npm t -- src/App.test.tsx --coverage
+npm t -- src/App.test.tsx -t 'Click logo' --coverage
+```

--- a/packages/fhirpath/jest.config.json
+++ b/packages/fhirpath/jest.config.json
@@ -5,8 +5,7 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]
 }

--- a/packages/infra/jest.config.json
+++ b/packages/infra/jest.config.json
@@ -5,8 +5,7 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]
 }

--- a/packages/mock/jest.config.json
+++ b/packages/mock/jest.config.json
@@ -5,8 +5,7 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": ["**/src/**/*"]
 }

--- a/packages/server/jest.config.json
+++ b/packages/server/jest.config.json
@@ -7,7 +7,6 @@
   },
   "moduleFileExtensions": ["ts", "js", "json", "node"],
   "testMatch": ["**/src/**/*.test.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
   "coverageReporters": ["json", "text"],
   "collectCoverageFrom": [

--- a/packages/ui/jest.config.json
+++ b/packages/ui/jest.config.json
@@ -9,9 +9,8 @@
   },
   "testMatch": ["**/src/**/*.test.ts", "**/src/**/*.test.tsx"],
   "setupFilesAfterEnv": ["./src/test.setup.ts"],
-  "collectCoverage": true,
   "coverageDirectory": "coverage",
-  "coverageReporters": ["json"],
+  "coverageReporters": ["json", "text"],
   "collectCoverageFrom": [
     "**/src/**/*",
     "!**/stories/**"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,7 +33,7 @@ done
 
 # Server has special test configuration
 pushd "packages/server"
-node --expose-gc --trace-uncaught --max_old_space_size=4096 ../../node_modules/jest/bin/jest.js --runInBand --logHeapUsage
+node --expose-gc --trace-uncaught --max_old_space_size=4096 ../../node_modules/jest/bin/jest.js --runInBand --logHeapUsage --coverage
 popd
 
 # Combine test coverage

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,7 +27,7 @@ done
 TEST_ORDER=("fhirpath" "core" "mock" "ui" "app" "infra" "cli")
 for PACKAGE in ${TEST_ORDER[@]}; do
   pushd "packages/$PACKAGE"
-  npm t
+  npm t -- --coverage
   popd
 done
 


### PR DESCRIPTION
This is minor, but it fixes an annoyance.

Before:
* Running tests always collected code coverage stats
* Code coverage stats were only output as JSON files

That was bad for two reasons:
* Collecting code coverage slows down tests, and you usually don't need that perf hit
* When you do want to see coverage, you want to see it printed in the console

After:
* Code coverage is not collected by default
* When coverage is collected, they are output as a JSON file and to the console

### What this means for developers

To run all tests for all packages, use the build script:

```bash
./scripts/build.sh
```

To run all tests for a single package, use `npm t` inside the package folder:

```bash
cd packages/app
npm t
```

To run tests for a single file, pass in the file name:

```bash
npm t -- src/App.test.tsx
```

To run a single test in a single file, pass the file name and the test name:

```bash
npm t -- src/App.test.tsx -t 'Click logo'
```

Any time you run `npm t`, you can optionally pass in `--coverage` to collect code coverage stats.  They will be printed in the terminal:

```bash
npm t -- --coverage
npm t -- src/App.test.tsx --coverage
npm t -- src/App.test.tsx -t 'Click logo' --coverage
```