### PR TITLE
Invalidate searches after batch delete

### DIFF
--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -109,6 +109,10 @@ describe('HomePage', () => {
     window.confirm = jest.fn(() => true);
 
     await setup();
+
+    // Make sure the patient is on the screen
+    await waitFor(() => screen.getByText(patient.id as string));
+
     await waitFor(() => screen.getByText('Delete...'));
 
     await act(async () => {
@@ -121,6 +125,9 @@ describe('HomePage', () => {
 
     const check = await medplum.readResource('Patient', patient.id as string);
     expect(check).toBeUndefined();
+
+    // Make sure the patient is *not* on the screen
+    await waitFor(() => screen.queryByText(patient.id as string) === null);
   });
 
   test('Export button', async () => {

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -6,7 +6,7 @@ import {
   SearchRequest,
   SortRule,
 } from '@medplum/core';
-import { UserConfiguration } from '@medplum/fhirtypes';
+import { ResourceType, UserConfiguration } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -66,6 +66,7 @@ export function HomePage(): JSX.Element {
       }}
       onDelete={(ids: string[]) => {
         if (window.confirm('Are you sure you want to delete these resources?')) {
+          medplum.invalidateSearches(search.resourceType as ResourceType);
           medplum
             .post('fhir/R4', {
               resourceType: 'Bundle',


### PR DESCRIPTION
Repro steps:  Batch delete multiple resources

Expected behavior:  Delete resources, and resources disappear from the screen

Actual behavior: Delete resources, but resources stayed on the screen

What's going on?  MedplumClient has an internal cache.  We try to be smart about flushing that cache on updates and deletes, but that logic is not implemented for "batch" requests.  

This PR fixes the proximal bug, which invalidates caches manually after batch delete.

The better long term fix is support for the intelligent batching, which would eliminate/minimize the need for manually batching, and would then support all of the flushing logic for batch requests.