### PR TITLE
Added loadOnFocus option to Autocomplete component

### DIFF
--- a/packages/react/src/Autocomplete.test.tsx
+++ b/packages/react/src/Autocomplete.test.tsx
@@ -509,21 +509,21 @@ describe('Autocomplete', () => {
     expect(onChange).toBeCalledWith(['Bob Jones']);
   });
 
-  test('Dropdown goes away if no input', async () => {
+  test('Load on focus', async () => {
     render(
       <Autocomplete
         name="foo"
         loadOptions={async () => ['Homer Simpson', 'Bob Jones']}
         getId={(item: string) => item}
         getDisplay={(item: string) => <span>{item}</span>}
+        loadOnFocus={true}
       />
     );
 
     const input = screen.getByTestId('input-element') as HTMLInputElement;
 
-    // Enter "Simpson"
     await act(async () => {
-      fireEvent.change(input, { target: { value: 'Simpson' } });
+      fireEvent.focus(input);
     });
 
     // Wait for the drop down
@@ -532,18 +532,7 @@ describe('Autocomplete', () => {
     });
 
     await waitFor(() => screen.getByTestId('dropdown'));
-
-    // Remove input
-    await act(async () => {
-      fireEvent.change(input, { target: { value: '' } });
-    });
-
-    // Wait for the drop down to go away
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    expect(screen.queryByTestId('dropdown')).toBeNull();
+    expect(screen.getByTestId('dropdown')).toBeInTheDocument();
   });
 
   test('Down arrow does not go past last entry', async () => {

--- a/packages/react/src/Autocomplete.tsx
+++ b/packages/react/src/Autocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { killEvent } from './utils/dom';
 import './Autocomplete.css';
+import { killEvent } from './utils/dom';
 
 export interface AutocompleteProps<T> {
   name: string;
@@ -9,6 +9,7 @@ export interface AutocompleteProps<T> {
   defaultValue?: T[];
   className?: string;
   placeholder?: string;
+  loadOnFocus?: boolean;
   loadOptions: (input: string, signal: AbortSignal) => Promise<T[]>;
   buildUnstructured?: (input: string) => T;
   getId: (item: T) => string;
@@ -22,7 +23,7 @@ export interface AutocompleteProps<T> {
 export function Autocomplete<T>(props: AutocompleteProps<T>): JSX.Element {
   const inputRef = useRef<HTMLInputElement>(null);
   const [focused, setFocused] = useState(false);
-  const [lastValue, setLastValue] = useState('');
+  const [lastValue, setLastValue] = useState<string | undefined>(undefined);
   const [timer, setTimer] = useState<number>();
   const [dropDownVisible, setDropDownVisible] = useState(false);
   const [values, setValues] = useState(props.defaultValue ?? []);
@@ -85,6 +86,9 @@ export function Autocomplete<T>(props: AutocompleteProps<T>): JSX.Element {
 
   function handleFocus(): void {
     setFocused(true);
+    if (props.loadOnFocus) {
+      handleInput();
+    }
   }
 
   function handleBlur(): void {
@@ -233,14 +237,6 @@ export function Autocomplete<T>(props: AutocompleteProps<T>): JSX.Element {
     const value = inputRef.current?.value?.trim() || '';
     if (value === lastValueRef.current) {
       // Nothing has changed, move on
-      return;
-    }
-
-    if (!value) {
-      setDropDownVisible(false);
-      setLastValue('');
-      setOptions([]);
-      setSelectedIndex(-1);
       return;
     }
 

--- a/packages/react/src/stories/Autocomplete.stories.tsx
+++ b/packages/react/src/stories/Autocomplete.stories.tsx
@@ -104,3 +104,15 @@ export const HelpText = (): JSX.Element => (
     />
   </Document>
 );
+
+export const LoadOnFocus = (): JSX.Element => (
+  <Document>
+    <Autocomplete
+      name="foo"
+      loadOptions={search}
+      getId={(option: string) => option}
+      getDisplay={(option: string) => <div>{option}</div>}
+      loadOnFocus={true}
+    />
+  </Document>
+);


### PR DESCRIPTION
Before:  The `<Autocomplete>` component, and everything based on it (`<ResourceInput>`, `<ReferenceInput>`, `<CodingInput>`, etc) waited until the user entered text before attempting to load.

After:  The `<Autocomplete>` has a `loadOnFocus` option, which initiates a search as soon as the user focuses on the input.

This will be particularly useful for resource inputs that do not have a searchable "name" field, and we want to support selection (i.e., `Schedule`).