### PR TITLE
More graphql introspection detection

### DIFF
--- a/packages/server/src/fhir/graphql.test.ts
+++ b/packages/server/src/fhir/graphql.test.ts
@@ -120,7 +120,7 @@ describe('GraphQL', () => {
     rmSync(binaryDir, { recursive: true, force: true });
   });
 
-  test('Get schema', async () => {
+  test('IntrospectionQuery', async () => {
     const introspectionRequest = {
       operationName: 'IntrospectionQuery',
       query: `
@@ -233,6 +233,45 @@ describe('GraphQL', () => {
       .send(introspectionRequest);
     expect(res2.status).toBe(200);
     expect(res2.text).toEqual(res1.text);
+  });
+
+  test('Get __schema', async () => {
+    // https://graphql.org/learn/introspection/
+    const res = await request(app)
+      .post('/fhir/R4/$graphql')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        operationName: 'IntrospectionQuery',
+        query: `{
+          __schema {
+            types {
+              name
+            }
+          }
+        }`,
+      });
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000');
+  });
+
+  test('Get __type', async () => {
+    // https://graphql.org/learn/introspection/
+    const res = await request(app)
+      .post('/fhir/R4/$graphql')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        operationName: 'IntrospectionQuery',
+        query: `{
+          __type(name: "Patient") {
+            name
+            kind
+          }
+        }`,
+      });
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('public, max-age=31536000');
   });
 
   test('Read by ID', async () => {

--- a/packages/server/src/fhir/graphql.ts
+++ b/packages/server/src/fhir/graphql.ts
@@ -97,7 +97,7 @@ export const graphqlHandler = asyncWrap(async (req: Request, res: Response) => {
   }
 
   try {
-    const introspection = query.includes('query IntrospectionQuery');
+    const introspection = isIntrospectionQuery(query);
     let result = introspection && introspectionResults.get(query);
     if (!result) {
       result = await execute({
@@ -122,6 +122,20 @@ export const graphqlHandler = asyncWrap(async (req: Request, res: Response) => {
     res.sendStatus(500);
   }
 });
+
+/**
+ * Returns true if the query is a GraphQL introspection query.
+ *
+ * Introspection queries ask for the schema, which is expensive.
+ *
+ * See: https://graphql.org/learn/introspection/
+ *
+ * @param query The GraphQL query.
+ * @returns True if the query is an introspection query.
+ */
+function isIntrospectionQuery(query: string): boolean {
+  return query.includes('query IntrospectionQuery') || query.includes('__schema') || query.includes('__type');
+}
 
 export function getRootSchema(): GraphQLSchema {
   if (!rootSchema) {


### PR DESCRIPTION
Common graphql debugging tools such as [GraphiQL](https://github.com/graphql/graphiql) and [Insomnia](https://insomnia.rest/) use `query IntrospectionQuery` as a marker for introspection queries.  But technically you could write your own introspection queries using `__schema` and/or `__type`.

Because these introspection query results can be so big (40MB+!), we want to handle them with care.