### PR TITLE
Do not use Blob in mock lib

### DIFF
--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -68,7 +68,7 @@ export class MockClient extends MedplumClient {
           console.log(`  ${JSON.stringify(tableLayouts, null, 2)},`);
           console.log(`  ${JSON.stringify(fonts, null, 2)});`);
         }
-        return Promise.resolve(new Blob());
+        return Promise.resolve({});
       },
       fetch: (url: string, options: any) => {
         const method = options.method || 'GET';


### PR DESCRIPTION
Before: Using `Blob` in `@medplum/mock` leads to `ReferenceError: Blob is not defined` in some testing tools, such as vi/vitest.

Now: Don't use `Blob` in `@medplum/mock`.