### PR TITLE
Generate PDF in client

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,14 @@
   "devDependencies": {
     "@medplum/fhirtypes": "0.9.7"
   },
+  "peerDependencies": {
+    "pdfmake": "0.2.5"
+  },
+  "peerDependenciesMeta": {
+    "pdfmake": {
+      "optional": true
+    }
+  },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -5,6 +5,11 @@ import { terser } from 'rollup-plugin-terser';
 
 const extensions = ['.ts'];
 
+const globals = {
+  pdfmake: 'pdfmake',
+  stream: 'stream',
+};
+
 export default {
   input: 'src/index.ts',
   output: [
@@ -24,6 +29,7 @@ export default {
       format: 'umd',
       name: 'medplum.core',
       sourcemap: true,
+      globals,
     },
     {
       file: 'dist/cjs/index.min.js',
@@ -31,6 +37,7 @@ export default {
       name: 'medplum.core',
       plugins: [terser()],
       sourcemap: true,
+      globals,
     },
   ],
   plugins: [
@@ -45,4 +52,5 @@ export default {
       },
     },
   ],
+  external: Object.keys(globals),
 };

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -556,28 +556,23 @@ describe('Client', () => {
   });
 
   test('Create pdf success', async () => {
-    const getBlob = jest.fn((cb: (blob: Blob) => void) => cb(new Blob()));
-    const createPdf = jest.fn(() => ({ getBlob }));
-    window.pdfMake = { createPdf } as any;
-
     const client = new MedplumClient(defaultOptions);
+    const footer = jest.fn(() => 'footer');
     const result = await client.createPdf({
       content: ['Hello World'],
       defaultStyle: {
         font: 'Helvetica',
       },
+      footer,
     });
     expect(result).toBeDefined();
     expect((result as any).request.url).toBe('https://x/fhir/R4/Binary');
     expect((result as any).request.options.method).toBe('POST');
     expect((result as any).request.options.headers['Content-Type']).toBe('application/pdf');
+    expect(footer).toHaveBeenCalled();
   });
 
   test('Create pdf with filename', async () => {
-    const getBlob = jest.fn((cb: (blob: Blob) => void) => cb(new Blob()));
-    const createPdf = jest.fn(() => ({ getBlob }));
-    (global as any).pdfMake = { createPdf };
-
     const client = new MedplumClient(defaultOptions);
     const result = await client.createPdf({ content: ['Hello world'] }, 'report.pdf');
     expect(result).toBeDefined();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -555,19 +555,18 @@ describe('Client', () => {
     expect((result as any).request.url).toBe('https://x/fhir/R4/Binary?_filename=hello.txt');
   });
 
-  test('Create pdf pdfmake not loaded', async () => {
-    expect.assertions(1);
-    const client = new MedplumClient(defaultOptions);
-    expect(async () => client.createPdf({ content: [] })).rejects.toThrow('pdfMake is not loaded');
-  });
-
   test('Create pdf success', async () => {
     const getBlob = jest.fn((cb: (blob: Blob) => void) => cb(new Blob()));
     const createPdf = jest.fn(() => ({ getBlob }));
-    (global as any).pdfMake = { createPdf };
+    window.pdfMake = { createPdf } as any;
 
     const client = new MedplumClient(defaultOptions);
-    const result = await client.createPdf({ content: ['Hello world'] });
+    const result = await client.createPdf({
+      content: ['Hello World'],
+      defaultStyle: {
+        font: 'Helvetica',
+      },
+    });
     expect(result).toBeDefined();
     expect((result as any).request.url).toBe('https://x/fhir/R4/Binary');
     expect((result as any).request.options.method).toBe('POST');

--- a/packages/core/src/pdf.test.ts
+++ b/packages/core/src/pdf.test.ts
@@ -4,7 +4,6 @@ describe('PDF', () => {
   test('Generate PDF client side', async () => {
     const getBlob = jest.fn((cb: (blob: Blob) => void) => cb(new Blob()));
     const createPdf = jest.fn(() => ({ getBlob }));
-    // (global as any).pdfMake = { createPdf };
     window.pdfMake = { createPdf } as any;
 
     const result = await generatePdf({
@@ -17,8 +16,6 @@ describe('PDF', () => {
   });
 
   test('Generate PDF server side', async () => {
-    // const result = await generatePdfServerSide({
-    // global.window = undefined as any;
     window.pdfMake = undefined as any;
     const result = await generatePdf({
       content: ['Hello World'],

--- a/packages/core/src/pdf.test.ts
+++ b/packages/core/src/pdf.test.ts
@@ -1,0 +1,31 @@
+import { generatePdf } from './pdf';
+
+describe('PDF', () => {
+  test('Generate PDF client side', async () => {
+    const getBlob = jest.fn((cb: (blob: Blob) => void) => cb(new Blob()));
+    const createPdf = jest.fn(() => ({ getBlob }));
+    // (global as any).pdfMake = { createPdf };
+    window.pdfMake = { createPdf } as any;
+
+    const result = await generatePdf({
+      content: ['Hello World'],
+      defaultStyle: {
+        font: 'Helvetica',
+      },
+    });
+    expect(result).toBeDefined();
+  });
+
+  test('Generate PDF server side', async () => {
+    // const result = await generatePdfServerSide({
+    // global.window = undefined as any;
+    window.pdfMake = undefined as any;
+    const result = await generatePdf({
+      content: ['Hello World'],
+      defaultStyle: {
+        font: 'Helvetica',
+      },
+    });
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/core/src/pdf.ts
+++ b/packages/core/src/pdf.ts
@@ -13,13 +13,11 @@ import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'p
 
 /**
  * Optional pdfmake global.
+ * On client-side, the user is expected to have loaded pdfmake via <script> tag.
+ * If pdfmake is avaiable, this global will be defined.
  * See: https://www.npmjs.com/package/pdfmake
  */
-declare const pdfMake:
-  | {
-      createPdf: typeof createPdf;
-    }
-  | undefined;
+declare const pdfMake: { createPdf: typeof createPdf };
 
 export async function generatePdf(
   docDefinition: TDocumentDefinitions,
@@ -36,7 +34,7 @@ export async function generatePdf(
   docDefinition.defaultStyle.fontSize = docDefinition.defaultStyle.fontSize || 11;
   docDefinition.defaultStyle.lineHeight = docDefinition.defaultStyle.lineHeight || 2.0;
 
-  if (typeof window === 'undefined') {
+  if (typeof pdfMake === 'undefined') {
     return generatePdfServerSide(docDefinition, tableLayouts, fonts);
   } else {
     return generatePdfClientSide(docDefinition, tableLayouts, fonts);
@@ -85,9 +83,6 @@ async function generatePdfClientSide(
   tableLayouts?: { [name: string]: CustomTableLayout },
   fonts?: TFontDictionary
 ): Promise<Blob> {
-  if (typeof pdfMake === 'undefined') {
-    throw new Error('pdfMake is not loaded');
-  }
   if (!fonts) {
     fonts = {
       Helvetica: {
@@ -108,10 +103,6 @@ async function generatePdfClientSide(
     };
   }
   return new Promise((resolve: (blob: Blob) => void) => {
-    // pdfMake.createPdf(docDefinition, tableLayouts, fonts).getBlob(resolve);
-    pdfMake.createPdf(docDefinition, tableLayouts, fonts).getBlob((blob: Blob) => {
-      console.log('getBlob:', blob);
-      resolve(blob);
-    });
+    pdfMake.createPdf(docDefinition, tableLayouts, fonts).getBlob(resolve);
   });
 }

--- a/packages/core/src/pdf.ts
+++ b/packages/core/src/pdf.ts
@@ -1,0 +1,117 @@
+/*
+ * This file attempts a unified "generatePdf" function that works both client-side and server-side.
+ * On client-side, it checks for a global "pdfMake" variable.
+ * On server-side, it dynamically loads "pdfmake" from the node_modules.
+ */
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import type { createPdf } from 'pdfmake/build/pdfmake';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
+
+/**
+ * Optional pdfmake global.
+ * See: https://www.npmjs.com/package/pdfmake
+ */
+declare const pdfMake:
+  | {
+      createPdf: typeof createPdf;
+    }
+  | undefined;
+
+export async function generatePdf(
+  docDefinition: TDocumentDefinitions,
+  tableLayouts?: { [name: string]: CustomTableLayout },
+  fonts?: TFontDictionary
+): Promise<Blob | Buffer> {
+  // Setup sane defaults
+  // See: https://pdfmake.github.io/docs/0.1/document-definition-object/styling/
+  docDefinition.pageSize = docDefinition.pageSize || 'LETTER';
+  docDefinition.pageMargins = docDefinition.pageMargins || [60, 60, 60, 60];
+  docDefinition.pageOrientation = docDefinition.pageOrientation || 'portrait';
+  docDefinition.defaultStyle = docDefinition.defaultStyle || {};
+  docDefinition.defaultStyle.font = docDefinition.defaultStyle.font || 'Helvetica';
+  docDefinition.defaultStyle.fontSize = docDefinition.defaultStyle.fontSize || 11;
+  docDefinition.defaultStyle.lineHeight = docDefinition.defaultStyle.lineHeight || 2.0;
+
+  if (typeof window === 'undefined') {
+    return generatePdfServerSide(docDefinition, tableLayouts, fonts);
+  } else {
+    return generatePdfClientSide(docDefinition, tableLayouts, fonts);
+  }
+}
+
+async function generatePdfServerSide(
+  docDefinition: TDocumentDefinitions,
+  tableLayouts?: { [name: string]: CustomTableLayout },
+  fonts?: TFontDictionary
+): Promise<Buffer> {
+  if (!fonts) {
+    fonts = {
+      Helvetica: {
+        normal: 'Helvetica',
+        bold: 'Helvetica-Bold',
+        italics: 'Helvetica-Oblique',
+        bolditalics: 'Helvetica-BoldOblique',
+      },
+      Roboto: {
+        normal: 'https://static.medplum.com/fonts/Roboto-Regular.ttf',
+        bold: 'https://static.medplum.com/fonts/Roboto-Medium.ttf',
+        italics: 'https://static.medplum.com/fonts/Roboto-Italic.ttf',
+        bolditalics: 'https://static.medplum.com/fonts/Roboto-MediumItalic.ttf',
+      },
+      Avenir: {
+        normal: 'https://static.medplum.com/fonts/avenir.ttf',
+      },
+    };
+  }
+  return new Promise<Buffer>((resolve, reject) => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const PdfPrinter = require('pdfmake');
+    const printer = new PdfPrinter(fonts);
+    const pdfDoc = printer.createPdfKitDocument(docDefinition, { tableLayouts });
+    const chunks: Uint8Array[] = [];
+    pdfDoc.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+    pdfDoc.on('end', () => resolve(Buffer.concat(chunks)));
+    pdfDoc.on('error', reject);
+    pdfDoc.end();
+  });
+}
+
+async function generatePdfClientSide(
+  docDefinition: TDocumentDefinitions,
+  tableLayouts?: { [name: string]: CustomTableLayout },
+  fonts?: TFontDictionary
+): Promise<Blob> {
+  if (typeof pdfMake === 'undefined') {
+    throw new Error('pdfMake is not loaded');
+  }
+  if (!fonts) {
+    fonts = {
+      Helvetica: {
+        normal: 'https://static.medplum.com/fonts/Helvetica.ttf',
+        bold: 'https://static.medplum.com/fonts/Helvetica-bold.ttf',
+        italics: 'https://static.medplum.com/fonts/Helvetica-italic.ttf',
+        bolditalics: 'https://static.medplum.com/fonts/Helvetica-bold-italic.ttf',
+      },
+      Roboto: {
+        normal: 'https://static.medplum.com/fonts/Roboto-Regular.ttf',
+        bold: 'https://static.medplum.com/fonts/Roboto-Medium.ttf',
+        italics: 'https://static.medplum.com/fonts/Roboto-Italic.ttf',
+        bolditalics: 'https://static.medplum.com/fonts/Roboto-MediumItalic.ttf',
+      },
+      Avenir: {
+        normal: 'https://static.medplum.com/fonts/avenir.ttf',
+      },
+    };
+  }
+  return new Promise((resolve: (blob: Blob) => void) => {
+    // pdfMake.createPdf(docDefinition, tableLayouts, fonts).getBlob(resolve);
+    pdfMake.createPdf(docDefinition, tableLayouts, fonts).getBlob((blob: Blob) => {
+      console.log('getBlob:', blob);
+      resolve(blob);
+    });
+  });
+}


### PR DESCRIPTION
Context:  We create PDF files using `pdfmake`.  The `MedplumClient` class has a method `createPdf` which accepts a `pdfmake` `TDocumentDefinition` and returns a FHIR `Binary`.

Before: We posted the `TDocumentDefinition` in entirety to a `/fhir/R4/Binary/$pdf` endpoint, and created the PDF on the server.  We returned the `Binary` as a result.

Unfortunately, there are a few properties of `TDocumentDefinition` that are not serializable to JSON, such as table layouts and dynamic footers.  Therefore, the strategy of posting as JSON was fundamentally flawed.

Now: We take the `TDocumentDefinition`, invoke `pdfmake`, post the `Blob` (in the browser) or the `Buffer` (in a node app) and post it to the normal `/fhir/R4/Binary` endpoint.  We returned the `Binary` as a result.

1. The API is the basically same.

Before:

```ts
createPdf(docDefinition: Record<string, unknown>, filename?: string): Promise<Binary>
```

After:

```ts
createPdf(
    docDefinition: TDocumentDefinitions,
    filename?: string,
    tableLayouts?: { [name: string]: CustomTableLayout },
    fonts?: TFontDictionary
  ): Promise<Binary>
```

This allows full control over the PDF generating process.

2. We now use `pdfmake` types.  You may recall that we have gone back and forth on this, because the types are supposed to be optional but historically caused problems for consumers who didn't use them.  We implement a number of strategies discussed in this thread: https://stackoverflow.com/questions/54392809/how-do-i-handle-optional-peer-dependencies-when-publishing-a-typescript-package

3. We go to great pains to make the API work the same in the browser and in a node app.  There are an annoying number of differences between the respective `pdfmake` API's, but I think we've smoothed them all over.  This has been tested:
  a. In browser with a simple HTML file with a simple `<script>` tag
  b. In a node app that imports `@medplum/core`
  c. In the bot lambda "execute" environment
  d. In the bot "simulate" environment

4. Fonts are still tricky.  In the browser, you can refer to fonts by HTTPS URL (as long as CORS is setup!).  I added default fonts to `static.medplum.com` for Helvetica, Roboto, and Avenir.  In a node app, the consumer will have to pass in font file paths.

5. In future PR, I recommend that we deprecate the `/fhir/R4/Binary/$pdf` endpoint, and remove `pdfmake` from server side dependencies entirely.  It's a nice opportunity to make a clean break.

Blocking https://github.com/medplum/medplum/pull/646