### PR TITLE
Handle 404 in readCached

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -816,7 +816,7 @@ export class MedplumClient extends EventTarget {
    */
   getCached<K extends ResourceType>(resourceType: K, id: string): ExtractResource<K> | undefined {
     const cached = this.#requestCache.get(this.fhirUrl(resourceType, id).toString())?.value;
-    return cached && !cached.isPending() ? (cached.read() as ExtractResource<K>) : undefined;
+    return cached && cached.isOk() ? (cached.read() as ExtractResource<K>) : undefined;
   }
 
   /**

--- a/packages/core/src/readablepromise.ts
+++ b/packages/core/src/readablepromise.ts
@@ -34,6 +34,14 @@ export class ReadablePromise<T> implements Promise<T> {
   }
 
   /**
+   * Returns true if the promise resolved successfully.
+   * @returns True if the Promise resolved successfully.
+   */
+  isOk(): boolean {
+    return this.#status === 'success';
+  }
+
+  /**
    * Attempts to read the value of the promise.
    * If the promise is pending, this method will throw a promise.
    * If the promise rejected, this method will throw the rejection reason.


### PR DESCRIPTION
`ReadablePromise` has 3 possible states:
* `pending` - waiting for the server
* `success` - results returned successfully
* `error` - error state

Before: Calls to `MedplumClient.getCached` or `MedplumClient.getCachedReference` on a `ReadablePromise` that failed would throw.

Now they silently return undefined, which is closer to the expected contract.
