### PR TITLE
Support Authentication header in client credentials

### DIFF
--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -114,6 +114,28 @@ describe('OAuth2 Token', () => {
     expect(res.body.error_description).toBe('Invalid secret');
   });
 
+  test('Token for client credentials authentication header success', async () => {
+    const res = await request(app)
+      .post('/oauth2/token')
+      .type('form')
+      .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'))
+      .send({
+        grant_type: 'client_credentials',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+    expect(res.body.access_token).toBeDefined();
+  });
+
+  test('Token for client credentials wrong authentication header', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').set('Authorization', 'Bearer xyz').send({
+      grant_type: 'client_credentials',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid_request');
+    expect(res.body.error_description).toBe('Invalid authorization header');
+  });
+
   test('Token for client empty secret', async () => {
     // Create a client without an secret
     const [outcome, badClient] = await systemRepo.createResource<ClientApplication>({

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -55,12 +55,23 @@ export const tokenHandler: RequestHandler = asyncWrap(async (req: Request, res: 
  * @returns Async promise to the response.
  */
 async function handleClientCredentials(req: Request, res: Response): Promise<Response> {
-  const clientId = req.body.client_id;
+  let clientId = req.body.client_id;
+  let clientSecret = req.body.client_secret;
+
+  const authHeader = req.headers.authorization;
+  if (authHeader) {
+    if (!authHeader.startsWith('Basic ')) {
+      return sendTokenError(res, 'invalid_request', 'Invalid authorization header');
+    }
+    const base64Credentials = authHeader.split(' ')[1];
+    const credentials = Buffer.from(base64Credentials, 'base64').toString('ascii');
+    [clientId, clientSecret] = credentials.split(':');
+  }
+
   if (!clientId) {
     return sendTokenError(res, 'invalid_request', 'Missing client_id');
   }
 
-  const clientSecret = req.body.client_secret;
   if (!clientSecret) {
     return sendTokenError(res, 'invalid_request', 'Missing client_secret');
   }


### PR DESCRIPTION
For client credentials, the client ID and client secret can be passed as form parameters or as Authentication header: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4

Using client credentials with [Insomnia](https://insomnia.rest/) requires Authentication header.