### PR TITLE
Fixed ReadablePromise on searchOne and searchResources

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -679,6 +679,18 @@ describe('Client', () => {
     expect(result?.resourceType).toBe('Patient');
   });
 
+  test('Search one ReadablePromise', async () => {
+    const client = new MedplumClient(defaultOptions);
+    const promise1 = client.searchOne('Patient?name:contains=alice');
+    expect(() => promise1.read()).toThrow();
+    const promise2 = client.searchOne('Patient?name:contains=alice');
+    expect(promise2).toBe(promise1);
+    await promise1;
+    const result = promise1.read();
+    expect(result).toBeDefined();
+    expect(result?.resourceType).toBe('Patient');
+  });
+
   test('Search resources', async () => {
     const client = new MedplumClient(defaultOptions);
     const result = await client.searchResources({
@@ -697,6 +709,19 @@ describe('Client', () => {
     const result = await client.searchResources('Patient?_count=1&name:contains=alice');
     expect(result).toBeDefined();
     expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result[0].resourceType).toBe('Patient');
+  });
+
+  test('Search resources ReadablePromise', async () => {
+    const client = new MedplumClient(defaultOptions);
+    const promise1 = client.searchResources('Patient?_count=1&name:contains=alice');
+    expect(() => promise1.read()).toThrow();
+    const promise2 = client.searchResources('Patient?_count=1&name:contains=alice');
+    expect(promise2).toBe(promise1);
+    await promise1;
+    const result = promise1.read();
+    expect(result).toBeDefined();
     expect(result.length).toBe(1);
     expect(result[0].resourceType).toBe('Patient');
   });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -559,6 +559,20 @@ export class MedplumClient extends EventTarget {
   }
 
   /**
+   * Builds a FHIR search URL from a search query or structured query object.
+   * @param query The FHIR search query or structured query object.
+   * @returns The well-formed FHIR URL.
+   */
+  fhirSearchUrl(query: string | SearchRequest): URL {
+    if (typeof query === 'string') {
+      return this.fhirUrl(query);
+    }
+    const url = this.fhirUrl(query.resourceType);
+    url.search = formatSearchQuery(query);
+    return url;
+  }
+
+  /**
    * Sends a FHIR search request.
    *
    * Example using a FHIR search string:
@@ -613,10 +627,7 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to the search result bundle.
    */
   search<T extends Resource>(query: string | SearchRequest, options: RequestInit = {}): ReadablePromise<Bundle<T>> {
-    return this.get(
-      typeof query === 'string' ? 'fhir/R4/' + query : this.fhirUrl(query.resourceType) + formatSearchQuery(query),
-      options
-    );
+    return this.get(this.fhirSearchUrl(query), options);
   }
 
   /**
@@ -644,7 +655,16 @@ export class MedplumClient extends EventTarget {
   ): ReadablePromise<T | undefined> {
     const search: SearchRequest = typeof query === 'string' ? parseSearchDefinition(query) : query;
     (search as any).count = 1;
-    return new ReadablePromise(this.search<T>(search, options).then((bundle) => bundle.entry?.[0]?.resource));
+    const cacheKey = this.fhirSearchUrl(query).toString() + '-searchOne';
+    if (!options?.cache) {
+      const cached = this.#requestCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+    const promise = new ReadablePromise(this.search<T>(search, options).then((b) => b.entry?.[0]?.resource));
+    this.#requestCache.set(cacheKey, promise);
+    return promise;
   }
 
   /**
@@ -667,9 +687,18 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to the search result bundle.
    */
   searchResources<T extends Resource>(query: string | SearchRequest, options: RequestInit = {}): ReadablePromise<T[]> {
-    return new ReadablePromise(
-      this.search<T>(query, options).then((bundle) => bundle.entry?.map((entry) => entry.resource as T) ?? [])
+    const cacheKey = this.fhirSearchUrl(query).toString() + '-searchResources';
+    if (!options?.cache) {
+      const cached = this.#requestCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
+    const promise = new ReadablePromise(
+      this.search<T>(query, options).then((b) => b.entry?.map((e) => e.resource as T) ?? [])
     );
+    this.#requestCache.set(cacheKey, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
Background on `ReadablePromise`: https://github.com/medplum/medplum/pull/540

Before:
* `MedplumClient` helpers `searchOne` and `searchResources` returned `ReadablePromise`
* However, they returned a ***new*** `ReadablePromise` for every call
* This does not work with React Suspense "render as you fetch" -- you have to return the exact same `ReadablePromise` for the same parameters

Now:
* We correctly cache the `ReadablePromise`
* This should fix `searchOne` and `searchResources` in React Suspense "render as you fetch"