### PR TITLE
Error on undefined element in JSON array

### DIFF
--- a/packages/server/src/fhir/schema.test.ts
+++ b/packages/server/src/fhir/schema.test.ts
@@ -75,6 +75,17 @@ describe('FHIR schema', () => {
     }
   });
 
+  test('Undefined array element', () => {
+    try {
+      validateResource({ resourceType: 'Patient', name: [{ given: [undefined] }] } as unknown as Patient);
+      fail('Expected error');
+    } catch (err) {
+      const outcome = (err as OperationOutcomeError).outcome;
+      expect(outcome.issue?.[0]?.severity).toEqual('error');
+      expect(outcome.issue?.[0]?.expression?.[0]).toEqual('name[0].given[0]');
+    }
+  });
+
   test('Nested null array element', () => {
     try {
       validateResource({

--- a/packages/server/src/fhir/schema.ts
+++ b/packages/server/src/fhir/schema.ts
@@ -82,7 +82,11 @@ function checkForNull(value: unknown, path: string, issues: OperationOutcomeIssu
 
 function checkArrayForNull(array: unknown[], path: string, issues: OperationOutcomeIssue[]): void {
   for (let i = 0; i < array.length; i++) {
-    checkForNull(array[i], `${path}[${i}]`, issues);
+    if (array[i] === undefined) {
+      issues.push(createIssue(`${path}[${i}]`, `Invalid undefined value`));
+    } else {
+      checkForNull(array[i], `${path}[${i}]`, issues);
+    }
   }
 }
 


### PR DESCRIPTION
Usually, we silently ignore `undefined` values in JSON input, because `JSON.stringify()` omits them in the string output.

However, if `undefined` is an array element, then `JSON.stringify()` replaces it with `null`, which is included in the string output, which causes downstream issues.  So we're now blocking `undefined` as an array element.