### PR TITLE
Handle 404 not found in useResource

### DIFF
--- a/packages/ui/src/useResource.test.tsx
+++ b/packages/ui/src/useResource.test.tsx
@@ -66,4 +66,11 @@ describe('useResource', () => {
     expect(el).toBeInTheDocument();
     expect(el.innerHTML).not.toBe('');
   });
+
+  test('Handles 404 not found', () => {
+    setup({ value: { reference: 'Patient/not-found' } });
+    const el = screen.getByTestId('test-component');
+    expect(el).toBeInTheDocument();
+    expect(el.innerHTML).toBe('');
+  });
 });

--- a/packages/ui/src/useResource.ts
+++ b/packages/ui/src/useResource.ts
@@ -27,11 +27,14 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
     let subscribed = true;
 
     if (!resource && value && 'reference' in value && value.reference) {
-      medplum.readCachedReference(value as Reference<T>).then((r) => {
-        if (subscribed) {
-          setResource(r);
-        }
-      });
+      medplum
+        .readCachedReference(value as Reference<T>)
+        .then((r) => {
+          if (subscribed) {
+            setResource(r);
+          }
+        })
+        .catch(() => setResource(undefined));
     }
 
     return (() => (subscribed = false)) as () => void;


### PR DESCRIPTION
The `useResource` React hook can be used to cleanly normalize a FHIR `Resource` or `Reference` into a resource.  This is an extremely common pattern, and we use it all over the place.

In the common case, `useResource` is called with valid references that resolve correctly.  If `useResource()` is called with an invalid reference, or a reference to a resource that the user does not have access to, then it would blow up with "unhandled rejection".  As we see projects with more creative `AccessPolicy` configurations, this becomes more common.

For example, consider a timeline event where the current user does not have access to the `Practition` resource author.  Before, that would throw an exception, and we would render `Something went wrong` at the nearest error boundary.  Now, we silently ignore the 404, and show a blank space.

In the future, we could try to do something clever with "not found" placeholder text.