### PR TITLE
Use TS Extract to determine return types

### DIFF
--- a/packages/app/src/BulkAppPage.tsx
+++ b/packages/app/src/BulkAppPage.tsx
@@ -14,7 +14,7 @@ export function BulkAppPage(): JSX.Element {
   const [questionnaires, setQuestionnaires] = useState<Questionnaire[]>();
 
   useEffect(() => {
-    medplum.searchResources<Questionnaire>(`Questionnaire?subject-type=${resourceType}`).then(setQuestionnaires);
+    medplum.searchResources('Questionnaire', `subject-type=${resourceType}`).then(setQuestionnaires);
   }, [medplum, resourceType]);
 
   if (!questionnaires) {

--- a/packages/app/src/QuickServiceRequests.tsx
+++ b/packages/app/src/QuickServiceRequests.tsx
@@ -1,4 +1,4 @@
-import { getReferenceString, Operator } from '@medplum/core';
+import { getReferenceString } from '@medplum/core';
 import { BundleEntry, Patient, Reference, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { MedplumLink, sortByDateAndPriority, useMedplum, useResource } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
@@ -23,18 +23,13 @@ export function QuickServiceRequests(props: QuickServiceRequestsProps): JSX.Elem
       return;
     }
     const patientRefStr = 'reference' in patient ? patient.reference : getReferenceString(patient as Patient);
-    medplum
-      .search<ServiceRequest>({
-        resourceType: 'ServiceRequest',
-        filters: [{ code: 'subject', operator: Operator.EQUALS, value: patientRefStr as string }],
-      })
-      .then((bundle) => {
-        const entries = bundle.entry as BundleEntry<ServiceRequest>[];
-        const resources = entries.map((e) => e.resource as ServiceRequest);
-        sortByDateAndPriority(resources);
-        resources.reverse();
-        setServiceRequests(resources);
-      });
+    medplum.search('ServiceRequest', 'subject=' + patientRefStr).then((bundle) => {
+      const entries = bundle.entry as BundleEntry<ServiceRequest>[];
+      const resources = entries.map((e) => e.resource as ServiceRequest);
+      sortByDateAndPriority(resources);
+      resources.reverse();
+      setServiceRequests(resources);
+    });
   }, [medplum, resource]);
 
   if (!serviceRequests) {

--- a/packages/app/src/ResourceVersionPage.tsx
+++ b/packages/app/src/ResourceVersionPage.tsx
@@ -1,4 +1,4 @@
-import { Bundle, BundleEntry, OperationOutcome, Resource } from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import {
   Document,
   Loading,
@@ -31,7 +31,7 @@ export function ResourceVersionPage(): JSX.Element {
     setError(undefined);
     setLoading(true);
     medplum
-      .readHistory(resourceType, id)
+      .readHistory(resourceType as ResourceType, id)
       .then((result) => setHistoryBundle(result))
       .then(() => setLoading(false))
       .catch((reason) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -102,7 +102,7 @@ describe('CLI', () => {
 
     await main(medplum, ['node', 'index.js', 'save-bot', 'hello-world']);
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
-    const check = await medplum.readResource<Bot>('Bot', bot.id as string);
+    const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeDefined();
     expect(check.code).not.toEqual('');
   });
@@ -131,7 +131,7 @@ describe('CLI', () => {
 
     await main(medplum, ['node', 'index.js', 'deploy-bot', 'hello-world']);
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
-    const check = await medplum.readResource<Bot>('Bot', bot.id as string);
+    const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeDefined();
     expect(check.code).not.toEqual('');
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -46,7 +46,7 @@ async function runBotCommands(medplum: MedplumClient, argv: string[], commands: 
     return;
   }
 
-  const bot = await medplum.readResource<Bot>('Bot', botConfig.id);
+  const bot = await medplum.readResource('Bot', botConfig.id);
   if (!bot) {
     console.log('Error: Bot does not exist: ' + botConfig.id);
     return;

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2,7 +2,6 @@ import { Bundle, Patient, SearchParameter, StructureDefinition } from '@medplum/
 import crypto, { randomUUID } from 'crypto';
 import { TextEncoder } from 'util';
 import { MedplumClient } from './client';
-import { Operator } from './search';
 import { ProfileResource, stringify } from './utils';
 
 const defaultOptions = {
@@ -648,18 +647,7 @@ describe('Client', () => {
 
   test('Search', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.search({
-      resourceType: 'Patient',
-      filters: [{ code: 'name', operator: Operator.CONTAINS, value: 'alice' }],
-    });
-    expect(result).toBeDefined();
-    expect((result as any).request.options.method).toBe('GET');
-    expect((result as any).request.url).toBe('https://x/fhir/R4/Patient?name:contains=alice');
-  });
-
-  test('Search by query', async () => {
-    const client = new MedplumClient(defaultOptions);
-    const result = await client.search('Patient?name:contains=alice');
+    const result = await client.search('Patient', 'name:contains=alice');
     expect(result).toBeDefined();
     expect((result as any).request.options.method).toBe('GET');
     expect((result as any).request.url).toBe('https://x/fhir/R4/Patient?name:contains=alice');
@@ -667,26 +655,16 @@ describe('Client', () => {
 
   test('Search one', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.searchOne({
-      resourceType: 'Patient',
-      filters: [{ code: 'name', operator: Operator.CONTAINS, value: 'alice' }],
-    });
-    expect(result).toBeDefined();
-    expect(result?.resourceType).toBe('Patient');
-  });
-
-  test('Search one by query', async () => {
-    const client = new MedplumClient(defaultOptions);
-    const result = await client.searchOne('Patient?name:contains=alice');
+    const result = await client.searchOne('Patient', 'name:contains=alice');
     expect(result).toBeDefined();
     expect(result?.resourceType).toBe('Patient');
   });
 
   test('Search one ReadablePromise', async () => {
     const client = new MedplumClient(defaultOptions);
-    const promise1 = client.searchOne('Patient?name:contains=alice');
+    const promise1 = client.searchOne('Patient', 'name:contains=alice');
     expect(() => promise1.read()).toThrow();
-    const promise2 = client.searchOne('Patient?name:contains=alice');
+    const promise2 = client.searchOne('Patient', 'name:contains=alice');
     expect(promise2).toBe(promise1);
     await promise1;
     const result = promise1.read();
@@ -696,20 +674,7 @@ describe('Client', () => {
 
   test('Search resources', async () => {
     const client = new MedplumClient(defaultOptions);
-    const result = await client.searchResources({
-      resourceType: 'Patient',
-      count: 1,
-      filters: [{ code: 'name', operator: Operator.CONTAINS, value: 'alice' }],
-    });
-    expect(result).toBeDefined();
-    expect(Array.isArray(result)).toBe(true);
-    expect(result.length).toBe(1);
-    expect(result[0].resourceType).toBe('Patient');
-  });
-
-  test('Search resources by query', async () => {
-    const client = new MedplumClient(defaultOptions);
-    const result = await client.searchResources('Patient?_count=1&name:contains=alice');
+    const result = await client.searchResources('Patient', '_count=1&name:contains=alice');
     expect(result).toBeDefined();
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
@@ -718,9 +683,9 @@ describe('Client', () => {
 
   test('Search resources ReadablePromise', async () => {
     const client = new MedplumClient(defaultOptions);
-    const promise1 = client.searchResources('Patient?_count=1&name:contains=alice');
+    const promise1 = client.searchResources('Patient', '_count=1&name:contains=alice');
     expect(() => promise1.read()).toThrow();
-    const promise2 = client.searchResources('Patient?_count=1&name:contains=alice');
+    const promise2 = client.searchResources('Patient', '_count=1&name:contains=alice');
     expect(promise2).toBe(promise1);
     await promise1;
     const result = promise1.read();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -110,7 +110,10 @@ function mockFetch(url: string, options: any): Promise<any> {
       resourceType: 'Patient',
       id: '123',
     };
-  } else if (method === 'GET' && url.endsWith('Patient?_count=1&name:contains=alice')) {
+  } else if (
+    method === 'GET' &&
+    (url.endsWith('Patient?_count=1&name:contains=alice') || url.endsWith('Patient?_count=1&name%3Acontains=alice'))
+  ) {
     result = {
       resourceType: 'Bundle',
       entry: [

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -6,12 +6,14 @@ import {
   Bundle,
   Communication,
   Encounter,
+  ExtractResource,
   OperationOutcome,
   Patient,
   Project,
   ProjectMembership,
   Reference,
   Resource,
+  ResourceType,
   SearchParameter,
   StructureDefinition,
   UserConfiguration,
@@ -28,7 +30,6 @@ import { parseJWTPayload } from './jwt';
 import { isOk } from './outcomes';
 import { generatePdf } from './pdf';
 import { ReadablePromise } from './readablepromise';
-import { formatSearchQuery, parseSearchDefinition, SearchRequest } from './search';
 import { ClientStorage } from './storage';
 import { createSchema, IndexedStructureDefinition, indexSearchParameter, indexStructureDefinition } from './types';
 import { arrayBufferToBase64, createReference, ProfileResource } from './utils';
@@ -383,7 +384,7 @@ export class MedplumClient extends EventTarget {
    * Invalidates all cached search results or cached requests for the given resourceType.
    * @param resourceType The resource type to invalidate.
    */
-  invalidateSearches(resourceType: string): void {
+  invalidateSearches<K extends ResourceType>(resourceType: K): void {
     const url = 'fhir/R4/' + resourceType;
     for (const key of this.#requestCache.keys()) {
       if (key.endsWith(url) || key.includes(url + '?')) {
@@ -589,12 +590,9 @@ export class MedplumClient extends EventTarget {
    * @param query The FHIR search query or structured query object.
    * @returns The well-formed FHIR URL.
    */
-  fhirSearchUrl(query: string | SearchRequest): URL {
-    if (typeof query === 'string') {
-      return this.fhirUrl(query);
-    }
-    const url = this.fhirUrl(query.resourceType);
-    url.search = formatSearchQuery(query);
+  fhirSearchUrl(resourceType: ResourceType, query: URLSearchParams | Record<string, string> | string): URL {
+    const url = this.fhirUrl(resourceType);
+    url.search = query.toString();
     return url;
   }
 
@@ -652,8 +650,12 @@ export class MedplumClient extends EventTarget {
    * @param query The search query as either a string or a structured search object.
    * @returns Promise to the search result bundle.
    */
-  search<T extends Resource>(query: string | SearchRequest, options: RequestInit = {}): ReadablePromise<Bundle<T>> {
-    return this.get(this.fhirSearchUrl(query), options);
+  search<K extends ResourceType>(
+    resourceType: K,
+    query: string,
+    options: RequestInit = {}
+  ): ReadablePromise<Bundle<ExtractResource<K>>> {
+    return this.get(this.fhirSearchUrl(resourceType, query), options);
   }
 
   /**
@@ -675,20 +677,23 @@ export class MedplumClient extends EventTarget {
    * @param query The search query as either a string or a structured search object.
    * @returns Promise to the search result bundle.
    */
-  searchOne<T extends Resource>(
-    query: string | SearchRequest,
+  searchOne<K extends ResourceType>(
+    resourceType: K,
+    query: string,
     options: RequestInit = {}
-  ): ReadablePromise<T | undefined> {
-    const search: SearchRequest = typeof query === 'string' ? parseSearchDefinition(query) : query;
-    (search as any).count = 1;
-    const cacheKey = this.fhirSearchUrl(query).toString() + '-searchOne';
+  ): ReadablePromise<ExtractResource<K> | undefined> {
+    const url = this.fhirSearchUrl(resourceType, query);
+    url.searchParams.set('_count', '1');
+    const cacheKey = url.toString() + '-searchOne';
     if (!options?.cache) {
       const cached = this.#requestCache.get(cacheKey);
       if (cached) {
         return cached;
       }
     }
-    const promise = new ReadablePromise(this.search<T>(search, options).then((b) => b.entry?.[0]?.resource));
+    const promise = new ReadablePromise(
+      this.search<K>(resourceType, query, options).then((b) => b.entry?.[0]?.resource)
+    );
     this.#requestCache.set(cacheKey, promise);
     return promise;
   }
@@ -712,8 +717,13 @@ export class MedplumClient extends EventTarget {
    * @param query The search query as either a string or a structured search object.
    * @returns Promise to the search result bundle.
    */
-  searchResources<T extends Resource>(query: string | SearchRequest, options: RequestInit = {}): ReadablePromise<T[]> {
-    const cacheKey = this.fhirSearchUrl(query).toString() + '-searchResources';
+  searchResources<K extends ResourceType>(
+    resourceType: K,
+    query: string,
+    options: RequestInit = {}
+  ): ReadablePromise<ExtractResource<K>[]> {
+    const url = this.fhirSearchUrl(resourceType, query);
+    const cacheKey = url.toString() + '-searchResources';
     if (!options?.cache) {
       const cached = this.#requestCache.get(cacheKey);
       if (cached) {
@@ -721,7 +731,9 @@ export class MedplumClient extends EventTarget {
       }
     }
     const promise = new ReadablePromise(
-      this.search<T>(query, options).then((b) => b.entry?.map((e) => e.resource as T) ?? [])
+      this.search<K>(resourceType, query, options).then(
+        (b) => b.entry?.map((e) => e.resource as ExtractResource<K>) ?? []
+      )
     );
     this.#requestCache.set(cacheKey, promise);
     return promise;
@@ -747,9 +759,9 @@ export class MedplumClient extends EventTarget {
    * @param id The FHIR resource ID.
    * @returns The resource if it is available in the cache; undefined otherwise.
    */
-  getCached<T extends Resource>(resourceType: string, id: string): T | undefined {
+  getCached<K extends ResourceType>(resourceType: K, id: string): ExtractResource<K> | undefined {
     const cached = this.#requestCache.get(this.fhirUrl(resourceType, id).toString());
-    return cached && !cached.isPending() ? (cached.read() as T) : undefined;
+    return cached && !cached.isPending() ? (cached.read() as ExtractResource<K>) : undefined;
   }
 
   /**
@@ -761,7 +773,7 @@ export class MedplumClient extends EventTarget {
   getCachedReference<T extends Resource>(reference: Reference<T>): T | undefined {
     const refString = reference.reference as string;
     const [resourceType, id] = refString.split('/');
-    return this.getCached(resourceType, id);
+    return this.getCached(resourceType as ResourceType, id) as T | undefined;
   }
 
   /**
@@ -780,8 +792,8 @@ export class MedplumClient extends EventTarget {
    * @param id The resource ID.
    * @returns The resource if available; undefined otherwise.
    */
-  readResource<T extends Resource>(resourceType: string, id: string): ReadablePromise<T> {
-    return this.get(this.fhirUrl(resourceType, id));
+  readResource<K extends ResourceType>(resourceType: K, id: string): ReadablePromise<ExtractResource<K>> {
+    return this.get<ExtractResource<K>>(this.fhirUrl(resourceType, id));
   }
 
   /**
@@ -808,7 +820,7 @@ export class MedplumClient extends EventTarget {
       return new ReadablePromise(Promise.reject(new Error('Missing reference')));
     }
     const [resourceType, id] = refString.split('/');
-    return this.readResource(resourceType, id);
+    return this.readResource(resourceType as ResourceType, id) as ReadablePromise<T>;
   }
 
   /**
@@ -894,7 +906,7 @@ export class MedplumClient extends EventTarget {
    * @param id The resource ID.
    * @returns Promise to the resource history.
    */
-  readHistory<T extends Resource>(resourceType: string, id: string): ReadablePromise<Bundle<T>> {
+  readHistory<K extends ResourceType>(resourceType: K, id: string): ReadablePromise<Bundle<ExtractResource<K>>> {
     return this.get(this.fhirUrl(resourceType, id, '_history'));
   }
 
@@ -914,7 +926,7 @@ export class MedplumClient extends EventTarget {
    * @param id The resource ID.
    * @returns The resource if available; undefined otherwise.
    */
-  readVersion<T extends Resource>(resourceType: string, id: string, vid: string): ReadablePromise<T> {
+  readVersion<K extends ResourceType>(resourceType: K, id: string, vid: string): ReadablePromise<ExtractResource<K>> {
     return this.get(this.fhirUrl(resourceType, id, '_history', vid));
   }
 
@@ -992,7 +1004,7 @@ export class MedplumClient extends EventTarget {
    * @returns The result of the create operation.
    */
   async createResourceIfNoneExist<T extends Resource>(resource: T, query: string): Promise<T> {
-    return (await this.searchOne<T>(`${resource.resourceType}?${query}`)) ?? this.createResource<T>(resource);
+    return ((await this.searchOne(resource.resourceType, query)) ?? this.createResource(resource)) as Promise<T>;
   }
 
   /**
@@ -1158,7 +1170,11 @@ export class MedplumClient extends EventTarget {
    * @param operations The JSONPatch operations.
    * @returns The result of the patch operations.
    */
-  patchResource<T extends Resource>(resourceType: string, id: string, operations: PatchOperation[]): Promise<T> {
+  patchResource<K extends ResourceType>(
+    resourceType: K,
+    id: string,
+    operations: PatchOperation[]
+  ): Promise<ExtractResource<K>> {
     this.invalidateSearches(resourceType);
     return this.patch(this.fhirUrl(resourceType, id), operations);
   }
@@ -1178,7 +1194,7 @@ export class MedplumClient extends EventTarget {
    * @param id The resource ID.
    * @returns The result of the delete operation.
    */
-  deleteResource(resourceType: string, id: string): Promise<any> {
+  deleteResource(resourceType: ResourceType, id: string): Promise<any> {
     this.invalidateSearches(resourceType);
     return this.delete(this.fhirUrl(resourceType, id));
   }

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1,3 +1,5 @@
+import { ResourceType } from '@medplum/fhirtypes';
+
 export const DEFAULT_SEARCH_COUNT = 20;
 
 export interface SearchRequest {
@@ -92,7 +94,7 @@ export function parseSearchDefinition(url: string): SearchRequest {
   const resourceType = location.pathname
     .replace(/(^\/)|(\/$)/g, '') // Remove leading and trailing slashes
     .split('/')
-    .pop() as string;
+    .pop() as ResourceType;
   const params = new URLSearchParams(location.search);
   let filters: Filter[] | undefined = undefined;
   let sortRules: SortRule[] | undefined = undefined;

--- a/packages/fhirtypes/dist/Resource.d.ts
+++ b/packages/fhirtypes/dist/Resource.d.ts
@@ -316,3 +316,6 @@ export type Resource = AccessPolicy
   | ValueSet
   | VerificationResult
   | VisionPrescription;
+
+  export type ResourceType = Resource['resourceType'];
+  export type ExtractResource<K extends ResourceType> = Extract<Resource, { resourceType: K }>;

--- a/packages/mock/src/repo.test.ts
+++ b/packages/mock/src/repo.test.ts
@@ -1,4 +1,3 @@
-import { Operator } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { MockClient } from './client';
@@ -56,32 +55,14 @@ describe('Mock Repo', () => {
 
   test('Search by name', async () => {
     const client = new MockClient();
-    const result = await client.search<Patient>({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.CONTAINS,
-          value: 'Simpson',
-        },
-      ],
-    });
+    const result = await client.search('Patient', 'name:contains=Simpson');
     expect(result).toBeDefined();
     expect(result.entry?.length).toBe(2);
   });
 
   test('Search with comma', async () => {
     const client = new MockClient();
-    const result = await client.search<Patient>({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.CONTAINS,
-          value: 'bart,homer',
-        },
-      ],
-    });
+    const result = await client.search('Patient', 'name:contains=Homer,Simpson');
     expect(result).toBeDefined();
     expect(result.entry?.length).toBe(2);
   });

--- a/packages/react/src/FhirPathTable.tsx
+++ b/packages/react/src/FhirPathTable.tsx
@@ -1,13 +1,13 @@
 import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
-import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
+import { OperationOutcome, Resource } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { FhirPathDisplay } from './FhirPathDisplay';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
 import { SearchClickEvent } from './SearchControl';
-import './SearchControl.css';
 import { isCheckboxCell, killEvent } from './utils/dom';
+import './SearchControl.css';
 
 export interface SmartSearchField {
   readonly propertyType: PropertyType;

--- a/packages/react/src/FhirPathTable.tsx
+++ b/packages/react/src/FhirPathTable.tsx
@@ -1,5 +1,5 @@
 import { IndexedStructureDefinition, PropertyType } from '@medplum/core';
-import { OperationOutcome, Resource } from '@medplum/fhirtypes';
+import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { FhirPathDisplay } from './FhirPathDisplay';

--- a/packages/react/src/ResourceBlame.tsx
+++ b/packages/react/src/ResourceBlame.tsx
@@ -1,4 +1,4 @@
-import { Bundle, Resource } from '@medplum/fhirtypes';
+import { Bundle, Resource, ResourceType } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
 import { InputRow } from './InputRow';
 import { MedplumLink } from './MedplumLink';
@@ -9,7 +9,7 @@ import './ResourceBlame.css';
 
 export interface ResourceBlameProps {
   history?: Bundle;
-  resourceType?: string;
+  resourceType?: ResourceType;
   id?: string;
 }
 

--- a/packages/react/src/ResourceHistoryTable.tsx
+++ b/packages/react/src/ResourceHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { Bundle, Resource } from '@medplum/fhirtypes';
+import { Bundle, Resource, ResourceType } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
 import { DateTimeDisplay } from './DateTimeDisplay';
 import { MedplumLink } from './MedplumLink';
@@ -18,7 +18,7 @@ export function ResourceHistoryTable(props: ResourceHistoryTableProps): JSX.Elem
 
   useEffect(() => {
     if (!props.history && props.resourceType && props.id) {
-      medplum.readHistory(props.resourceType, props.id).then((result) => setValue(result));
+      medplum.readHistory(props.resourceType as ResourceType, props.id).then((result) => setValue(result));
     }
   }, [medplum, props.history, props.resourceType, props.id]);
 

--- a/packages/react/src/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput.tsx
@@ -1,5 +1,4 @@
-import { Operator } from '@medplum/core';
-import { Bundle, BundleEntry, Reference, Resource } from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Autocomplete } from './Autocomplete';
 import { Avatar } from './Avatar';
@@ -39,16 +38,7 @@ export function ResourceInput<T extends Resource = Resource>(props: ResourceInpu
     <Autocomplete
       loadOptions={(input: string): Promise<T[]> => {
         return medplum
-          .search({
-            resourceType: resourceTypeRef.current,
-            filters: [
-              {
-                code: 'name',
-                operator: Operator.EQUALS,
-                value: input,
-              },
-            ],
-          })
+          .search(resourceTypeRef.current as ResourceType, 'name=' + encodeURIComponent(input))
           .then((bundle: Bundle) => (bundle.entry as BundleEntry[]).map((entry) => entry.resource as T));
       }}
       getId={(item: T) => {

--- a/packages/react/src/Scheduler.tsx
+++ b/packages/react/src/Scheduler.tsx
@@ -1,4 +1,4 @@
-import { getReferenceString, Operator } from '@medplum/core';
+import { getReferenceString } from '@medplum/core';
 import { BundleEntry, Reference, Schedule, Slot } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Avatar } from './Avatar';
@@ -30,20 +30,9 @@ export function Scheduler(props: SchedulerProps): JSX.Element | null {
 
   useEffect(() => {
     if (schedule) {
-      medplum
-        .search({
-          resourceType: 'Slot',
-          filters: [
-            {
-              code: 'schedule',
-              operator: Operator.EQUALS,
-              value: getReferenceString(schedule),
-            },
-          ],
-        })
-        .then((bundle) => {
-          setSlots((bundle.entry as BundleEntry<Slot>[]).map((entry) => entry.resource as Slot));
-        });
+      medplum.search('Slot', 'schedule=' + getReferenceString(schedule)).then((bundle) => {
+        setSlots((bundle.entry as BundleEntry<Slot>[]).map((entry) => entry.resource as Slot));
+      });
     } else {
       setSlots(undefined);
     }

--- a/packages/react/src/SearchControl.tsx
+++ b/packages/react/src/SearchControl.tsx
@@ -1,11 +1,19 @@
 import {
   DEFAULT_SEARCH_COUNT,
   Filter,
+  formatSearchQuery,
   IndexedStructureDefinition,
   parseSearchDefinition,
   SearchRequest,
 } from '@medplum/core';
-import { Bundle, OperationOutcome, Resource, SearchParameter, UserConfiguration } from '@medplum/fhirtypes';
+import {
+  Bundle,
+  OperationOutcome,
+  Resource,
+  ResourceType,
+  SearchParameter,
+  UserConfiguration,
+} from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Loading } from './Loading';
@@ -107,7 +115,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   useEffect(() => {
     setOutcome(undefined);
     medplum
-      .search({ ...search, total: 'accurate' })
+      .search(search.resourceType as ResourceType, formatSearchQuery({ ...search, total: 'accurate' }))
       .then((response) => {
         setState({ ...stateRef.current, searchResponse: response });
         if (onLoad) {
@@ -213,7 +221,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   }
 
   useEffect(() => {
-    medplum.requestSchema(props.search.resourceType).then((newSchema) => {
+    medplum.requestSchema(props.search.resourceType as ResourceType).then((newSchema) => {
       // The schema could have the same object identity,
       // so need to use the spread operator to kick React re-render.
       setSchema({ ...newSchema });


### PR DESCRIPTION
Current state:  There are many cases where developer consumers have to "double type":

```ts
return medplum.readResource<Patient>('Patient', '123');
```

Using the TypeScript feature `Extract<Type, Union>` we could infer the generic argument, and therefore infer the return type, so the developer could simply write:

```ts
return medplum.readResource('Patient', '123');
```

... and the return type Patient is inferred.

Here is the current implementation of readResource:

```ts
readResource<T extends Resource>(resourceType: string, id: string): ReadablePromise<T> {
  return this.get<T>(this.fhirUrl(resourceType, id));
}
```

Here is the inferred implementation:

```ts
readResource<K extends ResourceType>(resourceType: K, id: string): ReadablePromise<Extract<Resource, { resourceType: K }>> {
  return this.get<Extract<Resource, { resourceType: K }>>(this.fhirUrl(resourceType, id));
}
```

The implementation is definitely uglier, but the ergonomics for a consumer are much better.

### Breaking Changes

We need to change how search functions work to do this, but I think it might be worth it.

Today you pass in a search string like this:

```ts
medplum.search<Patient>('Patient?name=alice');
medplum.searchResources<Patient>('Patient?name=alice');
medplum.searchOne<Patient>('Patient?name=alice');
```

To be able to use the same Extract pattern, we would need to separate the resourceType from the rest of the search query:

```ts
medplum.search('Patient', 'name=alice');
medplum.searchResources('Patient', 'name=alice');
medplum.searchOne('Patient', 'name=alice');
```

### Performance

Notes on performance impact:
* Compared TypeScript compiler diagnostics using `npx tsc --extendedDiagnostics`
* Some metrics are slightly concerning: 5.5x instantiations, 100x cache size
* Overall compile time impact was +15%, so not that bad
* I think I'm OK with this

<img width="928" alt="image" src="https://user-images.githubusercontent.com/749094/172892012-5f80b0bf-73d7-411c-aeec-8c7cb60f74e4.png">
