### PR TITLE
Added options to hide SearchControl toolbar and filters

### DIFF
--- a/packages/react/src/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl.test.tsx
@@ -833,4 +833,64 @@ describe('SearchControl', () => {
 
     expect(onChange).toBeCalled();
   });
+
+  test('Hide toolbar', async () => {
+    const props = {
+      search: {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: 'Simpson',
+          },
+        ],
+        fields: ['id', '_lastUpdated', 'name'],
+      },
+      onLoad: jest.fn(),
+      hideToolbar: true,
+    };
+
+    await setup(props);
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('search-control'));
+    });
+
+    const control = screen.getByTestId('search-control');
+    expect(control).toBeDefined();
+    expect(props.onLoad).toBeCalled();
+    expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
+    expect(screen.queryByText('Patient')).not.toBeInTheDocument();
+  });
+
+  test('Hide filters', async () => {
+    const props = {
+      search: {
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: 'Simpson',
+          },
+        ],
+        fields: ['id', '_lastUpdated', 'name'],
+      },
+      onLoad: jest.fn(),
+      hideFilters: true,
+    };
+
+    await setup(props);
+
+    await act(async () => {
+      await waitFor(() => screen.getByTestId('search-control'));
+    });
+
+    const control = screen.getByTestId('search-control');
+    expect(control).toBeDefined();
+    expect(props.onLoad).toBeCalled();
+    expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
+    expect(screen.queryByText('no filters')).not.toBeInTheDocument();
+  });
 });

--- a/packages/react/src/SearchControl.tsx
+++ b/packages/react/src/SearchControl.tsx
@@ -18,7 +18,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
-import './SearchControl.css';
 import { getFieldDefinitions } from './SearchControlField';
 import { SearchFieldEditor } from './SearchFieldEditor';
 import { SearchFilterEditor } from './SearchFilterEditor';
@@ -29,6 +28,7 @@ import { addFilter, buildFieldNameString, getOpString, movePage, renderValue } f
 import { Select } from './Select';
 import { TitleBar } from './TitleBar';
 import { isCheckboxCell, killEvent } from './utils/dom';
+import './SearchControl.css';
 
 export class SearchChangeEvent extends Event {
   readonly definition: SearchRequest;

--- a/packages/react/src/SearchControl.tsx
+++ b/packages/react/src/SearchControl.tsx
@@ -18,6 +18,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
+import './SearchControl.css';
 import { getFieldDefinitions } from './SearchControlField';
 import { SearchFieldEditor } from './SearchFieldEditor';
 import { SearchFilterEditor } from './SearchFilterEditor';
@@ -28,7 +29,6 @@ import { addFilter, buildFieldNameString, getOpString, movePage, renderValue } f
 import { Select } from './Select';
 import { TitleBar } from './TitleBar';
 import { isCheckboxCell, killEvent } from './utils/dom';
-import './SearchControl.css';
 
 export class SearchChangeEvent extends Event {
   readonly definition: SearchRequest;
@@ -63,6 +63,8 @@ export interface SearchControlProps {
   search: SearchRequest;
   userConfig?: UserConfiguration;
   checkboxesEnabled?: boolean;
+  hideToolbar?: boolean;
+  hideFilters?: boolean;
   onLoad?: (e: SearchLoadEvent) => void;
   onChange?: (e: SearchChangeEvent) => void;
   onClick?: (e: SearchClickEvent) => void;
@@ -244,82 +246,87 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
 
   return (
     <div className="medplum-search-control" onContextMenu={(e) => killEvent(e)} data-testid="search-control">
-      <TitleBar>
-        <div>
-          <h1>
-            <a href={`https://www.hl7.org/fhir/${resourceType.toLowerCase()}.html`} target="_blank" rel="noopener">
-              {resourceType}
-            </a>
-          </h1>
-          {savedSearches && (
-            <Select
-              testid="saved-search-select"
-              style={{ width: 80 }}
-              onChange={(newValue) => {
-                emitSearchChange(parseSearchDefinition(newValue));
-              }}
-            >
-              <option></option>
-              {savedSearches.map((s, index) => (
-                <option key={`${index}-${savedSearches.length}`} value={s.criteria}>
-                  {s.name}
-                </option>
-              ))}
-            </Select>
-          )}
-          <Button
-            testid="fields-button"
-            size="small"
-            onClick={() => setState({ ...stateRef.current, fieldEditorVisible: true })}
-          >
-            Fields
-          </Button>
-          <Button
-            testid="filters-button"
-            size="small"
-            onClick={() => setState({ ...stateRef.current, filterEditorVisible: true })}
-          >
-            Filters
-          </Button>
-          {props.onNew && (
-            <Button size="small" onClick={props.onNew}>
-              New...
-            </Button>
-          )}
-          {props.onExport && (
-            <Button size="small" onClick={props.onExport}>
-              Export...
-            </Button>
-          )}
-          {props.onDelete && (
-            <Button
-              size="small"
-              onClick={() => (props.onDelete as (ids: string[]) => any)(Object.keys(state.selected))}
-            >
-              Delete...
-            </Button>
-          )}
-          {props.onBulk && (
-            <Button size="small" onClick={() => (props.onBulk as (ids: string[]) => any)(Object.keys(state.selected))}>
-              Bulk...
-            </Button>
-          )}
-        </div>
-        {lastResult && (
+      {!props.hideToolbar && (
+        <TitleBar>
           <div>
-            <span className="medplum-search-summary">
-              {getStart(search, lastResult.total as number)}-{getEnd(search, lastResult.total as number)} of{' '}
-              {lastResult.total?.toLocaleString()}
-            </span>
-            <Button testid="prev-page-button" size="small" onClick={() => emitSearchChange(movePage(search, -1))}>
-              &lt;&lt;
+            <h1>
+              <a href={`https://www.hl7.org/fhir/${resourceType.toLowerCase()}.html`} target="_blank" rel="noopener">
+                {resourceType}
+              </a>
+            </h1>
+            {savedSearches && (
+              <Select
+                testid="saved-search-select"
+                style={{ width: 80 }}
+                onChange={(newValue) => {
+                  emitSearchChange(parseSearchDefinition(newValue));
+                }}
+              >
+                <option></option>
+                {savedSearches.map((s, index) => (
+                  <option key={`${index}-${savedSearches.length}`} value={s.criteria}>
+                    {s.name}
+                  </option>
+                ))}
+              </Select>
+            )}
+            <Button
+              testid="fields-button"
+              size="small"
+              onClick={() => setState({ ...stateRef.current, fieldEditorVisible: true })}
+            >
+              Fields
             </Button>
-            <Button testid="next-page-button" size="small" onClick={() => emitSearchChange(movePage(search, 1))}>
-              &gt;&gt;
+            <Button
+              testid="filters-button"
+              size="small"
+              onClick={() => setState({ ...stateRef.current, filterEditorVisible: true })}
+            >
+              Filters
             </Button>
+            {props.onNew && (
+              <Button size="small" onClick={props.onNew}>
+                New...
+              </Button>
+            )}
+            {props.onExport && (
+              <Button size="small" onClick={props.onExport}>
+                Export...
+              </Button>
+            )}
+            {props.onDelete && (
+              <Button
+                size="small"
+                onClick={() => (props.onDelete as (ids: string[]) => any)(Object.keys(state.selected))}
+              >
+                Delete...
+              </Button>
+            )}
+            {props.onBulk && (
+              <Button
+                size="small"
+                onClick={() => (props.onBulk as (ids: string[]) => any)(Object.keys(state.selected))}
+              >
+                Bulk...
+              </Button>
+            )}
           </div>
-        )}
-      </TitleBar>
+          {lastResult && (
+            <div>
+              <span className="medplum-search-summary">
+                {getStart(search, lastResult.total as number)}-{getEnd(search, lastResult.total as number)} of{' '}
+                {lastResult.total?.toLocaleString()}
+              </span>
+              <Button testid="prev-page-button" size="small" onClick={() => emitSearchChange(movePage(search, -1))}>
+                &lt;&lt;
+              </Button>
+              <Button testid="next-page-button" size="small" onClick={() => emitSearchChange(movePage(search, 1))}>
+                &gt;&gt;
+              </Button>
+            </div>
+          )}
+        </TitleBar>
+      )}
       <table>
         <thead>
           <tr>
@@ -342,20 +349,22 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               </th>
             ))}
           </tr>
-          <tr>
-            {checkboxColumn && <th className="filters medplum-search-icon-cell" />}
-            {fields.map((field) => (
-              <th key={field.name} className="filters">
-                {field.searchParams && (
-                  <FilterDescription
-                    resourceType={resourceType}
-                    searchParams={field.searchParams}
-                    filters={props.search.filters}
-                  />
-                )}
-              </th>
-            ))}
-          </tr>
+          {!props.hideFilters && (
+            <tr>
+              {checkboxColumn && <th className="filters medplum-search-icon-cell" />}
+              {fields.map((field) => (
+                <th key={field.name} className="filters">
+                  {field.searchParams && (
+                    <FilterDescription
+                      resourceType={resourceType}
+                      searchParams={field.searchParams}
+                      filters={props.search.filters}
+                    />
+                  )}
+                </th>
+              ))}
+            </tr>
+          )}
         </thead>
         <tbody>
           {resources?.map(

--- a/packages/react/src/stories/SearchControl.stories.tsx
+++ b/packages/react/src/stories/SearchControl.stories.tsx
@@ -128,3 +128,67 @@ export const Observations = (): JSX.Element => {
     />
   );
 };
+
+export const HideToolbar = (): JSX.Element => {
+  const [search, setSearch] = useState<SearchRequest>({
+    resourceType: 'Patient',
+    fields: ['id', '_lastUpdated', 'name'],
+  });
+
+  return (
+    <SearchControl
+      search={search}
+      checkboxesEnabled={true}
+      hideToolbar={true}
+      onLoad={(e) => console.log('onLoad', e)}
+      onClick={(e) => console.log('onClick', e)}
+      onChange={(e) => {
+        console.log('onChange', e);
+        setSearch(e.definition);
+      }}
+    />
+  );
+};
+
+export const HideFilters = (): JSX.Element => {
+  const [search, setSearch] = useState<SearchRequest>({
+    resourceType: 'Patient',
+    fields: ['id', '_lastUpdated', 'name'],
+  });
+
+  return (
+    <SearchControl
+      search={search}
+      checkboxesEnabled={true}
+      hideFilters={true}
+      onLoad={(e) => console.log('onLoad', e)}
+      onClick={(e) => console.log('onClick', e)}
+      onChange={(e) => {
+        console.log('onChange', e);
+        setSearch(e.definition);
+      }}
+    />
+  );
+};
+
+export const HideToolbarAndFilters = (): JSX.Element => {
+  const [search, setSearch] = useState<SearchRequest>({
+    resourceType: 'Patient',
+    fields: ['id', '_lastUpdated', 'name'],
+  });
+
+  return (
+    <SearchControl
+      search={search}
+      checkboxesEnabled={true}
+      hideToolbar={true}
+      hideFilters={true}
+      onLoad={(e) => console.log('onLoad', e)}
+      onClick={(e) => console.log('onClick', e)}
+      onChange={(e) => {
+        console.log('onChange', e);
+        setSearch(e.definition);
+      }}
+    />
+  );
+};


### PR DESCRIPTION
Options to hide the "toolbar" and "filters" sections of the `<SearchControl>` component:

![image](https://user-images.githubusercontent.com/749094/176573433-78869954-76a8-481c-8cd8-634bd7caabd6.png)

<img width="524" alt="image" src="https://user-images.githubusercontent.com/749094/176573582-a39aab3f-ecf9-452b-afcb-575af8003f7a.png">

@rahul1 @reshmakh  For consideration: We could invert this? Which is better?

1. Enabled by default, opt out
2. Disabled by default, opt in
