### PR TITLE
FHIRPath between function

### DIFF
--- a/packages/fhirpath/src/functions.test.ts
+++ b/packages/fhirpath/src/functions.test.ts
@@ -524,6 +524,17 @@ describe('FHIRPath functions', () => {
     expect(functions.today()[0]).toBeDefined();
   });
 
+  test('between', () => {
+    expect(
+      functions.between(
+        undefined,
+        new LiteralAtom('2000-01-01'),
+        new LiteralAtom('2020-01-01'),
+        new LiteralAtom('years')
+      )
+    ).toEqual([{ value: 20, unit: 'years' }]);
+  });
+
   // Other
 
   test('resolve', () => {

--- a/packages/fhirpath/src/functions.test.ts
+++ b/packages/fhirpath/src/functions.test.ts
@@ -533,6 +533,33 @@ describe('FHIRPath functions', () => {
         new LiteralAtom('years')
       )
     ).toEqual([{ value: 20, unit: 'years' }]);
+
+    expect(() =>
+      functions.between(
+        undefined,
+        new LiteralAtom('xxxx-xx-xx'),
+        new LiteralAtom('2020-01-01'),
+        new LiteralAtom('years')
+      )
+    ).toThrow('Invalid start date');
+
+    expect(() =>
+      functions.between(
+        undefined,
+        new LiteralAtom('2020-01-01'),
+        new LiteralAtom('xxxx-xx-xx'),
+        new LiteralAtom('years')
+      )
+    ).toThrow('Invalid end date');
+
+    expect(() =>
+      functions.between(
+        undefined,
+        new LiteralAtom('2000-01-01'),
+        new LiteralAtom('2020-01-01'),
+        new LiteralAtom('xxxxx')
+      )
+    ).toThrow('Invalid units');
   });
 
   // Other

--- a/packages/fhirpath/src/parse.test.ts
+++ b/packages/fhirpath/src/parse.test.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@medplum/definitions';
-import { AuditEvent, Bundle, BundleEntry, Observation, SearchParameter } from '@medplum/fhirtypes';
+import { AuditEvent, Bundle, BundleEntry, Observation, Patient, SearchParameter } from '@medplum/fhirtypes';
 import { evalFhirPath, parseFhirPath } from './parse';
 
 describe('FHIRPath parser', () => {
@@ -389,5 +389,17 @@ describe('FHIRPath parser', () => {
 
     const result = evalFhirPath('AuditEvent.entity.what.where(resolve() is Patient)', auditEvent);
     expect(result).toEqual([]);
+  });
+
+  test('Calculate patient age', () => {
+    const birthDate = new Date();
+    birthDate.setFullYear(birthDate.getFullYear() - 20);
+
+    const patient: Patient = {
+      resourceType: 'Patient',
+      birthDate: birthDate.toLocaleDateString('sv'),
+    };
+    const result = evalFhirPath("between(birthDate, now(), 'years')", patient);
+    expect(result).toEqual([{ value: 20, unit: 'years' }]);
   });
 });

--- a/packages/fhirpath/src/utils.test.ts
+++ b/packages/fhirpath/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { applyMaybeArray, fhirPathEquals, fhirPathIs, toJsBoolean } from './utils';
+import { applyMaybeArray, calculateAge, fhirPathEquals, fhirPathIs, toJsBoolean } from './utils';
 
 describe('FHIRPath utils', () => {
   test('applyMaybeArray', () => {
@@ -34,5 +34,25 @@ describe('FHIRPath utils', () => {
     expect(fhirPathEquals(1, 1)).toEqual(true);
     expect(fhirPathEquals(1, 2)).toEqual(false);
     expect(fhirPathEquals(2, 1)).toEqual(false);
+  });
+
+  test('Calculate age', () => {
+    expect(calculateAge(new Date().toISOString().substring(0, 10))).toMatchObject({ years: 0, months: 0, days: 0 });
+    expect(calculateAge('2020-01-01', '2020-01-01')).toMatchObject({ years: 0, months: 0, days: 0 });
+    expect(calculateAge('2020-01-01', '2020-01-02')).toMatchObject({ years: 0, months: 0, days: 1 });
+    expect(calculateAge('2020-01-01', '2020-02-01')).toMatchObject({ years: 0, months: 1 });
+    expect(calculateAge('2020-01-01', '2020-02-02')).toMatchObject({ years: 0, months: 1 });
+    expect(calculateAge('2020-01-01', '2020-03-01')).toMatchObject({ years: 0, months: 2 });
+    expect(calculateAge('2020-01-01', '2020-03-02')).toMatchObject({ years: 0, months: 2 });
+    expect(calculateAge('2020-01-01', '2021-01-01')).toMatchObject({ years: 1, months: 12 });
+    expect(calculateAge('2020-01-01', '2021-01-02')).toMatchObject({ years: 1, months: 12 });
+    expect(calculateAge('2020-01-01', '2021-02-01')).toMatchObject({ years: 1, months: 13 });
+    expect(calculateAge('2020-01-01', '2021-02-02')).toMatchObject({ years: 1, months: 13 });
+
+    // End month < start month
+    expect(calculateAge('2020-06-01', '2022-05-01')).toMatchObject({ years: 1, months: 23 });
+
+    // End day < start day
+    expect(calculateAge('2020-06-30', '2022-06-29')).toMatchObject({ years: 1, months: 23 });
   });
 });

--- a/packages/fhirpath/src/utils.ts
+++ b/packages/fhirpath/src/utils.ts
@@ -238,3 +238,42 @@ function deepEquals<T1, T2>(object1: T1, object2: T2): boolean {
 function isObject(object: unknown): boolean {
   return object !== null && typeof object === 'object';
 }
+
+/**
+ * Calculates the age in years from the birth date.
+ * @param birthDateStr The birth date or start date in ISO-8601 format YYYY-MM-DD.
+ * @param endDateStr Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
+ * @returns The age in years, months, and days.
+ */
+export function calculateAge(
+  birthDateStr: string,
+  endDateStr?: string
+): { years: number; months: number; days: number } {
+  const startDate = new Date(birthDateStr);
+  startDate.setUTCHours(0, 0, 0, 0);
+
+  const endDate = endDateStr ? new Date(endDateStr) : new Date();
+  endDate.setUTCHours(0, 0, 0, 0);
+
+  const startYear = startDate.getUTCFullYear();
+  const startMonth = startDate.getUTCMonth();
+  const startDay = startDate.getUTCDate();
+
+  const endYear = endDate.getUTCFullYear();
+  const endMonth = endDate.getUTCMonth();
+  const endDay = endDate.getUTCDate();
+
+  let years = endYear - startYear;
+  if (endMonth < startMonth || (endMonth === startMonth && endDay < startDay)) {
+    years--;
+  }
+
+  let months = endYear * 12 + endMonth - (startYear * 12 + startMonth);
+  if (endDay < startDay) {
+    months--;
+  }
+
+  const days = Math.floor((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+
+  return { years, months, days };
+}


### PR DESCRIPTION
This is a non-standard FHIRPath function that calculates the duration of time between two DateTime-likes.

Based on the IBM FHIRPath function:
 * IBM FHIR issue: https://github.com/IBM/FHIR/issues/1014
 * IBM FHIR PR: https://github.com/IBM/FHIR/pull/1023

One unfortunate design consideration here is that our `calculateAge` method is in `@medplum/core`, which is not a dependency for `@medplum/fhirpath`.  For this PR, I duplicated the method, which Sonar will surely complain about.

This has come up in the past.  To address, it might be worth considering breaking off a chunk of `@medplum/core` into `@medplum/util` (and potentially renaming `@medplum/core` to `@medplum/client`).