### PR TITLE
Fixed boolean active filter

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1829,4 +1829,30 @@ describe('FHIR Repo', () => {
       expect(outcome.id).toEqual('too-many-requests');
     }
   });
+
+  test('Boolean search', async () => {
+    const family = randomUUID();
+    const patient = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      name: [{ family }],
+      active: true,
+    });
+    const searchResult = await systemRepo.search({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.EQUALS,
+          value: family,
+        },
+        {
+          code: 'active',
+          operator: Operator.EQUALS,
+          value: 'true',
+        },
+      ],
+    });
+    expect(searchResult.entry).toHaveLength(1);
+    expect(searchResult.entry?.[0]?.resource?.id).toEqual(patient.id);
+  });
 });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1003,7 +1003,7 @@ export class Repository {
    */
   #buildColumnValue(searchParam: SearchParameter, details: SearchParameterDetails, value: any): any {
     if (details.type === SearchParameterType.BOOLEAN) {
-      return value === 'true';
+      return value === true || value === 'true';
     }
 
     if (details.type === SearchParameterType.DATE) {


### PR DESCRIPTION
FHIR search parameters technically do not include "boolean", only a "token" that equals "true".