### PR TITLE
Search param shortcut cleanup

### DIFF
--- a/packages/react/src/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor.tsx
@@ -58,9 +58,9 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
       <div className="medplum-filter-editor">
         <table className="medplum-filter-editor-table">
           <colgroup>
-            <col style={{ width: 260 }} />
-            <col style={{ width: 260 }} />
-            <col style={{ width: 260 }} />
+            <col style={{ width: 200 }} />
+            <col style={{ width: 200 }} />
+            <col style={{ width: 380 }} />
             <col style={{ width: 120 }} />
           </colgroup>
           <thead>

--- a/packages/react/src/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu.test.tsx
@@ -46,6 +46,11 @@ const schema: IndexedStructureDefinition = {
     Observation: {
       display: 'Observation',
       properties: {
+        subject: {
+          id: 'Observation.subject',
+          path: 'Observation.subject',
+          type: [{ code: 'reference' }],
+        },
         'value[x]': {
           id: 'Observation.value[x]',
           path: 'Observation.value[x]',
@@ -53,6 +58,18 @@ const schema: IndexedStructureDefinition = {
         },
       },
       searchParams: {
+        patient: {
+          resourceType: 'SearchParameter',
+          code: 'patient',
+          type: 'reference',
+          expression: 'Observation.patient',
+        },
+        subject: {
+          resourceType: 'SearchParameter',
+          code: 'patient',
+          type: 'reference',
+          expression: 'Observation.patient',
+        },
         'value-quantity': {
           resourceType: 'SearchParameter',
           code: 'value-quantity',
@@ -639,5 +656,24 @@ describe('SearchPopupMenu', () => {
 
     expect(screen.getByText('Value Quantity')).toBeDefined();
     expect(screen.getByText('Value String')).toBeDefined();
+  });
+
+  test('Only one search parameter on exact match', () => {
+    const search = {
+      resourceType: 'Observation',
+      fields: ['subject'],
+    };
+
+    const fields = getFieldDefinitions(schema, search);
+
+    setup({
+      search: {
+        resourceType: 'Observation',
+      },
+      searchParams: fields[0].searchParams,
+    });
+
+    expect(screen.getByText('Equals...')).toBeDefined();
+    expect(screen.queryByText('Patient')).toBeNull();
   });
 });

--- a/packages/react/src/SearchUtils.tsx
+++ b/packages/react/src/SearchUtils.tsx
@@ -584,6 +584,7 @@ function renderSearchParameterValue(
         value={value[0].value}
         maxWidth={200}
         ignoreMissingValues={true}
+        link={false}
       />
     );
   }


### PR DESCRIPTION
Currently, some columns have weird double search params:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/749094/176079700-95e19672-9737-4309-8990-cbcf91ef8be0.png">

This PR fixes that.