### PR TITLE
Restrict project memberships to oauth client project

### DIFF
--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -176,7 +176,7 @@ describe('Google Auth', () => {
     expect(res2.body.code).toBeDefined();
   });
 
-  test('Custom Google client', async () => {
+  test('Custom Google client success', async () => {
     const email = `google-client${randomUUID()}@example.com`;
     const password = 'password!@#';
     const googleClientId = 'google-client-id-' + randomUUID();
@@ -213,6 +213,96 @@ describe('Google Auth', () => {
       });
     expect(res2.status).toBe(200);
     expect(res2.body.code).toBeDefined();
+  });
+
+  test('Custom Google client wrong project', async () => {
+    const email = `google-client${randomUUID()}@example.com`;
+    const password = 'password!@#';
+    const googleClientId = 'google-client-id-' + randomUUID();
+
+    // Register and create a project
+    const { project } = await registerNew({
+      firstName: 'Google',
+      lastName: 'Google',
+      projectName: 'Require Google Auth',
+      email,
+      password,
+    });
+
+    // As a super admin, set the google client ID
+    await systemRepo.updateResource({
+      ...project,
+      site: [
+        {
+          name: 'Test Site',
+          domain: ['example.com'],
+          googleClientId,
+        },
+      ],
+    });
+
+    // Try to login with the custom Google client
+    // This should succeed
+    const res2 = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: randomUUID(),
+        googleClientId: googleClientId,
+        googleCredential: createCredential('Test', 'Test', email),
+      });
+    expect(res2.status).toBe(400);
+    expect(res2.body.issue[0].details.text).toEqual('Invalid projectId');
+  });
+
+  test('Custom OAuth client success', async () => {
+    const email = `google-client${randomUUID()}@example.com`;
+    const password = 'password!@#';
+
+    const { project, client } = await registerNew({
+      firstName: 'Google',
+      lastName: 'Google',
+      projectName: 'Require Google Auth',
+      email,
+      password,
+    });
+
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: project.id,
+        clientId: client.id,
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Text', 'User', email),
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBeDefined();
+  });
+
+  test('Custom Google client wrong project', async () => {
+    const email = `google-client${randomUUID()}@example.com`;
+    const password = 'password!@#';
+
+    const { project, client } = await registerNew({
+      firstName: 'Google',
+      lastName: 'Google',
+      projectName: 'Require Google Auth',
+      email,
+      password,
+    });
+
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        projectId: project.id,
+        clientId: client.id,
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Text', 'User', email),
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.issue[0].details.text).toEqual('Invalid projectId');
   });
 });
 

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -284,7 +284,7 @@ describe('Google Auth', () => {
     const email = `google-client${randomUUID()}@example.com`;
     const password = 'password!@#';
 
-    const { project, client } = await registerNew({
+    const { client } = await registerNew({
       firstName: 'Google',
       lastName: 'Google',
       projectName: 'Require Google Auth',
@@ -296,7 +296,7 @@ describe('Google Auth', () => {
       .post('/auth/google')
       .type('json')
       .send({
-        projectId: project.id,
+        projectId: randomUUID(),
         clientId: client.id,
         googleClientId: getConfig().googleClientId,
         googleCredential: createCredential('Text', 'User', email),

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -1,30 +1,47 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { createReference } from '@medplum/core';
-import { ClientApplication } from '@medplum/fhirtypes';
+import { Project } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
 import { simpleParser } from 'mailparser';
 import fetch from 'node-fetch';
 import request from 'supertest';
+import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
-import { createTestClient, setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
+import { createTestProject, setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
+import { setPassword } from './setpassword';
 
 jest.mock('@aws-sdk/client-sesv2');
 jest.mock('hibp');
 jest.mock('node-fetch');
 
 const app = express();
-let client: ClientApplication;
+const email = randomUUID() + '@example.com';
+const password = randomUUID();
+let project: Project;
 
 describe('Login', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    client = await createTestClient();
+
+    // Create a test project
+    ({ project } = await createTestProject());
+
+    // Create a test user
+    const { user } = await inviteUser({
+      project,
+      firstName: 'Test',
+      lastName: 'User',
+      email,
+    });
+
+    // Set the test user password
+    await setPassword(user, password);
   });
 
   afterAll(async () => {
@@ -43,8 +60,8 @@ describe('Login', () => {
   test('Invalid client UUID', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
       clientId: '123',
-      email: 'admin@example.com',
-      password: 'medplum_admin',
+      email,
+      password,
       scope: 'openid',
     });
     expect(res.status).toBe(400);
@@ -55,8 +72,8 @@ describe('Login', () => {
   test('Invalid client ID', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
       clientId: 'e99126bb-c748-4c00-8d28-4e88dfb88278',
-      email: 'admin@example.com',
-      password: 'medplum_admin',
+      email,
+      password,
       scope: 'openid',
     });
     expect(res.status).toBe(404);
@@ -66,9 +83,8 @@ describe('Login', () => {
 
   test('Missing email', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
       email: '',
-      password: 'medplum_admin',
+      password,
       scope: 'openid',
     });
     expect(res.status).toBe(400);
@@ -78,9 +94,8 @@ describe('Login', () => {
 
   test('Invalid email', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
       email: 'xyz',
-      password: 'medplum_admin',
+      password,
       scope: 'openid',
     });
     expect(res.status).toBe(400);
@@ -90,8 +105,7 @@ describe('Login', () => {
 
   test('Missing password', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
-      email: 'admin@example.com',
+      email,
       password: '',
       scope: 'openid',
     });
@@ -102,8 +116,7 @@ describe('Login', () => {
 
   test('Wrong password', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
-      email: 'admin@example.com',
+      email,
       password: 'wrong-password',
       scope: 'openid',
     });
@@ -114,9 +127,8 @@ describe('Login', () => {
 
   test('Success', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
-      email: 'admin@example.com',
-      password: 'medplum_admin',
+      email,
+      password,
       scope: 'openid',
     });
     expect(res.status).toBe(200);
@@ -125,8 +137,8 @@ describe('Login', () => {
 
   test('Success default client', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      email: 'admin@example.com',
-      password: 'medplum_admin',
+      email,
+      password,
       scope: 'openid',
     });
     expect(res.status).toBe(200);
@@ -135,8 +147,8 @@ describe('Login', () => {
 
   test('Success new project', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
-      email: 'admin@example.com',
-      password: 'medplum_admin',
+      email,
+      password,
       scope: 'openid',
       projectId: 'new',
     });
@@ -260,7 +272,6 @@ describe('Login', () => {
 
     // Then login
     const res8 = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
       email: memberEmail,
       password: 'my-new-password',
       scope: 'openid',
@@ -272,7 +283,6 @@ describe('Login', () => {
     // Then get access token
     const res9 = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'authorization_code',
-      clientId: client.id,
       code: res8.body.code,
       code_verifier: 'xyz',
     });
@@ -344,7 +354,6 @@ describe('Login', () => {
     // Then try to login
     // This should fail with error message that google auth is required
     const res8 = await request(app).post('/auth/login').type('json').send({
-      clientId: client.id,
       email,
       password,
       scope: 'openid',

--- a/packages/server/src/auth/login.ts
+++ b/packages/server/src/auth/login.ts
@@ -1,7 +1,10 @@
+import { badRequest } from '@medplum/core';
+import { ClientApplication } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
+import { systemRepo } from '../fhir/repo';
 import { tryLogin } from '../oauth/utils';
 import { sendLoginResult } from './utils';
 
@@ -17,10 +20,28 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
     return;
   }
 
+  // Project ID can come from one of two sources
+  // 1) Passed in explicitly as projectId
+  // 2) Implicit with clientId
+  // The only rule is that they have to match
+  let projectId = req.body.projectId as string | undefined;
+
+  // For OAuth2 flow, check the clientId
+  const clientId = req.body.clientId;
+  if (clientId) {
+    const client = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+    const clientProjectId = client.meta?.project as string;
+    if (projectId !== undefined && projectId !== clientProjectId) {
+      sendOutcome(res, badRequest('Invalid projectId'));
+      return;
+    }
+    projectId = clientProjectId;
+  }
+
   const login = await tryLogin({
     authMethod: 'password',
-    clientId: req.body.clientId || undefined,
-    projectId: req.body.projectId || undefined,
+    clientId,
+    projectId,
     scope: req.body.scope || 'openid',
     nonce: req.body.nonce || randomUUID(),
     codeChallenge: req.body.codeChallenge,
@@ -31,5 +52,5 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
     remoteAddress: req.ip,
     userAgent: req.get('User-Agent'),
   });
-  await sendLoginResult(res, login, req.body.projectId === 'new');
+  await sendLoginResult(res, login, projectId);
 }

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -41,7 +41,7 @@ describe('Profile', () => {
     });
 
     profile1 = registerResult.profile;
-    profile2 = inviteResult;
+    profile2 = inviteResult.profile;
   });
 
   afterAll(async () => {

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -26,7 +26,7 @@ export interface RegisterResponse {
   readonly project: Project;
   readonly membership: ProjectMembership;
   readonly profile: ProfileResource;
-  readonly client?: ClientApplication;
+  readonly client: ClientApplication;
 }
 
 /**
@@ -54,7 +54,7 @@ export async function registerNew(request: RegisterRequest): Promise<RegisterRes
     remember: true,
   });
 
-  const membership = await createProject(login, projectName, firstName, lastName);
+  const { membership, client } = await createProject(login, projectName, firstName, lastName);
 
   const project = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
 
@@ -74,5 +74,6 @@ export async function registerNew(request: RegisterRequest): Promise<RegisterRes
     project,
     membership,
     profile,
+    client,
   };
 }

--- a/packages/server/src/auth/setpassword.ts
+++ b/packages/server/src/auth/setpassword.ts
@@ -40,8 +40,12 @@ export async function setPasswordHandler(req: Request, res: Response): Promise<v
     return;
   }
 
-  const passwordHash = await bcrypt.hash(req.body.password, 10);
-  await systemRepo.updateResource<User>({ ...user, passwordHash });
+  await setPassword(user, req.body.password);
   await systemRepo.updateResource<PasswordChangeRequest>({ ...pcr, used: true });
   sendOutcome(res, allOk);
+}
+
+export async function setPassword(user: User, password: string): Promise<void> {
+  const passwordHash = await bcrypt.hash(password, 10);
+  await systemRepo.updateResource<User>({ ...user, passwordHash });
 }

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -73,9 +73,10 @@ export async function createProjectMembership(
  * Otherwise, sends the authorization code.
  * @param res The response object.
  * @param login The login details.
+ * @param projectId The optional projectId for scoping.
  */
-export async function sendLoginResult(res: Response, login: Login, newProject: boolean): Promise<void> {
-  if (newProject) {
+export async function sendLoginResult(res: Response, login: Login, projectId: string | undefined): Promise<void> {
+  if (projectId === 'new') {
     // User is creating a new project.
     res.json({ login: login.id });
     return;
@@ -93,7 +94,7 @@ export async function sendLoginResult(res: Response, login: Login, newProject: b
   // User has multiple profiles, so the user needs to select
   // Safe to rewrite attachments,
   // because we know that these are all resources that the user has access to
-  const memberships = await getUserMemberships(login?.user as Reference<User>);
+  const memberships = await getUserMemberships(login?.user as Reference<User>, projectId);
   const redactedMemberships = memberships.map((m) => ({
     id: m.id,
     project: m.project,

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1,23 +1,41 @@
-import { ClientApplication } from '@medplum/fhirtypes';
+import { ClientApplication, Project } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
+import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
+import { setPassword } from '../auth/setpassword';
 import { loadTestConfig, MedplumServerConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
-import { createTestClient } from '../test.setup';
+import { createTestProject } from '../test.setup';
 import { generateSecret } from './keys';
 import { hashCode } from './token';
 
 const app = express();
+const email = randomUUID() + '@example.com';
+const password = randomUUID();
 let config: MedplumServerConfig;
+let project: Project;
 let client: ClientApplication;
 
 describe('OAuth2 Token', () => {
   beforeAll(async () => {
     config = await loadTestConfig();
     await initApp(app, config);
-    client = await createTestClient();
+
+    // Create a test project
+    ({ project, client } = await createTestProject());
+
+    // Create a test user
+    const { user } = await inviteUser({
+      project,
+      firstName: 'Test',
+      lastName: 'User',
+      email,
+    });
+
+    // Set the test user password
+    await setPassword(user, password);
   });
 
   afterAll(async () => {
@@ -205,8 +223,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         client_id: client.id as string,
         redirect_uri: client.redirectUri as string,
         scope: 'openid',
@@ -234,8 +252,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         client_id: client.id as string,
         redirect_uri: client.redirectUri as string,
         scope: 'openid',
@@ -264,8 +282,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -296,8 +314,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         client_id: client.id as string,
         redirect_uri: client.redirectUri as string,
         scope: 'openid',
@@ -322,8 +340,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         client_id: client.id as string,
         redirect_uri: client.redirectUri as string,
         scope: 'openid',
@@ -379,8 +397,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         client_id: client.id as string,
         redirect_uri: client.redirectUri as string,
         scope: 'openid',
@@ -421,8 +439,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         client_id: client.id as string,
         redirect_uri: client.redirectUri as string,
         scope: 'openid',
@@ -464,8 +482,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -491,8 +509,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -533,8 +551,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -579,8 +597,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -621,8 +639,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -663,8 +681,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',
@@ -712,8 +730,8 @@ describe('OAuth2 Token', () => {
       .post('/auth/login')
       .type('json')
       .send({
-        email: 'admin@example.com',
-        password: 'medplum_admin',
+        email,
+        password,
         clientId: client.id as string,
         redirectUri: client.redirectUri as string,
         scope: 'openid',


### PR DESCRIPTION
Context:
* 3rd party application uses the OAuth "authorization_code" flow
* User with multiple Medplum profiles signs in

Before:  The OAuth dialog would show the profile selector

After:  The OAuth dialog knows to only show profiles for the same project as the client

The diff is messier than I'd like because we were using "admin@example.com" in a bunch of tests, which has multiple profiles, which caused broken tests.