### PR TITLE
FHIRPath `resolve` w/ graphQL

### DIFF
--- a/packages/fhirpath/src/fhirpath.test.ts
+++ b/packages/fhirpath/src/fhirpath.test.ts
@@ -493,6 +493,65 @@ const valueset = {
   },
 };
 
+const diagnosticReport = {
+  resourceType: 'DiagnosticReport',
+  id: 'example',
+  status: 'preliminary',
+  code: {
+    coding: [
+      {
+        system: 'https://example.com',
+        code: 'example_report',
+        display: 'Example Report',
+      },
+    ],
+  },
+  result: [
+    {
+      reference: 'Observation/obs1',
+      display: 'TESTOSTERONE',
+      resource: {
+        resourceType: 'Observation',
+        id: 'obs1',
+        code: {
+          coding: [
+            {
+              system: 'https://example.com',
+              code: 'TESTOSTERONE',
+            },
+          ],
+          text: 'TESTOSTERONE',
+        },
+        valueQuantity: {
+          value: 216,
+          unit: 'ng/dL',
+        },
+      },
+    },
+    {
+      reference: 'Observation/obs2',
+      display: 'EGFR',
+      resource: {
+        resourceType: 'Observation',
+        id: 'obs2',
+        code: {
+          coding: [
+            {
+              system: 'https://example.com',
+              code: 'EGFR',
+            },
+          ],
+          text: 'EGFR',
+        },
+        valueQuantity: {
+          value: 1,
+          unit: 'ng/dL',
+        },
+      },
+    },
+  ],
+};
+
 describe('FHIRPath Test Suite', () => {
   describe('Miscellaneous accessor tests', () => {
     test('Extract birthDate', () => {
@@ -1498,6 +1557,17 @@ describe('FHIRPath Test Suite', () => {
 
     test('testSelect2', () => {
       expect(evalFhirPath('Patient.name.select(given | family).count() = 7', patient)).toEqual([true]);
+    });
+  });
+
+  describe('testResolve', () => {
+    test('testResolve1', () => {
+      expect(evalFhirPath('DiagnosticReport.result.resolve().id', diagnosticReport)).toEqual(['obs1', 'obs2']);
+    });
+    test('testResolvePolymorphism', () => {
+      expect(evalFhirPath('DiagnosticReport.result.resolve().value.as(Quantity).value', diagnosticReport)).toEqual([
+        216, 1,
+      ]);
     });
   });
 

--- a/packages/fhirpath/src/functions.test.ts
+++ b/packages/fhirpath/src/functions.test.ts
@@ -530,6 +530,18 @@ describe('FHIRPath functions', () => {
     expect(functions.resolve(['Patient/123'])).toEqual([{ resourceType: 'Patient', id: '123' }]);
     expect(functions.resolve([{ reference: 'Patient/123' }])).toEqual([{ resourceType: 'Patient', id: '123' }]);
     expect(functions.resolve([123])).toEqual([]);
+    expect(
+      functions.resolve([
+        {
+          reference: 'Patient/123',
+          resource: {
+            resourceType: 'Patient',
+            id: '123',
+            name: [{ family: 'Simpson', given: ['Homer'] }],
+          },
+        },
+      ])
+    ).toEqual([{ resourceType: 'Patient', id: '123', name: [{ family: 'Simpson', given: ['Homer'] }] }]);
   });
 
   test('as', () => {

--- a/packages/fhirpath/src/functions.ts
+++ b/packages/fhirpath/src/functions.ts
@@ -1429,7 +1429,11 @@ export function resolve(input: unknown[]): unknown[] {
       if (typeof e === 'string') {
         refStr = e;
       } else if (typeof e === 'object') {
-        refStr = (e as Reference).reference;
+        const ref = e as Reference;
+        if (ref.resource) {
+          return ref.resource;
+        }
+        refStr = ref.reference;
       }
       if (!refStr) {
         return undefined;


### PR DESCRIPTION
Implement 'resolve()' to work with the output of graphQL queries by l…ooking at the `resource` property, if it exists