### PR TITLE
PlanDefinition $apply operation

### DIFF
--- a/packages/app/src/PlanDefinitionApplyForm.tsx
+++ b/packages/app/src/PlanDefinitionApplyForm.tsx
@@ -1,0 +1,61 @@
+import { PlanDefinition, Reference, RequestGroup } from '@medplum/fhirtypes';
+import { Button, Form, FormSection, MedplumLink, ReferenceInput, useMedplum } from '@medplum/react';
+import React, { useState } from 'react';
+
+export interface PlanDefinitionApplyFormProps {
+  readonly planDefinition: PlanDefinition;
+}
+
+export function PlanDefinitionApplyForm(props: PlanDefinitionApplyFormProps): JSX.Element {
+  const medplum = useMedplum();
+  const [subject, setSubject] = useState<Reference>();
+  const [result, setResult] = useState<RequestGroup>();
+
+  if (result) {
+    return (
+      <>
+        <p>Request group created successfully.</p>
+        <ul>
+          <li>
+            Go to the{' '}
+            <MedplumLink to={result} suffix="checklist">
+              Request Group
+            </MedplumLink>
+          </li>
+          <li>
+            Back to the <MedplumLink to={props.planDefinition}>Plan Definition</MedplumLink>
+          </li>
+        </ul>
+      </>
+    );
+  }
+
+  return (
+    <Form
+      onSubmit={() => {
+        medplum
+          .post(medplum.fhirUrl('PlanDefinition', props.planDefinition.id as string, '$apply'), {
+            resourceType: 'Parameters',
+            parameter: [
+              {
+                name: 'subject',
+                valueReference: subject,
+              },
+            ],
+          })
+          .then(setResult)
+          .catch(console.log);
+      }}
+    >
+      <FormSection title="Subject">
+        <ReferenceInput
+          name="subject"
+          targetTypes={['Patient', 'Practitioner']}
+          defaultValue={subject}
+          onChange={setSubject}
+        />
+      </FormSection>
+      <Button type="submit">Go</Button>
+    </Form>
+  );
+}

--- a/packages/app/src/PlanDefinitionApplyForm.tsx
+++ b/packages/app/src/PlanDefinitionApplyForm.tsx
@@ -1,5 +1,13 @@
 import { PlanDefinition, Reference, RequestGroup } from '@medplum/fhirtypes';
-import { Button, Form, FormSection, MedplumLink, ReferenceInput, useMedplum } from '@medplum/react';
+import {
+  Button,
+  CodeableConceptDisplay,
+  Form,
+  FormSection,
+  MedplumLink,
+  ReferenceInput,
+  useMedplum,
+} from '@medplum/react';
 import React, { useState } from 'react';
 
 export interface PlanDefinitionApplyFormProps {
@@ -47,6 +55,20 @@ export function PlanDefinitionApplyForm(props: PlanDefinitionApplyFormProps): JS
           .catch(console.log);
       }}
     >
+      <h1>Start "{props.planDefinition.title}"</h1>
+      <p>
+        Use the <strong>Apply</strong> operation to create a group of tasks for a workflow.
+      </p>
+      <p>The following tasks will be created:</p>
+      <ul>
+        {props.planDefinition.action?.map((action, index) => (
+          <li key={`action-${index}`}>
+            {action.definitionCanonical?.startsWith('Questionnaire/') && 'Questionnaire request: '}
+            {action.title && <>{action.title}</>}
+            {action.code && <CodeableConceptDisplay value={action.code[0]} />}
+          </li>
+        ))}
+      </ul>
       <FormSection title="Subject">
         <ReferenceInput
           name="subject"

--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -209,6 +209,13 @@ describe('ResourcePage', () => {
     expect(screen.getByText('Checklist')).toBeInTheDocument();
   });
 
+  test('PlanDefinition apply', async () => {
+    await setup('/PlanDefinition/workflow-plan-definition-1/apply');
+    await waitFor(() => screen.getByText('Subject'));
+
+    expect(screen.getByText('Subject')).toBeInTheDocument();
+  });
+
   test('Left click on tab', async () => {
     window.open = jest.fn();
 

--- a/packages/app/src/ResourcePage.tsx
+++ b/packages/app/src/ResourcePage.tsx
@@ -24,6 +24,7 @@ import {
   PlanDefinitionBuilder,
   QuestionnaireBuilder,
   QuestionnaireForm,
+  ReferenceInput,
   RequestGroupDisplay,
   ResourceBlame,
   ResourceForm,
@@ -56,7 +57,7 @@ function getTabs(resourceType: string, questionnaires?: Bundle): string[] {
   }
 
   if (resourceType === 'PlanDefinition') {
-    result.push('Builder');
+    result.push('Apply', 'Builder');
   }
 
   if (resourceType === 'Questionnaire') {
@@ -357,6 +358,17 @@ function ResourceTab(props: ResourceTabProps): JSX.Element | null {
       return <DiagnosticReportDisplay value={props.resource as DiagnosticReport} />;
     case 'checklist':
       return <RequestGroupDisplay value={props.resource as RequestGroup} />;
+    case 'apply':
+      return (
+        <Form
+          onSubmit={(formData: Record<string, string>) => {
+            console.log('CODY formData', formData);
+          }}
+        >
+          <ReferenceInput name="subject" targetTypes={['Patient', 'Practitioner']} />
+          <Button type="submit">OK</Button>
+        </Form>
+      );
   }
   return null;
 }

--- a/packages/app/src/ResourcePage.tsx
+++ b/packages/app/src/ResourcePage.tsx
@@ -1,4 +1,4 @@
-import { getReferenceString, stringify } from '@medplum/core';
+import { getReferenceString, resolveId, stringify } from '@medplum/core';
 import {
   Bot,
   Bundle,
@@ -24,7 +24,6 @@ import {
   PlanDefinitionBuilder,
   QuestionnaireBuilder,
   QuestionnaireForm,
-  ReferenceInput,
   RequestGroupDisplay,
   ResourceBlame,
   ResourceForm,
@@ -43,6 +42,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { BotEditor } from './BotEditor';
 import { PatientHeader } from './PatientHeader';
+import { PlanDefinitionApplyForm } from './PlanDefinitionApplyForm';
 import { QuickServiceRequests } from './QuickServiceRequests';
 import { QuickStatus } from './QuickStatus';
 import { ResourceHeader } from './ResourceHeader';
@@ -357,18 +357,15 @@ function ResourceTab(props: ResourceTabProps): JSX.Element | null {
     case 'report':
       return <DiagnosticReportDisplay value={props.resource as DiagnosticReport} />;
     case 'checklist':
-      return <RequestGroupDisplay value={props.resource as RequestGroup} />;
-    case 'apply':
       return (
-        <Form
-          onSubmit={(formData: Record<string, string>) => {
-            console.log('CODY formData', formData);
-          }}
-        >
-          <ReferenceInput name="subject" targetTypes={['Patient', 'Practitioner']} />
-          <Button type="submit">OK</Button>
-        </Form>
+        <RequestGroupDisplay
+          value={props.resource as RequestGroup}
+          onStart={(_task, taskInput) => navigate(`/forms/${resolveId(taskInput)}`)}
+          onEdit={(_task, _taskInput, taskOutput) => navigate(`/${taskOutput.reference}}`)}
+        />
       );
+    case 'apply':
+      return <PlanDefinitionApplyForm planDefinition={props.resource as PlanDefinition} />;
   }
   return null;
 }

--- a/packages/react/src/MedplumLink.test.tsx
+++ b/packages/react/src/MedplumLink.test.tsx
@@ -64,6 +64,16 @@ describe('MedplumLink', () => {
     expect((screen.getByText('test') as HTMLAnchorElement).href).toEqual('http://localhost/Patient/123');
   });
 
+  test('Renders with suffix', () => {
+    setup(
+      <MedplumLink to={{ reference: 'Patient/123' }} suffix="foo">
+        test
+      </MedplumLink>
+    );
+    expect(screen.getByText('test')).toBeDefined();
+    expect((screen.getByText('test') as HTMLAnchorElement).href).toEqual('http://localhost/Patient/123/foo');
+  });
+
   test('Handles click with onClick', () => {
     const onClick = jest.fn();
     setup(

--- a/packages/react/src/MedplumLink.tsx
+++ b/packages/react/src/MedplumLink.tsx
@@ -5,6 +5,7 @@ import { killEvent } from './utils/dom';
 
 export interface MedplumLinkProps {
   to?: Resource | Reference | string;
+  suffix?: string;
   label?: string;
   id?: string;
   testid?: string;
@@ -24,6 +25,10 @@ export function MedplumLink(props: MedplumLinkProps): JSX.Element {
       href = `/${props.to.resourceType}/${props.to.id}`;
     } else if ('reference' in props.to) {
       href = `/${props.to.reference}`;
+    }
+
+    if (props.suffix) {
+      href += '/' + props.suffix;
     }
   }
 

--- a/packages/react/src/RequestGroupDisplay.test.tsx
+++ b/packages/react/src/RequestGroupDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { MockClient } from '@medplum/mock';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
@@ -20,11 +20,38 @@ async function setup(ui: React.ReactElement): Promise<void> {
 
 describe('RequestGroupDisplay', () => {
   test('Renders undefined', async () => {
-    await setup(<RequestGroupDisplay />);
+    await setup(<RequestGroupDisplay onStart={jest.fn()} onEdit={jest.fn()} />);
   });
 
   test('Renders reference', async () => {
-    await setup(<RequestGroupDisplay value={{ reference: 'RequestGroup/workflow-request-group-1' }} />);
+    const onStart = jest.fn();
+    const onEdit = jest.fn();
+
+    await setup(
+      <RequestGroupDisplay
+        onStart={onStart}
+        onEdit={onEdit}
+        value={{ reference: 'RequestGroup/workflow-request-group-1' }}
+      />
+    );
+
     expect(screen.getByText('Patient Registration')).toBeDefined();
+
+    const startButtons = screen.getAllByText('Start');
+    expect(startButtons).toHaveLength(2);
+
+    const editButtons = screen.getAllByText('Edit');
+    expect(editButtons).toHaveLength(1);
+
+    fireEvent.click(startButtons[0]);
+    expect(onStart).toHaveBeenCalled();
+    expect(onEdit).not.toHaveBeenCalled();
+
+    onStart.mockClear();
+    onEdit.mockClear();
+
+    fireEvent.click(editButtons[0]);
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onEdit).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/RequestGroupDisplay.tsx
+++ b/packages/react/src/RequestGroupDisplay.tsx
@@ -1,8 +1,8 @@
 import { getReferenceString } from '@medplum/core';
 import { Bundle, BundleEntry, Reference, RequestGroup, Resource, Task } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
+import { Button } from './Button';
 import { DateTimeDisplay } from './DateTimeDisplay';
-import { MedplumLink } from './MedplumLink';
 import { useMedplum } from './MedplumProvider';
 import { ResourceName } from './ResourceName';
 import { StatusBadge } from './StatusBadge';
@@ -11,6 +11,8 @@ import './RequestGroupDisplay.css';
 
 export interface RequestGroupDisplayProps {
   value?: RequestGroup | Reference<RequestGroup>;
+  onStart: (task: Task, input: Reference) => void;
+  onEdit: (task: Task, input: Reference, output: Reference) => void;
 }
 
 export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Element | null {
@@ -52,15 +54,9 @@ export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Elemen
               </div>
             </div>
             <div className="medplum-request-group-task-actions">
-              {taskInput && !taskOutput && (
-                <MedplumLink className="medplum-button" to={taskInput}>
-                  Start
-                </MedplumLink>
-              )}
+              {taskInput && !taskOutput && <Button onClick={() => props.onStart(task, taskInput)}>Start</Button>}
               {taskInput && taskOutput && (
-                <MedplumLink className="medplum-button" to={taskOutput}>
-                  Edit
-                </MedplumLink>
+                <Button onClick={() => props.onEdit(task, taskInput, taskOutput)}>Edit</Button>
               )}
             </div>
           </div>

--- a/packages/react/src/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput.tsx
@@ -38,7 +38,7 @@ export function ResourceInput<T extends Resource = Resource>(props: ResourceInpu
     <Autocomplete
       loadOptions={(input: string): Promise<T[]> => {
         return medplum
-          .search(resourceTypeRef.current as ResourceType, 'name=' + encodeURIComponent(input))
+          .search(resourceTypeRef.current as ResourceType, 'name=' + encodeURIComponent(input) + '&_count=10')
           .then((bundle: Bundle) => (bundle.entry as BundleEntry[]).map((entry) => entry.resource as T));
       }}
       getId={(item: T) => {

--- a/packages/react/src/stories/RequestGroupDisplay.stories.tsx
+++ b/packages/react/src/stories/RequestGroupDisplay.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta } from '@storybook/react';
 import { ExampleWorkflowRequestGroup } from '@medplum/mock';
+import { Meta } from '@storybook/react';
 import React from 'react';
-import { RequestGroupDisplay } from '../RequestGroupDisplay';
 import { Document } from '../Document';
+import { RequestGroupDisplay } from '../RequestGroupDisplay';
 
 export default {
   title: 'Medplum/RequestGroupDisplay',
@@ -11,6 +11,6 @@ export default {
 
 export const Simple = (): JSX.Element => (
   <Document>
-    <RequestGroupDisplay value={ExampleWorkflowRequestGroup} />
+    <RequestGroupDisplay onStart={console.log} onEdit={console.log} value={ExampleWorkflowRequestGroup} />
   </Document>
 );

--- a/packages/react/src/stories/UploadButton.stories.tsx
+++ b/packages/react/src/stories/UploadButton.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { Document } from '../Document';
+import { UploadButton } from '../UploadButton';
+
+export default {
+  title: 'Medplum/UploadButton',
+  component: UploadButton,
+} as Meta;
+
+export const Example = (): JSX.Element => (
+  <Document>
+    <UploadButton onUpload={console.log} />
+  </Document>
+);
+
+export const CustomText = (): JSX.Element => (
+  <Document>
+    <UploadButton onUpload={console.log}>My Upload</UploadButton>
+  </Document>
+);

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -2,6 +2,7 @@ import { assertOk, badRequest, createReference, getReferenceString, OperationOut
 import {
   CareTeam,
   Device,
+  Group,
   HealthcareService,
   Organization,
   Patient,
@@ -67,6 +68,7 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
   const [outcome3, requestGroup] = await repo.createResource<RequestGroup>({
     resourceType: 'RequestGroup',
     instantiatesCanonical: [getReferenceString(planDefinition)],
+    subject: createReference(params.subject) as Reference<Patient | Group>,
     status: 'active',
     action: actions,
   });

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,0 +1,113 @@
+import { allOk, assertOk, createReference } from '@medplum/core';
+import {
+  CareTeam,
+  Device,
+  HealthcareService,
+  Organization,
+  Patient,
+  PlanDefinition,
+  PlanDefinitionAction,
+  Practitioner,
+  PractitionerRole,
+  RelatedPerson,
+  RequestGroup,
+  RequestGroupAction,
+  Task,
+} from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import { sendOutcome } from '../outcomes';
+import { Repository } from '../repo';
+
+type SubjectType =
+  | CareTeam
+  | Device
+  | HealthcareService
+  | Organization
+  | Patient
+  | Practitioner
+  | PractitionerRole
+  | RelatedPerson;
+
+interface PlanDefinitionApplyParameters {
+  readonly subject: SubjectType;
+}
+
+/**
+ * Handles a PlanDefinition $apply request.
+ * @param req The HTTP request.
+ * @param res The HTTP response.
+ */
+export async function planDefinitionApplyHandler(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const repo = res.locals.repo as Repository;
+
+  const [outcome1, planDefinition] = await repo.readResource<PlanDefinition>('PlanDefinition', id);
+  assertOk(outcome1, planDefinition);
+
+  const [outcome2, subject] = await repo.readReference<SubjectType>({ reference: req.params.subject });
+  assertOk(outcome2, subject);
+
+  const params: PlanDefinitionApplyParameters = {
+    subject,
+  };
+
+  const actions: RequestGroupAction[] = [];
+
+  if (planDefinition.action) {
+    for (const action of planDefinition.action) {
+      actions.push(await createAction(repo, params, action));
+    }
+  }
+
+  const [outcome3, requestGroup] = await repo.createResource<RequestGroup>({
+    resourceType: 'RequestGroup',
+    action: actions,
+  });
+  assertOk(outcome3, requestGroup);
+
+  sendOutcome(res, allOk);
+}
+
+/**
+ *
+ * @param action The PlanDefinition action.
+ * @return The RequestGroup action.
+ */
+async function createAction(
+  repo: Repository,
+  params: PlanDefinitionApplyParameters,
+  action: PlanDefinitionAction
+): Promise<RequestGroupAction> {
+  if (action.definitionCanonical?.startsWith('Questionnaire/')) {
+    return createQuestionnaireTask(repo, params, action);
+  }
+  throw new Error('Unsupported action type');
+}
+
+async function createQuestionnaireTask(
+  repo: Repository,
+  params: PlanDefinitionApplyParameters,
+  action: PlanDefinitionAction
+): Promise<RequestGroupAction> {
+  const [outcome, task] = await repo.createResource<Task>({
+    resourceType: 'Task',
+    intent: 'order',
+    status: 'requested',
+    authoredOn: new Date().toISOString(),
+    owner: createReference(params.subject),
+    input: [
+      {
+        valueReference: {
+          display: action.title,
+          reference: action.definitionCanonical,
+        },
+      },
+    ],
+  });
+  assertOk(outcome, task);
+
+  return {
+    title: action.title,
+    resource: createReference(task),
+  };
+}

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,4 +1,4 @@
-import { allOk, assertOk, createReference } from '@medplum/core';
+import { assertOk, badRequest, createReference, getReferenceString, OperationOutcomeError } from '@medplum/core';
 import {
   CareTeam,
   Device,
@@ -9,14 +9,17 @@ import {
   PlanDefinitionAction,
   Practitioner,
   PractitionerRole,
+  Reference,
   RelatedPerson,
   RequestGroup,
   RequestGroupAction,
+  Resource,
   Task,
 } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { sendOutcome } from '../outcomes';
 import { Repository } from '../repo';
+import { isFhirJsonContentType, sendResponse } from '../routes';
 
 type SubjectType =
   | CareTeam
@@ -34,6 +37,11 @@ interface PlanDefinitionApplyParameters {
 
 /**
  * Handles a PlanDefinition $apply request.
+ *
+ * The operation converts a PlanDefinition to a RequestGroup.
+ *
+ * See: https://hl7.org/fhir/plandefinition-operation-apply.html
+ *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */
@@ -44,15 +52,12 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
   const [outcome1, planDefinition] = await repo.readResource<PlanDefinition>('PlanDefinition', id);
   assertOk(outcome1, planDefinition);
 
-  const [outcome2, subject] = await repo.readReference<SubjectType>({ reference: req.params.subject });
-  assertOk(outcome2, subject);
-
-  const params: PlanDefinitionApplyParameters = {
-    subject,
-  };
+  const params = await validateParameters(req, res);
+  if (!params) {
+    return;
+  }
 
   const actions: RequestGroupAction[] = [];
-
   if (planDefinition.action) {
     for (const action of planDefinition.action) {
       actions.push(await createAction(repo, params, action));
@@ -61,15 +66,52 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
 
   const [outcome3, requestGroup] = await repo.createResource<RequestGroup>({
     resourceType: 'RequestGroup',
+    instantiatesCanonical: [getReferenceString(planDefinition)],
+    status: 'active',
     action: actions,
   });
   assertOk(outcome3, requestGroup);
-
-  sendOutcome(res, allOk);
+  sendResponse(res, outcome3, requestGroup);
 }
 
 /**
- *
+ * Parses and validates the operation parameters.
+ * See: https://hl7.org/fhir/plandefinition-operation-apply.html
+ * @param req The HTTP request.
+ * @param res The HTTP response.
+ * @returns The operation parameters if available; otherwise, undefined.
+ */
+async function validateParameters(req: Request, res: Response): Promise<PlanDefinitionApplyParameters | undefined> {
+  if (!isFhirJsonContentType(req)) {
+    res.status(400).send('Unsupported content type');
+    return undefined;
+  }
+
+  const body = req.body as Resource;
+  if (body.resourceType !== 'Parameters') {
+    sendOutcome(res, badRequest('Incorrect parameters type'));
+    return undefined;
+  }
+
+  const subjectParam = body.parameter?.find((param) => param.name === 'subject');
+  if (!subjectParam?.valueReference) {
+    sendOutcome(res, badRequest('Missing subject parameter'));
+    return undefined;
+  }
+
+  const repo = res.locals.repo as Repository;
+  const [outcome2, subject] = await repo.readReference(subjectParam.valueReference as Reference<SubjectType>);
+  assertOk(outcome2, subject);
+
+  return {
+    subject,
+  };
+}
+
+/**
+ * Creates a RequestGroup action for the given PlanDefinition action.
+ * @param repo The repository configured for the current user.
+ * @param params The apply operation parameters (subject, etc).
  * @param action The PlanDefinition action.
  * @return The RequestGroup action.
  */
@@ -81,9 +123,16 @@ async function createAction(
   if (action.definitionCanonical?.startsWith('Questionnaire/')) {
     return createQuestionnaireTask(repo, params, action);
   }
-  throw new Error('Unsupported action type');
+  throw new OperationOutcomeError(badRequest('Unsupported action type'));
 }
 
+/**
+ * Creates a RequestGroup action for a Questionnaire.
+ * @param repo The repository configured for the current user.
+ * @param params The apply operation parameters (subject, etc).
+ * @param action The PlanDefinition action.
+ * @return The RequestGroup action.
+ */
 async function createQuestionnaireTask(
   repo: Repository,
   params: PlanDefinitionApplyParameters,

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -12,6 +12,7 @@ import { deployHandler } from './operations/deploy';
 import { executeHandler } from './operations/execute';
 import { expandOperator } from './operations/expand';
 import { graphqlHandler } from './operations/graphql';
+import { planDefinitionApplyHandler } from './operations/plandefinitionapply';
 import { sendOutcome } from './outcomes';
 import { Repository } from './repo';
 import { rewriteAttachments, RewriteMode } from './rewrite';
@@ -108,6 +109,9 @@ protectedRoutes.post('/Bot/:id/([$]|%24)deploy', deployHandler);
 
 // GraphQL
 protectedRoutes.post('/([$]|%24)graphql', graphqlHandler);
+
+// PlanDefinition $apply operation
+protectedRoutes.post('/PlanDefinition/:id/([$]|%24)apply', asyncWrap(planDefinitionApplyHandler));
 
 // Create batch
 protectedRoutes.post(
@@ -290,11 +294,11 @@ protectedRoutes.post(
   })
 );
 
-function isFhirJsonContentType(req: Request): boolean {
+export function isFhirJsonContentType(req: Request): boolean {
   return !!(req.is('application/json') || req.is('application/fhir+json'));
 }
 
-async function sendResponse(res: Response, outcome: OperationOutcome, body: any): Promise<void> {
+export async function sendResponse(res: Response, outcome: OperationOutcome, body: any): Promise<void> {
   const repo = res.locals.repo as Repository;
   res.status(getStatus(outcome)).json(await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, body));
 }


### PR DESCRIPTION
First draft of [`PlanDefinition`](https://hl7.org/fhir/plandefinition.html) [`$apply`](https://hl7.org/fhir/plandefinition-operation-apply.html) operation

Limitations:
* Only support `POST`, not `GET` - I'd actually prefer to keep it this way, but it is a deviation from the spec
* Only support [`Task`](https://hl7.org/fhir/task.html) with [`Questionnaire`](https://hl7.org/fhir/questionnaire.html) input for now
* Only support the `subject` input parameter