### PR TITLE
Fixed hosts in medplum.docker.config.json

### DIFF
--- a/packages/server/medplum.docker.config.json
+++ b/packages/server/medplum.docker.config.json
@@ -22,14 +22,14 @@
   "botLambdaRoleArn": "",
   "botLambdaLayerName": "medplum-bot-layer",
   "database": {
-    "host": "localhost",
+    "host": "host.docker.internal",
     "port": 5432,
     "dbname": "medplum",
     "username": "medplum",
     "password": "medplum"
   },
   "redis": {
-    "host": "localhost",
+    "host": "host.docker.internal",
     "port": 6379,
     "password": "medplum"
   }


### PR DESCRIPTION
Inside a Docker container, `localhost` refers to the container OS.  If you want to refer to the host OS, then you need to use `host.docker.internal`.

In this case, the server container tried to connect to postgres on `localhost`, but postgres is running in a different container, so it needs to use `host.docker.internal`.