### PR TITLE
Added ability to add/edit/remove project secrets

### DIFF
--- a/packages/app/src/admin/ProjectPage.test.tsx
+++ b/packages/app/src/admin/ProjectPage.test.tsx
@@ -79,10 +79,4 @@ describe('ProjectPage', () => {
     await waitFor(() => screen.getByText('Create new bot'));
     expect(screen.getByText('Create new bot')).toBeInTheDocument();
   });
-
-  test('Secrets page', async () => {
-    await setup('/admin/secrets');
-    await waitFor(() => screen.getByText('Coming soon'));
-    expect(screen.getByText('Coming soon')).toBeInTheDocument();
-  });
 });

--- a/packages/app/src/admin/SecretsPage.test.tsx
+++ b/packages/app/src/admin/SecretsPage.test.tsx
@@ -1,0 +1,72 @@
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { AppRoutes } from '../AppRoutes';
+
+const medplum = new MockClient();
+
+async function setup(url: string): Promise<void> {
+  await act(async () => {
+    render(
+      <MedplumProvider medplum={medplum}>
+        <MemoryRouter initialEntries={[url]} initialIndex={0}>
+          <AppRoutes />
+        </MemoryRouter>
+      </MedplumProvider>
+    );
+  });
+}
+
+describe('ProjectPage', () => {
+  beforeAll(() => {
+    medplum.setActiveLoginOverride({
+      accessToken: '123',
+      refreshToken: '456',
+      profile: {
+        reference: 'Practitioner/123',
+      },
+      project: {
+        reference: 'Project/123',
+      },
+    });
+  });
+
+  test('Renders', async () => {
+    await setup('/admin/secrets');
+    await waitFor(() => screen.getByText('Project Secrets'));
+    expect(screen.getByText('Project Secrets')).toBeInTheDocument();
+  });
+
+  test('Add and submit', async () => {
+    toast.success = jest.fn();
+
+    await setup('/admin/secrets');
+    await waitFor(() => screen.getByText('Add'));
+
+    // Click the "Add" button
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add'));
+    });
+
+    // Enter the secret name
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('name'), { target: { value: 'foo' } });
+    });
+
+    // Enter the secret value
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('value[x]'), { target: { value: 'bar' } });
+    });
+
+    // Click the "Save" button
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    // Wait for the toast
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Saved'));
+  });
+});

--- a/packages/app/src/admin/SecretsPage.tsx
+++ b/packages/app/src/admin/SecretsPage.tsx
@@ -1,11 +1,55 @@
-import React from 'react';
+import { IndexedStructureDefinition } from '@medplum/core';
+import { ProjectSecret } from '@medplum/fhirtypes';
+import { Button, ResourcePropertyInput, useMedplum } from '@medplum/react';
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import { getProjectId } from '../utils';
 
 export function SecretsPage(): JSX.Element {
+  const medplum = useMedplum();
+  const projectId = getProjectId(medplum);
+  const projectDetails = medplum.get(`admin/projects/${projectId}`).read();
+  const [schema, setSchema] = useState<IndexedStructureDefinition | undefined>();
+  const [secrets, setSecrets] = useState<ProjectSecret[] | undefined>();
+
+  useEffect(() => {
+    medplum.requestSchema('Project').then(setSchema).catch(console.log);
+  }, [medplum]);
+
+  useEffect(() => {
+    if (projectDetails) {
+      setSecrets(JSON.parse(JSON.stringify(projectDetails.project.secret || [])));
+    }
+  }, [medplum, projectDetails]);
+
+  if (!schema || !secrets) {
+    return <div>Loading...</div>;
+  }
+
   return (
-    <>
-      <h1>Secrets</h1>
-      <p>Manage your bot secrets here</p>
-      <p>Coming soon</p>
-    </>
+    <form
+      noValidate
+      autoComplete="off"
+      onSubmit={(e: React.FormEvent) => {
+        e.preventDefault();
+        medplum
+          .post(`admin/projects/${projectId}/secrets`, secrets)
+          .then(() => medplum.get(`admin/projects/${projectId}`, { cache: 'reload' }))
+          .then(() => toast.success('Saved'))
+          .catch(console.log);
+      }}
+    >
+      <h1>Project Secrets</h1>
+      <p>Use project secrets to store sensitive information such as API keys or other access credentials.</p>
+      <ResourcePropertyInput
+        property={schema.types['Project'].properties['secret']}
+        name="secret"
+        defaultValue={secrets}
+        onChange={setSecrets}
+      />
+      <Button type="submit" size="large">
+        Save
+      </Button>
+    </form>
   );
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -11,6 +11,7 @@ import {
   Patient,
   Project,
   ProjectMembership,
+  ProjectSecret,
   Reference,
   Resource,
   ResourceType,
@@ -266,9 +267,10 @@ export interface TokenResponse {
   readonly profile: Reference<ProfileResource>;
 }
 
-export interface BotEvent {
+export interface BotEvent<T = Resource | Hl7Message | string> {
   readonly contentType: string;
-  readonly input: Resource | Hl7Message | string;
+  readonly input: T;
+  readonly secrets?: ProjectSecret[];
 }
 
 /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -270,7 +270,7 @@ export interface TokenResponse {
 export interface BotEvent<T = Resource | Hl7Message | string> {
   readonly contentType: string;
   readonly input: T;
-  readonly secrets?: ProjectSecret[];
+  readonly secrets: Record<string, ProjectSecret>;
 }
 
 /**

--- a/packages/generator/src/storybook.ts
+++ b/packages/generator/src/storybook.ts
@@ -16,6 +16,7 @@ const resourceTypes = [
   'ServiceRequest',
   'Specimen',
   'Bot',
+  'Project',
 ];
 const properties = [
   'resourceType',

--- a/packages/mock/src/mocks/structuredefinitions.json
+++ b/packages/mock/src/mocks/structuredefinitions.json
@@ -6187,8 +6187,254 @@
   },
   {
     "resourceType": "StructureDefinition",
+    "id": "Project",
+    "name": "Project",
+    "type": "Project",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Project.id",
+          "path": "Project.id",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.meta",
+          "path": "Project.meta",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "Meta"
+            }
+          ]
+        },
+        {
+          "id": "Project.implicitRules",
+          "path": "Project.implicitRules",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "uri"
+            }
+          ]
+        },
+        {
+          "id": "Project.language",
+          "path": "Project.language",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "code"
+            }
+          ]
+        },
+        {
+          "id": "Project.name",
+          "path": "Project.name",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.description",
+          "path": "Project.description",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.superAdmin",
+          "path": "Project.superAdmin",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ]
+        },
+        {
+          "id": "Project.owner",
+          "path": "Project.owner",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "https://medplum.com/fhir/StructureDefinition/User"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "Project.features",
+          "path": "Project.features",
+          "min": 0,
+          "max": "*",
+          "type": [
+            {
+              "code": "code"
+            }
+          ]
+        },
+        {
+          "id": "Project.defaultPatientAccessPolicy",
+          "path": "Project.defaultPatientAccessPolicy",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "https://medplum.com/fhir/StructureDefinition/AccessPolicy"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "Project.secret",
+          "path": "Project.secret",
+          "min": 0,
+          "max": "*",
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ]
+        },
+        {
+          "id": "Project.secret.name",
+          "path": "Project.secret.name",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.secret.value[x]",
+          "path": "Project.secret.value[x]",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            },
+            {
+              "code": "boolean"
+            },
+            {
+              "code": "decimal"
+            },
+            {
+              "code": "integer"
+            }
+          ]
+        },
+        {
+          "id": "Project.site",
+          "path": "Project.site",
+          "min": 0,
+          "max": "*",
+          "type": [
+            {
+              "code": "BackboneElement"
+            }
+          ]
+        },
+        {
+          "id": "Project.site.name",
+          "path": "Project.site.name",
+          "min": 1,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.site.domain",
+          "path": "Project.site.domain",
+          "min": 1,
+          "max": "*",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.site.googleClientId",
+          "path": "Project.site.googleClientId",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.site.googleClientSecret",
+          "path": "Project.site.googleClientSecret",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.site.recaptchaSiteKey",
+          "path": "Project.site.recaptchaSiteKey",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        },
+        {
+          "id": "Project.site.recaptchaSecretKey",
+          "path": "Project.site.recaptchaSecretKey",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "StructureDefinition",
     "id": "Bot",
     "name": "Bot",
+    "type": "Bot",
     "snapshot": {
       "element": [
         {

--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -334,4 +334,36 @@ describe('Project Admin routes', () => {
       ],
     });
   });
+
+  test('Save project secrets', async () => {
+    // Register and create a project
+    const { project, accessToken } = await registerNew({
+      firstName: 'John',
+      lastName: 'Adams',
+      projectName: 'Adams Project',
+      email: `john${randomUUID()}@example.com`,
+      password: 'password!@#',
+    });
+
+    // Add a secret
+    const res2 = await request(app)
+      .post('/admin/projects/' + project.id + '/secrets')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send([
+        {
+          name: 'test_secret',
+          valueString: 'test_value',
+        },
+      ]);
+    expect(res2.status).toBe(200);
+
+    // Verify the secret was added
+    const res3 = await request(app)
+      .get('/admin/projects/' + project.id)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res3.status).toBe(200);
+    expect(res3.body.project.secret).toHaveLength(1);
+    expect(res3.body.project.secret[0].name).toEqual('test_secret');
+    expect(res3.body.project.secret[0].valueString).toEqual('test_value');
+  });
 });

--- a/packages/server/src/admin/project.ts
+++ b/packages/server/src/admin/project.ts
@@ -44,9 +44,28 @@ projectAdminRouter.get(
       project: {
         id: project?.id,
         name: project?.name,
+        secret: project?.secret,
       },
       members,
     });
+  })
+);
+
+projectAdminRouter.post(
+  '/:projectId/secrets',
+  asyncWrap(async (req: Request, res: Response) => {
+    const project = await verifyProjectAdmin(req, res);
+    if (!project) {
+      res.sendStatus(404);
+      return;
+    }
+
+    const result = await systemRepo.updateResource({
+      ...project,
+      secret: req.body,
+    });
+
+    res.json(result);
   })
 );
 

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -28,7 +28,7 @@ const PdfPrinter = require("pdfmake");
 const userCode = require("./user.js");
 
 exports.handler = async (event, context) => {
-  const { accessToken, input, contentType } = event;
+  const { accessToken, input, contentType, secrets } = event;
   const medplum = new MedplumClient({ fetch, createPdf });
   medplum.setAccessToken(accessToken);
   try {
@@ -38,6 +38,7 @@ exports.handler = async (event, context) => {
           ? Hl7Message.parse(input)
           : input,
       contentType,
+      secrets,
     });
   } catch (err) {
     if (err instanceof Error) {

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -125,6 +125,7 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
 
   // Get the project secrets
   const project = await systemRepo.readResource<Project>('Project', bot.meta?.project as string);
+  const secrets = Object.fromEntries(project.secret?.map((secret) => [secret.name, secret]) || []);
 
   const client = new LambdaClient({ region: 'us-east-1' });
   const name = `medplum-bot-lambda-${bot.id}`;
@@ -132,7 +133,7 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
     accessToken,
     input: input instanceof Hl7Message ? input.toString() : input,
     contentType,
-    secrets: project.secret,
+    secrets,
   };
 
   // Build the command

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -123,12 +123,16 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
     scope: 'openid',
   });
 
+  // Get the project secrets
+  const project = await systemRepo.readResource<Project>('Project', bot.meta?.project as string);
+
   const client = new LambdaClient({ region: 'us-east-1' });
   const name = `medplum-bot-lambda-${bot.id}`;
   const payload = {
     accessToken,
     input: input instanceof Hl7Message ? input.toString() : input,
     contentType,
+    secrets: project.secret,
   };
 
   // Build the command

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -16,6 +16,12 @@ export async function createTestProject(): Promise<{
       reference: 'User/' + randomUUID(),
     },
     features: ['bots', 'email'],
+    secret: [
+      {
+        name: 'foo',
+        valueString: 'bar',
+      },
+    ],
   });
 
   const client = await systemRepo.createResource<ClientApplication>({


### PR DESCRIPTION
Project administrators can now add/edit/remove project secrets.

Project secrets are passed to bots in the `BotEvent`

![image](https://user-images.githubusercontent.com/749094/184994731-749181c5-827f-459b-8bf7-aa43220d641d.png)


Asana: https://app.asana.com/0/1201910659736061/1202657398780157/f