### PR TITLE
Remove bot-layer from CI/CD

### DIFF
--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -81,11 +81,6 @@ if [[ "$DEPLOY_APP" = true ]]; then
   source ./scripts/deploy-app.sh
 fi
 
-if [[ "$DEPLOY_BOT_LAYER" = true ]]; then
-  echo "Deploy bot-layer"
-  source ./scripts/deploy-bot-layer.sh
-fi
-
 if [[ "$DEPLOY_DOCS" = true ]]; then
   echo "Deploy docs"
   source ./scripts/deploy-docs.sh


### PR DESCRIPTION
The `bot-layer` deploy step depends on the current version of `@medplum/core` to be published.  The only way this will work is after we integrate the `npm publish` step into the CI/CD pipeline.