### PR TITLE
Fixed setting :not modifier in search control popup

### DIFF
--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -52,6 +52,7 @@ export enum Operator {
 
   // Token
   TEXT = 'text',
+  NOT = 'not',
   ABOVE = 'above',
   BELOW = 'below',
   IN = 'in',
@@ -66,6 +67,7 @@ const MODIFIER_OPERATORS: Operator[] = [
   Operator.CONTAINS,
   Operator.EXACT,
   Operator.TEXT,
+  Operator.NOT,
   Operator.ABOVE,
   Operator.BELOW,
   Operator.IN,

--- a/packages/react/src/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu.test.tsx
@@ -420,7 +420,7 @@ describe('SearchPopupMenu', () => {
 
     const options = [
       { text: 'Equals...', operator: Operator.EQUALS },
-      { text: 'Does not equal...', operator: Operator.NOT_EQUALS },
+      { text: 'Does not equal...', operator: Operator.NOT },
     ];
 
     for (const option of options) {
@@ -537,7 +537,7 @@ describe('SearchPopupMenu', () => {
 
     const options = [
       { text: 'Equals...', operator: Operator.EQUALS },
-      { text: 'Does not equal...', operator: Operator.NOT_EQUALS },
+      { text: 'Does not equal...', operator: Operator.NOT },
       { text: 'Contains...', operator: Operator.CONTAINS },
       { text: 'Does not contain...', operator: Operator.EQUALS },
     ];

--- a/packages/react/src/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu.tsx
@@ -183,7 +183,7 @@ function ReferenceFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
   return (
     <>
       <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Equals...</MenuItem>
-      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT)}>Does not equal...</MenuItem>
       <MenuSeparator />
       <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code))}>Missing</MenuItem>
       <MenuItem onClick={() => props.onChange(addMissingFilter(props.search, code, false))}>Not missing</MenuItem>
@@ -202,7 +202,7 @@ function TextFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
       <MenuItem onClick={() => props.onSort(searchParam, true)}>Sort Z to A</MenuItem>
       <MenuSeparator />
       <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Equals...</MenuItem>
-      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT_EQUALS)}>Does not equal...</MenuItem>
+      <MenuItem onClick={() => props.onPrompt(searchParam, Operator.NOT)}>Does not equal...</MenuItem>
       <MenuSeparator />
       <MenuItem onClick={() => props.onPrompt(searchParam, Operator.CONTAINS)}>Contains...</MenuItem>
       <MenuItem onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>Does not contain...</MenuItem>

--- a/packages/react/src/SearchUtils.tsx
+++ b/packages/react/src/SearchUtils.tsx
@@ -6,10 +6,10 @@ import { getValueAndType, ResourcePropertyDisplay } from './ResourcePropertyDisp
 import { SearchControlField } from './SearchControlField';
 
 const searchParamToOperators: Record<string, Operator[]> = {
-  string: [Operator.EQUALS, Operator.NOT_EQUALS, Operator.CONTAINS, Operator.EXACT],
-  fulltext: [Operator.EQUALS, Operator.NOT_EQUALS, Operator.CONTAINS, Operator.EXACT],
-  token: [Operator.EQUALS, Operator.NOT_EQUALS],
-  reference: [Operator.EQUALS, Operator.NOT_EQUALS],
+  string: [Operator.EQUALS, Operator.NOT, Operator.CONTAINS, Operator.EXACT],
+  fulltext: [Operator.EQUALS, Operator.NOT, Operator.CONTAINS, Operator.EXACT],
+  token: [Operator.EQUALS, Operator.NOT],
+  reference: [Operator.EQUALS, Operator.NOT],
   numeric: [
     Operator.EQUALS,
     Operator.NOT_EQUALS,
@@ -55,6 +55,7 @@ const operatorNames: Record<Operator, string> = {
   contains: 'contains',
   exact: 'exact',
   text: 'text',
+  not: 'not',
   above: 'above',
   below: 'below',
   in: 'in',


### PR DESCRIPTION
Before: all SearchParameter types used "ne" for "not equals".  But that caused a bug, because "ne" is a prefix, which is prepended to the string, which obviously won't work for a string parameter.  So "name not alice" would become "name=nealice" (wrong).

After: token, string, and url SearchParameters use "not" instead of "ne", which is a "modifier" rather than a "prefix", so "name not alice" becomes "name:not=alice" (correct).

Server side already parsed the ":not" prefix correctly.

More details: https://www.hl7.org/fhir/search.html#token