### PR TITLE
Redis caching

### DIFF
--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -1,0 +1,28 @@
+class Redis {
+  private values: Map<string, string>;
+  constructor(readonly config: any) {
+    this.values = new Map<string, string>();
+  }
+
+  async ping(): Promise<string> {
+    return 'PONG';
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    return this.values.get(key);
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async del(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+
+  disconnect(): void {
+    // Disconnects
+  }
+}
+
+export default Redis;

--- a/packages/server/src/admin/bot.test.ts
+++ b/packages/server/src/admin/bot.test.ts
@@ -9,6 +9,7 @@ import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -21,6 +22,7 @@ const app = express();
 describe('Bot admin', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -29,6 +31,7 @@ describe('Bot admin', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -9,6 +9,7 @@ import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -21,6 +22,7 @@ const app = express();
 describe('Client admin', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -29,6 +31,7 @@ describe('Client admin', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -10,6 +10,7 @@ import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -22,6 +23,7 @@ const app = express();
 describe('Admin Invite', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -30,6 +32,7 @@ describe('Admin Invite', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -9,6 +9,7 @@ import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -21,6 +22,7 @@ const app = express();
 describe('Project Admin routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -29,6 +31,7 @@ describe('Project Admin routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -7,9 +7,10 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
-import { createTestProject } from '../test.setup';
 import { generateAccessToken, initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { createTestProject } from '../test.setup';
 
 const app = express();
 let project: Project;
@@ -20,6 +21,7 @@ let nonAdminAccessToken: string;
 describe('Super Admin routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -108,6 +110,7 @@ describe('Super Admin routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Rebuild ValueSetElements as super admin', async () => {

--- a/packages/server/src/auth/changepassword.test.ts
+++ b/packages/server/src/auth/changepassword.test.ts
@@ -9,6 +9,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -22,6 +23,7 @@ const app = express();
 describe('Change Password', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -30,6 +32,7 @@ describe('Change Password', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -10,6 +10,7 @@ import { getConfig, loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
 import { getUserByEmail, initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -43,6 +44,7 @@ const app = express();
 describe('Google Auth', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -51,6 +53,7 @@ describe('Google Auth', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -12,6 +12,7 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { createTestClient, setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -26,6 +27,7 @@ let client: ClientApplication;
 describe('Login', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -35,6 +37,7 @@ describe('Login', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/auth/me.test.ts
+++ b/packages/server/src/auth/me.test.ts
@@ -9,6 +9,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -21,6 +22,7 @@ const app = express();
 describe('Me', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -29,6 +31,7 @@ describe('Me', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(async () => {

--- a/packages/server/src/auth/newpatient.test.ts
+++ b/packages/server/src/auth/newpatient.test.ts
@@ -10,6 +10,7 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -21,6 +22,7 @@ const app = express();
 describe('New patient', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -29,6 +31,7 @@ describe('New patient', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(async () => {

--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -7,6 +7,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -18,6 +19,7 @@ const app = express();
 describe('New project', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -26,6 +28,7 @@ describe('New project', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(async () => {

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -10,6 +10,7 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -22,6 +23,7 @@ const app = express();
 describe('New user', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -30,6 +32,7 @@ describe('New user', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(async () => {

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -9,6 +9,7 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { registerNew } from './register';
 
@@ -24,6 +25,7 @@ let profile2: ProfileResource;
 describe('Profile', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -52,6 +54,7 @@ describe('Profile', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Missing login', async () => {

--- a/packages/server/src/auth/register.test.ts
+++ b/packages/server/src/auth/register.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -18,6 +19,7 @@ const app = express();
 describe('Register', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -26,6 +28,7 @@ describe('Register', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(async () => {

--- a/packages/server/src/auth/resetpassword.test.ts
+++ b/packages/server/src/auth/resetpassword.test.ts
@@ -9,6 +9,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -22,6 +23,7 @@ const app = express();
 describe('Reset Password', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -30,6 +32,7 @@ describe('Reset Password', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/auth/setpassword.test.ts
+++ b/packages/server/src/auth/setpassword.test.ts
@@ -10,6 +10,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { generateSecret, initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
@@ -22,6 +23,7 @@ const app = express();
 describe('Set Password', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -30,6 +32,7 @@ describe('Set Password', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/dicom/routes.test.ts
+++ b/packages/server/src/dicom/routes.test.ts
@@ -3,9 +3,10 @@ import request from 'supertest';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { initTestAuth } from '../test.setup';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { initTestAuth } from '../test.setup';
 
 const app = express();
 let accessToken: string;
@@ -13,6 +14,7 @@ let accessToken: string;
 describe('DICOM Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -22,6 +24,7 @@ describe('DICOM Routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Get studies', async () => {

--- a/packages/server/src/email/routes.test.ts
+++ b/packages/server/src/email/routes.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { initTestAuth } from '../test.setup';
 
@@ -17,6 +18,7 @@ let accessToken: string;
 describe('Email API Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -31,6 +33,7 @@ describe('Email API Routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Unauthenticated', async () => {

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -3,18 +3,21 @@ import { AccessPolicy, ClientApplication, Observation, Patient, ServiceRequest }
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { getRepoForLogin, Repository, systemRepo } from './repo';
 
 describe('AccessPolicy', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Access policy restricting read', async () => {

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -11,6 +11,7 @@ import {
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { processBatch } from './batch';
 import { Repository } from './repo';
@@ -20,6 +21,7 @@ let repo: Repository;
 describe('Batch', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
 
@@ -33,6 +35,7 @@ describe('Batch', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Process batch with missing bundle type', async () => {

--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -9,6 +9,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { initTestAuth } from '../test.setup';
 import { initBinaryStorage } from './storage';
@@ -20,6 +21,7 @@ let accessToken: string;
 describe('Binary', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -30,6 +32,7 @@ describe('Binary', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
     rmSync(binaryDir, { recursive: true, force: true });
   });
 

--- a/packages/server/src/fhir/lookups/address.test.ts
+++ b/packages/server/src/fhir/lookups/address.test.ts
@@ -3,18 +3,21 @@ import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { systemRepo } from '../repo';
 
 describe('Address Lookup Table', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Patient resource with address', async () => {

--- a/packages/server/src/fhir/lookups/contactpoint.test.ts
+++ b/packages/server/src/fhir/lookups/contactpoint.test.ts
@@ -3,18 +3,21 @@ import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { systemRepo } from '../repo';
 
 describe('Address Lookup Table', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Patient resource with telecom', async () => {

--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -3,19 +3,22 @@ import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
-import { bundleContains } from '../../test.setup';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
+import { bundleContains } from '../../test.setup';
 import { systemRepo } from '../repo';
 
 describe('HumanName Lookup Table', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('HumanName', async () => {

--- a/packages/server/src/fhir/lookups/identifier.test.ts
+++ b/packages/server/src/fhir/lookups/identifier.test.ts
@@ -3,6 +3,7 @@ import { Patient, SpecimenDefinition } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { bundleContains } from '../../test.setup';
 import { systemRepo } from '../repo';
@@ -10,12 +11,14 @@ import { systemRepo } from '../repo';
 describe('Identifier Lookup Table', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Identifier', async () => {

--- a/packages/server/src/fhir/operations/csv.test.ts
+++ b/packages/server/src/fhir/operations/csv.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
 import { initKeys } from '../../oauth';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 
@@ -15,6 +16,7 @@ let accessToken: string;
 describe('CSV Export', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -24,6 +26,7 @@ describe('CSV Export', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Export Patient', async () => {

--- a/packages/server/src/fhir/operations/deploy.test.ts
+++ b/packages/server/src/fhir/operations/deploy.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
 import { initKeys } from '../../oauth';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 
@@ -77,6 +78,7 @@ let accessToken: string;
 describe('Deploy', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -86,6 +88,7 @@ describe('Deploy', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   beforeEach(() => {

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -5,6 +5,7 @@ import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
 import { initKeys } from '../../oauth';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 
@@ -38,6 +39,7 @@ let bot: Bot;
 describe('Execute', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -59,6 +61,7 @@ describe('Execute', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Submit plain text', async () => {

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -5,6 +5,7 @@ import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
 import { initKeys } from '../../oauth';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 
@@ -14,6 +15,7 @@ let accessToken: string;
 describe('Expand', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -23,6 +25,7 @@ describe('Expand', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('No system', async () => {

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -9,6 +9,7 @@ import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
 import { initKeys } from '../../oauth';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 import { initBinaryStorage } from '../storage';
@@ -25,6 +26,7 @@ let encounter2: Encounter;
 describe('GraphQL', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -117,6 +119,7 @@ describe('GraphQL', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
     rmSync(binaryDir, { recursive: true, force: true });
   });
 

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { closeDatabase, initDatabase } from '../../database';
 import { initKeys } from '../../oauth';
+import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 
@@ -15,6 +16,7 @@ let accessToken: string;
 describe('PlanDefinition apply', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -24,6 +26,7 @@ describe('PlanDefinition apply', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Happy path', async () => {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -18,6 +18,7 @@ import { registerNew, RegisterRequest } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { bundleContains } from '../test.setup';
 import { processBatch } from './batch';
@@ -25,10 +26,12 @@ import { getRepoForLogin, Repository, systemRepo } from './repo';
 import { parseSearchRequest } from './search';
 
 jest.mock('hibp');
+jest.mock('ioredis');
 
 describe('FHIR Repo', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initKeys(config);
@@ -36,6 +39,7 @@ describe('FHIR Repo', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('getRepoForLogin', async () => {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -45,6 +45,7 @@ import { URL } from 'url';
 import validator from 'validator';
 import { getConfig } from '../config';
 import { getClient } from '../database';
+import { getRedis } from '../redis';
 import { addBackgroundJobs } from '../workers';
 import { addSubscriptionJobs } from '../workers/subscription';
 import { AddressTable, ContactPointTable, HumanNameTable, IdentifierTable, LookupTable } from './lookups';
@@ -166,6 +167,21 @@ export class Repository {
       return [accessDenied, undefined];
     }
 
+    if (!this.#context.accessPolicy) {
+      const cachedValue = await getRedis().get(`${resourceType}:${id}`);
+      if (cachedValue) {
+        const cachedResource = JSON.parse(cachedValue) as T;
+        if (
+          cachedResource.meta?.project !== undefined &&
+          this.#context.project !== undefined &&
+          this.#context.project !== cachedResource.meta?.project
+        ) {
+          return [notFound, undefined];
+        }
+        return [allOk, this.#removeHiddenFields(cachedResource)];
+      }
+    }
+
     const client = getClient();
     const builder = new SelectQuery(resourceType).column('content').column('deleted').where('id', Operator.EQUALS, id);
 
@@ -180,6 +196,7 @@ export class Repository {
       return [gone, undefined];
     }
 
+    getRedis().set(`${resourceType}:${id}`, rows[0].content as string);
     return [allOk, this.#removeHiddenFields(JSON.parse(rows[0].content as string))];
   }
 
@@ -317,6 +334,8 @@ export class Repository {
     }
 
     try {
+      await getRedis().set(`${resourceType}:${id}`, JSON.stringify(result));
+
       await this.#writeResource(result);
       await this.#writeResourceVersion(result);
       await this.#writeLookupTables(result);
@@ -445,6 +464,8 @@ export class Repository {
     if (!this.#canWriteResourceType(resourceType)) {
       return [accessDenied, undefined];
     }
+
+    getRedis().del(`${resourceType}:${id}`);
 
     const client = getClient();
     const lastUpdated = new Date();

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -92,6 +92,12 @@ export interface RepositoryContext {
   admin?: boolean;
 }
 
+export interface CacheEntry<T extends Resource> {
+  resource: T;
+  projectId: string;
+  compartments: string[];
+}
+
 export type RepositoryResult<T extends Resource | undefined> = Promise<[OperationOutcome, T | undefined]>;
 
 /**
@@ -168,17 +174,16 @@ export class Repository {
     }
 
     if (!this.#context.accessPolicy) {
-      const cachedValue = await getRedis().get(`${resourceType}:${id}`);
-      if (cachedValue) {
-        const cachedResource = JSON.parse(cachedValue) as T;
+      const cacheRecord = await getCacheEntry<T>(resourceType, id);
+      if (cacheRecord) {
         if (
-          cachedResource.meta?.project !== undefined &&
           this.#context.project !== undefined &&
-          this.#context.project !== cachedResource.meta?.project
+          cacheRecord.projectId !== undefined &&
+          cacheRecord.projectId !== this.#context.project
         ) {
           return [notFound, undefined];
         }
-        return [allOk, this.#removeHiddenFields(cachedResource)];
+        return [allOk, this.#removeHiddenFields(cacheRecord.resource)];
       }
     }
 
@@ -196,8 +201,9 @@ export class Repository {
       return [gone, undefined];
     }
 
-    getRedis().set(`${resourceType}:${id}`, rows[0].content as string);
-    return [allOk, this.#removeHiddenFields(JSON.parse(rows[0].content as string))];
+    const resource = JSON.parse(rows[0].content as string) as T;
+    setCacheEntry(resource);
+    return [allOk, this.#removeHiddenFields(resource)];
   }
 
   async readReference<T extends Resource>(reference: Reference<T>): RepositoryResult<T> {
@@ -334,8 +340,7 @@ export class Repository {
     }
 
     try {
-      await getRedis().set(`${resourceType}:${id}`, JSON.stringify(result));
-
+      await setCacheEntry(result);
       await this.#writeResource(result);
       await this.#writeResourceVersion(result);
       await this.#writeLookupTables(result);
@@ -465,7 +470,7 @@ export class Repository {
       return [accessDenied, undefined];
     }
 
-    getRedis().del(`${resourceType}:${id}`);
+    await deleteCacheEntry(resourceType, id);
 
     const client = getClient();
     const lastUpdated = new Date();
@@ -1440,6 +1445,47 @@ export class Repository {
     const { adminClientId } = getConfig();
     return !!adminClientId && this.#context.author.reference === 'ClientApplication/' + adminClientId;
   }
+}
+
+/**
+ * Tries to read a cache entry from Redis by resource type and ID.
+ * @param resourceType The resource type.
+ * @param id The resource ID.
+ * @returns The cache entry if found; otherwise, undefined.
+ */
+async function getCacheEntry<T extends Resource>(resourceType: string, id: string): Promise<CacheEntry<T> | undefined> {
+  const cachedValue = await getRedis().get(getCacheKey(resourceType, id));
+  return cachedValue ? (JSON.parse(cachedValue) as CacheEntry<T>) : undefined;
+}
+
+/**
+ * Writes a cache entry to Redis.
+ * @param resource The resource to cache.
+ */
+async function setCacheEntry(resource: Resource): Promise<void> {
+  await getRedis().set(
+    getCacheKey(resource.resourceType, resource.id as string),
+    JSON.stringify({ resource, projectId: resource.meta?.project })
+  );
+}
+
+/**
+ * Deletes a cache entry from Redis.
+ * @param resourceType The resource type.
+ * @param id The resource ID.
+ */
+async function deleteCacheEntry(resourceType: string, id: string): Promise<void> {
+  await getRedis().del(getCacheKey(resourceType, id));
+}
+
+/**
+ * Returns the redis cache key for the given resource type and resource ID.
+ * @param resourceType The resource type.
+ * @param id The resource ID.
+ * @returns The Redis cache key.
+ */
+function getCacheKey(resourceType: string, id: string): string {
+  return `${resourceType}/${id}`;
 }
 
 /**

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -3,6 +3,7 @@ import { Binary, Practitioner } from '@medplum/fhirtypes';
 import { URL } from 'url';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { systemRepo } from './repo';
 import { rewriteAttachments, RewriteMode } from './rewrite';
@@ -13,6 +14,7 @@ describe('URL rewrite', () => {
 
   beforeAll(async () => {
     config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
 
@@ -25,6 +27,7 @@ describe('URL rewrite', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Null', async () => {

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { initTestAuth } from '../test.setup';
 
@@ -18,6 +19,7 @@ let patientVersionId: string;
 describe('FHIR Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -45,6 +47,7 @@ describe('FHIR Routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Get CapabilityStatement anonymously', async () => {

--- a/packages/server/src/healthcheck.test.ts
+++ b/packages/server/src/healthcheck.test.ts
@@ -13,15 +13,15 @@ const app = express();
 describe('Health check', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
-    await initRedis(config.redis);
     await initApp(app);
     await initKeys(config);
   });
 
   afterAll(async () => {
     await closeDatabase();
-    await closeRedis();
+    closeRedis();
   });
 
   test('Get /healthcheck', async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
   logger.info('config: ' + JSON.stringify(config, undefined, 2));
 
   await initDatabase(config.database);
-  await initRedis(config.redis);
+  initRedis(config.redis);
   await initKeys(config);
   await seedDatabase();
   initBinaryStorage(config.binaryStorage);

--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -5,6 +5,7 @@ import { URL, URLSearchParams } from 'url';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { createTestClient } from '../test.setup';
 import { initKeys } from './keys';
@@ -15,6 +16,7 @@ let client: ClientApplication;
 describe('OAuth Authorize', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -24,6 +26,7 @@ describe('OAuth Authorize', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Authorize GET client not found', async () => {

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { generateKeyPair, SignJWT } from 'jose';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { closeDatabase, getClient, initDatabase } from '../database';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import {
   generateAccessToken,
@@ -17,12 +18,14 @@ import {
 describe('Keys', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Init keys', async () => {

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -7,9 +7,10 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
-import { createTestClient } from '../test.setup';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { createTestClient } from '../test.setup';
 import { generateAccessToken, generateSecret } from './keys';
 
 const app = express();
@@ -18,6 +19,7 @@ let client: ClientApplication;
 describe('Auth middleware', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -27,6 +29,7 @@ describe('Auth middleware', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Login not found', async () => {

--- a/packages/server/src/oauth/routes.test.ts
+++ b/packages/server/src/oauth/routes.test.ts
@@ -4,8 +4,9 @@ import request from 'supertest';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { createTestClient } from '../test.setup';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { createTestClient } from '../test.setup';
 import { initKeys } from './keys';
 
 const app = express();
@@ -14,6 +15,7 @@ let client: ClientApplication;
 describe('OAuth Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -23,6 +25,7 @@ describe('OAuth Routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Get token with client credentials', async () => {

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -7,6 +7,7 @@ import { initApp } from '../app';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { systemRepo } from '../fhir';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { createTestClient } from '../test.setup';
 import { generateSecret, initKeys } from './keys';
@@ -19,6 +20,7 @@ let client: ClientApplication;
 describe('OAuth2 Token', () => {
   beforeAll(async () => {
     config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -28,6 +30,7 @@ describe('OAuth2 Token', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Token with wrong Content-Type', async () => {

--- a/packages/server/src/oauth/userinfo.test.ts
+++ b/packages/server/src/oauth/userinfo.test.ts
@@ -6,6 +6,7 @@ import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 
 const app = express();
@@ -13,6 +14,7 @@ const app = express();
 describe('OAuth2 UserInfo', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -21,6 +23,7 @@ describe('OAuth2 UserInfo', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Get userinfo with profile email', async () => {

--- a/packages/server/src/oauth/utils.test.ts
+++ b/packages/server/src/oauth/utils.test.ts
@@ -3,8 +3,9 @@ import { ClientApplication } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { createTestClient } from '../test.setup';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { createTestClient } from '../test.setup';
 import { initKeys } from './keys';
 import { tryLogin, validateLoginRequest } from './utils';
 
@@ -13,6 +14,7 @@ let client: ClientApplication;
 describe('OAuth utils', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initKeys(config);
@@ -21,6 +23,7 @@ describe('OAuth utils', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Login with invalid client ID', async () => {

--- a/packages/server/src/openapi.test.ts
+++ b/packages/server/src/openapi.test.ts
@@ -4,12 +4,14 @@ import { initApp } from './app';
 import { loadTestConfig } from './config';
 import { closeDatabase, initDatabase } from './database';
 import { initKeys } from './oauth';
+import { closeRedis, initRedis } from './redis';
 
 const app = express();
 
 describe('OpenAPI', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await initApp(app);
     await initKeys(config);
@@ -17,6 +19,7 @@ describe('OpenAPI', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Get /openapi.json', async () => {

--- a/packages/server/src/redis.test.ts
+++ b/packages/server/src/redis.test.ts
@@ -6,7 +6,7 @@ jest.mock('ioredis');
 describe('Redis', () => {
   test('Get redis', async () => {
     const config = await loadTestConfig();
-    await initRedis(config.redis);
+    initRedis(config.redis);
     expect(getRedis()).toBeDefined();
     await closeRedis();
   });

--- a/packages/server/src/scim/routes.test.ts
+++ b/packages/server/src/scim/routes.test.ts
@@ -3,9 +3,10 @@ import request from 'supertest';
 import { initApp } from '../app';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
-import { initTestAuth } from '../test.setup';
 import { initKeys } from '../oauth';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { initTestAuth } from '../test.setup';
 
 const app = express();
 let accessToken: string;
@@ -13,6 +14,7 @@ let accessToken: string;
 describe('SCIM Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -22,6 +24,7 @@ describe('SCIM Routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Search users', async () => {

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -1,15 +1,18 @@
 import { loadTestConfig } from './config';
 import { closeDatabase, initDatabase } from './database';
+import { closeRedis, initRedis } from './redis';
 import { seedDatabase } from './seed';
 
 describe('Seed', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Seeder completes successfully', async () => {

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -9,6 +9,7 @@ import { initApp } from './app';
 import { loadTestConfig } from './config';
 import { closeDatabase, initDatabase } from './database';
 import { getBinaryStorage, initBinaryStorage, systemRepo } from './fhir';
+import { closeRedis, initRedis } from './redis';
 import { seedDatabase } from './seed';
 
 const app = express();
@@ -18,6 +19,7 @@ let binary: Binary;
 describe('Storage Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initApp(app);
@@ -39,6 +41,7 @@ describe('Storage Routes', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
     rmSync(binaryDir, { recursive: true, force: true });
   });
 

--- a/packages/server/src/util/pdf.test.ts
+++ b/packages/server/src/util/pdf.test.ts
@@ -4,6 +4,7 @@ import { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initBinaryStorage, Repository, systemRepo } from '../fhir';
+import { closeRedis, initRedis } from '../redis';
 import { createPdf } from './pdf';
 
 const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
@@ -13,12 +14,14 @@ const dd: TDocumentDefinitions = { content: ['Hello world'] };
 describe('Binary', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await initBinaryStorage('file:' + binaryDir);
   });
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
     rmSync(binaryDir, { recursive: true, force: true });
   });
 

--- a/packages/server/src/wellknown.test.ts
+++ b/packages/server/src/wellknown.test.ts
@@ -1,16 +1,18 @@
 import express from 'express';
-import validator from 'validator';
 import request from 'supertest';
+import validator from 'validator';
 import { initApp } from './app';
 import { loadTestConfig } from './config';
 import { closeDatabase, initDatabase } from './database';
 import { initKeys } from './oauth';
+import { closeRedis, initRedis } from './redis';
 
 const app = express();
 
 describe('Well Known', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await initApp(app);
     await initKeys(config);
@@ -18,6 +20,7 @@ describe('Well Known', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
   });
 
   test('Get /.well-known/jwks.json', async () => {

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -10,6 +10,7 @@ import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initBinaryStorage } from '../fhir';
 import { Repository } from '../fhir/repo';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { closeDownloadWorker, execDownloadJob, initDownloadWorker } from './download';
 
@@ -22,6 +23,7 @@ let repo: Repository;
 describe('Download Worker', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initBinaryStorage('file:' + binaryDir);
@@ -37,6 +39,7 @@ describe('Download Worker', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
     await closeDownloadWorker();
     await closeDownloadWorker(); // Double close to ensure quite ignore
     rmSync(binaryDir, { recursive: true, force: true });

--- a/packages/server/src/workers/index.test.ts
+++ b/packages/server/src/workers/index.test.ts
@@ -2,6 +2,7 @@ import { closeWorkers, initWorkers } from '.';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
 import { initBinaryStorage } from '../fhir';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 
 jest.mock('bullmq');
@@ -9,11 +10,13 @@ jest.mock('bullmq');
 describe('Workers', () => {
   test('Init and close', async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initBinaryStorage('file:binary');
     initWorkers(config.redis);
     await closeWorkers();
     await closeDatabase();
+    closeRedis();
   });
 });

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -17,8 +17,9 @@ import fetch from 'node-fetch';
 import { loadTestConfig } from '../config';
 import { closeDatabase, getClient, initDatabase } from '../database';
 import { getRepoForMembership, Repository, systemRepo } from '../fhir/repo';
-import { createTestProject } from '../test.setup';
+import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { createTestProject } from '../test.setup';
 import { closeSubscriptionWorker, execSubscriptionJob, initSubscriptionWorker } from './subscription';
 
 jest.mock('bullmq');
@@ -31,6 +32,7 @@ let botProject: Project;
 describe('Subscription Worker', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
+    initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
     await initSubscriptionWorker(config.redis);
@@ -63,6 +65,7 @@ describe('Subscription Worker', () => {
 
   afterAll(async () => {
     await closeDatabase();
+    closeRedis();
     await closeSubscriptionWorker();
     await closeSubscriptionWorker(); // Double close to ensure quite ignore
   });

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "lib": ["esnext"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "src/__mocks__/**/*.ts"]
 }


### PR DESCRIPTION
First draft of Redis caching.

We already use Redis in 2 ways:
1. All background jobs (mainly evaluating `Subscriptions`) are managed by `bullmq`, which uses Redis under the covers
2. The `/healthcheck` endpoint checks Redis connectivity

This PR adds MVP support for caching FHIR resources to avoid unnecessary Postgres load.

Writes:
* On resource update
* On `readResource` cache miss

Read:
* On `readResource` (by `resourceType` and `id`) and ***no*** access policy

Access policy is currently enforced by additional SQL queries.  I wanted to keep the scope of this PR small, so pushing that to another day.

Future work:
* Enforce access policies on cached resources
* Redis only resources -- i.e., short lived `Login` resources, which are not persisted in the database, especially for bot invocations