### PR TITLE
Set google button height to prevent flicker

### DIFF
--- a/packages/react/src/SignInForm.css
+++ b/packages/react/src/SignInForm.css
@@ -21,6 +21,7 @@
 .medplum-signin-google-container {
   padding: 20px 0 10px 0;
   margin: 20px 0 10px 0;
+  height: 70px;
   text-align: center;
   display: flex;
   align-items: center;


### PR DESCRIPTION
The "Sign in with Google" button is actually quite complex.  It includes an embedded iframe, and performs a whole bunch of checks.  Unfortunately that leads to a flickering effect, which causes the whole sign-in page to bounce up and down.  By setting a fix height, it minimizes the flicker.