### PR TITLE
Fixed optional type imports in core

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -18,7 +18,7 @@ import {
   ValueSet,
 } from '@medplum/fhirtypes';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
+/** @ts-ignore */
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
 import { LRUCache } from './cache';
 import { encryptSHA256, getRandomString } from './crypto';
@@ -1019,7 +1019,7 @@ export class MedplumClient extends EventTarget {
    * @returns The result of the create operation.
    */
   createBinary(
-    data: string | File | Blob | Buffer,
+    data: string | File | Blob | Uint8Array,
     filename: string | undefined,
     contentType: string
   ): Promise<Binary> {
@@ -1400,8 +1400,8 @@ export class MedplumClient extends EventTarget {
     if (
       typeof data === 'string' ||
       (typeof Blob !== 'undefined' && data instanceof Blob) ||
-      (typeof Buffer !== 'undefined' && data instanceof Buffer) ||
-      (typeof File !== 'undefined' && data instanceof File)
+      (typeof File !== 'undefined' && data instanceof File) ||
+      (typeof Uint8Array !== 'undefined' && data instanceof Uint8Array)
     ) {
       options.body = data;
     } else if (data) {


### PR DESCRIPTION

Context: we want to be able to refer to "optional types" such as pdfmake, nodejs Buffer, etc.  We want MedplumClient to work seamlessly in browser environments and nodejs environments.



To do this, we have found 3 requirements:
1. Use `peerDependenciesMeta` to flag dependencies as optional
2. Use `import type` rather than `import` to indicate that you only want the types
3. Add a magic comment of `// @ts-ignore` before import type statements that are optional



2 additional changes are required:

1. Removing `/// <reference types="node" />`.  Apparently any reference to `Buffer` automatically includes `/// <reference types="node" />`.  We worked around this by using `Uint8Array` rather than `Buffer`, which then removes `/// <reference types="node" />`


2. Preserving the `// @ts-ignore` comments by using `/** @ts-ignore */` (h/t https://github.com/microsoft/TypeScript/issues/29866#issuecomment-715140696 )


