### PR TITLE
Disable systemRepo strict mode

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1581,7 +1581,6 @@ export async function getRepoForLogin(login: Login, membership: ProjectMembershi
 
 export const systemRepo = new Repository({
   superAdmin: true,
-  strictMode: true,
   author: {
     reference: 'system',
   },


### PR DESCRIPTION
We recently enabled "strict mode" on the system repository by default.

Unfortunately it caused a regression in the auto-download service.  If the user's `Media` did not pass strict validation, then the "update" operation would fail when the download service tried to set the new URL.
