### PR TITLE
Removed RepositoryResult pattern

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -1,9 +1,9 @@
 import {
-  accessDenied,
   allOk,
   assertOk,
   badRequest,
   created,
+  forbidden,
   getStatus,
   gone,
   isGone,
@@ -13,6 +13,7 @@ import {
   notFound,
   notModified,
   tooManyRequests,
+  unauthorized,
 } from './outcomes';
 
 describe('Outcomes', () => {
@@ -43,7 +44,8 @@ describe('Outcomes', () => {
     expect(getStatus(allOk)).toBe(200);
     expect(getStatus(created)).toBe(201);
     expect(getStatus(notModified)).toBe(304);
-    expect(getStatus(accessDenied)).toBe(403);
+    expect(getStatus(unauthorized)).toBe(401);
+    expect(getStatus(forbidden)).toBe(403);
     expect(getStatus(notFound)).toBe(404);
     expect(getStatus(gone)).toBe(410);
     expect(getStatus(tooManyRequests)).toBe(429);

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -5,7 +5,8 @@ const CREATED_ID = 'created';
 const GONE_ID = 'gone';
 const NOT_MODIFIED_ID = 'not-modified';
 const NOT_FOUND_ID = 'not-found';
-const ACCESS_DENIED_ID = 'access-denied';
+const UNAUTHORIZED_ID = 'unauthorized';
+const FORBIDDEN_ID = 'forbidden';
 const TOO_MANY_REQUESTS_ID = 'too-many-requests';
 
 export const allOk: OperationOutcome = {
@@ -64,6 +65,34 @@ export const notFound: OperationOutcome = {
   ],
 };
 
+export const unauthorized: OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  id: UNAUTHORIZED_ID,
+  issue: [
+    {
+      severity: 'error',
+      code: 'login',
+      details: {
+        text: 'Unauthorized',
+      },
+    },
+  ],
+};
+
+export const forbidden: OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  id: FORBIDDEN_ID,
+  issue: [
+    {
+      severity: 'error',
+      code: 'forbidden',
+      details: {
+        text: 'Forbidden',
+      },
+    },
+  ],
+};
+
 export const gone: OperationOutcome = {
   resourceType: 'OperationOutcome',
   id: GONE_ID,
@@ -73,20 +102,6 @@ export const gone: OperationOutcome = {
       code: 'gone',
       details: {
         text: 'Gone',
-      },
-    },
-  ],
-};
-
-export const accessDenied: OperationOutcome = {
-  resourceType: 'OperationOutcome',
-  id: ACCESS_DENIED_ID,
-  issue: [
-    {
-      severity: 'error',
-      code: 'forbidden',
-      details: {
-        text: 'Access Denied',
       },
     },
   ],
@@ -141,7 +156,9 @@ export function getStatus(outcome: OperationOutcome): number {
     return 201;
   } else if (outcome.id === NOT_MODIFIED_ID) {
     return 304;
-  } else if (outcome.id === ACCESS_DENIED_ID) {
+  } else if (outcome.id === UNAUTHORIZED_ID) {
+    return 401;
+  } else if (outcome.id === FORBIDDEN_ID) {
     return 403;
   } else if (outcome.id === NOT_FOUND_ID) {
     return 404;

--- a/packages/server/src/admin/bot.ts
+++ b/packages/server/src/admin/bot.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import { AccessPolicy, Bot, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -36,7 +36,7 @@ export interface CreateBotRequest {
 }
 
 export async function createBot(repo: Repository, request: CreateBotRequest): Promise<Bot> {
-  const [clientOutcome, bot] = await repo.createResource<Bot>({
+  const bot = await repo.createResource<Bot>({
     meta: {
       project: request.project.id,
     },
@@ -45,9 +45,8 @@ export async function createBot(repo: Repository, request: CreateBotRequest): Pr
     description: request.description,
     runtimeVersion: 'awslambda',
   });
-  assertOk(clientOutcome, bot);
 
-  const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
+  await systemRepo.createResource<ProjectMembership>({
     meta: {
       project: request.project.id,
     },
@@ -57,6 +56,6 @@ export async function createBot(repo: Repository, request: CreateBotRequest): Pr
     profile: createReference(bot),
     accessPolicy: request.accessPolicy,
   });
-  assertOk(membershipOutcome, membership);
+
   return bot;
 }

--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import { AccessPolicy, ClientApplication, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -38,7 +38,7 @@ export interface CreateClientRequest {
 }
 
 export async function createClient(repo: Repository, request: CreateClientRequest): Promise<ClientApplication> {
-  const [clientOutcome, client] = await repo.createResource<ClientApplication>({
+  const client = await repo.createResource<ClientApplication>({
     meta: {
       project: request.project.id,
     },
@@ -48,9 +48,8 @@ export async function createClient(repo: Repository, request: CreateClientReques
     description: request.description,
     redirectUri: request.redirectUri,
   });
-  assertOk(clientOutcome, client);
 
-  const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
+  await systemRepo.createResource<ProjectMembership>({
     meta: {
       project: request.project.id,
     },
@@ -60,6 +59,6 @@ export async function createClient(repo: Repository, request: CreateClientReques
     profile: createReference(client),
     accessPolicy: request.accessPolicy,
   });
-  assertOk(membershipOutcome, membership);
+
   return client;
 }

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { AccessPolicy, Practitioner, Project, Reference, User } from '@medplum/fhirtypes';
 import bcrypt from 'bcryptjs';
 import { Request, Response } from 'express';
@@ -107,18 +107,17 @@ async function createUser(request: InviteRequest): Promise<User> {
   const password = generateSecret(16);
   logger.info('Create user ' + email);
   const passwordHash = await bcrypt.hash(password, 10);
-  const [outcome, result] = await systemRepo.createResource<User>({
+  const result = await systemRepo.createResource<User>({
     resourceType: 'User',
     email,
     passwordHash,
   });
-  assertOk(outcome, result);
   logger.info('Created: ' + result.id);
   return result;
 }
 
 async function searchForExistingPractitioner(project: Project, email: string): Promise<Practitioner | undefined> {
-  const [outcome, bundle] = await systemRepo.search<Practitioner>({
+  const bundle = await systemRepo.search<Practitioner>({
     resourceType: 'Practitioner',
     filters: [
       {
@@ -133,7 +132,6 @@ async function searchForExistingPractitioner(project: Project, email: string): P
       },
     ],
   });
-  assertOk(outcome, bundle);
   if (bundle.entry && bundle.entry.length > 0) {
     return bundle.entry[0].resource as Practitioner;
   }

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest, getStatus } from '@medplum/core';
+import { allOk, badRequest } from '@medplum/core';
 import { Project, ProjectMembership } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
@@ -60,9 +60,8 @@ projectAdminRouter.get(
     }
 
     const { membershipId } = req.params;
-    const [outcome, membership] = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
-    assertOk(outcome, membership);
-    res.status(getStatus(outcome)).json(membership);
+    const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
+    res.json(membership);
   })
 );
 
@@ -81,9 +80,8 @@ projectAdminRouter.post(
       return;
     }
 
-    const [outcome, result] = await systemRepo.updateResource(resource);
-    assertOk(outcome, result);
-    res.status(getStatus(outcome)).json(result);
+    const result = await systemRepo.updateResource(resource);
+    res.json(result);
   })
 );
 
@@ -97,20 +95,15 @@ projectAdminRouter.delete(
     }
 
     const { membershipId } = req.params;
-    const [readOutcome, membership] = await systemRepo.readResource<ProjectMembership>(
-      'ProjectMembership',
-      membershipId
-    );
-    assertOk(readOutcome, membership);
+    const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', membershipId);
 
     if (project.owner?.reference === membership.user?.reference) {
       sendOutcome(res, badRequest('Cannot delete the owner of the project'));
       return;
     }
 
-    const [outcome] = await systemRepo.deleteResource('ProjectMembership', req.params.membershipId);
-    assertOk(outcome, outcome);
-    sendOutcome(res, outcome);
+    await systemRepo.deleteResource('ProjectMembership', req.params.membershipId);
+    sendOutcome(res, allOk);
   })
 );
 

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference, getReferenceString } from '@medplum/core';
+import { createReference, getReferenceString } from '@medplum/core';
 import { ClientApplication, Login, Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -29,45 +29,39 @@ describe('Super Admin routes', () => {
 
     ({ project, client } = await createTestProject());
 
-    const [outcome1, practitioner1] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
-    assertOk(outcome1, practitioner1);
+    const practitioner1 = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
 
-    const [outcome2, practitioner2] = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
-    assertOk(outcome2, practitioner2);
+    const practitioner2 = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
 
-    const [outcome3, user1] = await systemRepo.createResource<User>({
+    const user1 = await systemRepo.createResource<User>({
       resourceType: 'User',
       email: `super${randomUUID()}@example.com`,
       passwordHash: 'abc',
       admin: true,
     });
-    assertOk(outcome3, user1);
 
-    const [outcome4, user2] = await systemRepo.createResource<User>({
+    const user2 = await systemRepo.createResource<User>({
       resourceType: 'User',
       email: `normie${randomUUID()}@example.com`,
       passwordHash: 'abc',
       admin: false,
     });
-    assertOk(outcome4, user2);
 
-    const [membershipOutcome1, membership1] = await systemRepo.createResource<ProjectMembership>({
+    const membership1 = await systemRepo.createResource<ProjectMembership>({
       resourceType: 'ProjectMembership',
       project: createReference(project),
       user: createReference(user1),
       profile: createReference(practitioner1),
     });
-    assertOk(membershipOutcome1, membership1);
 
-    const [membershipOutcome2, membership2] = await systemRepo.createResource<ProjectMembership>({
+    const membership2 = await systemRepo.createResource<ProjectMembership>({
       resourceType: 'ProjectMembership',
       project: createReference(project),
       user: createReference(user2),
       profile: createReference(practitioner2),
     });
-    assertOk(membershipOutcome2, membership2);
 
-    const [outcome5, login1] = await systemRepo.createResource<Login>({
+    const login1 = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       user: createReference(user1),
@@ -76,9 +70,8 @@ describe('Super Admin routes', () => {
       scope: 'openid',
       admin: true,
     });
-    assertOk(outcome5, login1);
 
-    const [outcome6, login2] = await systemRepo.createResource<Login>({
+    const login2 = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       user: createReference(user2),
@@ -87,7 +80,6 @@ describe('Super Admin routes', () => {
       scope: 'openid',
       admin: false,
     });
-    assertOk(outcome6, login2);
 
     adminAccessToken = await generateAccessToken({
       login_id: login1?.id as string,

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -1,4 +1,4 @@
-import { accessDenied, allOk, assertOk, isOk } from '@medplum/core';
+import { allOk, forbidden } from '@medplum/core';
 import { User } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
@@ -17,11 +17,9 @@ superAdminRouter.use(authenticateToken);
 superAdminRouter.post(
   '/valuesets',
   asyncWrap(async (_req: Request, res: Response) => {
-    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome, user);
-
+    const user = await systemRepo.readResource<User>('User', res.locals.user);
     if (!user.admin) {
-      sendOutcome(res, accessDenied);
+      sendOutcome(res, forbidden);
       return;
     }
 
@@ -36,11 +34,9 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/structuredefinitions',
   asyncWrap(async (_req: Request, res: Response) => {
-    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome, user);
-
+    const user = await systemRepo.readResource<User>('User', res.locals.user);
     if (!user.admin) {
-      sendOutcome(res, accessDenied);
+      sendOutcome(res, forbidden);
       return;
     }
 
@@ -55,11 +51,9 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/searchparameters',
   asyncWrap(async (_req: Request, res: Response) => {
-    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome, user);
-
+    const user = await systemRepo.readResource<User>('User', res.locals.user);
     if (!user.admin) {
-      sendOutcome(res, accessDenied);
+      sendOutcome(res, forbidden);
       return;
     }
 
@@ -74,22 +68,16 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/reindex',
   asyncWrap(async (req: Request, res: Response) => {
-    const [outcome, user] = await systemRepo.readResource<User>('User', res.locals.user);
-    assertOk(outcome, user);
-
+    const user = await systemRepo.readResource<User>('User', res.locals.user);
     if (!user.admin) {
-      sendOutcome(res, accessDenied);
+      sendOutcome(res, forbidden);
       return;
     }
 
     const resourceType = req.body.resourceType;
-    const validateOutcome = validateResourceType(resourceType);
-    if (!isOk(validateOutcome)) {
-      sendOutcome(res, validateOutcome);
-      return;
-    }
+    validateResourceType(resourceType);
 
-    const [reindexOutcome] = await systemRepo.reindexResourceType(resourceType);
-    sendOutcome(res, reindexOutcome);
+    await systemRepo.reindexResourceType(resourceType);
+    sendOutcome(res, allOk);
   })
 );

--- a/packages/server/src/admin/utils.ts
+++ b/packages/server/src/admin/utils.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { BundleEntry, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { systemRepo } from '../fhir';
@@ -14,10 +14,9 @@ import { systemRepo } from '../fhir';
 export async function verifyProjectAdmin(req: Request, res: Response): Promise<Project | undefined> {
   const { projectId } = req.params;
 
-  const [projectOutcome, project] = await systemRepo.readResource<Project>('Project', projectId);
-  assertOk(projectOutcome, project);
+  const project = await systemRepo.readResource<Project>('Project', projectId);
 
-  const [membershipOutcome, bundle] = await systemRepo.search<ProjectMembership>({
+  const bundle = await systemRepo.search<ProjectMembership>({
     resourceType: 'ProjectMembership',
     count: 1,
     filters: [
@@ -33,7 +32,6 @@ export async function verifyProjectAdmin(req: Request, res: Response): Promise<P
       },
     ],
   });
-  assertOk(membershipOutcome, bundle);
 
   if (bundle.entry?.length === 0) {
     return undefined;
@@ -53,7 +51,7 @@ export async function verifyProjectAdmin(req: Request, res: Response): Promise<P
  * @returns The list of project memberships.
  */
 export async function getProjectMemberships(projectId: string): Promise<ProjectMembership[]> {
-  const [membershipOutcome, bundle] = await systemRepo.search<ProjectMembership>({
+  const bundle = await systemRepo.search<ProjectMembership>({
     resourceType: 'ProjectMembership',
     count: 1000,
     filters: [
@@ -64,6 +62,5 @@ export async function getProjectMemberships(projectId: string): Promise<ProjectM
       },
     ],
   });
-  assertOk(membershipOutcome, bundle);
   return (bundle.entry as BundleEntry<ProjectMembership>[]).map((entry) => entry.resource as ProjectMembership);
 }

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -1,5 +1,4 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
-import { assertOk } from '@medplum/core';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
@@ -141,11 +140,10 @@ describe('Google Auth', () => {
     });
 
     // As a super admin, update the project to require Google auth
-    const [updateOutcome, updated] = await systemRepo.updateResource({
+    await systemRepo.updateResource({
       ...project,
       features: ['google-auth-required'],
     });
-    assertOk(updateOutcome, updated);
 
     // Then try to login with Google auth
     // This should succeed
@@ -172,7 +170,7 @@ describe('Google Auth', () => {
     });
 
     // As a super admin, set the google client ID
-    const [updateOutcome, updated] = await systemRepo.updateResource({
+    await systemRepo.updateResource({
       ...project,
       site: [
         {
@@ -182,7 +180,6 @@ describe('Google Auth', () => {
         },
       ],
     });
-    assertOk(updateOutcome, updated);
 
     // Try to login with the custom Google client
     // This should succeed

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -1,5 +1,5 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
-import { assertOk, createReference } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import { ClientApplication } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -332,11 +332,10 @@ describe('Login', () => {
     });
 
     // As a super admin, update the project to require Google auth
-    const [updateOutcome, updated] = await systemRepo.updateResource({
+    await systemRepo.updateResource({
       ...project,
       features: ['google-auth-required'],
     });
-    assertOk(updateOutcome, updated);
 
     // Then try to login
     // This should fail with error message that google auth is required

--- a/packages/server/src/auth/login.ts
+++ b/packages/server/src/auth/login.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -18,7 +17,7 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
     return;
   }
 
-  const [loginOutcome, login] = await tryLogin({
+  const login = await tryLogin({
     authMethod: 'password',
     clientId: req.body.clientId || undefined,
     projectId: req.body.projectId || undefined,
@@ -32,6 +31,5 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
     remoteAddress: req.ip,
     userAgent: req.get('User-Agent'),
   });
-  assertOk(loginOutcome, login);
   await sendLoginResult(res, login);
 }

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -1,4 +1,4 @@
-import { assertOk, ProfileResource } from '@medplum/core';
+import { ProfileResource } from '@medplum/core';
 import { ProjectMembership, Reference, UserConfiguration } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { systemRepo } from '../fhir';
@@ -7,10 +7,7 @@ import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 export async function meHandler(req: Request, res: Response): Promise<void> {
   const membership = res.locals.membership as ProjectMembership;
 
-  const [profileOutcome, profile] = await systemRepo.readReference<ProfileResource>(
-    membership.profile as Reference<ProfileResource>
-  );
-  assertOk(profileOutcome, profile);
+  const profile = await systemRepo.readReference<ProfileResource>(membership.profile as Reference<ProfileResource>);
 
   const config = await getUserConfiguration(membership);
 
@@ -24,9 +21,7 @@ export async function meHandler(req: Request, res: Response): Promise<void> {
 
 async function getUserConfiguration(membership: ProjectMembership): Promise<UserConfiguration> {
   if (membership.userConfiguration) {
-    const [configOutcome, config] = await systemRepo.readReference<UserConfiguration>(membership.userConfiguration);
-    assertOk(configOutcome, config);
-    return config;
+    return systemRepo.readReference<UserConfiguration>(membership.userConfiguration);
   }
 
   const favorites = ['Patient', 'Practitioner', 'Organization', 'ServiceRequest', 'DiagnosticReport', 'Questionnaire'];

--- a/packages/server/src/auth/newpatient.test.ts
+++ b/packages/server/src/auth/newpatient.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference, resolveId } from '@medplum/core';
+import { createReference, resolveId } from '@medplum/core';
 import { AccessPolicy, BundleEntry, Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -115,14 +115,13 @@ describe('New patient', () => {
     expect(res6.status).toBe(201);
 
     // As a super admin, enable patient registration
-    const [updateOutcome, updatedProject] = await systemRepo.patchResource('Project', projectId, [
+    await systemRepo.patchResource('Project', projectId, [
       {
         op: 'add',
         path: '/defaultPatientAccessPolicy',
         value: createReference(res6.body),
       },
     ]);
-    assertOk(updateOutcome, updatedProject);
 
     // Try to register as a patient in the new project
     // (This should succeed)

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest } from '@medplum/core';
+import { badRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -145,7 +145,7 @@ describe('New user', () => {
     });
 
     // As a super admin, set the recaptcha site key
-    const [updateOutcome, updated] = await systemRepo.updateResource({
+    await systemRepo.updateResource({
       ...project,
       site: [
         {
@@ -156,7 +156,6 @@ describe('New user', () => {
         },
       ],
     });
-    assertOk(updateOutcome, updated);
 
     const res = await request(app)
       .post('/auth/newuser')
@@ -207,7 +206,7 @@ describe('New user', () => {
     });
 
     // As a super admin, set the recaptcha site key
-    const [updateOutcome, updated] = await systemRepo.updateResource({
+    await systemRepo.updateResource({
       ...project,
       site: [
         {
@@ -217,7 +216,6 @@ describe('New user', () => {
         },
       ],
     });
-    assertOk(updateOutcome, updated);
 
     const res = await request(app)
       .post('/auth/newuser')

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, getReferenceString, ProfileResource } from '@medplum/core';
+import { getReferenceString, ProfileResource } from '@medplum/core';
 import { Login } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -97,8 +97,7 @@ describe('Profile', () => {
     expect(res1.status).toBe(200);
     expect(res1.body.login).toBeDefined();
 
-    const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
-    assertOk(readOutcome, login);
+    const login = await systemRepo.readResource<Login>('Login', res1.body.login);
     await systemRepo.updateResource({
       ...login,
       revoked: true,
@@ -125,8 +124,7 @@ describe('Profile', () => {
     expect(res1.status).toBe(200);
     expect(res1.body.login).toBeDefined();
 
-    const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
-    assertOk(readOutcome, login);
+    const login = await systemRepo.readResource<Login>('Login', res1.body.login);
     await systemRepo.updateResource({
       ...login,
       granted: true,
@@ -153,8 +151,7 @@ describe('Profile', () => {
     expect(res1.status).toBe(200);
     expect(res1.body.login).toBeDefined();
 
-    const [readOutcome, login] = await systemRepo.readResource<Login>('Login', res1.body.login);
-    assertOk(readOutcome, login);
+    const login = await systemRepo.readResource<Login>('Login', res1.body.login);
     await systemRepo.updateResource({
       ...login,
       membership: {

--- a/packages/server/src/auth/profile.ts
+++ b/packages/server/src/auth/profile.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { Login } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -22,12 +21,10 @@ export async function profileHandler(req: Request, res: Response): Promise<void>
     return;
   }
 
-  const [loginOutcome, login] = await systemRepo.readResource<Login>('Login', req.body.login);
-  assertOk(loginOutcome, login);
+  const login = await systemRepo.readResource<Login>('Login', req.body.login);
 
   // Update the login
-  const [updateOutcome, updated] = await setLoginMembership(login, req.body.profile);
-  assertOk(updateOutcome, updated);
+  const updated = await setLoginMembership(login, req.body.profile);
 
   res.status(200).json({
     login: updated?.id,

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import {
   AccessPolicy,
   Login,
@@ -24,7 +24,7 @@ export async function createProfile(
   email: string
 ): Promise<Patient | Practitioner> {
   logger.info(`Create ${resourceType}: ${firstName} ${lastName}`);
-  const [outcome, result] = await systemRepo.createResource<Patient | Practitioner>({
+  const result = await systemRepo.createResource<Patient | Practitioner>({
     resourceType,
     meta: {
       project: project.id,
@@ -43,7 +43,6 @@ export async function createProfile(
       },
     ],
   });
-  assertOk(outcome, result);
   logger.info('Created: ' + result.id);
   return result;
 }
@@ -56,7 +55,7 @@ export async function createProjectMembership(
   admin?: boolean
 ): Promise<ProjectMembership> {
   logger.info('Create project membership: ' + project.name);
-  const [outcome, result] = await systemRepo.createResource<ProjectMembership>({
+  const result = await systemRepo.createResource<ProjectMembership>({
     resourceType: 'ProjectMembership',
     project: createReference(project),
     user: createReference(user),
@@ -64,7 +63,6 @@ export async function createProjectMembership(
     accessPolicy,
     admin,
   });
-  assertOk(outcome, result);
   logger.info('Created: ' + result.id);
   return result;
 }

--- a/packages/server/src/email/routes.ts
+++ b/packages/server/src/email/routes.ts
@@ -1,4 +1,4 @@
-import { accessDenied, allOk, assertOk } from '@medplum/core';
+import { allOk, forbidden } from '@medplum/core';
 import { Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { body, check, validationResult } from 'express-validator';
@@ -27,12 +27,11 @@ emailRouter.post(
     }
 
     // Make sure the user project has the email feature enabled
-    const [projectOutcome, project] = await systemRepo.readReference(
+    const project = await systemRepo.readReference(
       (res.locals.membership as ProjectMembership).project as Reference<Project>
     );
-    assertOk(projectOutcome, project);
     if (!project.features?.includes('email')) {
-      sendOutcome(res, accessDenied);
+      sendOutcome(res, forbidden);
       return;
     }
 

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -1,5 +1,12 @@
-import { assertOk, createReference, Operator } from '@medplum/core';
-import { AccessPolicy, ClientApplication, Observation, Patient, ServiceRequest } from '@medplum/fhirtypes';
+import { createReference, Operator } from '@medplum/core';
+import {
+  AccessPolicy,
+  ClientApplication,
+  Observation,
+  OperationOutcome,
+  Patient,
+  ServiceRequest,
+} from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../config';
 import { closeDatabase, initDatabase } from '../database';
@@ -21,12 +28,11 @@ describe('AccessPolicy', () => {
   });
 
   test('Access policy restricting read', async () => {
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     // Empty access policy effectively blocks all reads and writes
@@ -41,8 +47,12 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome] = await repo2.readResource('Patient', patient?.id as string);
-    expect(readOutcome.id).toEqual('access-denied');
+    try {
+      await repo2.readResource('Patient', patient?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('forbidden');
+    }
   });
 
   test('Access policy restricting search', async () => {
@@ -58,8 +68,12 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [searchOutcome] = await repo2.search({ resourceType: 'Patient' });
-    expect(searchOutcome.id).toEqual('access-denied');
+    try {
+      await repo2.search({ resourceType: 'Patient' });
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('forbidden');
+    }
   });
 
   test('Access policy allows public resources', async () => {
@@ -74,19 +88,16 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [searchOutcome] = await repo2.search({
-      resourceType: 'StructureDefinition',
-    });
-    expect(searchOutcome.id).toEqual('ok');
+    const bundle = await repo2.search({ resourceType: 'StructureDefinition' });
+    expect(bundle).toBeDefined();
   });
 
   test('Access policy restricting write', async () => {
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     const accessPolicy: AccessPolicy = {
@@ -106,20 +117,23 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome, patient2] = await repo2.readResource('Patient', patient.id as string);
-    assertOk(readOutcome, patient2);
+    const patient2 = await repo2.readResource('Patient', patient.id as string);
+    expect(patient2).toBeDefined();
 
-    const [writeOutcome] = await repo2.updateResource(patient);
-    expect(writeOutcome.id).toEqual('access-denied');
+    try {
+      await repo2.updateResource(patient);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('forbidden');
+    }
   });
 
   test('Access policy restricting delete', async () => {
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
 
     const accessPolicy: AccessPolicy = {
@@ -139,11 +153,15 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome, patient2] = await repo2.readResource('Patient', patient.id as string);
-    assertOk(readOutcome, patient2);
+    const patient2 = await repo2.readResource('Patient', patient.id as string);
+    expect(patient2).toBeDefined();
 
-    const [deleteOutcome] = await repo2.deleteResource('Patient', patient.id as string);
-    expect(deleteOutcome.id).toEqual('access-denied');
+    try {
+      await repo2.deleteResource('Patient', patient.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('forbidden');
+    }
   });
 
   test('Access policy set compartment', async () => {
@@ -171,17 +189,15 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [createOutcome, patient] = await repo.createResource<Patient>({
+    const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome, patient);
     expect(patient).toBeDefined();
     expect(patient?.meta?.account?.reference).toEqual('Organization/' + orgId);
 
-    const [readOutcome, readPatient] = await repo.readResource('Patient', patient?.id as string);
-    assertOk(readOutcome, readPatient);
+    const readPatient = await repo.readResource('Patient', patient?.id as string);
     expect(readPatient).toBeDefined();
     expect(readPatient?.meta?.account?.reference).toEqual('Organization/' + orgId);
   });
@@ -216,7 +232,7 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [createOutcome, patient] = await repo.createResource<Patient>({
+    const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
@@ -226,12 +242,10 @@ describe('AccessPolicy', () => {
         },
       },
     });
-    assertOk(createOutcome, patient);
     expect(patient.meta?.account).toBeDefined();
     expect(patient.meta?.account?.reference).toEqual('Organization/' + orgId);
 
-    const [readOutcome, readPatient] = await repo.readResource('Patient', patient?.id as string);
-    assertOk(readOutcome, readPatient);
+    const readPatient = await repo.readResource('Patient', patient?.id as string);
     expect(readPatient.meta?.account).toBeDefined();
     expect(readPatient.meta?.account?.reference).toEqual('Organization/' + orgId);
   });
@@ -284,47 +298,49 @@ describe('AccessPolicy', () => {
       accessPolicy: accessPolicy2,
     });
 
-    const [createOutcome1, patient1] = await repo1.createResource<Patient>({
+    const patient1 = await repo1.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome1, patient1);
     expect(patient1).toBeDefined();
     expect(patient1?.meta?.account).toBeDefined();
     expect(patient1?.meta?.account?.reference).toEqual('Organization/' + org1);
 
-    const [readOutcome1, readPatient1] = await repo1.readResource('Patient', patient1?.id as string);
-    assertOk(readOutcome1, readPatient1);
+    const readPatient1 = await repo1.readResource('Patient', patient1?.id as string);
     expect(readPatient1).toBeDefined();
     expect(readPatient1?.meta?.account).toBeDefined();
 
-    const [createOutcome2, patient2] = await repo2.createResource<Patient>({
+    const patient2 = await repo2.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome2, patient2);
     expect(patient2).toBeDefined();
     expect(patient2?.meta?.account).toBeDefined();
     expect(patient2?.meta?.account?.reference).toEqual('Organization/' + org2);
 
-    const [readOutcome2, readPatient2] = await repo2.readResource('Patient', patient2?.id as string);
-    assertOk(readOutcome2, readPatient2);
+    const readPatient2 = await repo2.readResource('Patient', patient2?.id as string);
     expect(readPatient2).toBeDefined();
     expect(readPatient2?.meta?.account).toBeDefined();
 
     // Try to read patient1 with repo2
     // This should fail
-    const [readOutcome3, readPatient3] = await repo2.readResource('Patient', patient1?.id as string);
-    expect(readOutcome3.id).toEqual('not-found');
-    expect(readPatient3).toBeUndefined();
+    try {
+      await repo2.readResource('Patient', patient1?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('not-found');
+    }
 
     // Try to read patient2 with repo1
     // This should fail
-    const [readOutcome4, readPatient4] = await repo1.readResource('Patient', patient2?.id as string);
-    expect(readOutcome4.id).toEqual('not-found');
-    expect(readPatient4).toBeUndefined();
+    try {
+      await repo1.readResource('Patient', patient2?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('not-found');
+    }
   });
 
   test('Access policy restrict criteria', async () => {
@@ -371,47 +387,49 @@ describe('AccessPolicy', () => {
       accessPolicy: accessPolicy2,
     });
 
-    const [createOutcome1, patient1] = await repo1.createResource<Patient>({
+    const patient1 = await repo1.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome1, patient1);
     expect(patient1).toBeDefined();
     expect(patient1?.meta?.account).toBeDefined();
     expect(patient1?.meta?.account?.reference).toEqual('Organization/' + org1);
 
-    const [readOutcome1, readPatient1] = await repo1.readResource('Patient', patient1?.id as string);
-    assertOk(readOutcome1, readPatient1);
+    const readPatient1 = await repo1.readResource('Patient', patient1?.id as string);
     expect(readPatient1).toBeDefined();
     expect(readPatient1?.meta?.account).toBeDefined();
 
-    const [createOutcome2, patient2] = await repo2.createResource<Patient>({
+    const patient2 = await repo2.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome2, patient2);
     expect(patient2).toBeDefined();
     expect(patient2?.meta?.account).toBeDefined();
     expect(patient2?.meta?.account?.reference).toEqual('Organization/' + org2);
 
-    const [readOutcome2, readPatient2] = await repo2.readResource('Patient', patient2?.id as string);
-    assertOk(readOutcome2, readPatient2);
+    const readPatient2 = await repo2.readResource('Patient', patient2?.id as string);
     expect(readPatient2).toBeDefined();
     expect(readPatient2?.meta?.account).toBeDefined();
 
     // Try to read patient1 with repo2
     // This should fail
-    const [readOutcome3, readPatient3] = await repo2.readResource('Patient', patient1?.id as string);
-    expect(readOutcome3.id).toEqual('not-found');
-    expect(readPatient3).toBeUndefined();
+    try {
+      await repo2.readResource('Patient', patient1?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('not-found');
+    }
 
     // Try to read patient2 with repo1
     // This should fail
-    const [readOutcome4, readPatient4] = await repo1.readResource('Patient', patient2?.id as string);
-    expect(readOutcome4.id).toEqual('not-found');
-    expect(readPatient4).toBeUndefined();
+    try {
+      await repo1.readResource('Patient', patient2?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('not-found');
+    }
   });
 
   test('ClientApplication with account restriction', async () => {
@@ -419,7 +437,7 @@ describe('AccessPolicy', () => {
     const account = 'Organization/' + randomUUID();
 
     // Create the access policy
-    const [accessPolicyOutcome, accessPolicy] = await systemRepo.createResource<AccessPolicy>({
+    const accessPolicy = await systemRepo.createResource<AccessPolicy>({
       resourceType: 'AccessPolicy',
       compartment: {
         reference: account,
@@ -439,10 +457,9 @@ describe('AccessPolicy', () => {
         },
       ],
     });
-    assertOk(accessPolicyOutcome, accessPolicy);
 
     // Create a ClientApplication with an account value
-    const [outcome1, clientApplication] = await systemRepo.createResource<ClientApplication>({
+    const clientApplication = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       secret: 'foo',
       redirectUri: 'https://example.com/',
@@ -452,7 +469,6 @@ describe('AccessPolicy', () => {
         },
       },
     });
-    assertOk(outcome1, clientApplication);
     expect(clientApplication).toBeDefined();
 
     // Create a repo for the ClientApplication
@@ -472,19 +488,18 @@ describe('AccessPolicy', () => {
     );
 
     // Create a Patient using the ClientApplication
-    const [outcome2, patient] = await clientRepo.createResource<Patient>({
+    const patient = await clientRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Al'], family: 'Bundy' }],
       birthDate: '1975-12-12',
     });
-    assertOk(outcome2, patient);
     expect(patient).toBeDefined();
 
     // The Patient should have the account value set
     expect(patient?.meta?.account?.reference).toEqual(account);
 
     // Create an Observation using the ClientApplication
-    const [outcome3, observation] = await clientRepo.createResource<Observation>({
+    const observation = await clientRepo.createResource<Observation>({
       resourceType: 'Observation',
       subject: createReference(patient as Patient),
       code: {
@@ -492,27 +507,29 @@ describe('AccessPolicy', () => {
       },
       valueString: 'positive',
     });
-    assertOk(outcome3, observation);
     expect(observation).toBeDefined();
 
     // The Observation should have the account value set
     expect(observation?.meta?.account?.reference).toEqual(account);
 
     // Create a Patient outside of the account
-    const [outcome4, patient2] = await systemRepo.createResource<Patient>({
+    const patient2 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Peggy'], family: 'Bundy' }],
       birthDate: '1975-11-11',
     });
-    assertOk(outcome4, patient2);
     expect(patient2).toBeDefined();
 
     // The ClientApplication should not be able to access it
-    const [outcome5] = await clientRepo.readResource<Patient>('Patient', patient2?.id as string);
-    expect(outcome5.id).toEqual('not-found');
+    try {
+      await clientRepo.readResource<Patient>('Patient', patient2?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('not-found');
+    }
 
     // Create an Observation outside of the account
-    const [outcome6, observation2] = await systemRepo.createResource<Observation>({
+    const observation2 = await systemRepo.createResource<Observation>({
       resourceType: 'Observation',
       subject: createReference(patient2 as Patient),
       code: {
@@ -520,19 +537,22 @@ describe('AccessPolicy', () => {
       },
       valueString: 'positive',
     });
-    assertOk(outcome6, observation2);
     expect(observation2).toBeDefined();
 
     // The ClientApplication should not be able to access it
-    const [outcome7] = await clientRepo.readResource<Observation>('Observation', observation2?.id as string);
-    expect(outcome7.id).toEqual('not-found');
+    try {
+      await clientRepo.readResource<Observation>('Observation', observation2?.id as string);
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('not-found');
+    }
   });
 
   test('ClientApplication with access policy', async () => {
     const project = randomUUID();
 
     // Create the access policy
-    const [accessPolicyOutcome, accessPolicy] = await systemRepo.createResource<AccessPolicy>({
+    const accessPolicy = await systemRepo.createResource<AccessPolicy>({
       resourceType: 'AccessPolicy',
       resource: [
         {
@@ -540,15 +560,13 @@ describe('AccessPolicy', () => {
         },
       ],
     });
-    assertOk(accessPolicyOutcome, accessPolicy);
 
     // Create a ClientApplication
-    const [outcome1, clientApplication] = await systemRepo.createResource<ClientApplication>({
+    const clientApplication = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       secret: 'foo',
       redirectUri: 'https://example.com/',
     });
-    assertOk(outcome1, clientApplication);
     expect(clientApplication).toBeDefined();
 
     // Create a repo for the ClientApplication
@@ -567,36 +585,37 @@ describe('AccessPolicy', () => {
     );
 
     // Create a Patient using the ClientApplication
-    const [outcome2, patient] = await clientRepo.createResource<Patient>({
+    const patient = await clientRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Al'], family: 'Bundy' }],
       birthDate: '1975-12-12',
     });
-    assertOk(outcome2, patient);
     expect(patient).toBeDefined();
 
     // Create an Observation using the ClientApplication
     // Observation is not in the AccessPolicy
     // So this should fail
-    const [outcome3, observation] = await clientRepo.createResource<Observation>({
-      resourceType: 'Observation',
-      subject: createReference(patient as Patient),
-      code: {
-        text: 'test',
-      },
-      valueString: 'positive',
-    });
-    expect(outcome3.id).toEqual('access-denied');
-    expect(observation).toBeUndefined();
+    try {
+      await clientRepo.createResource<Observation>({
+        resourceType: 'Observation',
+        subject: createReference(patient as Patient),
+        code: {
+          text: 'test',
+        },
+        valueString: 'positive',
+      });
+      fail('Expected error');
+    } catch (err) {
+      expect((err as OperationOutcome).id).toEqual('forbidden');
+    }
   });
 
   test('Readonly fields on write', async () => {
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome, patient);
 
     // AccessPolicy that hides Patient name
     const accessPolicy: AccessPolicy = {
@@ -616,20 +635,18 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome, readResource] = await repo2.readResource<Patient>('Patient', patient?.id as string);
-    assertOk(readOutcome, readResource);
+    const readResource = await repo2.readResource<Patient>('Patient', patient?.id as string);
     expect(readResource).toMatchObject({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
 
-    const [writeOutcome, writeResource] = await repo2.updateResource<Patient>({
+    const writeResource = await repo2.updateResource<Patient>({
       ...readResource,
       active: true,
       name: [{ given: ['Bob'], family: 'Smith' }],
     });
-    assertOk(writeOutcome, writeResource);
     expect(writeResource).toMatchObject({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
@@ -660,12 +677,11 @@ describe('AccessPolicy', () => {
     });
 
     // Create a patient with an identifier
-    const [outcome, patient] = await repo.createResource<Patient>({
+    const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Identifier'], family: 'Test' }],
       identifier: [{ system: 'https://example.com/', value }],
     });
-    assertOk(outcome, patient);
     expect(patient.identifier).toBeUndefined();
   });
 
@@ -673,11 +689,10 @@ describe('AccessPolicy', () => {
     const value = randomUUID();
 
     // Create a patient
-    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Identifier'], family: 'Test' }],
     });
-    assertOk(outcome1, patient1);
 
     // AccessPolicy with Patient.identifier readonly
     const accessPolicy: AccessPolicy = {
@@ -699,16 +714,15 @@ describe('AccessPolicy', () => {
 
     // Try to add an identifier
     // This returns success, but the result should not have an identifier
-    const [outcome3, patient2] = await repo.updateResource<Patient>({
+    const patient2 = await repo.updateResource<Patient>({
       ...patient1,
       identifier: [{ system: 'https://example.com/', value }],
     });
-    assertOk(outcome3, patient2);
     expect(patient2.identifier).toBeUndefined();
 
     // Try to search for the identifier
     // This should still return the result succeed
-    const [outcome4, bundle2] = await repo.search<Patient>({
+    const bundle2 = await repo.search<Patient>({
       resourceType: 'Patient',
       filters: [
         {
@@ -718,7 +732,6 @@ describe('AccessPolicy', () => {
         },
       ],
     });
-    assertOk(outcome4, bundle2);
     expect(bundle2.entry?.length).toEqual(0);
   });
 
@@ -726,16 +739,15 @@ describe('AccessPolicy', () => {
     const value = randomUUID();
 
     // Create a patient with an identifier
-    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Identifier'], family: 'Test' }],
       identifier: [{ system: 'https://example.com/', value }],
     });
-    assertOk(outcome1, patient1);
 
     // Search for patient by identifier
     // This should succeed
-    const [outcome2, bundle1] = await systemRepo.search<Patient>({
+    const bundle1 = await systemRepo.search<Patient>({
       resourceType: 'Patient',
       filters: [
         {
@@ -745,7 +757,6 @@ describe('AccessPolicy', () => {
         },
       ],
     });
-    assertOk(outcome2, bundle1);
     expect(bundle1.entry?.length).toEqual(1);
 
     // AccessPolicy with Patient.identifier readonly
@@ -773,14 +784,13 @@ describe('AccessPolicy', () => {
     // Try to update the patient without the identifier
     // Effectively, try to remove the identifier
     // This returns success, but the identifier should still be there
-    const [outcome3, patient2] = await repo.updateResource<Patient>(rest);
-    assertOk(outcome3, patient2);
+    const patient2 = await repo.updateResource<Patient>(rest);
     expect(patient2.identifier).toBeDefined();
     expect(patient2.identifier?.[0]?.value).toEqual(value);
 
     // Try to search for the identifier
     // This should still return the result succeed
-    const [outcome4, bundle2] = await repo.search<Patient>({
+    const bundle2 = await repo.search<Patient>({
       resourceType: 'Patient',
       filters: [
         {
@@ -790,17 +800,15 @@ describe('AccessPolicy', () => {
         },
       ],
     });
-    assertOk(outcome4, bundle2);
     expect(bundle2.entry?.length).toEqual(1);
   });
 
   test('Hidden fields on read', async () => {
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       birthDate: '1970-01-01',
     });
-    assertOk(createOutcome, patient);
 
     // AccessPolicy that hides Patient name
     const accessPolicy: AccessPolicy = {
@@ -820,16 +828,14 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome, readResource] = await repo2.readResource<Patient>('Patient', patient?.id as string);
-    assertOk(readOutcome, readResource);
+    const readResource = await repo2.readResource<Patient>('Patient', patient?.id as string);
     expect(readResource).toMatchObject({
       resourceType: 'Patient',
       birthDate: '1970-01-01',
     });
     expect(readResource.name).toBeUndefined();
 
-    const [readHistoryOutcome, historyBundle] = await repo2.readHistory<Patient>('Patient', patient?.id as string);
-    assertOk(readHistoryOutcome, historyBundle);
+    const historyBundle = await repo2.readHistory<Patient>('Patient', patient?.id as string);
     expect(historyBundle).toMatchObject({
       resourceType: 'Bundle',
       type: 'history',
@@ -846,7 +852,7 @@ describe('AccessPolicy', () => {
   });
 
   test('Nested hidden fields on read', async () => {
-    const [createOutcome, serviceRequest] = await systemRepo.createResource<ServiceRequest>({
+    const serviceRequest = await systemRepo.createResource<ServiceRequest>({
       resourceType: 'ServiceRequest',
       code: {
         text: 'test',
@@ -856,7 +862,6 @@ describe('AccessPolicy', () => {
         display: 'Alice Smith',
       },
     });
-    assertOk(createOutcome, serviceRequest);
 
     // AccessPolicy that hides ServiceRequest subject.display
     const accessPolicy: AccessPolicy = {
@@ -876,11 +881,7 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome, readResource] = await repo2.readResource<ServiceRequest>(
-      'ServiceRequest',
-      serviceRequest?.id as string
-    );
-    assertOk(readOutcome, readResource);
+    const readResource = await repo2.readResource<ServiceRequest>('ServiceRequest', serviceRequest?.id as string);
     expect(readResource).toMatchObject({
       resourceType: 'ServiceRequest',
       code: {
@@ -891,11 +892,7 @@ describe('AccessPolicy', () => {
     expect(readResource.subject?.reference).toBeDefined();
     expect(readResource.subject?.display).toBeUndefined();
 
-    const [readHistoryOutcome, historyBundle] = await repo2.readHistory<ServiceRequest>(
-      'ServiceRequest',
-      serviceRequest?.id as string
-    );
-    assertOk(readHistoryOutcome, historyBundle);
+    const historyBundle = await repo2.readHistory<ServiceRequest>('ServiceRequest', serviceRequest?.id as string);
     expect(historyBundle).toMatchObject({
       resourceType: 'Bundle',
       type: 'history',
@@ -916,7 +913,7 @@ describe('AccessPolicy', () => {
   });
 
   test('Hide nonexistent field', async () => {
-    const [createOutcome, serviceRequest] = await systemRepo.createResource<ServiceRequest>({
+    const serviceRequest = await systemRepo.createResource<ServiceRequest>({
       resourceType: 'ServiceRequest',
       code: {
         text: 'test',
@@ -925,7 +922,6 @@ describe('AccessPolicy', () => {
         reference: 'Patient/' + randomUUID(),
       },
     });
-    assertOk(createOutcome, serviceRequest);
 
     // AccessPolicy that hides ServiceRequest subject.display
     const accessPolicy: AccessPolicy = {
@@ -945,11 +941,7 @@ describe('AccessPolicy', () => {
       accessPolicy,
     });
 
-    const [readOutcome, readResource] = await repo2.readResource<ServiceRequest>(
-      'ServiceRequest',
-      serviceRequest?.id as string
-    );
-    assertOk(readOutcome, readResource);
+    const readResource = await repo2.readResource<ServiceRequest>('ServiceRequest', serviceRequest?.id as string);
     expect(readResource).toMatchObject({
       resourceType: 'ServiceRequest',
       code: {
@@ -960,11 +952,7 @@ describe('AccessPolicy', () => {
     expect(readResource.subject?.reference).toBeDefined();
     expect(readResource.subject?.display).toBeUndefined();
 
-    const [readHistoryOutcome, historyBundle] = await repo2.readHistory<ServiceRequest>(
-      'ServiceRequest',
-      serviceRequest?.id as string
-    );
-    assertOk(readHistoryOutcome, historyBundle);
+    const historyBundle = await repo2.readHistory<ServiceRequest>('ServiceRequest', serviceRequest?.id as string);
     expect(historyBundle).toMatchObject({
       resourceType: 'Bundle',
       type: 'history',

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest } from '@medplum/core';
+import { badRequest } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import internal from 'stream';
@@ -18,14 +18,13 @@ binaryRouter.post(
     const filename = req.query['_filename'] as string | undefined;
     const contentType = req.get('Content-Type');
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.createResource<Binary>({
+    const resource = await repo.createResource<Binary>({
       resourceType: 'Binary',
       contentType,
       meta: {
         project: req.query['_project'] as string | undefined,
       },
     });
-    assertOk(outcome, resource);
 
     const stream = getContentStream(req);
     if (!stream) {
@@ -53,7 +52,7 @@ binaryRouter.put(
     const filename = req.query['_filename'] as string | undefined;
     const contentType = req.get('Content-Type');
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.updateResource<Binary>({
+    const resource = await repo.updateResource<Binary>({
       resourceType: 'Binary',
       id,
       contentType,
@@ -61,7 +60,6 @@ binaryRouter.put(
         project: req.query['_project'] as string | undefined,
       },
     });
-    assertOk(outcome, resource);
 
     const stream = getContentStream(req);
     if (!stream) {
@@ -80,8 +78,7 @@ binaryRouter.get(
   asyncWrap(async (req: Request, res: Response) => {
     const { id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, binary] = await repo.readResource<Binary>('Binary', id);
-    assertOk(outcome, binary);
+    const binary = await repo.readResource<Binary>('Binary', id);
 
     res.status(200).contentType(binary.contentType as string);
 

--- a/packages/server/src/fhir/lookups/address.test.ts
+++ b/packages/server/src/fhir/lookups/address.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
@@ -24,7 +24,7 @@ describe('Address Lookup Table', () => {
     const addressLine = randomUUID();
     const addressCity = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       address: [
@@ -38,9 +38,8 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome1, searchResult1] = await systemRepo.search({
+    const searchResult1 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -50,11 +49,10 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome1, searchResult1);
     expect(searchResult1.entry?.length).toEqual(1);
     expect(searchResult1.entry?.[0]?.resource?.id).toEqual(patient.id);
 
-    const [searchOutcome2, searchResult2] = await systemRepo.search({
+    const searchResult2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -64,7 +62,6 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome2, searchResult2);
     expect(searchResult2.entry?.length).toEqual(1);
     expect(searchResult2.entry?.[0]?.resource?.id).toEqual(patient.id);
   });
@@ -73,7 +70,7 @@ describe('Address Lookup Table', () => {
     const address = randomUUID();
     const other = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       address: [
@@ -81,9 +78,8 @@ describe('Address Lookup Table', () => {
         { use: 'home', line: [other] },
       ],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -93,11 +89,10 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient.id);
 
-    const [searchOutcome2, searchResult2] = await systemRepo.search({
+    const searchResult2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -107,7 +102,6 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome2, searchResult2);
     expect(searchResult2.entry?.length).toEqual(1);
     expect(searchResult2.entry?.[0]?.resource?.id).toEqual(patient.id);
   });
@@ -116,14 +110,13 @@ describe('Address Lookup Table', () => {
     const address1 = randomUUID();
     const address2 = randomUUID();
 
-    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       address: [{ use: 'home', line: [address1] }],
     });
-    assertOk(outcome1, patient1);
 
-    const [outcome2, bundle2] = await systemRepo.search({
+    const bundle2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -133,11 +126,10 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome2, bundle2);
     expect(bundle2.entry?.length).toEqual(1);
     expect(bundle2.entry?.[0]?.resource?.id).toEqual(patient1.id);
 
-    const [outcome3, bundle3] = await systemRepo.search({
+    const bundle3 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -147,16 +139,14 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome3, bundle3);
     expect(bundle3.entry?.length).toEqual(0);
 
-    const [outcome4, patient4] = await systemRepo.updateResource<Patient>({
+    await systemRepo.updateResource<Patient>({
       ...patient1,
       address: [{ use: 'home', line: [address2] }],
     });
-    assertOk(outcome4, patient4);
 
-    const [outcome5, bundle5] = await systemRepo.search({
+    const bundle5 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -166,10 +156,9 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome5, bundle5);
     expect(bundle5.entry?.length).toEqual(0);
 
-    const [outcome6, bundle6] = await systemRepo.search({
+    const bundle6 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -179,7 +168,6 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome6, bundle6);
     expect(bundle6.entry?.length).toEqual(1);
     expect(bundle6.entry?.[0]?.resource?.id).toEqual(patient1.id);
   });

--- a/packages/server/src/fhir/lookups/contactpoint.test.ts
+++ b/packages/server/src/fhir/lookups/contactpoint.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
@@ -24,7 +24,7 @@ describe('Address Lookup Table', () => {
     const email = randomUUID();
     const phone = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       telecom: [
@@ -39,9 +39,7 @@ describe('Address Lookup Table', () => {
       ],
     });
 
-    expect(createOutcome.id).toEqual('created');
-
-    const [searchOutcome1, searchResult1] = await systemRepo.search({
+    const searchResult1 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -52,11 +50,10 @@ describe('Address Lookup Table', () => {
       ],
     });
 
-    expect(searchOutcome1.id).toEqual('ok');
     expect(searchResult1?.entry?.length).toEqual(1);
     expect(searchResult1?.entry?.[0]?.resource?.id).toEqual(patient?.id);
 
-    const [searchOutcome2, searchResult2] = await systemRepo.search({
+    const searchResult2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -67,7 +64,6 @@ describe('Address Lookup Table', () => {
       ],
     });
 
-    expect(searchOutcome2.id).toEqual('ok');
     expect(searchResult2?.entry?.length).toEqual(1);
     expect(searchResult2?.entry?.[0]?.resource?.id).toEqual(patient?.id);
   });
@@ -76,14 +72,13 @@ describe('Address Lookup Table', () => {
     const value1 = randomUUID();
     const value2 = randomUUID();
 
-    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       telecom: [{ use: 'home', system: 'phone', value: value1 }],
     });
-    assertOk(outcome1, patient1);
 
-    const [outcome2, bundle2] = await systemRepo.search({
+    const bundle2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -93,11 +88,10 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome2, bundle2);
     expect(bundle2.entry?.length).toEqual(1);
     expect(bundle2.entry?.[0]?.resource?.id).toEqual(patient1.id);
 
-    const [outcome3, bundle3] = await systemRepo.search({
+    const bundle3 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -107,16 +101,14 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome3, bundle3);
     expect(bundle3.entry?.length).toEqual(0);
 
-    const [outcome4, patient4] = await systemRepo.updateResource<Patient>({
+    await systemRepo.updateResource<Patient>({
       ...patient1,
       telecom: [{ use: 'home', system: 'phone', value: value2 }],
     });
-    assertOk(outcome4, patient4);
 
-    const [outcome5, bundle5] = await systemRepo.search({
+    const bundle5 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -126,10 +118,9 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome5, bundle5);
     expect(bundle5.entry?.length).toEqual(0);
 
-    const [outcome6, bundle6] = await systemRepo.search({
+    const bundle6 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -139,7 +130,6 @@ describe('Address Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome6, bundle6);
     expect(bundle6.entry?.length).toEqual(1);
     expect(bundle6.entry?.[0]?.resource?.id).toEqual(patient1.id);
   });

--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
@@ -24,13 +24,12 @@ describe('HumanName Lookup Table', () => {
   test('HumanName', async () => {
     const name = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: name }],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -40,7 +39,6 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient?.id);
   });
@@ -50,13 +48,12 @@ describe('HumanName Lookup Table', () => {
     const name2 = randomUUID();
     const name3 = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: [name1, name2], family: name3 }],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -66,7 +63,6 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient?.id);
   });
@@ -76,15 +72,14 @@ describe('HumanName Lookup Table', () => {
     const patients = [];
 
     for (const name of names) {
-      const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+      const patient = await systemRepo.createResource<Patient>({
         resourceType: 'Patient',
         name: [{ family: name }],
       });
-      assertOk(createOutcome, patient);
       patients.push(patient);
     }
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -94,7 +89,6 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(2);
     expect(bundleContains(searchResult, patients[0])).toBe(true);
     expect(bundleContains(searchResult, patients[1])).toBe(true);
@@ -105,16 +99,15 @@ describe('HumanName Lookup Table', () => {
     const name = randomUUID();
     const other = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [
         { given: ['Alice'], family: name },
         { given: ['Alice'], family: other },
       ],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -124,11 +117,10 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient.id);
 
-    const [searchOutcome2, searchResult2] = await systemRepo.search({
+    const searchResult2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -138,7 +130,6 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome2, searchResult2);
     expect(searchResult2.entry?.length).toEqual(1);
     expect(searchResult2.entry?.[0]?.resource?.id).toEqual(patient.id);
   });
@@ -147,13 +138,12 @@ describe('HumanName Lookup Table', () => {
     const name1 = randomUUID();
     const name2 = randomUUID();
 
-    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: name1 }],
     });
-    assertOk(outcome1, patient1);
 
-    const [outcome2, bundle2] = await systemRepo.search({
+    const bundle2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -163,11 +153,10 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome2, bundle2);
     expect(bundle2.entry?.length).toEqual(1);
     expect(bundle2.entry?.[0]?.resource?.id).toEqual(patient1.id);
 
-    const [outcome3, bundle3] = await systemRepo.search({
+    const bundle3 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -177,16 +166,14 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome3, bundle3);
     expect(bundle3.entry?.length).toEqual(0);
 
-    const [outcome4, patient4] = await systemRepo.updateResource<Patient>({
+    await systemRepo.updateResource<Patient>({
       ...patient1,
       name: [{ given: ['Alice'], family: name2 }],
     });
-    assertOk(outcome4, patient4);
 
-    const [outcome5, bundle5] = await systemRepo.search({
+    const bundle5 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -196,10 +183,9 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome5, bundle5);
     expect(bundle5.entry?.length).toEqual(0);
 
-    const [outcome6, bundle6] = await systemRepo.search({
+    const bundle6 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -209,7 +195,6 @@ describe('HumanName Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome6, bundle6);
     expect(bundle6.entry?.length).toEqual(1);
     expect(bundle6.entry?.[0]?.resource?.id).toEqual(patient1.id);
   });

--- a/packages/server/src/fhir/lookups/identifier.test.ts
+++ b/packages/server/src/fhir/lookups/identifier.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { Patient, SpecimenDefinition } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { loadTestConfig } from '../../config';
@@ -24,14 +24,13 @@ describe('Identifier Lookup Table', () => {
   test('Identifier', async () => {
     const identifier = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       identifier: [{ system: 'https://www.example.com', value: identifier }],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -41,7 +40,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient?.id);
   });
@@ -50,7 +48,7 @@ describe('Identifier Lookup Table', () => {
     const identifier = randomUUID();
     const other = randomUUID();
 
-    const [createOutcome, patient] = await systemRepo.createResource<Patient>({
+    const patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       identifier: [
@@ -59,9 +57,8 @@ describe('Identifier Lookup Table', () => {
         { system: 'other', value: other },
       ],
     });
-    assertOk(createOutcome, patient);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -71,11 +68,10 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient.id);
 
-    const [searchOutcome2, searchResult2] = await systemRepo.search({
+    const searchResult2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -85,7 +81,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome2, searchResult2);
     expect(searchResult2.entry?.length).toEqual(1);
     expect(searchResult2.entry?.[0]?.resource?.id).toEqual(patient.id);
   });
@@ -94,14 +89,13 @@ describe('Identifier Lookup Table', () => {
     const identifier1 = randomUUID();
     const identifier2 = randomUUID();
 
-    const [outcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       identifier: [{ system: 'https://www.example.com', value: identifier1 }],
     });
-    assertOk(outcome1, patient1);
 
-    const [outcome2, bundle2] = await systemRepo.search({
+    const bundle2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -111,11 +105,10 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome2, bundle2);
     expect(bundle2.entry?.length).toEqual(1);
     expect(bundle2.entry?.[0]?.resource?.id).toEqual(patient1.id);
 
-    const [outcome3, bundle3] = await systemRepo.search({
+    const bundle3 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -125,16 +118,14 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome3, bundle3);
     expect(bundle3.entry?.length).toEqual(0);
 
-    const [outcome4, patient4] = await systemRepo.updateResource<Patient>({
+    await systemRepo.updateResource<Patient>({
       ...patient1,
       identifier: [{ system: 'https://www.example.com', value: identifier2 }],
     });
-    assertOk(outcome4, patient4);
 
-    const [outcome5, bundle5] = await systemRepo.search({
+    const bundle5 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -144,10 +135,9 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome5, bundle5);
     expect(bundle5.entry?.length).toEqual(0);
 
-    const [outcome6, bundle6] = await systemRepo.search({
+    const bundle6 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -157,7 +147,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(outcome6, bundle6);
     expect(bundle6.entry?.length).toEqual(1);
     expect(bundle6.entry?.[0]?.resource?.id).toEqual(patient1.id);
   });
@@ -165,21 +154,19 @@ describe('Identifier Lookup Table', () => {
   test('Search identifier exact', async () => {
     const identifier = randomUUID();
 
-    const [createOutcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       identifier: [{ system: 'https://www.example.com', value: identifier }],
     });
-    assertOk(createOutcome1, patient1);
 
-    const [createOutcome2, patient2] = await systemRepo.createResource<Patient>({
+    const patient2 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Jones' }],
       identifier: [{ system: 'https://www.example.com', value: identifier + 'xyz' }],
     });
-    assertOk(createOutcome2, patient2);
 
-    const [searchOutcome1, searchResult1] = await systemRepo.search({
+    const searchResult1 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -189,7 +176,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome1, searchResult1);
     expect(searchResult1?.entry?.length).toEqual(1);
     expect(bundleContains(searchResult1, patient1)).toBe(true);
     expect(bundleContains(searchResult1, patient2)).toBe(false);
@@ -199,21 +185,19 @@ describe('Identifier Lookup Table', () => {
     const identifier1 = randomUUID();
     const identifier2 = randomUUID();
 
-    const [createOutcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       identifier: [{ system: 'https://www.example.com', value: identifier1 }],
     });
-    assertOk(createOutcome1, patient1);
 
-    const [createOutcome2, patient2] = await systemRepo.createResource<Patient>({
+    const patient2 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Jones' }],
       identifier: [{ system: 'https://www.example.com', value: identifier2 }],
     });
-    assertOk(createOutcome2, patient2);
 
-    const [searchOutcome1, searchResult1] = await systemRepo.search({
+    const searchResult1 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -223,7 +207,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome1, searchResult1);
     expect(searchResult1?.entry?.length).toEqual(2);
     expect(bundleContains(searchResult1, patient1)).toBe(true);
     expect(bundleContains(searchResult1, patient2)).toBe(true);
@@ -234,21 +217,19 @@ describe('Identifier Lookup Table', () => {
     const system2 = 'https://bar.com';
     const identifier = randomUUID();
 
-    const [createOutcome1, patient1] = await systemRepo.createResource<Patient>({
+    const patient1 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Smith' }],
       identifier: [{ system: system1, value: identifier }],
     });
-    assertOk(createOutcome1, patient1);
 
-    const [createOutcome2, patient2] = await systemRepo.createResource<Patient>({
+    const patient2 = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       name: [{ given: ['Alice'], family: 'Jones' }],
       identifier: [{ system: system2, value: identifier }],
     });
-    assertOk(createOutcome2, patient2);
 
-    const [searchOutcome1, searchResult1] = await systemRepo.search({
+    const searchResult1 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -258,12 +239,11 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome1, searchResult1);
     expect(searchResult1?.entry?.length).toEqual(1);
     expect(bundleContains(searchResult1, patient1)).toBe(true);
     expect(bundleContains(searchResult1, patient2)).toBe(false);
 
-    const [searchOutcome2, searchResult2] = await systemRepo.search({
+    const searchResult2 = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -273,7 +253,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome2, searchResult2);
     expect(searchResult2?.entry?.length).toEqual(1);
     expect(bundleContains(searchResult2, patient1)).toBe(false);
     expect(bundleContains(searchResult2, patient2)).toBe(true);
@@ -282,13 +261,12 @@ describe('Identifier Lookup Table', () => {
   test('Non-array identifier', async () => {
     const identifier = randomUUID();
 
-    const [createOutcome, resource] = await systemRepo.createResource<SpecimenDefinition>({
+    const resource = await systemRepo.createResource<SpecimenDefinition>({
       resourceType: 'SpecimenDefinition',
       identifier: { system: 'https://www.example.com', value: identifier },
     });
-    assertOk(createOutcome, resource);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'SpecimenDefinition',
       filters: [
         {
@@ -298,7 +276,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(resource?.id);
   });
@@ -306,13 +283,12 @@ describe('Identifier Lookup Table', () => {
   test('Leading whitespace', async () => {
     const identifier = randomUUID();
 
-    const [createOutcome, resource] = await systemRepo.createResource<Patient>({
+    const resource = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
       identifier: [{ system: 'https://www.example.com', value: ' ' + identifier }],
     });
-    assertOk(createOutcome, resource);
 
-    const [searchOutcome, searchResult] = await systemRepo.search({
+    const searchResult = await systemRepo.search({
       resourceType: 'Patient',
       filters: [
         {
@@ -322,7 +298,6 @@ describe('Identifier Lookup Table', () => {
         },
       ],
     });
-    assertOk(searchOutcome, searchResult);
     expect(searchResult.entry?.length).toEqual(1);
     expect(searchResult.entry?.[0]?.resource?.id).toEqual(resource?.id);
   });

--- a/packages/server/src/fhir/operations/csv.ts
+++ b/packages/server/src/fhir/operations/csv.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest, evalFhirPath, formatAddress, formatHumanName } from '@medplum/core';
+import { badRequest, evalFhirPath, formatAddress, formatHumanName } from '@medplum/core';
 import { Address, BundleEntry, CodeableConcept, ContactPoint, HumanName, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { sendOutcome } from '../outcomes';
@@ -44,8 +44,7 @@ export async function csvHandler(req: Request, res: Response): Promise<void> {
   const query = req.query as Record<string, string[] | string | undefined>;
   const searchRequest = parseSearchRequest(resourceType, query);
   searchRequest.count = 10000;
-  const [outcome, bundle] = await repo.search(searchRequest);
-  assertOk(outcome, bundle);
+  const bundle = await repo.search(searchRequest);
 
   const columnEntries = Object.entries(columns);
   const output: string[][] = [];

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -8,7 +8,7 @@ import {
   UpdateFunctionCodeCommand,
   UpdateFunctionConfigurationCommand,
 } from '@aws-sdk/client-lambda';
-import { allOk, assertOk, badRequest } from '@medplum/core';
+import { allOk, badRequest } from '@medplum/core';
 import { Bot } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import JSZip from 'jszip';
@@ -84,8 +84,7 @@ function createPdf(docDefinition, tableLayouts, fonts) {
 export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
   const { id } = req.params;
   const repo = res.locals.repo as Repository;
-  const [outcome, bot] = await repo.readResource<Bot>('Bot', id);
-  assertOk(outcome, bot);
+  const bot = await repo.readResource<Bot>('Bot', id);
 
   const client = new LambdaClient({ region: 'us-east-1' });
   const name = `medplum-bot-lambda-${bot.id}`;

--- a/packages/server/src/fhir/operations/graphql.ts
+++ b/packages/server/src/fhir/operations/graphql.ts
@@ -417,8 +417,7 @@ async function resolveBySearch(
 async function resolveById(_source: any, args: any, ctx: any, info: GraphQLResolveInfo): Promise<Resource | undefined> {
   const repo = ctx.res.locals.repo as Repository;
   try {
-    const resource = await repo.readResource(info.fieldName, args.id);
-    return resource;
+    return await repo.readResource(info.fieldName, args.id);
   } catch (err) {
     throw new Error(normalizeErrorString(err));
   }
@@ -436,8 +435,7 @@ async function resolveById(_source: any, args: any, ctx: any, info: GraphQLResol
 async function resolveByReference(source: any, _args: any, ctx: any): Promise<Resource | undefined> {
   const repo = ctx.res.locals.repo as Repository;
   try {
-    const resource = await repo.readReference(source as Reference);
-    return resource;
+    return await repo.readReference(source as Reference);
   } catch (err) {
     throw new Error(normalizeErrorString(err));
   }

--- a/packages/server/src/fhir/operations/graphql.ts
+++ b/packages/server/src/fhir/operations/graphql.ts
@@ -1,4 +1,12 @@
-import { assertOk, badRequest, Filter, getReferenceString, LRUCache, Operator, SearchRequest } from '@medplum/core';
+import {
+  badRequest,
+  Filter,
+  getReferenceString,
+  LRUCache,
+  normalizeErrorString,
+  Operator,
+  SearchRequest,
+} from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import {
@@ -391,8 +399,7 @@ async function resolveBySearch(
   const resourceType = fieldName.substring(0, fieldName.length - 4); // Remove "List"
   const repo = ctx.res.locals.repo as Repository;
   const searchRequest = parseSearchArgs(resourceType, source, args);
-  const [outcome, bundle] = await repo.search(searchRequest);
-  assertOk(outcome, bundle);
+  const bundle = await repo.search(searchRequest);
   return bundle.entry?.map((e) => e.resource as Resource);
 }
 
@@ -409,9 +416,12 @@ async function resolveBySearch(
  */
 async function resolveById(_source: any, args: any, ctx: any, info: GraphQLResolveInfo): Promise<Resource | undefined> {
   const repo = ctx.res.locals.repo as Repository;
-  const [outcome, resource] = await repo.readResource(info.fieldName, args.id);
-  assertOk(outcome, resource);
-  return resource;
+  try {
+    const resource = await repo.readResource(info.fieldName, args.id);
+    return resource;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
 }
 
 /**
@@ -425,9 +435,12 @@ async function resolveById(_source: any, args: any, ctx: any, info: GraphQLResol
  */
 async function resolveByReference(source: any, _args: any, ctx: any): Promise<Resource | undefined> {
   const repo = ctx.res.locals.repo as Repository;
-  const [outcome, resource] = await repo.readReference(source as Reference);
-  assertOk(outcome, resource);
-  return resource;
+  try {
+    const resource = await repo.readReference(source as Reference);
+    return resource;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
 }
 
 /**

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -99,7 +99,7 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res4.status).toBe(201);
+    expect(res4.status).toBe(200);
     expect(res4.body.resourceType).toEqual('RequestGroup');
     expect((res4.body as RequestGroup).action).toHaveLength(1);
     expect((res4.body as RequestGroup).action?.[0]?.resource?.reference).toBeDefined();

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest, createReference, getReferenceString, OperationOutcomeError } from '@medplum/core';
+import { allOk, badRequest, createReference, getReferenceString, OperationOutcomeError } from '@medplum/core';
 import {
   CareTeam,
   Device,
@@ -50,8 +50,7 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
   const { id } = req.params;
   const repo = res.locals.repo as Repository;
 
-  const [outcome1, planDefinition] = await repo.readResource<PlanDefinition>('PlanDefinition', id);
-  assertOk(outcome1, planDefinition);
+  const planDefinition = await repo.readResource<PlanDefinition>('PlanDefinition', id);
 
   const params = await validateParameters(req, res);
   if (!params) {
@@ -65,15 +64,14 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
     }
   }
 
-  const [outcome3, requestGroup] = await repo.createResource<RequestGroup>({
+  const requestGroup = await repo.createResource<RequestGroup>({
     resourceType: 'RequestGroup',
     instantiatesCanonical: [getReferenceString(planDefinition)],
     subject: createReference(params.subject) as Reference<Patient | Group>,
     status: 'active',
     action: actions,
   });
-  assertOk(outcome3, requestGroup);
-  sendResponse(res, outcome3, requestGroup);
+  sendResponse(res, allOk, requestGroup);
 }
 
 /**
@@ -102,8 +100,7 @@ async function validateParameters(req: Request, res: Response): Promise<PlanDefi
   }
 
   const repo = res.locals.repo as Repository;
-  const [outcome2, subject] = await repo.readReference(subjectParam.valueReference as Reference<SubjectType>);
-  assertOk(outcome2, subject);
+  const subject = await repo.readReference(subjectParam.valueReference as Reference<SubjectType>);
 
   return {
     subject,
@@ -140,7 +137,7 @@ async function createQuestionnaireTask(
   params: PlanDefinitionApplyParameters,
   action: PlanDefinitionAction
 ): Promise<RequestGroupAction> {
-  const [outcome, task] = await repo.createResource<Task>({
+  const task = await repo.createResource<Task>({
     resourceType: 'Task',
     intent: 'order',
     status: 'requested',
@@ -155,7 +152,6 @@ async function createQuestionnaireTask(
       },
     ],
   });
-  assertOk(outcome, task);
 
   return {
     title: action.title,

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1,13 +1,10 @@
 import {
-  accessDenied,
-  allOk,
-  assertOk,
   badRequest,
-  created,
   deepEquals,
   DEFAULT_SEARCH_COUNT,
   evalFhirPath,
   Filter,
+  forbidden,
   formatSearchQuery,
   getSearchParameterDetails,
   getStatus,
@@ -16,7 +13,6 @@ import {
   isNotFound,
   isOk,
   notFound,
-  notModified,
   Operator as FhirOperator,
   resolveId,
   SearchParameterDetails,
@@ -46,6 +42,7 @@ import { URL } from 'url';
 import validator from 'validator';
 import { getConfig } from '../config';
 import { getClient } from '../database';
+import { logger } from '../logger';
 import { getRedis } from '../redis';
 import { addBackgroundJobs } from '../workers';
 import { addSubscriptionJobs } from '../workers/subscription';
@@ -99,8 +96,6 @@ export interface CacheEntry<T extends Resource> {
   compartments: string[];
 }
 
-export type RepositoryResult<T extends Resource | undefined> = Promise<[OperationOutcome, T | undefined]>;
-
 /**
  * Public resource types are in the "public" project.
  * They are available to all users.
@@ -145,12 +140,8 @@ export class Repository {
     }
   }
 
-  async createResource<T extends Resource>(resource: T): RepositoryResult<T> {
-    const validateOutcome = validateResource(resource);
-    if (!isOk(validateOutcome)) {
-      return [validateOutcome, undefined];
-    }
-
+  async createResource<T extends Resource>(resource: T): Promise<T> {
+    validateResource(resource);
     return this.#updateResourceImpl(
       {
         ...resource,
@@ -160,18 +151,15 @@ export class Repository {
     );
   }
 
-  async readResource<T extends Resource>(resourceType: string, id: string): RepositoryResult<T> {
+  async readResource<T extends Resource>(resourceType: string, id: string): Promise<T> {
     if (!id || !validator.isUUID(id)) {
-      return [badRequest('Invalid UUID'), undefined];
+      throw badRequest('Invalid UUID');
     }
 
-    const validateOutcome = validateResourceType(resourceType);
-    if (!isOk(validateOutcome)) {
-      return [validateOutcome, undefined];
-    }
+    validateResourceType(resourceType);
 
     if (!this.#canReadResourceType(resourceType)) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
     if (!this.#context.accessPolicy) {
@@ -183,9 +171,9 @@ export class Repository {
           cacheRecord.projectId !== undefined &&
           cacheRecord.projectId !== this.#context.project
         ) {
-          return [notFound, undefined];
+          throw notFound;
         }
-        return [allOk, this.#removeHiddenFields(cacheRecord.resource)];
+        return this.#removeHiddenFields(cacheRecord.resource);
       }
     }
 
@@ -196,22 +184,22 @@ export class Repository {
 
     const rows = await builder.execute(client);
     if (rows.length === 0) {
-      return [notFound, undefined];
+      throw notFound;
     }
 
     if (rows[0].deleted) {
-      return [gone, undefined];
+      throw gone;
     }
 
     const resource = JSON.parse(rows[0].content as string) as T;
     setCacheEntry(resource);
-    return [allOk, this.#removeHiddenFields(resource)];
+    return this.#removeHiddenFields(resource);
   }
 
-  async readReference<T extends Resource>(reference: Reference<T>): RepositoryResult<T> {
+  async readReference<T extends Resource>(reference: Reference<T>): Promise<T> {
     const parts = reference.reference?.split('/');
     if (!parts || parts.length !== 2) {
-      return [badRequest('Invalid reference'), undefined];
+      throw badRequest('Invalid reference');
     }
     return this.readResource(parts[0], parts[1]);
   }
@@ -227,11 +215,8 @@ export class Repository {
    * @param id The FHIR resource ID.
    * @returns Operation outcome and a history bundle.
    */
-  async readHistory<T extends Resource>(resourceType: string, id: string): RepositoryResult<Bundle<T>> {
-    const [resourceOutcome] = await this.readResource<T>(resourceType, id);
-    if (!isOk(resourceOutcome)) {
-      return [resourceOutcome, undefined];
-    }
+  async readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
+    await this.readResource<T>(resourceType, id);
 
     const client = getClient();
     const rows = await new SelectQuery(resourceType + '_History')
@@ -258,25 +243,19 @@ export class Repository {
       }
     }
 
-    return [
-      allOk,
-      {
-        resourceType: 'Bundle',
-        type: 'history',
-        entry: entries,
-      },
-    ];
+    return {
+      resourceType: 'Bundle',
+      type: 'history',
+      entry: entries,
+    };
   }
 
-  async readVersion<T extends Resource>(resourceType: string, id: string, vid: string): RepositoryResult<T> {
+  async readVersion<T extends Resource>(resourceType: string, id: string, vid: string): Promise<T> {
     if (!validator.isUUID(vid)) {
-      return [badRequest('Invalid UUID'), undefined];
+      throw badRequest('Invalid UUID');
     }
 
-    const [resourceOutcome] = await this.readResource<T>(resourceType, id);
-    if (!isOk(resourceOutcome) && !isGone(resourceOutcome)) {
-      return [resourceOutcome, undefined];
-    }
+    await this.readResource<T>(resourceType, id);
 
     const client = getClient();
     const rows = await new SelectQuery(resourceType + '_History')
@@ -286,42 +265,49 @@ export class Repository {
       .execute(client);
 
     if (rows.length === 0) {
-      return [notFound, undefined];
+      throw notFound;
     }
 
-    return [allOk, this.#removeHiddenFields(JSON.parse(rows[0].content as string))];
+    return this.#removeHiddenFields(JSON.parse(rows[0].content as string));
   }
 
-  async updateResource<T extends Resource>(resource: T): RepositoryResult<T> {
+  async updateResource<T extends Resource>(resource: T): Promise<T> {
     return this.#updateResourceImpl(resource, false);
   }
 
-  async #updateResourceImpl<T extends Resource>(resource: T, create: boolean): RepositoryResult<T> {
-    const validateOutcome = validateResource(resource);
-    if (!isOk(validateOutcome)) {
-      return [validateOutcome, undefined];
-    }
+  async #updateResourceImpl<T extends Resource>(resource: T, create: boolean): Promise<T> {
+    validateResource(resource);
 
     const { resourceType, id } = resource;
     if (!id) {
-      return [badRequest('Missing id'), undefined];
+      throw badRequest('Missing id');
     }
 
     if (!this.#canWriteResourceType(resourceType)) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
-    const [existingOutcome, existing] = await this.readResource<T>(resourceType, id);
-    if (!isOk(existingOutcome) && !isNotFound(existingOutcome) && !isGone(existingOutcome)) {
-      return [existingOutcome, undefined];
-    }
+    let existing: T | undefined = undefined;
 
-    if (!create && isNotFound(existingOutcome) && !this.#canSetId()) {
-      return [existingOutcome, undefined];
+    try {
+      existing = await this.readResource<T>(resourceType, id);
+    } catch (err) {
+      if (!err || typeof err !== 'object' || !('resourceType' in err)) {
+        throw err;
+      }
+
+      const existingOutcome = err as OperationOutcome;
+      if (!isOk(existingOutcome) && !isNotFound(existingOutcome) && !isGone(existingOutcome)) {
+        throw existingOutcome;
+      }
+
+      if (!create && isNotFound(existingOutcome) && !this.#canSetId()) {
+        throw existingOutcome;
+      }
     }
 
     if (await this.#isTooManyVersions(resourceType, id, create)) {
-      return [tooManyRequests, undefined];
+      throw tooManyRequests;
     }
 
     const updated = await rewriteAttachments<T>(RewriteMode.REFERENCE, this, {
@@ -333,7 +319,7 @@ export class Repository {
     });
 
     if (await this.#isNotModified(existing, updated)) {
-      return [notModified, existing];
+      return existing as T;
     }
 
     const result: T = {
@@ -356,18 +342,13 @@ export class Repository {
       (result.meta as Meta).account = account;
     }
 
-    try {
-      await setCacheEntry(result);
-      await this.#writeResource(result);
-      await this.#writeResourceVersion(result);
-      await this.#writeLookupTables(result);
-      await addBackgroundJobs(result);
-    } catch (error) {
-      return [badRequest((error as Error).message), undefined];
-    }
-
+    await setCacheEntry(result);
+    await this.#writeResource(result);
+    await this.#writeResourceVersion(result);
+    await this.#writeLookupTables(result);
+    await addBackgroundJobs(result);
     this.#removeHiddenFields(result);
-    return [existing ? allOk : created, result];
+    return result;
   }
 
   /**
@@ -416,9 +397,9 @@ export class Repository {
    * This should not result in any change to resources or history.
    * @param resourceType The resource type.
    */
-  async reindexResourceType(resourceType: string): RepositoryResult<undefined> {
+  async reindexResourceType(resourceType: string): Promise<void> {
     if (!this.#isSystem()) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
     const client = getClient();
@@ -429,7 +410,6 @@ export class Repository {
     for (const { id } of rows) {
       await this.reindexResource(resourceType, id);
     }
-    return [allOk, undefined];
   }
 
   /**
@@ -439,24 +419,15 @@ export class Repository {
    * @param resourceType The resource type.
    * @param id The resource ID.
    */
-  async reindexResource<T extends Resource>(resourceType: string, id: string): RepositoryResult<T> {
+  async reindexResource<T extends Resource>(resourceType: string, id: string): Promise<T> {
     if (!this.#isSystem() && !this.#isAdmin()) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
-    const [readOutcome, resource] = await this.readResource<T>(resourceType, id);
-    if (!isOk(readOutcome)) {
-      return [readOutcome, undefined];
-    }
-
-    try {
-      await this.#writeResource(resource as T);
-      await this.#writeLookupTables(resource as T);
-    } catch (error) {
-      return [badRequest((error as Error).message), undefined];
-    }
-
-    return [allOk, resource as T];
+    const resource = await this.readResource<T>(resourceType, id);
+    await this.#writeResource(resource as T);
+    await this.#writeLookupTables(resource as T);
+    return resource as T;
   }
 
   /**
@@ -466,25 +437,21 @@ export class Repository {
    * @param resourceType The resource type.
    * @param id The resource ID.
    */
-  async resendSubscriptions<T extends Resource>(resourceType: string, id: string): RepositoryResult<T> {
+  async resendSubscriptions<T extends Resource>(resourceType: string, id: string): Promise<T> {
     if (!this.#isSystem() && !this.#isAdmin()) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
-    const [readOutcome, resource] = await this.readResource<T>(resourceType, id);
-    assertOk(readOutcome, resource);
+    const resource = await this.readResource<T>(resourceType, id);
     await addSubscriptionJobs(resource);
-    return [allOk, resource as T];
+    return resource as T;
   }
 
-  async deleteResource(resourceType: string, id: string): RepositoryResult<undefined> {
-    const [readOutcome, resource] = await this.readResource(resourceType, id);
-    if (!isOk(readOutcome)) {
-      return [readOutcome, undefined];
-    }
+  async deleteResource(resourceType: string, id: string): Promise<void> {
+    const resource = await this.readResource(resourceType, id);
 
     if (!this.#canWriteResourceType(resourceType)) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
     await deleteCacheEntry(resourceType, id);
@@ -510,15 +477,10 @@ export class Repository {
     }).execute(client);
 
     await this.#deleteFromLookupTables(resource as Resource);
-
-    return [allOk, undefined];
   }
 
-  async patchResource(resourceType: string, id: string, patch: Operation[]): RepositoryResult<Resource> {
-    const [readOutcome, resource] = await this.readResource(resourceType, id);
-    if (!isOk(readOutcome)) {
-      return [readOutcome, undefined];
-    }
+  async patchResource(resourceType: string, id: string, patch: Operation[]): Promise<Resource> {
+    const resource = await this.readResource(resourceType, id);
 
     let patchResult;
     try {
@@ -526,22 +488,19 @@ export class Repository {
     } catch (err) {
       const patchError = err as JsonPatchError;
       const message = patchError.message?.split('\n')?.[0] || 'JSONPatch error';
-      return [badRequest(message), undefined];
+      throw badRequest(message);
     }
 
     const patchedResource = patchResult.newDocument;
     return this.updateResource(patchedResource);
   }
 
-  async search<T extends Resource>(searchRequest: SearchRequest): RepositoryResult<Bundle<T>> {
+  async search<T extends Resource>(searchRequest: SearchRequest): Promise<Bundle<T>> {
     const resourceType = searchRequest.resourceType;
-    const validateOutcome = validateResourceType(resourceType);
-    if (!isOk(validateOutcome)) {
-      return [validateOutcome, undefined];
-    }
+    validateResourceType(resourceType);
 
     if (!this.#canReadResourceType(resourceType)) {
-      return [accessDenied, undefined];
+      throw forbidden;
     }
 
     let entry = undefined;
@@ -554,16 +513,13 @@ export class Repository {
       total = await this.#getTotalCount(searchRequest);
     }
 
-    return [
-      allOk,
-      {
-        resourceType: 'Bundle',
-        type: 'searchest',
-        entry,
-        total,
-        link: this.#getSearchLinks(searchRequest),
-      },
-    ];
+    return {
+      resourceType: 'Bundle',
+      type: 'searchest',
+      entry,
+      total,
+      link: this.#getSearchLinks(searchRequest),
+    };
   }
 
   /**
@@ -1301,10 +1257,14 @@ export class Repository {
       const patientId = getPatientId(updated);
       if (patientId) {
         // If the resource is in a patient compartment, then lookup the patient.
-        const [patientOutcome, patient] = await systemRepo.readResource('Patient', patientId);
-        if (isOk(patientOutcome) && patient?.meta?.account) {
-          // If the patient has an account, then use it as the resource account.
-          return patient.meta.account;
+        try {
+          const patient = await systemRepo.readResource('Patient', patientId);
+          if (patient?.meta?.account) {
+            // If the patient has an account, then use it as the resource account.
+            return patient.meta.account;
+          }
+        } catch (err) {
+          logger.debug('Error setting patient compartment', err);
         }
       }
     }
@@ -1556,9 +1516,7 @@ export async function getRepoForMembership(membership: ProjectMembership): Promi
   let accessPolicy: AccessPolicy | undefined = undefined;
 
   if (membership.accessPolicy) {
-    const [accessPolicyOutcome, accessPolicyResource] = await systemRepo.readReference(membership.accessPolicy);
-    assertOk(accessPolicyOutcome, accessPolicyResource);
-    accessPolicy = accessPolicyResource;
+    accessPolicy = await systemRepo.readReference(membership.accessPolicy);
   }
 
   return new Repository({

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { Binary, Practitioner } from '@medplum/fhirtypes';
 import { URL } from 'url';
 import { loadTestConfig, MedplumServerConfig } from '../config';
@@ -18,10 +17,9 @@ describe('URL rewrite', () => {
     await initDatabase(config.database);
     await seedDatabase();
 
-    const [outcome, resource] = await systemRepo.createResource({
+    const resource = await systemRepo.createResource({
       resourceType: 'Binary',
     });
-    assertOk(outcome, resource);
     binary = resource;
   });
 

--- a/packages/server/src/fhir/rewrite.ts
+++ b/packages/server/src/fhir/rewrite.ts
@@ -1,5 +1,4 @@
-import { isOk } from '@medplum/core';
-import { Binary, OperationOutcome, Resource } from '@medplum/fhirtypes';
+import { Binary, Resource } from '@medplum/fhirtypes';
 import { getConfig } from '../config';
 import { Repository } from './repo';
 import { getPresignedUrl } from './signer';
@@ -147,16 +146,15 @@ async function getAttachmentPresignedUrl(
   id: string,
   versionId?: string
 ): Promise<string | boolean | undefined> {
-  let outcome: OperationOutcome;
   let binary: Binary | undefined;
 
   if (versionId) {
-    [outcome, binary] = await repo.readVersion<Binary>('Binary', id, versionId);
+    binary = await repo.readVersion<Binary>('Binary', id, versionId);
   } else {
-    [outcome, binary] = await repo.readResource<Binary>('Binary', id);
+    binary = await repo.readResource<Binary>('Binary', id);
   }
 
-  return isOk(outcome) && binary && getPresignedUrl(binary);
+  return getPresignedUrl(binary);
 }
 
 /**

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -269,7 +269,8 @@ describe('FHIR Routes', () => {
       .put(`/fhir/R4/Patient/${patient.id}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send(patient);
-    expect(res2.status).toBe(304);
+    expect(res2.status).toBe(200);
+    expect(res2.body.meta.versionId).toEqual(patient.meta.versionId);
   });
 
   test('Update resource not modified with empty strings', async () => {
@@ -295,7 +296,8 @@ describe('FHIR Routes', () => {
           display: '',
         },
       });
-    expect(res2.status).toBe(304);
+    expect(res2.status).toBe(200);
+    expect(res2.body.meta.versionId).toEqual(patient.meta.versionId);
   });
 
   test('Update resource invalid', async () => {

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -1,4 +1,4 @@
-import { assertOk, badRequest, getStatus } from '@medplum/core';
+import { allOk, badRequest, created, getStatus } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response, Router } from 'express';
 import { Operation } from 'fast-json-patch';
@@ -113,7 +113,7 @@ protectedRoutes.post('/([$]|%24)graphql', graphqlHandler);
 // PlanDefinition $apply operation
 protectedRoutes.post('/PlanDefinition/:id/([$]|%24)apply', asyncWrap(planDefinitionApplyHandler));
 
-// Create batch
+// Execute batch
 protectedRoutes.post(
   '/',
   asyncWrap(async (req: Request, res: Response) => {
@@ -127,9 +127,8 @@ protectedRoutes.post(
       return;
     }
     const repo = res.locals.repo as Repository;
-    const [outcome, result] = await processBatch(repo, bundle);
-    assertOk(outcome, result);
-    sendResponse(res, outcome, result);
+    const result = await processBatch(repo, bundle);
+    sendResponse(res, allOk, result);
   })
 );
 
@@ -140,9 +139,8 @@ protectedRoutes.get(
     const { resourceType } = req.params;
     const repo = res.locals.repo as Repository;
     const query = req.query as Record<string, string[] | string | undefined>;
-    const [outcome, bundle] = await repo.search(parseSearchRequest(resourceType, query));
-    assertOk(outcome, bundle);
-    sendResponse(res, outcome, bundle);
+    const bundle = await repo.search(parseSearchRequest(resourceType, query));
+    sendResponse(res, allOk, bundle);
   })
 );
 
@@ -161,9 +159,8 @@ protectedRoutes.post(
       return;
     }
     const repo = res.locals.repo as Repository;
-    const [outcome, result] = await repo.createResource(resource);
-    assertOk(outcome, result);
-    sendResponse(res, outcome, result);
+    const result = await repo.createResource(resource);
+    sendResponse(res, created, result);
   })
 );
 
@@ -173,9 +170,8 @@ protectedRoutes.get(
   asyncWrap(async (req: Request, res: Response) => {
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.readResource(resourceType, id);
-    assertOk(outcome, resource);
-    sendResponse(res, outcome, resource);
+    const resource = await repo.readResource(resourceType, id);
+    sendResponse(res, allOk, resource);
   })
 );
 
@@ -185,9 +181,8 @@ protectedRoutes.get(
   asyncWrap(async (req: Request, res: Response) => {
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, bundle] = await repo.readHistory(resourceType, id);
-    assertOk(outcome, bundle);
-    res.status(getStatus(outcome)).json(bundle);
+    const bundle = await repo.readHistory(resourceType, id);
+    sendResponse(res, allOk, bundle);
   })
 );
 
@@ -197,9 +192,8 @@ protectedRoutes.get(
   asyncWrap(async (req: Request, res: Response) => {
     const { resourceType, id, vid } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.readVersion(resourceType, id, vid);
-    assertOk(outcome, resource);
-    res.status(getStatus(outcome)).json(resource);
+    const resource = await repo.readVersion(resourceType, id, vid);
+    sendResponse(res, allOk, resource);
   })
 );
 
@@ -222,9 +216,8 @@ protectedRoutes.put(
       return;
     }
     const repo = res.locals.repo as Repository;
-    const [outcome, result] = await repo.updateResource(resource);
-    assertOk(outcome, result);
-    sendResponse(res, outcome, result);
+    const result = await repo.updateResource(resource);
+    sendResponse(res, allOk, result);
   })
 );
 
@@ -234,9 +227,8 @@ protectedRoutes.delete(
   asyncWrap(async (req: Request, res: Response) => {
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome] = await repo.deleteResource(resourceType, id);
-    assertOk(outcome, { resourceType });
-    sendOutcome(res, outcome);
+    await repo.deleteResource(resourceType, id);
+    sendOutcome(res, allOk);
   })
 );
 
@@ -251,9 +243,8 @@ protectedRoutes.patch(
     const { resourceType, id } = req.params;
     const patch = req.body as Operation[];
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.patchResource(resourceType, id, patch);
-    assertOk(outcome, resource);
-    sendResponse(res, outcome, resource);
+    const resource = await repo.patchResource(resourceType, id, patch);
+    sendResponse(res, allOk, resource);
   })
 );
 
@@ -265,8 +256,8 @@ protectedRoutes.post(
       res.status(400).send('Unsupported content type');
       return;
     }
-    const outcome = validateResource(req.body);
-    sendOutcome(res, outcome);
+    validateResource(req.body);
+    sendOutcome(res, allOk);
   })
 );
 
@@ -276,9 +267,8 @@ protectedRoutes.post(
   asyncWrap(async (req: Request, res: Response) => {
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.reindexResource(resourceType, id);
-    assertOk(outcome, resource);
-    sendResponse(res, outcome, resource);
+    const resource = await repo.reindexResource(resourceType, id);
+    sendResponse(res, allOk, resource);
   })
 );
 
@@ -288,9 +278,8 @@ protectedRoutes.post(
   asyncWrap(async (req: Request, res: Response) => {
     const { resourceType, id } = req.params;
     const repo = res.locals.repo as Repository;
-    const [outcome, resource] = await repo.resendSubscriptions(resourceType, id);
-    assertOk(outcome, resource);
-    sendResponse(res, outcome, resource);
+    const resource = await repo.resendSubscriptions(resourceType, id);
+    sendResponse(res, allOk, resource);
   })
 );
 

--- a/packages/server/src/fhir/schema.test.ts
+++ b/packages/server/src/fhir/schema.test.ts
@@ -1,4 +1,5 @@
-import { OperationOutcome, Patient, Questionnaire, Resource } from '@medplum/fhirtypes';
+import { OperationOutcomeError } from '@medplum/core';
+import { Patient, Questionnaire, Resource } from '@medplum/fhirtypes';
 import { validateResource, validateResourceType } from './schema';
 
 describe('FHIR schema', () => {
@@ -22,7 +23,7 @@ describe('FHIR schema', () => {
       validateResource({ resourceType: 'Patient', name: 'Homer' } as unknown as Resource);
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name');
     }
@@ -35,7 +36,7 @@ describe('FHIR schema', () => {
       validateResource({ resourceType: 'Patient', fakeProperty: 'test' } as unknown as Resource);
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('fakeProperty');
     }
@@ -46,7 +47,7 @@ describe('FHIR schema', () => {
       validateResource({ resourceType: 'DiagnosticReport' });
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('code');
     }
@@ -57,7 +58,7 @@ describe('FHIR schema', () => {
       validateResource({ resourceType: 'Patient', name: null } as unknown as Patient);
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name');
     }
@@ -68,7 +69,7 @@ describe('FHIR schema', () => {
       validateResource({ resourceType: 'Patient', name: [null] } as unknown as Patient);
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name[0]');
     }
@@ -96,7 +97,7 @@ describe('FHIR schema', () => {
       } as unknown as Patient);
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.length).toBe(2);
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('identifier[0].system');
@@ -129,7 +130,7 @@ describe('FHIR schema', () => {
       } as unknown as Questionnaire);
       fail('Expected error');
     } catch (err) {
-      const outcome = err as OperationOutcome;
+      const outcome = (err as OperationOutcomeError).outcome;
       expect(outcome.issue?.[0]?.severity).toEqual('error');
       expect(outcome.issue?.[0]?.expression?.[0]).toEqual('item[0].item[0].item[0].item[0].item');
     }

--- a/packages/server/src/fhir/schema.test.ts
+++ b/packages/server/src/fhir/schema.test.ts
@@ -1,127 +1,137 @@
-import { Patient, Questionnaire, Resource } from '@medplum/fhirtypes';
+import { OperationOutcome, Patient, Questionnaire, Resource } from '@medplum/fhirtypes';
 import { validateResource, validateResourceType } from './schema';
 
 describe('FHIR schema', () => {
   test('validateResourceType', () => {
-    expect(validateResourceType('').issue?.[0]?.severity).toEqual('error');
-    expect(validateResourceType('FakeResource').issue?.[0]?.severity).toEqual('error');
-    expect(validateResourceType('Patient').id).toEqual('ok');
+    expect(() => validateResourceType('')).toThrow();
+    expect(() => validateResourceType('FakeResource')).toThrow();
+    expect(() => validateResourceType('Patient')).not.toThrow();
   });
 
   test('validateResource', () => {
-    expect(validateResource(null as unknown as Resource).issue?.[0]?.severity).toEqual('error');
-    expect(validateResource({} as unknown as Resource).issue?.[0]?.severity).toEqual('error');
-    expect(validateResource({ resourceType: 'FakeResource' } as unknown as Resource).issue?.[0]?.severity).toEqual(
-      'error'
-    );
-    expect(validateResource({ resourceType: 'Patient' }).id).toEqual('ok');
+    expect(() => validateResource(null as unknown as Resource)).toThrow();
+    expect(() => validateResource({} as unknown as Resource)).toThrow();
+    expect(() => validateResource({ resourceType: 'FakeResource' } as unknown as Resource)).toThrow();
+    expect(() => validateResource({ resourceType: 'Patient' })).not.toThrow();
   });
 
   test('Array properties', () => {
-    expect(
-      validateResource({
-        resourceType: 'Patient',
-        name: [{ given: ['Homer'] }],
-      }).id
-    ).toEqual('ok');
+    expect(() => validateResource({ resourceType: 'Patient', name: [{ given: ['Homer'] }] })).not.toThrow();
 
-    const outcome = validateResource({
-      resourceType: 'Patient',
-      name: 'Homer',
-    } as unknown as Resource);
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name');
+    try {
+      validateResource({ resourceType: 'Patient', name: 'Homer' } as unknown as Resource);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name');
+    }
   });
 
   test('Additional properties', () => {
-    expect(
-      validateResource({
-        resourceType: 'Patient',
-        name: [{ given: ['Homer'] }],
-        meta: {},
-      }).id
-    ).toEqual('ok');
+    expect(() => validateResource({ resourceType: 'Patient', name: [{ given: ['Homer'] }], meta: {} })).not.toThrow();
 
-    const outcome = validateResource({
-      resourceType: 'Patient',
-      fakeProperty: 'test',
-    } as unknown as Resource);
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('fakeProperty');
+    try {
+      validateResource({ resourceType: 'Patient', fakeProperty: 'test' } as unknown as Resource);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('fakeProperty');
+    }
   });
 
   test('Required properties', () => {
-    const outcome = validateResource({ resourceType: 'DiagnosticReport' });
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('code');
+    try {
+      validateResource({ resourceType: 'DiagnosticReport' });
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('code');
+    }
   });
 
   test('Null value', () => {
-    const outcome = validateResource({
-      resourceType: 'Patient',
-      name: null,
-    } as unknown as Patient);
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name');
+    try {
+      validateResource({ resourceType: 'Patient', name: null } as unknown as Patient);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name');
+    }
   });
 
   test('Null array element', () => {
-    const outcome = validateResource({
-      resourceType: 'Patient',
-      name: [null],
-    } as unknown as Patient);
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name[0]');
+    try {
+      validateResource({ resourceType: 'Patient', name: [null] } as unknown as Patient);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name[0]');
+    }
   });
 
   test('Nested null array element', () => {
-    const outcome = validateResource({
-      resourceType: 'Patient',
-      identifier: [
-        {
-          system: null,
-        },
-      ],
-      name: [
-        {
-          given: ['Alice'],
-          family: 'Smith',
-        },
-        {
-          given: ['Alice', null],
-          family: 'Smith',
-        },
-      ],
-    } as unknown as Patient);
-    expect(outcome.issue?.length).toBe(2);
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('identifier[0].system');
-    expect(outcome.issue?.[1]?.severity).toEqual('error');
-    expect(outcome.issue?.[1]?.expression?.[0]).toEqual('name[1].given[1]');
+    try {
+      validateResource({
+        resourceType: 'Patient',
+        identifier: [
+          {
+            system: null,
+          },
+        ],
+        name: [
+          {
+            given: ['Alice'],
+            family: 'Smith',
+          },
+          {
+            given: ['Alice', null],
+            family: 'Smith',
+          },
+        ],
+      } as unknown as Patient);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.length).toBe(2);
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('identifier[0].system');
+      expect(outcome.issue?.[1]?.severity).toEqual('error');
+      expect(outcome.issue?.[1]?.expression?.[0]).toEqual('name[1].given[1]');
+    }
   });
 
   test('Deep nested null array element', () => {
-    const outcome = validateResource({
-      resourceType: 'Questionnaire',
-      item: [
-        {
-          item: [
-            {
-              item: [
-                {
-                  item: [
-                    {
-                      item: null,
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    } as unknown as Questionnaire);
-    expect(outcome.issue?.[0]?.severity).toEqual('error');
-    expect(outcome.issue?.[0]?.expression?.[0]).toEqual('item[0].item[0].item[0].item[0].item');
+    try {
+      validateResource({
+        resourceType: 'Questionnaire',
+        item: [
+          {
+            item: [
+              {
+                item: [
+                  {
+                    item: [
+                      {
+                        item: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as unknown as Questionnaire);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = err as OperationOutcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('item[0].item[0].item[0].item[0].item');
+    }
   });
 });

--- a/packages/server/src/fhir/schema.ts
+++ b/packages/server/src/fhir/schema.ts
@@ -1,4 +1,3 @@
-import { allOk } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { OperationOutcome, OperationOutcomeIssue, Resource } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
@@ -29,26 +28,28 @@ export function isResourceType(resourceType: string): boolean {
   return resourceType in getSchemaDefinitions();
 }
 
-export function validateResourceType(resourceType: string): OperationOutcome {
+export function validateResourceType(resourceType: string): void {
   if (!resourceType) {
-    return validationError('Resource type is null');
+    throw validationError('Resource type is null');
   }
-  return isResourceType(resourceType) ? allOk : validationError('Unknown resource type');
+  if (!isResourceType(resourceType)) {
+    throw validationError('Unknown resource type');
+  }
 }
 
-export function validateResource<T extends Resource>(resource: T): OperationOutcome {
+export function validateResource<T extends Resource>(resource: T): void {
   if (!resource) {
-    return validationError('Resource is null');
+    throw validationError('Resource is null');
   }
 
   const resourceType = resource.resourceType;
   if (!resourceType) {
-    return validationError('Missing resource type');
+    throw validationError('Missing resource type');
   }
 
   const definition = getSchemaDefinitions()[resourceType];
   if (!definition) {
-    return validationError('Unknown resource type');
+    throw validationError('Unknown resource type');
   }
 
   const issues: OperationOutcomeIssue[] = [];
@@ -59,15 +60,13 @@ export function validateResource<T extends Resource>(resource: T): OperationOutc
   checkAdditionalProperties(resource, propertyDefinitions, issues);
   checkRequiredProperties(resource, definition, issues);
 
-  if (issues.length === 0) {
-    return allOk;
+  if (issues.length > 0) {
+    throw {
+      resourceType: 'OperationOutcome',
+      id: randomUUID(),
+      issue: issues,
+    };
   }
-
-  return {
-    resourceType: 'OperationOutcome',
-    id: randomUUID(),
-    issue: issues,
-  };
 }
 
 function checkForNull(value: unknown, path: string, issues: OperationOutcomeIssue[]): void {

--- a/packages/server/src/fhir/schema.ts
+++ b/packages/server/src/fhir/schema.ts
@@ -1,3 +1,4 @@
+import { OperationOutcomeError } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { OperationOutcome, OperationOutcomeIssue, Resource } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
@@ -61,11 +62,11 @@ export function validateResource<T extends Resource>(resource: T): void {
   checkRequiredProperties(resource, definition, issues);
 
   if (issues.length > 0) {
-    throw {
+    throw new OperationOutcomeError({
       resourceType: 'OperationOutcome',
       id: randomUUID(),
       issue: issues,
-    };
+    });
   }
 }
 

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -1,4 +1,4 @@
-import { getDateProperty, isOk } from '@medplum/core';
+import { getDateProperty } from '@medplum/core';
 import { ClientApplication, Login } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { URL } from 'url';
@@ -37,11 +37,10 @@ export const authorizeGetHandler = asyncWrap(async (req: Request, res: Response)
 async function validateAuthorizeRequest(req: Request, res: Response): Promise<boolean> {
   // First validate the client and the redirect URI.
   // If these are invalid, then show an error page.
-  const [clientOutcome, client] = await systemRepo.readResource<ClientApplication>(
-    'ClientApplication',
-    req.query.client_id as string
-  );
-  if (!isOk(clientOutcome) || !client) {
+  let client = undefined;
+  try {
+    client = await systemRepo.readResource<ClientApplication>('ClientApplication', req.query.client_id as string);
+  } catch (err) {
     res.status(400).send('Client not found');
     return false;
   }
@@ -155,12 +154,7 @@ async function getExistingLoginFromIdTokenHint(req: Request): Promise<Login | un
     return undefined;
   }
 
-  const [existingOutcome, existing] = await systemRepo.readResource<Login>('Login', existingLoginId);
-  if (!isOk(existingOutcome) || !existing) {
-    return undefined;
-  }
-
-  return existing;
+  return systemRepo.readResource<Login>('Login', existingLoginId);
 }
 
 /**

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -1,4 +1,4 @@
-import { assertOk, Operator } from '@medplum/core';
+import { Operator } from '@medplum/core';
 import { JsonWebKey } from '@medplum/fhirtypes';
 import { randomBytes } from 'crypto';
 import {
@@ -101,11 +101,10 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     throw new Error('Missing issuer');
   }
 
-  const [searchOutcome, searchResult] = await systemRepo.search({
+  const searchResult = await systemRepo.search({
     resourceType: 'JsonWebKey',
     filters: [{ code: 'active', operator: Operator.EQUALS, value: 'true' }],
   });
-  assertOk(searchOutcome, searchResult);
 
   let jsonWebKeys: JsonWebKey[] | undefined;
 
@@ -118,12 +117,11 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     logger.info('No keys found.  Creating new key...');
     const keyResult = await generateKeyPair(ALG);
     const jwk = await exportJWK(keyResult.privateKey);
-    const [createOutcome, createResult] = await systemRepo.createResource<JsonWebKey>({
+    const createResult = await systemRepo.createResource<JsonWebKey>({
       resourceType: 'JsonWebKey',
       active: true,
       ...jwk,
     } as JsonWebKey);
-    assertOk(createOutcome, createResult);
     jsonWebKeys = [createResult];
   }
 

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import { ClientApplication, Login } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -51,15 +51,13 @@ describe('Auth middleware', () => {
   test('Login revoked', async () => {
     const scope = 'openid';
 
-    const [loginOutcome, login] = await systemRepo.createResource<Login>({
+    const login = await systemRepo.createResource<Login>({
       resourceType: 'Login',
       client: createReference(client),
       authTime: new Date().toISOString(),
       revoked: true,
       scope,
     });
-
-    assertOk(loginOutcome, login);
 
     const accessToken = await generateAccessToken({
       login_id: login?.id as string,
@@ -161,12 +159,11 @@ describe('Auth middleware', () => {
   });
 
   test('Basic auth without project membership', async () => {
-    const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
+    const client = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       name: 'Client without project membership',
       secret: generateSecret(48),
     });
-    assertOk(clientOutcome, client);
 
     const res = await request(app)
       .get('/fhir/R4/Patient')

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { ClientApplication } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -140,14 +139,13 @@ describe('OAuth2 Token', () => {
 
   test('Token for client empty secret', async () => {
     // Create a client without an secret
-    const [outcome, badClient] = await systemRepo.createResource<ClientApplication>({
+    const badClient = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       name: 'Bad Client',
       description: 'Bad Client',
       secret: '',
       redirectUri: 'https://example.com',
     });
-    assertOk(outcome, badClient);
 
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
@@ -160,12 +158,11 @@ describe('OAuth2 Token', () => {
   });
 
   test('Token for client without project membership', async () => {
-    const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
+    const client = await systemRepo.createResource<ClientApplication>({
       resourceType: 'ClientApplication',
       name: 'Client without project membership',
       secret: generateSecret(48),
     });
-    assertOk(clientOutcome, client);
 
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -1,5 +1,4 @@
 import {
-  assertOk,
   formatAddress,
   formatFamilyName,
   formatGivenName,
@@ -21,10 +20,9 @@ export const userInfoHandler: RequestHandler = asyncWrap(async (_req: Request, r
     sub: res.locals.user,
   };
 
-  const [outcome, resource] = await systemRepo.readReference({
+  const resource = await systemRepo.readReference({
     reference: res.locals.profile,
   });
-  assertOk(outcome, resource);
 
   const profile = resource as ProfileResource;
 

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -71,7 +71,6 @@ export interface GoogleCredentialClaims extends JWTPayload {
 export async function tryLogin(request: LoginRequest): Promise<Login> {
   validateLoginRequest(request);
 
-  // let clientOutcome: OperationOutcome | undefined;
   let client: ClientApplication | undefined;
   if (request.clientId) {
     client = await systemRepo.readResource<ClientApplication>('ClientApplication', request.clientId);

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -1,25 +1,13 @@
 import {
-  allOk,
-  assertOk,
   badRequest,
   createReference,
   Filter,
   getDateProperty,
-  isOk,
   Operator,
   ProfileResource,
   resolveId,
 } from '@medplum/core';
-import {
-  BundleEntry,
-  ClientApplication,
-  Login,
-  OperationOutcome,
-  Project,
-  ProjectMembership,
-  Reference,
-  User,
-} from '@medplum/fhirtypes';
+import { BundleEntry, ClientApplication, Login, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import bcrypt from 'bcryptjs';
 import { timingSafeEqual } from 'crypto';
 import { JWTPayload } from 'jose';
@@ -80,34 +68,25 @@ export interface GoogleCredentialClaims extends JWTPayload {
   readonly picture: string;
 }
 
-export async function tryLogin(request: LoginRequest): Promise<[OperationOutcome, Login | undefined]> {
-  const validateOutcome = validateLoginRequest(request);
-  if (validateOutcome) {
-    return [validateOutcome, undefined];
-  }
+export async function tryLogin(request: LoginRequest): Promise<Login> {
+  validateLoginRequest(request);
 
-  let clientOutcome: OperationOutcome | undefined;
+  // let clientOutcome: OperationOutcome | undefined;
   let client: ClientApplication | undefined;
   if (request.clientId) {
-    [clientOutcome, client] = await systemRepo.readResource<ClientApplication>('ClientApplication', request.clientId);
-    if (!isOk(clientOutcome)) {
-      return [clientOutcome, undefined];
-    }
+    client = await systemRepo.readResource<ClientApplication>('ClientApplication', request.clientId);
   }
 
   const user = await getUserByEmail(request.email, request.projectId);
   if (!user) {
-    return [badRequest('Email or password is invalid'), undefined];
+    throw badRequest('Email or password is invalid');
   }
 
-  const authOutcome = await authenticate(request, user);
-  if (!isOk(authOutcome)) {
-    return [authOutcome, undefined];
-  }
+  await authenticate(request, user);
 
   const refreshSecret = request.remember ? generateSecret(48) : undefined;
 
-  const [loginOutcome, login] = await systemRepo.createResource<Login>({
+  const login = await systemRepo.createResource<Login>({
     resourceType: 'Login',
     client: client && createReference(client),
     user: createReference(user),
@@ -123,7 +102,6 @@ export async function tryLogin(request: LoginRequest): Promise<[OperationOutcome
     remoteAddress: request.remoteAddress,
     userAgent: request.userAgent,
   });
-  assertOk(loginOutcome, login);
 
   // Try to get user memberships
   // If they only have one membership, set it now
@@ -132,37 +110,37 @@ export async function tryLogin(request: LoginRequest): Promise<[OperationOutcome
   if (memberships.length === 1) {
     return setLoginMembership(login, memberships[0].id as string);
   } else {
-    return [loginOutcome, login];
+    return login;
   }
 }
 
-export function validateLoginRequest(request: LoginRequest): OperationOutcome | undefined {
+export function validateLoginRequest(request: LoginRequest): void {
   if (!request.email) {
-    return badRequest('Invalid email', 'email');
+    throw badRequest('Invalid email', 'email');
   }
 
   if (!request.authMethod) {
-    return badRequest('Invalid authentication method', 'authMethod');
+    throw badRequest('Invalid authentication method', 'authMethod');
   }
 
   if (request.authMethod === 'password' && !request.password) {
-    return badRequest('Invalid password', 'password');
+    throw badRequest('Invalid password', 'password');
   }
 
   if (request.authMethod === 'google' && !request.googleCredentials) {
-    return badRequest('Invalid google credentials', 'googleCredentials');
+    throw badRequest('Invalid google credentials', 'googleCredentials');
   }
 
   if (!request.scope) {
-    return badRequest('Invalid scope', 'scope');
+    throw badRequest('Invalid scope', 'scope');
   }
 
   if (!request.codeChallenge && request.codeChallengeMethod) {
-    return badRequest('Invalid code challenge', 'code_challenge');
+    throw badRequest('Invalid code challenge', 'code_challenge');
   }
 
   if (request.codeChallenge && !request.codeChallengeMethod) {
-    return badRequest('Invalid code challenge method', 'code_challenge_method');
+    throw badRequest('Invalid code challenge method', 'code_challenge_method');
   }
 
   if (
@@ -170,28 +148,27 @@ export function validateLoginRequest(request: LoginRequest): OperationOutcome | 
     request.codeChallengeMethod !== 'plain' &&
     request.codeChallengeMethod !== 'S256'
   ) {
-    return badRequest('Invalid code challenge method', 'code_challenge_method');
+    throw badRequest('Invalid code challenge method', 'code_challenge_method');
   }
 
   return undefined;
 }
 
-async function authenticate(request: LoginRequest, user: User): Promise<OperationOutcome> {
+async function authenticate(request: LoginRequest, user: User): Promise<void> {
   if (request.password) {
     const bcryptResult = await bcrypt.compare(request.password, user.passwordHash as string);
     if (!bcryptResult) {
-      return badRequest('Email or password is invalid');
+      throw badRequest('Email or password is invalid');
     }
-
-    return allOk;
+    return;
   }
 
   if (request.googleCredentials) {
     // Verify Google user id
-    return allOk;
+    return;
   }
 
-  return badRequest('Invalid authentication method');
+  throw badRequest('Invalid authentication method');
 }
 
 /**
@@ -227,11 +204,10 @@ export async function getUserMemberships(
     });
   }
 
-  const [membershipsOutcome, memberships] = await systemRepo.search<ProjectMembership>({
+  const memberships = await systemRepo.search<ProjectMembership>({
     resourceType: 'ProjectMembership',
     filters,
   });
-  assertOk(membershipsOutcome, memberships);
   return (memberships.entry as BundleEntry<ProjectMembership>[]).map((entry) => entry.resource as ProjectMembership);
 }
 
@@ -244,54 +220,47 @@ export async function getUserMemberships(
  * @param membership The membership to set.
  * @returns The updated login.
  */
-export async function setLoginMembership(
-  login: Login,
-  membershipId: string
-): Promise<[OperationOutcome, Login | undefined]> {
+export async function setLoginMembership(login: Login, membershipId: string): Promise<Login> {
   if (login.revoked) {
-    return [badRequest('Login revoked'), undefined];
+    throw badRequest('Login revoked');
   }
 
   if (login.granted) {
-    return [badRequest('Login granted'), undefined];
+    throw badRequest('Login granted');
   }
 
   if (login.membership) {
-    return [badRequest('Login profile already set'), undefined];
+    throw badRequest('Login profile already set');
   }
 
   // Find the membership for the user
   const memberships = await getUserMemberships(login?.user as Reference<User>);
   const membership = memberships.find((m) => m.id === membershipId);
   if (!membership) {
-    return [badRequest('Profile not found'), undefined];
+    throw badRequest('Profile not found');
   }
 
   // Get the project
-  const [projectOutcome, project] = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
-  assertOk(projectOutcome, project);
+  const project = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
 
   // Make sure the membership satisfies the project requirements
   if (project.features?.includes('google-auth-required') && login.authMethod !== 'google') {
-    return [badRequest('Google authentication is required'), undefined];
+    throw badRequest('Google authentication is required');
   }
 
   // Everything checks out, update the login
   return systemRepo.updateResource<Login>({ ...login, membership: createReference(membership) });
 }
 
-export async function getAuthTokens(
-  login: Login,
-  profile: Reference<ProfileResource>
-): Promise<[OperationOutcome, TokenResult | undefined]> {
+export async function getAuthTokens(login: Login, profile: Reference<ProfileResource>): Promise<TokenResult> {
   const clientId = login.client && resolveId(login.client);
   const userId = resolveId(login.user);
   if (!userId) {
-    return [badRequest('Login missing user'), undefined];
+    throw badRequest('Login missing user');
   }
 
   if (!login.membership) {
-    return [badRequest('Login missing profile'), undefined];
+    throw badRequest('Login missing profile');
   }
 
   if (!login.granted) {
@@ -328,14 +297,11 @@ export async function getAuthTokens(
       })
     : undefined;
 
-  return [
-    allOk,
-    {
-      idToken,
-      accessToken,
-      refreshToken,
-    },
-  ];
+  return {
+    idToken,
+    accessToken,
+    refreshToken,
+  };
 }
 
 export async function revokeLogin(login: Login): Promise<void> {
@@ -371,7 +337,7 @@ export async function getUserByEmail(email: string, projectId: string | undefine
  * @returns The user if found; otherwise, undefined.
  */
 async function getUserByEmailInProject(email: string, projectId: string): Promise<User | undefined> {
-  const [outcome, bundle] = await systemRepo.search({
+  const bundle = await systemRepo.search({
     resourceType: 'User',
     filters: [
       {
@@ -386,7 +352,6 @@ async function getUserByEmailInProject(email: string, projectId: string): Promis
       },
     ],
   });
-  assertOk(outcome, bundle);
   return bundle.entry && bundle.entry.length > 0 ? (bundle.entry[0].resource as User) : undefined;
 }
 
@@ -397,7 +362,7 @@ async function getUserByEmailInProject(email: string, projectId: string): Promis
  * @returns The user if found; otherwise, undefined.
  */
 async function getUserByEmailWithoutProject(email: string): Promise<User | undefined> {
-  const [outcome, bundle] = await systemRepo.search({
+  const bundle = await systemRepo.search({
     resourceType: 'User',
     filters: [
       {
@@ -412,7 +377,6 @@ async function getUserByEmailWithoutProject(email: string): Promise<User | undef
       },
     ],
   });
-  assertOk(outcome, bundle);
   return bundle.entry && bundle.entry.length > 0 ? (bundle.entry[0].resource as User) : undefined;
 }
 

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, SearchParameter } from '@medplum/fhirtypes';
 import { getClient } from '../database';
@@ -18,10 +17,9 @@ export async function createSearchParameters(): Promise<void> {
     const searchParam = entry.resource as SearchParameter;
 
     logger.debug('SearchParameter: ' + searchParam.name);
-    const [outcome, result] = await systemRepo.createResource<SearchParameter>({
+    await systemRepo.createResource<SearchParameter>({
       ...searchParam,
       text: undefined,
     });
-    assertOk(outcome, result);
   }
 }

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
 import { getClient } from '../database';
@@ -21,12 +20,11 @@ async function createStructureDefinitionsForBundle(structureDefinitions: Bundle)
 
     if (resource.resourceType === 'StructureDefinition' && resource.name) {
       logger.debug('StructureDefinition: ' + resource.name);
-      const [outcome, result] = await systemRepo.createResource<StructureDefinition>({
+      const result = await systemRepo.createResource<StructureDefinition>({
         ...resource,
         text: undefined,
         differential: undefined,
       });
-      assertOk(outcome, result);
       logger.debug('Created: ' + result.id);
     }
   }

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express, { Request } from 'express';
@@ -26,12 +25,10 @@ describe('Storage Routes', () => {
     await initApp(app);
     await initBinaryStorage('file:' + binaryDir);
 
-    const [outcome, resource] = await systemRepo.createResource<Binary>({
+    binary = await systemRepo.createResource<Binary>({
       resourceType: 'Binary',
       contentType: 'text/plain',
     });
-    assertOk(outcome, resource);
-    binary = resource;
 
     const req = new Readable();
     req.push('hello world');
@@ -62,11 +59,10 @@ describe('Storage Routes', () => {
   });
 
   test('File not found', async () => {
-    const [outcome, resource] = await systemRepo.createResource<Binary>({
+    const resource = await systemRepo.createResource<Binary>({
       resourceType: 'Binary',
       contentType: 'text/plain',
     });
-    assertOk(outcome, resource);
 
     const req = new Readable();
     req.push('hello world');

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from './async';
@@ -18,8 +17,7 @@ storageRouter.get(
     }
 
     const { id } = req.params;
-    const [outcome, binary] = await systemRepo.readResource<Binary>('Binary', id);
-    assertOk(outcome, binary);
+    const binary = await systemRepo.readResource<Binary>('Binary', id);
 
     try {
       const stream = await getBinaryStorage().readBinary(binary);

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -1,4 +1,4 @@
-import { assertOk, createReference, isOk } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import { Bundle, ClientApplication, Login, Project, ProjectMembership, Resource } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { systemRepo } from './fhir';
@@ -9,7 +9,7 @@ export async function createTestProject(): Promise<{
   client: ClientApplication;
   membership: ProjectMembership;
 }> {
-  const [projectOutcome, project] = await systemRepo.createResource<Project>({
+  const project = await systemRepo.createResource<Project>({
     resourceType: 'Project',
     name: 'Test Project',
     owner: {
@@ -17,9 +17,8 @@ export async function createTestProject(): Promise<{
     },
     features: ['bots', 'email'],
   });
-  assertOk(projectOutcome, project);
 
-  const [clientOutcome, client] = await systemRepo.createResource<ClientApplication>({
+  const client = await systemRepo.createResource<ClientApplication>({
     resourceType: 'ClientApplication',
     secret: randomUUID(),
     redirectUri: 'https://example.com/',
@@ -27,15 +26,13 @@ export async function createTestProject(): Promise<{
       project: project.id as string,
     },
   });
-  assertOk(clientOutcome, client);
 
-  const [membershipOutcome, membership] = await systemRepo.createResource<ProjectMembership>({
+  const membership = await systemRepo.createResource<ProjectMembership>({
     resourceType: 'ProjectMembership',
     user: createReference(client),
     profile: createReference(client),
     project: createReference(project),
   });
-  assertOk(membershipOutcome, membership);
 
   return {
     project,
@@ -52,17 +49,13 @@ export async function initTestAuth(): Promise<string> {
   const { client, membership } = await createTestProject();
   const scope = 'openid';
 
-  const [loginOutcome, login] = await systemRepo.createResource<Login>({
+  const login = await systemRepo.createResource<Login>({
     resourceType: 'Login',
     client: createReference(client),
     membership: createReference(membership),
     authTime: new Date().toISOString(),
     scope,
   });
-
-  if (!isOk(loginOutcome) || !login) {
-    throw new Error('Error creating login');
-  }
 
   return generateAccessToken({
     login_id: login.id as string,

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -1,4 +1,3 @@
-import { assertOk } from '@medplum/core';
 import { Media } from '@medplum/fhirtypes';
 import { Job, Queue } from 'bullmq';
 import { randomUUID } from 'crypto';
@@ -55,15 +54,13 @@ describe('Download Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [mediaOutcome, media] = await repo.createResource<Media>({
+    const media = await repo.createResource<Media>({
       resourceType: 'Media',
       content: {
         contentType: 'text/plain',
         url,
       },
     });
-
-    expect(mediaOutcome.id).toEqual('created');
     expect(media).toBeDefined();
     expect(queue.add).toHaveBeenCalled();
 
@@ -89,15 +86,13 @@ describe('Download Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [mediaOutcome, media] = await repo.createResource<Media>({
+    const media = await repo.createResource<Media>({
       resourceType: 'Media',
       content: {
         contentType: 'text/plain',
         url: '',
       },
     });
-
-    expect(mediaOutcome.id).toEqual('created');
     expect(media).toBeDefined();
     expect(queue.add).not.toHaveBeenCalled();
   });
@@ -108,15 +103,13 @@ describe('Download Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [mediaOutcome, media] = await repo.createResource<Media>({
+    const media = await repo.createResource<Media>({
       resourceType: 'Media',
       content: {
         contentType: 'text/plain',
         url,
       },
     });
-
-    expect(mediaOutcome.id).toEqual('created');
     expect(media).toBeDefined();
     expect(queue.add).toHaveBeenCalled();
 
@@ -134,15 +127,13 @@ describe('Download Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [mediaOutcome, media] = await repo.createResource<Media>({
+    const media = await repo.createResource<Media>({
       resourceType: 'Media',
       content: {
         contentType: 'text/plain',
         url,
       },
     });
-
-    expect(mediaOutcome.id).toEqual('created');
     expect(media).toBeDefined();
     expect(queue.add).toHaveBeenCalled();
 
@@ -160,7 +151,7 @@ describe('Download Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [mediaOutcome, media] = await repo.createResource<Media>({
+    const media = await repo.createResource<Media>({
       resourceType: 'Media',
       content: {
         contentType: 'text/plain',
@@ -168,13 +159,11 @@ describe('Download Worker', () => {
       },
     });
 
-    assertOk(mediaOutcome, media);
     expect(queue.add).toHaveBeenCalled();
 
     // At this point the job should be in the queue
     // But let's delete the resource
-    const [deleteOutcome] = await repo.deleteResource('Media', media?.id as string);
-    assertOk(deleteOutcome, media);
+    await repo.deleteResource('Media', media?.id as string);
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
     await execDownloadJob(job);
@@ -187,28 +176,25 @@ describe('Download Worker', () => {
     const queue = (Queue as unknown as jest.Mock).mock.instances[0];
     queue.add.mockClear();
 
-    const [mediaOutcome, media] = await repo.createResource<Media>({
+    const media = await repo.createResource<Media>({
       resourceType: 'Media',
       content: {
         contentType: 'text/plain',
         url: 'https://example.com/download',
       },
     });
-
-    expect(mediaOutcome.id).toEqual('created');
     expect(media).toBeDefined();
     expect(queue.add).toHaveBeenCalled();
 
     // At this point the job should be in the queue
     // But let's change the URL to an internal Binary resource
-    const [updateOutcome, updated] = await repo.updateResource({
+    await repo.updateResource({
       ...(media as Media),
       content: {
         contentType: 'text/plain',
         url: 'Binary/' + randomUUID(),
       },
     });
-    assertOk(updateOutcome, updated);
 
     const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
     await execDownloadJob(job);


### PR DESCRIPTION
This is mostly a pure refactor to remove the `RepositoryResult` pattern.

Before:  Most calls to the `Repository` class looked like this:

```ts
const [outcome, resource] = await repo.readResource('Patient', id);
assertOk(outcome);
```

The return value was `RepositoryResult`, a 2-element tuple of `OperationOutcome` and optional `Resource`.

The logic was that callers would need the `outcome`, and that explicit error handling was better.

Over time, that proved to be more annoying than helpful.  Yes, there are some cases where explicit error handling is required.  But those are a tiny percentage of cases.  In the vast majority of cases, we simply called `assertOk()` and discarded the `outcome` variable.

Now: A much more straightforward:

```ts
const resource = await repo.readResource('Patient', id);
```

If the call fails, it will `throw` an `OperationOutcome`.

We have wanted to do this for a while, but we were blocked by backwards compatibility constraints in VMContext bots.  VMContext bots are gone now, so this is unblocked.

This also is one step closer to a unified interface between `MedplumClient` (the client-side SDK) and `Repository` (the server-side data access object).  That opens some interesting possibilities of a shared base class for common helper utilities.

Other changes:
* Split `accessDenied` into `unauthenticated` and `forbidden` -- with the new `throw` control flow, those needed to be separated.
* Return HTTP 200 when a PUT operation is "not modified".  Before we returned 304 and no content body.  That was not to spec, and ended up causing more bugs than being helpful.
* Otherwise this is a pretty straightforward refactor.  Mostly done using regexes.