### PR TITLE
Fixed click on checkbox cell

### DIFF
--- a/packages/ui/src/FhirPathTable.tsx
+++ b/packages/ui/src/FhirPathTable.tsx
@@ -2,12 +2,12 @@ import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
 import { OperationOutcome, Resource } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
+import { FhirPathDisplay } from './FhirPathDisplay';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
 import { SearchClickEvent } from './SearchControl';
-import { killEvent } from './utils/dom';
 import './SearchControl.css';
-import { FhirPathDisplay } from './FhirPathDisplay';
+import { isCheckboxCell, killEvent } from './utils/dom';
 
 export interface SmartSearchField {
   readonly propertyType: PropertyType;
@@ -98,7 +98,7 @@ export function FhirPathTable(props: FhirPathTableProps): JSX.Element {
   }
 
   function handleRowClick(e: React.MouseEvent, resource: Resource): void {
-    if (e.target instanceof HTMLInputElement && e.target.type === 'checkbox') {
+    if (isCheckboxCell(e.target as Element)) {
       // Ignore clicks on checkboxes
       return;
     }

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -20,7 +20,7 @@ import { SearchPopupMenu } from './SearchPopupMenu';
 import { addFilter, buildFieldNameString, getOpString, movePage, renderValue } from './SearchUtils';
 import { Select } from './Select';
 import { TitleBar } from './TitleBar';
-import { killEvent } from './utils/dom';
+import { isCheckboxCell, killEvent } from './utils/dom';
 
 export class SearchChangeEvent extends Event {
   readonly definition: SearchRequest;
@@ -196,7 +196,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
    * @param resource The FHIR resource.
    */
   function handleRowClick(e: React.MouseEvent, resource: Resource): void {
-    if (e.target instanceof HTMLInputElement && e.target.type === 'checkbox') {
+    if (isCheckboxCell(e.target as Element)) {
       // Ignore clicks on checkboxes
       return;
     }

--- a/packages/ui/src/utils/dom.test.ts
+++ b/packages/ui/src/utils/dom.test.ts
@@ -1,4 +1,4 @@
-import { killEvent } from './dom';
+import { isCheckboxCell, killEvent } from './dom';
 
 describe('DOM utils', () => {
   test('killEvent', () => {
@@ -10,5 +10,32 @@ describe('DOM utils', () => {
     killEvent(e as unknown as Event);
     expect(e.preventDefault).toBeCalled();
     expect(e.stopPropagation).toBeCalled();
+  });
+
+  test('isCheckboxCell', () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <table>
+        <tbody>
+          <tr>
+            <td id="td1"><input id="input1" type="checkbox"></td>
+            <td id="td2"><input id="input2" type="text"></td>
+            <td id="td3">
+              <input id="input3" type="checkbox">
+              <input id="input4" type="checkbox">
+            </td>
+            <td id="td4">hello</td>
+          </tr>
+        </tbody>
+      </table>
+    `;
+
+    expect(isCheckboxCell(div.querySelector('#td1') as Element)).toBe(true);
+    expect(isCheckboxCell(div.querySelector('#td2') as Element)).toBe(false);
+    expect(isCheckboxCell(div.querySelector('#td3') as Element)).toBe(false);
+    expect(isCheckboxCell(div.querySelector('#td4') as Element)).toBe(false);
+
+    expect(isCheckboxCell(div.querySelector('#input1') as Element)).toBe(true);
+    expect(isCheckboxCell(div.querySelector('#input2') as Element)).toBe(false);
   });
 });

--- a/packages/ui/src/utils/dom.ts
+++ b/packages/ui/src/utils/dom.ts
@@ -8,3 +8,28 @@ export function killEvent(e: Event | React.SyntheticEvent): void {
   e.preventDefault();
   e.stopPropagation();
 }
+
+/**
+ * Returns true if the element is a checkbox or a table cell containing a checkbox.
+ * Table cells containing checkboxes are commonly accidentally clicked.
+ * @param el The HTML DOM element.
+ * @returns True if the element is a checkbox or a table cell containing a checkbox.
+ */
+export function isCheckboxCell(el: Element): boolean {
+  if (isCheckboxElement(el)) {
+    return true;
+  }
+
+  if (el instanceof HTMLTableCellElement) {
+    const children = el.children;
+    if (children.length === 1 && isCheckboxElement(children[0])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isCheckboxElement(el: Element): boolean {
+  return el instanceof HTMLInputElement && el.type === 'checkbox';
+}


### PR DESCRIPTION
Imagine you click here:

![image](https://user-images.githubusercontent.com/749094/168393982-37919b11-d555-4815-b232-56f831baba3b.png)

Before: You technically clicked on the row, so it takes you to the resource.

Now: We mercifully detect an accidental click, and quietly ignore it.