### PR TITLE
Push docker images to docker hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Login to Amazon ECR
         if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
         uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Docker Hub
+        if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Deploy
         if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
         run: ./scripts/cicd-deploy.sh

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -44,20 +44,20 @@ tar \
 # Build the Docker image
 # Tag for both Docker Hub and AWS Elastic Container Registry (ECR)
 docker build . \
-  -t $DOCKERHUB_REPOSITORY:latest \
-  -t $DOCKERHUB_REPOSITORY:$GITHUB_SHA \
-  -t $ECR_REPOSITORY:latest \
-  -t $ECR_REPOSITORY:$GITHUB_SHA
+  -t "$DOCKERHUB_REPOSITORY:latest" \
+  -t "$DOCKERHUB_REPOSITORY:$GITHUB_SHA" \
+  -t "$ECR_REPOSITORY:latest" \
+  -t "$ECR_REPOSITORY:$GITHUB_SHA"
 
 # Push the Docker image
-docker push $DOCKERHUB_REPOSITORY:latest
-docker push $DOCKERHUB_REPOSITORY:$GITHUB_SHA
-docker push $ECR_REPOSITORY:latest
-docker push $ECR_REPOSITORY:$GITHUB_SHA
+docker push "$DOCKERHUB_REPOSITORY:latest"
+docker push "$DOCKERHUB_REPOSITORY:$GITHUB_SHA"
+docker push "$ECR_REPOSITORY:latest"
+docker push "$ECR_REPOSITORY:$GITHUB_SHA"
 
 # Update the medplum fargate service
 aws ecs update-service \
-  --region $AWS_REGION \
-  --cluster $ECS_CLUSTER \
-  --service $ECS_SERVICE \
+  --region "$AWS_REGION" \
+  --cluster "$ECS_CLUSTER" \
+  --service "$ECS_SERVICE" \
   --force-new-deployment

--- a/scripts/deploy-server.sh
+++ b/scripts/deploy-server.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -z "${DOCKERHUB_REPOSITORY}" ]]; then
+  echo "DOCKERHUB_REPOSITORY is missing"
+  exit 1
+fi
+
 if [[ -z "${ECR_REPOSITORY}" ]]; then
   echo "ECR_REPOSITORY is missing"
   exit 1
@@ -37,9 +42,16 @@ tar \
   packages/server/dist
 
 # Build the Docker image
-docker build . -t $ECR_REPOSITORY:latest -t $ECR_REPOSITORY:$GITHUB_SHA
+# Tag for both Docker Hub and AWS Elastic Container Registry (ECR)
+docker build . \
+  -t $DOCKERHUB_REPOSITORY:latest \
+  -t $DOCKERHUB_REPOSITORY:$GITHUB_SHA \
+  -t $ECR_REPOSITORY:latest \
+  -t $ECR_REPOSITORY:$GITHUB_SHA
 
 # Push the Docker image
+docker push $DOCKERHUB_REPOSITORY:latest
+docker push $DOCKERHUB_REPOSITORY:$GITHUB_SHA
 docker push $ECR_REPOSITORY:latest
 docker push $ECR_REPOSITORY:$GITHUB_SHA
 


### PR DESCRIPTION
The current server deploy process:
* On commit to `main`...
* Run `build.sh` to generate `medplum-server.tar.gz`
* Run `deploy-server.sh` which calls `docker build` and `docker push`

Before: Only pushed to AWS ECR, which is not publicly available

After: Push to both AWS ECR and to Docker Hub

In the future, we want to also experiment with using Docker Hub for production deploys as well, and removing AWS ECR entirely.  That will provide more transparency, and make it easier for developers to setup self-hosting.'

Fixes https://github.com/medplum/medplum/issues/580