### PR TITLE
Docs broken links, spelling mistakes, and SEO

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,4 +1,4 @@
-// PKCE auth ased on:
+// PKCE auth based on:
 // https://aws.amazon.com/blogs/security/how-to-add-authentication-single-page-web-application-with-amazon-cognito-oauth2-implementation/
 
 import {

--- a/packages/docs/blog/2021-12-06-learning-fhir-quickly.md
+++ b/packages/docs/blog/2021-12-06-learning-fhir-quickly.md
@@ -11,7 +11,7 @@ Fast Healthcare Interoperability Resources (FHIR) specification is a data standa
 
 Major healthcare platforms such as Epic and Cerner, as well as big tech - Apple, Google, etc. support FHIR in various capacities, making it increasingly popular.
 
-FHIR is very powerful and expressive, but that can make it hard to understand. It can feel indimidating, even for those with a healthcare background and a lot of domain expertise.
+FHIR is very powerful and expressive, but that can make it hard to understand. It can feel intimidating, even for those with a healthcare background and a lot of domain expertise.
 
 Medplum is designed to help you implement FHIR, of course, but also to help you learn FHIR. The app is built on a JAM stack (Javascript, APIs and Markup), and the API calls are... FHIR API calls!
 
@@ -21,7 +21,7 @@ Using Chrome Developer tools can see directly which calls are made to render the
 
 To try for yourself:
 
-0. Pre-requisite, you have set up your Medplum account and created at least one patient [instructions here](https://docs.medplum.com/app/intro) and are using Google Chrome.
+0. Pre-requisite, you have set up your Medplum account and created at least one patient [instructions here](/app/) and are using Google Chrome.
 1. Open the Medplum App and navigate to the Patient page.
 2. Open up Chrome Developer Tools and navigate to the Network tab and refresh the page [instructions here](https://everything.curl.dev/usingcurl/copyas).
 

--- a/packages/docs/blog/2021-12-23-fhir-questionnaires.md
+++ b/packages/docs/blog/2021-12-23-fhir-questionnaires.md
@@ -1,21 +1,21 @@
 ---
-slug: understanding-fhir-questionniares
-title: Understanding FHIR Questionniares
+slug: understanding-fhir-questionnaires
+title: Understanding FHIR Questionnaires
 authors:
   name: reshma
   title: Medplum Core Team
   url: https://github.com/reshmakh
   image_url: https://github.com/reshmakh.png
-tags: [fhir, questionniares, healthcare, api]
+tags: [fhir, questionnaires, healthcare, api]
 ---
 
 # Easy Custom Forms for Your Healthcare App
 
-At Medplum we know that customizable forms are critical for any healthcare app.  Is it even a healthcare app without tons of forms?
+At Medplum we know that customizable forms are critical for any healthcare app. Is it even a healthcare app without tons of forms?
 
 To serve that need, we have created a Form builder similar to common tools like [SurveyMonkey](https://www.surveymonkey.com/) or [Google Forms](https://docs.google.com/forms) but based on the [FHIR Questionnaires](https://www.hl7.org/fhir/questionnaire.html).
 
-FHIR Questionniares are very powerful and are widely used in healthcare systems.  Medplum can help you author questionniares or import them from other systems and manipulate them programmatically to get the workflow and data capture you desire.
+FHIR Questionnaires are very powerful and are widely used in healthcare systems. Medplum can help you author questionnaires or import them from other systems and manipulate them programmatically to get the workflow and data capture you desire.
 
 Here is a 2 minute video introducing the product.
 
@@ -23,21 +23,21 @@ Here is a 2 minute video introducing the product.
 
 ## Here's how to get FHIR Questionnaires set up
 
-0. This tutorial assumes you have registered for an account.  If you have not, you can do so [here](https://docs.medplum.com/app/register).
-1. You can create new questionniares using the [Questionniare Tool](https://app.medplum.com/Questionnaire/new) on Medplum. (Here are all [Questionnaires](https://app.medplum.com/Questionnaire) in your account.)
+0. This tutorial assumes you have registered for an account. If you have not, you can do so [here](/app/register).
+1. You can create new questionnaires using the [Questionnaire Tool](https://app.medplum.com/Questionnaire/new) on Medplum. (Here are all [Questionnaires](https://app.medplum.com/Questionnaire) in your account.)
 2. You can use the Builder to add questions that have different types, and they can be common types like `strings` or `integers`, or they can be FHIR objects like `Organizations` or `Patients`
-3. Each questionnaire has one or more `Subject`s, which will link the Questionnaire in the tool to the `Subject` data type.  For example if the `Subject` is a `Patient`, then the Questionnare can be found in the `Apps` tab on the `Patient` object (see video to get a visual).  
+3. Each questionnaire has one or more `Subject`s, which will link the Questionnaire in the tool to the `Subject` data type. For example if the `Subject` is a `Patient`, then the Questionnaire can be found in the `Apps` tab on the `Patient` object (see video to get a visual).
 4. Once the `Form` is filled out a [QuestionnaireResponse](https://app.medplum.com/QuestionnaireResponse) will be created with all the appropriate data.
-5. This is an advanced topic which will be covered in another tutorial, but you can use [Bots](https://docs.medplum.com/app/bot-for-questionnaire-response) to create new FHIR objects and execute an advanced workflows.
-6. Questionnaires can be embedded in applications such as your webapp, this is also an advanced topic for another time but if you want to get started building app [start here](https://docs.medplum.com/tutorials/react-hello-world/hello-world-part-1)
+5. This is an advanced topic which will be covered in another tutorial, but you can use [Bots](/app/bot-for-questionnaire-response) to create new FHIR objects and execute an advanced workflows.
+6. Questionnaires can be embedded in applications such as your webapp, this is also an advanced topic for another time but if you want to get started building app [start here](/tutorials/react-components/hello-world-part-1)
 
-## Open Source Questionaires
+## Open Source Questionnaires
 
-There are tons of standard questionnaires available online, and some insitutions have proprietary ones that are tailored for a use case, or in some cases even validated experimentally.
+There are tons of standard questionnaires available online, and some institutions have proprietary ones that are tailored for a use case, or in some cases even validated experimentally.
 
-Some institutions publish their questionniares - for example:
+Some institutions publish their questionnaires - for example:
 
-* [MDCalc](https://www.mdcalc.com/) publishes a large number of questionniares like [PHQ9](https://www.mdcalc.com/phq-9-patient-health-questionnaire-9)
-* [Ages and Stages](https://agesandstages.com/products-pricing/asq3/) publishes widely used pediatric screening tools.
+- [MDCalc](https://www.mdcalc.com/) publishes a large number of questionnaires like [PHQ9](https://www.mdcalc.com/phq-9-patient-health-questionnaire-9)
+- [Ages and Stages](https://agesandstages.com/products-pricing/asq3/) publishes widely used pediatric screening tools.
 
 Having a well managed and documented Questionnaire set with version tracking and attribution can be a huge asset for an organization and we encourage everyone to think of it as such.

--- a/packages/docs/docs/api/fhir/overview.md
+++ b/packages/docs/docs/api/fhir/overview.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+slug: /api/fhir
 ---
 
 # Overview

--- a/packages/docs/docs/api/fhir/resources/_category_.json
+++ b/packages/docs/docs/api/fhir/resources/_category_.json
@@ -4,6 +4,7 @@
   "link": {
     "type": "generated-index",
     "title": "FHIR Resources",
-    "description": "FHIR Resource Reference"
+    "description": "FHIR Resource Reference",
+    "slug": "/api/fhir/resources"
   }
 }

--- a/packages/docs/docs/app/bots.md
+++ b/packages/docs/docs/app/bots.md
@@ -144,7 +144,7 @@ You can find the `id` of your Bot by clicking on the **Details** tab of the Bot 
 
 | Content-Type               | typeof `event.input`                    | Description                                                                                                                                                         |
 | -------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `application/fhir+json`    | [`Resource`](/category/resources)       | `<INPUT_DATA>` is parsed as a [FHIR Resource](/fhir-basics#resources) encoded as a JSON string                                                                      |
+| `application/fhir+json`    | [`Resource`](/api/fhir/resources)       | `<INPUT_DATA>` is parsed as a [FHIR Resource](/fhir-basics#resources) encoded as a JSON string                                                                      |
 | `text/plain`               | `string`                                | `<INPUT_DATA>` is parsed as plaintext string                                                                                                                        |
 | `x-application/hl7-v2+er7` | [`HL7Message`](/sdk/classes/Hl7Message) | `<INPUT_DATA>` is a string that should be parsed as a pipe-delimited HL7v2 message. HL7v2 is a common text-based message protocol used in legacy healthcare systems |
 

--- a/packages/docs/docs/app/bots.md
+++ b/packages/docs/docs/app/bots.md
@@ -75,11 +75,11 @@ export async function handler(medplum, event) {
 
 The following function arguments are available to the Bot code, to enable it to do the functionality it requires.
 
-| Name          | Type                                           | Description                                                                                           |
-| ------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `medplum`     | [MedplumClient](/sdk/classes/MedplumClient)    | An instance of the medplum JS SDK ([documentation](https://docs.medplum.com/typedoc/core/index.html)) |
-| `event`       | [BotEvent](/sdk/interfaces/BotEvent)           | The event that object that triggered the Bot                                                          |
-| `event.input` | `string` &#124; `Resource` &#124; `Hl7Message` | The bot input, usually a FHIR resource or content that was posted to a bot endpoint                   |
+| Name          | Type                                           | Description                                                                         |
+| ------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `medplum`     | [MedplumClient](/sdk/classes/MedplumClient)    | An instance of the medplum JS SDK ([documentation](/sdk/))                          |
+| `event`       | [BotEvent](/sdk/interfaces/BotEvent)           | The event that object that triggered the Bot                                        |
+| `event.input` | `string` &#124; `Resource` &#124; `Hl7Message` | The bot input, usually a FHIR resource or content that was posted to a bot endpoint |
 
 In this example, we'll assume the input is a `Patient` resource and print out the patient's name.
 

--- a/packages/docs/docs/fhir-basics.md
+++ b/packages/docs/docs/fhir-basics.md
@@ -17,7 +17,7 @@ While FHIR is quite powerful, it can have a bit of a learning curve. The page wi
 
 ## Resources
 
-A core data object in FHIR is called a [**Resource**](https://www.hl7.org/fhir/resource.html). You can think of Resources as **objects** in object oriented languages. The FHIR standard defines a set of [**Resource Types**](/category/resources), similar to **classes**, that have been built for healthcare applications.
+A core data object in FHIR is called a [**Resource**](https://www.hl7.org/fhir/resource.html). You can think of Resources as **objects** in object oriented languages. The FHIR standard defines a set of [**Resource Types**](/api/fhir/resources), similar to **classes**, that have been built for healthcare applications.
 
 Resources can represent a broad range of healthcare ideas, from very **concrete healthcare items** (e.g. [Patient](/api/fhir/resources/patient), [Medication](/api/fhir/resources/medication), [Device](/api/fhir/resources/device)) or more **abstract concepts** (e.g. [Procedure](/api/fhir/resources/procedure), [Care Plan](/api/fhir/resources/careplan), [Encounter](/api/fhir/resources/encounter)).
 
@@ -176,7 +176,7 @@ The example `Patient` below has three identifiers: **an SSN and two MRN identifi
 
 There are many caeses in which a client would like to query resources that fulfill certain criteria. **FHIR resources cannot be searched by arbitrary fields**. Instead, the specification **defines specific search parameters for each resource** that can be used for queries.
 
-You can find the search parameters on the [reference page](/category/resources) for each resource. **Refer to the [FHIR Search](https://www.hl7.org/fhir/search.html) documentation** for how construct search queries using these parameters.
+You can find the search parameters on the [reference page](/api/fhir/resources) for each resource. **Refer to the [FHIR Search](https://www.hl7.org/fhir/search.html) documentation** for how construct search queries using these parameters.
 
 ### Example
 

--- a/packages/docs/docs/home.md
+++ b/packages/docs/docs/home.md
@@ -18,7 +18,7 @@ import HomepageCallout from '@site/src/components/HomepageCallout'
 
 Medplum is a **developer platform** that enables **flexible and rapid development** of healthcare apps. In consists of the following components:
 
-1. **Medplum Clinical Data Repository (CDR)** - This is the the backend server and data store that hosts your healthcare data in a secure, compliant, and standards based respository.
+1. **Medplum Clinical Data Repository (CDR)** - This is the the backend server and data store that hosts your healthcare data in a secure, compliant, and standards based repository.
 2. **Medplum API** - The Medplum CDR also exposes a **[FHIR-based API](/api)** for sending, receiving, and manipulating healthcare data. This includes support for binary files like images, videos, and pdfs.
 3. **Medplum SDK** - This is a set of client libraries that simplify the process of interacting with the **Medplum API**. Currently, we only offer a **Typescript** library, but are planning to support more languages in the future. If there's a language you'd like supported, feel free to open a [Github Issue](https://github.com/medplum/medplum/issues).
 4. **Medplum App** - This is a web application where can you can view your data, perform basic editing tasks. You can also use the Medplum App to manage basic workflows.
@@ -58,5 +58,5 @@ The following diagram shows how all of these pieces fit together.
 
 ## Community
 
-- **Contributing** - Medplum is open source because we believe that streamling healthcare is based on _transparency_ and _collaboration_. If you are interested contributing to Medplum, check out our [Contributors](/contributing) page
+- **Contributing** - Medplum is open source because we believe that streamlining healthcare is based on _transparency_ and _collaboration_. If you are interested contributing to Medplum, check out our [Contributors](/contributing) page
 - **Discord** - Join the conversation by checking us out on [Discord](https://discord.gg/UBAWwvrVeN)

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Medplum',
-  tagline: 'Healthcare infrastructure and application development',
+  tagline: 'Fast and easy healthcare dev',
   url: 'https://docs.medplum.com',
   baseUrl: '/',
   trailingSlash: false,
@@ -16,7 +16,6 @@ const config = {
   favicon: 'img/favicon.ico',
   organizationName: 'medplum', // Usually your GitHub org/user name.
   projectName: 'medplum', // Usually your repo name.
-
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/packages/docs/src/components/HomepageCallout.module.css
+++ b/packages/docs/src/components/HomepageCallout.module.css
@@ -23,11 +23,15 @@
   order: 0;
   align-self: stretch;
   flex-grow: 1;
+
+  box-shadow:  rgba(0, 0, 0, 0.15) 0 5px 15px;
 }
 
 [data-theme='dark'] .container {
-  background: #0D0D0D;
-  border: 1px solid #333333;
+  background-color: rgb(27 27 29);
+  border: 1px solid #0d0d0d4b;
+
+  box-shadow:  rgba(0, 0, 0, 0.35) 0 5px 15px
 }
 
 .content {

--- a/packages/docs/src/components/HomepageCallout.module.css
+++ b/packages/docs/src/components/HomepageCallout.module.css
@@ -93,3 +93,6 @@
   line-height: 100%;
 }
 
+.icon {
+  box-shadow: none;
+}

--- a/packages/docs/src/components/HomepageCallout.tsx
+++ b/packages/docs/src/components/HomepageCallout.tsx
@@ -16,7 +16,7 @@ export default function HomepageCallout(props: HomepageCalloutProps): JSX.Elemen
         <div className={styles['link-container']}>
           <a href={props.linkRef}>{props.linkText}</a>
           <a href={props.linkRef} style={{ maxHeight: '26px' }}>
-            <img src="img/small_arrow.svg" />
+            <img className={styles['icon']} src="img/small_arrow.svg" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
This PR has a bunch of miscellaneous fixes to clean up the docs links and prevent crawlers from getting to weird legacy pages