### PR TITLE
Fix the newuser bug for closed projects

### DIFF
--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -50,6 +50,10 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
       sendOutcome(res, badRequest('Invalid recaptchaSecretKey'));
       return;
     }
+    if (!project.defaultPatientAccessPolicy) {
+      sendOutcome(res, badRequest('Project does not allow open registration'));
+      return;
+    }
   }
 
   if (!(await verifyRecaptcha(secretKey as string, req.body.recaptchaToken))) {


### PR DESCRIPTION
The bug:
* Consider a project that is "closed", i.e. not accepting patient registration
* But then assume that a developer sets up a website with a registration flow for that project
* The registration flow involves 2 http requests:
  * 1) Create a user or authenticate as existing user, either with email/password or google (/auth/newuser or /auth/google?create=true)
  * 2) Create the patient using /auth/newpatient
* We checked for whether patient registration is open, but only in step 2.
* That meant that step 1 could create orphaned users with zero project memberships

This PR fixes that by checking for open registration in both step 1 and step 2.

Asana: https://app.asana.com/0/1201910659736061/1202823196699602/f