### PR TITLE
Added more named table layouts

### DIFF
--- a/packages/server/src/util/pdf.test.ts
+++ b/packages/server/src/util/pdf.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, rmSync } from 'fs';
 import { sep } from 'path';
-import { TDocumentDefinitions } from 'pdfmake/interfaces';
+import { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initBinaryStorage, Repository, systemRepo } from '../fhir';
@@ -42,6 +42,42 @@ describe('Binary', () => {
       content: ['Hello world'],
     };
     const binary = await createPdf(systemRepo, 'custom-font.pdf', custom);
+    expect(binary).toBeDefined();
+  });
+
+  test('Custom table layouts', async () => {
+    const layoutNames = [
+      'noBorders',
+      'headerLineOnly',
+      'lightHorizontalLines',
+      'medplumNoBorders',
+      'medplumMetadata',
+      'medplumObservations',
+    ];
+
+    const content: Content[] = layoutNames
+      .map((name) => [
+        {
+          text: name,
+        },
+        {
+          layout: name,
+          table: {
+            body: [
+              ['First', 'Second', 'Third', 'The last one'],
+              ['Value 1', 'Value 2', 'Value 3', 'Value 4'],
+              ['Value 1', 'Value 2', 'Value 3', 'Value 4'],
+            ],
+          },
+        },
+      ])
+      .flat();
+
+    const docDefinition: TDocumentDefinitions = {
+      content,
+    };
+
+    const binary = await createPdf(systemRepo, 'custom-table.pdf', docDefinition);
     expect(binary).toBeDefined();
   });
 });

--- a/packages/server/src/util/pdf.ts
+++ b/packages/server/src/util/pdf.ts
@@ -2,9 +2,41 @@ import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { resolve } from 'path';
 import PdfPrinter from 'pdfmake';
-import { TDocumentDefinitions } from 'pdfmake/interfaces';
+import { ContentTable, CustomTableLayout, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { PassThrough } from 'stream';
 import { getBinaryStorage, Repository } from '../fhir';
+
+const tableLayouts: { [key: string]: CustomTableLayout } = {
+  medplumNoBorders: {
+    hLineWidth: () => 0,
+    vLineWidth: () => 0,
+    paddingLeft: () => 0,
+    paddingRight: () => 0,
+    paddingTop: () => 0,
+    paddingBottom: () => 0,
+  },
+  medplumMetadata: {
+    hLineWidth: () => 1,
+    vLineWidth: () => 0,
+    hLineColor: (i: number) => (i === 0 ? 'black' : 'white'),
+    vLineColor: () => 'white',
+    paddingLeft: () => 0,
+    paddingRight: () => 0,
+    paddingTop: () => 1,
+    paddingBottom: () => 1,
+  },
+  medplumObservations: {
+    hLineWidth: (i: number, node: ContentTable) => (i === 0 || i === node.table?.body.length ? 2 : 1),
+    vLineWidth: () => 0,
+    hLineColor: (i: number, node: ContentTable) => (i <= 1 || i === node.table?.body.length ? 'black' : '#999'),
+    vLineColor: () => 'white',
+    fillColor: (row: number) => (row > 0 ? '#eee' : null),
+    paddingLeft: () => 0,
+    paddingRight: () => 0,
+    paddingTop: () => 0,
+    paddingBottom: () => 0,
+  },
+};
 
 export async function createPdf(
   repo: Repository,
@@ -60,7 +92,7 @@ export async function createPdf(
   // Start the stream producer
   // This will print the PDF to the stream buffer
   const printer = new PdfPrinter(fonts);
-  const pdfDoc = printer.createPdfKitDocument(docDefinition, {});
+  const pdfDoc = printer.createPdfKitDocument(docDefinition, { tableLayouts });
   pdfDoc.pipe(stream);
   pdfDoc.end();
 


### PR DESCRIPTION
PDFMake Table Layouts:

PDFMake provides three default layouts:
* `noBorders`
* `headerLineOnly`
* `lightHorizontalLines`

This PR adds three more layouts:
* `medplumNoBorders`
* `medplumMetadata`
* `medplumObservations`
