### PR TITLE
Enabled ESLint rule prefer-promise-reject-errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "prefer-promise-reject-errors": "error"
   }
 }

--- a/packages/core/src/readablepromise.test.ts
+++ b/packages/core/src/readablepromise.test.ts
@@ -12,11 +12,11 @@ describe('ReadablePromise', () => {
 
   test('read reject', async () => {
     expect.assertions(2);
-    const promise = new ReadablePromise(Promise.reject('x'));
+    const promise = new ReadablePromise(Promise.reject(new Error('x')));
     try {
       await promise;
     } catch (err) {
-      expect(err).toBe('x');
+      expect((err as Error).message).toBe('x');
     }
     expect(() => promise.read()).toThrow('x');
   });
@@ -30,11 +30,11 @@ describe('ReadablePromise', () => {
 
   test('catch', async () => {
     const onRejected = jest.fn();
-    const promise = new ReadablePromise(Promise.reject('x')).catch(onRejected);
+    const promise = new ReadablePromise(Promise.reject(new Error('x'))).catch(onRejected);
     try {
       await promise;
     } catch (err) {
-      expect(err).toBe('x');
+      expect((err as Error).message).toBe('x');
     }
     expect(onRejected).toHaveBeenCalled();
   });

--- a/packages/core/src/readablepromise.ts
+++ b/packages/core/src/readablepromise.ts
@@ -8,7 +8,7 @@ export class ReadablePromise<T> implements Promise<T> {
   #suspender: Promise<T>;
   #status: 'pending' | 'error' | 'success' = 'pending';
   #response: T | undefined;
-  #error: any;
+  #error: Error | undefined;
 
   constructor(requestPromise: Promise<T>) {
     this.#suspender = requestPromise.then(

--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -206,6 +206,6 @@ async function createBufferForStream(message: string, stream: Duplex): Promise<B
     const _buf = Array<any>();
     stream.on('data', (chunk) => _buf.push(chunk));
     stream.on('end', () => resolve(Buffer.concat(_buf)));
-    stream.on('error', (err) => reject(`error converting stream - ${err}`));
+    stream.on('error', (err) => reject(new Error(`error converting stream - ${err}`)));
   });
 }

--- a/packages/server/src/fhir/operations/deploy.test.ts
+++ b/packages/server/src/fhir/operations/deploy.test.ts
@@ -26,7 +26,7 @@ jest.mock('@aws-sdk/client-lambda', () => {
             },
           };
         } else {
-          return Promise.reject('Function not found');
+          return Promise.reject(new Error('Function not found'));
         }
       }
       if (command instanceof original.CreateFunctionCommand) {

--- a/packages/server/src/fhir/storage.test.ts
+++ b/packages/server/src/fhir/storage.test.ts
@@ -151,7 +151,7 @@ describe('Storage', () => {
 
     const binary = null as unknown as Binary;
     const stream = null as unknown as internal.Readable;
-    expect(storage.writeBinary(binary, 'test.exe', 'text/plain', stream)).rejects.toEqual('Invalid file extension');
+    expect(storage.writeBinary(binary, 'test.exe', 'text/plain', stream)).rejects.toThrow('Invalid file extension');
     expect(Upload).not.toHaveBeenCalled();
   });
 
@@ -164,7 +164,7 @@ describe('Storage', () => {
 
     const binary = null as unknown as Binary;
     const stream = null as unknown as internal.Readable;
-    expect(storage.writeBinary(binary, 'test.sh', 'application/x-sh', stream)).rejects.toEqual('Invalid content type');
+    expect(storage.writeBinary(binary, 'test.sh', 'application/x-sh', stream)).rejects.toThrow('Invalid content type');
     expect(Upload).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -59,12 +59,7 @@ class FileSystemStorage implements BinaryStorage {
     contentType: string | undefined,
     stream: internal.Readable | NodeJS.ReadableStream
   ): Promise<void> {
-    if (checkFileExtension(filename)) {
-      return Promise.reject('Invalid file extension');
-    }
-    if (checkContentType(contentType)) {
-      return Promise.reject('Invalid content type');
-    }
+    checkFileMetadata(filename, contentType);
     const dir = this.#getDir(binary);
     if (!existsSync(dir)) {
       mkdirSync(dir);
@@ -135,12 +130,7 @@ class S3Storage implements BinaryStorage {
     contentType: string | undefined,
     stream: internal.Readable | NodeJS.ReadableStream
   ): Promise<void> {
-    if (checkFileExtension(filename)) {
-      return Promise.reject('Invalid file extension');
-    }
-    if (checkContentType(contentType)) {
-      return Promise.reject('Invalid content type');
-    }
+    checkFileMetadata(filename, contentType);
     const upload = new Upload({
       params: {
         Bucket: this.#bucket,
@@ -244,6 +234,21 @@ const BLOCKED_CONTENT_TYPES = [
   'application/zip',
   'text/javascript',
 ];
+
+/**
+ * Checks file metadata against blocked lists.
+ * Throws an execption if the file metadata is blocked.
+ * @param filename The input filename.
+ * @param contentType The input content type.
+ */
+function checkFileMetadata(filename: string | undefined, contentType: string | undefined): void {
+  if (checkFileExtension(filename)) {
+    throw new Error('Invalid file extension');
+  }
+  if (checkContentType(contentType)) {
+    throw new Error('Invalid content type');
+  }
+}
 
 /**
  * Checks if the file extension is blocked.

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -62,7 +62,7 @@ describe('Keys', () => {
     try {
       await generateIdToken({ iss: config.issuer, login_id: '123', nonce: randomUUID() });
     } catch (err) {
-      expect(err).toEqual('Signing key not initialized');
+      expect((err as Error).message).toEqual('Signing key not initialized');
     }
   });
 
@@ -79,13 +79,13 @@ describe('Keys', () => {
     try {
       await generateIdToken({ iss: config.issuer, login_id: '123', nonce: randomUUID() });
     } catch (err) {
-      expect(err).toEqual('Signing key not initialized');
+      expect((err as Error).message).toEqual('Signing key not initialized');
     }
 
     try {
       await verifyJwt('xyz');
     } catch (err) {
-      expect(err).toEqual('Signing key not initialized');
+      expect((err as Error).message).toEqual('Signing key not initialized');
     }
   });
 

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -214,9 +214,9 @@ export function generateRefreshToken(claims: MedplumRefreshTokenClaims): Promise
  * @param claims The key/value pairs to include in the payload section.
  * @returns Promise to generate and sign the JWT.
  */
-function generateJwt(exp: '1h' | '2w', claims: JWTPayload): Promise<string> {
+async function generateJwt(exp: '1h' | '2w', claims: JWTPayload): Promise<string> {
   if (!signingKey || !issuer) {
-    return Promise.reject('Signing key not initialized');
+    throw new Error('Signing key not initialized');
   }
 
   return new SignJWT(claims)
@@ -233,9 +233,9 @@ function generateJwt(exp: '1h' | '2w', claims: JWTPayload): Promise<string> {
  * @param jwt The jwt token / bearer token.
  * @returns Returns the decoded claims on success.
  */
-export function verifyJwt(token: string): Promise<{ payload: JWTPayload; protectedHeader: JWSHeaderParameters }> {
+export async function verifyJwt(token: string): Promise<{ payload: JWTPayload; protectedHeader: JWSHeaderParameters }> {
   if (!issuer) {
-    return Promise.reject('Signing key not initialized');
+    throw new Error('Signing key not initialized');
   }
 
   const verifyOptions: JWTVerifyOptions = {

--- a/packages/server/src/util/pdf.test.ts
+++ b/packages/server/src/util/pdf.test.ts
@@ -28,8 +28,8 @@ describe('Binary', () => {
   });
 
   test('Missing values', () => {
-    expect(() => createPdf(null as unknown as Repository, 'test.pdf', dd)).rejects.toEqual('Missing repository');
-    expect(() => createPdf(systemRepo, 'x', null as unknown as TDocumentDefinitions)).rejects.toEqual(
+    expect(() => createPdf(null as unknown as Repository, 'test.pdf', dd)).rejects.toThrow('Missing repository');
+    expect(() => createPdf(systemRepo, 'x', null as unknown as TDocumentDefinitions)).rejects.toThrow(
       'Missing document definition'
     );
   });

--- a/packages/server/src/util/pdf.ts
+++ b/packages/server/src/util/pdf.ts
@@ -12,11 +12,11 @@ export async function createPdf(
   docDefinition: TDocumentDefinitions
 ): Promise<Binary> {
   if (!repo) {
-    return Promise.reject('Missing repository');
+    throw new Error('Missing repository');
   }
 
   if (!docDefinition) {
-    return Promise.reject('Missing document definition');
+    throw new Error('Missing document definition');
   }
 
   // Setup standard fonts

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -358,7 +358,7 @@ async function execBot(subscription: Subscription, resource: Resource): Promise<
   }
 
   if (!runAs) {
-    return Promise.reject('Could not find project membership for bot');
+    throw new Error('Could not find project membership for bot');
   }
 
   let outcome: AuditEventOutcome;


### PR DESCRIPTION
See: https://eslint.org/docs/rules/prefer-promise-reject-errors

Before: To handle errors, we inconsistently used one of the following:

1. `throw new Error('message')
2. `return Promise.reject('message')
3. `return Promise.reject(new Error('message'))

Which was probably confusing to any consumer.

Now:

1. In `async` functions, prefer `throw new Error('message')`
2. If you have to use `Promise.reject`, you have to `Promise.reject(new Error('message'))`
3. `return Promise.reject('message')` is a lint error