### PR TITLE
Cleaned up globalSchema

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1042,11 +1042,11 @@ export class MedplumClient extends EventTarget {
     const response = (await this.graphql(query)) as SchemaGraphQLResponse;
 
     for (const structureDefinition of response.data.StructureDefinitionList) {
-      indexStructureDefinition(globalSchema, structureDefinition);
+      indexStructureDefinition(structureDefinition);
     }
 
     for (const searchParameter of response.data.SearchParameterList) {
-      indexSearchParameter(globalSchema, searchParameter);
+      indexSearchParameter(searchParameter);
     }
 
     return globalSchema;

--- a/packages/core/src/searchparams.ts
+++ b/packages/core/src/searchparams.ts
@@ -44,7 +44,7 @@ export function getSearchParameterDetails(resourceType: string, searchParam: Sea
 }
 
 function setSearchParamterDetails(resourceType: string, code: string, details: SearchParameterDetails): void {
-  const typeSchema = globalSchema.types[resourceType] as TypeSchema;
+  const typeSchema = globalSchema.types[resourceType];
   if (!typeSchema.searchParamsDetails) {
     typeSchema.searchParamsDetails = {};
   }

--- a/packages/core/src/searchparams.ts
+++ b/packages/core/src/searchparams.ts
@@ -1,5 +1,5 @@
 import { ElementDefinition, SearchParameter } from '@medplum/fhirtypes';
-import { IndexedStructureDefinition, PropertyType } from './types';
+import { globalSchema, PropertyType, TypeSchema } from './types';
 import { capitalize } from './utils';
 
 export enum SearchParameterType {
@@ -30,21 +30,34 @@ export interface SearchParameterDetails {
  *   2) The "token" type includes enums and booleans.
  *   3) Arrays/multiple values are not reflected at all.
  *
- * @param structureDefinitions Collection of StructureDefinition resources indexed by name.
  * @param resourceType The root resource type.
  * @param searchParam The search parameter.
  * @returns The search parameter type details.
  */
-export function getSearchParameterDetails(
-  structureDefinitions: IndexedStructureDefinition,
-  resourceType: string,
-  searchParam: SearchParameter
-): SearchParameterDetails {
+export function getSearchParameterDetails(resourceType: string, searchParam: SearchParameter): SearchParameterDetails {
+  let result: SearchParameterDetails | undefined =
+    globalSchema.types[resourceType]?.searchParamsDetails?.[searchParam.code as string];
+  if (!result) {
+    result = buildSearchParamterDetails(resourceType, searchParam);
+  }
+  return result;
+}
+
+function setSearchParamterDetails(resourceType: string, code: string, details: SearchParameterDetails): void {
+  const typeSchema = globalSchema.types[resourceType] as TypeSchema;
+  if (!typeSchema.searchParamsDetails) {
+    typeSchema.searchParamsDetails = {};
+  }
+  typeSchema.searchParamsDetails[code] = details;
+}
+
+function buildSearchParamterDetails(resourceType: string, searchParam: SearchParameter): SearchParameterDetails {
   if (searchParam.code === '_lastUpdated') {
     return { columnName: 'lastUpdated', type: SearchParameterType.DATETIME };
   }
 
-  const columnName = convertCodeToColumnName(searchParam.code as string);
+  const code = searchParam.code as string;
+  const columnName = convertCodeToColumnName(code);
   const expression = getExpressionForResourceType(resourceType, searchParam.expression as string)?.split('.');
   if (!expression) {
     // This happens on compound types
@@ -61,8 +74,8 @@ export function getSearchParameterDetails(
   for (let i = 1; i < expression.length; i++) {
     const propertyName = expression[i];
     elementDefinition =
-      structureDefinitions.types[baseType]?.properties?.[propertyName] ??
-      structureDefinitions.types[baseType]?.properties?.[propertyName + '[x]'];
+      globalSchema.types[baseType]?.properties?.[propertyName] ??
+      globalSchema.types[baseType]?.properties?.[propertyName + '[x]'];
     if (!elementDefinition) {
       throw new Error(`Element definition not found for ${resourceType} ${searchParam.code}`);
     }
@@ -88,7 +101,9 @@ export function getSearchParameterDetails(
   }
 
   const type = getSearchParameterType(searchParam, propertyType as PropertyType);
-  return { columnName, type, elementDefinition, array };
+  const result = { columnName, type, elementDefinition, array };
+  setSearchParamterDetails(resourceType, code, result);
+  return result;
 }
 
 /**

--- a/packages/core/src/searchparams.ts
+++ b/packages/core/src/searchparams.ts
@@ -1,5 +1,5 @@
 import { ElementDefinition, SearchParameter } from '@medplum/fhirtypes';
-import { globalSchema, PropertyType, TypeSchema } from './types';
+import { globalSchema, PropertyType } from './types';
 import { capitalize } from './utils';
 
 export enum SearchParameterType {

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,22 +1,19 @@
-import { createSchema, getPropertyDisplayName, indexSearchParameter, indexStructureDefinition } from './types';
+import { getPropertyDisplayName, globalSchema, indexSearchParameter, indexStructureDefinition } from './types';
 
 describe('Type Utils', () => {
   test('indexStructureDefinition', () => {
-    const schema = createSchema();
-    expect(schema.types).toBeDefined();
-
     // Silently ignore empty structure definitions
-    indexStructureDefinition(schema, { resourceType: 'StructureDefinition' });
+    indexStructureDefinition({ resourceType: 'StructureDefinition' });
 
     // Silently ignore structure definitions without any elements
-    indexStructureDefinition(schema, {
+    indexStructureDefinition({
       resourceType: 'StructureDefinition',
       name: 'EmptyStructureDefinition',
       snapshot: {},
     });
 
     // Index a patient definition
-    indexStructureDefinition(schema, {
+    indexStructureDefinition({
       resourceType: 'StructureDefinition',
       id: '123',
       name: 'Patient',
@@ -39,19 +36,19 @@ describe('Type Utils', () => {
         ],
       },
     });
-    expect(schema.types['Patient']).toBeDefined();
-    expect(schema.types['Patient'].properties).toBeDefined();
-    expect(schema.types['Patient'].properties['name']).toBeDefined();
+    expect(globalSchema.types['Patient']).toBeDefined();
+    expect(globalSchema.types['Patient'].properties).toBeDefined();
+    expect(globalSchema.types['Patient'].properties['name']).toBeDefined();
 
     // Silently ignore search parameters without base
-    indexSearchParameter(schema, { resourceType: 'SearchParameter' });
+    indexSearchParameter({ resourceType: 'SearchParameter' });
 
     // Silently ignore search parameters for types without a StructureDefinition
-    indexSearchParameter(schema, { resourceType: 'SearchParameter', base: ['XYZ'] });
-    expect(schema.types['XYZ']).toBeUndefined();
+    indexSearchParameter({ resourceType: 'SearchParameter', base: ['XYZ'] });
+    expect(globalSchema.types['XYZ']).toBeUndefined();
 
     // Index a patient search parameter
-    indexSearchParameter(schema, {
+    indexSearchParameter({
       resourceType: 'SearchParameter',
       id: 'Patient-name',
       base: ['Patient'],
@@ -60,10 +57,10 @@ describe('Type Utils', () => {
       type: 'string',
       expression: 'Patient.name',
     });
-    expect(schema.types['Patient'].searchParams?.['name']).toBeDefined();
+    expect(globalSchema.types['Patient'].searchParams?.['name']).toBeDefined();
 
     // Index again and silently ignore
-    indexSearchParameter(schema, {
+    indexSearchParameter({
       resourceType: 'SearchParameter',
       id: 'Patient-name',
       base: ['Patient'],
@@ -72,7 +69,7 @@ describe('Type Utils', () => {
       type: 'string',
       expression: 'Patient.name',
     });
-    expect(schema.types['Patient'].searchParams?.['name']).toBeDefined();
+    expect(globalSchema.types['Patient'].searchParams?.['name']).toBeDefined();
   });
 
   test('getPropertyDisplayName', () => {

--- a/packages/react/src/SearchControl.tsx
+++ b/packages/react/src/SearchControl.tsx
@@ -97,6 +97,7 @@ interface SearchControlState {
  */
 export function SearchControl(props: SearchControlProps): JSX.Element {
   const medplum = useMedplum();
+  const [schemaLoaded, setSchemaLoaded] = useState<boolean>(false);
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
   const { search, onLoad } = props;
 
@@ -223,10 +224,13 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   }
 
   useEffect(() => {
-    medplum.requestSchema(props.search.resourceType as ResourceType).catch(console.log);
+    medplum
+      .requestSchema(props.search.resourceType as ResourceType)
+      .then(() => setSchemaLoaded(true))
+      .catch(console.log);
   }, [medplum, props.search.resourceType]);
 
-  const typeSchema = globalSchema?.types?.[props.search.resourceType];
+  const typeSchema = schemaLoaded && globalSchema?.types?.[props.search.resourceType];
   if (!typeSchema) {
     return <Loading />;
   }

--- a/packages/react/src/SearchControl.tsx
+++ b/packages/react/src/SearchControl.tsx
@@ -2,7 +2,7 @@ import {
   DEFAULT_SEARCH_COUNT,
   Filter,
   formatSearchQuery,
-  IndexedStructureDefinition,
+  globalSchema,
   parseSearchDefinition,
   SearchRequest,
 } from '@medplum/core';
@@ -18,7 +18,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Loading } from './Loading';
 import { useMedplum } from './MedplumProvider';
-import './SearchControl.css';
 import { getFieldDefinitions } from './SearchControlField';
 import { SearchFieldEditor } from './SearchFieldEditor';
 import { SearchFilterEditor } from './SearchFilterEditor';
@@ -29,6 +28,7 @@ import { addFilter, buildFieldNameString, getOpString, movePage, renderValue } f
 import { Select } from './Select';
 import { TitleBar } from './TitleBar';
 import { isCheckboxCell, killEvent } from './utils/dom';
+import './SearchControl.css';
 
 export class SearchChangeEvent extends Event {
   readonly definition: SearchRequest;
@@ -97,7 +97,6 @@ interface SearchControlState {
  */
 export function SearchControl(props: SearchControlProps): JSX.Element {
   const medplum = useMedplum();
-  const [schema, setSchema] = useState<IndexedStructureDefinition | undefined>();
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
   const { search, onLoad } = props;
 
@@ -224,23 +223,16 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   }
 
   useEffect(() => {
-    medplum
-      .requestSchema(props.search.resourceType as ResourceType)
-      .then((newSchema) => {
-        // The schema could have the same object identity,
-        // so need to use the spread operator to kick React re-render.
-        setSchema({ ...newSchema });
-      })
-      .catch(console.log);
+    medplum.requestSchema(props.search.resourceType as ResourceType).catch(console.log);
   }, [medplum, props.search.resourceType]);
 
-  const typeSchema = schema?.types?.[props.search.resourceType];
+  const typeSchema = globalSchema?.types?.[props.search.resourceType];
   if (!typeSchema) {
     return <Loading />;
   }
 
   const checkboxColumn = props.checkboxesEnabled;
-  const fields = getFieldDefinitions(schema, search);
+  const fields = getFieldDefinitions(search);
   const resourceType = search.resourceType;
   const lastResult = state.searchResponse;
   const entries = lastResult?.entry;
@@ -410,7 +402,6 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         </div>
       )}
       <SearchPopupMenu
-        schema={schema}
         search={props.search}
         visible={state.popupVisible}
         x={state.popupX}
@@ -442,7 +433,6 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         }}
       />
       <SearchFieldEditor
-        schema={schema}
         search={props.search}
         visible={stateRef.current.fieldEditorVisible}
         onOk={(result) => {
@@ -460,7 +450,6 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         }}
       />
       <SearchFilterEditor
-        schema={schema}
         search={props.search}
         visible={stateRef.current.filterEditorVisible}
         onOk={(result) => {
@@ -480,7 +469,6 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
       <SearchFilterValueDialog
         visible={stateRef.current.filterDialogVisible}
         title={'Input'}
-        schema={schema}
         resourceType={resourceType}
         searchParam={state.filterDialogSearchParam}
         filter={state.filterDialogFilter}

--- a/packages/react/src/SearchFieldEditor.test.tsx
+++ b/packages/react/src/SearchFieldEditor.test.tsx
@@ -1,60 +1,21 @@
-import { IndexedStructureDefinition, SearchRequest } from '@medplum/core';
+import { SearchRequest } from '@medplum/core';
+import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { SearchFieldEditor } from './SearchFieldEditor';
 
-const schema: IndexedStructureDefinition = {
-  types: {
-    Patient: {
-      display: 'Patient',
-      properties: {
-        name: {
-          id: 'Patient.name',
-          path: 'Patient.name',
-          type: [
-            {
-              code: 'HumanName',
-            },
-          ],
-        },
-        birthDate: {
-          id: 'Patient.birthDate',
-          path: 'Patient.birthDate',
-          type: [
-            {
-              code: 'date',
-            },
-          ],
-        },
-      },
-    },
-    Observation: {
-      display: 'Observation',
-      properties: {
-        valueInteger: {
-          id: 'Observation.value[x]',
-          path: 'Observation.value[x]',
-          type: [
-            {
-              code: 'integer',
-            },
-          ],
-        },
-      },
-    },
-  },
-};
-
 describe('SearchFieldEditor', () => {
+  beforeAll(async () => {
+    await new MockClient().requestSchema('Patient');
+  });
+
   test('Render not visible', () => {
     const currSearch: SearchRequest = {
       resourceType: 'Patient',
       fields: ['name'],
     };
 
-    render(
-      <SearchFieldEditor schema={schema} search={currSearch} visible={false} onOk={jest.fn()} onCancel={jest.fn()} />
-    );
+    render(<SearchFieldEditor search={currSearch} visible={false} onOk={jest.fn()} onCancel={jest.fn()} />);
 
     expect(screen.queryByText('OK')).toBeNull();
   });
@@ -67,7 +28,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -98,7 +58,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -132,7 +91,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -163,7 +121,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -194,7 +151,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -225,7 +181,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -259,7 +214,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -290,7 +244,6 @@ describe('SearchFieldEditor', () => {
 
     render(
       <SearchFieldEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}

--- a/packages/react/src/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor.tsx
@@ -1,11 +1,10 @@
-import { IndexedStructureDefinition, SearchRequest, stringify, TypeSchema } from '@medplum/core';
+import { globalSchema, SearchRequest, stringify, TypeSchema } from '@medplum/core';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
 import { Dialog } from './Dialog';
 import { buildFieldNameString } from './SearchUtils';
 
 interface SearchFieldEditorProps {
-  schema: IndexedStructureDefinition;
   visible: boolean;
   search: SearchRequest;
   onOk: (search: SearchRequest) => void;
@@ -160,7 +159,7 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
   }
 
   const resourceType = props.search.resourceType;
-  const typeDef = props.schema.types[resourceType];
+  const typeDef = globalSchema.types[resourceType];
 
   const selected = state.search.fields ?? [];
   const available = getFieldsList(typeDef)

--- a/packages/react/src/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor.test.tsx
@@ -1,4 +1,4 @@
-import { IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
+import { Operator, SearchRequest } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -6,7 +6,6 @@ import { MedplumProvider } from './MedplumProvider';
 import { SearchFilterEditor } from './SearchFilterEditor';
 
 const medplum = new MockClient();
-let schema: IndexedStructureDefinition;
 
 async function setup(child: React.ReactNode): Promise<void> {
   await act(async () => {
@@ -16,7 +15,7 @@ async function setup(child: React.ReactNode): Promise<void> {
 
 describe('SearchFilterEditor', () => {
   beforeAll(async () => {
-    schema = await medplum.requestSchema('Patient');
+    await medplum.requestSchema('Patient');
   });
 
   beforeEach(() => {
@@ -32,13 +31,7 @@ describe('SearchFilterEditor', () => {
 
   test('Not visible', async () => {
     await setup(
-      <SearchFilterEditor
-        schema={schema}
-        search={{ resourceType: 'Patient' }}
-        visible={false}
-        onOk={jest.fn()}
-        onCancel={jest.fn()}
-      />
+      <SearchFilterEditor search={{ resourceType: 'Patient' }} visible={false} onOk={jest.fn()} onCancel={jest.fn()} />
     );
 
     expect(screen.queryByTestId('filter-field')).toBeNull();
@@ -55,7 +48,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -112,7 +104,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -182,7 +173,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -215,7 +205,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -257,7 +246,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -303,7 +291,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -335,7 +322,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}
@@ -370,7 +356,6 @@ describe('SearchFilterEditor', () => {
 
     await setup(
       <SearchFilterEditor
-        schema={schema}
         search={currSearch}
         visible={true}
         onOk={(e) => (currSearch = e)}

--- a/packages/react/src/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor.tsx
@@ -1,4 +1,4 @@
-import { Filter, IndexedStructureDefinition, Operator, SearchRequest, stringify } from '@medplum/core';
+import { Filter, globalSchema, Operator, SearchRequest, stringify } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './Button';
@@ -17,7 +17,6 @@ import { Select } from './Select';
 import './SearchFilterEditor.css';
 
 export interface SearchFilterEditorProps {
-  schema: IndexedStructureDefinition;
   visible: boolean;
   search: SearchRequest;
   onOk: (search: SearchRequest) => void;
@@ -43,9 +42,8 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
     return null;
   }
 
-  const schema = props.schema;
   const resourceType = props.search.resourceType;
-  const searchParams = schema.types[resourceType].searchParams as Record<string, SearchParameter>;
+  const searchParams = globalSchema.types[resourceType].searchParams as Record<string, SearchParameter>;
   const filters = search.filters || [];
 
   return (
@@ -77,7 +75,6 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
                 return (
                   <FilterRowInput
                     key={`filter-${index}-${filters.length}-input`}
-                    schema={schema}
                     resourceType={resourceType}
                     searchParams={searchParams}
                     defaultValue={filter}
@@ -104,13 +101,7 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
                 );
               }
             })}
-            <FilterRowInput
-              schema={schema}
-              resourceType={resourceType}
-              searchParams={searchParams}
-              okText="Add"
-              onOk={onAddFilter}
-            />
+            <FilterRowInput resourceType={resourceType} searchParams={searchParams} okText="Add" onOk={onAddFilter} />
           </tbody>
         </table>
       </div>
@@ -148,7 +139,6 @@ function FilterRowDisplay(props: FilterRowDisplayProps): JSX.Element | null {
 }
 
 interface FilterRowInputProps {
-  schema: IndexedStructureDefinition;
   resourceType: string;
   searchParams: Record<string, SearchParameter>;
   defaultValue?: Filter;
@@ -208,7 +198,6 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       <td>
         {searchParam && value.operator && (
           <SearchFilterValueInput
-            schema={props.schema}
             resourceType={props.resourceType}
             searchParam={searchParam}
             defaultValue={value.value}

--- a/packages/react/src/SearchFilterValueDialog.tsx
+++ b/packages/react/src/SearchFilterValueDialog.tsx
@@ -1,4 +1,4 @@
-import { Filter, IndexedStructureDefinition } from '@medplum/core';
+import { Filter } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { Dialog } from './Dialog';
@@ -8,7 +8,6 @@ import { SearchFilterValueInput } from './SearchFilterValueInput';
 export interface SearchFilterValueDialogProps {
   title: string;
   visible: boolean;
-  schema: IndexedStructureDefinition;
   resourceType: string;
   searchParam?: SearchParameter;
   filter?: Filter;
@@ -33,7 +32,6 @@ export function SearchFilterValueDialog(props: SearchFilterValueDialogProps): JS
       <div style={{ width: 500 }}>
         <Form onSubmit={onOk}>
           <SearchFilterValueInput
-            schema={props.schema}
             resourceType={props.resourceType}
             searchParam={props.searchParam}
             defaultValue={value}

--- a/packages/react/src/SearchFilterValueInput.tsx
+++ b/packages/react/src/SearchFilterValueInput.tsx
@@ -1,4 +1,4 @@
-import { getSearchParameterDetails, IndexedStructureDefinition, SearchParameterType } from '@medplum/core';
+import { getSearchParameterDetails, SearchParameterType } from '@medplum/core';
 import { Quantity, Reference, SearchParameter } from '@medplum/fhirtypes';
 import React from 'react';
 import { Checkbox } from './Checkbox';
@@ -8,7 +8,6 @@ import { QuantityInput } from './QuantityInput';
 import { ReferenceInput } from './ReferenceInput';
 
 export interface SearchFilterValueInputProps {
-  schema: IndexedStructureDefinition;
   resourceType: string;
   searchParam: SearchParameter;
   defaultValue?: string;
@@ -17,7 +16,7 @@ export interface SearchFilterValueInputProps {
 }
 
 export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.Element | null {
-  const details = getSearchParameterDetails(props.schema, props.resourceType, props.searchParam);
+  const details = getSearchParameterDetails(props.resourceType, props.searchParam);
   const name = 'filter-value';
 
   switch (details.type) {

--- a/packages/react/src/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu.test.tsx
@@ -1,6 +1,6 @@
-import { Filter, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
+import { Filter, globalSchema, Operator, SearchRequest } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
-import { MockClient, PatientSearchParameters } from '@medplum/mock';
+import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -8,91 +8,15 @@ import { MedplumProvider } from './MedplumProvider';
 import { getFieldDefinitions } from './SearchControlField';
 import { SearchPopupMenu, SearchPopupMenuProps } from './SearchPopupMenu';
 
-const schema: IndexedStructureDefinition = {
-  types: {
-    Patient: {
-      display: 'Patient',
-      properties: {
-        name: {
-          id: 'Patient.name',
-          path: 'Patient.name',
-          type: [
-            {
-              code: 'HumanName',
-            },
-          ],
-        },
-        birthDate: {
-          id: 'Patient.birthDate',
-          path: 'Patient.birthDate',
-          type: [
-            {
-              code: 'date',
-            },
-          ],
-        },
-        managingOrganization: {
-          id: 'Patient.managingOrganization',
-          path: 'Patient.managingOrganization',
-          type: [
-            {
-              code: 'reference',
-            },
-          ],
-        },
-      },
-      searchParams: Object.fromEntries(PatientSearchParameters.map((p) => [p.code, p])),
-    },
-    Observation: {
-      display: 'Observation',
-      properties: {
-        subject: {
-          id: 'Observation.subject',
-          path: 'Observation.subject',
-          type: [{ code: 'reference' }],
-        },
-        'value[x]': {
-          id: 'Observation.value[x]',
-          path: 'Observation.value[x]',
-          type: [{ code: 'integer' }, { code: 'quantity' }, { code: 'string' }],
-        },
-      },
-      searchParams: {
-        patient: {
-          resourceType: 'SearchParameter',
-          code: 'patient',
-          type: 'reference',
-          expression: 'Observation.patient',
-        },
-        subject: {
-          resourceType: 'SearchParameter',
-          code: 'patient',
-          type: 'reference',
-          expression: 'Observation.patient',
-        },
-        'value-quantity': {
-          resourceType: 'SearchParameter',
-          code: 'value-quantity',
-          type: 'quantity',
-          expression: 'Observation.value',
-        },
-        'value-string': {
-          resourceType: 'SearchParameter',
-          code: 'value-string',
-          type: 'string',
-          expression: 'Observation.value',
-        },
-      },
-    },
-  },
-};
-
 const medplum = new MockClient();
 
 describe('SearchPopupMenu', () => {
+  beforeAll(async () => {
+    await new MockClient().requestSchema('Patient');
+  });
+
   function setup(partialProps: Partial<SearchPopupMenuProps>): void {
     const props = {
-      schema,
       visible: true,
       x: 0,
       y: 0,
@@ -130,7 +54,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -154,7 +78,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Date submenu prompt', async () => {
-    const searchParam = schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter;
+    const searchParam = globalSchema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter;
     const onPrompt = jest.fn();
 
     setup({
@@ -195,7 +119,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -227,7 +151,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -262,7 +186,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['birthdate'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -274,7 +198,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Quantity sort', async () => {
-    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+    const searchParam = globalSchema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
 
     let currSearch: SearchRequest = {
       resourceType: 'Patient',
@@ -306,7 +230,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Quantity submenu prompt', async () => {
-    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+    const searchParam = globalSchema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
     const onPrompt = jest.fn();
 
     setup({
@@ -342,7 +266,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Quantity missing', async () => {
-    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+    const searchParam = globalSchema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
 
     let currSearch: SearchRequest = {
       resourceType: 'Observation',
@@ -372,7 +296,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Quantity clear filters', async () => {
-    const searchParam = schema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
+    const searchParam = globalSchema.types['Observation']?.searchParams?.['value-quantity'] as SearchParameter;
 
     let currSearch: SearchRequest = {
       resourceType: 'Observation',
@@ -412,7 +336,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['organization'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['organization'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -424,7 +348,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Reference submenu prompt', async () => {
-    const searchParam = schema.types['Patient']?.searchParams?.['organization'] as SearchParameter;
+    const searchParam = globalSchema.types['Patient']?.searchParams?.['organization'] as SearchParameter;
     const onPrompt = jest.fn();
 
     setup({
@@ -456,7 +380,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Reference missing', async () => {
-    const searchParam = schema.types['Patient']?.searchParams?.['organization'] as SearchParameter;
+    const searchParam = globalSchema.types['Patient']?.searchParams?.['organization'] as SearchParameter;
 
     let currSearch: SearchRequest = {
       resourceType: 'Patient',
@@ -492,7 +416,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['name'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['name'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -529,7 +453,7 @@ describe('SearchPopupMenu', () => {
 
     setup({
       search: currSearch,
-      searchParams: [schema.types['Patient']?.searchParams?.['name'] as SearchParameter],
+      searchParams: [globalSchema.types['Patient']?.searchParams?.['name'] as SearchParameter],
       onChange: (e) => (currSearch = e),
     });
 
@@ -541,7 +465,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Text submenu prompt', async () => {
-    const searchParam = schema.types['Patient']?.searchParams?.['name'] as SearchParameter;
+    const searchParam = globalSchema.types['Patient']?.searchParams?.['name'] as SearchParameter;
     const onPrompt = jest.fn();
 
     setup({
@@ -575,7 +499,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Text missing', async () => {
-    const searchParam = schema.types['Patient']?.searchParams?.['name'] as SearchParameter;
+    const searchParam = globalSchema.types['Patient']?.searchParams?.['name'] as SearchParameter;
 
     let currSearch: SearchRequest = {
       resourceType: 'Patient',
@@ -610,7 +534,7 @@ describe('SearchPopupMenu', () => {
       fields: ['meta.versionId'],
     };
 
-    const fields = getFieldDefinitions(schema, search);
+    const fields = getFieldDefinitions(search);
 
     setup({
       search,
@@ -626,7 +550,7 @@ describe('SearchPopupMenu', () => {
       fields: ['_lastUpdated'],
     };
 
-    const fields = getFieldDefinitions(schema, search);
+    const fields = getFieldDefinitions(search);
 
     setup({
       search: {
@@ -645,7 +569,7 @@ describe('SearchPopupMenu', () => {
       fields: ['value[x]'],
     };
 
-    const fields = getFieldDefinitions(schema, search);
+    const fields = getFieldDefinitions(search);
 
     setup({
       search: {
@@ -659,12 +583,21 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Only one search parameter on exact match', () => {
+    globalSchema.types['Observation'].searchParams = {
+      subject: {
+        resourceType: 'SearchParameter',
+        code: 'patient',
+        type: 'reference',
+        expression: 'Observation.patient',
+      },
+    };
+
     const search = {
       resourceType: 'Observation',
       fields: ['subject'],
     };
 
-    const fields = getFieldDefinitions(schema, search);
+    const fields = getFieldDefinitions(search);
 
     setup({
       search: {

--- a/packages/react/src/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu.tsx
@@ -1,4 +1,4 @@
-import { Filter, IndexedStructureDefinition, Operator, SearchRequest } from '@medplum/core';
+import { Filter, Operator, SearchRequest } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import React from 'react';
 import { MenuItem } from './MenuItem';
@@ -20,7 +20,6 @@ import {
 import { SubMenu } from './SubMenu';
 
 export interface SearchPopupMenuProps {
-  schema: IndexedStructureDefinition;
   search: SearchRequest;
   visible: boolean;
   x: number;

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -27,6 +27,8 @@ export abstract class LookupTable<T> {
   /**
    * Determines if the search parameter is indexed by this index table.
    * @param searchParam The search parameter.
+   * @param resourceType The resource type.
+   * @returns True if the search parameter is indexed.
    */
   abstract isIndexed(searchParam: SearchParameter): boolean;
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -63,7 +63,7 @@ import {
   Operator,
   SelectQuery,
 } from './sql';
-import { getSearchParameter, getSearchParameters, getStructureDefinitions } from './structure';
+import { getSearchParameter, getSearchParameters } from './structure';
 
 /**
  * The RepositoryContext interface defines standard metadata for repository actions.
@@ -801,7 +801,7 @@ export class Repository {
       return;
     }
 
-    const details = getSearchParameterDetails(getStructureDefinitions(), resourceType, param);
+    const details = getSearchParameterDetails(resourceType, param);
     if (filter.operator === FhirOperator.MISSING) {
       predicate.where(details.columnName, filter.value === 'true' ? Operator.EQUALS : Operator.NOT_EQUALS, null);
     } else if (param.type === 'string') {
@@ -941,7 +941,7 @@ export class Repository {
       return;
     }
 
-    const details = getSearchParameterDetails(getStructureDefinitions(), resourceType, param);
+    const details = getSearchParameterDetails(resourceType, param);
     builder.orderBy(details.columnName, !!sortRule.descending);
   }
 
@@ -1035,7 +1035,7 @@ export class Repository {
       return;
     }
 
-    const details = getSearchParameterDetails(getStructureDefinitions(), resource.resourceType, searchParam);
+    const details = getSearchParameterDetails(resource.resourceType, searchParam);
     const values = evalFhirPath(searchParam.expression as string, resource);
 
     if (values.length > 0) {

--- a/packages/server/src/fhir/search/match.ts
+++ b/packages/server/src/fhir/search/match.ts
@@ -7,7 +7,7 @@ import {
   SearchRequest,
 } from '@medplum/core';
 import { Reference, Resource, SearchParameter } from '@medplum/fhirtypes';
-import { getSearchParameter, getStructureDefinitions } from '../structure';
+import { getSearchParameter } from '../structure';
 
 /**
  * Determines if the resource matches the search request.
@@ -83,7 +83,7 @@ function matchesStringFilter(resource: Resource, filter: Filter, searchParam: Se
 }
 
 function matchesTokenFilter(resource: Resource, filter: Filter, searchParam: SearchParameter): boolean {
-  const details = getSearchParameterDetails(getStructureDefinitions(), resource.resourceType, searchParam);
+  const details = getSearchParameterDetails(resource.resourceType, searchParam);
   if (details.type === SearchParameterType.BOOLEAN) {
     return matchesBooleanFilter(resource, filter, searchParam);
   } else {

--- a/packages/server/src/fhir/structure.ts
+++ b/packages/server/src/fhir/structure.ts
@@ -31,6 +31,6 @@ export function getSearchParameter(resourceType: string, code: string): SearchPa
 function buildSearchParameters(): void {
   const searchParams = readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>;
   for (const entry of searchParams.entry as BundleEntry<SearchParameter>[]) {
-    indexSearchParameter(globalSchema, entry.resource as SearchParameter);
+    indexSearchParameter(entry.resource as SearchParameter);
   }
 }


### PR DESCRIPTION
This is motivated by and related to https://github.com/medplum/medplum/pull/891

Context:
* Medplum client and server are all mostly driven by FHIR `StructureDefinition` and `SearchParameter` resources
* Those resources are (1) big and (2) somewhat unwieldy in their native format
* So we load them, and massage them into an `IndexedStructureDefinition` (custom type of our own) called `globalSchema`
* The data is just more conveniently organized.  For example, you can say `globalSchema.types['Patient'].properties['name']` to get the `ElementDefinition`, rather than iterating through a big object hierarchy
* Originally, we maintained many different instances of `IndexedStructureDefinition` for various reasons, and it was up to the developer to juggle those instances and pass them to different methods.
* Over time, we realized that was silly, and started consolidating everything into the one `globalSchema` instance
* On the server, at server startup, we read in the full FHIR spec into memory
* On the client, you can call `MedplumClient.requestSchema(resourceType)` to fetch and digest the resources.
* Unfortunately, the migration from "many different instances" to "only use `globalSchema`" was not complete.

Enter this PR:
* Big cleanup push to eliminate extra instances of `IndexedStructureDefinition`
* Add `SearchParameterDetails` to `IndexedStructureDefinition` for faster cached access to search param details