### PR TITLE
Implmented fhir :missing modifier

### DIFF
--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -57,6 +57,9 @@ export enum Operator {
   IN = 'in',
   NOT_IN = 'not-in',
   OF_TYPE = 'of-type',
+
+  // All
+  MISSING = 'missing',
 }
 
 const MODIFIER_OPERATORS: Operator[] = [
@@ -68,6 +71,7 @@ const MODIFIER_OPERATORS: Operator[] = [
   Operator.IN,
   Operator.NOT_IN,
   Operator.OF_TYPE,
+  Operator.MISSING,
 ];
 
 const PREFIX_OPERATORS: Operator[] = [

--- a/packages/react/src/SearchUtils.tsx
+++ b/packages/react/src/SearchUtils.tsx
@@ -60,6 +60,7 @@ const operatorNames: Record<Operator, string> = {
   in: 'in',
   'not-in': 'not in',
   'of-type': 'of type',
+  missing: 'missing',
 };
 
 /**

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -674,12 +674,16 @@ export class Repository {
     }
 
     const details = getSearchParameterDetails(getStructureDefinitions(), resourceType, param);
-    if (param.type === 'string') {
+    if (filter.operator === FhirOperator.MISSING) {
+      predicate.where(details.columnName, filter.value === 'true' ? Operator.EQUALS : Operator.NOT_EQUALS, null);
+    } else if (param.type === 'string') {
       this.#addStringSearchFilter(predicate, details, filter);
     } else if (param.type === 'token') {
       this.#addTokenSearchFilter(predicate, details, filter);
     } else if (param.type === 'reference') {
       this.#addReferenceSearchFilter(predicate, details, filter);
+    } else if (param.type === 'quantity') {
+      predicate.where(details.columnName, fhirOperatorToSqlOperator(filter.operator), parseFloat(filter.value));
     } else {
       predicate.where(details.columnName, fhirOperatorToSqlOperator(filter.operator), filter.value);
     }

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -180,6 +180,14 @@ class SearchParser implements SearchRequest {
   }
 
   #parseParameter(searchParam: SearchParameter, modifier: string, value: string): void {
+    if (modifier === 'missing') {
+      this.filters.push({
+        code: searchParam.code as string,
+        operator: Operator.MISSING,
+        value,
+      });
+      return;
+    }
     switch (searchParam.type) {
       case 'number':
       case 'date':

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -203,11 +203,18 @@ export class SqlBuilder {
 
   async execute(conn: Client | Pool): Promise<any[]> {
     const sql = this.toString();
+    let startTime = 0;
     if (DEBUG) {
       console.log('sql', sql);
       console.log('values', this.#values);
+      startTime = Date.now();
     }
     const result = await conn.query(sql, this.#values);
+    if (DEBUG) {
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+      console.log('duration', duration);
+    }
     return result.rows;
   }
 }


### PR DESCRIPTION
https://www.hl7.org/fhir/search.html#modifiers

> For all parameters (except combination): :missing; e.g. gender:missing=true (or false). Searching for gender:missing=true will return all the resources that don't have a value for the gender parameter (which usually equates to not having the relevant element in the resource). Searching for gender:missing=false will return all the resources that have a value for the gender parameter. For simple data type elements, :missing=true will match on all elements where either the underlying element is omitted or where the element is present with extensions but no value is specified