### PR TITLE
Remove expected errors from console log

### DIFF
--- a/packages/ui/src/ErrorBoundary.test.tsx
+++ b/packages/ui/src/ErrorBoundary.test.tsx
@@ -21,6 +21,7 @@ describe('ErrorBoundary', () => {
   });
 
   test('Handles error', () => {
+    console.error = jest.fn();
     render(
       <div>
         <div>outside</div>
@@ -33,5 +34,6 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('outside')).toBeInTheDocument();
     expect(screen.queryByText('inside')).toBeNull();
     expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+    expect(console.error).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/FhirPathDisplay.test.tsx
+++ b/packages/ui/src/FhirPathDisplay.test.tsx
@@ -21,6 +21,7 @@ describe('FhirPathDisplay', () => {
   });
 
   test('Error on multiple values', () => {
+    console.error = jest.fn();
     const patient: Patient = {
       resourceType: 'Patient',
       name: [
@@ -33,6 +34,7 @@ describe('FhirPathDisplay', () => {
     expect(() =>
       render(<FhirPathDisplay resource={patient} path="Patient.name.given" propertyType={PropertyType.string} />)
     ).toThrow('must resolve to a single element');
+    expect(console.error).toHaveBeenCalled();
   });
 
   test('Handles null name', () => {


### PR DESCRIPTION
Before:  React unit tests where we expected an error would pollute the console output.

Now: We capture the output for a tidy console output.