### PR TITLE
Use rollup preserveModules to enable tree shaking

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc && npm run rollup",
+    "build": "npm run clean && npm run rollup",
     "rollup": "rollup --config rollup.config.js",
     "test": "jest"
   },
@@ -34,7 +34,7 @@
     "require": "./dist/cjs/index.js",
     "import": "./dist/esm/index.js"
   },
-  "types": "dist/types/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "medplum",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -11,48 +11,61 @@ const globals = {
   stream: 'stream',
 };
 
-export default {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'dist/esm/index.js',
-      format: 'esm',
-      sourcemap: true,
-    },
-    {
-      file: 'dist/esm/index.min.js',
-      format: 'esm',
-      plugins: [terser()],
-      sourcemap: true,
-    },
-    {
-      file: 'dist/cjs/index.js',
-      format: 'umd',
-      name: 'medplum.core',
-      sourcemap: true,
-      globals,
-    },
-    {
-      file: 'dist/cjs/index.min.js',
-      format: 'umd',
-      name: 'medplum.core',
-      plugins: [terser()],
-      sourcemap: true,
-      globals,
-    },
-  ],
-  plugins: [
-    json(),
-    resolve({ extensions }),
-    typescript({ resolveJsonModule: true }),
-    {
-      buildEnd: () => {
-        mkdirSync('./dist/cjs', { recursive: true });
-        mkdirSync('./dist/esm', { recursive: true });
-        writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}');
-        writeFileSync('./dist/esm/package.json', '{"type": "module"}');
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/cjs/index.js',
+        format: 'umd',
+        name: 'medplum.core',
+        sourcemap: true,
+        globals,
       },
-    },
-  ],
-  external: Object.keys(globals),
-};
+      {
+        file: 'dist/cjs/index.min.js',
+        format: 'umd',
+        name: 'medplum.core',
+        plugins: [terser()],
+        sourcemap: true,
+        globals,
+      },
+    ],
+    plugins: [
+      json(),
+      resolve({ extensions }),
+      typescript({ tsconfig: 'tsconfig.cjs.json', resolveJsonModule: true }),
+      {
+        buildEnd: () => {
+          mkdirSync('./dist/cjs', { recursive: true });
+          writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}');
+        },
+      },
+    ],
+    external: Object.keys(globals),
+  },
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        dir: 'dist/esm',
+        format: 'esm',
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      json(),
+      resolve({ extensions }),
+      typescript({ tsconfig: 'tsconfig.esm.json', resolveJsonModule: true }),
+      {
+        buildEnd: () => {
+          mkdirSync('./dist/esm', { recursive: true });
+          writeFileSync('./dist/esm/package.json', '{"type": "module"}');
+        },
+      },
+    ],
+    external: Object.keys(globals),
+  },
+];

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -11,6 +11,8 @@ const globals = {
   stream: 'stream',
 };
 
+const sourcemapPathTransform = (path) => path.replaceAll('\\', '/').replaceAll('../../../src', '../../src');
+
 export default [
   {
     input: 'src/index.ts',
@@ -20,6 +22,7 @@ export default [
         format: 'umd',
         name: 'medplum.core',
         sourcemap: true,
+        sourcemapPathTransform,
         globals,
       },
       {
@@ -28,6 +31,7 @@ export default [
         name: 'medplum.core',
         plugins: [terser()],
         sourcemap: true,
+        sourcemapPathTransform,
         globals,
       },
     ],
@@ -53,6 +57,14 @@ export default [
         preserveModules: true,
         preserveModulesRoot: 'src',
         sourcemap: true,
+        sourcemapPathTransform,
+      },
+      {
+        file: 'dist/esm/index.min.js',
+        format: 'esm',
+        plugins: [terser()],
+        sourcemap: true,
+        sourcemapPathTransform,
       },
     ],
     plugins: [

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs"
+  },
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
+    "outDir": "dist/esm"
   },
   "exclude": ["**/*.test.ts"]
 }

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+  },
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist/types",
+    "rootDir": "src",
     "lib": ["esnext", "dom"],
     "emitDeclarationOnly": true,
     "resolveJsonModule": true

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "clean": "rimraf dist storybook-static",
     "dev": "start-storybook -p 6006",
-    "build": "npm run clean && tsc && npm run rollup",
+    "build": "npm run clean && npm run rollup",
     "rollup": "rollup --config rollup.config.js",
     "test": "jest",
     "storybook": "build-storybook"
@@ -69,7 +69,7 @@
       "import": "./dist/esm/styles.css"
     }
   },
-  "types": "dist/types/index.d.ts",
+  "types": "dist/esm/index.d.ts",
   "sideEffects": [
     "*.css"
   ],

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -20,6 +20,8 @@ const globals = {
   'react-router-dom': 'ReactRouterDOM',
 };
 
+const sourcemapPathTransform = (path) => path.replaceAll('\\', '/').replaceAll('../../../src', '../../src');
+
 export default [
   {
     input: 'src/index.ts',
@@ -29,6 +31,7 @@ export default [
         format: 'umd',
         name: 'medplum.ui',
         sourcemap: true,
+        sourcemapPathTransform,
         globals,
       },
       {
@@ -37,6 +40,7 @@ export default [
         name: 'medplum.ui',
         plugins: [terser()],
         sourcemap: true,
+        sourcemapPathTransform,
         globals,
       },
     ],
@@ -74,13 +78,14 @@ export default [
         preserveModules: true,
         preserveModulesRoot: 'src',
         sourcemap: true,
-        sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
-          // will replace relative paths with absolute paths
-          // return path.resolve(path.dirname(sourcemapPath), relativeSourcePath);
-          // console.log('CODY sourcemapPathTransform', relativeSourcePath, sourcemapPath);
-          // return relativeSourcePath;
-          return relativeSourcePath.replaceAll('\\', '/').replaceAll('../../../src', '../../src');
-        },
+        sourcemapPathTransform,
+      },
+      {
+        file: 'dist/esm/index.min.js',
+        format: 'esm',
+        plugins: [terser()],
+        sourcemap: true,
+        sourcemapPathTransform,
       },
     ],
     plugins: [

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -20,63 +20,92 @@ const globals = {
   'react-router-dom': 'ReactRouterDOM',
 };
 
-export default {
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'dist/esm/index.js',
-      format: 'esm',
-      sourcemap: true,
-    },
-    {
-      file: 'dist/esm/index.min.js',
-      format: 'esm',
-      plugins: [terser()],
-      sourcemap: true,
-    },
-    {
-      file: 'dist/cjs/index.js',
-      format: 'umd',
-      name: 'medplum.ui',
-      sourcemap: true,
-      globals,
-    },
-    {
-      file: 'dist/cjs/index.min.js',
-      format: 'umd',
-      name: 'medplum.ui',
-      plugins: [terser()],
-      sourcemap: true,
-      globals,
-    },
-  ],
-  plugins: [
-    replace({
-      preventAssignment: true,
-      values: {
-        'process.env.NODE_ENV': '"production"',
-        'process.env.GOOGLE_AUTH_ORIGINS': `"${process.env.GOOGLE_AUTH_ORIGINS}"`,
-        'process.env.GOOGLE_CLIENT_ID': `"${process.env.GOOGLE_CLIENT_ID}"`,
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/cjs/index.js',
+        format: 'umd',
+        name: 'medplum.ui',
+        sourcemap: true,
+        globals,
       },
-    }),
-    peerDepsExternal(),
-    postcss({ extract: 'styles.css' }),
-    resolve({ extensions }),
-    typescript(),
-    copy({
-      targets: [
-        { src: 'src/defaulttheme.css', dest: 'dist/esm/' },
-        { src: 'src/defaulttheme.css', dest: 'dist/cjs/' },
-      ],
-    }),
-    {
-      buildEnd: () => {
-        mkdirSync('./dist/cjs', { recursive: true });
-        mkdirSync('./dist/esm', { recursive: true });
-        writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}');
-        writeFileSync('./dist/esm/package.json', '{"type": "module"}');
+      {
+        file: 'dist/cjs/index.min.js',
+        format: 'umd',
+        name: 'medplum.ui',
+        plugins: [terser()],
+        sourcemap: true,
+        globals,
       },
-    },
-  ],
-  external: Object.keys(globals),
-};
+    ],
+    plugins: [
+      replace({
+        preventAssignment: true,
+        values: {
+          'process.env.NODE_ENV': '"production"',
+          'process.env.GOOGLE_AUTH_ORIGINS': `"${process.env.GOOGLE_AUTH_ORIGINS}"`,
+          'process.env.GOOGLE_CLIENT_ID': `"${process.env.GOOGLE_CLIENT_ID}"`,
+        },
+      }),
+      peerDepsExternal(),
+      postcss({ extract: 'styles.css' }),
+      resolve({ extensions }),
+      typescript({ tsconfig: 'tsconfig.cjs.json', resolveJsonModule: true }),
+      copy({
+        targets: [{ src: 'src/defaulttheme.css', dest: 'dist/cjs/' }],
+      }),
+      {
+        buildEnd: () => {
+          mkdirSync('./dist/cjs', { recursive: true });
+          writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}');
+        },
+      },
+    ],
+    external: Object.keys(globals),
+  },
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        dir: 'dist/esm',
+        format: 'esm',
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+        sourcemap: true,
+        sourcemapPathTransform: (relativeSourcePath, sourcemapPath) => {
+          // will replace relative paths with absolute paths
+          // return path.resolve(path.dirname(sourcemapPath), relativeSourcePath);
+          // console.log('CODY sourcemapPathTransform', relativeSourcePath, sourcemapPath);
+          // return relativeSourcePath;
+          return relativeSourcePath.replaceAll('\\', '/').replaceAll('../../../src', '../../src');
+        },
+      },
+    ],
+    plugins: [
+      replace({
+        preventAssignment: true,
+        values: {
+          'process.env.NODE_ENV': '"production"',
+          'process.env.GOOGLE_AUTH_ORIGINS': `"${process.env.GOOGLE_AUTH_ORIGINS}"`,
+          'process.env.GOOGLE_CLIENT_ID': `"${process.env.GOOGLE_CLIENT_ID}"`,
+        },
+      }),
+      peerDepsExternal(),
+      postcss({ extract: 'styles.css' }),
+      resolve({ extensions }),
+      typescript({ tsconfig: 'tsconfig.esm.json', resolveJsonModule: true }),
+      copy({
+        targets: [{ src: 'src/defaulttheme.css', dest: 'dist/esm/' }],
+      }),
+      {
+        buildEnd: () => {
+          mkdirSync('./dist/esm', { recursive: true });
+          writeFileSync('./dist/esm/package.json', '{"type": "module"}');
+        },
+      },
+    ],
+    external: Object.keys(globals),
+  },
+];

--- a/packages/react/tsconfig.cjs.json
+++ b/packages/react/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs"
+  },
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+  },
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/esm",
+    "outDir": "dist/esm"
   },
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist/types",
+    "rootDir": "src",
     "lib": ["esnext", "dom", "dom.iterable"],
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
Tree shaking:

> Tree shaking is a term commonly used within a JavaScript context to describe the removal of dead code.
> 
> It relies on the import and export statements in ES2015 to detect if code modules are exported and imported for use between JavaScript files.
> 
> In modern JavaScript applications, we use module bundlers (e.g., webpack or Rollup) to automatically remove dead code when bundling multiple JavaScript files into single files. This is important for preparing code that is production ready, for example with clean structures and minimal file size.

https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking

Before:
* We generated 4 files for the 4 different build types
  * `dist/cjs/index.min.js` - CommonJS minified
  * `dist/cjs/index.js` - CommonJS not-minified
  * `dist/esm/index.min.js` - ESM minified
  * `dist/esm/index.js` - ESM not-minified
* These were tree-shakable by some tools (i.e., Google Closure) but not most (i.e., Webpack or Rollup)

After:
* We still generate 3 of the 4 original files:
  * `dist/cjs/index.min.js` - CommonJS minified
  * `dist/cjs/index.js` - CommonJS not-minified
  * `dist/esm/index.min.js` - ESM minified
* ESM not-minified (`dist/esm/index.js`) is replaced by a larger build using Rollup's `preserveModules`
  * Basically each individual TS file is compiled individually
  * When a customer `import { MedplumClient } from '@medplum/core', they only pull in the necessary classes
  * For example, they do not pull in all of the fhirpath implementation
  * This shaves ~100kb (pre-gzip) off of foomedical

This should be a transparent change to any consumer.  Tree shaking should "just work" for anyone using Webpack, Rollup, or Vite.