### PR TITLE
Fixed missing Observation search params

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -748,7 +748,7 @@ export class MedplumClient extends EventTarget {
           }
         }
       }
-      SearchParameterList(base: "${encodeURIComponent(resourceType)}") {
+      SearchParameterList(base: "${encodeURIComponent(resourceType)}", _count: 100) {
         base,
         code,
         type,


### PR DESCRIPTION
Before: When searching for SearchParameters for a resource type for the search page, we used default search page size of 20 resources

Now: We use page size of 100