### PR TITLE
Unified app test routes

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,36 +1,9 @@
 import { getReferenceString } from '@medplum/core';
 import { ErrorBoundary, FooterLinks, Header, Loading, useMedplum, useMedplumProfile } from '@medplum/react';
 import React, { Suspense } from 'react';
-import { Route, Routes, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Slide, ToastContainer } from 'react-toastify';
-import { BotsPage } from './admin/BotsPage';
-import { ClientsPage } from './admin/ClientsPage';
-import { CreateBotPage } from './admin/CreateBotPage';
-import { CreateClientPage } from './admin/CreateClientPage';
-import { EditMembershipPage } from './admin/EditMembershipPage';
-import { InvitePage } from './admin/InvitePage';
-import { PatientsPage } from './admin/PatientsPage';
-import { ProjectDetailsPage } from './admin/ProjectDetailsPage';
-import { ProjectPage } from './admin/ProjectPage';
-import { SecretsPage } from './admin/SecretsPage';
-import { SuperAdminPage } from './admin/SuperAdminPage';
-import { UsersPage } from './admin/UsersPage';
-import { BatchPage } from './BatchPage';
-import { BulkAppPage } from './BulkAppPage';
-import { ChangePasswordPage } from './ChangePasswordPage';
-import { CreateResourcePage } from './CreateResourcePage';
-import { FormPage } from './FormPage';
-import { HomePage } from './HomePage';
-import { AssaysPage } from './lab/AssaysPage';
-import { PanelsPage } from './lab/PanelsPage';
-import { OAuthPage } from './OAuthPage';
-import { RegisterPage } from './RegisterPage';
-import { ResetPasswordPage } from './ResetPasswordPage';
-import { ResourcePage } from './ResourcePage';
-import { ResourceVersionPage } from './ResourceVersionPage';
-import { SetPasswordPage } from './SetPasswordPage';
-import { SignInPage } from './SignInPage';
-import { SmartSearchPage } from './SmartSearchPage';
+import { AppRoutes } from './AppRoutes';
 import '@medplum/react/defaulttheme.css';
 import '@medplum/react/styles.css';
 import 'react-toastify/dist/ReactToastify.css';
@@ -69,41 +42,7 @@ export function App(): JSX.Element {
       )}
       <ErrorBoundary>
         <Suspense fallback={<Loading />}>
-          <Routes>
-            <Route path="/signin" element={<SignInPage />} />
-            <Route path="/oauth" element={<OAuthPage />} />
-            <Route path="/resetpassword" element={<ResetPasswordPage />} />
-            <Route path="/setpassword/:id/:secret" element={<SetPasswordPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-            <Route path="/changepassword" element={<ChangePasswordPage />} />
-            <Route path="/batch" element={<BatchPage />} />
-            <Route path="/bulk/:resourceType" element={<BulkAppPage />} />
-            <Route path="/smart" element={<SmartSearchPage />} />
-            <Route path="/forms/:id" element={<FormPage />} />
-            <Route path="/admin/super" element={<SuperAdminPage />} />
-            <Route path="/admin" element={<ProjectPage />}>
-              <Route path="patients" element={<PatientsPage />} />
-              <Route path="bots/new" element={<CreateBotPage />} />
-              <Route path="bots" element={<BotsPage />} />
-              <Route path="clients/new" element={<CreateClientPage />} />
-              <Route path="clients" element={<ClientsPage />} />
-              <Route path="details" element={<ProjectDetailsPage />} />
-              <Route path="invite" element={<InvitePage />} />
-              <Route path="users" element={<UsersPage />} />
-              <Route path="project" element={<ProjectDetailsPage />} />
-              <Route path="secrets" element={<SecretsPage />} />
-              <Route path="members/:membershipId" element={<EditMembershipPage />} />
-            </Route>
-            <Route path="/lab/assays" element={<AssaysPage />} />
-            <Route path="/lab/panels" element={<PanelsPage />} />
-            <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
-            <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
-            <Route path="/:resourceType/new" element={<CreateResourcePage />} />
-            <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
-            <Route path="/:resourceType/:id" element={<ResourcePage />} />
-            <Route path="/:resourceType" element={<HomePage />} />
-            <Route path="/" element={<HomePage />} />
-          </Routes>
+          <AppRoutes />
         </Suspense>
       </ErrorBoundary>
       {!profile && (

--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+import { BotsPage } from './admin/BotsPage';
+import { ClientsPage } from './admin/ClientsPage';
+import { CreateBotPage } from './admin/CreateBotPage';
+import { CreateClientPage } from './admin/CreateClientPage';
+import { EditMembershipPage } from './admin/EditMembershipPage';
+import { InvitePage } from './admin/InvitePage';
+import { PatientsPage } from './admin/PatientsPage';
+import { ProjectDetailsPage } from './admin/ProjectDetailsPage';
+import { ProjectPage } from './admin/ProjectPage';
+import { SecretsPage } from './admin/SecretsPage';
+import { SuperAdminPage } from './admin/SuperAdminPage';
+import { UsersPage } from './admin/UsersPage';
+import { BatchPage } from './BatchPage';
+import { BulkAppPage } from './BulkAppPage';
+import { ChangePasswordPage } from './ChangePasswordPage';
+import { CreateResourcePage } from './CreateResourcePage';
+import { FormPage } from './FormPage';
+import { HomePage } from './HomePage';
+import { AssaysPage } from './lab/AssaysPage';
+import { PanelsPage } from './lab/PanelsPage';
+import { OAuthPage } from './OAuthPage';
+import { RegisterPage } from './RegisterPage';
+import { ResetPasswordPage } from './ResetPasswordPage';
+import { ResourcePage } from './ResourcePage';
+import { ResourceVersionPage } from './ResourceVersionPage';
+import { SetPasswordPage } from './SetPasswordPage';
+import { SignInPage } from './SignInPage';
+import { SmartSearchPage } from './SmartSearchPage';
+
+export function AppRoutes(): JSX.Element {
+  return (
+    <Routes>
+      <Route path="/signin" element={<SignInPage />} />
+      <Route path="/oauth" element={<OAuthPage />} />
+      <Route path="/resetpassword" element={<ResetPasswordPage />} />
+      <Route path="/setpassword/:id/:secret" element={<SetPasswordPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/changepassword" element={<ChangePasswordPage />} />
+      <Route path="/batch" element={<BatchPage />} />
+      <Route path="/bulk/:resourceType" element={<BulkAppPage />} />
+      <Route path="/smart" element={<SmartSearchPage />} />
+      <Route path="/forms/:id" element={<FormPage />} />
+      <Route path="/admin/super" element={<SuperAdminPage />} />
+      <Route path="/admin" element={<ProjectPage />}>
+        <Route path="patients" element={<PatientsPage />} />
+        <Route path="bots/new" element={<CreateBotPage />} />
+        <Route path="bots" element={<BotsPage />} />
+        <Route path="clients/new" element={<CreateClientPage />} />
+        <Route path="clients" element={<ClientsPage />} />
+        <Route path="details" element={<ProjectDetailsPage />} />
+        <Route path="invite" element={<InvitePage />} />
+        <Route path="users" element={<UsersPage />} />
+        <Route path="project" element={<ProjectDetailsPage />} />
+        <Route path="secrets" element={<SecretsPage />} />
+        <Route path="members/:membershipId" element={<EditMembershipPage />} />
+      </Route>
+      <Route path="/lab/assays" element={<AssaysPage />} />
+      <Route path="/lab/panels" element={<PanelsPage />} />
+      <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
+      <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
+      <Route path="/:resourceType/new" element={<CreateResourcePage />} />
+      <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
+      <Route path="/:resourceType/:id" element={<ResourcePage />} />
+      <Route path="/:resourceType" element={<HomePage />} />
+      <Route path="/" element={<HomePage />} />
+    </Routes>
+  );
+}

--- a/packages/app/src/BotEditor.test.tsx
+++ b/packages/app/src/BotEditor.test.tsx
@@ -3,9 +3,9 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { ResourcePage } from './ResourcePage';
+import { AppRoutes } from './AppRoutes';
 
 jest.mock('react-toastify', () => ({
   toast: {
@@ -23,9 +23,7 @@ describe('BotEditor', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/BulkAppPage.test.tsx
+++ b/packages/app/src/BulkAppPage.test.tsx
@@ -2,8 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { BulkAppPage } from './BulkAppPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 
@@ -20,9 +20,7 @@ describe('ResourcePage', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/bulk/:resourceType" element={<BulkAppPage />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/CreateResourcePage.test.tsx
+++ b/packages/app/src/CreateResourcePage.test.tsx
@@ -2,9 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { CreateResourcePage } from './CreateResourcePage';
-import { ResourcePage } from './ResourcePage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 
@@ -14,10 +13,7 @@ describe('CreateResourcePage', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/:resourceType/new" element={<CreateResourcePage />} />
-              <Route path="/:resourceType/:id" element={<ResourcePage />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/FormPage.test.tsx
+++ b/packages/app/src/FormPage.test.tsx
@@ -2,8 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { FormPage } from './FormPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 
@@ -13,10 +13,7 @@ describe('FormPage', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/forms/:id" element={<FormPage />} />
-              <Route path="/:resourceType/:id" element={<div />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -3,20 +3,16 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { getDefaultFields, HomePage } from './HomePage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
+import { getDefaultFields } from './HomePage';
 
 async function setup(url = '/Patient', medplum = new MockClient()): Promise<void> {
   await act(async () => {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/:resourceType/new" element={<div>Create Resource Page</div>} />
-            <Route path="/:resourceType/:id" element={<div>Resource Page</div>} />
-            <Route path="/:resourceType" element={<HomePage />} />
-            <Route path="/" element={<HomePage />} />
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );
@@ -188,7 +184,7 @@ describe('HomePage', () => {
     });
 
     // Change the tab
-    expect(screen.getByText('Resource Page')).toBeInTheDocument();
+    expect(screen.getByText('Timeline')).toBeInTheDocument();
 
     // Do not open a new browser tab
     expect(window.open).not.toHaveBeenCalled();

--- a/packages/app/src/OAuthPage.test.tsx
+++ b/packages/app/src/OAuthPage.test.tsx
@@ -3,9 +3,9 @@ import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import crypto from 'crypto';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
-import { OAuthPage } from './OAuthPage';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 
@@ -15,11 +15,7 @@ describe('OAuthPage', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/oauth" element={<OAuthPage />} />
-              <Route path="/register" element={<div />} />
-              <Route path="/resetpassword" element={<div />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/QuickStatus.test.tsx
+++ b/packages/app/src/QuickStatus.test.tsx
@@ -3,8 +3,8 @@ import { ExampleUserConfiguration, HomerServiceRequest, MockClient } from '@medp
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { ResourcePage } from './ResourcePage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 medplum.getUserConfiguration = () => ExampleUserConfiguration;
@@ -15,9 +15,7 @@ describe('QuickStatus', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/:resourceType/:id" element={<ResourcePage />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -4,20 +4,16 @@ import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import crypto from 'crypto';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
-import { RegisterPage } from './RegisterPage';
-import { SignInPage } from './SignInPage';
+import { AppRoutes } from './AppRoutes';
 
 async function setup(medplum: MedplumClient): Promise<void> {
   await act(async () => {
     render(
       <MemoryRouter initialEntries={['/register']} initialIndex={0}>
         <MedplumProvider medplum={medplum}>
-          <Routes>
-            <Route path="/signin" element={<SignInPage />} />
-            <Route path="/register" element={<RegisterPage />} />
-          </Routes>
+          <AppRoutes />
         </MedplumProvider>
       </MemoryRouter>
     );

--- a/packages/app/src/ResourcePage.test.tsx
+++ b/packages/app/src/ResourcePage.test.tsx
@@ -3,9 +3,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { HomePage } from './HomePage';
-import { ResourcePage } from './ResourcePage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 describe('ResourcePage', () => {
   async function setup(url: string, medplum = new MockClient()): Promise<void> {
@@ -13,11 +12,7 @@ describe('ResourcePage', () => {
       render(
         <MedplumProvider medplum={medplum}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
-            <Routes>
-              <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
-              <Route path="/:resourceType/:id" element={<ResourcePage />} />
-              <Route path="/:resourceType" element={<HomePage />} />
-            </Routes>
+            <AppRoutes />
           </MemoryRouter>
         </MedplumProvider>
       );

--- a/packages/app/src/ResourceVersionPage.test.tsx
+++ b/packages/app/src/ResourceVersionPage.test.tsx
@@ -2,8 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { ResourceVersionPage } from './ResourceVersionPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 
@@ -12,10 +12,7 @@ describe('ResourceVersionPage', () => {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
-            <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );

--- a/packages/app/src/SetPasswordPage.test.tsx
+++ b/packages/app/src/SetPasswordPage.test.tsx
@@ -2,8 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SetPasswordPage } from './SetPasswordPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const medplum = new MockClient();
 
@@ -11,9 +11,7 @@ function setup(url: string): void {
   render(
     <MedplumProvider medplum={medplum}>
       <MemoryRouter initialEntries={[url]} initialIndex={0}>
-        <Routes>
-          <Route path="/setpassword/:id/:secret" element={<SetPasswordPage />} />
-        </Routes>
+        <AppRoutes />
       </MemoryRouter>
     </MedplumProvider>
   );

--- a/packages/app/src/SmartSearchPage.test.tsx
+++ b/packages/app/src/SmartSearchPage.test.tsx
@@ -3,8 +3,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider, SmartSearchField } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { SmartSearchPage } from './SmartSearchPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from './AppRoutes';
 
 const query = `{
 ResourceList: ServiceRequestList {
@@ -97,10 +97,7 @@ async function setup(url = '/Patient'): Promise<void> {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/smart" element={<SmartSearchPage />} />
-            <Route path="/:resourceType/:id" element={<div>Resource Page</div>} />
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );
@@ -131,7 +128,7 @@ describe('SmartSearchPage', () => {
     });
 
     // Change the tab
-    expect(screen.getByText('Resource Page')).toBeInTheDocument();
+    expect(screen.getByText('Timeline')).toBeInTheDocument();
 
     // Do not open a new browser tab
     expect(window.open).not.toHaveBeenCalled();

--- a/packages/app/src/admin/CreateBotPage.test.tsx
+++ b/packages/app/src/admin/CreateBotPage.test.tsx
@@ -2,9 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { CreateBotPage } from './CreateBotPage';
-import { ProjectPage } from './ProjectPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
 
 const medplum = new MockClient();
 
@@ -13,11 +12,7 @@ async function setup(url: string): Promise<void> {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/admin" element={<ProjectPage />}>
-              <Route path="bots/new" element={<CreateBotPage />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );

--- a/packages/app/src/admin/CreateClientPage.test.tsx
+++ b/packages/app/src/admin/CreateClientPage.test.tsx
@@ -2,9 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { CreateClientPage } from './CreateClientPage';
-import { ProjectPage } from './ProjectPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
 
 const medplum = new MockClient();
 
@@ -13,11 +12,7 @@ async function setup(url: string): Promise<void> {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/admin" element={<ProjectPage />}>
-              <Route path="clients/new" element={<CreateClientPage />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );

--- a/packages/app/src/admin/EditMembershipPage.test.tsx
+++ b/packages/app/src/admin/EditMembershipPage.test.tsx
@@ -2,9 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { EditMembershipPage } from './EditMembershipPage';
-import { ProjectPage } from './ProjectPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
 
 let medplum = new MockClient();
 
@@ -13,11 +12,7 @@ async function setup(url: string): Promise<void> {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/admin" element={<ProjectPage />}>
-              <Route path="members/:membershipId" element={<EditMembershipPage />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );

--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -2,9 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { InvitePage } from './InvitePage';
-import { ProjectPage } from './ProjectPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
 
 const medplum = new MockClient();
 
@@ -13,11 +12,7 @@ async function setup(url: string): Promise<void> {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/admin" element={<ProjectPage />}>
-              <Route path="invite" element={<InvitePage />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );

--- a/packages/app/src/admin/ProjectPage.test.tsx
+++ b/packages/app/src/admin/ProjectPage.test.tsx
@@ -2,17 +2,8 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { BotsPage } from './BotsPage';
-import { ClientsPage } from './ClientsPage';
-import { CreateBotPage } from './CreateBotPage';
-import { CreateClientPage } from './CreateClientPage';
-import { InvitePage } from './InvitePage';
-import { PatientsPage } from './PatientsPage';
-import { ProjectDetailsPage } from './ProjectDetailsPage';
-import { ProjectPage } from './ProjectPage';
-import { SecretsPage } from './SecretsPage';
-import { UsersPage } from './UsersPage';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
 
 const medplum = new MockClient();
 
@@ -21,20 +12,7 @@ async function setup(url: string): Promise<void> {
     render(
       <MedplumProvider medplum={medplum}>
         <MemoryRouter initialEntries={[url]} initialIndex={0}>
-          <Routes>
-            <Route path="/admin" element={<ProjectPage />}>
-              <Route path="patients" element={<PatientsPage />} />
-              <Route path="bots/new" element={<CreateBotPage />} />
-              <Route path="bots" element={<BotsPage />} />
-              <Route path="clients/new" element={<CreateClientPage />} />
-              <Route path="clients" element={<ClientsPage />} />
-              <Route path="details" element={<ProjectDetailsPage />} />
-              <Route path="invite" element={<InvitePage />} />
-              <Route path="users" element={<UsersPage />} />
-              <Route path="project" element={<ProjectDetailsPage />} />
-              <Route path="secrets" element={<SecretsPage />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </MemoryRouter>
       </MedplumProvider>
     );

--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -2,9 +2,9 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { SuperAdminPage } from './SuperAdminPage';
+import { AppRoutes } from '../AppRoutes';
 
 const medplum = new MockClient();
 
@@ -12,9 +12,7 @@ function setup(): void {
   render(
     <MedplumProvider medplum={medplum}>
       <MemoryRouter initialEntries={['/admin/super']} initialIndex={0}>
-        <Routes>
-          <Route path="/admin/super" element={<SuperAdminPage />} />
-        </Routes>
+        <AppRoutes />
       </MemoryRouter>
     </MedplumProvider>
   );


### PR DESCRIPTION
Before:  react-router-dom routes were setup manually in tests, for a more surgical test environment.  Unfortunately, that led to discrepancies between prod routes and test routes, which led to regressions.

After:  All routes are in `<AppRoutes>`, which are used in the prod app and in unit tests.