### PR TITLE
Make recaptchaSiteKey a React prop

### DIFF
--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -6,7 +6,12 @@ export function RegisterPage(): JSX.Element {
   const navigate = useNavigate();
 
   return (
-    <RegisterForm type="project" onSuccess={() => navigate('/')} googleClientId={process.env.GOOGLE_CLIENT_ID}>
+    <RegisterForm
+      type="project"
+      onSuccess={() => navigate('/')}
+      googleClientId={process.env.GOOGLE_CLIENT_ID}
+      recaptchaSiteKey={process.env.RECAPTCHA_SITE_KEY as string}
+    >
       <Logo size={32} />
       <h1>Create a new account</h1>
     </RegisterForm>

--- a/packages/app/src/ResetPasswordPage.tsx
+++ b/packages/app/src/ResetPasswordPage.tsx
@@ -13,13 +13,15 @@ import {
 } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
 
+const recaptchaSiteKey = process.env.RECAPTCHA_SITE_KEY as string;
+
 export function ResetPasswordPage(): JSX.Element {
   const medplum = useMedplum();
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const [success, setSuccess] = useState(false);
 
   useEffect(() => {
-    initRecaptcha();
+    initRecaptcha(recaptchaSiteKey);
   }, []);
 
   return (
@@ -27,7 +29,7 @@ export function ResetPasswordPage(): JSX.Element {
       <Form
         style={{ maxWidth: 400 }}
         onSubmit={(formData: Record<string, string>) => {
-          getRecaptcha().then((recaptchaToken: string) => {
+          getRecaptcha(recaptchaSiteKey).then((recaptchaToken: string) => {
             medplum
               .post('auth/resetpassword', { ...formData, recaptchaToken })
               .then(() => setSuccess(true))

--- a/packages/react/src/RegisterForm.test.tsx
+++ b/packages/react/src/RegisterForm.test.tsx
@@ -7,6 +7,8 @@ import { TextEncoder } from 'util';
 import { MedplumProvider } from './MedplumProvider';
 import { RegisterForm, RegisterFormProps } from './RegisterForm';
 
+const recaptchaSiteKey = 'abc';
+
 function mockFetch(url: string, options: any): Promise<any> {
   let status = 404;
   let result: any;
@@ -152,6 +154,7 @@ describe('RegisterForm', () => {
 
     await setup({
       type: 'project',
+      recaptchaSiteKey,
       onSuccess,
     });
 
@@ -195,6 +198,7 @@ describe('RegisterForm', () => {
     await setup({
       type: 'patient',
       projectId,
+      recaptchaSiteKey,
       onSuccess,
     });
 
@@ -272,6 +276,7 @@ describe('RegisterForm', () => {
         type: 'project',
         onSuccess,
         googleClientId: clientId,
+        recaptchaSiteKey,
       });
     });
 

--- a/packages/react/src/RegisterForm.tsx
+++ b/packages/react/src/RegisterForm.tsx
@@ -15,6 +15,7 @@ import './util.css';
 
 export interface BaseRegisterFormProps {
   readonly googleClientId?: string;
+  readonly recaptchaSiteKey: string;
   readonly children?: React.ReactNode;
   readonly onSuccess: () => void;
 }
@@ -33,10 +34,11 @@ export type RegisterFormProps = PatientRegisterFormProps | ProjectRegisterFormPr
 export function RegisterForm(props: RegisterFormProps): JSX.Element {
   const medplum = useMedplum();
   const googleClientId = getGoogleClientId(props.googleClientId);
+  const recaptchaSiteKey = props.recaptchaSiteKey;
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const issues = getIssuesForExpression(outcome, undefined);
 
-  useEffect(initRecaptcha, []);
+  useEffect(() => initRecaptcha(recaptchaSiteKey), [recaptchaSiteKey]);
 
   async function handleAuthResponse(
     registerRequest: RegisterRequest,
@@ -62,7 +64,7 @@ export function RegisterForm(props: RegisterFormProps): JSX.Element {
         style={{ maxWidth: 400 }}
         onSubmit={async (formData: Record<string, string>) => {
           try {
-            const recaptchaToken = await getRecaptcha();
+            const recaptchaToken = await getRecaptcha(recaptchaSiteKey);
             const registerRequest = { ...formData, recaptchaToken } as RegisterRequest;
             const userLogin = await medplum.startNewUser(registerRequest);
             handleAuthResponse(registerRequest, userLogin);

--- a/packages/react/src/stories/RegisterForm.stories.tsx
+++ b/packages/react/src/stories/RegisterForm.stories.tsx
@@ -9,9 +9,11 @@ export default {
   component: RegisterForm,
 } as Meta;
 
+const recaptchaSiteKey = 'abc';
+
 export function Basic(): JSX.Element {
   return (
-    <RegisterForm type="project" onSuccess={() => alert('Signed in!')}>
+    <RegisterForm type="project" recaptchaSiteKey={recaptchaSiteKey} onSuccess={() => alert('Registered!')}>
       <Logo size={32} />
       <h1>Register new account</h1>
     </RegisterForm>
@@ -21,7 +23,7 @@ export function Basic(): JSX.Element {
 export function WithFooter(): JSX.Element {
   return (
     <>
-      <RegisterForm type="project" onSuccess={() => alert('Signed in!')}>
+      <RegisterForm type="project" recaptchaSiteKey={recaptchaSiteKey} onSuccess={() => alert('Registered!')}>
         <Logo size={32} />
         <h1>Register new account</h1>
       </RegisterForm>
@@ -37,7 +39,12 @@ export function WithFooter(): JSX.Element {
 export function WithGoogle(): JSX.Element {
   return (
     <>
-      <RegisterForm type="project" onSuccess={() => alert('Signed in!')} googleClientId="xyz">
+      <RegisterForm
+        type="project"
+        recaptchaSiteKey={recaptchaSiteKey}
+        onSuccess={() => alert('Registered!')}
+        googleClientId="xyz"
+      >
         <Logo size={32} />
         <h1>Register new account</h1>
       </RegisterForm>

--- a/packages/react/src/utils/recaptcha.test.ts
+++ b/packages/react/src/utils/recaptcha.test.ts
@@ -11,14 +11,14 @@ describe('reCAPTCHA', () => {
 
     // Init Recaptcha
     // Should create a <script> tag for the Recaptcha script.
-    initRecaptcha();
+    initRecaptcha('xyz');
     expect(document.getElementsByTagName('script').length).toBe(1);
 
     // Simulate loading the script
     Object.defineProperty(global, 'grecaptcha', { value: {} });
 
     // Initializing again should not create more <script> tags
-    initRecaptcha();
+    initRecaptcha('xyz');
     expect(document.getElementsByTagName('script').length).toBe(1);
   });
 });

--- a/packages/react/src/utils/recaptcha.ts
+++ b/packages/react/src/utils/recaptcha.ts
@@ -3,21 +3,23 @@ import { createScriptTag } from '../utils';
 /**
  * Dynamically loads the recaptcha script.
  * We do not want to load the script on page load unless the user needs it.
+ * @param siteKey The reCAPTCHA site key, available from the reCAPTCHA admin page.
  */
-export function initRecaptcha(): void {
+export function initRecaptcha(siteKey: string): void {
   if (typeof grecaptcha === 'undefined') {
-    createScriptTag('https://www.google.com/recaptcha/api.js?render=' + process.env.RECAPTCHA_SITE_KEY);
+    createScriptTag('https://www.google.com/recaptcha/api.js?render=' + siteKey);
   }
 }
 
 /**
  * Starts a request to generate a recapcha token.
+ * @param siteKey The reCAPTCHA site key, available from the reCAPTCHA admin page.
  * @returns Promise to a recaptcha token for the current user.
  */
-export function getRecaptcha(): Promise<string> {
+export function getRecaptcha(siteKey: string): Promise<string> {
   return new Promise((resolve) => {
     grecaptcha.ready(() => {
-      grecaptcha.execute(process.env.RECAPTCHA_SITE_KEY as string, { action: 'submit' }).then(resolve);
+      grecaptcha.execute(siteKey, { action: 'submit' }).then(resolve);
     });
   });
 }


### PR DESCRIPTION
Before:  Recaptcha site key was assumed to be an environment variable in `process.env`

That was valid for some build tools (Webpack, Rollup) but not all build tools (Vite)

Now: Recaptcha site key is a React prop