### PR TITLE
Customizable header text and color

### DIFF
--- a/packages/react/src/Header.test.tsx
+++ b/packages/react/src/Header.test.tsx
@@ -41,6 +41,13 @@ describe('Header', () => {
   test('Renders', () => {
     setup();
     expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByText('Medplum')).toBeInTheDocument();
+  });
+
+  test('Custom title', () => {
+    setup({ title: 'Custom title' });
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByText('Custom title')).toBeInTheDocument();
   });
 
   test('Renders sidebar links', async () => {

--- a/packages/react/src/Header.tsx
+++ b/packages/react/src/Header.tsx
@@ -12,10 +12,12 @@ import { Popup } from './Popup';
 import './Header.css';
 
 export interface HeaderProps {
-  onLogo?: () => void;
-  onProfile?: () => void;
-  onSignOut?: () => void;
-  config?: UserConfiguration;
+  readonly title?: string;
+  readonly bgColor?: string;
+  readonly onLogo?: () => void;
+  readonly onProfile?: () => void;
+  readonly onSignOut?: () => void;
+  readonly config?: UserConfiguration;
 }
 
 export function Header(props: HeaderProps): JSX.Element {
@@ -29,7 +31,7 @@ export function Header(props: HeaderProps): JSX.Element {
 
   return (
     <>
-      <header role="banner" data-testid="header">
+      <header role="banner" data-testid="header" style={{ background: props.bgColor }}>
         <div>
           <MedplumLink
             label="Toggle sidebar"
@@ -50,7 +52,7 @@ export function Header(props: HeaderProps): JSX.Element {
             </svg>
           </MedplumLink>
           <MedplumLink id="medplum-header-logo" testid="header-logo" onClick={props.onLogo}>
-            Medplum
+            {props.title || 'Medplum'}
           </MedplumLink>
           {context.profile && (
             <HeaderSearchInput

--- a/packages/react/src/defaulttheme.css
+++ b/packages/react/src/defaulttheme.css
@@ -3,10 +3,8 @@
   --medplum-surface: #ffffff;
   --medplum-foreground: #424242;
   --medplum-navbar: #5b2876;
-  --medplum-navbar-textbox: #7a4696;
-  --medplum-navbar-icon: #5b2876;
-  --medplum-navbar-placeholder: #ddc4eb;
-  --medplum-navbar-hover: #5d5d85;
+  --medplum-navbar-textbox: rgba(255, 255, 255, 0.2);
+  --medplum-navbar-placeholder: rgba(255, 255, 255, 0.6);
   --medplum-shadow: rgba(0, 0, 0, 0.1);
   /* font sizes */
   --medplum-font-small: 12px;
@@ -97,10 +95,8 @@
     --medplum-surface: #000;
     --medplum-foreground: #eee;
     --medplum-navbar: #5b2876;
-    --medplum-navbar-textbox: #7a4696;
-    --medplum-navbar-icon: #5b2876;
-    --medplum-navbar-placeholder: #ddc4eb;
-    --medplum-navbar-hover: #5d5d85;
+    --medplum-navbar-textbox: rgba(255, 255, 255, 0.2);
+    --medplum-navbar-placeholder: rgba(255, 255, 255, 0.6);
     --medplum-shadow: rgba(0, 0, 0, 0.2);
     /* gray */
     --medplum-gray-900: #fafafa;

--- a/packages/react/src/stories/Header.stories.tsx
+++ b/packages/react/src/stories/Header.stories.tsx
@@ -15,6 +15,30 @@ const manyLinks: UserConfigurationMenuLink[] = new Array(50).fill(0).map((el, in
 }));
 
 export const Basic = (args: HeaderProps): JSX.Element => {
+  return <Header {...args} />;
+};
+
+export const CustomColor = (args: HeaderProps): JSX.Element => {
+  return (
+    <>
+      <Header title="Medplum" {...args} />
+      <Spacer />
+      <Header title="AWS" bgColor="#232f3e" {...args} />
+      <Spacer />
+      <Header title="Facebook" bgColor="#4267B2" {...args} />
+      <Spacer />
+      <Header title="GitHub" bgColor="#161b22" {...args} />
+      <Spacer />
+      <Header title="GitLab" bgColor="#292961" {...args} />
+      <Spacer />
+      <Header title="Google Cloud" bgColor="#1a73e8" {...args} />
+      <Spacer />
+      <Header title="Gradient" bgColor="linear-gradient(to right, #e66465, #9198e5)" {...args} />
+    </>
+  );
+};
+
+export const Search = (args: HeaderProps): JSX.Element => {
   const ctx = useMedplumContext();
   const medplum = ctx.medplum;
 
@@ -77,3 +101,7 @@ export const Basic = (args: HeaderProps): JSX.Element => {
     />
   );
 };
+
+function Spacer(): JSX.Element {
+  return <div style={{ height: 50, minHeight: 50 }} />;
+}


### PR DESCRIPTION
Default header title is "Medplum".  Default header color is Medplum purple.

Both are now customizable with the `<Header>` component:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/749094/173204160-261f26fe-5f14-4be5-9a07-6b5f11208444.png">

The search text box colors are now derived from the primary header color, which eliminates a bunch of complexity of color tuning.