### PR TITLE
UI to restore and view deleted resources

### DIFF
--- a/packages/react/src/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline.tsx
@@ -83,7 +83,9 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
 
         if (bundle.entry) {
           for (const entry of bundle.entry) {
-            newItems.push(entry.resource as Resource);
+            if (entry.resource) {
+              newItems.push(entry.resource);
+            }
           }
         }
       }

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -768,19 +768,14 @@ describe('FHIR Repo', () => {
     // Delete the patient
     await systemRepo.deleteResource('Patient', patient?.id as string);
 
-    try {
-      await systemRepo.readHistory('Patient', patient?.id as string);
-      fail('Should have thrown');
-    } catch (err) {
-      const outcome = err as OperationOutcome;
-      expect(outcome.id).toEqual('gone');
-    }
+    const history2 = await systemRepo.readHistory('Patient', patient?.id as string);
+    expect(history2?.entry?.length).toBe(2);
 
     // Restore the patient
     await systemRepo.updateResource({ ...patient, meta: undefined });
 
-    const history2 = await systemRepo.readHistory('Patient', patient?.id as string);
-    expect(history2?.entry?.length).toBe(3);
+    const history3 = await systemRepo.readHistory('Patient', patient?.id as string);
+    expect(history3?.entry?.length).toBe(3);
   });
 
   test('Search birthDate after delete', async () => {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -221,7 +221,13 @@ export class Repository {
    * @returns Operation outcome and a history bundle.
    */
   async readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
-    await this.readResource<T>(resourceType, id);
+    try {
+      await this.readResource<T>(resourceType, id);
+    } catch (err) {
+      if (!isGone(err)) {
+        throw err;
+      }
+    }
 
     const client = getClient();
     const rows = await new SelectQuery(resourceType + '_History')

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -224,7 +224,7 @@ export class Repository {
     try {
       await this.readResource<T>(resourceType, id);
     } catch (err) {
-      if (!isGone(err)) {
+      if (!isGone(err as OperationOutcome)) {
         throw err;
       }
     }


### PR DESCRIPTION
By default, a FHIR "delete" operation is a soft delete.

API users have always been able to "update" a deleted resource to restore it to a previous state.  The app/UI experience was lacking through.

In this PR:
* Allows GET _history on deleted resources
* ResourcePage recognizes a deleted resource, shows a friendly error message, and a button to restore
* Correctly handles missing history entries in `<ResourceTimeline>` and `<ResourceHistoryTable>`

Future work:
* Ability to search for deleted resources?