### PR TITLE
Fixed broken type dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40654,9 +40654,7 @@
       "version": "0.9.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@medplum/fhirtypes": "0.9.6",
-        "@types/nodemailer": "6.4.4",
-        "fast-json-patch": "3.1.1"
+        "@medplum/fhirtypes": "0.9.6"
       }
     },
     "packages/definitions": {
@@ -45427,9 +45425,7 @@
     "@medplum/core": {
       "version": "file:packages/core",
       "requires": {
-        "@medplum/fhirtypes": "0.9.6",
-        "@types/nodemailer": "6.4.4",
-        "fast-json-patch": "3.1.1"
+        "@medplum/fhirtypes": "0.9.6"
       }
     },
     "@medplum/definitions": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,9 +17,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@medplum/fhirtypes": "0.9.6",
-    "@types/nodemailer": "6.4.4",
-    "fast-json-patch": "3.1.1"
+    "@medplum/fhirtypes": "0.9.6"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
`@medplum/core` had 2 dependencies only for TypeScript type definitions, not for actual runtime code:
* `@types/nodemailer`
* `fast-json-patch`

They were listed as `devDependencies` with the desired behavior that consumers could use them if they wanted type definitions, or ignore them if they didn't care.

Unfortunately, TypeScript does not have a great story for "optional type definitions".  There are some hacky solutions, but they are hacky:
* https://stackoverflow.com/questions/54392809/how-do-i-handle-optional-peer-dependencies-when-publishing-a-typescript-package
* https://stackoverflow.com/questions/54392809/how-do-i-handle-optional-peer-dependencies-when-publishing-a-typescript-package/70096366#70096366

Instead, this PR exports a subset of the type definitions which are compatible with the upstream libraries.  This keeps our dependency tree clean.  This fixes build breaks for some `@medplum/core` consumers.