### PR TITLE
Super admin cleanup

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61077,6 +61077,10 @@
           "description": "A summary, characterization or explanation of the Project.",
           "$ref": "#/definitions/string"
         },
+        "superAdmin": {
+          "description": "Whether this project is the super administrator project. A super administrator is a user who has complete access to all resources in all projects.",
+          "$ref": "#/definitions/boolean"
+        },
         "owner": {
           "description": "Indicates the user with responsibility for managing the Project.",
           "$ref": "#/definitions/Reference"
@@ -61443,6 +61447,10 @@
         },
         "admin": {
           "description": "Whether this login has system administrator privileges.",
+          "$ref": "#/definitions/boolean"
+        },
+        "superAdmin": {
+          "description": "Whether this login has super administrator privileges.",
           "$ref": "#/definitions/boolean"
         },
         "remoteAddress": {

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -75,6 +75,17 @@
             }]
           },
           {
+            "id" : "Project.superAdmin",
+            "path" : "Project.superAdmin",
+            "short" : "Whether this project is the super administrator project.",
+            "definition" : "Whether this project is the super administrator project. A super administrator is a user who has complete access to all resources in all projects.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "boolean"
+            }]
+          },
+          {
             "id" : "Project.owner",
             "path" : "Project.owner",
             "definition" : "The user who owns the project.",
@@ -405,8 +416,8 @@
           {
             "id" : "User.admin",
             "path" : "User.admin",
-            "short" : "Whether this user is a system administrator.",
-            "definition" : "Whether this user is a system administrator.",
+            "short" : "DEPRECATED",
+            "definition" : "DEPRECATED",
             "min" : 0,
             "max" : "1",
             "type" : [{
@@ -875,7 +886,17 @@
           {
             "id" : "Login.admin",
             "path" : "Login.admin",
-            "definition" : "Whether this login has system administrator privileges.",
+            "definition" : "DEPRECATED",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "boolean"
+            }]
+          },
+          {
+            "id" : "Login.superAdmin",
+            "path" : "Login.superAdmin",
+            "definition" : "Whether this login has super administrator privileges.",
             "min" : 0,
             "max" : "1",
             "type" : [{

--- a/packages/fhirtypes/dist/Login.d.ts
+++ b/packages/fhirtypes/dist/Login.d.ts
@@ -130,9 +130,14 @@ export interface Login {
   revoked?: boolean;
 
   /**
-   * Whether this login has system administrator privileges.
+   * DEPRECATED
    */
   admin?: boolean;
+
+  /**
+   * Whether this login has super administrator privileges.
+   */
+  superAdmin?: boolean;
 
   /**
    * The Internet Protocol (IP) address of the client or last proxy that

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -52,6 +52,13 @@ export interface Project {
   description?: string;
 
   /**
+   * Whether this project is the super administrator project. A super
+   * administrator is a user who has complete access to all resources in
+   * all projects.
+   */
+  superAdmin?: boolean;
+
+  /**
    * The user who owns the project.
    */
   owner?: Reference<User>;

--- a/packages/fhirtypes/dist/User.d.ts
+++ b/packages/fhirtypes/dist/User.d.ts
@@ -67,7 +67,7 @@ export interface User {
   emailVerified?: boolean;
 
   /**
-   * Whether this user is a system administrator.
+   * DEPRECATED
    */
   admin?: boolean;
 

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -252,7 +252,11 @@ export async function setLoginMembership(login: Login, membershipId: string): Pr
   }
 
   // Everything checks out, update the login
-  return systemRepo.updateResource<Login>({ ...login, membership: createReference(membership) });
+  return systemRepo.updateResource<Login>({
+    ...login,
+    membership: createReference(membership),
+    superAdmin: project.superAdmin,
+  });
 }
 
 export async function getAuthTokens(login: Login, profile: Reference<ProfileResource>): Promise<TokenResult> {

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -1,3 +1,4 @@
+import { Project } from '@medplum/fhirtypes';
 import { loadTestConfig } from './config';
 import { closeDatabase, getClient, initDatabase } from './database';
 import { Operator, SelectQuery } from './fhir/sql';
@@ -20,13 +21,15 @@ describe('Seed', () => {
     // First time, seeder should run
     await seedDatabase();
 
-    // Make sure the first user is a super admin
-    const rows = await new SelectQuery('User')
+    // Make sure the first project is a super admin
+    const rows = await new SelectQuery('Project')
       .column('content')
-      .where('email', Operator.EQUALS, 'admin@example.com')
+      .where('name', Operator.EQUALS, 'Super Admin')
       .execute(getClient());
-    const user = JSON.parse(rows[0].content);
-    expect(user.admin).toBe(true);
+    expect(rows.length).toBe(1);
+
+    const project = JSON.parse(rows[0].content) as Project;
+    expect(project.superAdmin).toBe(true);
 
     // Second time, seeder should silently ignore
     await seedDatabase();

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -15,7 +15,7 @@ export async function seedDatabase(): Promise<void> {
 
   const firstName = 'Medplum';
   const lastName = 'Admin';
-  const projectName = 'Medplum';
+  const projectName = 'Super Admin';
   const email = 'admin@example.com';
   const password = 'medplum_admin';
 
@@ -24,13 +24,13 @@ export async function seedDatabase(): Promise<void> {
     resourceType: 'User',
     email,
     passwordHash,
-    admin: true,
   });
 
   const project = await systemRepo.createResource<Project>({
     resourceType: 'Project',
     name: projectName,
     owner: createReference(user),
+    superAdmin: true,
   });
 
   const practitioner = await systemRepo.createResource<Practitioner>({
@@ -61,7 +61,6 @@ export async function seedDatabase(): Promise<void> {
     admin: true,
   });
 
-  await createPublicProject(user);
   await createValueSetElements();
   await createSearchParameters();
   await createStructureDefinitions();
@@ -77,19 +76,4 @@ async function isSeeded(): Promise<boolean> {
     count: 1,
   });
   return !!bundle.entry && bundle.entry.length > 0;
-}
-
-/**
- * Creates the public project.
- * This is a special project that is available to all users.
- * It includes 'implementation' resources such as CapabilityStatement.
- */
-async function createPublicProject(owner: User): Promise<void> {
-  logger.info('Create Public project...');
-  const result = await systemRepo.createResource<Project>({
-    resourceType: 'Project',
-    name: 'Public',
-    owner: createReference(owner),
-  });
-  logger.info('Created: ' + result.id);
 }


### PR DESCRIPTION
Before:
* There was an `admin` flag on the `User` resource that marked that user as a super admin
* No matter what project that user signed into, they always had super admin privileges
* In practice, that meant there were separate super admin accounts used in "break glass" situations
* Because they were separate accounts, it made it difficult to use SSO like Google Auth

After:
* There is a `superAdmin` flag on the `Project` resource
* Users can optionally choose that super admin project at signin
* This cleanly allows SSO / Google Auth

Also:
* There are two distinct "admin" types:  "Super Admin" (global system administrator) and "Project Admin" (project administrator)
* Given the risk of confusion, I'm making it a point to always use `superAdmin` when referring to super admins to minimize the risk
* For existing deployments, this will require a migration step, for an existing super admin `User` to configure a super admin `Project`
* In a future PR, the notion of super admin `User` will be removed