### PR TITLE
Set code editor value with postMessage

### DIFF
--- a/packages/app/src/BotEditor.test.tsx
+++ b/packages/app/src/BotEditor.test.tsx
@@ -41,6 +41,14 @@ describe('BotEditor', () => {
     await setup('/Bot/123/editor');
     await waitFor(() => screen.getByText('Editor'));
     expect(screen.getByText('Editor')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.load(screen.getByTestId<HTMLIFrameElement>('code-frame'));
+    });
+
+    await act(async () => {
+      fireEvent.load(screen.getByTestId<HTMLIFrameElement>('input-frame'));
+    });
   });
 
   test('Save', async () => {

--- a/packages/app/src/BotEditor.tsx
+++ b/packages/app/src/BotEditor.tsx
@@ -3,6 +3,7 @@ import { Button, useMedplum } from '@medplum/ui';
 import React, { useRef } from 'react';
 import { BotRunner } from './BotRunner';
 import { CodeEditor } from './CodeEditor';
+import { sendCommand } from './utils';
 import './BotEditor.css';
 
 export interface BotEditorProps {
@@ -105,33 +106,4 @@ export function BotEditor(props: BotEditorProps): JSX.Element {
       </div>
     </div>
   );
-}
-
-/**
- * Sends a structured command to the iframe using postMessage.
- *
- * Normally postMessage implies global event listeners. This method uses
- * MessageChannel to create a message channel between the iframe and the parent.
- *
- * See: https://advancedweb.hu/how-to-use-async-await-with-postmessage/
- *
- * @param frame The receiving IFrame.
- * @param command The command to send.
- * @returns Promise to the response from the IFrame.
- */
-function sendCommand(frame: HTMLIFrameElement, command: any): Promise<any> {
-  return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
-
-    channel.port1.onmessage = ({ data }) => {
-      channel.port1.close();
-      if (data.error) {
-        reject(data.error);
-      } else {
-        resolve(data.result);
-      }
-    };
-
-    frame.contentWindow?.postMessage(command, 'https://codeeditor.medplum.com', [channel.port2]);
-  });
 }

--- a/packages/app/src/CodeEditor.tsx
+++ b/packages/app/src/CodeEditor.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { sendCommand } from './utils';
 
 export interface CodeEditorProps {
   language: 'typescript' | 'json';
@@ -11,8 +12,15 @@ export interface CodeEditorProps {
 
 export function CodeEditor(props: CodeEditorProps): JSX.Element {
   const code = props.defaultValue;
-  const url = `https://codeeditor.medplum.com/${props.language}-editor.html?code=${encodeURIComponent(code)}`;
+  const url = `https://codeeditor.medplum.com/${props.language}-editor.html`;
   return (
-    <iframe frameBorder="0" src={url} className={props.className} ref={props.iframeRef} data-testid={props.testId} />
+    <iframe
+      frameBorder="0"
+      src={url}
+      className={props.className}
+      ref={props.iframeRef}
+      data-testid={props.testId}
+      onLoad={(e) => sendCommand(e.currentTarget as HTMLIFrameElement, { command: 'setValue', value: code })}
+    />
   );
 }

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -50,3 +50,32 @@ export function getRecaptcha(): Promise<string> {
     });
   });
 }
+
+/**
+ * Sends a structured command to the iframe using postMessage.
+ *
+ * Normally postMessage implies global event listeners. This method uses
+ * MessageChannel to create a message channel between the iframe and the parent.
+ *
+ * See: https://advancedweb.hu/how-to-use-async-await-with-postmessage/
+ *
+ * @param frame The receiving IFrame.
+ * @param command The command to send.
+ * @returns Promise to the response from the IFrame.
+ */
+export function sendCommand(frame: HTMLIFrameElement, command: any): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = ({ data }) => {
+      channel.port1.close();
+      if (data.error) {
+        reject(data.error);
+      } else {
+        resolve(data.result);
+      }
+    };
+
+    frame.contentWindow?.postMessage(command, 'https://codeeditor.medplum.com', [channel.port2]);
+  });
+}


### PR DESCRIPTION
Before: Initial code set by query string parameter.

Unfortunately, some bots are huge, which led to URL's bigger than CloudFront supported.

Now: Initial code set by JavaScript `postMessage`