### PR TITLE
Removing absolute links to other docs pages

### DIFF
--- a/packages/docs/docs/tutorials/bots/bots-basics.md
+++ b/packages/docs/docs/tutorials/bots/bots-basics.md
@@ -26,8 +26,6 @@ These capabilities would normally require writing custom code, HTTP servers, web
 
 By using Bots, the entire logic is self contained and managed in one place. Like all FHIR resources in Medplum, the [Bot resource](https://app.medplum.com/Bot) is versioned with full history tracking, so you can see exactly what changed over time.
 
-We have a full suite of detailed [Bot tutorials](https://docs.medplum.com/tutorials/bots/intro) that go through use cases in detail.
-
 ## Creating a Bot
 
 :::caution Note
@@ -171,7 +169,7 @@ To ensure the Subscription is running, change "Status" to `Active`
 
 ![Activate Subscription](/img/app/bots/subscription_active.png)
 
-Specify which Resources will trigger this subscription using a FHIR search string. If you're not familiar with FHIR search semantics, check out [this tutorial](https://docs.medplum.com/tutorials/api-basics/basic-fhir-search) for a primer.
+Specify which Resources will trigger this subscription using a FHIR search string. If you're not familiar with FHIR search semantics, check out [this tutorial](/tutorials/api-basics/basic-fhir-search) for a primer.
 
 For this example, we will trigger the Subscription after a change to _any_ `Patient` resource.
 

--- a/packages/docs/docs/tutorials/bots/hl7-into-fhir.md
+++ b/packages/docs/docs/tutorials/bots/hl7-into-fhir.md
@@ -1,93 +1,96 @@
-
 # Converting an HL7 Feed into FHIR Objects
 
-HL7 interfaces are common in healthcare, and widely supported by legacy EHRs, RIS/PACS systems, lab machines and more.  Some common HL7 feeds include:
+HL7 interfaces are common in healthcare, and widely supported by legacy EHRs, RIS/PACS systems, lab machines and more. Some common HL7 feeds include:
 
-* Admission, Discharge and Transfer fees (ADT Feed)
-* Observation Results (OBX Feed)
-* Scheduling Information Unsolicited (SIU feed)
+- Admission, Discharge and Transfer fees (ADT Feed)
+- Observation Results (OBX Feed)
+- Scheduling Information Unsolicited (SIU feed)
 
-These feeds contain a wealth of information, but can be hard to manage, programmatically.  Medplum makes consuming and managing these feeds straightforward.
+These feeds contain a wealth of information, but can be hard to manage, programmatically. Medplum makes consuming and managing these feeds straightforward.
 
 ## This guide will show you
 
-* How to integrate Medplum with an HL7 feed bi-directionally, receiving messages and sending back confirmation messages.
-* How to convert those HL7 messages into FHIR objects
+- How to integrate Medplum with an HL7 feed bi-directionally, receiving messages and sending back confirmation messages.
+- How to convert those HL7 messages into FHIR objects
 
 ## The Workflow
 
 When we this implementation is complete we will:
 
-* Recieve an HL7 message over HTTPS from another EHR that produces HL7 feeds
-* Create FHIR objects that capture the parts of the feed we care about.
-* Respond to the EHR with an HL7 acknowledgment that the message was received
-* (Optional) Send a notification to another application, indicating that new FHIR resources are available.
+- Recieve an HL7 message over HTTPS from another EHR that produces HL7 feeds
+- Create FHIR objects that capture the parts of the feed we care about.
+- Respond to the EHR with an HL7 acknowledgment that the message was received
+- (Optional) Send a notification to another application, indicating that new FHIR resources are available.
 
 ## The Implementation
 
 ### Account and Policy Setup
 
-* Make sure you have an account on Medplum, if not, [register](https://app.medplum.com/register).
-* Create a [ClientApplication](https://app.medplum.com/admin/project) on Medplum called "ADT Bot Client Application".
-* (Optional) Create a very restrictive [AccessPolicy](https://app.medplum.com/AccessPolicy) called "ADT Bot Policy", make it so that the policy only allows readwrite on the Patient object.
-* (Optional) In the [ProjectAdmin dashboard](https://app.medplum.com/admin/project) apply the "ADT Bot Policy" policy to the `ClientApplication` by clicking `Access`.
+- Make sure you have an account on Medplum, if not, [register](https://app.medplum.com/register).
+- Create a [ClientApplication](https://app.medplum.com/admin/project) on Medplum called "ADT Bot Client Application".
+- (Optional) Create a very restrictive [AccessPolicy](https://app.medplum.com/AccessPolicy) called "ADT Bot Policy", make it so that the policy only allows readwrite on the Patient object.
+- (Optional) In the [ProjectAdmin dashboard](https://app.medplum.com/admin/project) apply the "ADT Bot Policy" policy to the `ClientApplication` by clicking `Access`.
 
 ### Bot Setup
 
-* Linking the ADT feed to Medplum is done through [Medplum Bots](https://app.medplum.com/Bot).
-* At a high level, each Bot exposes an endpoint and HL7 messages are posted over HTTPS to that endpoint.
-* The HL7 message is parsed and then converted to a corresponding FHIR object.  
-* (Optional) If needed, you can link a [Subscription](https://app.medplum.com/Subscription) to the FHIR objects that the Bot creates to notify downstream applications that new data is available.
+- Linking the ADT feed to Medplum is done through [Medplum Bots](https://app.medplum.com/Bot).
+- At a high level, each Bot exposes an endpoint and HL7 messages are posted over HTTPS to that endpoint.
+- The HL7 message is parsed and then converted to a corresponding FHIR object.
+- (Optional) If needed, you can link a [Subscription](https://app.medplum.com/Subscription) to the FHIR objects that the Bot creates to notify downstream applications that new data is available.
 
-* Make the bot that will listen for HL7 messages
-  * First, [create a bot](https://app.medplum.com/admin/project) called ADT Handler Bot and save it
-  * Paste the code below into the Bot you created and save.
+- Make the bot that will listen for HL7 messages
+  - First, [create a bot](https://app.medplum.com/admin/project) called ADT Handler Bot and save it
+  - Paste the code below into the Bot you created and save.
 
 ```js
-  export async function handler(medplum, event) {
-    const input = event.input;
-    // Log Message Type
-    const messageType = input.get('MSH').get(8);
-    console.log(messageType);
+export async function handler(medplum, event) {
+  const input = event.input;
+  // Log Message Type
+  const messageType = input.get('MSH').get(8);
+  console.log(messageType);
 
-    // Get patient name
-    const givenName = input.get('EVN').get(5).get(1);
-    const familyName = input.get('EVN').get(5).get(2);
+  // Get patient name
+  const givenName = input.get('EVN').get(5).get(1);
+  const familyName = input.get('EVN').get(5).get(2);
 
-    // Get patient ID
-    const mrnNumber = input.get('PID').get(3).get(4);
+  // Get patient ID
+  const mrnNumber = input.get('PID').get(3).get(4);
 
-    const patient = await medplum.searchOne('Patient', 'identifier=' + mrnNumber);
+  const patient = await medplum.searchOne('Patient', 'identifier=' + mrnNumber);
 
-    if (patient) {
-        console.log('Patient already in the system');
-    } else {
-        patient = await medplum.createResource({
-            resourceType: 'Patient',
-            name: [{
-                given: [givenName],
-                family: familyName,
-            }, ],
-            identifier: [{
-                system: 'www.myhospitalsystem.org/IDs',
-                value: mrnNumber
-            }]
-        });
-        console.log('Created patient', patient.id);
-    }
-
-    // Based on the messageType, you may consider making additional FHIR objects here
-
-    // Return Ack
-    return input.buildAck().toString();
+  if (patient) {
+    console.log('Patient already in the system');
+  } else {
+    patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [
+        {
+          given: [givenName],
+          family: familyName,
+        },
+      ],
+      identifier: [
+        {
+          system: 'www.myhospitalsystem.org/IDs',
+          value: mrnNumber,
+        },
+      ],
+    });
+    console.log('Created patient', patient.id);
   }
+
+  // Based on the messageType, you may consider making additional FHIR objects here
+
+  // Return Ack
+  return input.buildAck().toString();
+}
 ```
 
 Functionally, the code above will create a new patient with the `mrnNumber` provided, assuming that patient isn't aready in this system.
 
 ### Testing your Bot
 
-You'll need your bot id (see [bot list](https://app.medplum.com/Bot) and click) to execute the bot. Once you have found it, you can attempt to execute your Bot using an HTTP message by sending the following via curl.  Note the content type.
+You'll need your bot id (see [bot list](https://app.medplum.com/Bot) and click) to execute the bot. Once you have found it, you can attempt to execute your Bot using an HTTP message by sending the following via curl. Note the content type.
 
 ```bash
 curl -x POST 'https://api.medplum.com/fhir/R4/Bot/<bot-id>/$execute' \
@@ -118,12 +121,12 @@ curl -x POST 'https://api.medplum.com/fhir/R4/Bot/<bot-id>/$execute' \
 
 ### Creating a subscription
 
-If you want to receive a notification whenever a Patient (or other FHIR resource) is created, you can do so by creating a [Subscription](https://docs.medplum.com/api/fhir/resources/subscription) ([documentation](https://docs.medplum.com/api/fhir/resources/subscription)).
+If you want to receive a notification whenever a Patient (or other FHIR resource) is created, you can do so by creating a [Subscription](/tutorials/bots/bots-basics#executing-automatically-using-a-subscription).
 
-Subscriptions have a concept of `Criteria` which indicates when they should be triggered.  Link them to the FHIR resource of choice.
+Subscriptions have a concept of `Criteria` which indicates when they should be triggered. Link them to the FHIR resource of choice.
 
 ### Complex Logic in Bots
 
 Creating a patient from a single type of HL7 message is straightforward and doesn't require much code.
 
-In practice, this is unrealistic, and the code will soon require a more complex application with testing and strongly typed objects.  To support that we have a Bot toolkit for development and deployment that you can find here: [CLI Tool](https://github.com/medplum/medplum-demo-bots).
+In practice, this is unrealistic, and the code will soon require a more complex application with testing and strongly typed objects. To support that we have a Bot toolkit for development and deployment that you can find here: [CLI Tool](https://github.com/medplum/medplum-demo-bots).

--- a/packages/docs/docs/tutorials/bots/insurance-eligibility-check.md
+++ b/packages/docs/docs/tutorials/bots/insurance-eligibility-check.md
@@ -16,7 +16,7 @@ _This guide includes an example of a bot written in Typescript, deployed using t
 
 ## Background: Insurance Eligibility Check Concepts
 
-The term *eligbility check* implies a yes or no answer, but in practice this tends to be more complex.  Medical billing is run off of an [X12](https://x12.org/products/by-industry) data standard, and claims are submitted and managed using that standard.  Eligibility checks, though they do not submit a full claim, use some of the data outlined by the format. In this simple example, the request has the following inputs and outputs.
+The term _eligbility check_ implies a yes or no answer, but in practice this tends to be more complex. Medical billing is run off of an [X12](https://x12.org/products/by-industry) data standard, and claims are submitted and managed using that standard. Eligibility checks, though they do not submit a full claim, use some of the data outlined by the format. In this simple example, the request has the following inputs and outputs.
 
 - Data Inputs
   - Patient information like **name** and **date of birth**
@@ -65,8 +65,8 @@ Full [bot source code](https://github.com/medplum/medplum-demo-bots/blob/main/sr
   - Then, clone [demo bot repo](https://github.com/medplum/medplum-demo-bots), create a .env file in the root directory and put the ClientId and ClientSecret in the .env file.
   - Add your Opkit public key to the `eligibility-check-opkit.ts` bot.
   - Follow the deployment instructions in the [demo bot repo](https://github.com/medplum/medplum-demo-bots) README.
-- Create a `Subscription` that invokes the bot when a `Coverage` object is created. (Here's the guide on [Setting up Subscriptions](https://docs.medplum.com/app/bots#setup-the-bot-subscription))
-- When a new Coverage object is created, your bot will trigger.  Go to the [Subscription](https://app.medplum.com/Subscription) page that you created to view events and logs.
+- Create a `Subscription` that invokes the bot when a `Coverage` object is created. (Here's the guide on [Setting up Subscriptions](/tutorials/bots/bots-basics#executing-automatically-using-a-subscription))
+- When a new Coverage object is created, your bot will trigger. Go to the [Subscription](https://app.medplum.com/Subscription) page that you created to view events and logs.
 
 ### Testing your Bot
 
@@ -92,10 +92,10 @@ These are a function of the deductible, out of pocket stop loss, in-network data
 
 #### Payer IDs
 
-In this example, we provided a payor identifier (this is usually an insurance company, like Blue Shield) as part of the request, but to make this work in practice, you'll need a correct identifier to send along with the request.  Eligibility providers generally use different identifier systems.
+In this example, we provided a payor identifier (this is usually an insurance company, like Blue Shield) as part of the request, but to make this work in practice, you'll need a correct identifier to send along with the request. Eligibility providers generally use different identifier systems.
 
 If, for example, you are performing an eligibility check with Opkit, you must supply an Opkit payer ID. This is supplied by including the Opkit payer ID as an identifier on the Organization FHIR resource (see `eligibility-check-opkit.test.ts` for an example). To find the appropriate Opkit payer ID for a given insurance company, see [this guide](https://docs.opkit.co/docs/faq#which-payer-should-i-use).
 
 #### Is the service in network?
 
-Eligibility checking systems generally do not keep track of whether a specific provider is in network or not.  As a provider, you should maintain a list of which plans are in-network.  We recommend maintaining a list of `Organization`s in FHIR and adding a `type` to them indicating whether they are in-network or not.  The in-network status will be a big factor in the out-of-pocket cost for the patient.
+Eligibility checking systems generally do not keep track of whether a specific provider is in network or not. As a provider, you should maintain a list of which plans are in-network. We recommend maintaining a list of `Organization`s in FHIR and adding a `type` to them indicating whether they are in-network or not. The in-network status will be a big factor in the out-of-pocket cost for the patient.

--- a/packages/docs/docs/tutorials/bots/intro.md
+++ b/packages/docs/docs/tutorials/bots/intro.md
@@ -5,16 +5,16 @@ slug: /tutorials/bots
 
 # Intro
 
-If you have never heard of Medplum Bots, we encourage you to read the intro material in the [Bot Guide](https://docs.medplum.com/app/bots).
+If you have never heard of Medplum Bots, we encourage you to read the intro material in the [Bot Guide](/tutorials/bots).
 
-Medplum bots are functions that execute when triggered. They are similar to AWS Lambda functions, and in Medplum we make them easy to write and deploy and trigger with [FHIR Subscriptions](https://docs.medplum.com/tutorials/api-basics/publish-and-subscribe). For the purpose of the tutorials found in this section, it's important to understand that **Bots drive many of the major integrations that you see in Medplum**.
+Medplum bots are functions that execute when triggered. They are similar to AWS Lambda functions, and in Medplum we make them easy to write and deploy and trigger with [FHIR Subscriptions](/tutorials/api-basics/publish-and-subscribe). For the purpose of the tutorials found in this section, it's important to understand that **Bots drive many of the major integrations that you see in Medplum**.
 
 The following tutorials will walk through some of the use cases for Bots, to give you a sense of how they can work for you.
 
 ## Consume event data or webhooks from other platforms
 
-1. [Integrating Logistics (3PL) into your EHR](https://docs.medplum.com/tutorials/bots/logistics-into-ehr)
-2. [Consuming HL7 Feeds and Converting to FHIR](https://docs.medplum.com/tutorials/bots/hl7-into-fhir)
+1. [Integrating Logistics (3PL) into your EHR](/tutorials/bots/logistics-into-ehr)
+2. [Consuming HL7 Feeds and Converting to FHIR](/tutorials/bots/insurance-eligibility-check)
 3. Coming Soon: Consuming Lab Results from a lab instrument or LIS
 
 ## Export data to other systems


### PR DESCRIPTION
Replacing absolute links to docs.medplum.com/* with relative links so that they can be validated by docusaurus