### PR TITLE
Do not reset bot timeout on layer update

### DIFF
--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -195,7 +195,6 @@ async function updateLambda(client: LambdaClient, name: string, zipFile: Uint8Ar
         Runtime: LAMBDA_RUNTIME,
         Handler: LAMBDA_HANDLER,
         Layers: [layerVersion],
-        Timeout: 10, // seconds
       })
     );
   }


### PR DESCRIPTION
Context:  We use AWS Lambda Layers for the AWS Lambda Bots.  When user deploys a bot, we first check if there is a new version of the layer.  If yes, then we update the lambda configuration to use the latest layer version.

Before: When updating the layer version, we also updated the lambda timeout to the default 10 seconds.  However, for bots that had manually been updated to longer timeouts, that meant every update could possibly undo the timeout change.

After: Updating layer version does not affect timeout.