### PR TITLE
Better 404 handling in FileSystemStorage

### DIFF
--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -73,7 +73,11 @@ class FileSystemStorage implements BinaryStorage {
   }
 
   async readBinary(binary: Binary): Promise<internal.Readable> {
-    return createReadStream(this.#getPath(binary));
+    const path = this.#getPath(binary);
+    if (!existsSync(path)) {
+      throw new Error('File not found');
+    }
+    return createReadStream(path);
   }
 
   #getDir(binary: Binary): string {

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -2,8 +2,8 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { Binary } from '@medplum/fhirtypes';
 import { createReadStream, createWriteStream, existsSync, mkdirSync } from 'fs';
-import path from 'path';
-import internal from 'stream';
+import { resolve } from 'path';
+import { Readable } from 'stream';
 import { ReadableStream } from 'stream/web';
 
 let binaryStorage: BinaryStorage | undefined = undefined;
@@ -33,10 +33,10 @@ interface BinaryStorage {
     binary: Binary,
     filename: string | undefined,
     contentType: string | undefined,
-    stream: internal.Readable | NodeJS.ReadableStream
+    stream: Readable | NodeJS.ReadableStream
   ): Promise<void>;
 
-  readBinary(binary: Binary): Promise<internal.Readable>;
+  readBinary(binary: Binary): Promise<Readable>;
 }
 
 /**
@@ -48,8 +48,8 @@ class FileSystemStorage implements BinaryStorage {
 
   constructor(baseDir: string) {
     this.#baseDir = baseDir;
-    if (!existsSync(path.resolve(baseDir))) {
-      mkdirSync(path.resolve(baseDir));
+    if (!existsSync(resolve(baseDir))) {
+      mkdirSync(resolve(baseDir));
     }
   }
 
@@ -57,7 +57,7 @@ class FileSystemStorage implements BinaryStorage {
     binary: Binary,
     filename: string | undefined,
     contentType: string | undefined,
-    stream: internal.Readable | NodeJS.ReadableStream
+    stream: Readable | NodeJS.ReadableStream
   ): Promise<void> {
     checkFileMetadata(filename, contentType);
     const dir = this.#getDir(binary);
@@ -72,20 +72,20 @@ class FileSystemStorage implements BinaryStorage {
     });
   }
 
-  async readBinary(binary: Binary): Promise<internal.Readable> {
-    const path = this.#getPath(binary);
-    if (!existsSync(path)) {
+  async readBinary(binary: Binary): Promise<Readable> {
+    const filePath = this.#getPath(binary);
+    if (!existsSync(filePath)) {
       throw new Error('File not found');
     }
-    return createReadStream(path);
+    return createReadStream(filePath);
   }
 
   #getDir(binary: Binary): string {
-    return path.resolve(this.#baseDir, binary.id as string);
+    return resolve(this.#baseDir, binary.id as string);
   }
 
   #getPath(binary: Binary): string {
-    return path.resolve(this.#getDir(binary), binary.meta?.versionId as string);
+    return resolve(this.#getDir(binary), binary.meta?.versionId as string);
   }
 }
 
@@ -132,7 +132,7 @@ class S3Storage implements BinaryStorage {
     binary: Binary,
     filename: string | undefined,
     contentType: string | undefined,
-    stream: internal.Readable | NodeJS.ReadableStream
+    stream: Readable | NodeJS.ReadableStream
   ): Promise<void> {
     checkFileMetadata(filename, contentType);
     const upload = new Upload({
@@ -141,7 +141,7 @@ class S3Storage implements BinaryStorage {
         Key: this.#getKey(binary),
         CacheControl: 'max-age=3600, s-maxage=86400',
         ContentType: contentType || 'application/octet-stream',
-        Body: stream as internal.Readable | ReadableStream<any>,
+        Body: stream as Readable | ReadableStream<any>,
       },
       client: this.#client,
       queueSize: 3,
@@ -150,14 +150,14 @@ class S3Storage implements BinaryStorage {
     await upload.done();
   }
 
-  async readBinary(binary: Binary): Promise<internal.Readable> {
+  async readBinary(binary: Binary): Promise<Readable> {
     const output = await this.#client.send(
       new GetObjectCommand({
         Bucket: this.#bucket,
         Key: this.#getKey(binary),
       })
     );
-    return output.Body as internal.Readable;
+    return output.Body as Readable;
   }
 
   #getKey(binary: Binary): string {

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -1,5 +1,6 @@
 import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
 import express, { Request } from 'express';
 import { mkdtempSync, rmSync } from 'fs';
 import { sep } from 'path';
@@ -53,5 +54,10 @@ describe('Storage Routes', () => {
   test('Success', async () => {
     const res = await request(app).get(`/storage/${binary.id}?Signature=xyz&Expires=123`);
     expect(res.status).toBe(200);
+  });
+
+  test('File not found', async () => {
+    const res = await request(app).get(`/storage/${randomUUID()}?Signature=xyz&Expires=123`);
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -2,8 +2,8 @@ import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express, { Request } from 'express';
-import { mkdtempSync, rmSync } from 'fs';
-import { sep } from 'path';
+import { mkdtempSync, rmSync, unlinkSync } from 'fs';
+import { resolve, sep } from 'path';
 import { Readable } from 'stream';
 import request from 'supertest';
 import { initApp } from './app';
@@ -56,8 +56,28 @@ describe('Storage Routes', () => {
     expect(res.status).toBe(200);
   });
 
-  test('File not found', async () => {
+  test('Binary not found', async () => {
     const res = await request(app).get(`/storage/${randomUUID()}?Signature=xyz&Expires=123`);
+    expect(res.status).toBe(404);
+  });
+
+  test('File not found', async () => {
+    const [outcome, resource] = await systemRepo.createResource<Binary>({
+      resourceType: 'Binary',
+      contentType: 'text/plain',
+    });
+    assertOk(outcome, resource);
+
+    const req = new Readable();
+    req.push('hello world');
+    req.push(null);
+    (req as any).headers = {};
+    await getBinaryStorage().writeBinary(resource, 'hello.txt', 'text/plain', req as Request);
+
+    // Delete the file on disk
+    unlinkSync(resolve(binaryDir, `${resource.id}/${resource.meta?.versionId}`));
+
+    const res = await request(app).get(`/storage/${resource.id}?Signature=xyz&Expires=123`);
     expect(res.status).toBe(404);
   });
 });

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -21,9 +21,12 @@ storageRouter.get(
     const [outcome, binary] = await systemRepo.readResource<Binary>('Binary', id);
     assertOk(outcome, binary);
 
-    res.status(200).contentType(binary.contentType as string);
-
-    const stream = await getBinaryStorage().readBinary(binary);
-    stream.pipe(res);
+    try {
+      const stream = await getBinaryStorage().readBinary(binary);
+      res.status(200).contentType(binary.contentType as string);
+      stream.pipe(res);
+    } catch (err) {
+      res.sendStatus(404);
+    }
   })
 );


### PR DESCRIPTION
File system storage can be used for local development, so binary files such as images and PDFs are stored on disk rather than S3.

Properly handling 404's in file system storage.