### PR TITLE
Fixed the search count display text

### DIFF
--- a/packages/ui/src/Button.css
+++ b/packages/ui/src/Button.css
@@ -34,6 +34,7 @@
   font-size: var(--medplum-font-small);
   line-height: 24px;
   padding: 1px 6px;
+  box-shadow: 0 1px 0.5px rgba(0, 0, 0, 0.1);
 }
 
 .medplum-button.medplum-button-primary {

--- a/packages/ui/src/SearchControl.css
+++ b/packages/ui/src/SearchControl.css
@@ -6,6 +6,13 @@
   background: var(--medplum-surface);
 }
 
+.medplum-search-control .medplum-search-summary {
+  line-height: 28px;
+  padding: 2px 6px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
 /*
  * Table styles
  */
@@ -54,6 +61,14 @@
   background-color: var(--medplum-gray-100);
   text-align: center;
   color: var(--medplum-gray-600);
+}
+
+.medplum-search-control > table thead th svg {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 14px;
+  height: 14px;
 }
 
 /* Body cells */

--- a/packages/ui/src/SearchControl.css
+++ b/packages/ui/src/SearchControl.css
@@ -3,6 +3,7 @@
   overflow: auto;
   text-align: left;
   margin-bottom: 20px;
+  background: var(--medplum-surface);
 }
 
 /*

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -298,14 +298,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         </div>
         {lastResult && (
           <div>
-            <span
-              style={{
-                lineHeight: '28px',
-                padding: '2px 6px',
-                fontSize: '12px',
-                whiteSpace: 'nowrap',
-              }}
-            >
+            <span className="medplum-search-summary">
               {getStart(search, lastResult.total as number)}-{getEnd(search, lastResult.total as number)} of{' '}
               {lastResult.total?.toLocaleString()}
             </span>
@@ -522,9 +515,8 @@ function FilterIcon(): JSX.Element {
       className="h-6 w-6"
       fill="none"
       viewBox="0 0 24 24"
-      stroke="currentColor"
+      stroke="rgba(0, 0, 0, 0.3)"
       strokeWidth={2}
-      style={{ width: 14, height: 14, float: 'right', verticalAlign: 'text-top' }}
     >
       <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16m-7 6h7" />
     </svg>

--- a/packages/ui/src/SearchControl.tsx
+++ b/packages/ui/src/SearchControl.tsx
@@ -303,10 +303,11 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
                 lineHeight: '28px',
                 padding: '2px 6px',
                 fontSize: '12px',
+                whiteSpace: 'nowrap',
               }}
             >
               {getStart(search, lastResult.total as number)}-{getEnd(search, lastResult.total as number)} of{' '}
-              {lastResult.total}
+              {lastResult.total?.toLocaleString()}
             </span>
             <Button testid="prev-page-button" size="small" onClick={() => emitSearchChange(movePage(search, -1))}>
               &lt;&lt;

--- a/packages/ui/src/stories/SearchControl.stories.tsx
+++ b/packages/ui/src/stories/SearchControl.stories.tsx
@@ -47,6 +47,29 @@ export const NoCheckboxes = (): JSX.Element => {
   );
 };
 
+export const AllButtons = (): JSX.Element => {
+  const [search, setSearch] = useState<SearchRequest>({
+    resourceType: 'Patient',
+    fields: ['id', '_lastUpdated', 'name'],
+  });
+
+  return (
+    <SearchControl
+      search={search}
+      onLoad={(e) => console.log('onLoad', e)}
+      onClick={(e) => console.log('onClick', e)}
+      onNew={() => console.log('onNew')}
+      onExport={() => console.log('onExport')}
+      onDelete={() => console.log('onDelete')}
+      onBulk={() => console.log('onBulk')}
+      onChange={(e) => {
+        console.log('onChange', e);
+        setSearch(e.definition);
+      }}
+    />
+  );
+};
+
 export const ExtraFields = (): JSX.Element => {
   const [search, setSearch] = useState<SearchRequest>({
     resourceType: 'Patient',


### PR DESCRIPTION
The search control header bar on mobile wrapped poorly.

Before:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/749094/170846493-75745043-b01b-491f-b491-6d40519e364d.png">


After:

<img width="314" alt="image" src="https://user-images.githubusercontent.com/749094/170846666-a5a2fd91-e576-4ba4-9ff8-111d03973c05.png">
