### PR TITLE
MedplumClient customizable cache time

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -471,6 +471,19 @@ describe('Client', () => {
     expect(client.getCachedReference({ reference: 'xyz?abc' })).toBeUndefined();
   });
 
+  test('Disabled cache read cached resource', async () => {
+    const client = new MedplumClient({ ...defaultOptions, cacheTime: 0 });
+    expect(client.getCached('Patient', '123')).toBeUndefined(); // Nothing in the cache
+    const readPromise = client.readResource('Patient', '123');
+    expect(client.getCached('Patient', '123')).toBeUndefined(); // Cache is disabled
+    const result = await readPromise;
+    expect(result).toBeDefined();
+    expect((result as any).request.url).toBe('https://x/fhir/R4/Patient/123');
+    expect(result.resourceType).toBe('Patient');
+    expect(result.id).toBe('123');
+    expect(client.getCached('Patient', '123')).toBeUndefined(); // Cache is disabled
+  });
+
   test('Read history', async () => {
     const client = new MedplumClient(defaultOptions);
     const result = await client.readHistory('Patient', '123');


### PR DESCRIPTION
Before: `MedplumClient` cached all resources by default indefinitely.  Cache could only be disabled per-request by passing in cache options.

Now: `MedplumClient` cache is time based, defaulting to 10 seconds.  Cache time can be customized, or disabled entirely, in the `MedplumClient` constructor options.  Cache can still be disabled per-request with cache options.

### Default behavior

```ts
const medplum = new MedplumClient();
const patient = await medplum.readResource('Patient', '123'); // resource will be cached for 10 seconds
```

### Custom cache time

```ts
const medplum = new MedplumClient({ cacheTime: 3000 });
const patient = await medplum.readResource('Patient', '123'); // resource will be cached for 3 seconds
```

### Disable cache entirely

```ts
const medplum = new MedplumClient({ cacheTime: 0 });
const patient = await medplum.readResource('Patient', '123'); // cache disabled
```

### Disable cache for single request

```ts
const medplum = new MedplumClient();
const patient = await medplum.readResource('Patient', '123'); // resource will be cached for 10 seconds
const check = await medplum.readResource('Patient', '123', { cache: 'reload' }); // force reload
```
