### PR TITLE
Implemented FHIRPath 'as' filter and 'ofType' function

### DIFF
--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -1,8 +1,15 @@
-import { PropertyType } from '../types';
+import { readJson } from '@medplum/definitions';
+import { Bundle, Observation } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle, PropertyType } from '../types';
 import { LiteralAtom } from './atoms';
 import { evalFhirPath } from './parse';
 
 describe('Atoms', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
   test('LiteralAtom', () => {
     const a = { type: PropertyType.string, value: 'a' };
     expect(new LiteralAtom(a).eval()).toEqual([a]);
@@ -16,5 +23,22 @@ describe('Atoms', () => {
   test('UnionAtom', () => {
     expect(evalFhirPath('{} | {}', [])).toEqual([]);
     expect(evalFhirPath('x | y', [])).toEqual([]);
+  });
+
+  test('AsAtom', () => {
+    const obs1: Observation = {
+      resourceType: 'Observation',
+      valueQuantity: { value: 100, unit: 'mg' },
+    };
+
+    const obs2: Observation = {
+      resourceType: 'Observation',
+      valueCodeableConcept: { coding: [{ code: 'xyz' }] },
+    };
+
+    expect(evalFhirPath('value as Quantity', obs1)).toEqual([obs1.valueQuantity]);
+    expect(evalFhirPath('value as Quantity', obs2)).toEqual([]);
+    expect(evalFhirPath('value as CodeableConcept', obs1)).toEqual([]);
+    expect(evalFhirPath('value as CodeableConcept', obs2)).toEqual([obs2.valueCodeableConcept]);
   });
 });

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -1,6 +1,6 @@
 import { Resource } from '@medplum/fhirtypes';
 import { PropertyType } from '../types';
-import { FhirPathFunction } from './functions';
+import { FhirPathFunction, functions } from './functions';
 import {
   booleanToTypedValue,
   fhirPathArrayEquals,
@@ -90,7 +90,7 @@ export class AsAtom implements Atom {
   constructor(public readonly left: Atom, public readonly right: Atom) {}
 
   eval(context: TypedValue[]): TypedValue[] {
-    return this.left.eval(context);
+    return functions.ofType(this.left.eval(context), this.right);
   }
 }
 

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -290,7 +290,9 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: http://hl7.org/fhirpath/#oftypetype-type-specifier-collection
    */
-  ofType: stub,
+  ofType: (input: TypedValue[], criteria: Atom): TypedValue[] => {
+    return input.filter((e) => e.type === (criteria as SymbolAtom).name);
+  },
 
   /*
    * 5.3 Subsetting


### PR DESCRIPTION
Consider the `Observation`:

```json
{
  "resourceType": "Observation",
  "valueQuantity": { "value": 100, "unit": "mg" }
}
```

Consider the FHIRPath expression: `value as CodeableConcept`

Before: We would return the `Quantity` object (incorrect)

Now: We return empty array (correct)

(This is required for some in-development work to properly index `CodeableConcept` values)