### PR TITLE
Renamed DOCKER env vars to ECR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
         run: ./scripts/cicd-deploy.sh
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
-          DOCKER_SERVER: ${{ secrets.DOCKER_SERVER }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
           ECS_SERVICE: ${{ secrets.ECS_SERVICE }}

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ -z "${DOCKER_REPOSITORY}" ]]; then
-  echo "DOCKER_REPOSITORY is missing"
+if [[ -z "${ECR_REPOSITORY}" ]]; then
+  echo "ECR_REPOSITORY is missing"
   exit 1
 fi
 
@@ -37,11 +37,11 @@ tar \
   packages/server/dist
 
 # Build the Docker image
-docker build . -t $DOCKER_REPOSITORY:latest -t $DOCKER_REPOSITORY:$GITHUB_SHA
+docker build . -t $ECR_REPOSITORY:latest -t $ECR_REPOSITORY:$GITHUB_SHA
 
 # Push the Docker image
-docker push $DOCKER_REPOSITORY:latest
-docker push $DOCKER_REPOSITORY:$GITHUB_SHA
+docker push $ECR_REPOSITORY:latest
+docker push $ECR_REPOSITORY:$GITHUB_SHA
 
 # Update the medplum fargate service
 aws ecs update-service \


### PR DESCRIPTION
In future PR, we will push the docker image to both Docker Hub and AWS ECR.

As prep work, this PR renames environment variable names to be more clear.