### PR TITLE
Fixes #627 - updated search control popup menu

### DIFF
--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -57,6 +57,9 @@ export enum Operator {
   IN = 'in',
   NOT_IN = 'not-in',
   OF_TYPE = 'of-type',
+
+  // All
+  MISSING = 'missing',
 }
 
 const MODIFIER_OPERATORS: Operator[] = [
@@ -68,6 +71,7 @@ const MODIFIER_OPERATORS: Operator[] = [
   Operator.IN,
   Operator.NOT_IN,
   Operator.OF_TYPE,
+  Operator.MISSING,
 ];
 
 const PREFIX_OPERATORS: Operator[] = [

--- a/packages/mock/src/mocks/types.ts
+++ b/packages/mock/src/mocks/types.ts
@@ -111,6 +111,14 @@ export const PatientSearchParameters: SearchParameter[] = [
   },
   {
     resourceType: 'SearchParameter',
+    id: 'Observation-value-string',
+    code: 'value-string',
+    base: ['Observation'],
+    type: 'string',
+    expression: '(Observation.value as string) | (Observation.value as CodeableConcept).text',
+  },
+  {
+    resourceType: 'SearchParameter',
     id: 'Encounter-length',
     code: 'length',
     base: ['Encounter'],

--- a/packages/react/src/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl.test.tsx
@@ -645,7 +645,7 @@ describe('SearchControl', () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Search'));
+      fireEvent.click(screen.getByText('Contains...'));
     });
 
     await act(async () => {

--- a/packages/react/src/SearchControl.tsx
+++ b/packages/react/src/SearchControl.tsx
@@ -80,11 +80,12 @@ interface SearchControlState {
   popupVisible: boolean;
   popupX: number;
   popupY: number;
-  popupSearchParam?: SearchParameter;
+  popupSearchParams?: SearchParameter[];
   fieldEditorVisible: boolean;
   filterEditorVisible: boolean;
   filterDialogVisible: boolean;
   filterDialogFilter?: Filter;
+  filterDialogSearchParam?: SearchParameter;
 }
 
 /**
@@ -103,7 +104,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
     popupVisible: false,
     popupX: 0,
     popupY: 0,
-    popupSearchParam: undefined,
+    popupSearchParams: undefined,
     fieldEditorVisible: false,
     filterEditorVisible: false,
     filterDialogVisible: false,
@@ -177,13 +178,13 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
    * @param e The click event.
    * @param key The field key.
    */
-  function handleSortClick(e: React.MouseEvent, searchParam: SearchParameter | undefined): void {
+  function handleSortClick(e: React.MouseEvent, searchParams: SearchParameter[] | undefined): void {
     setState({
       ...stateRef.current,
       popupVisible: true,
       popupX: e.clientX,
       popupY: e.clientY,
-      popupSearchParam: searchParam,
+      popupSearchParams: searchParams,
     });
   }
 
@@ -335,9 +336,9 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               </th>
             )}
             {fields.map((field) => (
-              <th key={field.name} onClick={(e) => handleSortClick(e, field.searchParam)}>
+              <th key={field.name} onClick={(e) => handleSortClick(e, field.searchParams)}>
                 {buildFieldNameString(field.name)}
-                {field.searchParam && <FilterIcon />}
+                {field.searchParams && <FilterIcon />}
               </th>
             ))}
           </tr>
@@ -345,10 +346,10 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
             {checkboxColumn && <th className="filters medplum-search-icon-cell" />}
             {fields.map((field) => (
               <th key={field.name} className="filters">
-                {field.searchParam && (
+                {field.searchParams && (
                   <FilterDescription
                     resourceType={resourceType}
-                    searchParam={field.searchParam}
+                    searchParams={field.searchParams}
                     filters={props.search.filters}
                   />
                 )}
@@ -402,12 +403,13 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         visible={state.popupVisible}
         x={state.popupX}
         y={state.popupY}
-        searchParam={state.popupSearchParam}
-        onPrompt={(filter) => {
+        searchParams={state.popupSearchParams}
+        onPrompt={(searchParam, filter) => {
           setState({
             ...stateRef.current,
             popupVisible: false,
             filterDialogVisible: true,
+            filterDialogSearchParam: searchParam,
             filterDialogFilter: filter,
           });
         }}
@@ -416,14 +418,14 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
           setState({
             ...stateRef.current,
             popupVisible: false,
-            popupSearchParam: undefined,
+            popupSearchParams: undefined,
           });
         }}
         onClose={() => {
           setState({
             ...stateRef.current,
             popupVisible: false,
-            popupSearchParam: undefined,
+            popupSearchParams: undefined,
           });
         }}
       />
@@ -468,7 +470,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         title={'Input'}
         schema={schema}
         resourceType={resourceType}
-        searchParam={state.popupSearchParam}
+        searchParam={state.filterDialogSearchParam}
         filter={state.filterDialogFilter}
         defaultValue={''}
         onOk={(filter) => {
@@ -493,12 +495,12 @@ export const MemoizedSearchControl = React.memo(SearchControl);
 
 interface FilterDescriptionProps {
   readonly resourceType: string;
-  readonly searchParam: SearchParameter;
+  readonly searchParams: SearchParameter[];
   readonly filters?: Filter[];
 }
 
 function FilterDescription(props: FilterDescriptionProps): JSX.Element {
-  const filters = (props.filters ?? []).filter((f) => f.code === props.searchParam.code);
+  const filters = (props.filters ?? []).filter((f) => props.searchParams.find((p) => p.code === f.code));
   if (filters.length === 0) {
     return <span>no filters</span>;
   }

--- a/packages/react/src/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor.tsx
@@ -255,23 +255,26 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
  * @param typeSchema The type definition.
  */
 function getFieldsList(typeSchema: TypeSchema): string[] {
-  let keys = Object.keys(typeSchema.properties);
+  const result = [] as string[];
+  const keys = new Set<string>();
+  const names = new Set<string>();
 
-  if (typeSchema.searchParams) {
-    // Combine the arrays and de-dupe
-    keys = [...new Set([...keys, ...Object.keys(typeSchema.searchParams)])];
+  // Add properties first
+  for (const key of Object.keys(typeSchema.properties)) {
+    result.push(key);
+    keys.add(key.toLowerCase());
+    names.add(buildFieldNameString(key));
   }
 
-  const result = [] as string[];
-  const names = [] as string[];
-
-  for (const key of keys) {
-    // Dedupe by display name
-    // Many properties and search parameters have the same name
-    const name = buildFieldNameString(key);
-    if (!names.includes(name)) {
-      result.push(key);
-      names.push(name);
+  // Add search parameters if unique
+  if (typeSchema.searchParams) {
+    for (const code of Object.keys(typeSchema.searchParams)) {
+      const name = buildFieldNameString(code);
+      if (!keys.has(code) && !names.has(name)) {
+        result.push(code);
+        keys.add(code);
+        names.add(buildFieldNameString(code));
+      }
     }
   }
 

--- a/packages/react/src/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu.test.tsx
@@ -1,4 +1,5 @@
 import { Filter, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
+import { SearchParameter } from '@medplum/fhirtypes';
 import { MockClient, PatientSearchParameters } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -36,14 +37,10 @@ const schema: IndexedStructureDefinition = {
     Observation: {
       display: 'Observation',
       properties: {
-        valueInteger: {
+        'value[x]': {
           id: 'Observation.value[x]',
           path: 'Observation.value[x]',
-          type: [
-            {
-              code: 'integer',
-            },
-          ],
+          type: [{ code: 'integer' }, { code: 'quantity' }, { code: 'string' }],
         },
       },
       searchParams: {
@@ -51,6 +48,13 @@ const schema: IndexedStructureDefinition = {
           resourceType: 'SearchParameter',
           code: 'value-quantity',
           type: 'quantity',
+          expression: 'Observation.value',
+        },
+        'value-string': {
+          resourceType: 'SearchParameter',
+          code: 'value-string',
+          type: 'string',
+          expression: 'Observation.value',
         },
       },
     },
@@ -98,7 +102,7 @@ describe('SearchPopupMenu', () => {
       search: {
         resourceType: 'Patient',
       },
-      searchParam: schema.types['Patient']?.searchParams?.['name'],
+      searchParams: [schema.types['Patient']?.searchParams?.['name'] as SearchParameter],
     });
 
     expect(screen.getByText('Equals...')).toBeDefined();
@@ -109,7 +113,7 @@ describe('SearchPopupMenu', () => {
       search: {
         resourceType: 'Patient',
       },
-      searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
+      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
     });
 
     expect(screen.getByText('Before...')).toBeDefined();
@@ -121,18 +125,11 @@ describe('SearchPopupMenu', () => {
       search: {
         resourceType: 'Patient',
       },
-      searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
+      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
     });
 
     expect(screen.getByText('Before...')).toBeDefined();
     expect(screen.getByText('After...')).toBeDefined();
-
-    const dateFiltersSubmenu = screen.getByText('Date filters');
-
-    await act(async () => {
-      fireEvent.click(dateFiltersSubmenu);
-    });
-
     expect(screen.getByText('Tomorrow')).toBeDefined();
     expect(screen.getByText('Today')).toBeDefined();
     expect(screen.getByText('Yesterday')).toBeDefined();
@@ -143,21 +140,140 @@ describe('SearchPopupMenu', () => {
       search: {
         resourceType: 'Observation',
       },
-      searchParam: schema.types['Observation']?.searchParams?.['value-quantity'],
+      searchParams: [schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter],
     });
 
     expect(screen.getByText('Sort Largest to Smallest')).toBeDefined();
     expect(screen.getByText('Sort Smallest to Largest')).toBeDefined();
   });
 
-  test('Sort', async () => {
+  test('Text sort', async () => {
     let currSearch: SearchRequest = {
       resourceType: 'Patient',
     };
 
     setup({
       search: currSearch,
-      searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
+      searchParams: [schema.types['Patient']?.searchParams?.['name'] as SearchParameter],
+      onChange: (e) => (currSearch = e),
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sort A to Z'));
+    });
+
+    expect(currSearch.sortRules).toBeDefined();
+    expect(currSearch.sortRules?.length).toEqual(1);
+    expect(currSearch.sortRules?.[0].code).toEqual('name');
+    expect(currSearch.sortRules?.[0].descending).toEqual(false);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sort Z to A'));
+    });
+
+    expect(currSearch.sortRules).toBeDefined();
+    expect(currSearch.sortRules?.length).toEqual(1);
+    expect(currSearch.sortRules?.[0].code).toEqual('name');
+    expect(currSearch.sortRules?.[0].descending).toEqual(true);
+  });
+
+  test('Text clear filters', async () => {
+    let currSearch: SearchRequest = {
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.EQUALS,
+          value: 'Alice',
+        },
+      ],
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [schema.types['Patient']?.searchParams?.['name'] as SearchParameter],
+      onChange: (e) => (currSearch = e),
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Clear filters'));
+    });
+
+    expect(currSearch.filters?.length).toEqual(0);
+  });
+
+  test('Text submenu prompt', async () => {
+    const searchParam = schema.types['Patient']?.searchParams?.['name'] as SearchParameter;
+    const onPrompt = jest.fn();
+
+    setup({
+      search: {
+        resourceType: 'Patient',
+      },
+      searchParams: [searchParam],
+      onPrompt,
+    });
+
+    const options = [
+      { text: 'Equals...', operator: Operator.EQUALS },
+      { text: 'Does not equal...', operator: Operator.NOT_EQUALS },
+      { text: 'Contains...', operator: Operator.CONTAINS },
+      { text: 'Does not contain...', operator: Operator.EQUALS },
+    ];
+
+    for (const option of options) {
+      onPrompt.mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText(option.text));
+      });
+
+      expect(onPrompt).toBeCalledWith(searchParam, {
+        code: 'name',
+        operator: option.operator,
+        value: '',
+      } as Filter);
+    }
+  });
+
+  test('Text missing', async () => {
+    const searchParam = schema.types['Patient']?.searchParams?.['name'] as SearchParameter;
+
+    let currSearch: SearchRequest = {
+      resourceType: 'Observation',
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [searchParam],
+      onChange: (e) => (currSearch = e),
+    });
+
+    const options = ['Missing', 'Not missing'];
+    for (const option of options) {
+      await act(async () => {
+        fireEvent.click(screen.getByText(option));
+      });
+
+      expect(currSearch.filters).toBeDefined();
+      expect(currSearch.filters?.length).toEqual(1);
+      expect(currSearch.filters).toMatchObject([
+        {
+          code: 'name',
+          operator: Operator.MISSING,
+        },
+      ]);
+    }
+  });
+
+  test('Date sort', async () => {
+    let currSearch: SearchRequest = {
+      resourceType: 'Patient',
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -180,94 +296,15 @@ describe('SearchPopupMenu', () => {
     expect(currSearch.sortRules?.[0].descending).toEqual(true);
   });
 
-  test('Clear filters', async () => {
-    let currSearch: SearchRequest = {
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.EQUALS,
-          value: 'Alice',
-        },
-      ],
-    };
-
-    setup({
-      search: currSearch,
-      searchParam: schema.types['Patient']?.searchParams?.['name'],
-      onChange: (e) => (currSearch = e),
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Clear filters'));
-    });
-
-    expect(currSearch.filters?.length).toEqual(0);
-  });
-
-  test('Text submenu prompt', async () => {
-    const onPrompt = jest.fn();
-
-    setup({
-      search: {
-        resourceType: 'Patient',
-      },
-      searchParam: schema.types['Patient']?.searchParams?.['name'],
-      onPrompt,
-    });
-
-    const options = [
-      { text: 'Equals...', operator: Operator.EQUALS },
-      { text: 'Does not equal...', operator: Operator.NOT_EQUALS },
-      { text: 'Contains...', operator: Operator.CONTAINS },
-      { text: 'Does not contain...', operator: Operator.EQUALS },
-    ];
-
-    for (const option of options) {
-      onPrompt.mockClear();
-
-      await act(async () => {
-        fireEvent.click(screen.getByText(option.text));
-      });
-
-      expect(onPrompt).toBeCalledWith({
-        code: 'name',
-        operator: option.operator,
-        value: '',
-      } as Filter);
-    }
-  });
-
-  test('Text search prompt', async () => {
-    const onPrompt = jest.fn();
-
-    setup({
-      search: {
-        resourceType: 'Patient',
-      },
-      searchParam: schema.types['Patient']?.searchParams?.['name'],
-      onPrompt,
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Search'));
-    });
-
-    expect(onPrompt).toBeCalledWith({
-      code: 'name',
-      operator: Operator.CONTAINS,
-      value: '',
-    } as Filter);
-  });
-
   test('Date submenu prompt', async () => {
+    const searchParam = schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter;
     const onPrompt = jest.fn();
 
     setup({
       search: {
         resourceType: 'Patient',
       },
-      searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
+      searchParams: [searchParam],
       onPrompt,
     });
 
@@ -277,8 +314,6 @@ describe('SearchPopupMenu', () => {
       { text: 'Before...', operator: Operator.ENDS_BEFORE },
       { text: 'After...', operator: Operator.STARTS_AFTER },
       { text: 'Between...', operator: Operator.EQUALS },
-      { text: 'Is set', operator: Operator.EQUALS },
-      { text: 'Is not set', operator: Operator.EQUALS },
     ];
 
     for (const option of options) {
@@ -288,7 +323,7 @@ describe('SearchPopupMenu', () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(onPrompt).toBeCalledWith({
+      expect(onPrompt).toBeCalledWith(searchParam, {
         code: 'birthdate',
         operator: option.operator,
         value: '',
@@ -303,7 +338,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParam: schema.types['Patient']?.searchParams?.['birthdate'],
+      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -328,6 +363,184 @@ describe('SearchPopupMenu', () => {
     }
   });
 
+  test('Date missing', async () => {
+    let currSearch: SearchRequest = {
+      resourceType: 'Patient',
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
+      onChange: (e) => (currSearch = e),
+    });
+
+    const options = ['Missing', 'Not missing'];
+    for (const option of options) {
+      await act(async () => {
+        fireEvent.click(screen.getByText(option));
+      });
+
+      expect(currSearch.filters).toBeDefined();
+      expect(currSearch.filters?.length).toEqual(1);
+      expect(currSearch.filters).toMatchObject([
+        {
+          code: 'birthdate',
+          operator: Operator.MISSING,
+        },
+      ]);
+    }
+  });
+
+  test('Date clear filters', async () => {
+    let currSearch: SearchRequest = {
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'birthdate',
+          operator: Operator.EQUALS,
+          value: '2020-01-01',
+        },
+      ],
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
+      onChange: (e) => (currSearch = e),
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Clear filters'));
+    });
+
+    expect(currSearch.filters?.length).toEqual(0);
+  });
+
+  test('Quantity sort', async () => {
+    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+
+    let currSearch: SearchRequest = {
+      resourceType: 'Patient',
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [searchParam],
+      onChange: (e) => (currSearch = e),
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sort Smallest to Largest'));
+    });
+
+    expect(currSearch.sortRules).toBeDefined();
+    expect(currSearch.sortRules?.length).toEqual(1);
+    expect(currSearch.sortRules?.[0].code).toEqual('value-quantity');
+    expect(currSearch.sortRules?.[0].descending).toEqual(false);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Sort Largest to Smallest'));
+    });
+
+    expect(currSearch.sortRules).toBeDefined();
+    expect(currSearch.sortRules?.length).toEqual(1);
+    expect(currSearch.sortRules?.[0].code).toEqual('value-quantity');
+    expect(currSearch.sortRules?.[0].descending).toEqual(true);
+  });
+
+  test('Quantity submenu prompt', async () => {
+    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+    const onPrompt = jest.fn();
+
+    setup({
+      search: {
+        resourceType: 'Observation',
+      },
+      searchParams: [searchParam],
+      onPrompt,
+    });
+
+    const options = [
+      { text: 'Equals...', operator: Operator.EQUALS },
+      { text: 'Does not equal...', operator: Operator.NOT_EQUALS },
+      { text: 'Greater than...', operator: Operator.GREATER_THAN },
+      { text: 'Greater than or equal to...', operator: Operator.GREATER_THAN_OR_EQUALS },
+      { text: 'Less than...', operator: Operator.LESS_THAN },
+      { text: 'Less than or equal to...', operator: Operator.LESS_THAN_OR_EQUALS },
+    ];
+
+    for (const option of options) {
+      onPrompt.mockClear();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText(option.text));
+      });
+
+      expect(onPrompt).toBeCalledWith(searchParam, {
+        code: 'value-quantity',
+        operator: option.operator,
+        value: '',
+      } as Filter);
+    }
+  });
+
+  test('Quantity missing', async () => {
+    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+
+    let currSearch: SearchRequest = {
+      resourceType: 'Observation',
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [searchParam],
+      onChange: (e) => (currSearch = e),
+    });
+
+    const options = ['Missing', 'Not missing'];
+    for (const option of options) {
+      await act(async () => {
+        fireEvent.click(screen.getByText(option));
+      });
+
+      expect(currSearch.filters).toBeDefined();
+      expect(currSearch.filters?.length).toEqual(1);
+      expect(currSearch.filters).toMatchObject([
+        {
+          code: 'value-quantity',
+          operator: Operator.MISSING,
+        },
+      ]);
+    }
+  });
+
+  test('Quantity clear filters', async () => {
+    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+
+    let currSearch: SearchRequest = {
+      resourceType: 'Observation',
+      filters: [
+        {
+          code: 'value-quantity',
+          operator: Operator.EQUALS,
+          value: '100',
+        },
+      ],
+    };
+
+    setup({
+      search: currSearch,
+      searchParams: [searchParam],
+      onChange: (e) => (currSearch = e),
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Clear filters'));
+    });
+
+    expect(currSearch.filters?.length).toEqual(0);
+  });
+
   test('Renders meta.versionId', () => {
     const search = {
       resourceType: 'Patient',
@@ -338,7 +551,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search,
-      searchParam: fields[0].searchParam,
+      searchParams: fields[0].searchParams,
     });
 
     expect(screen.getByText('Equals...')).toBeDefined();
@@ -356,10 +569,29 @@ describe('SearchPopupMenu', () => {
       search: {
         resourceType: 'Patient',
       },
-      searchParam: fields[0].searchParam,
+      searchParams: fields[0].searchParams,
     });
 
     expect(screen.getByText('Before...')).toBeDefined();
     expect(screen.getByText('After...')).toBeDefined();
+  });
+
+  test('Search parameter choice', () => {
+    const search = {
+      resourceType: 'Observation',
+      fields: ['value[x]'],
+    };
+
+    const fields = getFieldDefinitions(schema, search);
+
+    setup({
+      search: {
+        resourceType: 'Observation',
+      },
+      searchParams: fields[0].searchParams,
+    });
+
+    expect(screen.getByText('Value Quantity')).toBeDefined();
+    expect(screen.getByText('Value String')).toBeDefined();
   });
 });

--- a/packages/react/src/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu.tsx
@@ -105,8 +105,11 @@ function SearchParameterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
     case 'number':
     case 'quantity':
       return <NumericFilterSubMenu {...props} />;
+    case 'reference':
+      return <ReferenceFilterSubMenu {...props} />;
     case 'string':
     case 'token':
+    case 'uri':
       return <TextFilterSubMenu {...props} />;
     default:
       return <>Unknown search param type: {props.searchParam.type}</>;
@@ -165,6 +168,22 @@ function NumericFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
       <MenuItem onClick={() => props.onPrompt(searchParam, Operator.LESS_THAN_OR_EQUALS)}>
         Less than or equal to...
       </MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code))}>Missing</MenuItem>
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code, false))}>Not missing</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onClear(searchParam)}>Clear filters</MenuItem>
+    </>
+  );
+}
+
+function ReferenceFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  const { searchParam } = props;
+  const code = searchParam.code as string;
+  return (
+    <>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Equals...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
       <MenuSeparator />
       <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code))}>Missing</MenuItem>
       <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code, false))}>Not missing</MenuItem>

--- a/packages/react/src/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu.tsx
@@ -6,12 +6,14 @@ import { MenuSeparator } from './MenuSeparator';
 import { Popup } from './Popup';
 import {
   addLastMonthFilter,
+  addMissingFilter,
   addNextMonthFilter,
   addThisMonthFilter,
   addTodayFilter,
   addTomorrowFilter,
   addYearToDateFilter,
   addYesterdayFilter,
+  buildFieldNameString,
   clearFiltersOnField,
   setSort,
 } from './SearchUtils';
@@ -23,150 +25,173 @@ export interface SearchPopupMenuProps {
   visible: boolean;
   x: number;
   y: number;
-  searchParam?: SearchParameter;
-  onPrompt: (filter: Filter) => void;
+  searchParams?: SearchParameter[];
+  onPrompt: (searchParam: SearchParameter, filter: Filter) => void;
   onChange: (definition: SearchRequest) => void;
   onClose: () => void;
 }
 
 export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null {
-  if (!props.searchParam) {
+  if (!props.searchParams) {
     return null;
   }
 
-  const code = props.searchParam.code as string;
-  const paramType = props.searchParam.type as string;
-
-  /**
-   * Returns the string that represents the "sort ascending" operation.
-   *
-   * @return {string} The string that represents "sort ascending".
-   */
-  function getAscSortString(): string {
-    switch (paramType) {
-      case 'date':
-        return 'Sort Oldest to Newest';
-      case 'number':
-      case 'quantity':
-        return 'Sort Smallest to Largest';
-      default:
-        return 'Sort A to Z';
-    }
+  function onSort(searchParam: SearchParameter, desc: boolean): void {
+    onChange(setSort(props.search, searchParam.code as string, desc));
   }
 
-  /**
-   * Returns the string that represents the "sort descending" operation.
-   *
-   * @return {string} The string that represents "sort descending".
-   */
-  function getDescSortString(): string {
-    switch (paramType) {
-      case 'date':
-        return 'Sort Newest to Oldest';
-      case 'number':
-      case 'quantity':
-        return 'Sort Largest to Smallest';
-      default:
-        return 'Sort Z to A';
-    }
+  function onClear(searchParam: SearchParameter): void {
+    onChange(clearFiltersOnField(props.search, searchParam.code as string));
   }
 
-  /**
-   * Returns the submenu of specialized tools for a particular property type.
-   *
-   * @return {SubMenu} The new submenu.
-   */
-  function renderSubMenu(): JSX.Element {
-    return paramType === 'date' ? renderDateTimeSubMenu() : renderTextSubMenu();
-  }
-
-  /**
-   * Returns the submenu of specialized tools for date/time fields.
-   *
-   * @return {SubMenu} The date/time submenu.
-   */
-  function renderDateTimeSubMenu(): JSX.Element {
-    return (
-      <SubMenu title="Date filters">
-        <MenuItem onClick={() => prompt(Operator.EQUALS)}>Equals...</MenuItem>
-        <MenuItem onClick={() => prompt(Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
-        <MenuSeparator />
-        <MenuItem onClick={() => prompt(Operator.ENDS_BEFORE)}>Before...</MenuItem>
-        <MenuItem onClick={() => prompt(Operator.STARTS_AFTER)}>After...</MenuItem>
-        <MenuItem onClick={() => prompt(Operator.EQUALS)}>Between...</MenuItem>
-        <MenuSeparator />
-        <MenuItem onClick={() => onChange(addTomorrowFilter(props.search, code))}>Tomorrow</MenuItem>
-        <MenuItem onClick={() => onChange(addTodayFilter(props.search, code))}>Today</MenuItem>
-        <MenuItem onClick={() => onChange(addYesterdayFilter(props.search, code))}>Yesterday</MenuItem>
-        <MenuSeparator />
-        <MenuItem onClick={() => onChange(addNextMonthFilter(props.search, code))}>Next Month</MenuItem>
-        <MenuItem onClick={() => onChange(addThisMonthFilter(props.search, code))}>This Month</MenuItem>
-        <MenuItem onClick={() => onChange(addLastMonthFilter(props.search, code))}>Last Month</MenuItem>
-        <MenuSeparator />
-        <MenuItem onClick={() => onChange(addYearToDateFilter(props.search, code))}>Year to date</MenuItem>
-        <MenuSeparator />
-        <MenuItem onClick={() => prompt(Operator.EQUALS)}>Is set</MenuItem>
-        <MenuItem onClick={() => prompt(Operator.EQUALS)}>Is not set</MenuItem>
-      </SubMenu>
-    );
-  }
-
-  /**
-   * Returns the submenu of specialized tools for text fields.
-   *
-   * @return {SubMenu} The text property submenu.
-   */
-  function renderTextSubMenu(): JSX.Element {
-    return (
-      <SubMenu title="Text filters">
-        <MenuItem onClick={() => prompt(Operator.EQUALS)}>Equals...</MenuItem>
-        <MenuItem onClick={() => prompt(Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
-        <MenuSeparator />
-        <MenuItem onClick={() => prompt(Operator.CONTAINS)}>Contains...</MenuItem>
-        <MenuItem onClick={() => prompt(Operator.EQUALS)}>Does not contain...</MenuItem>
-      </SubMenu>
-    );
-  }
-
-  function sort(desc: boolean): void {
-    onChange(setSort(props.search, code, desc));
-  }
-
-  function clearFilters(): void {
-    onChange(clearFiltersOnField(props.search, code));
-  }
-
-  /**
-   * Prompts the user for a value to use in a filter.
-   *
-   * @param {Operator} op The filter operation.
-   */
-  function prompt(operator: Operator): void {
-    props.onPrompt({ code, operator, value: '' });
+  function onPrompt(searchParam: SearchParameter, operator: Operator): void {
+    props.onPrompt(searchParam, { code: searchParam.code as string, operator, value: '' });
   }
 
   function onChange(definition: SearchRequest): void {
-    if (props.onChange) {
-      props.onChange(definition);
-    }
+    props.onChange(definition);
   }
 
+  const anchor = { left: props.x, right: props.x, top: props.y, bottom: props.y } as DOMRectReadOnly;
+
+  // If there is only one search parameter, then show it directly
+  if (props.searchParams.length === 1) {
+    return (
+      <Popup visible={props.visible} anchor={anchor} autoClose={true} onClose={props.onClose}>
+        <SearchParameterSubMenu
+          search={props.search}
+          searchParam={props.searchParams[0]}
+          onSort={onSort}
+          onPrompt={onPrompt}
+          onChange={onChange}
+          onClear={onClear}
+        />
+      </Popup>
+    );
+  }
+
+  // Otherwise, show a menu, with each search parameter as a sub menu
   return (
-    <Popup
-      visible={props.visible}
-      anchor={{ left: props.x, right: props.x, top: props.y, bottom: props.y } as DOMRectReadOnly}
-      autoClose={true}
-      onClose={props.onClose}
-    >
-      <MenuItem onClick={() => sort(false)}>{getAscSortString()}</MenuItem>
-      <MenuItem onClick={() => sort(true)}>{getDescSortString()}</MenuItem>
-      <MenuSeparator />
-      <MenuItem onClick={() => clearFilters()}>Clear filters</MenuItem>
-      {renderSubMenu()}
-      <MenuSeparator />
-      <MenuItem onClick={() => prompt(props.searchParam?.type === 'reference' ? Operator.EQUALS : Operator.CONTAINS)}>
-        Search
-      </MenuItem>
+    <Popup visible={props.visible} anchor={anchor} autoClose={true} onClose={props.onClose}>
+      {props.searchParams.map((searchParam) => (
+        <SubMenu key={searchParam.code as string} title={buildFieldNameString(searchParam.code as string)}>
+          <SearchParameterSubMenu
+            search={props.search}
+            searchParam={searchParam}
+            onSort={onSort}
+            onPrompt={onPrompt}
+            onChange={onChange}
+            onClear={onClear}
+          />
+        </SubMenu>
+      ))}
     </Popup>
+  );
+}
+
+interface SearchPopupSubMenuProps {
+  search: SearchRequest;
+  searchParam: SearchParameter;
+  onSort: (searchParam: SearchParameter, descending: boolean) => void;
+  onPrompt: (searchParam: SearchParameter, operator: Operator) => void;
+  onChange: (search: SearchRequest) => void;
+  onClear: (searchParam: SearchParameter) => void;
+}
+
+function SearchParameterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  switch (props.searchParam.type) {
+    case 'date':
+      return <DateFilterSubMenu {...props} />;
+    case 'number':
+    case 'quantity':
+      return <NumericFilterSubMenu {...props} />;
+    case 'string':
+    case 'token':
+      return <TextFilterSubMenu {...props} />;
+    default:
+      return <>Unknown search param type: {props.searchParam.type}</>;
+  }
+}
+
+function DateFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  const { searchParam } = props;
+  const code = searchParam.code as string;
+  return (
+    <>
+      <MenuItem onClick={() => props.onSort(searchParam, false)}>Sort Oldest to Newest</MenuItem>
+      <MenuItem onClick={() => props.onSort(searchParam, true)}>Sort Newest to Oldest</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Equals...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.ENDS_BEFORE)}>Before...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.STARTS_AFTER)}>After...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Between...</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addTomorrowFilter(props.search, code))}>Tomorrow</MenuItem>
+      <MenuItem onClick={() => props.onChange(addTodayFilter(props.search, code))}>Today</MenuItem>
+      <MenuItem onClick={() => props.onChange(addYesterdayFilter(props.search, code))}>Yesterday</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addNextMonthFilter(props.search, code))}>Next Month</MenuItem>
+      <MenuItem onClick={() => props.onChange(addThisMonthFilter(props.search, code))}>This Month</MenuItem>
+      <MenuItem onClick={() => props.onChange(addLastMonthFilter(props.search, code))}>Last Month</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addYearToDateFilter(props.search, code))}>Year to date</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code))}>Missing</MenuItem>
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code, false))}>Not missing</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onClear(searchParam)}>Clear filters</MenuItem>
+    </>
+  );
+}
+
+function NumericFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  const { searchParam } = props;
+  const code = searchParam.code as string;
+  return (
+    <>
+      <MenuItem onClick={() => props.onSort(searchParam, false)}>Sort Smallest to Largest</MenuItem>
+      <MenuItem onClick={() => props.onSort(searchParam, true)}>Sort Largest to Smallest</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Equals...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.GREATER_THAN)}>Greater than...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.GREATER_THAN_OR_EQUALS)}>
+        Greater than or equal to...
+      </MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.LESS_THAN)}>Less than...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.LESS_THAN_OR_EQUALS)}>
+        Less than or equal to...
+      </MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code))}>Missing</MenuItem>
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code, false))}>Not missing</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onClear(searchParam)}>Clear filters</MenuItem>
+    </>
+  );
+}
+
+function TextFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  const { searchParam } = props;
+  const code = searchParam.code as string;
+  return (
+    <>
+      <MenuItem onClick={() => props.onSort(searchParam, false)}>Sort A to Z</MenuItem>
+      <MenuItem onClick={() => props.onSort(searchParam, true)}>Sort Z to A</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Equals...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.CONTAINS)}>Contains...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Does not contain...</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code))}>Missing</MenuItem>
+      <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code, false))}>Not missing</MenuItem>
+      <MenuSeparator />
+      <MenuItem onClick={() => props.onClear(searchParam)}>Clear filters</MenuItem>
+    </>
   );
 }

--- a/packages/react/src/SearchUtils.tsx
+++ b/packages/react/src/SearchUtils.tsx
@@ -60,6 +60,7 @@ const operatorNames: Record<Operator, string> = {
   in: 'in',
   'not-in': 'not in',
   'of-type': 'of type',
+  missing: 'missing',
 };
 
 /**
@@ -327,15 +328,12 @@ function addDateFilterImpl(definition: SearchRequest, field: string, op: Operato
 }
 
 /**
- * Adds a filter for a user field.
+ * Adds a filter that constrains the specified field to "missing".
  *
- * @param field
- * @param op
- * @param value
+ * @param {string} field The field key name.
  */
-export function addUserFilter(definition: SearchRequest, field: string, op: Operator, value: string): SearchRequest {
-  definition = clearFiltersOnField(definition, field);
-  return addFilter(definition, field, op, value);
+export function addMissingFilter(definition: SearchRequest, field: string, value = true): SearchRequest {
+  return addFilter(definition, field, Operator.MISSING, value.toString());
 }
 
 /**
@@ -520,8 +518,8 @@ export function renderValue(resource: Resource, field: SearchControlField): stri
   }
 
   // Priority 2: SearchParameter by exact match
-  if (field.searchParam && field.name === field.searchParam.code) {
-    return renderSearchParameterValue(resource, field.searchParam, field.elementDefinition);
+  if (field.searchParams && field.searchParams.length === 1 && field.name === field.searchParams[0].code) {
+    return renderSearchParameterValue(resource, field.searchParams[0], field.elementDefinition);
   }
 
   // We don't know how to render this field definition

--- a/packages/react/src/stories/SearchControl.stories.tsx
+++ b/packages/react/src/stories/SearchControl.stories.tsx
@@ -112,7 +112,7 @@ export const ServiceRequests = (): JSX.Element => {
 export const Observations = (): JSX.Element => {
   const [search, setSearch] = useState<SearchRequest>({
     resourceType: 'Observation',
-    fields: ['id', '_lastUpdated', 'subject', 'code', 'value-quantity'],
+    fields: ['id', '_lastUpdated', 'subject', 'code', 'value[x]', 'value-quantity'],
   });
 
   return (


### PR DESCRIPTION
Overhauled the `<SearchControl>` popup menu.  This is 100% client side, no server changes.

### Defined logic for "ElementDefinition" vs "SearchParameter":

First, add a field definition for every ElementDefinition

Next, add each SearchParameter as long as it does not share a code (case insensitive) or display name

This fixes #627 

### Defined logic for multiple SearchParameters for one ElementDefinition

If there are zero SearchParameters for a column, then no filter icon and no search popup menu.

If there is one SearchParameter, then show the submenu inline

If there are multiple SearchParameters, then show a submenu selector, one item for each parameter:

Observation.value:

<img width="452" alt="image" src="https://user-images.githubusercontent.com/749094/175830339-45206276-e408-4636-bff2-8913cb32e875.png">

Patient.telecom:

<img width="479" alt="image" src="https://user-images.githubusercontent.com/749094/175830355-94d2b3eb-381d-4c84-ace5-514bdad6f2bb.png">
