### PR TITLE
Do not create google user on signin

### DIFF
--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -48,6 +48,7 @@ describe('RegisterPage', () => {
   test('Submit success', async () => {
     const medplum = new MockClient();
     medplum.getProfile = jest.fn(() => undefined) as any;
+    medplum.startNewUser = jest.fn(() => Promise.resolve({ login: '1' }));
     await setup(medplum);
 
     Object.defineProperty(global, 'grecaptcha', {
@@ -68,15 +69,20 @@ describe('RegisterPage', () => {
       fireEvent.change(screen.getByTestId('lastName'), {
         target: { value: 'Washington' },
       });
-      fireEvent.change(screen.getByTestId('projectName'), {
-        target: { value: 'Test Project' },
-      });
       fireEvent.change(screen.getByTestId('email'), {
         target: { value: 'george@example.com' },
       });
       fireEvent.change(screen.getByTestId('password'), {
         target: { value: 'password' },
       });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+
+    fireEvent.change(screen.getByTestId('projectName'), {
+      target: { value: 'Test Project' },
     });
 
     await act(async () => {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -359,10 +359,11 @@ describe('Client', () => {
     expect(response1).toBeDefined();
 
     const newProjectRequest: NewProjectRequest = {
+      login: response1.login,
       projectName: 'Sally World',
     };
 
-    const response2 = await client.startNewProject(newProjectRequest, response1);
+    const response2 = await client.startNewProject(newProjectRequest);
     expect(response2).toBeDefined();
 
     const response3 = await client.processCode(response2.code as string);
@@ -384,10 +385,11 @@ describe('Client', () => {
     expect(response1).toBeDefined();
 
     const newPatientRequest: NewPatientRequest = {
+      login: response1.login,
       projectId: '123',
     };
 
-    const response2 = await client.startNewPatient(newPatientRequest, response1);
+    const response2 = await client.startNewPatient(newPatientRequest);
     expect(response2).toBeDefined();
 
     const response3 = await client.processCode(response2.code as string);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -209,10 +209,12 @@ export interface NewUserRequest {
 }
 
 export interface NewProjectRequest {
+  readonly login: string;
   readonly projectName: string;
 }
 
 export interface NewPatientRequest {
+  readonly login: string;
   readonly projectId: string;
 }
 
@@ -228,6 +230,7 @@ export interface GoogleLoginRequest {
   readonly clientId?: string;
   readonly scope?: string;
   readonly nonce?: string;
+  readonly createUser?: boolean;
 }
 
 export interface LoginAuthenticationResponse {
@@ -628,17 +631,10 @@ export class MedplumClient extends EventTarget {
    * This requires a partial login from `startNewUser` or `startNewGoogleUser`.
    *
    * @param newProjectRequest Register request including email and password.
-   * @param login The partial login to complete.  This should come from the `startNewUser` method.
    * @returns Promise to the authentication response.
    */
-  async startNewProject(
-    newProjectRequest: NewProjectRequest,
-    login: LoginAuthenticationResponse
-  ): Promise<LoginAuthenticationResponse> {
-    return this.post('auth/newproject', {
-      ...newProjectRequest,
-      ...login,
-    }) as Promise<LoginAuthenticationResponse>;
+  async startNewProject(newProjectRequest: NewProjectRequest): Promise<LoginAuthenticationResponse> {
+    return this.post('auth/newproject', newProjectRequest) as Promise<LoginAuthenticationResponse>;
   }
 
   /**
@@ -647,17 +643,10 @@ export class MedplumClient extends EventTarget {
    * This requires a partial login from `startNewUser` or `startNewGoogleUser`.
    *
    * @param newPatientRequest Register request including email and password.
-   * @param login The partial login to complete.  This should come from the `startNewUser` method.
    * @returns Promise to the authentication response.
    */
-  async startNewPatient(
-    newPatientRequest: NewPatientRequest,
-    login: LoginAuthenticationResponse
-  ): Promise<LoginAuthenticationResponse> {
-    return this.post('auth/newpatient', {
-      ...newPatientRequest,
-      ...login,
-    }) as Promise<LoginAuthenticationResponse>;
+  async startNewPatient(newPatientRequest: NewPatientRequest): Promise<LoginAuthenticationResponse> {
+    return this.post('auth/newpatient', newPatientRequest) as Promise<LoginAuthenticationResponse>;
   }
 
   /**

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -100,10 +100,11 @@ describe('MockClient', () => {
     expect(response1).toBeDefined();
 
     const newProjectRequest: NewProjectRequest = {
+      login: response1.login,
       projectName: 'Sally World',
     };
 
-    const response2 = await client.startNewProject(newProjectRequest, response1);
+    const response2 = await client.startNewProject(newProjectRequest);
     expect(response2).toBeDefined();
 
     const response3 = await client.processCode(response2.code as string);
@@ -125,10 +126,11 @@ describe('MockClient', () => {
     expect(response1).toBeDefined();
 
     const newPatientRequest: NewPatientRequest = {
+      login: response1.login,
       projectId: '123',
     };
 
-    const response2 = await client.startNewPatient(newPatientRequest, response1);
+    const response2 = await client.startNewPatient(newPatientRequest);
     expect(response2).toBeDefined();
 
     const response3 = await client.processCode(response2.code as string);

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -1,0 +1,115 @@
+import { GoogleCredentialResponse, LoginAuthenticationResponse } from '@medplum/core';
+import { OperationOutcome } from '@medplum/fhirtypes';
+import React, { useState } from 'react';
+import { Button } from '../Button';
+import { Form } from '../Form';
+import { FormSection } from '../FormSection';
+import { getGoogleClientId, GoogleButton } from '../GoogleButton';
+import { Input } from '../Input';
+import { MedplumLink } from '../MedplumLink';
+import { useMedplum } from '../MedplumProvider';
+import { getIssuesForExpression } from '../utils/outcomes';
+
+export interface AuthenticationFormProps {
+  readonly projectId?: string;
+  readonly clientId?: string;
+  readonly scope?: string;
+  readonly nonce?: string;
+  readonly googleClientId?: string;
+  readonly onForgotPassword?: () => void;
+  readonly onRegister?: () => void;
+  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly children?: React.ReactNode;
+}
+
+export function AuthenticationForm(props: AuthenticationFormProps): JSX.Element {
+  const medplum = useMedplum();
+  const googleClientId = getGoogleClientId(props.googleClientId);
+  const [outcome, setOutcome] = useState<OperationOutcome>();
+  const issues = getIssuesForExpression(outcome, undefined);
+
+  return (
+    <Form
+      style={{ maxWidth: 400 }}
+      onSubmit={(formData: Record<string, string>) => {
+        medplum
+          .startLogin({
+            projectId: props.projectId,
+            clientId: props.clientId,
+            scope: props.scope,
+            nonce: props.nonce,
+            email: formData.email,
+            password: formData.password,
+            remember: formData.remember === 'true',
+          })
+          .then(props.handleAuthResponse)
+          .catch(setOutcome);
+      }}
+    >
+      <div className="medplum-center">{props.children}</div>
+      {issues && (
+        <div className="medplum-input-error">
+          {issues.map((issue) => (
+            <div data-testid="text-field-error" key={issue.details?.text}>
+              {issue.details?.text}
+            </div>
+          ))}
+        </div>
+      )}
+      {googleClientId && (
+        <>
+          <div className="medplum-signin-google-container">
+            <GoogleButton
+              googleClientId={googleClientId}
+              handleGoogleCredential={(response: GoogleCredentialResponse) => {
+                medplum
+                  .startGoogleLogin({
+                    projectId: props.projectId,
+                    clientId: props.clientId,
+                    scope: props.scope,
+                    nonce: props.nonce,
+                    googleClientId: response.clientId,
+                    googleCredential: response.credential,
+                  })
+                  .then(props.handleAuthResponse)
+                  .catch(setOutcome);
+              }}
+            />
+          </div>
+          <div className="medplum-signin-separator">or</div>
+        </>
+      )}
+      <FormSection title="Email" htmlFor="email" outcome={outcome}>
+        <Input name="email" type="email" testid="email" required={true} autoFocus={true} outcome={outcome} />
+      </FormSection>
+      <FormSection title="Password" htmlFor="password" outcome={outcome}>
+        <Input name="password" type="password" testid="password" autoComplete="off" required={true} outcome={outcome} />
+      </FormSection>
+      <div className="medplum-signin-buttons">
+        {(props.onForgotPassword || props.onRegister) && (
+          <div>
+            {props.onForgotPassword && (
+              <MedplumLink testid="forgotpassword" onClick={props.onForgotPassword}>
+                Forgot password
+              </MedplumLink>
+            )}
+            {props.onRegister && (
+              <MedplumLink testid="register" onClick={props.onRegister}>
+                Register
+              </MedplumLink>
+            )}
+          </div>
+        )}
+        <div>
+          <input type="checkbox" id="remember" name="remember" value="true" />
+          <label htmlFor="remember">Remember me</label>
+        </div>
+        <div>
+          <Button type="submit" testid="submit">
+            Sign in
+          </Button>
+        </div>
+      </div>
+    </Form>
+  );
+}

--- a/packages/react/src/auth/ChooseProfileForm.tsx
+++ b/packages/react/src/auth/ChooseProfileForm.tsx
@@ -1,0 +1,46 @@
+import { ProjectMembership } from '@medplum/fhirtypes';
+import React from 'react';
+import { Avatar } from '../Avatar';
+import { Logo } from '../Logo';
+import { useMedplum } from '../MedplumProvider';
+
+export interface ChooseProfileFormProps {
+  login: string;
+  memberships: ProjectMembership[];
+  handleAuthResponse: (response: any) => void;
+}
+
+export function ChooseProfileForm(props: ChooseProfileFormProps): JSX.Element {
+  const medplum = useMedplum();
+  return (
+    <div>
+      <div className="medplum-center">
+        <Logo size={32} />
+        <h1>Choose profile</h1>
+      </div>
+      {props.memberships.map((membership: ProjectMembership) => (
+        <div
+          className="medplum-nav-menu-profile"
+          key={membership.id}
+          onClick={() => {
+            medplum
+              .post('auth/profile', {
+                login: props.login,
+                profile: membership.id,
+              })
+              .then(props.handleAuthResponse)
+              .catch(console.log);
+          }}
+        >
+          <div className="medplum-nav-menu-profile-icon">
+            <Avatar alt={membership.profile?.display} />
+          </div>
+          <div className="medplum-nav-menu-profile-label">
+            {membership.profile?.display}
+            <div className="medplum-nav-menu-profile-help-text">{membership.project?.display}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/react/src/auth/NewProjectForm.tsx
+++ b/packages/react/src/auth/NewProjectForm.tsx
@@ -1,0 +1,64 @@
+import { LoginAuthenticationResponse } from '@medplum/core';
+import { OperationOutcome } from '@medplum/fhirtypes';
+import React, { useState } from 'react';
+import { Button } from '../Button';
+import { Form } from '../Form';
+import { FormSection } from '../FormSection';
+import { Input } from '../Input';
+import { Logo } from '../Logo';
+import { useMedplum } from '../MedplumProvider';
+
+export interface NewProjectFormProps {
+  login: string;
+  handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+}
+
+export function NewProjectForm(props: NewProjectFormProps): JSX.Element {
+  const medplum = useMedplum();
+  const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
+  return (
+    <Form
+      style={{ maxWidth: 400 }}
+      onSubmit={async (formData: Record<string, string>) => {
+        try {
+          props.handleAuthResponse(
+            await medplum.startNewProject({
+              login: props.login,
+              projectName: formData.projectName,
+            })
+          );
+        } catch (err) {
+          setOutcome(err as OperationOutcome);
+        }
+      }}
+    >
+      <div className="medplum-center">
+        <Logo size={32} />
+        <h1>Create project</h1>
+      </div>
+      <FormSection title="Project Name" htmlFor="projectName" outcome={outcome}>
+        <Input
+          name="projectName"
+          type="text"
+          testid="projectName"
+          placeholder="My Project"
+          required={true}
+          outcome={outcome}
+        />
+      </FormSection>
+      <p style={{ fontSize: '12px', color: '#888' }}>
+        By clicking submit you agree to the Medplum <a href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</a>
+        {' and '}
+        <a href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</a>.
+      </p>
+      <div className="medplum-signin-buttons">
+        <div />
+        <div>
+          <Button type="submit" testid="submit">
+            Create project
+          </Button>
+        </div>
+      </div>
+    </Form>
+  );
+}

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -1,0 +1,144 @@
+import { GoogleCredentialResponse, LoginAuthenticationResponse } from '@medplum/core';
+import { OperationOutcome } from '@medplum/fhirtypes';
+import React, { useEffect, useState } from 'react';
+import { Button } from '../Button';
+import { Form } from '../Form';
+import { FormSection } from '../FormSection';
+import { getGoogleClientId, GoogleButton } from '../GoogleButton';
+import { Input } from '../Input';
+import { useMedplum } from '../MedplumProvider';
+import { getIssuesForExpression } from '../utils/outcomes';
+import { getRecaptcha, initRecaptcha } from '../utils/recaptcha';
+
+export interface NewUserFormProps {
+  readonly projectId: string;
+  readonly googleClientId?: string;
+  readonly recaptchaSiteKey: string;
+  readonly children?: React.ReactNode;
+  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+}
+
+export function NewUserForm(props: NewUserFormProps): JSX.Element {
+  const googleClientId = getGoogleClientId(props.googleClientId);
+  const recaptchaSiteKey = props.recaptchaSiteKey;
+  const medplum = useMedplum();
+  const [outcome, setOutcome] = useState<OperationOutcome>();
+  const issues = getIssuesForExpression(outcome, undefined);
+
+  useEffect(() => initRecaptcha(recaptchaSiteKey), [recaptchaSiteKey]);
+
+  return (
+    <Form
+      style={{ maxWidth: 400 }}
+      onSubmit={async (formData: Record<string, string>) => {
+        try {
+          const recaptchaToken = await getRecaptcha(recaptchaSiteKey);
+          props.handleAuthResponse(
+            await medplum.startNewUser({
+              projectId: props.projectId,
+              firstName: formData.firstName,
+              lastName: formData.lastName,
+              email: formData.email,
+              password: formData.password,
+              remember: formData.remember === 'true',
+              recaptchaSiteKey,
+              recaptchaToken,
+            })
+          );
+        } catch (err) {
+          setOutcome(err as OperationOutcome);
+        }
+      }}
+    >
+      <div className="medplum-center">{props.children}</div>
+      {issues && (
+        <div className="medplum-input-error">
+          {issues.map((issue) => (
+            <div data-testid="text-field-error" key={issue.details?.text}>
+              {issue.details?.text}
+            </div>
+          ))}
+        </div>
+      )}
+      {googleClientId && (
+        <>
+          <div className="medplum-signin-google-container">
+            <GoogleButton
+              googleClientId={googleClientId}
+              handleGoogleCredential={async (response: GoogleCredentialResponse) => {
+                try {
+                  props.handleAuthResponse(
+                    await medplum.startGoogleLogin({
+                      googleClientId: response.clientId,
+                      googleCredential: response.credential,
+                      createUser: true,
+                    })
+                  );
+                } catch (err) {
+                  setOutcome(err as OperationOutcome);
+                }
+              }}
+            />
+          </div>
+          <div className="medplum-signin-separator">or</div>
+        </>
+      )}
+      <FormSection title="First Name" htmlFor="firstName" outcome={outcome}>
+        <Input
+          name="firstName"
+          type="text"
+          testid="firstName"
+          placeholder="First name"
+          required={true}
+          autoFocus={true}
+          outcome={outcome}
+        />
+      </FormSection>
+      <FormSection title="Last Name" htmlFor="lastName" outcome={outcome}>
+        <Input
+          name="lastName"
+          type="text"
+          testid="lastName"
+          placeholder="Last name"
+          required={true}
+          outcome={outcome}
+        />
+      </FormSection>
+      <FormSection title="Email" htmlFor="email" outcome={outcome}>
+        <Input
+          name="email"
+          type="email"
+          testid="email"
+          placeholder="name@domain.com"
+          required={true}
+          outcome={outcome}
+        />
+      </FormSection>
+      <FormSection title="Password" htmlFor="password" outcome={outcome}>
+        <Input name="password" type="password" testid="password" autoComplete="off" required={true} outcome={outcome} />
+      </FormSection>
+      <p style={{ fontSize: '12px', color: '#888' }}>
+        By clicking submit you agree to the Medplum <a href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</a>
+        {' and '}
+        <a href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</a>.
+      </p>
+      <p style={{ fontSize: '12px', color: '#888' }}>
+        This site is protected by reCAPTCHA and the Google{' '}
+        <a href="https://policies.google.com/privacy">Privacy&nbsp;Policy</a>
+        {' and '}
+        <a href="https://policies.google.com/terms">Terms&nbsp;of&nbsp;Service</a> apply.
+      </p>
+      <div className="medplum-signin-buttons">
+        <div>
+          <input type="checkbox" id="remember" name="remember" value="true" />
+          <label htmlFor="remember">Remember me</label>
+        </div>
+        <div>
+          <Button type="submit" testid="submit">
+            Create account
+          </Button>
+        </div>
+      </div>
+    </Form>
+  );
+}

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -19,12 +19,6 @@ function mockFetch(url: string, options: any): Promise<any> {
       status = 200;
       result = {
         login: '1',
-        code: '1',
-      };
-    } else if (email === 'new-project@example.com' && password === 'new-password') {
-      status = 200;
-      result = {
-        login: '1',
       };
     } else {
       status = 400;
@@ -173,7 +167,7 @@ describe('RegisterForm', () => {
 
     await act(async () => {
       fireEvent.change(screen.getByTestId('email'), {
-        target: { value: 'new-project@example.com' },
+        target: { value: 'new-user@example.com' },
       });
     });
 

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -21,6 +21,11 @@ function mockFetch(url: string, options: any): Promise<any> {
         login: '1',
         code: '1',
       };
+    } else if (email === 'new-project@example.com' && password === 'new-password') {
+      status = 200;
+      result = {
+        login: '1',
+      };
     } else {
       status = 400;
       result = {
@@ -167,12 +172,8 @@ describe('RegisterForm', () => {
     });
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('projectName'), { target: { value: 'My Project' } });
-    });
-
-    await act(async () => {
       fireEvent.change(screen.getByTestId('email'), {
-        target: { value: 'new-user@example.com' },
+        target: { value: 'new-project@example.com' },
       });
     });
 
@@ -180,6 +181,16 @@ describe('RegisterForm', () => {
       fireEvent.change(screen.getByTestId('password'), {
         target: { value: 'new-password' },
       });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+
+    await waitFor(() => screen.getByTestId('projectName'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('projectName'), { target: { value: 'My Project' } });
     });
 
     await act(async () => {

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -1,209 +1,61 @@
-import {
-  GoogleCredentialResponse,
-  LoginAuthenticationResponse,
-  NewPatientRequest,
-  NewProjectRequest,
-  parseJWTPayload,
-} from '@medplum/core';
+import { LoginAuthenticationResponse } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
-import { Button } from '../Button';
 import { Document } from '../Document';
-import { Form } from '../Form';
-import { FormSection } from '../FormSection';
-import { getGoogleClientId, GoogleButton } from '../GoogleButton';
-import { Input } from '../Input';
 import { useMedplum } from '../MedplumProvider';
-import { getIssuesForExpression } from '../utils/outcomes';
-import { getRecaptcha, initRecaptcha } from '../utils/recaptcha';
-import './SignInForm.css';
 import '../util.css';
+import { NewProjectForm } from './NewProjectForm';
+import { NewUserForm } from './NewUserForm';
+import './SignInForm.css';
 
-export interface BaseRegisterFormProps {
+export interface RegisterFormProps {
+  readonly type: 'patient' | 'project';
+  readonly projectId?: string;
   readonly googleClientId?: string;
   readonly recaptchaSiteKey: string;
   readonly children?: React.ReactNode;
   readonly onSuccess: () => void;
 }
 
-export interface PatientRegisterFormProps extends BaseRegisterFormProps {
-  readonly type: 'patient';
-  readonly projectId: string;
-}
-
-export interface ProjectRegisterFormProps extends BaseRegisterFormProps {
-  readonly type: 'project';
-}
-
-export type RegisterFormProps = PatientRegisterFormProps | ProjectRegisterFormProps;
-
 export function RegisterForm(props: RegisterFormProps): JSX.Element {
+  const { type, projectId, googleClientId, recaptchaSiteKey, onSuccess } = props;
   const medplum = useMedplum();
-  const googleClientId = getGoogleClientId(props.googleClientId);
-  const recaptchaSiteKey = props.recaptchaSiteKey;
+  const [login, setLogin] = useState<string | undefined>(undefined);
   const [outcome, setOutcome] = useState<OperationOutcome>();
-  const issues = getIssuesForExpression(outcome, undefined);
 
-  useEffect(() => initRecaptcha(recaptchaSiteKey), [recaptchaSiteKey]);
+  useEffect(() => {
+    if (type === 'patient' && login) {
+      medplum
+        .startNewPatient({ login, projectId: projectId as string })
+        .then((response) => medplum.processCode(response.code as string))
+        .then(() => onSuccess())
+        .catch((err) => setOutcome(err as OperationOutcome));
+    }
+  }, [medplum, type, projectId, login, onSuccess]);
 
-  async function handleAuthResponse(
-    registerRequest: NewPatientRequest | NewProjectRequest,
-    partialLogin: LoginAuthenticationResponse
-  ): Promise<void> {
-    try {
-      let login;
-      if (props.type === 'patient') {
-        login = await medplum.startNewPatient(registerRequest as NewPatientRequest, partialLogin);
-      } else {
-        login = await medplum.startNewProject(registerRequest as NewProjectRequest, partialLogin);
-      }
-      await medplum.processCode(login.code as string);
-      props.onSuccess();
-    } catch (err) {
-      setOutcome(err as OperationOutcome);
+  function handleAuthResponse(response: LoginAuthenticationResponse): void {
+    if (response.code) {
+      medplum
+        .processCode(response.code)
+        .then(() => onSuccess())
+        .catch(console.log);
+    } else if (response.login) {
+      setLogin(response.login);
     }
   }
 
   return (
     <Document width={450}>
-      <Form
-        style={{ maxWidth: 400 }}
-        onSubmit={async (formData: Record<string, string>) => {
-          try {
-            const recaptchaToken = await getRecaptcha(recaptchaSiteKey);
-            const registerRequest = {
-              projectId: (props as PatientRegisterFormProps).projectId,
-              projectName: formData.projectName,
-              firstName: formData.firstName,
-              lastName: formData.lastName,
-              email: formData.email,
-              password: formData.password,
-              remember: formData.remember === 'true',
-              recaptchaSiteKey,
-              recaptchaToken,
-            };
-            const userLogin = await medplum.startNewUser(registerRequest);
-            await handleAuthResponse(registerRequest, userLogin);
-          } catch (err) {
-            setOutcome(err as OperationOutcome);
-          }
-        }}
-      >
-        <div className="medplum-center">{props.children}</div>
-        {issues && (
-          <div className="medplum-input-error">
-            {issues.map((issue) => (
-              <div data-testid="text-field-error" key={issue.details?.text}>
-                {issue.details?.text}
-              </div>
-            ))}
-          </div>
-        )}
-        {googleClientId && (
-          <>
-            <div className="medplum-signin-google-container">
-              <GoogleButton
-                googleClientId={googleClientId}
-                handleGoogleCredential={async (response: GoogleCredentialResponse) => {
-                  try {
-                    const loginRequest = {
-                      googleClientId: response.clientId,
-                      googleCredential: response.credential,
-                    };
-                    const userLogin = await medplum.startGoogleLogin(loginRequest);
-                    const googleClaims = parseJWTPayload(loginRequest.googleCredential);
-                    const registerRequest = {
-                      projectId: (props as PatientRegisterFormProps).projectId,
-                      firstName: googleClaims.given_name as string,
-                      lastName: googleClaims.family_name as string,
-                      email: googleClaims.email as string,
-                    };
-                    await handleAuthResponse(registerRequest, userLogin);
-                  } catch (err) {
-                    setOutcome(err as OperationOutcome);
-                  }
-                }}
-              />
-            </div>
-            <div className="medplum-signin-separator">or</div>
-          </>
-        )}
-        <FormSection title="First Name" htmlFor="firstName" outcome={outcome}>
-          <Input
-            name="firstName"
-            type="text"
-            testid="firstName"
-            placeholder="First name"
-            required={true}
-            autoFocus={true}
-            outcome={outcome}
-          />
-        </FormSection>
-        <FormSection title="Last Name" htmlFor="lastName" outcome={outcome}>
-          <Input
-            name="lastName"
-            type="text"
-            testid="lastName"
-            placeholder="Last name"
-            required={true}
-            outcome={outcome}
-          />
-        </FormSection>
-        {props.type === 'project' && (
-          <FormSection title="Project Name" htmlFor="projectName" outcome={outcome}>
-            <Input
-              name="projectName"
-              type="text"
-              testid="projectName"
-              placeholder="My Project"
-              required={true}
-              outcome={outcome}
-            />
-          </FormSection>
-        )}
-        <FormSection title="Email" htmlFor="email" outcome={outcome}>
-          <Input
-            name="email"
-            type="email"
-            testid="email"
-            placeholder="name@domain.com"
-            required={true}
-            outcome={outcome}
-          />
-        </FormSection>
-        <FormSection title="Password" htmlFor="password" outcome={outcome}>
-          <Input
-            name="password"
-            type="password"
-            testid="password"
-            autoComplete="off"
-            required={true}
-            outcome={outcome}
-          />
-        </FormSection>
-        <p style={{ fontSize: '12px', color: '#888' }}>
-          By clicking submit you agree to the Medplum <a href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</a>
-          {' and '}
-          <a href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</a>.
-        </p>
-        <p style={{ fontSize: '12px', color: '#888' }}>
-          This site is protected by reCAPTCHA and the Google{' '}
-          <a href="https://policies.google.com/privacy">Privacy&nbsp;Policy</a>
-          {' and '}
-          <a href="https://policies.google.com/terms">Terms&nbsp;of&nbsp;Service</a> apply.
-        </p>
-        <div className="medplum-signin-buttons">
-          <div>
-            <input type="checkbox" id="remember" name="remember" value="true" />
-            <label htmlFor="remember">Remember me</label>
-          </div>
-          <div>
-            <Button type="submit" testid="submit">
-              Create account
-            </Button>
-          </div>
-        </div>
-      </Form>
+      {outcome && <pre>{JSON.stringify(outcome, null, 2)}</pre>}
+      {!login && (
+        <NewUserForm
+          projectId={projectId as string}
+          googleClientId={googleClientId}
+          recaptchaSiteKey={recaptchaSiteKey}
+          handleAuthResponse={handleAuthResponse}
+        />
+      )}
+      {login && type === 'project' && <NewProjectForm login={login} handleAuthResponse={handleAuthResponse} />}
     </Document>
   );
 }

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -3,10 +3,10 @@ import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
 import { Document } from '../Document';
 import { useMedplum } from '../MedplumProvider';
-import '../util.css';
 import { NewProjectForm } from './NewProjectForm';
 import { NewUserForm } from './NewUserForm';
 import './SignInForm.css';
+import '../util.css';
 
 export interface RegisterFormProps {
   readonly type: 'patient' | 'project';

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -1,19 +1,13 @@
-import { GoogleCredentialResponse, LoginAuthenticationResponse } from '@medplum/core';
-import { OperationOutcome, ProjectMembership } from '@medplum/fhirtypes';
+import { LoginAuthenticationResponse } from '@medplum/core';
+import { ProjectMembership } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
-import { Avatar } from '../Avatar';
-import { Button } from '../Button';
 import { Document } from '../Document';
-import { Form } from '../Form';
-import { FormSection } from '../FormSection';
-import { getGoogleClientId, GoogleButton } from '../GoogleButton';
-import { Input } from '../Input';
-import { Logo } from '../Logo';
-import { MedplumLink } from '../MedplumLink';
 import { useMedplum } from '../MedplumProvider';
-import { getIssuesForExpression } from '../utils/outcomes';
-import './SignInForm.css';
+import { AuthenticationForm } from './AuthenticationForm';
+import { ChooseProfileForm } from './ChooseProfileForm';
+import { NewProjectForm } from './NewProjectForm';
 import '../util.css';
+import './SignInForm.css';
 
 export interface SignInFormProps {
   readonly remember?: boolean;
@@ -78,7 +72,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
             </AuthenticationForm>
           );
         } else if (memberships) {
-          return <ProfileForm login={login} memberships={memberships} handleAuthResponse={handleAuthResponse} />;
+          return <ChooseProfileForm login={login} memberships={memberships} handleAuthResponse={handleAuthResponse} />;
         } else if (props.projectId === 'new') {
           return <NewProjectForm login={login} handleAuthResponse={handleAuthResponse} />;
         } else {
@@ -86,203 +80,5 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
         }
       })()}
     </Document>
-  );
-}
-
-interface AuthenticationFormProps {
-  readonly projectId?: string;
-  readonly clientId?: string;
-  readonly scope?: string;
-  readonly nonce?: string;
-  readonly googleClientId?: string;
-  readonly onForgotPassword?: () => void;
-  readonly onRegister?: () => void;
-  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
-  readonly children?: React.ReactNode;
-}
-
-function AuthenticationForm(props: AuthenticationFormProps): JSX.Element {
-  const medplum = useMedplum();
-  const googleClientId = getGoogleClientId(props.googleClientId);
-  const [outcome, setOutcome] = useState<OperationOutcome>();
-  const issues = getIssuesForExpression(outcome, undefined);
-
-  return (
-    <Form
-      style={{ maxWidth: 400 }}
-      onSubmit={(formData: Record<string, string>) => {
-        medplum
-          .startLogin({
-            projectId: props.projectId,
-            clientId: props.clientId,
-            scope: props.scope,
-            nonce: props.nonce,
-            email: formData.email,
-            password: formData.password,
-            remember: formData.remember === 'true',
-          })
-          .then(props.handleAuthResponse)
-          .catch(setOutcome);
-      }}
-    >
-      <div className="medplum-center">{props.children}</div>
-      {issues && (
-        <div className="medplum-input-error">
-          {issues.map((issue) => (
-            <div data-testid="text-field-error" key={issue.details?.text}>
-              {issue.details?.text}
-            </div>
-          ))}
-        </div>
-      )}
-      {googleClientId && (
-        <>
-          <div className="medplum-signin-google-container">
-            <GoogleButton
-              googleClientId={googleClientId}
-              handleGoogleCredential={(response: GoogleCredentialResponse) => {
-                medplum
-                  .startGoogleLogin({
-                    projectId: props.projectId,
-                    clientId: props.clientId,
-                    scope: props.scope,
-                    nonce: props.nonce,
-                    googleClientId: response.clientId,
-                    googleCredential: response.credential,
-                  })
-                  .then(props.handleAuthResponse)
-                  .catch(setOutcome);
-              }}
-            />
-          </div>
-          <div className="medplum-signin-separator">or</div>
-        </>
-      )}
-      <FormSection title="Email" htmlFor="email" outcome={outcome}>
-        <Input name="email" type="email" testid="email" required={true} autoFocus={true} outcome={outcome} />
-      </FormSection>
-      <FormSection title="Password" htmlFor="password" outcome={outcome}>
-        <Input name="password" type="password" testid="password" autoComplete="off" required={true} outcome={outcome} />
-      </FormSection>
-      <div className="medplum-signin-buttons">
-        {(props.onForgotPassword || props.onRegister) && (
-          <div>
-            {props.onForgotPassword && (
-              <MedplumLink testid="forgotpassword" onClick={props.onForgotPassword}>
-                Forgot password
-              </MedplumLink>
-            )}
-            {props.onRegister && (
-              <MedplumLink testid="register" onClick={props.onRegister}>
-                Register
-              </MedplumLink>
-            )}
-          </div>
-        )}
-        <div>
-          <input type="checkbox" id="remember" name="remember" value="true" />
-          <label htmlFor="remember">Remember me</label>
-        </div>
-        <div>
-          <Button type="submit" testid="submit">
-            Sign in
-          </Button>
-        </div>
-      </div>
-    </Form>
-  );
-}
-
-interface ProfileFormProps {
-  login: string;
-  memberships: ProjectMembership[];
-  handleAuthResponse: (response: any) => void;
-}
-
-function ProfileForm(props: ProfileFormProps): JSX.Element {
-  const medplum = useMedplum();
-  return (
-    <div>
-      <div className="medplum-center">
-        <Logo size={32} />
-        <h1>Choose profile</h1>
-      </div>
-      {props.memberships.map((membership: ProjectMembership) => (
-        <div
-          className="medplum-nav-menu-profile"
-          key={membership.id}
-          onClick={() => {
-            medplum
-              .post('auth/profile', {
-                login: props.login,
-                profile: membership.id,
-              })
-              .then(props.handleAuthResponse)
-              .catch(console.log);
-          }}
-        >
-          <div className="medplum-nav-menu-profile-icon">
-            <Avatar alt={membership.profile?.display} />
-          </div>
-          <div className="medplum-nav-menu-profile-label">
-            {membership.profile?.display}
-            <div className="medplum-nav-menu-profile-help-text">{membership.project?.display}</div>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-interface NewProjectFormProps {
-  login: string;
-  handleAuthResponse: (response: any) => void;
-}
-
-function NewProjectForm(props: NewProjectFormProps): JSX.Element {
-  const medplum = useMedplum();
-  const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
-  return (
-    <Form
-      style={{ maxWidth: 400 }}
-      onSubmit={async (formData: Record<string, string>) => {
-        try {
-          const registerRequest = { projectName: formData.projectName };
-          const partialLogin = { login: props.login };
-          const login = await medplum.startNewProject(registerRequest, partialLogin);
-          props.handleAuthResponse(login);
-        } catch (err) {
-          setOutcome(err as OperationOutcome);
-        }
-      }}
-    >
-      <div className="medplum-center">
-        <Logo size={32} />
-        <h1>Create project</h1>
-      </div>
-      <FormSection title="Project Name" htmlFor="projectName" outcome={outcome}>
-        <Input
-          name="projectName"
-          type="text"
-          testid="projectName"
-          placeholder="My Project"
-          required={true}
-          outcome={outcome}
-        />
-      </FormSection>
-      <p style={{ fontSize: '12px', color: '#888' }}>
-        By clicking submit you agree to the Medplum <a href="https://www.medplum.com/privacy">Privacy&nbsp;Policy</a>
-        {' and '}
-        <a href="https://www.medplum.com/terms">Terms&nbsp;of&nbsp;Service</a>.
-      </p>
-      <div className="medplum-signin-buttons">
-        <div />
-        <div>
-          <Button type="submit" testid="submit">
-            Create project
-          </Button>
-        </div>
-      </div>
-    </Form>
   );
 }

--- a/packages/server/medplum.config.json
+++ b/packages/server/medplum.config.json
@@ -16,6 +16,7 @@
   "supportEmail": "\"Medplum\" <support@medplum.com>",
   "googleClientId": "397236612778-c0b5tnjv98frbo1tfuuha5vkme3cmq4s.apps.googleusercontent.com",
   "googleClientSecret": "",
+  "recaptchaSiteKey": "6LfHdsYdAAAAAC0uLnnRrDrhcXnziiUwKd8VtLNq",
   "recaptchaSecretKey": "6LfHdsYdAAAAAH9dN154jbJ3zpQife3xaiTvPChL",
   "adminClientId": "2a4b77f2-4d4e-43c6-9b01-330eb5ca772f",
   "maxJsonSize": "1mb",

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -112,11 +112,24 @@ describe('Google Auth', () => {
     expect(res.body.code).toBeDefined();
   });
 
+  test('Do not create user', async () => {
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    const res = await request(app).post('/auth/google').type('json').send({
+      googleClientId: getConfig().googleClientId,
+      googleCredential: email,
+    });
+    expect(res.status).toBe(400);
+
+    const user = await getUserByEmail(email, undefined);
+    expect(user).toBeUndefined();
+  });
+
   test('Create new user account', async () => {
     const email = 'new-google-' + randomUUID() + '@example.com';
     const res = await request(app).post('/auth/google').type('json').send({
       googleClientId: getConfig().googleClientId,
       googleCredential: email,
+      createUser: true,
     });
     expect(res.status).toBe(200);
     expect(res.body.login).toBeDefined();

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -83,8 +83,14 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
 
   const existingUser = await getUserByEmail(claims.email, project?.id);
   if (!existingUser) {
+    if (!req.body.createUser) {
+      sendOutcome(res, badRequest('User not found'));
+      return;
+    }
     await systemRepo.createResource<User>({
       resourceType: 'User',
+      firstName: claims.given_name,
+      lastName: claims.family_name,
       email: claims.email,
       project: project ? createReference(project) : undefined,
     });

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -35,7 +35,7 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
   let secretKey: string | undefined = getConfig().recaptchaSecretKey;
   let project: Project | undefined;
 
-  if (recaptchaSiteKey !== getConfig().recaptchaSiteKey) {
+  if (recaptchaSiteKey && recaptchaSiteKey !== getConfig().recaptchaSiteKey) {
     // If the recaptcha site key is not the main Medplum recaptcha site key,
     // then it must be associated with a Project.
     // The user can only authenticate with that project.


### PR DESCRIPTION
Fixes #839

There was a broken assumption in the Google Auth flow, that we could always create the `User` for a Google request.  That is false, because it can lead to the situation where the user is orphaned without any projects, and without the ability to create a new project.

The diff is big because I went ahead with some nearby refactoring, notably cleaning up the duplicate code in `<SignInForm>` and `<RegisterForm>` for creating new projects.

Notable changes:
* Do not create a `User` during Google auth unless explicitly instructed
* "Project Name" input is always in 2nd step after creating user
* Refactored sub-page components into separate files (AuthenticationForm, ChooseProfileForm, NewProjectForm, etc)
