### PR TITLE
Bot logging update

### DIFF
--- a/packages/app/src/BotEditor.tsx
+++ b/packages/app/src/BotEditor.tsx
@@ -61,7 +61,11 @@ export function BotEditor(props: BotEditorProps): JSX.Element {
 
   async function executeBot(): Promise<void> {
     const input = await getSampleInput();
-    medplum.post(medplum.fhirUrl('Bot', bot.id as string, '$execute'), { input });
+    const result = await medplum.post(medplum.fhirUrl('Bot', bot.id as string, '$execute'), input);
+    await sendCommand(outputFrameRef.current as HTMLIFrameElement, {
+      command: 'setValue',
+      value: result,
+    });
   }
 
   return (

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -22,10 +22,19 @@ export async function handler(event, context) {
   const { accessToken, input, contentType } = event;
   const medplum = new MedplumClient({ fetch });
   medplum.setAccessToken(accessToken);
-  return userCode.handler(medplum, {
-    input: contentType === 'x-application/hl7-v2+er7' ? Hl7Message.parse(input) : input,
-    contentType,
-  });
+  try {
+    return await userCode.handler(medplum, {
+      input: contentType === 'x-application/hl7-v2+er7' ? Hl7Message.parse(input) : input,
+      contentType,
+    });
+  } catch (err) {
+    if (err instanceof Error) {
+      console.log('Unhandled error: ' + err.message + '\\n' + err.stack);
+    } else {
+      console.log('Unhandled error: ' + err);
+    }
+    throw err;
+  }
 }
 `;
 

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -14,7 +14,10 @@ jest.mock('@aws-sdk/client-lambda', () => {
   class LambdaClient {
     async send(): Promise<any> {
       return {
-        LogResult: '',
+        LogResult: `START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
+2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
+END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873`,
         Payload: '',
       };
     }

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -4,20 +4,22 @@ import request from 'supertest';
 import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
-import { initTestAuth } from '../../test.setup';
 import { initKeys } from '../../oauth';
 import { seedDatabase } from '../../seed';
+import { initTestAuth } from '../../test.setup';
 
 jest.mock('@aws-sdk/client-lambda', () => {
   const original = jest.requireActual('@aws-sdk/client-lambda');
 
   class LambdaClient {
     async send(): Promise<any> {
+      // LogResult:
+      // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
+      // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
+      // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+      // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
       return {
-        LogResult: `START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
-2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
-END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873`,
+        LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
         Payload: '',
       };
     }

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -176,7 +176,7 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
  * @returns The parsed log result.
  */
 function parseLambdaLog(logResult: string): string {
-  const logBuffer = Buffer.from(logResult as string, 'base64');
+  const logBuffer = Buffer.from(logResult, 'base64');
   const log = logBuffer.toString('ascii');
   if (!log.startsWith('START RequestId: ')) {
     return log;

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -147,12 +147,11 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
   // Execute the command
   try {
     const response = await client.send(command);
-    const logBuffer = Buffer.from(response.LogResult as string, 'base64');
     const responseStr = response.Payload ? new TextDecoder().decode(response.Payload) : undefined;
     const returnValue = responseStr && isJsonContentType(contentType) ? JSON.parse(responseStr) : responseStr;
     return {
-      success: true,
-      logResult: logBuffer.toString('ascii'),
+      success: !response.FunctionError,
+      logResult: parseLambdaLog(response.LogResult as string),
       returnValue,
     };
   } catch (err) {
@@ -161,6 +160,51 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
       logResult: (err as Error).message,
     };
   }
+}
+
+/**
+ * Parses the AWS Lambda log result.
+ *
+ * The raw logs include markup metadata such as timestamps and billing information.
+ *
+ * We only want to include the actual log contents in the AuditEvent,
+ * so we attempt to scrub away all of that extra metadata.
+ *
+ * See: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html
+ *
+ * @param logResult The raw log result from the AWS lambda event.
+ * @returns The parsed log result.
+ */
+function parseLambdaLog(logResult: string): string {
+  const logBuffer = Buffer.from(logResult as string, 'base64');
+  const log = logBuffer.toString('ascii');
+  if (!log.startsWith('START RequestId: ')) {
+    return log;
+  }
+  const lines = log.split('\n');
+  const requestId = lines[0].split(' ')[2];
+  const requestRegex = new RegExp(`${requestId}\\s+\\w+`);
+  const result = [];
+  for (const line of lines) {
+    if (
+      line.startsWith(`START RequestId: ${requestId}`) ||
+      line.startsWith(`END RequestId: ${requestId}`) ||
+      line.startsWith(`REPORT RequestId: ${requestId}`)
+    ) {
+      // Ignore the metadata lines
+      continue;
+    }
+    const match = requestRegex.exec(line);
+    if (match) {
+      const trimmed = line.substring(match.index + match[0].length).trimStart();
+      if (!trimmed.startsWith('Invoke Error')) {
+        result.push(trimmed);
+      }
+    } else {
+      result.push(line);
+    }
+  }
+  return result.join('\n');
 }
 
 /**


### PR DESCRIPTION
Updates:
* Catch unhandled errors in "Simulate", and show the stack trace
* Catch unhandled errors in "Execute", and show the stack trace
* Scrub the raw AWS Lambda logs
  * Remove "START", "END", and "RESULT" lines
  * Remove "requestId" metadata