### PR TITLE
Added TypedValue to fhirpath

### DIFF
--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -1,18 +1,20 @@
+import { PropertyType } from '../types';
 import { LiteralAtom } from './atoms';
 import { evalFhirPath } from './parse';
 
 describe('Atoms', () => {
   test('LiteralAtom', () => {
-    expect(new LiteralAtom('a').eval()).toEqual('a');
+    const a = { type: PropertyType.string, value: 'a' };
+    expect(new LiteralAtom(a).eval()).toEqual([a]);
   });
 
   test('ConcatAtom', () => {
-    expect(evalFhirPath('{} & {}', null)).toEqual([]);
-    expect(evalFhirPath('x & y', null)).toEqual([]);
+    expect(evalFhirPath('{} & {}', [])).toEqual([]);
+    expect(evalFhirPath('x & y', [])).toEqual([]);
   });
 
   test('UnionAtom', () => {
-    expect(evalFhirPath('{} | {}', null)).toEqual([]);
-    expect(evalFhirPath('x | y', null)).toEqual([]);
+    expect(evalFhirPath('{} | {}', [])).toEqual([]);
+    expect(evalFhirPath('x | y', [])).toEqual([]);
   });
 });

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -72,7 +72,6 @@ export class SymbolAtom implements Atom {
     } else {
       const propertyName = Object.keys(input).find((k) => k.startsWith(this.name));
       if (propertyName) {
-        // TODO: Get the PropertyType from the choice of type
         result = (input as { [key: string]: unknown })[propertyName];
       }
     }

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -2,9 +2,10 @@ import { Resource } from '@medplum/fhirtypes';
 import { PropertyType } from '../types';
 import {
   booleanToTypedValue,
-  fhirPathEquals,
-  fhirPathEquivalent,
+  fhirPathArrayEquals,
+  fhirPathArrayEquivalent,
   fhirPathIs,
+  fhirPathNot,
   isQuantity,
   removeDuplicates,
   toJsBoolean,
@@ -227,7 +228,7 @@ export class EqualsAtom implements Atom {
   eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    return fhirPathEquals(leftValue, rightValue);
+    return fhirPathArrayEquals(leftValue, rightValue);
   }
 }
 
@@ -237,7 +238,7 @@ export class NotEqualsAtom implements Atom {
   eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    return booleanToTypedValue(!toJsBoolean(fhirPathEquals(leftValue, rightValue)));
+    return fhirPathNot(fhirPathArrayEquals(leftValue, rightValue));
   }
 }
 
@@ -247,7 +248,7 @@ export class EquivalentAtom implements Atom {
   eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    return fhirPathEquivalent(leftValue, rightValue);
+    return fhirPathArrayEquivalent(leftValue, rightValue);
   }
 }
 
@@ -257,7 +258,7 @@ export class NotEquivalentAtom implements Atom {
   eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    return booleanToTypedValue(!toJsBoolean(fhirPathEquivalent(leftValue, rightValue)));
+    return fhirPathNot(fhirPathArrayEquivalent(leftValue, rightValue));
   }
 }
 

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -1,7 +1,7 @@
-import { Quantity, Resource } from '@medplum/fhirtypes';
+import { Resource } from '@medplum/fhirtypes';
+import { PropertyType } from '../types';
 import {
-  applyMaybeArray,
-  ensureArray,
+  booleanToTypedValue,
   fhirPathEquals,
   fhirPathEquivalent,
   fhirPathIs,
@@ -10,22 +10,24 @@ import {
   toJsBoolean,
 } from './utils';
 
+export interface TypedValue {
+  readonly type: PropertyType;
+  readonly value: any;
+}
+
 export interface Atom {
-  eval(context: unknown): unknown;
+  eval(context: TypedValue[]): TypedValue[];
 }
 
 export class FhirPathAtom implements Atom {
   constructor(public readonly original: string, public readonly child: Atom) {}
 
-  eval(context: unknown): unknown[] {
+  eval(context: TypedValue[]): TypedValue[] {
     try {
-      const result = applyMaybeArray(context, (e) => this.child.eval(e));
-      if (Array.isArray(result)) {
-        return result.flat();
-      } else if (result === undefined || result === null) {
-        return [];
+      if (context.length > 0) {
+        return context.map((e) => this.child.eval([e])).flat();
       } else {
-        return [result];
+        return this.child.eval(context);
       }
     } catch (error) {
       throw new Error(`FhirPathError on "${this.original}": ${error}`);
@@ -34,33 +36,47 @@ export class FhirPathAtom implements Atom {
 }
 
 export class LiteralAtom implements Atom {
-  constructor(public readonly value: Quantity | boolean | number | string) {}
-  eval(): unknown {
-    return this.value;
+  constructor(public readonly value: TypedValue) {}
+  eval(): TypedValue[] {
+    return [this.value];
   }
 }
 
 export class SymbolAtom implements Atom {
   constructor(public readonly name: string) {}
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     if (this.name === '$this') {
       return context;
     }
-    return applyMaybeArray(context, (e) => {
-      if (e && typeof e === 'object') {
-        if ('resourceType' in e && (e as Resource).resourceType === this.name) {
-          return e;
+    return context
+      .map((e: TypedValue) => {
+        const input = e.value;
+        let result: any = undefined;
+        if (input && typeof input === 'object') {
+          if ('resourceType' in input && (input as Resource).resourceType === this.name) {
+            return e;
+          }
+          if (this.name in input) {
+            // TODO: Get PropertyType from the schema
+            result = (input as { [key: string]: unknown })[this.name];
+          }
+          const propertyName = Object.keys(input).find((k) => k.startsWith(this.name));
+          if (propertyName) {
+            // TODO: Get the PropertyType from the choice of type
+            result = (input as { [key: string]: unknown })[propertyName];
+          }
         }
-        if (this.name in e) {
-          return (e as { [key: string]: unknown })[this.name];
+        // TODO: Get the PropertyType from the choice of type
+        if (result === undefined) {
+          return { type: PropertyType.string, value: undefined };
+        } else if (Array.isArray(result)) {
+          return result.map((e) => ({ type: PropertyType.string, value: e }));
+        } else {
+          return [{ type: PropertyType.string, value: result }];
         }
-        const propertyName = Object.keys(e).find((k) => k.startsWith(this.name));
-        if (propertyName) {
-          return (e as { [key: string]: unknown })[propertyName];
-        }
-      }
-      return undefined;
-    });
+      })
+      .flat()
+      .filter((e) => e.value !== undefined);
   }
 }
 
@@ -71,9 +87,9 @@ export class EmptySetAtom implements Atom {
 }
 
 export class UnaryOperatorAtom implements Atom {
-  constructor(public readonly child: Atom, public readonly impl: (x: unknown) => unknown) {}
+  constructor(public readonly child: Atom, public readonly impl: (x: TypedValue[]) => TypedValue[]) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     return this.impl(this.child.eval(context));
   }
 }
@@ -81,7 +97,7 @@ export class UnaryOperatorAtom implements Atom {
 export class AsAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     return this.left.eval(context);
   }
 }
@@ -93,16 +109,29 @@ export class ArithemticOperatorAtom implements Atom {
     public readonly impl: (x: number, y: number) => number
   ) {}
 
-  eval(context: unknown): unknown {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: TypedValue[]): TypedValue[] {
+    const leftEvalResult = this.left.eval(context);
+    if (leftEvalResult.length !== 1) {
+      return [];
+    }
+    const rightEvalResult = this.right.eval(context);
+    if (rightEvalResult.length !== 1) {
+      return [];
+    }
+    const leftValue = leftEvalResult[0].value;
+    const rightValue = rightEvalResult[0].value;
     if (isQuantity(leftValue) && isQuantity(rightValue)) {
-      return {
-        ...leftValue,
-        value: this.impl(leftValue.value as number, rightValue.value as number),
-      };
+      return [
+        {
+          type: PropertyType.Quantity,
+          value: {
+            ...leftValue,
+            value: this.impl(leftValue.value as number, rightValue.value as number),
+          },
+        },
+      ];
     } else {
-      return this.impl(leftValue as number, rightValue as number);
+      return [{ type: leftEvalResult[0].type, value: this.impl(leftValue as number, rightValue as number) }];
     }
   }
 }
@@ -114,13 +143,21 @@ export class ComparisonOperatorAtom implements Atom {
     public readonly impl: (x: number, y: number) => boolean
   ) {}
 
-  eval(context: unknown): unknown {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: TypedValue[]): TypedValue[] {
+    const leftEvalResult = this.left.eval(context);
+    if (leftEvalResult.length !== 1) {
+      return [];
+    }
+    const rightEvalResult = this.right.eval(context);
+    if (rightEvalResult.length !== 1) {
+      return [];
+    }
+    const leftValue = leftEvalResult[0].value;
+    const rightValue = rightEvalResult[0].value;
     if (isQuantity(leftValue) && isQuantity(rightValue)) {
-      return this.impl(leftValue.value as number, rightValue.value as number);
+      return booleanToTypedValue(this.impl(leftValue.value as number, rightValue.value as number));
     } else {
-      return this.impl(leftValue as number, rightValue as number);
+      return booleanToTypedValue(this.impl(leftValue as number, rightValue as number));
     }
   }
 }
@@ -128,23 +165,12 @@ export class ComparisonOperatorAtom implements Atom {
 export class ConcatAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    const result: unknown[] = [];
-    function add(value: unknown): void {
-      if (value) {
-        if (Array.isArray(value)) {
-          result.push(...value);
-        } else {
-          result.push(value);
-        }
-      }
-    }
-    add(leftValue);
-    add(rightValue);
-    if (result.length > 0 && result.every((e) => typeof e === 'string')) {
-      return result.join('');
+    const result = [...leftValue, ...rightValue];
+    if (result.length > 0 && result.every((e) => typeof e.value === 'string')) {
+      return [{ type: PropertyType.string, value: result.map((e) => e.value as string).join('') }];
     }
     return result;
   }
@@ -153,113 +179,89 @@ export class ConcatAtom implements Atom {
 export class ContainsAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    return ensureArray(leftValue).includes(rightValue);
+    return booleanToTypedValue(leftValue.some((e) => e.value === rightValue[0].value));
   }
 }
 
 export class InAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    return ensureArray(rightValue).includes(leftValue);
+    return booleanToTypedValue(rightValue.some((e) => e.value === leftValue[0].value));
   }
 }
 
 export class DotAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     return this.right.eval(this.left.eval(context));
   }
 }
 
 export class UnionAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftResult = this.left.eval(context);
     const rightResult = this.right.eval(context);
-    let resultArray: unknown[];
-    if (leftResult !== undefined && rightResult !== undefined) {
-      resultArray = [leftResult, rightResult].flat();
-    } else if (leftResult !== undefined) {
-      resultArray = ensureArray(leftResult);
-    } else if (rightResult !== undefined) {
-      resultArray = ensureArray(rightResult);
-    } else {
-      resultArray = [];
-    }
-    return removeDuplicates(resultArray);
+    return removeDuplicates([...leftResult, ...rightResult]);
   }
 }
 
 export class EqualsAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    if (Array.isArray(leftValue) && Array.isArray(rightValue)) {
-      return fhirPathEquals(leftValue.flat(), rightValue);
-    }
-    return applyMaybeArray(leftValue, (e) => fhirPathEquals(e, rightValue));
+    return fhirPathEquals(leftValue, rightValue);
   }
 }
 
 export class NotEqualsAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    let result;
-    if (Array.isArray(rightValue)) {
-      result = fhirPathEquals(leftValue, rightValue);
-    } else {
-      result = applyMaybeArray(leftValue, (e) => fhirPathEquals(e, rightValue));
-    }
-    return !toJsBoolean(result);
+    return booleanToTypedValue(!toJsBoolean(fhirPathEquals(leftValue, rightValue)));
   }
 }
 
 export class EquivalentAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    if (Array.isArray(rightValue)) {
-      return fhirPathEquivalent(leftValue, rightValue);
-    }
-    return applyMaybeArray(leftValue, (e) => fhirPathEquivalent(e, rightValue));
+    return fhirPathEquivalent(leftValue, rightValue);
   }
 }
 
 export class NotEquivalentAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    let result;
-    if (Array.isArray(rightValue)) {
-      result = fhirPathEquivalent(leftValue, rightValue);
-    } else {
-      result = applyMaybeArray(leftValue, (e) => fhirPathEquivalent(e, rightValue));
-    }
-    return !toJsBoolean(result);
+    return booleanToTypedValue(!toJsBoolean(fhirPathEquivalent(leftValue, rightValue)));
   }
 }
 
 export class IsAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context);
+    if (leftValue.length !== 1) {
+      return [];
+    }
     const typeName = (this.right as SymbolAtom).name;
-    return applyMaybeArray(this.left.eval(context), (e) => fhirPathIs(e, typeName));
+    return booleanToTypedValue(fhirPathIs(leftValue[0], typeName));
   }
 }
 
@@ -270,14 +272,14 @@ export class IsAtom implements Atom {
 export class AndAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     const rightValue = this.right.eval(context);
-    if (leftValue === true && rightValue === true) {
-      return true;
+    if (leftValue[0]?.value === true && rightValue[0]?.value === true) {
+      return booleanToTypedValue(true);
     }
-    if (leftValue === false || rightValue === false) {
-      return false;
+    if (leftValue[0]?.value === false || rightValue[0]?.value === false) {
+      return booleanToTypedValue(false);
     }
     return [];
   }
@@ -286,7 +288,7 @@ export class AndAtom implements Atom {
 export class OrAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
+  eval(context: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context);
     if (toJsBoolean(leftValue)) {
       return leftValue;
@@ -310,14 +312,19 @@ export class OrAtom implements Atom {
 export class XorAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
-  eval(context: unknown): unknown {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: TypedValue[]): TypedValue[] {
+    const leftResult = this.left.eval(context);
+    const rightResult = this.right.eval(context);
+    if (leftResult.length === 0 && rightResult.length === 0) {
+      return [];
+    }
+    const leftValue = leftResult.length === 0 ? null : leftResult[0].value;
+    const rightValue = rightResult.length === 0 ? null : rightResult[0].value;
     if ((leftValue === true && rightValue !== true) || (leftValue !== true && rightValue === true)) {
-      return true;
+      return booleanToTypedValue(true);
     }
     if ((leftValue === true && rightValue === true) || (leftValue === false && rightValue === false)) {
-      return false;
+      return booleanToTypedValue(false);
     }
     return [];
   }
@@ -327,24 +334,28 @@ export class FunctionAtom implements Atom {
   constructor(
     public readonly name: string,
     public readonly args: Atom[],
-    public readonly impl: (context: unknown[], ...a: Atom[]) => unknown[]
+    public readonly impl: (context: TypedValue[], ...a: Atom[]) => TypedValue[]
   ) {}
-  eval(context: unknown): unknown {
-    return this.impl(ensureArray(context), ...this.args);
+  eval(context: TypedValue[]): TypedValue[] {
+    return this.impl(context, ...this.args);
   }
 }
 
 export class IndexerAtom implements Atom {
   constructor(public readonly left: Atom, public readonly expr: Atom) {}
-  eval(context: unknown): unknown {
-    const index = this.expr.eval(context);
+  eval(context: TypedValue[]): TypedValue[] {
+    const evalResult = this.expr.eval(context);
+    if (evalResult.length !== 1) {
+      return [];
+    }
+    const index = evalResult[0].value;
     if (typeof index !== 'number') {
       throw new Error(`Invalid indexer expression: should return integer}`);
     }
-    const leftResult: unknown[] = this.left.eval(context) as unknown[];
+    const leftResult = this.left.eval(context);
     if (!(index in leftResult)) {
       return [];
     }
-    return leftResult[index];
+    return [leftResult[index]];
   }
 }

--- a/packages/core/src/fhirpath/functions.test.ts
+++ b/packages/core/src/fhirpath/functions.test.ts
@@ -1,205 +1,231 @@
-import { Atom, LiteralAtom } from './atoms';
-import * as functions from './functions';
+import { PropertyType } from '../types';
+import { Atom, LiteralAtom, TypedValue } from './atoms';
+import { functions } from './functions';
+import { booleanToTypedValue, toTypedValue } from './utils';
 
 const isEven: Atom = {
-  eval: (num) => [(num as number) % 2 === 0],
+  eval: (num: TypedValue[]) => booleanToTypedValue((num[0].value as number) % 2 === 0),
 };
+
+const TYPED_TRUE = toTypedValue(true);
+const TYPED_FALSE = toTypedValue(false);
+const TYPED_0 = toTypedValue(0);
+const TYPED_1 = toTypedValue(1);
+const TYPED_2 = toTypedValue(2);
+const TYPED_3 = toTypedValue(3);
+const TYPED_4 = toTypedValue(4);
+const TYPED_A = toTypedValue('a');
+const TYPED_B = toTypedValue('b');
+const TYPED_X = toTypedValue('x');
+const TYPED_Y = toTypedValue('y');
+const TYPED_Z = toTypedValue('z');
+const TYPED_APPLE = toTypedValue('apple');
+const TYPED_XYZ = toTypedValue('xyz');
+
+const LITERAL_TRUE = new LiteralAtom(TYPED_TRUE);
+const LITERAL_FALSE = new LiteralAtom(TYPED_FALSE);
+const LITERAL_X = new LiteralAtom(TYPED_X);
+const LITERAL_Y = new LiteralAtom(TYPED_Y);
 
 describe('FHIRPath functions', () => {
   // 5.1 Existence
 
   test('empty', () => {
-    expect(functions.empty([])).toEqual([true]);
-    expect(functions.empty([1])).toEqual([false]);
-    expect(functions.empty([1, 2])).toEqual([false]);
+    expect(functions.empty([])).toEqual([TYPED_TRUE]);
+    expect(functions.empty([TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.empty([TYPED_1, TYPED_2])).toEqual([TYPED_FALSE]);
   });
 
   test('exists', () => {
-    expect(functions.exists([])).toEqual([false]);
-    expect(functions.exists([1])).toEqual([true]);
-    expect(functions.exists([1, 2])).toEqual([true]);
-    expect(functions.exists([], isEven)).toEqual([false]);
-    expect(functions.exists([1], isEven)).toEqual([false]);
-    expect(functions.exists([1, 2], isEven)).toEqual([true]);
+    expect(functions.exists([])).toEqual([TYPED_FALSE]);
+    expect(functions.exists([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(functions.exists([TYPED_1, TYPED_2])).toEqual([TYPED_TRUE]);
+    expect(functions.exists([], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.exists([TYPED_1], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.exists([TYPED_1, TYPED_2], isEven)).toEqual([TYPED_TRUE]);
   });
 
   test('all', () => {
-    expect(functions.all([], isEven)).toEqual([true]);
-    expect(functions.all([1], isEven)).toEqual([false]);
-    expect(functions.all([2], isEven)).toEqual([true]);
-    expect(functions.all([1, 2], isEven)).toEqual([false]);
-    expect(functions.all([2, 4], isEven)).toEqual([true]);
+    expect(functions.all([], isEven)).toEqual([TYPED_TRUE]);
+    expect(functions.all([TYPED_1], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.all([TYPED_2], isEven)).toEqual([TYPED_TRUE]);
+    expect(functions.all([TYPED_1, TYPED_2], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.all([TYPED_2, TYPED_4], isEven)).toEqual([TYPED_TRUE]);
   });
 
   test('allTrue', () => {
-    expect(functions.allTrue([])).toEqual([true]);
-    expect(functions.allTrue([true])).toEqual([true]);
-    expect(functions.allTrue([false])).toEqual([false]);
-    expect(functions.allTrue([true, false])).toEqual([false]);
-    expect(functions.allTrue([true, true])).toEqual([true]);
-    expect(functions.allTrue([false, false])).toEqual([false]);
+    expect(functions.allTrue([])).toEqual([TYPED_TRUE]);
+    expect(functions.allTrue([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.allTrue([TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allTrue([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allTrue([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.allTrue([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
   });
 
   test('anyTrue', () => {
-    expect(functions.anyTrue([])).toEqual([false]);
-    expect(functions.anyTrue([true])).toEqual([true]);
-    expect(functions.anyTrue([false])).toEqual([false]);
-    expect(functions.anyTrue([true, false])).toEqual([true]);
-    expect(functions.anyTrue([true, true])).toEqual([true]);
-    expect(functions.anyTrue([false, false])).toEqual([false]);
+    expect(functions.anyTrue([])).toEqual([TYPED_FALSE]);
+    expect(functions.anyTrue([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyTrue([TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyTrue([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyTrue([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyTrue([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
   });
 
   test('allFalse', () => {
-    expect(functions.allFalse([])).toEqual([true]);
-    expect(functions.allFalse([true])).toEqual([false]);
-    expect(functions.allFalse([false])).toEqual([true]);
-    expect(functions.allFalse([true, false])).toEqual([false]);
-    expect(functions.allFalse([true, true])).toEqual([false]);
-    expect(functions.allFalse([false, false])).toEqual([true]);
+    expect(functions.allFalse([])).toEqual([TYPED_TRUE]);
+    expect(functions.allFalse([TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.allFalse([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.allFalse([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allFalse([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.allFalse([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
   });
 
   test('anyFalse', () => {
-    expect(functions.anyFalse([])).toEqual([false]);
-    expect(functions.anyFalse([true])).toEqual([false]);
-    expect(functions.anyFalse([false])).toEqual([true]);
-    expect(functions.anyFalse([true, false])).toEqual([true]);
-    expect(functions.anyFalse([true, true])).toEqual([false]);
-    expect(functions.anyFalse([false, false])).toEqual([true]);
+    expect(functions.anyFalse([])).toEqual([TYPED_FALSE]);
+    expect(functions.anyFalse([TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyFalse([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyFalse([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyFalse([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyFalse([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
   });
 
   test('count', () => {
-    expect(functions.count([])).toEqual([0]);
-    expect(functions.count([1])).toEqual([1]);
-    expect(functions.count([1, 2])).toEqual([2]);
+    expect(functions.count([])).toEqual([TYPED_0]);
+    expect(functions.count([TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.count([TYPED_1, TYPED_2])).toEqual([TYPED_2]);
   });
 
   test('distinct', () => {
     expect(functions.distinct([])).toEqual([]);
-    expect(functions.distinct([1])).toEqual([1]);
-    expect(functions.distinct([1, 2])).toEqual([1, 2]);
-    expect(functions.distinct([1, 1])).toEqual([1]);
-    expect(functions.distinct(['a'])).toEqual(['a']);
-    expect(functions.distinct(['a', 'b'])).toEqual(['a', 'b']);
-    expect(functions.distinct(['a', 'a'])).toEqual(['a']);
+    expect(functions.distinct([TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.distinct([TYPED_1, TYPED_2])).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.distinct([TYPED_1, TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.distinct([TYPED_A])).toEqual([TYPED_A]);
+    expect(functions.distinct([TYPED_A, TYPED_B])).toEqual([TYPED_A, TYPED_B]);
+    expect(functions.distinct([TYPED_A, TYPED_A])).toEqual([TYPED_A]);
   });
 
   test('isDistinct', () => {
-    expect(functions.isDistinct([])).toEqual([true]);
-    expect(functions.isDistinct([1])).toEqual([true]);
-    expect(functions.isDistinct([1, 2])).toEqual([true]);
-    expect(functions.isDistinct([1, 1])).toEqual([false]);
-    expect(functions.isDistinct(['a'])).toEqual([true]);
-    expect(functions.isDistinct(['a', 'b'])).toEqual([true]);
-    expect(functions.isDistinct(['a', 'a'])).toEqual([false]);
+    expect(functions.isDistinct([])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct([TYPED_1, TYPED_2])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct([TYPED_1, TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.isDistinct([TYPED_A])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct([TYPED_A, TYPED_B])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct([TYPED_A, TYPED_A])).toEqual([TYPED_FALSE]);
   });
 
   // 5.2. Filtering and projection
 
   test('where', () => {
     expect(functions.where([], isEven)).toEqual([]);
-    expect(functions.where([1], isEven)).toEqual([]);
-    expect(functions.where([1, 2], isEven)).toEqual([2]);
-    expect(functions.where([1, 2, 3, 4], isEven)).toEqual([2, 4]);
+    expect(functions.where([TYPED_1], isEven)).toEqual([]);
+    expect(functions.where([TYPED_1, TYPED_2], isEven)).toEqual([TYPED_2]);
+    expect(functions.where([TYPED_1, TYPED_2, TYPED_3, TYPED_4], isEven)).toEqual([TYPED_2, TYPED_4]);
   });
 
   // 5.3 Subsetting
 
   test('single', () => {
     expect(functions.single([])).toEqual([]);
-    expect(functions.single([1])).toEqual([1]);
-    expect(() => functions.single([1, 2])).toThrowError('Expected input length one for single()');
+    expect(functions.single([TYPED_1])).toEqual([TYPED_1]);
+    expect(() => functions.single([TYPED_1, TYPED_2])).toThrowError('Expected input length one for single()');
   });
 
   test('first', () => {
     expect(functions.first([])).toEqual([]);
-    expect(functions.first([1])).toEqual([1]);
-    expect(functions.first([1, 2])).toEqual([1]);
-    expect(functions.first([1, 2, 3])).toEqual([1]);
-    expect(functions.first([1, 2, 3, 4])).toEqual([1]);
+    expect(functions.first([TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.first([TYPED_1, TYPED_2])).toEqual([TYPED_1]);
+    expect(functions.first([TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_1]);
+    expect(functions.first([TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_1]);
   });
 
   test('last', () => {
     expect(functions.last([])).toEqual([]);
-    expect(functions.last([1])).toEqual([1]);
-    expect(functions.last([1, 2])).toEqual([2]);
-    expect(functions.last([1, 2, 3])).toEqual([3]);
-    expect(functions.last([1, 2, 3, 4])).toEqual([4]);
+    expect(functions.last([TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.last([TYPED_1, TYPED_2])).toEqual([TYPED_2]);
+    expect(functions.last([TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_3]);
+    expect(functions.last([TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_4]);
   });
 
   test('tail', () => {
     expect(functions.tail([])).toEqual([]);
-    expect(functions.tail([1])).toEqual([]);
-    expect(functions.tail([1, 2])).toEqual([2]);
-    expect(functions.tail([1, 2, 3])).toEqual([2, 3]);
-    expect(functions.tail([1, 2, 3, 4])).toEqual([2, 3, 4]);
+    expect(functions.tail([TYPED_1])).toEqual([]);
+    expect(functions.tail([TYPED_1, TYPED_2])).toEqual([TYPED_2]);
+    expect(functions.tail([TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_2, TYPED_3]);
+    expect(functions.tail([TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_2, TYPED_3, TYPED_4]);
   });
 
   test('skip', () => {
-    const nonNumber: Atom = { eval: () => 'xyz' };
-    expect(() => functions.skip([1, 2, 3], nonNumber)).toThrowError('Expected a number for skip(num)');
+    const nonNumber: Atom = { eval: () => [TYPED_XYZ] };
+    expect(() => functions.skip([TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
+      'Expected a number for skip(num)'
+    );
 
-    const num0: Atom = { eval: () => 0 };
+    const num0: Atom = { eval: () => [TYPED_0] };
     expect(functions.skip([], num0)).toEqual([]);
-    expect(functions.skip([1], num0)).toEqual([1]);
-    expect(functions.skip([1, 2], num0)).toEqual([1, 2]);
-    expect(functions.skip([1, 2, 3], num0)).toEqual([1, 2, 3]);
+    expect(functions.skip([TYPED_1], num0)).toEqual([TYPED_1]);
+    expect(functions.skip([TYPED_1, TYPED_2], num0)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.skip([TYPED_1, TYPED_2, TYPED_3], num0)).toEqual([TYPED_1, TYPED_2, TYPED_3]);
 
-    const num1: Atom = { eval: () => 1 };
+    const num1: Atom = { eval: () => [TYPED_1] };
     expect(functions.skip([], num1)).toEqual([]);
-    expect(functions.skip([1], num1)).toEqual([]);
-    expect(functions.skip([1, 2], num1)).toEqual([2]);
-    expect(functions.skip([1, 2, 3], num1)).toEqual([2, 3]);
+    expect(functions.skip([TYPED_1], num1)).toEqual([]);
+    expect(functions.skip([TYPED_1, TYPED_2], num1)).toEqual([TYPED_2]);
+    expect(functions.skip([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_2, TYPED_3]);
 
-    const num2: Atom = { eval: () => 2 };
+    const num2: Atom = { eval: () => [TYPED_2] };
     expect(functions.skip([], num2)).toEqual([]);
-    expect(functions.skip([1], num2)).toEqual([]);
-    expect(functions.skip([1, 2], num2)).toEqual([]);
-    expect(functions.skip([1, 2, 3], num2)).toEqual([3]);
+    expect(functions.skip([TYPED_1], num2)).toEqual([]);
+    expect(functions.skip([TYPED_1, TYPED_2], num2)).toEqual([]);
+    expect(functions.skip([TYPED_1, TYPED_2, TYPED_3], num2)).toEqual([TYPED_3]);
   });
 
   test('take', () => {
-    const nonNumber: Atom = { eval: () => 'xyz' };
-    expect(() => functions.take([1, 2, 3], nonNumber)).toThrowError('Expected a number for take(num)');
+    const nonNumber: Atom = { eval: () => [TYPED_XYZ] };
+    expect(() => functions.take([TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
+      'Expected a number for take(num)'
+    );
 
-    const num0: Atom = { eval: () => 0 };
+    const num0: Atom = { eval: () => [TYPED_0] };
     expect(functions.take([], num0)).toEqual([]);
-    expect(functions.take([1], num0)).toEqual([]);
-    expect(functions.take([1, 2], num0)).toEqual([]);
-    expect(functions.take([1, 2, 3], num0)).toEqual([]);
+    expect(functions.take([TYPED_1], num0)).toEqual([]);
+    expect(functions.take([TYPED_1, TYPED_2], num0)).toEqual([]);
+    expect(functions.take([TYPED_1, TYPED_2, TYPED_3], num0)).toEqual([]);
 
-    const num1: Atom = { eval: () => 1 };
+    const num1: Atom = { eval: () => [TYPED_1] };
     expect(functions.take([], num1)).toEqual([]);
-    expect(functions.take([1], num1)).toEqual([1]);
-    expect(functions.take([1, 2], num1)).toEqual([1]);
-    expect(functions.take([1, 2, 3], num1)).toEqual([1]);
+    expect(functions.take([TYPED_1], num1)).toEqual([TYPED_1]);
+    expect(functions.take([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1]);
+    expect(functions.take([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1]);
 
-    const num2: Atom = { eval: () => 2 };
+    const num2: Atom = { eval: () => [TYPED_2] };
     expect(functions.take([], num2)).toEqual([]);
-    expect(functions.take([1], num2)).toEqual([1]);
-    expect(functions.take([1, 2], num2)).toEqual([1, 2]);
-    expect(functions.take([1, 2, 3], num2)).toEqual([1, 2]);
+    expect(functions.take([TYPED_1], num2)).toEqual([TYPED_1]);
+    expect(functions.take([TYPED_1, TYPED_2], num2)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.take([TYPED_1, TYPED_2, TYPED_3], num2)).toEqual([TYPED_1, TYPED_2]);
   });
 
   test('intersect', () => {
     expect(functions.intersect([], undefined as unknown as Atom)).toEqual([]);
     expect(functions.intersect([], null as unknown as Atom)).toEqual([]);
 
-    const num1: Atom = { eval: () => 1 };
+    const num1: Atom = { eval: () => [TYPED_1] };
     expect(functions.intersect([], num1)).toEqual([]);
-    expect(functions.intersect([1], num1)).toEqual([1]);
-    expect(functions.intersect([1, 2], num1)).toEqual([1]);
-    expect(functions.intersect([1, 1, 3], num1)).toEqual([1]);
+    expect(functions.intersect([TYPED_1], num1)).toEqual([TYPED_1]);
+    expect(functions.intersect([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1]);
+    expect(functions.intersect([TYPED_1, TYPED_1, TYPED_3], num1)).toEqual([TYPED_1]);
   });
 
   test('exclude', () => {
     expect(functions.exclude([], undefined as unknown as Atom)).toEqual([]);
     expect(functions.exclude([], null as unknown as Atom)).toEqual([]);
 
-    const num1: Atom = { eval: () => 1 };
+    const num1: Atom = { eval: () => [TYPED_1] };
     expect(functions.exclude([], num1)).toEqual([]);
-    expect(functions.exclude([1], num1)).toEqual([]);
-    expect(functions.exclude([1, 2], num1)).toEqual([2]);
-    expect(functions.exclude([1, 2, 3], num1)).toEqual([2, 3]);
+    expect(functions.exclude([TYPED_1], num1)).toEqual([]);
+    expect(functions.exclude([TYPED_1, TYPED_2], num1)).toEqual([TYPED_2]);
+    expect(functions.exclude([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_2, TYPED_3]);
   });
 
   // 5.4. Combining
@@ -208,304 +234,328 @@ describe('FHIRPath functions', () => {
     expect(functions.union([], undefined as unknown as Atom)).toEqual([]);
     expect(functions.union([], null as unknown as Atom)).toEqual([]);
 
-    const num1: Atom = { eval: () => 1 };
-    expect(functions.union([], num1)).toEqual([1]);
-    expect(functions.union([1], num1)).toEqual([1]);
-    expect(functions.union([1, 2], num1)).toEqual([1, 2]);
-    expect(functions.union([1, 2, 3], num1)).toEqual([1, 2, 3]);
+    const num1: Atom = { eval: () => [TYPED_1] };
+    expect(functions.union([], num1)).toEqual([TYPED_1]);
+    expect(functions.union([TYPED_1], num1)).toEqual([TYPED_1]);
+    expect(functions.union([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.union([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1, TYPED_2, TYPED_3]);
   });
 
   test('combine', () => {
     expect(functions.combine([], undefined as unknown as Atom)).toEqual([]);
     expect(functions.combine([], null as unknown as Atom)).toEqual([]);
 
-    const num1: Atom = { eval: () => 1 };
-    expect(functions.combine([], num1)).toEqual([1]);
-    expect(functions.combine([1], num1)).toEqual([1, 1]);
-    expect(functions.combine([1, 2], num1)).toEqual([1, 2, 1]);
-    expect(functions.combine([1, 2, 3], num1)).toEqual([1, 2, 3, 1]);
+    const num1: Atom = { eval: () => [TYPED_1] };
+    expect(functions.combine([], num1)).toEqual([TYPED_1]);
+    expect(functions.combine([TYPED_1], num1)).toEqual([TYPED_1, TYPED_1]);
+    expect(functions.combine([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1, TYPED_2, TYPED_1]);
+    expect(functions.combine([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1, TYPED_2, TYPED_3, TYPED_1]);
   });
 
   // 5.5. Conversion
 
   test('iif', () => {
-    expect(functions.iif([], new LiteralAtom(true), new LiteralAtom('x'))).toEqual(['x']);
-    expect(functions.iif([], new LiteralAtom(false), new LiteralAtom('x'))).toEqual([]);
-    expect(functions.iif([], new LiteralAtom(true), new LiteralAtom('x'), new LiteralAtom('y'))).toEqual(['x']);
-    expect(functions.iif([], new LiteralAtom(false), new LiteralAtom('x'), new LiteralAtom('y'))).toEqual(['y']);
+    expect(functions.iif([], LITERAL_TRUE, LITERAL_X)).toEqual([TYPED_X]);
+    expect(functions.iif([], LITERAL_FALSE, LITERAL_X)).toEqual([]);
+    expect(functions.iif([], LITERAL_TRUE, LITERAL_X, LITERAL_Y)).toEqual([TYPED_X]);
+    expect(functions.iif([], LITERAL_FALSE, LITERAL_X, LITERAL_Y)).toEqual([TYPED_Y]);
   });
 
   test('toBoolean', () => {
     expect(functions.toBoolean([])).toEqual([]);
-    expect(functions.toBoolean([true])).toEqual([true]);
-    expect(functions.toBoolean([false])).toEqual([false]);
-    expect(functions.toBoolean([1])).toEqual([true]);
-    expect(() => functions.toBoolean([1, 2])).toThrow();
-    expect(functions.toBoolean(['true'])).toEqual([true]);
-    expect(functions.toBoolean(['false'])).toEqual([false]);
-    expect(functions.toBoolean(['xyz'])).toEqual([]);
-    expect(functions.toBoolean([{}])).toEqual([]);
+    expect(functions.toBoolean([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.toBoolean([TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.toBoolean([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.toBoolean([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toBoolean([toTypedValue('true')])).toEqual([TYPED_TRUE]);
+    expect(functions.toBoolean([toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.toBoolean([toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toBoolean([toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToBoolean', () => {
     expect(functions.convertsToBoolean([])).toEqual([]);
-    expect(functions.convertsToBoolean([true])).toEqual([true]);
-    expect(functions.convertsToBoolean([false])).toEqual([true]);
-    expect(functions.convertsToBoolean([1])).toEqual([true]);
-    expect(() => functions.convertsToBoolean([1, 2])).toThrow();
-    expect(functions.convertsToBoolean(['true'])).toEqual([true]);
-    expect(functions.convertsToBoolean(['false'])).toEqual([true]);
-    expect(functions.convertsToBoolean(['xyz'])).toEqual([false]);
-    expect(functions.convertsToBoolean([{}])).toEqual([false]);
+    expect(functions.convertsToBoolean([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToBoolean([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToBoolean([toTypedValue('true')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean([toTypedValue('false')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToBoolean([toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toInteger', () => {
     expect(functions.toInteger([])).toEqual([]);
-    expect(functions.toInteger([true])).toEqual([1]);
-    expect(functions.toInteger([false])).toEqual([0]);
-    expect(functions.toInteger([0])).toEqual([0]);
-    expect(functions.toInteger([1])).toEqual([1]);
-    expect(() => functions.toInteger([1, 2])).toThrow();
-    expect(functions.toInteger(['1'])).toEqual([1]);
-    expect(functions.toInteger(['true'])).toEqual([]);
-    expect(functions.toInteger(['false'])).toEqual([]);
-    expect(functions.toInteger(['xyz'])).toEqual([]);
-    expect(functions.toInteger([{}])).toEqual([]);
+    expect(functions.toInteger([TYPED_TRUE])).toEqual([TYPED_1]);
+    expect(functions.toInteger([TYPED_FALSE])).toEqual([TYPED_0]);
+    expect(functions.toInteger([TYPED_0])).toEqual([TYPED_0]);
+    expect(functions.toInteger([TYPED_1])).toEqual([TYPED_1]);
+    expect(() => functions.toInteger([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toInteger([toTypedValue('1')])).toEqual([TYPED_1]);
+    expect(functions.toInteger([toTypedValue('true')])).toEqual([]);
+    expect(functions.toInteger([toTypedValue('false')])).toEqual([]);
+    expect(functions.toInteger([toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toInteger([toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToInteger', () => {
     expect(functions.convertsToInteger([])).toEqual([]);
-    expect(functions.convertsToInteger([true])).toEqual([true]);
-    expect(functions.convertsToInteger([false])).toEqual([true]);
-    expect(functions.convertsToInteger([0])).toEqual([true]);
-    expect(functions.convertsToInteger([1])).toEqual([true]);
-    expect(() => functions.convertsToInteger([1, 2])).toThrow();
-    expect(functions.convertsToInteger(['1'])).toEqual([true]);
-    expect(functions.convertsToInteger(['true'])).toEqual([false]);
-    expect(functions.convertsToInteger(['false'])).toEqual([false]);
-    expect(functions.convertsToInteger(['xyz'])).toEqual([false]);
-    expect(functions.convertsToInteger([{}])).toEqual([false]);
+    expect(functions.convertsToInteger([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger([TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToInteger([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToInteger([toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger([toTypedValue('true')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger([toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger([toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toDate', () => {
     expect(functions.toDate([])).toEqual([]);
-    expect(() => functions.toDate([1, 2])).toThrow();
-    expect(functions.toDate(['2020-01-01'])).toEqual(['2020-01-01']);
-    expect(functions.toDate([1])).toEqual([]);
-    expect(functions.toDate([true])).toEqual([]);
+    expect(() => functions.toDate([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toDate([toTypedValue('2020-01-01')])).toEqual([{ type: PropertyType.date, value: '2020-01-01' }]);
+    expect(functions.toDate([TYPED_1])).toEqual([]);
+    expect(functions.toDate([TYPED_TRUE])).toEqual([]);
   });
 
   test('convertsToDate', () => {
     expect(functions.convertsToDate([])).toEqual([]);
-    expect(() => functions.convertsToDate([1, 2])).toThrow();
-    expect(functions.convertsToDate(['2020-01-01'])).toEqual([true]);
-    expect(functions.convertsToDate([1])).toEqual([false]);
-    expect(functions.convertsToDate([true])).toEqual([false]);
+    expect(() => functions.convertsToDate([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToDate([toTypedValue('2020-01-01')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDate([TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDate([TYPED_TRUE])).toEqual([TYPED_FALSE]);
   });
 
   test('toDateTime', () => {
     expect(functions.toDateTime([])).toEqual([]);
-    expect(() => functions.toDateTime([1, 2])).toThrow();
-    expect(functions.toDateTime(['2020-01-01'])).toEqual(['2020-01-01']);
-    expect(functions.toDateTime(['2020-01-01T12:00:00Z'])).toEqual(['2020-01-01T12:00:00.000Z']);
-    expect(functions.toDateTime([1])).toEqual([]);
-    expect(functions.toDateTime([true])).toEqual([]);
+    expect(() => functions.toDateTime([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toDateTime([toTypedValue('2020-01-01')])).toEqual([
+      { type: PropertyType.dateTime, value: '2020-01-01' },
+    ]);
+    expect(functions.toDateTime([toTypedValue('2020-01-01T12:00:00Z')])).toEqual([
+      { type: PropertyType.dateTime, value: '2020-01-01T12:00:00.000Z' },
+    ]);
+    expect(functions.toDateTime([TYPED_1])).toEqual([]);
+    expect(functions.toDateTime([TYPED_TRUE])).toEqual([]);
   });
 
   test('convertsToDateTime', () => {
     expect(functions.convertsToDateTime([])).toEqual([]);
-    expect(() => functions.convertsToDateTime([1, 2])).toThrow();
-    expect(functions.convertsToDateTime(['2020-01-01'])).toEqual([true]);
-    expect(functions.convertsToDateTime(['2020-01-01T12:00:00Z'])).toEqual([true]);
-    expect(functions.convertsToDateTime([1])).toEqual([false]);
-    expect(functions.convertsToDateTime([true])).toEqual([false]);
+    expect(() => functions.convertsToDateTime([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToDateTime([toTypedValue('2020-01-01')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDateTime([toTypedValue('2020-01-01T12:00:00Z')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDateTime([TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDateTime([TYPED_TRUE])).toEqual([TYPED_FALSE]);
   });
 
   test('toDecimal', () => {
     expect(functions.toDecimal([])).toEqual([]);
-    expect(functions.toDecimal([true])).toEqual([1]);
-    expect(functions.toDecimal([false])).toEqual([0]);
-    expect(functions.toDecimal([0])).toEqual([0]);
-    expect(functions.toDecimal([1])).toEqual([1]);
-    expect(() => functions.toDecimal([1, 2])).toThrow();
-    expect(functions.toDecimal(['1'])).toEqual([1]);
-    expect(functions.toDecimal(['true'])).toEqual([]);
-    expect(functions.toDecimal(['false'])).toEqual([]);
-    expect(functions.toDecimal(['xyz'])).toEqual([]);
-    expect(functions.toDecimal([{}])).toEqual([]);
+    expect(functions.toDecimal([TYPED_TRUE])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
+    expect(functions.toDecimal([TYPED_FALSE])).toEqual([{ type: PropertyType.decimal, value: 0 }]);
+    expect(functions.toDecimal([TYPED_0])).toEqual([{ type: PropertyType.decimal, value: 0 }]);
+    expect(functions.toDecimal([TYPED_1])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
+    expect(() => functions.toDecimal([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toDecimal([toTypedValue('1')])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
+    expect(functions.toDecimal([toTypedValue('true')])).toEqual([]);
+    expect(functions.toDecimal([toTypedValue('false')])).toEqual([]);
+    expect(functions.toDecimal([toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toDecimal([toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToDecimal', () => {
     expect(functions.convertsToDecimal([])).toEqual([]);
-    expect(functions.convertsToDecimal([true])).toEqual([true]);
-    expect(functions.convertsToDecimal([false])).toEqual([true]);
-    expect(functions.convertsToDecimal([0])).toEqual([true]);
-    expect(functions.convertsToDecimal([1])).toEqual([true]);
-    expect(() => functions.convertsToDecimal([1, 2])).toThrow();
-    expect(functions.convertsToDecimal(['1'])).toEqual([true]);
-    expect(functions.convertsToDecimal(['true'])).toEqual([false]);
-    expect(functions.convertsToDecimal(['false'])).toEqual([false]);
-    expect(functions.convertsToDecimal(['xyz'])).toEqual([false]);
-    expect(functions.convertsToDecimal([{}])).toEqual([false]);
+    expect(functions.convertsToDecimal([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal([TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToDecimal([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToDecimal([toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal([toTypedValue('true')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal([toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal([toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toQuantity', () => {
     expect(functions.toQuantity([])).toEqual([]);
-    expect(functions.toQuantity([{ value: 123, unit: 'mg' }])).toEqual([{ value: 123, unit: 'mg' }]);
-    expect(functions.toQuantity([true])).toEqual([{ value: 1, unit: '1' }]);
-    expect(functions.toQuantity([false])).toEqual([{ value: 0, unit: '1' }]);
-    expect(functions.toQuantity([0])).toEqual([{ value: 0, unit: '1' }]);
-    expect(functions.toQuantity([1])).toEqual([{ value: 1, unit: '1' }]);
-    expect(() => functions.toQuantity([1, 2])).toThrow();
-    expect(functions.toQuantity(['1'])).toEqual([{ value: 1, unit: '1' }]);
-    expect(functions.toQuantity(['true'])).toEqual([]);
-    expect(functions.toQuantity(['false'])).toEqual([]);
-    expect(functions.toQuantity(['xyz'])).toEqual([]);
-    expect(functions.toQuantity([{}])).toEqual([]);
+    expect(functions.toQuantity([toTypedValue({ value: 123, unit: 'mg' })])).toEqual([
+      toTypedValue({ value: 123, unit: 'mg' }),
+    ]);
+    expect(functions.toQuantity([TYPED_TRUE])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
+    expect(functions.toQuantity([TYPED_FALSE])).toEqual([toTypedValue({ value: 0, unit: '1' })]);
+    expect(functions.toQuantity([TYPED_0])).toEqual([toTypedValue({ value: 0, unit: '1' })]);
+    expect(functions.toQuantity([TYPED_1])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
+    expect(() => functions.toQuantity([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toQuantity([toTypedValue('1')])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
+    expect(functions.toQuantity([toTypedValue('true')])).toEqual([]);
+    expect(functions.toQuantity([toTypedValue('false')])).toEqual([]);
+    expect(functions.toQuantity([toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toQuantity([toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToQuantity', () => {
     expect(functions.convertsToQuantity([])).toEqual([]);
-    expect(functions.convertsToQuantity([true])).toEqual([true]);
-    expect(functions.convertsToQuantity([false])).toEqual([true]);
-    expect(functions.convertsToQuantity([0])).toEqual([true]);
-    expect(functions.convertsToQuantity([1])).toEqual([true]);
-    expect(() => functions.convertsToQuantity([1, 2])).toThrow();
-    expect(functions.convertsToQuantity(['1'])).toEqual([true]);
-    expect(functions.convertsToQuantity(['true'])).toEqual([false]);
-    expect(functions.convertsToQuantity(['false'])).toEqual([false]);
-    expect(functions.convertsToQuantity(['xyz'])).toEqual([false]);
-    expect(functions.convertsToQuantity([{}])).toEqual([false]);
+    expect(functions.convertsToQuantity([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity([TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToQuantity([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToQuantity([toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity([toTypedValue('true')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity([toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity([toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toString', () => {
     const toString = functions.toString as unknown as (input: unknown[]) => string[];
     expect(toString([])).toEqual([]);
-    expect(toString([null])).toEqual([]);
-    expect(toString([undefined])).toEqual([]);
-    expect(() => toString([1, 2])).toThrow();
-    expect(toString([true])).toEqual(['true']);
-    expect(toString([false])).toEqual(['false']);
-    expect(toString([0])).toEqual(['0']);
-    expect(toString([1])).toEqual(['1']);
-    expect(toString(['1'])).toEqual(['1']);
-    expect(toString(['true'])).toEqual(['true']);
-    expect(toString(['false'])).toEqual(['false']);
-    expect(toString(['xyz'])).toEqual(['xyz']);
+    expect(() => toString([null])).toThrow();
+    expect(() => toString([undefined])).toThrow();
+    expect(() => toString([TYPED_1, TYPED_2])).toThrow();
+    expect(toString([TYPED_TRUE])).toEqual([toTypedValue('true')]);
+    expect(toString([TYPED_FALSE])).toEqual([toTypedValue('false')]);
+    expect(toString([TYPED_0])).toEqual([toTypedValue('0')]);
+    expect(toString([TYPED_1])).toEqual([toTypedValue('1')]);
+    expect(toString([toTypedValue(null)])).toEqual([]);
+    expect(toString([toTypedValue(undefined)])).toEqual([]);
+    expect(toString([toTypedValue('1')])).toEqual([toTypedValue('1')]);
+    expect(toString([toTypedValue('true')])).toEqual([toTypedValue('true')]);
+    expect(toString([toTypedValue('false')])).toEqual([toTypedValue('false')]);
+    expect(toString([toTypedValue('xyz')])).toEqual([toTypedValue('xyz')]);
   });
 
   test('convertsToString', () => {
     expect(functions.convertsToString([])).toEqual([]);
-    expect(() => functions.convertsToString([1, 2])).toThrow();
-    expect(functions.convertsToString([true])).toEqual([true]);
-    expect(functions.convertsToString([false])).toEqual([true]);
-    expect(functions.convertsToString([0])).toEqual([true]);
-    expect(functions.convertsToString([1])).toEqual([true]);
-    expect(functions.convertsToString(['1'])).toEqual([true]);
-    expect(functions.convertsToString(['true'])).toEqual([true]);
-    expect(functions.convertsToString(['false'])).toEqual([true]);
-    expect(functions.convertsToString(['xyz'])).toEqual([true]);
-    expect(functions.convertsToString([{}])).toEqual([true]);
+    expect(() => functions.convertsToString([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToString([TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([toTypedValue('true')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([toTypedValue('false')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([toTypedValue('xyz')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString([toTypedValue({})])).toEqual([TYPED_TRUE]);
   });
 
   test('toTime', () => {
     expect(functions.toTime([])).toEqual([]);
-    expect(() => functions.toTime([1, 2])).toThrow();
-    expect(functions.toTime(['12:00:00'])).toEqual(['T12:00:00.000Z']);
-    expect(functions.toTime(['T12:00:00'])).toEqual(['T12:00:00.000Z']);
-    expect(functions.toTime(['foo'])).toEqual([]);
-    expect(functions.toTime([1])).toEqual([]);
-    expect(functions.toTime([true])).toEqual([]);
+    expect(() => functions.toTime([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toTime([toTypedValue('12:00:00')])).toEqual([
+      { type: PropertyType.time, value: 'T12:00:00.000Z' },
+    ]);
+    expect(functions.toTime([toTypedValue('T12:00:00')])).toEqual([
+      { type: PropertyType.time, value: 'T12:00:00.000Z' },
+    ]);
+    expect(functions.toTime([toTypedValue('foo')])).toEqual([]);
+    expect(functions.toTime([TYPED_1])).toEqual([]);
+    expect(functions.toTime([TYPED_TRUE])).toEqual([]);
   });
 
   test('convertsToTime', () => {
     expect(functions.convertsToTime([])).toEqual([]);
-    expect(() => functions.convertsToTime([1, 2])).toThrow();
-    expect(functions.convertsToTime(['12:00:00'])).toEqual([true]);
-    expect(functions.convertsToTime(['T12:00:00'])).toEqual([true]);
-    expect(functions.convertsToTime(['foo'])).toEqual([false]);
-    expect(functions.convertsToTime([1])).toEqual([false]);
-    expect(functions.convertsToTime([true])).toEqual([false]);
+    expect(() => functions.convertsToTime([TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToTime([toTypedValue('12:00:00')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToTime([toTypedValue('T12:00:00')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToTime([toTypedValue('foo')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToTime([TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToTime([TYPED_TRUE])).toEqual([TYPED_FALSE]);
   });
 
   // 5.6. String Manipulation.
 
   test('indexOf', () => {
-    expect(functions.indexOf(['apple'], new LiteralAtom('a'))).toEqual([0]);
+    expect(functions.indexOf([TYPED_APPLE], new LiteralAtom(toTypedValue('a')))).toEqual([TYPED_0]);
   });
 
   test('substring', () => {
-    expect(functions.substring([], new LiteralAtom(0))).toEqual([]);
-    expect(() => functions.substring([1], new LiteralAtom(0))).toThrow();
-    expect(functions.substring(['apple'], new LiteralAtom(-1))).toEqual([]);
-    expect(functions.substring(['apple'], new LiteralAtom(6))).toEqual([]);
-    expect(functions.substring(['apple'], new LiteralAtom(0))).toEqual(['apple']);
-    expect(functions.substring(['apple'], new LiteralAtom(2))).toEqual(['ple']);
+    expect(functions.substring([], new LiteralAtom(toTypedValue(0)))).toEqual([]);
+    expect(() => functions.substring([TYPED_1], new LiteralAtom(toTypedValue(0)))).toThrow();
+    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(-1)))).toEqual([]);
+    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(6)))).toEqual([]);
+    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(0)))).toEqual([TYPED_APPLE]);
+    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(2)))).toEqual([toTypedValue('ple')]);
   });
 
   test('startsWith', () => {
-    expect(functions.startsWith(['apple'], new LiteralAtom('app'))).toEqual([true]);
-    expect(functions.startsWith(['apple'], new LiteralAtom('ple'))).toEqual([false]);
+    expect(functions.startsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_TRUE]);
+    expect(functions.startsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_FALSE]);
   });
 
   test('endsWith', () => {
-    expect(functions.endsWith(['apple'], new LiteralAtom('app'))).toEqual([false]);
-    expect(functions.endsWith(['apple'], new LiteralAtom('ple'))).toEqual([true]);
+    expect(functions.endsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_FALSE]);
+    expect(functions.endsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_TRUE]);
   });
 
   test('contains', () => {
-    expect(functions.contains(['apple'], new LiteralAtom('app'))).toEqual([true]);
-    expect(functions.contains(['apple'], new LiteralAtom('ple'))).toEqual([true]);
-    expect(functions.contains(['apple'], new LiteralAtom('ppl'))).toEqual([true]);
-    expect(functions.contains(['apple'], new LiteralAtom('xyz'))).toEqual([false]);
+    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_TRUE]);
+    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_TRUE]);
+    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('ppl')))).toEqual([TYPED_TRUE]);
+    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('xyz')))).toEqual([TYPED_FALSE]);
   });
 
   test('upper', () => {
-    expect(functions.upper(['apple'])).toEqual(['APPLE']);
-    expect(functions.upper(['Apple'])).toEqual(['APPLE']);
-    expect(functions.upper(['APPLE'])).toEqual(['APPLE']);
+    expect(functions.upper([toTypedValue('apple')])).toEqual([toTypedValue('APPLE')]);
+    expect(functions.upper([toTypedValue('Apple')])).toEqual([toTypedValue('APPLE')]);
+    expect(functions.upper([toTypedValue('APPLE')])).toEqual([toTypedValue('APPLE')]);
   });
 
   test('lower', () => {
-    expect(functions.lower(['apple'])).toEqual(['apple']);
-    expect(functions.lower(['Apple'])).toEqual(['apple']);
-    expect(functions.lower(['APPLE'])).toEqual(['apple']);
+    expect(functions.lower([TYPED_APPLE])).toEqual([TYPED_APPLE]);
+    expect(functions.lower([toTypedValue('Apple')])).toEqual([TYPED_APPLE]);
+    expect(functions.lower([toTypedValue('APPLE')])).toEqual([TYPED_APPLE]);
   });
 
   test('replace', () => {
-    expect(functions.replace(['banana'], new LiteralAtom('nana'), new LiteralAtom('tman'))).toEqual(['batman']);
+    expect(
+      functions.replace(
+        [toTypedValue('banana')],
+        new LiteralAtom(toTypedValue('nana')),
+        new LiteralAtom(toTypedValue('tman'))
+      )
+    ).toEqual([toTypedValue('batman')]);
   });
 
   test('matches', () => {
-    expect(functions.matches(['apple'], new LiteralAtom('a'))).toEqual([true]);
+    expect(functions.matches([TYPED_APPLE], new LiteralAtom(TYPED_A))).toEqual([TYPED_TRUE]);
   });
 
   test('replaceMatches', () => {
-    expect(functions.replaceMatches(['banana'], new LiteralAtom('nana'), new LiteralAtom('tman'))).toEqual(['batman']);
+    expect(
+      functions.replaceMatches(
+        [toTypedValue('banana')],
+        new LiteralAtom(toTypedValue('nana')),
+        new LiteralAtom(toTypedValue('tman'))
+      )
+    ).toEqual([toTypedValue('batman')]);
   });
 
   test('length', () => {
-    expect(functions.length([''])).toEqual([0]);
-    expect(functions.length(['x'])).toEqual([1]);
-    expect(functions.length(['xy'])).toEqual([2]);
-    expect(functions.length(['xyz'])).toEqual([3]);
+    expect(functions.length([toTypedValue('')])).toEqual([TYPED_0]);
+    expect(functions.length([toTypedValue('x')])).toEqual([TYPED_1]);
+    expect(functions.length([toTypedValue('xy')])).toEqual([TYPED_2]);
+    expect(functions.length([toTypedValue('xyz')])).toEqual([TYPED_3]);
   });
 
   test('toChars', () => {
-    expect(functions.toChars([''])).toEqual([]);
-    expect(functions.toChars(['x'])).toEqual([['x']]);
-    expect(functions.toChars(['xy'])).toEqual([['x', 'y']]);
-    expect(functions.toChars(['xyz'])).toEqual([['x', 'y', 'z']]);
+    expect(functions.toChars([toTypedValue('')])).toEqual([]);
+    expect(functions.toChars([toTypedValue('x')])).toEqual([TYPED_X]);
+    expect(functions.toChars([toTypedValue('xy')])).toEqual([TYPED_X, TYPED_Y]);
+    expect(functions.toChars([toTypedValue('xyz')])).toEqual([TYPED_X, TYPED_Y, TYPED_Z]);
   });
 
   // 5.7. Math
 
   test('abs', () => {
-    expect(() => functions.abs(['xyz'])).toThrow();
+    expect(() => functions.abs([toTypedValue('xyz')])).toThrow();
     expect(functions.abs([])).toEqual([]);
-    expect(functions.abs([-1])).toEqual([1]);
-    expect(functions.abs([0])).toEqual([0]);
-    expect(functions.abs([1])).toEqual([1]);
+    expect(functions.abs([toTypedValue(-1)])).toEqual([TYPED_1]);
+    expect(functions.abs([TYPED_0])).toEqual([TYPED_0]);
+    expect(functions.abs([TYPED_1])).toEqual([TYPED_1]);
   });
 
   // 5.8. Tree navigation
@@ -513,51 +563,56 @@ describe('FHIRPath functions', () => {
   // 5.9. Utility functions
 
   test('now', () => {
-    expect(functions.now()[0]).toBeDefined();
+    expect(functions.now([])[0]).toBeDefined();
   });
 
   test('timeOfDay', () => {
-    expect(functions.timeOfDay()[0]).toBeDefined();
+    expect(functions.timeOfDay([])[0]).toBeDefined();
   });
 
   test('today', () => {
-    expect(functions.today()[0]).toBeDefined();
+    expect(functions.today([])[0]).toBeDefined();
   });
 
   test('between', () => {
     expect(
       functions.between(
-        undefined,
-        new LiteralAtom('2000-01-01'),
-        new LiteralAtom('2020-01-01'),
-        new LiteralAtom('years')
+        [],
+        new LiteralAtom(toTypedValue('2000-01-01')),
+        new LiteralAtom(toTypedValue('2020-01-01')),
+        new LiteralAtom(toTypedValue('years'))
       )
-    ).toEqual([{ value: 20, unit: 'years' }]);
+    ).toEqual([
+      {
+        type: PropertyType.Quantity,
+        value: { value: 20, unit: 'years' },
+      },
+    ]);
 
     expect(() =>
       functions.between(
-        undefined,
-        new LiteralAtom('xxxx-xx-xx'),
-        new LiteralAtom('2020-01-01'),
-        new LiteralAtom('years')
+        [],
+        new LiteralAtom(toTypedValue('xxxx-xx-xx')),
+        new LiteralAtom(toTypedValue('2020-01-01')),
+        new LiteralAtom(toTypedValue('years'))
       )
     ).toThrow('Invalid start date');
 
     expect(() =>
       functions.between(
-        undefined,
-        new LiteralAtom('2020-01-01'),
-        new LiteralAtom('xxxx-xx-xx'),
-        new LiteralAtom('years')
+        [],
+        new LiteralAtom(toTypedValue('2020-01-01')),
+        new LiteralAtom(toTypedValue('xxxx-xx-xx')),
+        new LiteralAtom(toTypedValue('years'))
       )
     ).toThrow('Invalid end date');
 
     expect(() =>
       functions.between(
-        undefined,
-        new LiteralAtom('2000-01-01'),
-        new LiteralAtom('2020-01-01'),
-        new LiteralAtom('xxxxx')
+        [],
+        new LiteralAtom(toTypedValue('2000-01-01')),
+        new LiteralAtom(toTypedValue('2020-01-01')),
+        new LiteralAtom(toTypedValue('xxxxx'))
       )
     ).toThrow('Invalid units');
   });
@@ -565,33 +620,46 @@ describe('FHIRPath functions', () => {
   // Other
 
   test('resolve', () => {
-    expect(functions.resolve(['Patient/123'])).toEqual([{ resourceType: 'Patient', id: '123' }]);
-    expect(functions.resolve([{ reference: 'Patient/123' }])).toEqual([{ resourceType: 'Patient', id: '123' }]);
-    expect(functions.resolve([123])).toEqual([]);
+    expect(functions.resolve([toTypedValue('Patient/123')])).toEqual([
+      {
+        type: PropertyType.BackboneElement,
+        value: { resourceType: 'Patient', id: '123' },
+      },
+    ]);
+    expect(functions.resolve([{ type: PropertyType.Reference, value: { reference: 'Patient/123' } }])).toEqual([
+      {
+        type: PropertyType.BackboneElement,
+        value: { resourceType: 'Patient', id: '123' },
+      },
+    ]);
+    expect(functions.resolve([toTypedValue(123)])).toEqual([]);
     expect(
       functions.resolve([
-        {
+        toTypedValue({
           reference: 'Patient/123',
           resource: {
             resourceType: 'Patient',
             id: '123',
             name: [{ family: 'Simpson', given: ['Homer'] }],
           },
-        },
+        }),
       ])
-    ).toEqual([{ resourceType: 'Patient', id: '123', name: [{ family: 'Simpson', given: ['Homer'] }] }]);
+    ).toEqual([toTypedValue({ resourceType: 'Patient', id: '123', name: [{ family: 'Simpson', given: ['Homer'] }] })]);
   });
 
   test('as', () => {
-    expect(functions.as([{ resourceType: 'Patient', id: '123' }])).toEqual([{ resourceType: 'Patient', id: '123' }]);
+    expect(functions.as([toTypedValue({ resourceType: 'Patient', id: '123' })])).toEqual([
+      toTypedValue({ resourceType: 'Patient', id: '123' }),
+    ]);
   });
 
   // 12. Formal Specifications
 
   test('type', () => {
-    expect(functions.type([true])).toEqual([{ namespace: 'System', name: 'Boolean' }]);
-    expect(functions.type([123])).toEqual([{ namespace: 'System', name: 'Integer' }]);
-    expect(functions.type([{ resourceType: 'Patient', id: '123' }])).toEqual([{ namespace: 'FHIR', name: 'Patient' }]);
-    expect(functions.type([{}])).toEqual([null]);
+    expect(functions.type([TYPED_TRUE])).toEqual([toTypedValue({ namespace: 'System', name: 'Boolean' })]);
+    expect(functions.type([toTypedValue(123)])).toEqual([toTypedValue({ namespace: 'System', name: 'Integer' })]);
+    expect(functions.type([toTypedValue({ resourceType: 'Patient', id: '123' })])).toEqual([
+      toTypedValue({ namespace: 'FHIR', name: 'Patient' }),
+    ]);
   });
 });

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1558,7 +1558,7 @@ export const functions: Record<string, FhirPathFunction> = {
     const expectedResourceType = system.replace('http://hl7.org/fhir/StructureDefinition/', '');
     return input.map((value) => ({
       type: PropertyType.boolean,
-      value: (value.value as Resource | undefined)?.resourceType === expectedResourceType,
+      value: value.value?.resourceType === expectedResourceType,
     }));
   },
 };

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1,693 +1,719 @@
-import { Quantity, Reference, Resource } from '@medplum/fhirtypes';
+import { Reference, Resource } from '@medplum/fhirtypes';
+import { PropertyType } from '../types';
 import { calculateAge } from '../utils';
-import { Atom, SymbolAtom } from './atoms';
+import { Atom, DotAtom, SymbolAtom, TypedValue } from './atoms';
 import { parseDateString } from './date';
-import { ensureArray, fhirPathIs, isQuantity, removeDuplicates, toJsBoolean } from './utils';
+import { booleanToTypedValue, fhirPathIs, isQuantity, removeDuplicates, toJsBoolean, toTypedValue } from './utils';
 
 /*
  * Collection of FHIRPath
  * See: https://hl7.org/fhirpath/#functions
  */
 
+export interface FhirPathFunction {
+  (input: TypedValue[], ...args: Atom[]): TypedValue[];
+}
+
 /**
  * Temporary placholder for unimplemented methods.
  */
-const stub = (): [] => [];
+const stub: FhirPathFunction = (): [] => [];
 
-/*
- * 5.1 Existence
- * See: https://hl7.org/fhirpath/#existence
- */
+export const functions: Record<string, FhirPathFunction> = {
+  /*
+   * 5.1 Existence
+   * See: https://hl7.org/fhirpath/#existence
+   */
 
-/**
- * Returns true if the input collection is empty ({ }) and false otherwise.
- *
- * See: https://hl7.org/fhirpath/#empty-boolean
- *
- * @param input The input collection.
- * @returns True if the input collection is empty ({ }) and false otherwise.
- */
-export function empty(input: unknown[]): [boolean] {
-  return [input.length === 0];
-}
+  /**
+   * Returns true if the input collection is empty ({ }) and false otherwise.
+   *
+   * See: https://hl7.org/fhirpath/#empty-boolean
+   *
+   * @param input The input collection.
+   * @returns True if the input collection is empty ({ }) and false otherwise.
+   */
+  empty: (input: TypedValue[]): TypedValue[] => {
+    return booleanToTypedValue(input.length === 0);
+  },
 
-/**
- * Returns true if the collection has unknown elements, and false otherwise.
- * This is the opposite of empty(), and as such is a shorthand for empty().not().
- * If the input collection is empty ({ }), the result is false.
- *
- * The function can also take an optional criteria to be applied to the collection
- * prior to the determination of the exists. In this case, the function is shorthand
- * for where(criteria).exists().
- *
- * See: https://hl7.org/fhirpath/#existscriteria-expression-boolean
- *
- * @param input
- * @param criteria
- * @returns True if the collection has unknown elements, and false otherwise.
- */
-export function exists(input: unknown[], criteria?: Atom): [boolean] {
-  if (criteria) {
-    return [input.filter((e) => toJsBoolean(criteria.eval(e))).length > 0];
-  } else {
-    return [input.length > 0];
-  }
-}
-
-/**
- * Returns true if for every element in the input collection, criteria evaluates to true.
- * Otherwise, the result is false.
- *
- * If the input collection is empty ({ }), the result is true.
- *
- * See: https://hl7.org/fhirpath/#allcriteria-expression-boolean
- *
- * @param input The input collection.
- * @param criteria The evaluation criteria.
- * @returns True if for every element in the input collection, criteria evaluates to true.
- */
-export function all(input: unknown[], criteria: Atom): [boolean] {
-  return [input.every((e) => toJsBoolean(criteria.eval(e)))];
-}
-
-/**
- * Takes a collection of Boolean values and returns true if all the items are true.
- * If unknown items are false, the result is false.
- * If the input is empty ({ }), the result is true.
- *
- * See: https://hl7.org/fhirpath/#alltrue-boolean
- *
- * @param input The input collection.
- * @param criteria The evaluation criteria.
- * @returns True if all the items are true.
- */
-export function allTrue(input: unknown[]): [boolean] {
-  for (const value of input) {
-    if (!value) {
-      return [false];
+  /**
+   * Returns true if the collection has unknown elements, and false otherwise.
+   * This is the opposite of empty(), and as such is a shorthand for empty().not().
+   * If the input collection is empty ({ }), the result is false.
+   *
+   * The function can also take an optional criteria to be applied to the collection
+   * prior to the determination of the exists. In this case, the function is shorthand
+   * for where(criteria).exists().
+   *
+   * See: https://hl7.org/fhirpath/#existscriteria-expression-boolean
+   *
+   * @param input
+   * @param criteria
+   * @returns True if the collection has unknown elements, and false otherwise.
+   */
+  exists: (input: TypedValue[], criteria?: Atom): TypedValue[] => {
+    if (criteria) {
+      return booleanToTypedValue(input.filter((e) => toJsBoolean(criteria.eval([e]))).length > 0);
+    } else {
+      return booleanToTypedValue(input.length > 0);
     }
-  }
-  return [true];
-}
+  },
 
-/**
- * Takes a collection of Boolean values and returns true if unknown of the items are true.
- * If all the items are false, or if the input is empty ({ }), the result is false.
- *
- * See: https://hl7.org/fhirpath/#anytrue-boolean
- *
- * @param input The input collection.
- * @param criteria The evaluation criteria.
- * @returns True if unknown of the items are true.
- */
-export function anyTrue(input: unknown[]): [boolean] {
-  for (const value of input) {
-    if (value) {
-      return [true];
+  /**
+   * Returns true if for every element in the input collection, criteria evaluates to true.
+   * Otherwise, the result is false.
+   *
+   * If the input collection is empty ({ }), the result is true.
+   *
+   * See: https://hl7.org/fhirpath/#allcriteria-expression-boolean
+   *
+   * @param input The input collection.
+   * @param criteria The evaluation criteria.
+   * @returns True if for every element in the input collection, criteria evaluates to true.
+   */
+  all: (input: TypedValue[], criteria: Atom): TypedValue[] => {
+    return booleanToTypedValue(input.every((e) => toJsBoolean(criteria.eval([e]))));
+  },
+
+  /**
+   * Takes a collection of Boolean values and returns true if all the items are true.
+   * If unknown items are false, the result is false.
+   * If the input is empty ({ }), the result is true.
+   *
+   * See: https://hl7.org/fhirpath/#alltrue-boolean
+   *
+   * @param input The input collection.
+   * @param criteria The evaluation criteria.
+   * @returns True if all the items are true.
+   */
+  allTrue: (input: TypedValue[]): TypedValue[] => {
+    for (const value of input) {
+      if (!value.value) {
+        return booleanToTypedValue(false);
+      }
     }
-  }
-  return [false];
-}
+    return booleanToTypedValue(true);
+  },
 
-/**
- * Takes a collection of Boolean values and returns true if all the items are false.
- * If unknown items are true, the result is false.
- * If the input is empty ({ }), the result is true.
- *
- * See: https://hl7.org/fhirpath/#allfalse-boolean
- *
- * @param input The input collection.
- * @param criteria The evaluation criteria.
- * @returns True if all the items are false.
- */
-export function allFalse(input: unknown[]): [boolean] {
-  for (const value of input) {
-    if (value) {
-      return [false];
+  /**
+   * Takes a collection of Boolean values and returns true if unknown of the items are true.
+   * If all the items are false, or if the input is empty ({ }), the result is false.
+   *
+   * See: https://hl7.org/fhirpath/#anytrue-boolean
+   *
+   * @param input The input collection.
+   * @param criteria The evaluation criteria.
+   * @returns True if unknown of the items are true.
+   */
+  anyTrue: (input: TypedValue[]): TypedValue[] => {
+    for (const value of input) {
+      if (value.value) {
+        return booleanToTypedValue(true);
+      }
     }
-  }
-  return [true];
-}
+    return booleanToTypedValue(false);
+  },
 
-/**
- * Takes a collection of Boolean values and returns true if unknown of the items are false.
- * If all the items are true, or if the input is empty ({ }), the result is false.
- *
- * See: https://hl7.org/fhirpath/#anyfalse-boolean
- *
- * @param input The input collection.
- * @param criteria The evaluation criteria.
- * @returns True if for every element in the input collection, criteria evaluates to true.
- */
-export function anyFalse(input: unknown[]): [boolean] {
-  for (const value of input) {
-    if (!value) {
-      return [true];
+  /**
+   * Takes a collection of Boolean values and returns true if all the items are false.
+   * If unknown items are true, the result is false.
+   * If the input is empty ({ }), the result is true.
+   *
+   * See: https://hl7.org/fhirpath/#allfalse-boolean
+   *
+   * @param input The input collection.
+   * @param criteria The evaluation criteria.
+   * @returns True if all the items are false.
+   */
+  allFalse: (input: TypedValue[]): TypedValue[] => {
+    for (const value of input) {
+      if (value.value) {
+        return booleanToTypedValue(false);
+      }
     }
-  }
-  return [false];
-}
+    return booleanToTypedValue(true);
+  },
 
-/**
- * Returns true if all items in the input collection are members of the collection passed
- * as the other argument. Membership is determined using the = (Equals) (=) operation.
- *
- * Conceptually, this function is evaluated by testing each element in the input collection
- * for membership in the other collection, with a default of true. This means that if the
- * input collection is empty ({ }), the result is true, otherwise if the other collection
- * is empty ({ }), the result is false.
- *
- * See: http://hl7.org/fhirpath/#subsetofother-collection-boolean
- */
-export const subsetOf = stub;
-
-/**
- * Returns true if all items in the collection passed as the other argument are members of
- * the input collection. Membership is determined using the = (Equals) (=) operation.
- *
- * Conceptually, this function is evaluated by testing each element in the other collection
- * for membership in the input collection, with a default of true. This means that if the
- * other collection is empty ({ }), the result is true, otherwise if the input collection
- * is empty ({ }), the result is false.
- *
- * See: http://hl7.org/fhirpath/#supersetofother-collection-boolean
- */
-export const supersetOf = stub;
-
-/**
- * Returns the integer count of the number of items in the input collection.
- * Returns 0 when the input collection is empty.
- *
- * See: https://hl7.org/fhirpath/#count-integer
- *
- * @param input The input collection.
- * @returns The integer count of the number of items in the input collection.
- */
-export function count(input: unknown[]): [number] {
-  return [input.length];
-}
-
-/**
- * Returns a collection containing only the unique items in the input collection.
- * To determine whether two items are the same, the = (Equals) (=) operator is used,
- * as defined below.
- *
- * If the input collection is empty ({ }), the result is empty.
- *
- * Note that the order of elements in the input collection is not guaranteed to be
- * preserved in the result.
- *
- * See: https://hl7.org/fhirpath/#distinct-collection
- *
- * @param input The input collection.
- * @returns The integer count of the number of items in the input collection.
- */
-export function distinct(input: unknown[]): unknown[] {
-  return Array.from(new Set(input));
-}
-
-/**
- * Returns true if all the items in the input collection are distinct.
- * To determine whether two items are distinct, the = (Equals) (=) operator is used,
- * as defined below.
- *
- * See: https://hl7.org/fhirpath/#isdistinct-boolean
- *
- * @param input The input collection.
- * @returns The integer count of the number of items in the input collection.
- */
-export function isDistinct(input: unknown[]): [boolean] {
-  return [input.length === new Set(input).size];
-}
-
-/*
- * 5.2 Filtering and projection
- */
-
-/**
- * Returns a collection containing only those elements in the input collection
- * for which the stated criteria expression evaluates to true.
- * Elements for which the expression evaluates to false or empty ({ }) are not
- * included in the result.
- *
- * If the input collection is empty ({ }), the result is empty.
- *
- * If the result of evaluating the condition is other than a single boolean value,
- * the evaluation will end and signal an error to the calling environment,
- * consistent with singleton evaluation of collections behavior.
- *
- * See: https://hl7.org/fhirpath/#wherecriteria-expression-collection
- *
- * @param input The input collection.
- * @param condition The condition atom.
- * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
- */
-export function where(input: unknown[], criteria: Atom): unknown[] {
-  return input.filter((e) => toJsBoolean(criteria.eval(e)));
-}
-
-/**
- * Evaluates the projection expression for each item in the input collection.
- * The result of each evaluation is added to the output collection. If the
- * evaluation results in a collection with multiple items, all items are added
- * to the output collection (collections resulting from evaluation of projection
- * are flattened). This means that if the evaluation for an element results in
- * the empty collection ({ }), no element is added to the result, and that if
- * the input collection is empty ({ }), the result is empty as well.
- *
- * See: http://hl7.org/fhirpath/#selectprojection-expression-collection
- */
-export function select(input: unknown[], criteria: Atom): unknown[] {
-  return ensureArray(input.map((e) => criteria.eval(e)).flat());
-}
-
-/**
- * A version of select that will repeat the projection and add it to the output
- * collection, as long as the projection yields new items (as determined by
- * the = (Equals) (=) operator).
- *
- * See: http://hl7.org/fhirpath/#repeatprojection-expression-collection
- */
-export const repeat = stub;
-
-/**
- * Returns a collection that contains all items in the input collection that
- * are of the given type or a subclass thereof. If the input collection is
- * empty ({ }), the result is empty. The type argument is an identifier that
- * must resolve to the name of a type in a model
- *
- * See: http://hl7.org/fhirpath/#oftypetype-type-specifier-collection
- */
-export const ofType = stub;
-
-/*
- * 5.3 Subsetting
- */
-
-/**
- * Will return the single item in the input if there is just one item.
- * If the input collection is empty ({ }), the result is empty.
- * If there are multiple items, an error is signaled to the evaluation environment.
- * This function is useful for ensuring that an error is returned if an assumption
- * about cardinality is violated at run-time.
- *
- * See: https://hl7.org/fhirpath/#single-collection
- *
- * @param input The input collection.
- * @returns The single item in the input if there is just one item.
- */
-export function single(input: unknown[]): unknown[] {
-  if (input.length > 1) {
-    throw new Error('Expected input length one for single()');
-  }
-  return input.length === 0 ? [] : input.slice(0, 1);
-}
-
-/**
- * Returns a collection containing only the first item in the input collection.
- * This function is equivalent to item[0], so it will return an empty collection if the input collection has no items.
- *
- * See: https://hl7.org/fhirpath/#first-collection
- *
- * @param input The input collection.
- * @returns A collection containing only the first item in the input collection.
- */
-export function first(input: unknown[]): unknown[] {
-  return input.length === 0 ? [] : [input[0]];
-}
-
-/**
- * Returns a collection containing only the last item in the input collection.
- * Will return an empty collection if the input collection has no items.
- *
- * See: https://hl7.org/fhirpath/#last-collection
- *
- * @param input The input collection.
- * @returns A collection containing only the last item in the input collection.
- */
-export function last(input: unknown[]): unknown[] {
-  return input.length === 0 ? [] : [input[input.length - 1]];
-}
-
-/**
- * Returns a collection containing all but the first item in the input collection.
- * Will return an empty collection if the input collection has no items, or only one item.
- *
- * See: https://hl7.org/fhirpath/#tail-collection
- *
- * @param input The input collection.
- * @returns A collection containing all but the first item in the input collection.
- */
-export function tail(input: unknown[]): unknown[] {
-  return input.length === 0 ? [] : input.slice(1, input.length);
-}
-
-/**
- * Returns a collection containing all but the first num items in the input collection.
- * Will return an empty collection if there are no items remaining after the
- * indicated number of items have been skipped, or if the input collection is empty.
- * If num is less than or equal to zero, the input collection is simply returned.
- *
- * See: https://hl7.org/fhirpath/#skipnum-integer-collection
- *
- * @param input The input collection.
- * @returns A collection containing all but the first item in the input collection.
- */
-export function skip(input: unknown[], num: Atom): unknown[] {
-  const numValue = num.eval(0);
-  if (typeof numValue !== 'number') {
-    throw new Error('Expected a number for skip(num)');
-  }
-  if (numValue >= input.length) {
-    return [];
-  }
-  if (numValue <= 0) {
-    return input;
-  }
-  return input.slice(numValue, input.length);
-}
-
-/**
- * Returns a collection containing the first num items in the input collection,
- * or less if there are less than num items.
- * If num is less than or equal to 0, or if the input collection is empty ({ }),
- * take returns an empty collection.
- *
- * See: https://hl7.org/fhirpath/#takenum-integer-collection
- *
- * @param input The input collection.
- * @returns A collection containing the first num items in the input collection.
- */
-export function take(input: unknown[], num: Atom): unknown[] {
-  const numValue = num.eval(0);
-  if (typeof numValue !== 'number') {
-    throw new Error('Expected a number for take(num)');
-  }
-  if (numValue >= input.length) {
-    return input;
-  }
-  if (numValue <= 0) {
-    return [];
-  }
-  return input.slice(0, numValue);
-}
-
-/**
- * Returns the set of elements that are in both collections.
- * Duplicate items will be eliminated by this function.
- * Order of items is not guaranteed to be preserved in the result of this function.
- *
- * See: http://hl7.org/fhirpath/#intersectother-collection-collection
- */
-export function intersect(input: unknown[], other: Atom): unknown[] {
-  if (!other) {
-    return input;
-  }
-  const otherArray = ensureArray(other.eval(0));
-  return removeDuplicates(input.filter((e) => otherArray.includes(e)));
-}
-
-/**
- * Returns the set of elements that are not in the other collection.
- * Duplicate items will not be eliminated by this function, and order will be preserved.
- *
- * e.g. (1 | 2 | 3).exclude(2) returns (1 | 3).
- *
- * See: http://hl7.org/fhirpath/#excludeother-collection-collection
- */
-export function exclude(input: unknown[], other: Atom): unknown[] {
-  if (!other) {
-    return input;
-  }
-  const otherArray = ensureArray(other.eval(0));
-  return input.filter((e) => !otherArray.includes(e));
-}
-
-/*
- * 5.4. Combining
- *
- * See: https://hl7.org/fhirpath/#combining
- */
-
-/**
- * Merge the two collections into a single collection,
- * eliminating unknown duplicate values (using = (Equals) (=) to determine equality).
- * There is no expectation of order in the resulting collection.
- *
- * In other words, this function returns the distinct list of elements from both inputs.
- *
- * See: http://hl7.org/fhirpath/#unionother-collection
- */
-export function union(input: unknown[], other: Atom): unknown[] {
-  if (!other) {
-    return input;
-  }
-  return removeDuplicates([input, other.eval(0)].flat());
-}
-
-/**
- * Merge the input and other collections into a single collection
- * without eliminating duplicate values. Combining an empty collection
- * with a non-empty collection will return the non-empty collection.
- *
- * There is no expectation of order in the resulting collection.
- *
- * See: http://hl7.org/fhirpath/#combineother-collection-collection
- */
-export function combine(input: unknown[], other: Atom): unknown[] {
-  if (!other) {
-    return input;
-  }
-  return [input, other.eval(0)].flat();
-}
-
-/*
- * 5.5. Conversion
- *
- * See: https://hl7.org/fhirpath/#conversion
- */
-
-/**
- * The iif function in FHIRPath is an immediate if,
- * also known as a conditional operator (such as C’s ? : operator).
- *
- * The criterion expression is expected to evaluate to a Boolean.
- *
- * If criterion is true, the function returns the value of the true-result argument.
- *
- * If criterion is false or an empty collection, the function returns otherwise-result,
- * unless the optional otherwise-result is not given, in which case the function returns an empty collection.
- *
- * Note that short-circuit behavior is expected in this function. In other words,
- * true-result should only be evaluated if the criterion evaluates to true,
- * and otherwise-result should only be evaluated otherwise. For implementations,
- * this means delaying evaluation of the arguments.
- *
- * @param input
- * @param criterion
- * @param trueResult
- * @param otherwiseResult
- * @returns
- */
-export function iif(input: unknown[], criterion: Atom, trueResult: Atom, otherwiseResult?: Atom): unknown[] {
-  const evalResult = ensureArray(criterion.eval(input));
-  if (evalResult.length > 1 || (evalResult.length === 1 && typeof evalResult[0] !== 'boolean')) {
-    throw new Error('Expected criterion to evaluate to a Boolean');
-  }
-
-  if (toJsBoolean(evalResult)) {
-    return ensureArray(trueResult.eval(input));
-  }
-
-  if (otherwiseResult) {
-    return ensureArray(otherwiseResult.eval(input));
-  }
-
-  return [];
-}
-
-/**
- * Converts an input collection to a boolean.
- *
- * If the input collection contains a single item, this function will return a single boolean if:
- *   1) the item is a Boolean
- *   2) the item is an Integer and is equal to one of the possible integer representations of Boolean values
- *   3) the item is a Decimal that is equal to one of the possible decimal representations of Boolean values
- *   4) the item is a String that is equal to one of the possible string representations of Boolean values
- *
- * If the item is not one the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#toboolean-boolean
- *
- * @param input
- * @returns
- */
-export function toBoolean(input: unknown[]): boolean[] {
-  if (input.length === 0) {
-    return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (typeof value === 'boolean') {
-    return [value];
-  }
-  if (typeof value === 'number') {
-    if (value === 0 || value === 1) {
-      return [!!value];
+  /**
+   * Takes a collection of Boolean values and returns true if unknown of the items are false.
+   * If all the items are true, or if the input is empty ({ }), the result is false.
+   *
+   * See: https://hl7.org/fhirpath/#anyfalse-boolean
+   *
+   * @param input The input collection.
+   * @param criteria The evaluation criteria.
+   * @returns True if for every element in the input collection, criteria evaluates to true.
+   */
+  anyFalse: (input: TypedValue[]): TypedValue[] => {
+    for (const value of input) {
+      if (!value.value) {
+        return booleanToTypedValue(true);
+      }
     }
-  }
-  if (typeof value === 'string') {
-    const lowerStr = value.toLowerCase();
-    if (['true', 't', 'yes', 'y', '1', '1.0'].includes(lowerStr)) {
-      return [true];
+    return booleanToTypedValue(false);
+  },
+
+  /**
+   * Returns true if all items in the input collection are members of the collection passed
+   * as the other argument. Membership is determined using the = (Equals) (=) operation.
+   *
+   * Conceptually, this function is evaluated by testing each element in the input collection
+   * for membership in the other collection, with a default of true. This means that if the
+   * input collection is empty ({ }), the result is true, otherwise if the other collection
+   * is empty ({ }), the result is false.
+   *
+   * See: http://hl7.org/fhirpath/#subsetofother-collection-boolean
+   */
+  subsetOf: stub,
+
+  /**
+   * Returns true if all items in the collection passed as the other argument are members of
+   * the input collection. Membership is determined using the = (Equals) (=) operation.
+   *
+   * Conceptually, this function is evaluated by testing each element in the other collection
+   * for membership in the input collection, with a default of true. This means that if the
+   * other collection is empty ({ }), the result is true, otherwise if the input collection
+   * is empty ({ }), the result is false.
+   *
+   * See: http://hl7.org/fhirpath/#supersetofother-collection-boolean
+   */
+  supersetOf: stub,
+
+  /**
+   * Returns the integer count of the number of items in the input collection.
+   * Returns 0 when the input collection is empty.
+   *
+   * See: https://hl7.org/fhirpath/#count-integer
+   *
+   * @param input The input collection.
+   * @returns The integer count of the number of items in the input collection.
+   */
+  count: (input: TypedValue[]): TypedValue[] => {
+    return [{ type: PropertyType.integer, value: input.length }];
+  },
+
+  /**
+   * Returns a collection containing only the unique items in the input collection.
+   * To determine whether two items are the same, the = (Equals) (=) operator is used,
+   * as defined below.
+   *
+   * If the input collection is empty ({ }), the result is empty.
+   *
+   * Note that the order of elements in the input collection is not guaranteed to be
+   * preserved in the result.
+   *
+   * See: https://hl7.org/fhirpath/#distinct-collection
+   *
+   * @param input The input collection.
+   * @returns The integer count of the number of items in the input collection.
+   */
+  distinct: (input: TypedValue[]): TypedValue[] => {
+    const result: TypedValue[] = [];
+    for (const value of input) {
+      if (!result.some((e) => e.value === value.value)) {
+        result.push(value);
+      }
     }
-    if (['false', 'f', 'no', 'n', '0', '0.0'].includes(lowerStr)) {
-      return [false];
+    return result;
+  },
+
+  /**
+   * Returns true if all the items in the input collection are distinct.
+   * To determine whether two items are distinct, the = (Equals) (=) operator is used,
+   * as defined below.
+   *
+   * See: https://hl7.org/fhirpath/#isdistinct-boolean
+   *
+   * @param input The input collection.
+   * @returns The integer count of the number of items in the input collection.
+   */
+  isDistinct: (input: TypedValue[]): TypedValue[] => {
+    return booleanToTypedValue(input.length === functions.distinct(input).length);
+  },
+
+  /*
+   * 5.2 Filtering and projection
+   */
+
+  /**
+   * Returns a collection containing only those elements in the input collection
+   * for which the stated criteria expression evaluates to true.
+   * Elements for which the expression evaluates to false or empty ({ }) are not
+   * included in the result.
+   *
+   * If the input collection is empty ({ }), the result is empty.
+   *
+   * If the result of evaluating the condition is other than a single boolean value,
+   * the evaluation will end and signal an error to the calling environment,
+   * consistent with singleton evaluation of collections behavior.
+   *
+   * See: https://hl7.org/fhirpath/#wherecriteria-expression-collection
+   *
+   * @param input The input collection.
+   * @param condition The condition atom.
+   * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
+   */
+  where: (input: TypedValue[], criteria: Atom): TypedValue[] => {
+    return input.filter((e) => toJsBoolean(criteria.eval([e])));
+  },
+
+  /**
+   * Evaluates the projection expression for each item in the input collection.
+   * The result of each evaluation is added to the output collection. If the
+   * evaluation results in a collection with multiple items, all items are added
+   * to the output collection (collections resulting from evaluation of projection
+   * are flattened). This means that if the evaluation for an element results in
+   * the empty collection ({ }), no element is added to the result, and that if
+   * the input collection is empty ({ }), the result is empty as well.
+   *
+   * See: http://hl7.org/fhirpath/#selectprojection-expression-collection
+   */
+  select: (input: TypedValue[], criteria: Atom): TypedValue[] => {
+    return input.map((e) => criteria.eval([e])).flat();
+  },
+
+  /**
+   * A version of select that will repeat the projection and add it to the output
+   * collection, as long as the projection yields new items (as determined by
+   * the = (Equals) (=) operator).
+   *
+   * See: http://hl7.org/fhirpath/#repeatprojection-expression-collection
+   */
+  repeat: stub,
+
+  /**
+   * Returns a collection that contains all items in the input collection that
+   * are of the given type or a subclass thereof. If the input collection is
+   * empty ({ }), the result is empty. The type argument is an identifier that
+   * must resolve to the name of a type in a model
+   *
+   * See: http://hl7.org/fhirpath/#oftypetype-type-specifier-collection
+   */
+  ofType: stub,
+
+  /*
+   * 5.3 Subsetting
+   */
+
+  /**
+   * Will return the single item in the input if there is just one item.
+   * If the input collection is empty ({ }), the result is empty.
+   * If there are multiple items, an error is signaled to the evaluation environment.
+   * This function is useful for ensuring that an error is returned if an assumption
+   * about cardinality is violated at run-time.
+   *
+   * See: https://hl7.org/fhirpath/#single-collection
+   *
+   * @param input The input collection.
+   * @returns The single item in the input if there is just one item.
+   */
+  single: (input: TypedValue[]): TypedValue[] => {
+    if (input.length > 1) {
+      throw new Error('Expected input length one for single()');
     }
-  }
-  return [];
-}
+    return input.length === 0 ? [] : input.slice(0, 1);
+  },
 
-/**
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is a Boolean
- *   2) the item is an Integer that is equal to one of the possible integer representations of Boolean values
- *   3) the item is a Decimal that is equal to one of the possible decimal representations of Boolean values
- *   4) the item is a String that is equal to one of the possible string representations of Boolean values
- *
- * If the item is not one of the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is false.
- *
- * Possible values for Integer, Decimal, and String are described in the toBoolean() function.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: http://hl7.org/fhirpath/#convertstoboolean-boolean
- *
- * @param input
- * @returns
- */
-export function convertsToBoolean(input: unknown[]): boolean[] {
-  if (input.length === 0) {
+  /**
+   * Returns a collection containing only the first item in the input collection.
+   * This function is equivalent to item[0], so it will return an empty collection if the input collection has no items.
+   *
+   * See: https://hl7.org/fhirpath/#first-collection
+   *
+   * @param input The input collection.
+   * @returns A collection containing only the first item in the input collection.
+   */
+  first: (input: TypedValue[]): TypedValue[] => {
+    return input.length === 0 ? [] : input.slice(0, 1);
+  },
+
+  /**
+   * Returns a collection containing only the last item in the input collection.
+   * Will return an empty collection if the input collection has no items.
+   *
+   * See: https://hl7.org/fhirpath/#last-collection
+   *
+   * @param input The input collection.
+   * @returns A collection containing only the last item in the input collection.
+   */
+  last: (input: TypedValue[]): TypedValue[] => {
+    return input.length === 0 ? [] : input.slice(input.length - 1, input.length);
+  },
+
+  /**
+   * Returns a collection containing all but the first item in the input collection.
+   * Will return an empty collection if the input collection has no items, or only one item.
+   *
+   * See: https://hl7.org/fhirpath/#tail-collection
+   *
+   * @param input The input collection.
+   * @returns A collection containing all but the first item in the input collection.
+   */
+  tail: (input: TypedValue[]): TypedValue[] => {
+    return input.length === 0 ? [] : input.slice(1, input.length);
+  },
+
+  /**
+   * Returns a collection containing all but the first num items in the input collection.
+   * Will return an empty collection if there are no items remaining after the
+   * indicated number of items have been skipped, or if the input collection is empty.
+   * If num is less than or equal to zero, the input collection is simply returned.
+   *
+   * See: https://hl7.org/fhirpath/#skipnum-integer-collection
+   *
+   * @param input The input collection.
+   * @returns A collection containing all but the first item in the input collection.
+   */
+  skip: (input: TypedValue[], num: Atom): TypedValue[] => {
+    const numValue = num.eval([])[0]?.value;
+    if (typeof numValue !== 'number') {
+      throw new Error('Expected a number for skip(num)');
+    }
+    if (numValue >= input.length) {
+      return [];
+    }
+    if (numValue <= 0) {
+      return input;
+    }
+    return input.slice(numValue, input.length);
+  },
+
+  /**
+   * Returns a collection containing the first num items in the input collection,
+   * or less if there are less than num items.
+   * If num is less than or equal to 0, or if the input collection is empty ({ }),
+   * take returns an empty collection.
+   *
+   * See: https://hl7.org/fhirpath/#takenum-integer-collection
+   *
+   * @param input The input collection.
+   * @returns A collection containing the first num items in the input collection.
+   */
+  take: (input: TypedValue[], num: Atom): TypedValue[] => {
+    const numValue = num.eval([])[0]?.value;
+    if (typeof numValue !== 'number') {
+      throw new Error('Expected a number for take(num)');
+    }
+    if (numValue >= input.length) {
+      return input;
+    }
+    if (numValue <= 0) {
+      return [];
+    }
+    return input.slice(0, numValue);
+  },
+
+  /**
+   * Returns the set of elements that are in both collections.
+   * Duplicate items will be eliminated by this function.
+   * Order of items is not guaranteed to be preserved in the result of this function.
+   *
+   * See: http://hl7.org/fhirpath/#intersectother-collection-collection
+   */
+  intersect: (input: TypedValue[], other: Atom): TypedValue[] => {
+    if (!other) {
+      return input;
+    }
+    const otherArray = other.eval([]);
+    const result: TypedValue[] = [];
+    for (const value of input) {
+      if (!result.some((e) => e.value === value.value) && otherArray.some((e) => e.value === value.value)) {
+        result.push(value);
+      }
+    }
+    return result;
+  },
+
+  /**
+   * Returns the set of elements that are not in the other collection.
+   * Duplicate items will not be eliminated by this function, and order will be preserved.
+   *
+   * e.g. (1 | 2 | 3).exclude(2) returns (1 | 3).
+   *
+   * See: http://hl7.org/fhirpath/#excludeother-collection-collection
+   */
+  exclude: (input: TypedValue[], other: Atom): TypedValue[] => {
+    if (!other) {
+      return input;
+    }
+    const otherArray = other.eval([]);
+    const result: TypedValue[] = [];
+    for (const value of input) {
+      if (!otherArray.some((e) => e.value === value.value)) {
+        result.push(value);
+      }
+    }
+    return result;
+  },
+
+  /*
+   * 5.4. Combining
+   *
+   * See: https://hl7.org/fhirpath/#combining
+   */
+
+  /**
+   * Merge the two collections into a single collection,
+   * eliminating unknown duplicate values (using = (Equals) (=) to determine equality).
+   * There is no expectation of order in the resulting collection.
+   *
+   * In other words, this function returns the distinct list of elements from both inputs.
+   *
+   * See: http://hl7.org/fhirpath/#unionother-collection
+   */
+  union: (input: TypedValue[], other: Atom): TypedValue[] => {
+    if (!other) {
+      return input;
+    }
+    const otherArray = other.eval([]);
+    return removeDuplicates([...input, ...otherArray]);
+  },
+
+  /**
+   * Merge the input and other collections into a single collection
+   * without eliminating duplicate values. Combining an empty collection
+   * with a non-empty collection will return the non-empty collection.
+   *
+   * There is no expectation of order in the resulting collection.
+   *
+   * See: http://hl7.org/fhirpath/#combineother-collection-collection
+   */
+  combine: (input: TypedValue[], other: Atom): TypedValue[] => {
+    if (!other) {
+      return input;
+    }
+    const otherArray = other.eval([]);
+    return [...input, ...otherArray];
+  },
+
+  /*
+   * 5.5. Conversion
+   *
+   * See: https://hl7.org/fhirpath/#conversion
+   */
+
+  /**
+   * The iif function in FHIRPath is an immediate if,
+   * also known as a conditional operator (such as C’s ? : operator).
+   *
+   * The criterion expression is expected to evaluate to a Boolean.
+   *
+   * If criterion is true, the function returns the value of the true-result argument.
+   *
+   * If criterion is false or an empty collection, the function returns otherwise-result,
+   * unless the optional otherwise-result is not given, in which case the function returns an empty collection.
+   *
+   * Note that short-circuit behavior is expected in this function. In other words,
+   * true-result should only be evaluated if the criterion evaluates to true,
+   * and otherwise-result should only be evaluated otherwise. For implementations,
+   * this means delaying evaluation of the arguments.
+   *
+   * @param input
+   * @param criterion
+   * @param trueResult
+   * @param otherwiseResult
+   * @returns
+   */
+  iif: (input: TypedValue[], criterion: Atom, trueResult: Atom, otherwiseResult?: Atom): TypedValue[] => {
+    const evalResult = criterion.eval(input);
+    if (evalResult.length > 1 || (evalResult.length === 1 && typeof evalResult[0].value !== 'boolean')) {
+      throw new Error('Expected criterion to evaluate to a Boolean');
+    }
+
+    if (toJsBoolean(evalResult)) {
+      return trueResult.eval(input);
+    }
+
+    if (otherwiseResult) {
+      return otherwiseResult.eval(input);
+    }
+
     return [];
-  }
-  return [toBoolean(input).length === 1];
-}
+  },
 
-/**
- * Returns the integer representation of the input.
- *
- * If the input collection contains a single item, this function will return a single integer if:
- *   1) the item is an Integer
- *   2) the item is a String and is convertible to an integer
- *   3) the item is a Boolean, where true results in a 1 and false results in a 0.
- *
- * If the item is not one the above types, the result is empty.
- *
- * If the item is a String, but the string is not convertible to an integer (using the regex format (\\+|-)?\d+), the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#tointeger-integer
- *
- * @param input The input collection.
- * @returns The string representation of the input.
- */
-export function toInteger(input: unknown[]): number[] {
-  if (input.length === 0) {
+  /**
+   * Converts an input collection to a boolean.
+   *
+   * If the input collection contains a single item, this function will return a single boolean if:
+   *   1) the item is a Boolean
+   *   2) the item is an Integer and is equal to one of the possible integer representations of Boolean values
+   *   3) the item is a Decimal that is equal to one of the possible decimal representations of Boolean values
+   *   4) the item is a String that is equal to one of the possible string representations of Boolean values
+   *
+   * If the item is not one the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#toboolean-boolean
+   *
+   * @param input
+   * @returns
+   */
+  toBoolean: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (typeof value === 'boolean') {
+      return [{ type: PropertyType.boolean, value }];
+    }
+    if (typeof value === 'number') {
+      if (value === 0 || value === 1) {
+        return booleanToTypedValue(!!value);
+      }
+    }
+    if (typeof value === 'string') {
+      const lowerStr = value.toLowerCase();
+      if (['true', 't', 'yes', 'y', '1', '1.0'].includes(lowerStr)) {
+        return booleanToTypedValue(true);
+      }
+      if (['false', 'f', 'no', 'n', '0', '0.0'].includes(lowerStr)) {
+        return booleanToTypedValue(false);
+      }
+    }
     return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (typeof value === 'number') {
-    return [value];
-  }
-  if (typeof value === 'string' && value.match(/^[+-]?\d+$/)) {
-    return [parseInt(value, 10)];
-  }
-  if (typeof value === 'boolean') {
-    return [value ? 1 : 0];
-  }
-  return [];
-}
+  },
 
-/**
- * Returns true if the input can be converted to string.
- *
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is an Integer
- *   2) the item is a String and is convertible to an Integer
- *   3) the item is a Boolean
- *   4) If the item is not one of the above types, or the item is a String, but is not convertible to an Integer (using the regex format (\\+|-)?\d+), the result is false.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#convertstointeger-boolean
- *
- * @param input The input collection.
- * @returns
- */
-export function convertsToInteger(input: unknown[]): boolean[] {
-  if (input.length === 0) {
+  /**
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is a Boolean
+   *   2) the item is an Integer that is equal to one of the possible integer representations of Boolean values
+   *   3) the item is a Decimal that is equal to one of the possible decimal representations of Boolean values
+   *   4) the item is a String that is equal to one of the possible string representations of Boolean values
+   *
+   * If the item is not one of the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is false.
+   *
+   * Possible values for Integer, Decimal, and String are described in the toBoolean() function.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: http://hl7.org/fhirpath/#convertstoboolean-boolean
+   *
+   * @param input
+   * @returns
+   */
+  convertsToBoolean: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue(functions.toBoolean(input).length === 1);
+  },
+
+  /**
+   * Returns the integer representation of the input.
+   *
+   * If the input collection contains a single item, this function will return a single integer if:
+   *   1) the item is an Integer
+   *   2) the item is a String and is convertible to an integer
+   *   3) the item is a Boolean, where true results in a 1 and false results in a 0.
+   *
+   * If the item is not one the above types, the result is empty.
+   *
+   * If the item is a String, but the string is not convertible to an integer (using the regex format (\\+|-)?\d+), the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#tointeger-integer
+   *
+   * @param input The input collection.
+   * @returns The string representation of the input.
+   */
+  toInteger: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (typeof value === 'number') {
+      return [{ type: PropertyType.integer, value }];
+    }
+    if (typeof value === 'string' && value.match(/^[+-]?\d+$/)) {
+      return [{ type: PropertyType.integer, value: parseInt(value, 10) }];
+    }
+    if (typeof value === 'boolean') {
+      return [{ type: PropertyType.integer, value: value ? 1 : 0 }];
+    }
     return [];
-  }
-  return [toInteger(input).length === 1];
-}
+  },
 
-/**
- * If the input collection contains a single item, this function will return a single date if:
- *   1) the item is a Date
- *   2) the item is a DateTime
- *   3) the item is a String and is convertible to a Date
- *
- * If the item is not one of the above types, the result is empty.
- *
- * If the item is a String, but the string is not convertible to a Date (using the format YYYY-MM-DD), the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#todate-date
- */
-export function toDate(input: unknown[]): string[] {
-  if (input.length === 0) {
+  /**
+   * Returns true if the input can be converted to string.
+   *
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is an Integer
+   *   2) the item is a String and is convertible to an Integer
+   *   3) the item is a Boolean
+   *   4) If the item is not one of the above types, or the item is a String, but is not convertible to an Integer (using the regex format (\\+|-)?\d+), the result is false.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#convertstointeger-boolean
+   *
+   * @param input The input collection.
+   * @returns
+   */
+  convertsToInteger: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue(functions.toInteger(input).length === 1);
+  },
+
+  /**
+   * If the input collection contains a single item, this function will return a single date if:
+   *   1) the item is a Date
+   *   2) the item is a DateTime
+   *   3) the item is a String and is convertible to a Date
+   *
+   * If the item is not one of the above types, the result is empty.
+   *
+   * If the item is a String, but the string is not convertible to a Date (using the format YYYY-MM-DD), the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#todate-date
+   */
+  toDate: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (typeof value === 'string' && value.match(/^\d{4}(-\d{2}(-\d{2})?)?/)) {
+      return [{ type: PropertyType.date, value: parseDateString(value) }];
+    }
     return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (typeof value === 'string' && value.match(/^\d{4}(-\d{2}(-\d{2})?)?/)) {
-    return [parseDateString(value)];
-  }
-  return [];
-}
+  },
 
-/**
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is a Date
- *   2) the item is a DateTime
- *   3) the item is a String and is convertible to a Date
- *
- * If the item is not one of the above types, or is not convertible to a Date (using the format YYYY-MM-DD), the result is false.
- *
- * If the item contains a partial date (e.g. '2012-01'), the result is a partial date.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#convertstodate-boolean
- */
-export function convertsToDate(input: unknown[]): boolean[] {
-  if (input.length === 0) {
-    return [];
-  }
-  return [toDate(input).length === 1];
-}
+  /**
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is a Date
+   *   2) the item is a DateTime
+   *   3) the item is a String and is convertible to a Date
+   *
+   * If the item is not one of the above types, or is not convertible to a Date (using the format YYYY-MM-DD), the result is false.
+   *
+   * If the item contains a partial date (e.g. '2012-01'), the result is a partial date.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#convertstodate-boolean
+   */
+  convertsToDate: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue(functions.toDate(input).length === 1);
+  },
 
-/**
+  /**
  * If the input collection contains a single item, this function will return a single datetime if:
  *   1) the item is a DateTime
  *   2) the item is a Date, in which case the result is a DateTime with the year, month, and day of the Date, and the time components empty (not set to zero)
@@ -708,77 +734,77 @@ export function convertsToDate(input: unknown[]): boolean[] {
  * @param input
  * @returns
  */
-export function toDateTime(input: unknown[]): string[] {
-  if (input.length === 0) {
+  toDateTime: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (typeof value === 'string' && value.match(/^\d{4}(-\d{2}(-\d{2})?)?/)) {
+      return [{ type: PropertyType.dateTime, value: parseDateString(value) }];
+    }
     return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (typeof value === 'string' && value.match(/^\d{4}(-\d{2}(-\d{2})?)?/)) {
-    return [parseDateString(value)];
-  }
-  return [];
-}
+  },
 
-/**
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is a DateTime
- *   2) the item is a Date
- *   3) the item is a String and is convertible to a DateTime
- *
- * If the item is not one of the above types, or is not convertible to a DateTime (using the format YYYY-MM-DDThh:mm:ss.fff(+|-)hh:mm), the result is false.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#convertstodatetime-boolean
- *
- * @param input
- * @returns
- */
-export function convertsToDateTime(input: unknown[]): boolean[] {
-  if (input.length === 0) {
+  /**
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is a DateTime
+   *   2) the item is a Date
+   *   3) the item is a String and is convertible to a DateTime
+   *
+   * If the item is not one of the above types, or is not convertible to a DateTime (using the format YYYY-MM-DDThh:mm:ss.fff(+|-)hh:mm), the result is false.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#convertstodatetime-boolean
+   *
+   * @param input
+   * @returns
+   */
+  convertsToDateTime: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue(functions.toDateTime(input).length === 1);
+  },
+
+  /**
+   * If the input collection contains a single item, this function will return a single decimal if:
+   *   1) the item is an Integer or Decimal
+   *   2) the item is a String and is convertible to a Decimal
+   *   3) the item is a Boolean, where true results in a 1.0 and false results in a 0.0.
+   *   4) If the item is not one of the above types, the result is empty.
+   *
+   * If the item is a String, but the string is not convertible to a Decimal (using the regex format (\\+|-)?\d+(\.\d+)?), the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#decimal-conversion-functions
+   *
+   * @param input The input collection.
+   * @returns
+   */
+  toDecimal: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (typeof value === 'number') {
+      return [{ type: PropertyType.decimal, value }];
+    }
+    if (typeof value === 'string' && value.match(/^-?\d{1,9}(\.\d{1,9})?$/)) {
+      return [{ type: PropertyType.decimal, value: parseFloat(value) }];
+    }
+    if (typeof value === 'boolean') {
+      return [{ type: PropertyType.decimal, value: value ? 1 : 0 }];
+    }
     return [];
-  }
-  return [toDateTime(input).length === 1];
-}
+  },
 
-/**
- * If the input collection contains a single item, this function will return a single decimal if:
- *   1) the item is an Integer or Decimal
- *   2) the item is a String and is convertible to a Decimal
- *   3) the item is a Boolean, where true results in a 1.0 and false results in a 0.0.
- *   4) If the item is not one of the above types, the result is empty.
- *
- * If the item is a String, but the string is not convertible to a Decimal (using the regex format (\\+|-)?\d+(\.\d+)?), the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#decimal-conversion-functions
- *
- * @param input The input collection.
- * @returns
- */
-export function toDecimal(input: unknown[]): number[] {
-  if (input.length === 0) {
-    return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (typeof value === 'number') {
-    return [value];
-  }
-  if (typeof value === 'string' && value.match(/^-?\d{1,9}(\.\d{1,9})?$/)) {
-    return [parseFloat(value)];
-  }
-  if (typeof value === 'boolean') {
-    return [value ? 1 : 0];
-  }
-  return [];
-}
-
-/**
+  /**
  * If the input collection contains a single item, this function will true if:
  *   1) the item is an Integer or Decimal
  *   2) the item is a String and is convertible to a Decimal
@@ -795,731 +821,747 @@ export function toDecimal(input: unknown[]): number[] {
  * @param input The input collection.
  * @returns
  */
-export function convertsToDecimal(input: unknown[]): boolean[] {
-  if (input.length === 0) {
-    return [];
-  }
-  return [toDecimal(input).length === 1];
-}
-
-/**
- * If the input collection contains a single item, this function will return a single quantity if:
- *   1) the item is an Integer, or Decimal, where the resulting quantity will have the default unit ('1')
- *   2) the item is a Quantity
- *   3) the item is a String and is convertible to a Quantity
- *   4) the item is a Boolean, where true results in the quantity 1.0 '1', and false results in the quantity 0.0 '1'
- *
- * If the item is not one of the above types, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#quantity-conversion-functions
- *
- * @param input The input collection.
- * @returns
- */
-export function toQuantity(input: unknown[]): Quantity[] {
-  if (input.length === 0) {
-    return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (isQuantity(value)) {
-    return [value];
-  }
-  if (typeof value === 'number') {
-    return [{ value, unit: '1' }];
-  }
-  if (typeof value === 'string' && value.match(/^-?\d{1,9}(\.\d{1,9})?/)) {
-    return [{ value: parseFloat(value), unit: '1' }];
-  }
-  if (typeof value === 'boolean') {
-    return [{ value: value ? 1 : 0, unit: '1' }];
-  }
-  return [];
-}
-
-/**
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is an Integer, Decimal, or Quantity
- *   2) the item is a String that is convertible to a Quantity
- *   3) the item is a Boolean
- *
- * If the item is not one of the above types, or is not convertible to a Quantity using the following regex format:
- *
- *     (?'value'(\+|-)?\d+(\.\d+)?)\s*('(?'unit'[^']+)'|(?'time'[a-zA-Z]+))?
- *
- * then the result is false.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the unit argument is provided, it must be the string representation of a UCUM code (or a FHIRPath calendar duration keyword), and is used to determine whether the input quantity can be converted to the given unit, according to the unit conversion rules specified by UCUM. If the input quantity can be converted, the result is true, otherwise, the result is false.
- *
- * See: https://hl7.org/fhirpath/#convertstoquantityunit-string-boolean
- *
- * @param input The input collection.
- * @returns
- */
-export function convertsToQuantity(input: unknown[]): boolean[] {
-  if (input.length === 0) {
-    return [];
-  }
-  return [toQuantity(input).length === 1];
-}
-
-/**
- * Returns the string representation of the input.
- *
- * If the input collection contains a single item, this function will return a single String if:
- *
- *  1) the item in the input collection is a String
- *  2) the item in the input collection is an Integer, Decimal, Date, Time, DateTime, or Quantity the output will contain its String representation
- *  3) the item is a Boolean, where true results in 'true' and false in 'false'.
- *
- * If the item is not one of the above types, the result is false.
- *
- * See: https://hl7.org/fhirpath/#tostring-string
- *
- * @param input The input collection.
- * @returns The string representation of the input.
- */
-export function toString(input: unknown[]): string[] {
-  if (input.length === 0) {
-    return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (value === null || value === undefined) {
-    return [];
-  }
-  if (isQuantity(value)) {
-    return [`${value.value} '${value.unit}'`];
-  }
-  return [(value as boolean | number | string).toString()];
-}
-
-/**
- * Returns true if the input can be converted to string.
- *
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is a String
- *   2) the item is an Integer, Decimal, Date, Time, or DateTime
- *   3) the item is a Boolean
- *   4) the item is a Quantity
- *
- * If the item is not one of the above types, the result is false.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#tostring-string
- *
- * @param input The input collection.
- * @returns
- */
-export function convertsToString(input: unknown[]): boolean[] {
-  if (input.length === 0) {
-    return [];
-  }
-  return [toString(input).length === 1];
-}
-
-/**
- * If the input collection contains a single item, this function will return a single time if:
- *   1) the item is a Time
- *   2) the item is a String and is convertible to a Time
- *
- * If the item is not one of the above types, the result is empty.
- *
- * If the item is a String, but the string is not convertible to a Time (using the format hh:mm:ss.fff(+|-)hh:mm), the result is empty.
- *
- * If the item contains a partial time (e.g. '10:00'), the result is a partial time.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#totime-time
- *
- * @param input
- * @returns
- */
-export function toTime(input: unknown[]): string[] {
-  if (input.length === 0) {
-    return [];
-  }
-  const [value] = validateInput(input, 1);
-  if (typeof value === 'string') {
-    const match = value.match(/^T?(\d{2}(:\d{2}(:\d{2})?)?)/);
-    if (match) {
-      return [parseDateString('T' + match[1])];
+  convertsToDecimal: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
     }
-  }
-  return [];
-}
+    return booleanToTypedValue(functions.toDecimal(input).length === 1);
+  },
 
-/**
- * If the input collection contains a single item, this function will return true if:
- *   1) the item is a Time
- *   2) the item is a String and is convertible to a Time
- *
- * If the item is not one of the above types, or is not convertible to a Time (using the format hh:mm:ss.fff(+|-)hh:mm), the result is false.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
- *
- * See: https://hl7.org/fhirpath/#convertstotime-boolean
- *
- * @param input
- * @returns
- */
-export function convertsToTime(input: unknown[]): boolean[] {
-  if (input.length === 0) {
-    return [];
-  }
-  return [toTime(input).length === 1];
-}
-
-/*
- * 5.6. String Manipulation.
- *
- * See: https://hl7.org/fhirpath/#string-manipulation
- */
-
-/**
- * Returns the 0-based index of the first position substring is found in the input string, or -1 if it is not found.
- *
- * If substring is an empty string (''), the function returns 0.
- *
- * If the input or substring is empty ({ }), the result is empty ({ }).
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#indexofsubstring-string-integer
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function indexOf(input: unknown[], substringAtom: Atom): number[] {
-  return applyStringFunc((str, substring) => str.indexOf(substring as string), input, substringAtom);
-}
-
-/**
- * Returns the part of the string starting at position start (zero-based). If length is given, will return at most length number of characters from the input string.
- *
- * If start lies outside the length of the string, the function returns empty ({ }). If there are less remaining characters in the string than indicated by length, the function returns just the remaining characters.
- *
- * If the input or start is empty, the result is empty.
- *
- * If an empty length is provided, the behavior is the same as if length had not been provided.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function substring(input: unknown[], startAtom: Atom, lengthAtom?: Atom): string[] {
-  return applyStringFunc(
-    (str, start, length) => {
-      const startIndex = start as number;
-      const endIndex = length ? startIndex + (length as number) : str.length;
-      return startIndex < 0 || startIndex >= str.length ? undefined : str.substring(startIndex, endIndex);
-    },
-    input,
-    startAtom,
-    lengthAtom
-  );
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function startsWith(input: unknown[], prefixAtom: Atom): boolean[] {
-  return applyStringFunc((str, prefix) => str.startsWith(prefix as string), input, prefixAtom);
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function endsWith(input: unknown[], suffixAtom: Atom): boolean[] {
-  return applyStringFunc((str, suffix) => str.endsWith(suffix as string), input, suffixAtom);
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function contains(input: unknown[], substringAtom: Atom): boolean[] {
-  return applyStringFunc((str, substring) => str.includes(substring as string), input, substringAtom);
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function upper(input: unknown[]): string[] {
-  return applyStringFunc((str) => str.toUpperCase(), input);
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function lower(input: unknown[]): string[] {
-  return applyStringFunc((str) => str.toLowerCase(), input);
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function replace(input: unknown[], patternAtom: Atom, substitionAtom: Atom): string[] {
-  return applyStringFunc(
-    (str, pattern, substition) => str.replaceAll(pattern as string, substition as string),
-    input,
-    patternAtom,
-    substitionAtom
-  );
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function matches(input: unknown[], regexAtom: Atom): boolean[] {
-  return applyStringFunc((str, regex) => !!str.match(regex as string), input, regexAtom);
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function replaceMatches(input: unknown[], regexAtom: Atom, substitionAtom: Atom): string[] {
-  return applyStringFunc(
-    (str, pattern, substition) => str.replaceAll(pattern as string, substition as string),
-    input,
-    regexAtom,
-    substitionAtom
-  );
-}
-
-/**
- *
- * @param input The input collection.
- * @returns The index of the substring.
- */
-export function length(input: unknown[]): number[] {
-  return applyStringFunc((str) => str.length, input);
-}
-
-/**
- * Returns the list of characters in the input string. If the input collection is empty ({ }), the result is empty.
- *
- * See: https://hl7.org/fhirpath/#tochars-collection
- *
- * @param input The input collection.
- */
-export function toChars(input: unknown[]): string[][] {
-  return applyStringFunc((str) => (str ? str.split('') : undefined), input);
-}
-
-/*
- * 5.7. Math
- */
-
-/**
- * Returns the absolute value of the input. When taking the absolute value of a quantity, the unit is unchanged.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#abs-integer-decimal-quantity
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function abs(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.abs, input);
-}
-
-/**
- * Returns the first integer greater than or equal to the input.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#ceiling-integer
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function ceiling(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.ceil, input);
-}
-
-/**
- * Returns e raised to the power of the input.
- *
- * If the input collection contains an Integer, it will be implicitly converted to a Decimal and the result will be a Decimal.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#exp-decimal
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function exp(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.exp, input);
-}
-
-/**
- * Returns the first integer less than or equal to the input.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#floor-integer
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function floor(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.floor, input);
-}
-
-/**
- * Returns the natural logarithm of the input (i.e. the logarithm base e).
- *
- * When used with an Integer, it will be implicitly converted to a Decimal.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#ln-decimal
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function ln(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.log, input);
-}
-
-/**
- * Returns the logarithm base base of the input number.
- *
- * When used with Integers, the arguments will be implicitly converted to Decimal.
- *
- * If base is empty, the result is empty.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#logbase-decimal-decimal
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function log(input: unknown[], baseAtom: Atom): Quantity[] | number[] {
-  return applyMathFunc((value, base) => Math.log(value) / Math.log(base as number), input, baseAtom);
-}
-
-/**
- * Raises a number to the exponent power. If this function is used with Integers, the result is an Integer. If the function is used with Decimals, the result is a Decimal. If the function is used with a mixture of Integer and Decimal, the Integer is implicitly converted to a Decimal and the result is a Decimal.
- *
- * If the power cannot be represented (such as the -1 raised to the 0.5), the result is empty.
- *
- * If the input is empty, or exponent is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#powerexponent-integer-decimal-integer-decimal
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function power(input: unknown[], expAtom: Atom): Quantity[] | number[] {
-  return applyMathFunc(Math.pow as (x: number, ...args: unknown[]) => number, input, expAtom);
-}
-
-/**
- * Rounds the decimal to the nearest whole number using a traditional round (i.e. 0.5 or higher will round to 1). If specified, the precision argument determines the decimal place at which the rounding will occur. If not specified, the rounding will default to 0 decimal places.
- *
- * If specified, the number of digits of precision must be >= 0 or the evaluation will end and signal an error to the calling environment.
- *
- * If the input collection contains a single item of type Integer, it will be implicitly converted to a Decimal.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#roundprecision-integer-decimal
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function round(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.round, input);
-}
-
-/**
- * Returns the square root of the input number as a Decimal.
- *
- * If the square root cannot be represented (such as the square root of -1), the result is empty.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
- *
- * See: https://hl7.org/fhirpath/#sqrt-decimal
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function sqrt(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc(Math.sqrt, input);
-}
-
-/**
- * Returns the integer portion of the input.
- *
- * If the input collection is empty, the result is empty.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * See: https://hl7.org/fhirpath/#truncate-integer
- *
- * @param input The input collection.
- * @returns A collection containing the result.
- */
-export function truncate(input: unknown[]): Quantity[] | number[] {
-  return applyMathFunc((x) => x | 0, input);
-}
-
-/*
- * 5.8. Tree navigation
- */
-
-export const children = stub;
-
-export const descendants = stub;
-
-/*
- * 5.9. Utility functions
- */
-
-/**
- * Adds a String representation of the input collection to the diagnostic log,
- * using the name argument as the name in the log. This log should be made available
- * to the user in some appropriate fashion. Does not change the input, so returns
- * the input collection as output.
- *
- * If the projection argument is used, the trace would log the result of evaluating
- * the project expression on the input, but still return the input to the trace
- * function unchanged.
- *
- * See: https://hl7.org/fhirpath/#tracename-string-projection-expression-collection
- *
- * @param input The input collection.
- * @param nameAtom The log name.
- */
-export function trace(input: unknown[], nameAtom: Atom): unknown[] {
-  console.log('trace', input, nameAtom);
-  return input;
-}
-
-/**
- * Returns the current date and time, including timezone offset.
- *
- * See: https://hl7.org/fhirpath/#now-datetime
- */
-export function now(): string[] {
-  return [new Date().toISOString()];
-}
-
-/**
- * Returns the current time.
- *
- * See: https://hl7.org/fhirpath/#timeofday-time
- */
-export function timeOfDay(): string[] {
-  return [new Date().toISOString().substring(11)];
-}
-
-/**
- * Returns the current date.
- *
- * See: https://hl7.org/fhirpath/#today-date
- */
-export function today(): string[] {
-  return [new Date().toISOString().substring(0, 10)];
-}
-
-/**
- * Calculates the difference between two dates or date/times.
- *
- * This is not part of the official FHIRPath spec.
- *
- * IBM FHIR issue: https://github.com/IBM/FHIR/issues/1014
- * IBM FHIR PR: https://github.com/IBM/FHIR/pull/1023
- */
-export function between(context: unknown, startAtom: Atom, endAtom: Atom, unitsAtom: Atom): Quantity[] {
-  const startDate = toDateTime(ensureArray(startAtom.eval(context)));
-  if (startDate.length === 0) {
-    throw new Error('Invalid start date');
-  }
-  const endDate = toDateTime(ensureArray(endAtom.eval(context)));
-  if (endDate.length === 0) {
-    throw new Error('Invalid end date');
-  }
-  const unit = unitsAtom.eval(context);
-  if (unit !== 'years' && unit !== 'months' && unit !== 'days') {
-    throw new Error('Invalid units');
-  }
-  const age = calculateAge(startDate[0], endDate[0]);
-  return [{ value: age[unit], unit }];
-}
-
-/*
- * 6.3 Types
- */
-
-/**
- * The is() function is supported for backwards compatibility with previous
- * implementations of FHIRPath. Just as with the is keyword, the type argument
- * is an identifier that must resolve to the name of a type in a model.
- *
- * For implementations with compile-time typing, this requires special-case
- * handling when processing the argument to treat it as a type specifier rather
- * than an identifier expression:
- *
- * @param input
- * @param typeAtom
- * @returns
- */
-export function is(input: unknown[], typeAtom: Atom): boolean[] {
-  const typeName = (typeAtom as SymbolAtom).name;
-  return input.map((value) => fhirPathIs(value, typeName));
-}
-
-/*
- * 6.5 Boolean logic
- */
-
-/**
- * 6.5.3. not() : Boolean
- *
- * Returns true if the input collection evaluates to false, and false if it evaluates to true. Otherwise, the result is empty ({ }):
- *
- * @param input
- * @returns
- */
-export function not(input: unknown[]): boolean[] {
-  return toBoolean(input).map((value) => !value);
-}
-
-/*
- * Additional functions
- * See: https://hl7.org/fhir/fhirpath.html#functions
- */
-
-/**
- * For each item in the collection, if it is a string that is a uri (or canonical or url), locate the target of the reference, and add it to the resulting collection. If the item does not resolve to a resource, the item is ignored and nothing is added to the output collection.
- * The items in the collection may also represent a Reference, in which case the Reference.reference is resolved.
- * @param input The input collection.
- * @returns
- */
-export function resolve(input: unknown[]): unknown[] {
-  return input
-    .map((e) => {
-      let refStr: string | undefined;
-      if (typeof e === 'string') {
-        refStr = e;
-      } else if (typeof e === 'object') {
-        const ref = e as Reference;
-        if (ref.resource) {
-          return ref.resource;
-        }
-        refStr = ref.reference;
-      }
-      if (!refStr) {
-        return undefined;
-      }
-      const [resourceType, id] = refStr.split('/');
-      return { resourceType, id };
-    })
-    .filter((e) => !!e);
-}
-
-/**
- * The as operator can be used to treat a value as a specific type.
- * @param context The context value.
- * @returns The value as the specific type.
- */
-export function as(context: unknown): unknown {
-  return context;
-}
-
-/*
- * 12. Formal Specifications
- */
-
-/**
- * Returns the type of the input.
- *
- * 12.2. Model Information
- *
- * The model information returned by the reflection function type() is specified as an
- * XML Schema document (xsd) and included in this specification at the following link:
- * https://hl7.org/fhirpath/modelinfo.xsd
- *
- * See: https://hl7.org/fhirpath/#model-information
- *
- * @param input The input collection.
- * @returns
- */
-export function type(input: unknown[]): unknown[] {
-  return input.map((value) => {
-    if (typeof value === 'boolean') {
-      return { namespace: 'System', name: 'Boolean' };
+  /**
+   * If the input collection contains a single item, this function will return a single quantity if:
+   *   1) the item is an Integer, or Decimal, where the resulting quantity will have the default unit ('1')
+   *   2) the item is a Quantity
+   *   3) the item is a String and is convertible to a Quantity
+   *   4) the item is a Boolean, where true results in the quantity 1.0 '1', and false results in the quantity 0.0 '1'
+   *
+   * If the item is not one of the above types, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#quantity-conversion-functions
+   *
+   * @param input The input collection.
+   * @returns
+   */
+  toQuantity: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (isQuantity(value)) {
+      return [{ type: PropertyType.Quantity, value }];
     }
     if (typeof value === 'number') {
-      return { namespace: 'System', name: 'Integer' };
+      return [{ type: PropertyType.Quantity, value: { value, unit: '1' } }];
     }
-    if (value && typeof value === 'object' && 'resourceType' in value) {
-      return { namespace: 'FHIR', name: (value as Resource).resourceType };
+    if (typeof value === 'string' && value.match(/^-?\d{1,9}(\.\d{1,9})?/)) {
+      return [{ type: PropertyType.Quantity, value: { value: parseFloat(value), unit: '1' } }];
     }
-    return null;
-  });
-}
+    if (typeof value === 'boolean') {
+      return [{ type: PropertyType.Quantity, value: { value: value ? 1 : 0, unit: '1' } }];
+    }
+    return [];
+  },
 
-export function conformsTo(input: unknown[], systemAtom: Atom): boolean[] {
-  const system = systemAtom.eval(undefined) as string;
-  if (!system.startsWith('http://hl7.org/fhir/StructureDefinition/')) {
-    throw new Error('Expected a StructureDefinition URL');
-  }
-  const expectedResourceType = system.replace('http://hl7.org/fhir/StructureDefinition/', '');
-  return input.map((resource) => (resource as Resource | undefined)?.resourceType === expectedResourceType);
-}
+  /**
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is an Integer, Decimal, or Quantity
+   *   2) the item is a String that is convertible to a Quantity
+   *   3) the item is a Boolean
+   *
+   * If the item is not one of the above types, or is not convertible to a Quantity using the following regex format:
+   *
+   *     (?'value'(\+|-)?\d+(\.\d+)?)\s*('(?'unit'[^']+)'|(?'time'[a-zA-Z]+))?
+   *
+   * then the result is false.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the unit argument is provided, it must be the string representation of a UCUM code (or a FHIRPath calendar duration keyword), and is used to determine whether the input quantity can be converted to the given unit, according to the unit conversion rules specified by UCUM. If the input quantity can be converted, the result is true, otherwise, the result is false.
+   *
+   * See: https://hl7.org/fhirpath/#convertstoquantityunit-string-boolean
+   *
+   * @param input The input collection.
+   * @returns
+   */
+  convertsToQuantity: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue(functions.toQuantity(input).length === 1);
+  },
+
+  /**
+   * Returns the string representation of the input.
+   *
+   * If the input collection contains a single item, this function will return a single String if:
+   *
+   *  1) the item in the input collection is a String
+   *  2) the item in the input collection is an Integer, Decimal, Date, Time, DateTime, or Quantity the output will contain its String representation
+   *  3) the item is a Boolean, where true results in 'true' and false in 'false'.
+   *
+   * If the item is not one of the above types, the result is false.
+   *
+   * See: https://hl7.org/fhirpath/#tostring-string
+   *
+   * @param input The input collection.
+   * @returns The string representation of the input.
+   */
+  toString: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (value === null || value === undefined) {
+      return [];
+    }
+    if (isQuantity(value)) {
+      return [{ type: PropertyType.string, value: `${value.value} '${value.unit}'` }];
+    }
+    return [{ type: PropertyType.string, value: (value as boolean | number | string).toString() }];
+  },
+
+  /**
+   * Returns true if the input can be converted to string.
+   *
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is a String
+   *   2) the item is an Integer, Decimal, Date, Time, or DateTime
+   *   3) the item is a Boolean
+   *   4) the item is a Quantity
+   *
+   * If the item is not one of the above types, the result is false.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#tostring-string
+   *
+   * @param input The input collection.
+   * @returns
+   */
+  convertsToString: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue((functions.toString as unknown as FhirPathFunction)(input).length === 1);
+  },
+
+  /**
+   * If the input collection contains a single item, this function will return a single time if:
+   *   1) the item is a Time
+   *   2) the item is a String and is convertible to a Time
+   *
+   * If the item is not one of the above types, the result is empty.
+   *
+   * If the item is a String, but the string is not convertible to a Time (using the format hh:mm:ss.fff(+|-)hh:mm), the result is empty.
+   *
+   * If the item contains a partial time (e.g. '10:00'), the result is a partial time.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#totime-time
+   *
+   * @param input
+   * @returns
+   */
+  toTime: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    const [{ value }] = validateInput(input, 1);
+    if (typeof value === 'string') {
+      const match = value.match(/^T?(\d{2}(:\d{2}(:\d{2})?)?)/);
+      if (match) {
+        return [{ type: PropertyType.time, value: parseDateString('T' + match[1]) }];
+      }
+    }
+    return [];
+  },
+
+  /**
+   * If the input collection contains a single item, this function will return true if:
+   *   1) the item is a Time
+   *   2) the item is a String and is convertible to a Time
+   *
+   * If the item is not one of the above types, or is not convertible to a Time (using the format hh:mm:ss.fff(+|-)hh:mm), the result is false.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#convertstotime-boolean
+   *
+   * @param input
+   * @returns
+   */
+  convertsToTime: (input: TypedValue[]): TypedValue[] => {
+    if (input.length === 0) {
+      return [];
+    }
+    return booleanToTypedValue(functions.toTime(input).length === 1);
+  },
+
+  /*
+   * 5.6. String Manipulation.
+   *
+   * See: https://hl7.org/fhirpath/#string-manipulation
+   */
+
+  /**
+   * Returns the 0-based index of the first position substring is found in the input string, or -1 if it is not found.
+   *
+   * If substring is an empty string (''), the function returns 0.
+   *
+   * If the input or substring is empty ({ }), the result is empty ({ }).
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#indexofsubstring-string-integer
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  indexOf: (input: TypedValue[], substringAtom: Atom): TypedValue[] => {
+    return applyStringFunc((str, substring) => str.indexOf(substring as string), input, substringAtom);
+  },
+
+  /**
+   * Returns the part of the string starting at position start (zero-based). If length is given, will return at most length number of characters from the input string.
+   *
+   * If start lies outside the length of the string, the function returns empty ({ }). If there are less remaining characters in the string than indicated by length, the function returns just the remaining characters.
+   *
+   * If the input or start is empty, the result is empty.
+   *
+   * If an empty length is provided, the behavior is the same as if length had not been provided.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  substring: (input: TypedValue[], startAtom: Atom, lengthAtom?: Atom): TypedValue[] => {
+    return applyStringFunc(
+      (str, start, length) => {
+        const startIndex = start as number;
+        const endIndex = length ? startIndex + (length as number) : str.length;
+        return startIndex < 0 || startIndex >= str.length ? undefined : str.substring(startIndex, endIndex);
+      },
+      input,
+      startAtom,
+      lengthAtom
+    );
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  startsWith: (input: TypedValue[], prefixAtom: Atom): TypedValue[] => {
+    return applyStringFunc((str, prefix) => str.startsWith(prefix as string), input, prefixAtom);
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  endsWith: (input: TypedValue[], suffixAtom: Atom): TypedValue[] => {
+    return applyStringFunc((str, suffix) => str.endsWith(suffix as string), input, suffixAtom);
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  contains: (input: TypedValue[], substringAtom: Atom): TypedValue[] => {
+    return applyStringFunc((str, substring) => str.includes(substring as string), input, substringAtom);
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  upper: (input: TypedValue[]): TypedValue[] => {
+    return applyStringFunc((str) => str.toUpperCase(), input);
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  lower: (input: TypedValue[]): TypedValue[] => {
+    return applyStringFunc((str) => str.toLowerCase(), input);
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  replace: (input: TypedValue[], patternAtom: Atom, substitionAtom: Atom): TypedValue[] => {
+    return applyStringFunc(
+      (str, pattern, substition) => str.replaceAll(pattern as string, substition as string),
+      input,
+      patternAtom,
+      substitionAtom
+    );
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  matches: (input: TypedValue[], regexAtom: Atom): TypedValue[] => {
+    return applyStringFunc((str, regex) => !!str.match(regex as string), input, regexAtom);
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  replaceMatches: (input: TypedValue[], regexAtom: Atom, substitionAtom: Atom): TypedValue[] => {
+    return applyStringFunc(
+      (str, pattern, substition) => str.replaceAll(pattern as string, substition as string),
+      input,
+      regexAtom,
+      substitionAtom
+    );
+  },
+
+  /**
+   *
+   * @param input The input collection.
+   * @returns The index of the substring.
+   */
+  length: (input: TypedValue[]): TypedValue[] => {
+    return applyStringFunc((str) => str.length, input);
+  },
+
+  /**
+   * Returns the list of characters in the input string. If the input collection is empty ({ }), the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#tochars-collection
+   *
+   * @param input The input collection.
+   */
+  toChars: (input: TypedValue[]): TypedValue[] => {
+    return applyStringFunc((str) => (str ? str.split('') : undefined), input);
+  },
+
+  /*
+   * 5.7. Math
+   */
+
+  /**
+   * Returns the absolute value of the input. When taking the absolute value of a quantity, the unit is unchanged.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#abs-integer-decimal-quantity
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  abs: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.abs, input);
+  },
+
+  /**
+   * Returns the first integer greater than or equal to the input.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#ceiling-integer
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  ceiling: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.ceil, input);
+  },
+
+  /**
+   * Returns e raised to the power of the input.
+   *
+   * If the input collection contains an Integer, it will be implicitly converted to a Decimal and the result will be a Decimal.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#exp-decimal
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  exp: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.exp, input);
+  },
+
+  /**
+   * Returns the first integer less than or equal to the input.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#floor-integer
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  floor: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.floor, input);
+  },
+
+  /**
+   * Returns the natural logarithm of the input (i.e. the logarithm base e).
+   *
+   * When used with an Integer, it will be implicitly converted to a Decimal.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#ln-decimal
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  ln: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.log, input);
+  },
+
+  /**
+   * Returns the logarithm base base of the input number.
+   *
+   * When used with Integers, the arguments will be implicitly converted to Decimal.
+   *
+   * If base is empty, the result is empty.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#logbase-decimal-decimal
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  log: (input: TypedValue[], baseAtom: Atom): TypedValue[] => {
+    return applyMathFunc((value, base) => Math.log(value) / Math.log(base as number), input, baseAtom);
+  },
+
+  /**
+   * Raises a number to the exponent power. If this function is used with Integers, the result is an Integer. If the function is used with Decimals, the result is a Decimal. If the function is used with a mixture of Integer and Decimal, the Integer is implicitly converted to a Decimal and the result is a Decimal.
+   *
+   * If the power cannot be represented (such as the -1 raised to the 0.5), the result is empty.
+   *
+   * If the input is empty, or exponent is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#powerexponent-integer-decimal-integer-decimal
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  power: (input: TypedValue[], expAtom: Atom): TypedValue[] => {
+    return applyMathFunc(Math.pow as (x: number, ...args: unknown[]) => number, input, expAtom);
+  },
+
+  /**
+   * Rounds the decimal to the nearest whole number using a traditional round (i.e. 0.5 or higher will round to 1). If specified, the precision argument determines the decimal place at which the rounding will occur. If not specified, the rounding will default to 0 decimal places.
+   *
+   * If specified, the number of digits of precision must be >= 0 or the evaluation will end and signal an error to the calling environment.
+   *
+   * If the input collection contains a single item of type Integer, it will be implicitly converted to a Decimal.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#roundprecision-integer-decimal
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  round: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.round, input);
+  },
+
+  /**
+   * Returns the square root of the input number as a Decimal.
+   *
+   * If the square root cannot be represented (such as the square root of -1), the result is empty.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
+   *
+   * See: https://hl7.org/fhirpath/#sqrt-decimal
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  sqrt: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc(Math.sqrt, input);
+  },
+
+  /**
+   * Returns the integer portion of the input.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#truncate-integer
+   *
+   * @param input The input collection.
+   * @returns A collection containing the result.
+   */
+  truncate: (input: TypedValue[]): TypedValue[] => {
+    return applyMathFunc((x) => x | 0, input);
+  },
+
+  /*
+   * 5.8. Tree navigation
+   */
+
+  children: stub,
+
+  descendants: stub,
+
+  /*
+   * 5.9. Utility functions
+   */
+
+  /**
+   * Adds a String representation of the input collection to the diagnostic log,
+   * using the name argument as the name in the log. This log should be made available
+   * to the user in some appropriate fashion. Does not change the input, so returns
+   * the input collection as output.
+   *
+   * If the projection argument is used, the trace would log the result of evaluating
+   * the project expression on the input, but still return the input to the trace
+   * function unchanged.
+   *
+   * See: https://hl7.org/fhirpath/#tracename-string-projection-expression-collection
+   *
+   * @param input The input collection.
+   * @param nameAtom The log name.
+   */
+  trace: (input: TypedValue[], nameAtom: Atom): TypedValue[] => {
+    console.log('trace', input, nameAtom);
+    return input;
+  },
+
+  /**
+   * Returns the current date and time, including timezone offset.
+   *
+   * See: https://hl7.org/fhirpath/#now-datetime
+   */
+  now: (): TypedValue[] => {
+    return [{ type: PropertyType.dateTime, value: new Date().toISOString() }];
+  },
+
+  /**
+   * Returns the current time.
+   *
+   * See: https://hl7.org/fhirpath/#timeofday-time
+   */
+  timeOfDay: (): TypedValue[] => {
+    return [{ type: PropertyType.time, value: new Date().toISOString().substring(11) }];
+  },
+
+  /**
+   * Returns the current date.
+   *
+   * See: https://hl7.org/fhirpath/#today-date
+   */
+  today: (): TypedValue[] => {
+    return [{ type: PropertyType.date, value: new Date().toISOString().substring(0, 10) }];
+  },
+
+  /**
+   * Calculates the difference between two dates or date/times.
+   *
+   * This is not part of the official FHIRPath spec.
+   *
+   * IBM FHIR issue: https://github.com/IBM/FHIR/issues/1014
+   * IBM FHIR PR: https://github.com/IBM/FHIR/pull/1023
+   */
+  between: (context: TypedValue[], startAtom: Atom, endAtom: Atom, unitsAtom: Atom): TypedValue[] => {
+    const startDate = functions.toDateTime(startAtom.eval(context));
+    if (startDate.length === 0) {
+      throw new Error('Invalid start date');
+    }
+    const endDate = functions.toDateTime(endAtom.eval(context));
+    if (endDate.length === 0) {
+      throw new Error('Invalid end date');
+    }
+    const unit = unitsAtom.eval(context)[0].value as string;
+    if (unit !== 'years' && unit !== 'months' && unit !== 'days') {
+      throw new Error('Invalid units');
+    }
+    const age = calculateAge(startDate[0].value, endDate[0].value);
+    return [{ type: PropertyType.Quantity, value: { value: age[unit], unit } }];
+  },
+
+  /*
+   * 6.3 Types
+   */
+
+  /**
+   * The is() function is supported for backwards compatibility with previous
+   * implementations of FHIRPath. Just as with the is keyword, the type argument
+   * is an identifier that must resolve to the name of a type in a model.
+   *
+   * For implementations with compile-time typing, this requires special-case
+   * handling when processing the argument to treat it as a type specifier rather
+   * than an identifier expression:
+   *
+   * @param input
+   * @param typeAtom
+   * @returns
+   */
+  is: (input: TypedValue[], typeAtom: Atom): TypedValue[] => {
+    let typeName = '';
+    if (typeAtom instanceof SymbolAtom) {
+      typeName = typeAtom.name;
+    } else if (typeAtom instanceof DotAtom) {
+      typeName = (typeAtom.left as SymbolAtom).name + '.' + (typeAtom.right as SymbolAtom).name;
+    }
+    if (!typeName) {
+      return [];
+    }
+    return input.map((value) => ({ type: PropertyType.boolean, value: fhirPathIs(value, typeName) }));
+  },
+
+  /*
+   * 6.5 Boolean logic
+   */
+
+  /**
+   * 6.5.3. not() : Boolean
+   *
+   * Returns true if the input collection evaluates to false, and false if it evaluates to true. Otherwise, the result is empty ({ }):
+   *
+   * @param input
+   * @returns
+   */
+  not: (input: TypedValue[]): TypedValue[] => {
+    return functions.toBoolean(input).map((value) => ({ type: PropertyType.boolean, value: !value.value }));
+  },
+
+  /*
+   * Additional functions
+   * See: https://hl7.org/fhir/fhirpath.html#functions
+   */
+
+  /**
+   * For each item in the collection, if it is a string that is a uri (or canonical or url), locate the target of the reference, and add it to the resulting collection. If the item does not resolve to a resource, the item is ignored and nothing is added to the output collection.
+   * The items in the collection may also represent a Reference, in which case the Reference.reference is resolved.
+   * @param input The input collection.
+   * @returns
+   */
+  resolve: (input: TypedValue[]): TypedValue[] => {
+    return input
+      .map((e) => {
+        const value = e.value;
+        let refStr: string | undefined;
+        if (typeof value === 'string') {
+          refStr = value;
+        } else if (typeof value === 'object') {
+          const ref = value as Reference;
+          if (ref.resource) {
+            return { type: PropertyType.BackboneElement, value: ref.resource };
+          }
+          refStr = ref.reference;
+        }
+        if (!refStr) {
+          return { type: PropertyType.BackboneElement, value: null };
+        }
+        const [resourceType, id] = refStr.split('/');
+        return { type: PropertyType.BackboneElement, value: { resourceType, id } };
+      })
+      .filter((e) => !!e.value);
+  },
+
+  /**
+   * The as operator can be used to treat a value as a specific type.
+   * @param context The context value.
+   * @returns The value as the specific type.
+   */
+  as: (context: TypedValue[]): TypedValue[] => {
+    return context;
+  },
+
+  /*
+   * 12. Formal Specifications
+   */
+
+  /**
+   * Returns the type of the input.
+   *
+   * 12.2. Model Information
+   *
+   * The model information returned by the reflection function type() is specified as an
+   * XML Schema document (xsd) and included in this specification at the following link:
+   * https://hl7.org/fhirpath/modelinfo.xsd
+   *
+   * See: https://hl7.org/fhirpath/#model-information
+   *
+   * @param input The input collection.
+   * @returns
+   */
+  type: (input: TypedValue[]): TypedValue[] => {
+    return input.map(({ value }) => {
+      if (typeof value === 'boolean') {
+        return { type: PropertyType.BackboneElement, value: { namespace: 'System', name: 'Boolean' } };
+      }
+      if (typeof value === 'number') {
+        return { type: PropertyType.BackboneElement, value: { namespace: 'System', name: 'Integer' } };
+      }
+      if (value && typeof value === 'object' && 'resourceType' in value) {
+        return {
+          type: PropertyType.BackboneElement,
+          value: { namespace: 'FHIR', name: (value as Resource).resourceType },
+        };
+      }
+      return { type: PropertyType.BackboneElement, value: null };
+    });
+  },
+
+  conformsTo: (input: TypedValue[], systemAtom: Atom): TypedValue[] => {
+    const system = systemAtom.eval([])[0].value as string;
+    if (!system.startsWith('http://hl7.org/fhir/StructureDefinition/')) {
+      throw new Error('Expected a StructureDefinition URL');
+    }
+    const expectedResourceType = system.replace('http://hl7.org/fhir/StructureDefinition/', '');
+    return input.map((value) => ({
+      type: PropertyType.boolean,
+      value: (value.value as Resource | undefined)?.resourceType === expectedResourceType,
+    }));
+  },
+};
 
 /*
  * Helper utilities
@@ -1527,41 +1569,54 @@ export function conformsTo(input: unknown[], systemAtom: Atom): boolean[] {
 
 function applyStringFunc<T>(
   func: (str: string, ...args: unknown[]) => T | undefined,
-  input: unknown[],
+  input: TypedValue[],
   ...argsAtoms: (Atom | undefined)[]
-): T[] {
+): TypedValue[] {
   if (input.length === 0) {
     return [];
   }
-  const [value] = validateInput(input, 1);
+  const [{ value }] = validateInput(input, 1);
   if (typeof value !== 'string') {
     throw new Error('String function cannot be called with non-string');
   }
-  const result = func(value, ...argsAtoms.map((atom) => atom && atom.eval(value)));
-  return result === undefined ? [] : [result];
+  const result = func(value, ...argsAtoms.map((atom) => atom && atom.eval(input)?.[0]?.value));
+  if (result === undefined) {
+    return [];
+  }
+  if (Array.isArray(result)) {
+    return result.map(toTypedValue);
+  }
+  return [toTypedValue(result)];
 }
 
 function applyMathFunc(
   func: (x: number, ...args: unknown[]) => number,
-  input: unknown[],
+  input: TypedValue[],
   ...argsAtoms: Atom[]
-): Quantity[] | number[] {
+): TypedValue[] {
   if (input.length === 0) {
     return [];
   }
-  const [value] = validateInput(input, 1);
+  const [{ value }] = validateInput(input, 1);
   const quantity = isQuantity(value);
   const numberInput = quantity ? value.value : value;
   if (typeof numberInput !== 'number') {
     throw new Error('Math function cannot be called with non-number');
   }
-  const result = func(numberInput, ...argsAtoms.map((atom) => atom.eval(undefined)));
-  return quantity ? [{ ...value, value: result }] : [result];
+  const result = func(numberInput, ...argsAtoms.map((atom) => atom.eval([])?.[0]?.value));
+  const type = quantity ? PropertyType.Quantity : input[0].type;
+  const returnValue = quantity ? { ...value, value: result } : result;
+  return [{ type, value: returnValue }];
 }
 
-function validateInput(input: unknown[], count: number): unknown[] {
+function validateInput(input: TypedValue[], count: number): TypedValue[] {
   if (input.length !== count) {
     throw new Error(`Expected ${count} arguments`);
+  }
+  for (const element of input) {
+    if (element === null || element === undefined) {
+      throw new Error('Expected non-null argument');
+    }
   }
   return input;
 }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -1,4 +1,5 @@
 import { Quantity } from '@medplum/fhirtypes';
+import { PropertyType } from '../types';
 import {
   AndAtom,
   ArithemticOperatorAtom,
@@ -13,8 +14,8 @@ import {
   EquivalentAtom,
   FhirPathAtom,
   FunctionAtom,
-  IndexerAtom,
   InAtom,
+  IndexerAtom,
   IsAtom,
   LiteralAtom,
   NotEqualsAtom,
@@ -26,7 +27,7 @@ import {
   XorAtom,
 } from './atoms';
 import { parseDateString } from './date';
-import * as functions from './functions';
+import { functions } from './functions';
 import { Token, tokenize } from './tokenize';
 
 interface PrefixParselet {
@@ -222,11 +223,7 @@ const FUNCTION_CALL_PARSELET: InfixParselet = {
       parser.match(',');
     }
 
-    return new FunctionAtom(
-      left.name,
-      args,
-      (functions as Record<string, (context: unknown[], ...a: Atom[]) => unknown[]>)[left.name]
-    );
+    return new FunctionAtom(left.name, args, functions[left.name]);
   },
   precedence: Precedence.FunctionCall,
 };
@@ -245,24 +242,24 @@ function parseQuantity(str: string): Quantity {
 
 const parserBuilder = new ParserBuilder()
   .registerPrefix('String', {
-    parse: (_, token) => new LiteralAtom(token.value),
+    parse: (_, token) => new LiteralAtom({ type: PropertyType.string, value: token.value }),
   })
   .registerPrefix('DateTime', {
-    parse: (_, token) => new LiteralAtom(parseDateString(token.value)),
+    parse: (_, token) => new LiteralAtom({ type: PropertyType.dateTime, value: parseDateString(token.value) }),
   })
   .registerPrefix('Quantity', {
-    parse: (_, token) => new LiteralAtom(parseQuantity(token.value)),
+    parse: (_, token) => new LiteralAtom({ type: PropertyType.Quantity, value: parseQuantity(token.value) }),
   })
   .registerPrefix('Number', {
-    parse: (_, token) => new LiteralAtom(parseFloat(token.value)),
+    parse: (_, token) => new LiteralAtom({ type: PropertyType.decimal, value: parseFloat(token.value) }),
   })
   .registerPrefix('Symbol', {
     parse: (_, token) => {
       if (token.value === 'false') {
-        return new LiteralAtom(false);
+        return new LiteralAtom({ type: PropertyType.boolean, value: false });
       }
       if (token.value === 'true') {
-        return new LiteralAtom(true);
+        return new LiteralAtom({ type: PropertyType.boolean, value: true });
       }
       return new SymbolAtom(token.value);
     },
@@ -331,6 +328,7 @@ const parserBuilder = new ParserBuilder()
  */
 export function parseFhirPath(input: string): FhirPathAtom {
   try {
+    // console.log(parserBuilder.construct(input).consumeAndParse());
     return new FhirPathAtom(input, parserBuilder.construct(input).consumeAndParse());
   } catch (error) {
     throw new Error(`FhirPathError on "${input}": ${error}`);
@@ -344,5 +342,19 @@ export function parseFhirPath(input: string): FhirPathAtom {
  * @returns The result of the FHIRPath expression against the resource or object.
  */
 export function evalFhirPath(input: string, context: unknown): unknown[] {
-  return parseFhirPath(input).eval(context);
+  // eval requires a TypedValue array
+  // As a convenience, we can accept array or non-array, and TypedValue or unknown value
+  if (!Array.isArray(context)) {
+    context = [context];
+  }
+  const array = Array.isArray(context) ? context : [context];
+  for (let i = 0; i < array.length; i++) {
+    const el = array[i];
+    if (!(typeof el === 'object' && 'type' in el && 'value' in el)) {
+      array[i] = { type: PropertyType.BackboneElement, value: el };
+    }
+  }
+  return parseFhirPath(input)
+    .eval(array)
+    .map((e) => e.value);
 }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -5,7 +5,6 @@ import {
   ArithemticOperatorAtom,
   AsAtom,
   Atom,
-  ComparisonOperatorAtom,
   ConcatAtom,
   ContainsAtom,
   DotAtom,
@@ -280,17 +279,17 @@ const parserBuilder = new ParserBuilder()
   .infixLeft('!=', Precedence.Equals, (left, _, right) => new NotEqualsAtom(left, right))
   .infixLeft('~', Precedence.Equivalent, (left, _, right) => new EquivalentAtom(left, right))
   .infixLeft('!~', Precedence.NotEquivalent, (left, _, right) => new NotEquivalentAtom(left, right))
-  .infixLeft('<', Precedence.LessThan, (left, _, right) => new ComparisonOperatorAtom(left, right, (x, y) => x < y))
+  .infixLeft('<', Precedence.LessThan, (left, _, right) => new ArithemticOperatorAtom(left, right, (x, y) => x < y))
   .infixLeft(
     '<=',
     Precedence.LessThanOrEquals,
-    (left, _, right) => new ComparisonOperatorAtom(left, right, (x, y) => x <= y)
+    (left, _, right) => new ArithemticOperatorAtom(left, right, (x, y) => x <= y)
   )
-  .infixLeft('>', Precedence.GreaterThan, (left, _, right) => new ComparisonOperatorAtom(left, right, (x, y) => x > y))
+  .infixLeft('>', Precedence.GreaterThan, (left, _, right) => new ArithemticOperatorAtom(left, right, (x, y) => x > y))
   .infixLeft(
     '>=',
     Precedence.GreaterThanOrEquals,
-    (left, _, right) => new ComparisonOperatorAtom(left, right, (x, y) => x >= y)
+    (left, _, right) => new ArithemticOperatorAtom(left, right, (x, y) => x >= y)
   )
   .infixLeft('&', Precedence.Ampersand, (left, _, right) => new ConcatAtom(left, right))
   .infixLeft('Symbol', Precedence.Is, (left: Atom, symbol: Token, right: Atom) => {

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -328,7 +328,6 @@ const parserBuilder = new ParserBuilder()
  */
 export function parseFhirPath(input: string): FhirPathAtom {
   try {
-    // console.log(parserBuilder.construct(input).consumeAndParse());
     return new FhirPathAtom(input, parserBuilder.construct(input).consumeAndParse());
   } catch (error) {
     throw new Error(`FhirPathError on "${input}": ${error}`);

--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -1,38 +1,39 @@
-import { applyMaybeArray, fhirPathEquals, fhirPathIs, toJsBoolean } from './utils';
+import { PropertyType } from '../types';
+import { fhirPathEquals, fhirPathIs, toJsBoolean } from './utils';
+
+const TYPED_TRUE = { type: PropertyType.boolean, value: true };
+const TYPED_FALSE = { type: PropertyType.boolean, value: false };
+const TYPED_1 = { type: PropertyType.integer, value: 1 };
+const TYPED_2 = { type: PropertyType.integer, value: 2 };
 
 describe('FHIRPath utils', () => {
-  test('applyMaybeArray', () => {
-    expect(applyMaybeArray(undefined, (e) => e)).toBeUndefined();
-    expect(applyMaybeArray(123, (e) => e)).toEqual(123);
-    expect(applyMaybeArray([1, 2, 3], (e) => e)).toEqual([1, 2, 3]);
-    expect(applyMaybeArray([1, undefined, 3], (e) => e)).toEqual([1, 3]);
-  });
-
   test('toJsBoolean', () => {
-    expect(toJsBoolean(undefined)).toEqual(false);
-    expect(toJsBoolean(null)).toEqual(false);
-    expect(toJsBoolean(false)).toEqual(false);
-    expect(toJsBoolean(true)).toEqual(true);
-    expect(toJsBoolean('')).toEqual(false);
-    expect(toJsBoolean('hi')).toEqual(true);
-    expect(toJsBoolean([])).toEqual(false);
-    expect(toJsBoolean(['hi'])).toEqual(true);
+    expect(toJsBoolean([{ type: PropertyType.BackboneElement, value: undefined }])).toEqual(false);
+    expect(toJsBoolean([{ type: PropertyType.BackboneElement, value: null }])).toEqual(false);
+    expect(toJsBoolean([{ type: PropertyType.boolean, value: false }])).toEqual(false);
+    expect(toJsBoolean([{ type: PropertyType.boolean, value: true }])).toEqual(true);
+    expect(toJsBoolean([{ type: PropertyType.string, value: '' }])).toEqual(false);
+    expect(toJsBoolean([{ type: PropertyType.string, value: 'hi' }])).toEqual(true);
   });
 
   test('fhirPathIs', () => {
-    expect(fhirPathIs(undefined, 'string')).toEqual(false);
-    expect(fhirPathIs({}, 'Patient')).toEqual(false);
-    expect(fhirPathIs({ resourceType: 'Patient' }, 'Patient')).toEqual(true);
-    expect(fhirPathIs({ resourceType: 'Observation' }, 'Patient')).toEqual(false);
-    expect(fhirPathIs(true, 'Boolean')).toEqual(true);
-    expect(fhirPathIs(false, 'Boolean')).toEqual(true);
-    expect(fhirPathIs(100, 'Boolean')).toEqual(false);
-    expect(fhirPathIs({}, 'Boolean')).toEqual(false);
+    expect(fhirPathIs({ type: PropertyType.string, value: undefined }, 'string')).toEqual(false);
+    expect(fhirPathIs({ type: PropertyType.BackboneElement, value: {} }, 'Patient')).toEqual(false);
+    expect(fhirPathIs({ type: PropertyType.BackboneElement, value: { resourceType: 'Patient' } }, 'Patient')).toEqual(
+      true
+    );
+    expect(
+      fhirPathIs({ type: PropertyType.BackboneElement, value: { resourceType: 'Observation' } }, 'Patient')
+    ).toEqual(false);
+    expect(fhirPathIs({ type: PropertyType.boolean, value: true }, 'Boolean')).toEqual(true);
+    expect(fhirPathIs({ type: PropertyType.boolean, value: false }, 'Boolean')).toEqual(true);
+    expect(fhirPathIs({ type: PropertyType.integer, value: 100 }, 'Boolean')).toEqual(false);
+    expect(fhirPathIs({ type: PropertyType.BackboneElement, value: {} }, 'Boolean')).toEqual(false);
   });
 
   test('fhirPathEquals', () => {
-    expect(fhirPathEquals(1, 1)).toEqual(true);
-    expect(fhirPathEquals(1, 2)).toEqual(false);
-    expect(fhirPathEquals(2, 1)).toEqual(false);
+    expect(fhirPathEquals(TYPED_1, TYPED_1)).toEqual([TYPED_TRUE]);
+    expect(fhirPathEquals(TYPED_1, TYPED_2)).toEqual([TYPED_FALSE]);
+    expect(fhirPathEquals(TYPED_2, TYPED_1)).toEqual([TYPED_FALSE]);
   });
 });

--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -24,6 +24,18 @@ describe('FHIRPath utils', () => {
     expect(toJsBoolean([{ type: PropertyType.string, value: 'hi' }])).toEqual(true);
   });
 
+  test('toTypedValue', () => {
+    expect(toTypedValue(1)).toEqual(TYPED_1);
+    expect(toTypedValue(1.5)).toEqual({ type: PropertyType.decimal, value: 1.5 });
+    expect(toTypedValue(true)).toEqual(TYPED_TRUE);
+    expect(toTypedValue(false)).toEqual(TYPED_FALSE);
+    expect(toTypedValue('xyz')).toEqual({ type: PropertyType.string, value: 'xyz' });
+    expect(toTypedValue({ value: 123, unit: 'mg' })).toEqual({
+      type: PropertyType.Quantity,
+      value: { value: 123, unit: 'mg' },
+    });
+  });
+
   test('fhirPathIs', () => {
     expect(fhirPathIs({ type: PropertyType.string, value: undefined }, 'string')).toEqual(false);
     expect(fhirPathIs({ type: PropertyType.BackboneElement, value: {} }, 'Patient')).toEqual(false);

--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -1,5 +1,13 @@
 import { PropertyType } from '../types';
-import { fhirPathEquals, fhirPathIs, toJsBoolean } from './utils';
+import {
+  fhirPathArrayEquals,
+  fhirPathArrayEquivalent,
+  fhirPathEquals,
+  fhirPathEquivalent,
+  fhirPathIs,
+  toJsBoolean,
+  toTypedValue,
+} from './utils';
 
 const TYPED_TRUE = { type: PropertyType.boolean, value: true };
 const TYPED_FALSE = { type: PropertyType.boolean, value: false };
@@ -32,8 +40,44 @@ describe('FHIRPath utils', () => {
   });
 
   test('fhirPathEquals', () => {
+    expect(fhirPathEquals(TYPED_TRUE, TYPED_TRUE)).toEqual([TYPED_TRUE]);
+    expect(fhirPathEquals(TYPED_TRUE, TYPED_FALSE)).toEqual([TYPED_FALSE]);
     expect(fhirPathEquals(TYPED_1, TYPED_1)).toEqual([TYPED_TRUE]);
     expect(fhirPathEquals(TYPED_1, TYPED_2)).toEqual([TYPED_FALSE]);
     expect(fhirPathEquals(TYPED_2, TYPED_1)).toEqual([TYPED_FALSE]);
+  });
+
+  test('fhirPathArrayEquals', () => {
+    expect(fhirPathArrayEquals([TYPED_1], [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(fhirPathArrayEquals([TYPED_1], [TYPED_2])).toEqual([TYPED_FALSE]);
+
+    // Acceptable threshold
+    expect(fhirPathArrayEquals([toTypedValue(1.0)], [toTypedValue(1.0001)])).toEqual([TYPED_FALSE]);
+    expect(fhirPathArrayEquals([toTypedValue(1.0)], [toTypedValue(1.5)])).toEqual([TYPED_FALSE]);
+
+    // Sort order does matter
+    expect(fhirPathArrayEquals([TYPED_1, TYPED_2], [TYPED_2, TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(fhirPathArrayEquals([TYPED_1, TYPED_2], [TYPED_1, TYPED_1])).toEqual([TYPED_FALSE]);
+  });
+
+  test('fhirPathEquivalent', () => {
+    expect(fhirPathEquivalent(TYPED_TRUE, TYPED_TRUE)).toEqual([TYPED_TRUE]);
+    expect(fhirPathEquivalent(TYPED_TRUE, TYPED_FALSE)).toEqual([TYPED_FALSE]);
+    expect(fhirPathEquivalent(TYPED_1, TYPED_1)).toEqual([TYPED_TRUE]);
+    expect(fhirPathEquivalent(TYPED_1, TYPED_2)).toEqual([TYPED_FALSE]);
+    expect(fhirPathEquivalent(TYPED_2, TYPED_1)).toEqual([TYPED_FALSE]);
+  });
+
+  test('fhirPathArrayEquivalent', () => {
+    expect(fhirPathArrayEquivalent([TYPED_1], [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(fhirPathArrayEquivalent([TYPED_1], [TYPED_2])).toEqual([TYPED_FALSE]);
+
+    // Acceptable threshold
+    expect(fhirPathArrayEquivalent([toTypedValue(1.0)], [toTypedValue(1.0001)])).toEqual([TYPED_TRUE]);
+    expect(fhirPathArrayEquivalent([toTypedValue(1.0)], [toTypedValue(1.5)])).toEqual([TYPED_FALSE]);
+
+    // Sort order does not matter
+    expect(fhirPathArrayEquivalent([TYPED_1, TYPED_2], [TYPED_2, TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(fhirPathArrayEquivalent([TYPED_1, TYPED_2], [TYPED_1, TYPED_1])).toEqual([TYPED_FALSE]);
   });
 });

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -1,4 +1,4 @@
-import { Period, Quantity, Resource } from '@medplum/fhirtypes';
+import { Period, Quantity } from '@medplum/fhirtypes';
 import { PropertyType } from '../types';
 import { TypedValue } from './atoms';
 
@@ -196,7 +196,7 @@ export function fhirPathIs(typedValue: TypedValue, desiredType: string): boolean
     case 'Quantity':
       return isQuantity(value);
     default:
-      return typeof value === 'object' && (value as Resource | undefined)?.resourceType === desiredType;
+      return typeof value === 'object' && value?.resourceType === desiredType;
   }
 }
 

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -17,8 +17,10 @@ export function booleanToTypedValue(value: boolean): [TypedValue] {
  * @returns A "best guess" TypedValue for the given value.
  */
 export function toTypedValue(value: unknown): TypedValue {
-  if (typeof value === 'number') {
+  if (Number.isSafeInteger(value)) {
     return { type: PropertyType.integer, value };
+  } else if (typeof value === 'number') {
+    return { type: PropertyType.decimal, value };
   } else if (typeof value === 'boolean') {
     return { type: PropertyType.boolean, value };
   } else if (typeof value === 'string') {

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -95,9 +95,6 @@ export function fhirPathArrayEquals(x: TypedValue[], y: TypedValue[]): TypedValu
  * @returns True if equal.
  */
 export function fhirPathEquals(x: TypedValue, y: TypedValue): TypedValue[] {
-  if (!x && !y) {
-    return booleanToTypedValue(true);
-  }
   const xValue = x.value;
   const yValue = y.value;
   if (typeof xValue === 'number' && typeof yValue === 'number') {
@@ -137,11 +134,8 @@ export function fhirPathArrayEquivalent(x: TypedValue[], y: TypedValue[]): Typed
  * @returns True if equivalent.
  */
 export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
-  if (!x && !y) {
-    return booleanToTypedValue(true);
-  }
-  const xValue = (x as TypedValue).value;
-  const yValue = (y as TypedValue).value;
+  const xValue = x.value;
+  const yValue = y.value;
   if (typeof xValue === 'number' && typeof yValue === 'number') {
     // Use more generous threshold than equality
     // Decimal: values must be equal, comparison is done on values rounded to the precision of the least precise operand.
@@ -164,18 +158,18 @@ export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
 
 /**
  * Returns the sort order of two values for FHIRPath array equivalence.
- * @param a The first value.
- * @param b The second value.
+ * @param x The first value.
+ * @param y The second value.
  * @returns The sort order of the values.
  */
-function fhirPathEquivalentCompare(a: TypedValue, b: TypedValue): number {
-  const aVal = a.value;
-  const bVal = b.value;
-  if (typeof aVal === 'number' && typeof bVal === 'number') {
-    return aVal - bVal;
+function fhirPathEquivalentCompare(x: TypedValue, y: TypedValue): number {
+  const xValue = x.value;
+  const yValue = y.value;
+  if (typeof xValue === 'number' && typeof yValue === 'number') {
+    return xValue - yValue;
   }
-  if (typeof aVal === 'string' && typeof bVal === 'string') {
-    return aVal.localeCompare(bVal);
+  if (typeof xValue === 'string' && typeof yValue === 'string') {
+    return xValue.localeCompare(yValue);
   }
   return 0;
 }


### PR DESCRIPTION
This is a pretty big change, but it's mostly future-looking foundational work.  The goal is zero-to-minimal change in behavior in this PR.  It will allow us to add improvements in future PR's.

Major changes:
* Added `TypedValue` - a simple enum with `type: PropertyType` and `value: any`
  * Currently, the behavior "guesses" the `type`, basically emulating the past behavior
  * In the future, the `type` can come from a schema, for better accuracy
  * When returning values with "choice of type", it provides a mechanism for returning the actual type
* Atom signature changed to `eval(context: TypedValue[]): TypedValue[]`
  * Before `context` could be a single value or an array -- now it must be an array
  * Before the return value could be a single value or an array -- now it must be an array
  * Originally, the single values were included for performance reasons, to avoid creating tons of single element arrays
  * In practice, we still ended up creating tons of single element arrays anyway, so the performance was a wash
  * By enforcing an always an array, there are tons of simplifying assumptions throughout the code
* Function signature changed to `(input: TypedValue[], ...args: Atom[]): TypedValue[]`
  * Changes to `input` and return value similar to the changes to `Atom`
  * Before, the "function signature" was implicit
  * Now it is a proper `interface` and all FHIRPath functions implement that interface