### PR TITLE
Resource delete page

### DIFF
--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -1,4 +1,5 @@
 import { allOk, badRequest, LoginState, notFound } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from './client';
 import { HomerSimpson } from './mocks';
 
@@ -150,5 +151,23 @@ describe('MockClient', () => {
       title: 'test.txt',
       contentType: 'text/plain',
     });
+  });
+
+  test('Delete resource', async () => {
+    const client = new MockClient();
+
+    const resource1 = await client.createResource<Patient>({
+      resourceType: 'Patient',
+    });
+    expect(resource1).toBeDefined();
+
+    const resource2 = await client.readResource('Patient', resource1.id as string);
+    expect(resource2).toBeDefined();
+    expect(resource2.id).toEqual(resource1.id);
+
+    await client.deleteResource('Patient', resource1.id as string);
+
+    const resource3 = await client.readResource('Patient', resource1.id as string);
+    expect(resource3).toBeUndefined();
   });
 });

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -338,6 +338,12 @@ function mockFhirHandler(method: string, url: string, options: any): any {
     }
   } else if (method === 'PUT') {
     return mockRepo.createResource(JSON.parse(options.body));
+  } else if (method === 'DELETE') {
+    if (resourceType && id) {
+      return mockRepo.deleteResource(resourceType, id);
+    } else {
+      return notFound;
+    }
   }
 }
 

--- a/packages/mock/src/repo.test.ts
+++ b/packages/mock/src/repo.test.ts
@@ -69,4 +69,20 @@ describe('Mock Repo', () => {
     expect(result).toBeDefined();
     expect(result.entry?.length).toBe(2);
   });
+
+  test('Delete resource', async () => {
+    const client = new MockClient();
+    const resource1 = await client.createResource<Patient>({
+      resourceType: 'Patient',
+    });
+
+    const resource2 = await client.readResource('Patient', resource1.id as string);
+    expect(resource2).toBeDefined();
+    expect(resource2.id).toEqual(resource1.id);
+
+    await client.deleteResource('Patient', resource1.id as string);
+
+    const resource4 = await client.readResource('Patient', resource1.id as string);
+    expect(resource4).toBeUndefined();
+  });
 });

--- a/packages/mock/src/repo.ts
+++ b/packages/mock/src/repo.ts
@@ -78,6 +78,12 @@ export class MemoryRepository {
     };
   }
 
+  deleteResource(resourceType: string, id: string): void {
+    if (this.#resources?.[resourceType]?.[id]) {
+      delete this.#resources[resourceType][id];
+    }
+  }
+
   private generateId(): string {
     return Date.now().toString(36);
   }

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -370,7 +370,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
                         type="checkbox"
                         value="checked"
                         data-testid="row-checkbox"
-                        aria-label={resource.id}
+                        aria-label={`Checkbox for ${resource.id}`}
                         checked={!!state.selected[resource.id as string]}
                         onChange={(e) => handleSingleCheckboxClick(e, resource.id as string)}
                       />


### PR DESCRIPTION
Both before and after:

To delete a resource, first go to the "Edit" page:
![image](https://user-images.githubusercontent.com/749094/167316489-3f090b89-aec7-4428-8022-14419d0118b6.png)

Scroll to the bottom and click "Delete":
![image](https://user-images.githubusercontent.com/749094/167316511-9d45cbae-aa4b-4807-b142-042b2dab5226.png)

Before:

User is prompted with a `confirm()` dialog:
![image](https://user-images.githubusercontent.com/749094/167316527-f3da2b7d-a50d-4ad7-9492-064d7a996afd.png)

That is ok, but it has a few problems:
1. It's not a great UX.  It's an unstyled dialog that is kinda confusing.
2. Google Chrome has been hinting for years that they intend to deprecate `alert()` and `confirm()`, so it's a temporary so
3. You cannot "link" into the experience, so it needs to be reimplemented everywhere you want to delete something

In this PR:

User is prompted with a separate "Delete Confirmation" page:
![image](https://user-images.githubusercontent.com/749094/167316704-ab4c99e3-b771-46c3-a07d-4bc1ca4e0446.png)

This is partially motivated by https://github.com/medplum/medplum/pull/550 . If a user chooses "Delete..." from a timeline item action menu, it will link directly to this "Delete Confirmation" page.
