### PR TITLE
Remove vm context bot

### DIFF
--- a/packages/server/src/__mocks__/@aws-sdk/client-lambda.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-lambda.ts
@@ -1,0 +1,118 @@
+export enum PackageType {
+  Image = 'Image',
+  Zip = 'Zip',
+}
+
+export class CreateFunctionCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class GetFunctionCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class GetFunctionConfigurationCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class ListLayerVersionsCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class UpdateFunctionCodeCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class UpdateFunctionConfigurationCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class InvokeCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class LambdaClient {
+  static created = false;
+  static updated = false;
+
+  async send(command: any): Promise<any> {
+    if (command instanceof CreateFunctionCommand) {
+      LambdaClient.created = true;
+      return {
+        FunctionName: command.input.FunctionName,
+      };
+    }
+
+    if (command instanceof GetFunctionCommand) {
+      if (LambdaClient.created) {
+        return {
+          Configuration: {
+            FunctionName: command.input.FunctionName,
+          },
+        };
+      } else {
+        throw new Error('Function not found');
+      }
+    }
+
+    if (command instanceof GetFunctionConfigurationCommand) {
+      return {
+        FunctionName: command.input.FunctionName,
+        Runtime: 'node16.x',
+        Handler: 'index.handler',
+        Layers: [
+          {
+            Arn: 'arn:aws:lambda:us-east-1:123456789012:layer:test-layer:1',
+          },
+        ],
+      };
+    }
+
+    if (command instanceof ListLayerVersionsCommand) {
+      return {
+        LayerVersions: [
+          {
+            LayerVersionArn: 'xyz',
+          },
+        ],
+      };
+    }
+
+    if (command instanceof UpdateFunctionCodeCommand) {
+      LambdaClient.updated = true;
+      return {
+        FunctionName: command.input.FunctionName,
+      };
+    }
+
+    if (command instanceof InvokeCommand) {
+      const decoder = new TextDecoder();
+      const event = JSON.parse(decoder.decode(command.input.Payload));
+      const output = typeof event.input === 'string' ? event.input : JSON.stringify(event.input);
+      const encoder = new TextEncoder();
+
+      // console.log('mock lambda client input', decoder.decode(command.input.Payload));
+      // LogResult:
+      // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
+      // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
+      // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+      // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+      return {
+        LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
+        Payload: encoder.encode(output),
+      };
+
+      // // LogResult:
+      // // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
+      // // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
+      // // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+      // // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+      // return {
+      //   LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
+      //   Payload: '',
+      // };
+    }
+
+    return undefined;
+  }
+}

--- a/packages/server/src/__mocks__/@aws-sdk/client-lambda.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-lambda.ts
@@ -101,16 +101,6 @@ export class LambdaClient {
         LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
         Payload: encoder.encode(output),
       };
-
-      // // LogResult:
-      // // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
-      // // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
-      // // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-      // // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-      // return {
-      //   LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
-      //   Payload: '',
-      // };
     }
 
     return undefined;

--- a/packages/server/src/__mocks__/@aws-sdk/client-sesv2.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-sesv2.ts
@@ -1,0 +1,4 @@
+export const SendEmailCommand = jest.fn(() => ({}));
+export const SESv2Client = jest.fn(() => ({
+  send: jest.fn(),
+}));

--- a/packages/server/src/__mocks__/@aws-sdk/lib-storage.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/lib-storage.ts
@@ -1,0 +1,3 @@
+export const Upload = jest.fn(() => ({
+  done: jest.fn(),
+}));

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -15,7 +15,6 @@ import { seedDatabase } from '../seed';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
 
-jest.mock('@aws-sdk/client-sesv2');
 jest.mock('hibp');
 jest.mock('node-fetch');
 

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -9,38 +9,6 @@ import { closeRedis, initRedis } from '../../redis';
 import { seedDatabase } from '../../seed';
 import { initTestAuth } from '../../test.setup';
 
-jest.mock('@aws-sdk/client-lambda', () => {
-  const original = jest.requireActual('@aws-sdk/client-lambda');
-
-  class LambdaClient {
-    async send(command: any): Promise<any> {
-      if (command instanceof original.InvokeCommand) {
-        const decoder = new TextDecoder();
-        const event = JSON.parse(decoder.decode(command.input.Payload));
-        const output = typeof event.input === 'string' ? event.input : JSON.stringify(event.input);
-        const encoder = new TextEncoder();
-
-        // console.log('mock lambda client input', decoder.decode(command.input.Payload));
-        // LogResult:
-        // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
-        // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
-        // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-        // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-        return {
-          LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
-          Payload: encoder.encode(output),
-        };
-      }
-      return {};
-    }
-  }
-
-  return {
-    ...original,
-    LambdaClient,
-  };
-});
-
 const app = express();
 let accessToken: string;
 let bot: Bot;
@@ -63,7 +31,6 @@ describe('Execute', () => {
         resourceType: 'Bot',
         name: 'Test Bot',
         runtimeVersion: 'awslambda',
-        // code: `console.log('input', input); return input;`,
         code: `
           export async function handler(medplum, event) {
             console.log('input', event.input);

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -13,16 +13,25 @@ jest.mock('@aws-sdk/client-lambda', () => {
   const original = jest.requireActual('@aws-sdk/client-lambda');
 
   class LambdaClient {
-    async send(): Promise<any> {
-      // LogResult:
-      // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
-      // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
-      // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-      // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
-      return {
-        LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
-        Payload: '',
-      };
+    async send(command: any): Promise<any> {
+      if (command instanceof original.InvokeCommand) {
+        const decoder = new TextDecoder();
+        const event = JSON.parse(decoder.decode(command.input.Payload));
+        const output = typeof event.input === 'string' ? event.input : JSON.stringify(event.input);
+        const encoder = new TextEncoder();
+
+        // console.log('mock lambda client input', decoder.decode(command.input.Payload));
+        // LogResult:
+        // START RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873 Version: $LATEST
+        // 2022-05-30T16:12:22.685Z	146fcfcf-c32b-43f5-82a6-ee0f3132d873	INFO test
+        // END RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+        // REPORT RequestId: 146fcfcf-c32b-43f5-82a6-ee0f3132d873
+        return {
+          LogResult: `U1RBUlQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMgVmVyc2lvbjogJExBVEVTVAoyMDIyLTA1LTMwVDE2OjEyOjIyLjY4NVoJMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODczCUlORk8gdGVzdApFTkQgUmVxdWVzdElkOiAxNDZmY2ZjZi1jMzJiLTQzZjUtODJhNi1lZTBmMzEzMmQ4NzMKUkVQT1JUIFJlcXVlc3RJZDogMTQ2ZmNmY2YtYzMyYi00M2Y1LTgyYTYtZWUwZjMxMzJkODcz`,
+          Payload: encoder.encode(output),
+        };
+      }
+      return {};
     }
   }
 
@@ -53,7 +62,14 @@ describe('Execute', () => {
       .send({
         resourceType: 'Bot',
         name: 'Test Bot',
-        code: `console.log('input', input); return input;`,
+        runtimeVersion: 'awslambda',
+        // code: `console.log('input', input); return input;`,
+        code: `
+          export async function handler(medplum, event) {
+            console.log('input', event.input);
+            return event.input;
+          }
+        `,
       });
     expect(res.status).toBe(201);
     bot = res.body as Bot;

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -120,8 +120,7 @@ describe('Execute', () => {
     expect(res2.status).toBe(400);
   });
 
-  test('Execute on AWS Lambda', async () => {
-    // Step 1: Create a bot
+  test('Unsupported runtime version', async () => {
     const res1 = await request(app)
       .post(`/fhir/R4/Bot`)
       .set('Content-Type', 'application/fhir+json')
@@ -129,7 +128,7 @@ describe('Execute', () => {
       .send({
         resourceType: 'Bot',
         name: 'Test Bot',
-        runtimeVersion: 'awslambda',
+        runtimeVersion: 'unsupported',
         code: `
         export async function handler() {
           console.log('input', input);
@@ -154,6 +153,6 @@ describe('Execute', () => {
       .set('Content-Type', 'application/fhir+json')
       .set('Authorization', 'Bearer ' + accessToken)
       .send({});
-    expect(res3.status).toBe(200);
+    expect(res3.status).toBe(400);
   });
 });

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -83,7 +83,7 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
   if (bot.runtimeVersion === 'awslambda') {
     return runInLambda(request);
   } else {
-    throw new Error('Unsupported bot runtime');
+    return { success: false, logResult: 'Unsupported bot runtime' };
   }
 }
 

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -2,18 +2,11 @@ import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { assertOk, createReference, Hl7Message, resolveId } from '@medplum/core';
 import { AuditEvent, Bot, Login, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import fetch from 'node-fetch';
-import Mail from 'nodemailer/lib/mailer';
 import { TextDecoder, TextEncoder } from 'util';
-import vm from 'vm';
 import { asyncWrap } from '../../async';
-import { sendEmail } from '../../email/email';
 import { generateAccessToken } from '../../oauth';
 import { AuditEventOutcome } from '../../util/auditevent';
-import { MockConsole } from '../../util/console';
-import { createPdf } from '../../util/pdf';
-import { getRepoForMembership, Repository, systemRepo } from '../repo';
-import { rewriteAttachments, RewriteMode } from '../rewrite';
+import { Repository, systemRepo } from '../repo';
 
 export const EXECUTE_CONTENT_TYPES = [
   'application/json',
@@ -90,7 +83,7 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
   if (bot.runtimeVersion === 'awslambda') {
     return runInLambda(request);
   } else {
-    return runInVmContext(request);
+    throw new Error('Unsupported bot runtime');
   }
 }
 
@@ -209,54 +202,6 @@ function parseLambdaLog(logResult: string): string {
     }
   }
   return result.join('\n');
-}
-
-/**
- * Executes a Bot in a VM sandbox.
- * @param request The bot request.
- * @returns The bot execution result.
- */
-async function runInVmContext(request: BotExecutionRequest): Promise<BotExecutionResult> {
-  const { bot, runAs, input } = request;
-  const botRepo = await getRepoForMembership(runAs);
-  const botConsole = new MockConsole();
-
-  const sandbox = {
-    input,
-    resource: input,
-    repo: botRepo,
-    console: botConsole,
-    fetch,
-    assertOk,
-    createReference,
-    createPdf,
-    sendEmail: async (args: Mail.Options) => {
-      await sendEmail(await rewriteAttachments(RewriteMode.PRESIGNED_URL, botRepo, args));
-    },
-  };
-
-  const options: vm.RunningScriptOptions = {
-    timeout: 100,
-  };
-
-  // Wrap code in an async block for top-level await support
-  const wrappedCode = '(async () => {' + bot.code + '})();';
-
-  // Return the result of the code execution
-  try {
-    const returnValue = (await vm.runInNewContext(wrappedCode, sandbox, options)) as any;
-    return {
-      success: true,
-      logResult: botConsole.toString(),
-      returnValue,
-    };
-  } catch (err) {
-    botConsole.log('Error', (err as Error).message);
-    return {
-      success: false,
-      logResult: botConsole.toString(),
-    };
-  }
 }
 
 function getResponseContentType(req: Request): string {

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1,22 +1,12 @@
 import { assertOk, createReference, getReferenceString, Operator, stringify } from '@medplum/core';
-import {
-  AccessPolicy,
-  AuditEvent,
-  Bot,
-  Observation,
-  Patient,
-  Practitioner,
-  Project,
-  ProjectMembership,
-  QuestionnaireResponse,
-  Subscription,
-} from '@medplum/fhirtypes';
+import { AuditEvent, Bot, Observation, Patient, Project, ProjectMembership, Subscription } from '@medplum/fhirtypes';
 import { Job, Queue } from 'bullmq';
 import { createHmac, randomUUID } from 'crypto';
 import fetch from 'node-fetch';
 import { loadTestConfig } from '../config';
 import { closeDatabase, getClient, initDatabase } from '../database';
-import { getRepoForMembership, Repository, systemRepo } from '../fhir/repo';
+import { Repository, systemRepo } from '../fhir/repo';
+import { initKeys } from '../oauth';
 import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { createTestProject } from '../test.setup';
@@ -27,7 +17,6 @@ jest.mock('node-fetch');
 
 let repo: Repository;
 let botRepo: Repository;
-let botProject: Project;
 
 describe('Subscription Worker', () => {
   beforeAll(async () => {
@@ -35,6 +24,7 @@ describe('Subscription Worker', () => {
     initRedis(config.redis);
     await initDatabase(config.database);
     await seedDatabase();
+    await initKeys(config);
     await initSubscriptionWorker(config.redis);
 
     // Create one simple project with no advanced features enabled
@@ -56,7 +46,6 @@ describe('Subscription Worker', () => {
 
     // Create another project, this one with bots enabled
     const botProjectDetails = await createTestProject();
-    botProject = botProjectDetails.project;
     botRepo = new Repository({
       project: botProjectDetails.project.id,
       author: createReference(botProjectDetails.client),
@@ -523,7 +512,13 @@ describe('Subscription Worker', () => {
       resourceType: 'Bot',
       name: 'Test Bot',
       description: 'Test Bot',
-      code: `console.log('${nonce}');`,
+      runtimeVersion: 'awslambda',
+      code: `
+        export async function handler(medplum, event) {
+          console.log('${nonce}');
+          return event.input;
+        }
+      `,
     });
     assertOk(botOutcome, bot);
 
@@ -580,13 +575,16 @@ describe('Subscription Worker', () => {
   });
 
   test('Execute bot subscriptions', async () => {
-    const nonce = randomUUID();
-
     const [botOutcome, bot] = await botRepo.createResource<Bot>({
       resourceType: 'Bot',
       name: 'Test Bot',
       description: 'Test Bot',
-      code: `console.log('${nonce}');`,
+      runtimeVersion: 'awslambda',
+      code: `
+        export async function handler(medplum, event) {
+          return event.input;
+        }
+      `,
     });
     assertOk(botOutcome, bot);
 
@@ -640,465 +638,6 @@ describe('Subscription Worker', () => {
     assertOk(searchOutcome, bundle);
     expect(bundle.entry?.length).toEqual(1);
     expect(bundle.entry?.[0]?.resource?.outcome).toEqual('0');
-    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain(nonce);
-  });
-
-  test('Bot run as user', async () => {
-    const nonce = randomUUID();
-
-    // Create a bot
-    // This bot takes a QuestionnaireResponse as an input
-    // And creates a patient as an output
-    const [botOutcome, bot] = await botRepo.createResource<Bot>({
-      resourceType: 'Bot',
-      name: 'Test Bot',
-      description: 'Test Bot',
-      code: `
-        const [outcome, patient] = await repo.createResource({
-          resourceType: 'Patient',
-          name: [{ family: resource.item[0].answer[0].valueString }],
-        });
-        assertOk(outcome, patient);
-      `,
-      runAsUser: true,
-    });
-    assertOk(botOutcome, bot);
-
-    // Create the subscription that listens for QuestionnaireResponses
-    const [subscriptionOutcome, subscription] = await botRepo.createResource<Subscription>({
-      resourceType: 'Subscription',
-      status: 'active',
-      criteria: 'QuestionnaireResponse',
-      channel: {
-        type: 'rest-hook',
-        endpoint: getReferenceString(bot as Bot),
-      },
-    });
-    assertOk(subscriptionOutcome, subscription);
-
-    const queue = (Queue as unknown as jest.Mock).mock.instances[0];
-    queue.add.mockClear();
-
-    const [qrOutcome, qr] = await botRepo.createResource<QuestionnaireResponse>({
-      resourceType: 'QuestionnaireResponse',
-      item: [
-        {
-          linkId: 'q1',
-          answer: [
-            {
-              valueString: nonce,
-            },
-          ],
-        },
-      ],
-    });
-    assertOk(qrOutcome, qr);
-    expect(queue.add).toHaveBeenCalled();
-
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
-    await execSubscriptionJob(job);
-
-    const [auditEventOutcome, auditEventBundle] = await botRepo.search<AuditEvent>({
-      resourceType: 'AuditEvent',
-      filters: [
-        {
-          code: 'entity',
-          operator: Operator.EQUALS,
-          value: getReferenceString(subscription as Subscription),
-        },
-      ],
-    });
-    assertOk(auditEventOutcome, auditEventBundle);
-    expect(auditEventBundle.entry?.length).toEqual(1);
-    expect(auditEventBundle.entry?.[0]?.resource?.outcome).toEqual('0');
-
-    // Search for the new patient
-    // 1) This patient should exist
-    // 2) In the meta, the author should be the client, not the bot
-    const [patientOutcome, patientBundle] = await botRepo.search<Patient>({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.CONTAINS,
-          value: nonce,
-        },
-      ],
-    });
-    assertOk(patientOutcome, patientBundle);
-    expect(patientBundle.entry?.length).toEqual(1);
-    expect(patientBundle.entry?.[0]?.resource?.name?.[0]?.family).toEqual(nonce);
-    expect(patientBundle.entry?.[0]?.resource?.meta?.author?.reference?.startsWith('ClientApplication')).toBe(true);
-  });
-
-  test('Bot run as user with restricted access policy', async () => {
-    const nonce = randomUUID();
-
-    // Create a practitioner profile
-    const [practitionerOutcome, practitioner] = await botRepo.createResource<Practitioner>({
-      resourceType: 'Practitioner',
-    });
-    assertOk(practitionerOutcome, practitioner);
-
-    // Create an access policy
-    // Can only access QuestionnaireResponse resources
-    const [accessPolicyOutcome, accessPolicy] = await botRepo.createResource<AccessPolicy>({
-      resourceType: 'AccessPolicy',
-      resource: [
-        {
-          resourceType: 'QuestionnaireResponse',
-        },
-      ],
-    });
-    assertOk(accessPolicyOutcome, accessPolicy);
-
-    // Create a membership for the practitioner and the access policy
-    const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
-      resourceType: 'ProjectMembership',
-      project: createReference(botProject),
-      profile: createReference(practitioner),
-      accessPolicy: createReference(accessPolicy),
-      user: {
-        reference: 'User/' + randomUUID(),
-      },
-    });
-    assertOk(membershipOutcome, membership);
-
-    // Create a bot
-    // This bot takes a QuestionnaireResponse as an input
-    // It just performs a patient search
-    // The new practitioner user does not have access to patients, so this will fail.
-    const [botOutcome, bot] = await botRepo.createResource<Bot>({
-      resourceType: 'Bot',
-      name: 'Test Bot',
-      description: 'Test Bot',
-      code: `
-        const [outcome, patient] = await repo.search({
-          resourceType: 'Patient',
-        });
-        assertOk(outcome, patient);
-      `,
-      runAsUser: true,
-    });
-    assertOk(botOutcome, bot);
-
-    // Create the subscription that listens for QuestionnaireResponses
-    const [subscriptionOutcome, subscription] = await botRepo.createResource<Subscription>({
-      resourceType: 'Subscription',
-      status: 'active',
-      criteria: 'QuestionnaireResponse',
-      channel: {
-        type: 'rest-hook',
-        endpoint: getReferenceString(bot as Bot),
-      },
-    });
-    assertOk(subscriptionOutcome, subscription);
-
-    const queue = (Queue as unknown as jest.Mock).mock.instances[0];
-    queue.add.mockClear();
-
-    // Start acting as the user
-    const userRepo = await getRepoForMembership(membership);
-
-    const [qrOutcome, qr] = await userRepo.createResource<QuestionnaireResponse>({
-      resourceType: 'QuestionnaireResponse',
-      item: [
-        {
-          linkId: 'q1',
-          answer: [
-            {
-              valueString: nonce,
-            },
-          ],
-        },
-      ],
-    });
-    assertOk(qrOutcome, qr);
-    expect(queue.add).toHaveBeenCalled();
-
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
-    await execSubscriptionJob(job);
-
-    const [auditEventOutcome, auditEventBundle] = await botRepo.search<AuditEvent>({
-      resourceType: 'AuditEvent',
-      filters: [
-        {
-          code: 'entity',
-          operator: Operator.EQUALS,
-          value: getReferenceString(subscription as Subscription),
-        },
-      ],
-    });
-    assertOk(auditEventOutcome, auditEventBundle);
-    expect(auditEventBundle.entry?.length).toEqual(1);
-    expect(auditEventBundle.entry?.[0]?.resource?.outcome).toEqual('4');
-  });
-
-  test('Bot run as user with readonly access policy', async () => {
-    const nonce = randomUUID();
-
-    // Create a practitioner profile
-    const [practitionerOutcome, practitioner] = await botRepo.createResource<Practitioner>({
-      resourceType: 'Practitioner',
-    });
-    assertOk(practitionerOutcome, practitioner);
-
-    // Create an access policy
-    // Patients are readonly
-    const [accessPolicyOutcome, accessPolicy] = await botRepo.createResource<AccessPolicy>({
-      resourceType: 'AccessPolicy',
-      resource: [
-        {
-          resourceType: 'QuestionnaireResponse',
-        },
-        {
-          resourceType: 'Patient',
-          readonly: true,
-        },
-      ],
-    });
-    assertOk(accessPolicyOutcome, accessPolicy);
-
-    // Create a membership for the practitioner and the access policy
-    const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
-      resourceType: 'ProjectMembership',
-      project: createReference(botProject),
-      profile: createReference(practitioner),
-      accessPolicy: createReference(accessPolicy),
-      user: {
-        reference: 'User/' + randomUUID(),
-      },
-    });
-    assertOk(membershipOutcome, membership);
-
-    // Create a bot
-    // This bot takes a QuestionnaireResponse as an input
-    // And creates a patient as an output
-    const [botOutcome, bot] = await botRepo.createResource<Bot>({
-      resourceType: 'Bot',
-      name: 'Test Bot',
-      description: 'Test Bot',
-      code: `
-        const [outcome, patient] = await repo.createResource({
-          resourceType: 'Patient',
-          name: [{ family: resource.item[0].answer[0].valueString }],
-        });
-        assertOk(outcome, patient);
-      `,
-      runAsUser: true,
-    });
-    assertOk(botOutcome, bot);
-
-    // Create the subscription that listens for QuestionnaireResponses
-    const [subscriptionOutcome, subscription] = await botRepo.createResource<Subscription>({
-      resourceType: 'Subscription',
-      status: 'active',
-      criteria: 'QuestionnaireResponse',
-      channel: {
-        type: 'rest-hook',
-        endpoint: getReferenceString(bot as Bot),
-      },
-    });
-    assertOk(subscriptionOutcome, subscription);
-
-    const queue = (Queue as unknown as jest.Mock).mock.instances[0];
-    queue.add.mockClear();
-
-    // Start acting as the user
-    const userRepo = await getRepoForMembership(membership);
-
-    const [qrOutcome, qr] = await userRepo.createResource<QuestionnaireResponse>({
-      resourceType: 'QuestionnaireResponse',
-      item: [
-        {
-          linkId: 'q1',
-          answer: [
-            {
-              valueString: nonce,
-            },
-          ],
-        },
-      ],
-    });
-    assertOk(qrOutcome, qr);
-    expect(queue.add).toHaveBeenCalled();
-
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
-    await execSubscriptionJob(job);
-
-    const [auditEventOutcome, auditEventBundle] = await botRepo.search<AuditEvent>({
-      resourceType: 'AuditEvent',
-      filters: [
-        {
-          code: 'entity',
-          operator: Operator.EQUALS,
-          value: getReferenceString(subscription as Subscription),
-        },
-      ],
-    });
-    assertOk(auditEventOutcome, auditEventBundle);
-    expect(auditEventBundle.entry?.length).toEqual(1);
-    expect(auditEventBundle.entry?.[0]?.resource?.outcome).toEqual('4');
-
-    // Search for the new patient
-    // No patient should be created
-    const [patientOutcome, patientBundle] = await botRepo.search<Patient>({
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.CONTAINS,
-          value: nonce,
-        },
-      ],
-    });
-    assertOk(patientOutcome, patientBundle);
-    expect(patientBundle.entry?.length).toEqual(0);
-  });
-
-  test('Async Bot with await', async () => {
-    const code = `
-      const [outcome, appointment] = await repo.createResource({
-        resourceType: 'Appointment',
-        status: 'booked',
-        start: new Date().toISOString(),
-        participant: [
-          {
-            actor: createReference(resource),
-            status: 'accepted',
-          },
-        ],
-      });
-      assertOk(outcome, appointment);
-      console.log(JSON.stringify(appointment, null, 2));
-      return appointment;
-    `;
-
-    const [botOutcome, bot] = await botRepo.createResource<Bot>({
-      resourceType: 'Bot',
-      name: 'Test Bot',
-      description: 'Test Bot',
-      code,
-    });
-    assertOk(botOutcome, bot);
-
-    const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
-      resourceType: 'ProjectMembership',
-      project: { reference: 'Project/' + bot.meta?.project },
-      user: createReference(bot),
-      profile: createReference(bot),
-    });
-    assertOk(membershipOutcome, membership);
-
-    const [subscriptionOutcome, subscription] = await botRepo.createResource<Subscription>({
-      resourceType: 'Subscription',
-      status: 'active',
-      criteria: 'Patient',
-      channel: {
-        type: 'rest-hook',
-        endpoint: getReferenceString(bot as Bot),
-      },
-    });
-    assertOk(subscriptionOutcome, subscription);
-
-    const queue = (Queue as unknown as jest.Mock).mock.instances[0];
-    queue.add.mockClear();
-
-    const [patientOutcome, patient] = await botRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-    });
-
-    expect(patientOutcome.id).toEqual('created');
-    expect(patient).toBeDefined();
-    expect(queue.add).toHaveBeenCalled();
-
-    (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
-
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
-    await execSubscriptionJob(job);
-    expect(fetch).not.toHaveBeenCalled();
-
-    const [searchOutcome, bundle] = await botRepo.search<AuditEvent>({
-      resourceType: 'AuditEvent',
-      filters: [
-        {
-          code: 'entity',
-          operator: Operator.EQUALS,
-          value: getReferenceString(subscription as Subscription),
-        },
-      ],
-    });
-    assertOk(searchOutcome, bundle);
-    expect(bundle.entry?.length).toEqual(1);
-    expect(bundle.entry?.[0]?.resource?.outcome).toEqual('0');
-    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain('"resourceType": "Appointment"');
-  });
-
-  test('Bot failure', async () => {
-    const nonce = randomUUID();
-
-    const [botOutcome, bot] = await botRepo.createResource<Bot>({
-      resourceType: 'Bot',
-      name: 'Test Bot',
-      description: 'Test Bot',
-      code: `throw new Error('${nonce}');`,
-    });
-    assertOk(botOutcome, bot);
-
-    const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
-      resourceType: 'ProjectMembership',
-      project: { reference: 'Project/' + bot.meta?.project },
-      user: createReference(bot),
-      profile: createReference(bot),
-    });
-    assertOk(membershipOutcome, membership);
-
-    const [subscriptionOutcome, subscription] = await botRepo.createResource<Subscription>({
-      resourceType: 'Subscription',
-      status: 'active',
-      criteria: 'Patient',
-      channel: {
-        type: 'rest-hook',
-        endpoint: getReferenceString(bot as Bot),
-      },
-    });
-    expect(subscriptionOutcome.id).toEqual('created');
-    expect(subscription).toBeDefined();
-
-    const queue = (Queue as unknown as jest.Mock).mock.instances[0];
-    queue.add.mockClear();
-
-    const [patientOutcome, patient] = await botRepo.createResource<Patient>({
-      resourceType: 'Patient',
-      name: [{ given: ['Alice'], family: 'Smith' }],
-    });
-
-    expect(patientOutcome.id).toEqual('created');
-    expect(patient).toBeDefined();
-    expect(queue.add).toHaveBeenCalled();
-
-    (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
-
-    const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
-    await execSubscriptionJob(job);
-    expect(fetch).not.toHaveBeenCalled();
-
-    const [searchOutcome, bundle] = await botRepo.search<AuditEvent>({
-      resourceType: 'AuditEvent',
-      filters: [
-        {
-          code: 'entity',
-          operator: Operator.EQUALS,
-          value: getReferenceString(subscription as Subscription),
-        },
-      ],
-    });
-    assertOk(searchOutcome, bundle);
-    expect(bundle.entry?.length).toEqual(1);
-    expect(bundle.entry?.[0]?.resource?.outcome).not.toEqual('0');
-    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain('Error');
-    expect(bundle.entry?.[0]?.resource?.outcomeDesc).toContain(nonce);
   });
 
   test('Stop retries if Subscription status not active', async () => {


### PR DESCRIPTION
Getting this ready.  We still have a handful of vmcontext bots in production, so this is gated until that is complete.

All new bots in all new projects are awslambda-only, and that is clearly the future of bots.