### PR TITLE
Fix links in Reference Types

### DIFF
--- a/packages/docs/src/components/ResourceTables.tsx
+++ b/packages/docs/src/components/ResourceTables.tsx
@@ -119,7 +119,7 @@ function renderReferenceType(referenceTypes: string[]): JSX.Element {
       {referenceTypes?.map((refType, i) => (
         <>
           {
-            <a href={`./${refType}`}>
+            <a href={`./${refType.toLowerCase()}`}>
               {i === 0 && verticalizeLinks ? '\n  ' : ''}
               {refType}
             </a>


### PR DESCRIPTION
Another issue of localhost development not being case-sensitive, while production _is_.

Interestingly, I'm not sure that vercel caught this issue