### PR TITLE
Removed unnecessary mocks

### DIFF
--- a/packages/server/src/admin/bot.test.ts
+++ b/packages/server/src/admin/bot.test.ts
@@ -1,17 +1,9 @@
-import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { randomUUID } from 'crypto';
 import express from 'express';
-import { pwnedPassword } from 'hibp';
-import fetch from 'node-fetch';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
-
-jest.mock('@aws-sdk/client-sesv2');
-jest.mock('hibp');
-jest.mock('node-fetch');
 
 const app = express();
 
@@ -23,15 +15,6 @@ describe('Bot admin', () => {
 
   afterAll(async () => {
     await shutdownApp();
-  });
-
-  beforeEach(() => {
-    (SESv2Client as unknown as jest.Mock).mockClear();
-    (SendEmailCommand as unknown as jest.Mock).mockClear();
-    (fetch as unknown as jest.Mock).mockClear();
-    (pwnedPassword as unknown as jest.Mock).mockClear();
-    setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
-    setupRecaptchaMock(fetch as unknown as jest.Mock, true);
   });
 
   test('Create new bot', async () => {

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -1,17 +1,9 @@
-import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { randomUUID } from 'crypto';
 import express from 'express';
-import { pwnedPassword } from 'hibp';
-import fetch from 'node-fetch';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
-
-jest.mock('@aws-sdk/client-sesv2');
-jest.mock('hibp');
-jest.mock('node-fetch');
 
 const app = express();
 
@@ -23,15 +15,6 @@ describe('Client admin', () => {
 
   afterAll(async () => {
     await shutdownApp();
-  });
-
-  beforeEach(() => {
-    (SESv2Client as unknown as jest.Mock).mockClear();
-    (SendEmailCommand as unknown as jest.Mock).mockClear();
-    (fetch as unknown as jest.Mock).mockClear();
-    (pwnedPassword as unknown as jest.Mock).mockClear();
-    setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
-    setupRecaptchaMock(fetch as unknown as jest.Mock, true);
   });
 
   test('Create new client', async () => {

--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -1,18 +1,11 @@
-import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { randomUUID } from 'crypto';
 import express from 'express';
-import { pwnedPassword } from 'hibp';
-import fetch from 'node-fetch';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
 import { getUserByEmail } from '../oauth/utils';
-import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
-
-jest.mock('hibp');
-jest.mock('node-fetch');
 
 jest.mock('jose', () => {
   const original = jest.requireActual('jose');
@@ -42,15 +35,6 @@ describe('Google Auth', () => {
 
   afterAll(async () => {
     await shutdownApp();
-  });
-
-  beforeEach(() => {
-    (SESv2Client as unknown as jest.Mock).mockClear();
-    (SendEmailCommand as unknown as jest.Mock).mockClear();
-    (fetch as unknown as jest.Mock).mockClear();
-    (pwnedPassword as unknown as jest.Mock).mockClear();
-    setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
-    setupRecaptchaMock(fetch as unknown as jest.Mock, true);
   });
 
   test('Missing client ID', async () => {


### PR DESCRIPTION
We recently added the `registerNew()` helper, which is an internal utility for registering a new user and project.

Before that, tests had to mock out the full "regsiter" flow, including sending emails, password checks, etc.

This PR cleans up a bunch of unnecessary mocks.