### PR TITLE
Handle missing resource type in smart table

### DIFF
--- a/packages/app/src/SmartSearchPage.tsx
+++ b/packages/app/src/SmartSearchPage.tsx
@@ -26,8 +26,8 @@ export function SmartSearchPage(): JSX.Element | null {
       checkboxesEnabled={true}
       query={query}
       fields={fields}
-      onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
-      onAuxClick={(e) => window.open(`/${e.resource.resourceType}/${e.resource.id}`, '_blank')}
+      onClick={(e) => navigate(`/${resourceType}/${e.resource.id}`)}
+      onAuxClick={(e) => window.open(`/${resourceType}/${e.resource.id}`, '_blank')}
       onBulk={(ids: string[]) => {
         navigate(`/bulk/${resourceType}?ids=${ids.join(',')}`);
       }}


### PR DESCRIPTION
Before: The `<SmartSearchPage>` click handler assumed that resources will have a `resourceType` property.  If the graphql query did not explicilty include `resourceType`, then it was missing, and the user would navigate to an incorrect URL such as `/undefined/123`.

Now: The `<SmartSearchPage>` click handler uses the page-level `resourceType` and ignores the value on the resource.

If you need a temporary workaround, you can include `resourceType` in the graphql query.