### PR TITLE
Fixed baseUrl link in docs

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -49,7 +49,7 @@ export interface MedplumClientOptions {
   /**
    * Base server URL.
    *
-   * Default value is "https://api.medplum.com/".
+   * Default value is https://api.medplum.com/
    *
    * Use this to point to a custom Medplum deployment.
    */


### PR DESCRIPTION
This generated a broken link to https://api.medplum.com/%22 on https://docs.medplum.com/sdk/interfaces/MedplumClientOptions
