### PR TITLE
Project secret storage

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61092,17 +61092,10 @@
           "description": "The default access policy for patients using open registration.",
           "$ref": "#/definitions/Reference"
         },
-        "googleClientId": {
-          "description": "DEPRECATED",
+        "secret": {
+          "description": "Secure environment variable that can be used to store secrets for bots.",
           "items": {
-            "$ref": "#/definitions/string"
-          },
-          "type": "array"
-        },
-        "recaptchaSiteKey": {
-          "description": "DEPRECATED",
-          "items": {
-            "$ref": "#/definitions/string"
+            "$ref": "#/definitions/Project_Secret"
           },
           "type": "array"
         },
@@ -61119,17 +61112,38 @@
         "owner"
       ]
     },
+    "Project_Secret": {
+      "description": "Secure environment variable that can be used to store secrets for bots.",
+      "properties": {
+        "name": {
+          "description": "A name associated with the Project.",
+          "$ref": "#/definitions/string"
+        },
+        "valueBoolean": {
+          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+          "pattern": "^true|false$",
+          "type": "boolean"
+        },
+        "valueDecimal": {
+          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+          "pattern": "^-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
+          "type": "number"
+        },
+        "valueInteger": {
+          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+          "pattern": "^-?([0]|([1-9][0-9]*))$",
+          "type": "number"
+        },
+        "valueString": {
+          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+          "pattern": "^[ \\r\\n\\t\\S]+$",
+          "type": "string"
+        }
+      }
+    },
     "Project_Site": {
       "description": "Web application or web site that is associated with the project.",
       "properties": {
-        "resourceType": {
-          "description": "This is a Project resource",
-          "const": "Project"
-        },
-        "id": {
-          "description": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-          "$ref": "#/definitions/string"
-        },
         "name": {
           "description": "A name associated with the Project.",
           "$ref": "#/definitions/string"

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -107,23 +107,42 @@
             }]
           },
           {
-            "id" : "Project.googleClientId",
-            "path" : "Project.googleClientId",
-            "definition" : "DEPRECATED",
+            "id" : "Project.secret",
+            "path" : "Project.secret",
+            "definition" : "Secure environment variable that can be used to store secrets for bots.",
             "min" : 0,
             "max" : "*",
+            "type" : [{
+              "code" : "BackboneElement"
+            }]
+          },
+          {
+            "id" : "Project.secret.name",
+            "path" : "Project.secret.name",
+            "definition" : "The secret name.",
+            "min" : 1,
+            "max" : "1",
             "type" : [{
               "code" : "string"
             }]
           },
           {
-            "id" : "Project.recaptchaSiteKey",
-            "path" : "Project.recaptchaSiteKey",
-            "definition" : "DEPRECATED",
-            "min" : 0,
-            "max" : "*",
+            "id" : "Project.secret.value[x]",
+            "path" : "Project.secret.value[x]",
+            "definition" : "The secret value.",
+            "min" : 1,
+            "max" : "1",
             "type" : [{
               "code" : "string"
+            },
+            {
+              "code" : "boolean"
+            },
+            {
+              "code" : "decimal"
+            },
+            {
+              "code" : "integer"
             }]
           },
           {

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -67,19 +67,47 @@ export interface Project {
   defaultPatientAccessPolicy?: Reference<AccessPolicy>;
 
   /**
-   * DEPRECATED
+   * Secure environment variable that can be used to store secrets for
+   * bots.
    */
-  googleClientId?: string[];
-
-  /**
-   * DEPRECATED
-   */
-  recaptchaSiteKey?: string[];
+  secret?: ProjectSecret[];
 
   /**
    * Web application or web site that is associated with the project.
    */
   site?: ProjectSite[];
+}
+
+/**
+ * Secure environment variable that can be used to store secrets for
+ * bots.
+ */
+export interface ProjectSecret {
+
+  /**
+   * The secret name.
+   */
+  name?: string;
+
+  /**
+   * The secret value.
+   */
+  valueString?: string;
+
+  /**
+   * The secret value.
+   */
+  valueBoolean?: boolean;
+
+  /**
+   * The secret value.
+   */
+  valueDecimal?: number;
+
+  /**
+   * The secret value.
+   */
+  valueInteger?: number;
 }
 
 /**


### PR DESCRIPTION
Added "Project.secret", an array of name/value pairs.

Removed deprecated Project properties.

For context, `Project` is an internal only data structure that is only used by the server application.  Updates are managed through `/admin/` api endpoints.  This is prep work for bot secrets.