### PR TITLE
Code/Coding/CodeableConcept input enhancements

### DIFF
--- a/packages/react/src/Autocomplete.tsx
+++ b/packages/react/src/Autocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import './Autocomplete.css';
 import { killEvent } from './utils/dom';
+import './Autocomplete.css';
 
 export interface AutocompleteProps<T> {
   name: string;
@@ -92,6 +92,7 @@ export function Autocomplete<T>(props: AutocompleteProps<T>): JSX.Element {
   }
 
   function handleBlur(): void {
+    tryAddOption();
     setFocused(false);
     dismissOnDelay();
   }

--- a/packages/react/src/CodeInput.tsx
+++ b/packages/react/src/CodeInput.tsx
@@ -35,6 +35,7 @@ export function CodeInput(props: CodeInputProps): JSX.Element {
       getDisplay={(item: string) => <>{cachedDisplayValues[item] || item}</>}
       name={props.name}
       defaultValue={defaultValue}
+      loadOnFocus={true}
       onChange={(values: string[]) => {
         if (props.onChange) {
           props.onChange(values[0]);

--- a/packages/react/src/CodeableConceptInput.tsx
+++ b/packages/react/src/CodeableConceptInput.tsx
@@ -40,6 +40,7 @@ export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Elem
       getDisplay={getDisplay}
       name={props.name}
       defaultValue={defaultValue}
+      loadOnFocus={true}
       onChange={(values: CodeableConcept[]) => {
         if (props.onChange) {
           props.onChange(values[0]);

--- a/packages/react/src/CodingInput.tsx
+++ b/packages/react/src/CodingInput.tsx
@@ -39,6 +39,7 @@ export function CodingInput(props: CodingInputProps): JSX.Element {
       getDisplay={(item: Coding) => <CodingDisplay value={item} />}
       name={props.name}
       defaultValue={defaultValue}
+      loadOnFocus={true}
       onChange={(values: Coding[]) => {
         if (props.onChange) {
           props.onChange(values[0]);


### PR DESCRIPTION
This applies to `<CodeInput>`, `<CodingInput>`, `<CodeableConceptInput>`

By way of example, consider setting `Organization.type`, which is a `CodeableConcept`.

- Creating an organization without "Type" works fine
- Creating an organization with pre-existing "Type" (e.g., "Healthcare Provider") works fine
- Creating an organization with custom "Type" works, as long as you hit "tab"
- Creating an organization with custom "Type" BUT without hitting "tab" causes an error

The "tab" button takes the current text entry, and turns it into a custom "code", "Coding", or "CodeableConcept", whatever the input type is.

The "tab" thing is janky, and it always has been.  This PR attempts to smooth over those challenges.

Key changes:
* Enable `loadOnFocus` so that the input shows you a list of options on focus, which minimizes the confusion at the start
* Enable "try input on blur", which has the same behavior as the tab button on blur