### PR TITLE
Fixed sendEmail content-type

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -676,6 +676,19 @@ describe('Client', () => {
     expect(result.resourceType).toBe('ValueSet');
   });
 
+  test('Send email', async () => {
+    const client = new MedplumClient(defaultOptions);
+    const result = await client.sendEmail({
+      to: 'alice@example.com',
+      subject: 'Test',
+      text: 'Hello',
+    });
+    expect(result).toBeDefined();
+    expect((result as any).request.url).toBe('https://x/email/v1/send');
+    expect((result as any).request.options.method).toBe('POST');
+    expect((result as any).request.options.headers['Content-Type']).toBe('application/json');
+  });
+
   test('Storage events', async () => {
     // Make window.location writeable
     Object.defineProperty(window, 'location', {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1077,7 +1077,7 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to the operation outcome.
    */
   sendEmail(email: Mail.Options): Promise<OperationOutcome> {
-    return this.post('email/v1/send', email);
+    return this.post('email/v1/send', email, 'application/json');
   }
 
   graphql(query: string, options?: RequestInit): Promise<any> {


### PR DESCRIPTION
`MedplumClient.sendEmail` does not specify content-type, so it falls back to the default of `application/fhir+json`.

At some point, we changed the email endpoint to require `application/json`, so this broke.

If you need a temporary work around, you can replace the call to `sendEmail` with a call to `post`:

```ts
  // sendEmail
  await medplum.sendEmail({
    to: "alice@example.com",
    subject: "Subject",
    text: "Body",
  });

  // post equivalent
  await medplum.post('email/v1/send', {
    to: "alice@example.com",
    subject: "Subject",
    text: "Body",
  }, 'application/json');
```