### PR TITLE
Prototype of inline edit components

### DIFF
--- a/packages/react/src/InlineBackboneElement.tsx
+++ b/packages/react/src/InlineBackboneElement.tsx
@@ -1,0 +1,75 @@
+import { getPropertyDisplayName, globalSchema } from '@medplum/core';
+import { OperationOutcome } from '@medplum/fhirtypes';
+import React, { useState } from 'react';
+import { DEFAULT_IGNORED_PROPERTIES } from './constants';
+import { InlineFormSection } from './InlineFormSection';
+import { setPropertyValue } from './ResourceForm';
+import { getValueAndType, ResourcePropertyDisplay } from './ResourcePropertyDisplay';
+import { ResourcePropertyInput } from './ResourcePropertyInput';
+
+export interface InlineBackboneElementProps {
+  typeName: string;
+  defaultValue?: any;
+  outcome?: OperationOutcome;
+  onChange?: (value: any) => void;
+}
+
+export function InlineBackboneElement(props: InlineBackboneElementProps): JSX.Element {
+  const [value, setValue] = useState<any>(props.defaultValue ?? {});
+
+  function setValueWrapper(newValue: any): void {
+    setValue(newValue);
+    if (props.onChange) {
+      props.onChange(newValue);
+    }
+  }
+
+  const typeName = props.typeName;
+  const typeSchema = globalSchema.types[typeName];
+  if (!typeSchema) {
+    return <div>{typeName}&nbsp;not implemented</div>;
+  }
+
+  const typedValue = { type: typeName, value };
+
+  return (
+    <>
+      {Object.entries(typeSchema.properties).map((entry) => {
+        const key = entry[0];
+        if (key === 'id' || DEFAULT_IGNORED_PROPERTIES.indexOf(key) >= 0) {
+          return null;
+        }
+
+        const property = entry[1];
+        if (!property.type) {
+          return null;
+        }
+
+        const [propertyValue, propertyType] = getValueAndType(typedValue, key);
+
+        return (
+          <InlineFormSection
+            key={key}
+            title={getPropertyDisplayName(key)}
+            description={property.definition}
+            htmlFor={key}
+            outcome={props.outcome}
+            input={
+              <ResourcePropertyInput
+                property={property}
+                name={key}
+                defaultPropertyType={propertyType}
+                defaultValue={propertyValue}
+                outcome={props.outcome}
+                onChange={(newValue: any, propName?: string) => {
+                  setValueWrapper(setPropertyValue(value, key, propName ?? key, entry[1], newValue));
+                }}
+              />
+            }
+            display={<ResourcePropertyDisplay property={property} propertyType={propertyType} value={propertyValue} />}
+          ></InlineFormSection>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/react/src/InlineFormSection.css
+++ b/packages/react/src/InlineFormSection.css
@@ -1,0 +1,17 @@
+fieldset.medplum-form-section > label.medplum-inline-label {
+  display: flex;
+  align-items: center;
+}
+
+.medplum-inline-icon {
+  font-size: 10px;
+  margin-left: 4px;
+  text-decoration: none;
+  line-height: 16px;
+  color: transparent;
+  text-shadow: 0 0 0 var(--medplum-gray-500);
+}
+
+.medplum-inline-icon:hover {
+  text-decoration: none;
+}

--- a/packages/react/src/InlineFormSection.tsx
+++ b/packages/react/src/InlineFormSection.tsx
@@ -1,0 +1,75 @@
+import { OperationOutcome } from '@medplum/fhirtypes';
+import React from 'react';
+import { killEvent } from './utils/dom';
+import { getIssuesForExpression } from './utils/outcomes';
+import './InlineFormSection.css';
+
+export interface InlineFormSectionProps {
+  title?: string;
+  htmlFor?: string;
+  description?: string;
+  outcome?: OperationOutcome;
+  display: React.ReactNode;
+  input: React.ReactNode;
+}
+
+export function InlineFormSection(props: InlineFormSectionProps): JSX.Element {
+  const [editing, setEditing] = React.useState(false);
+  const issues = getIssuesForExpression(props.outcome, props.htmlFor);
+  const invalid = issues && issues.length > 0;
+  return (
+    <fieldset className="medplum-form-section">
+      <label className="medplum-inline-label" htmlFor={props.htmlFor}>
+        {props.title}
+        {!editing && (
+          <InlineEditButton color="#888" onClick={() => setEditing(true)}>
+            ✏️
+          </InlineEditButton>
+        )}
+        {editing && (
+          <InlineEditButton color="#1eca1e" onClick={() => setEditing(false)}>
+            ✔️
+          </InlineEditButton>
+        )}
+        {editing && (
+          <InlineEditButton color="#cb2525" onClick={() => setEditing(false)}>
+            ❌
+          </InlineEditButton>
+        )}
+      </label>
+      {props.description && <p>{props.description}</p>}
+      {editing ? props.input : props.display}
+      {invalid && (
+        <div id={props.htmlFor + '-errors'} className="medplum-input-error">
+          {issues?.map((issue) => (
+            <div data-testid="text-field-error" key={issue.details?.text}>
+              {issue.details?.text}
+            </div>
+          ))}
+        </div>
+      )}
+    </fieldset>
+  );
+}
+
+interface InlineEditButtonProps {
+  color: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function InlineEditButton(props: InlineEditButtonProps): JSX.Element {
+  return (
+    <a
+      className="medplum-inline-icon"
+      style={{ textShadow: '0 0 0 ' + props.color }}
+      href="#"
+      onClick={(e: React.SyntheticEvent) => {
+        killEvent(e);
+        props.onClick();
+      }}
+    >
+      {props.children}
+    </a>
+  );
+}

--- a/packages/react/src/InlineResourceForm.tsx
+++ b/packages/react/src/InlineResourceForm.tsx
@@ -1,0 +1,58 @@
+import { IndexedStructureDefinition } from '@medplum/core';
+import { OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
+import React, { useEffect, useState } from 'react';
+import { FormSection } from './FormSection';
+import { InlineBackboneElement } from './InlineBackboneElement';
+import { useMedplum } from './MedplumProvider';
+import { useResource } from './useResource';
+
+export interface InlineResourceFormProps {
+  defaultValue: Resource | Reference;
+  outcome?: OperationOutcome;
+  onSubmit: (resource: Resource) => void;
+  onDelete?: (resource: Resource) => void;
+}
+
+export function InlineResourceForm(props: InlineResourceFormProps): JSX.Element {
+  const medplum = useMedplum();
+  const defaultValue = useResource(props.defaultValue);
+  const [schema, setSchema] = useState<IndexedStructureDefinition | undefined>();
+  const [value, setValue] = useState<Resource | undefined>();
+
+  useEffect(() => {
+    if (defaultValue) {
+      setValue(JSON.parse(JSON.stringify(defaultValue)));
+      medplum.requestSchema(defaultValue.resourceType).then(setSchema).catch(console.log);
+    }
+  }, [medplum, defaultValue]);
+
+  if (!schema || !value) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <form
+      noValidate
+      autoComplete="off"
+      onSubmit={(e: React.FormEvent) => {
+        e.preventDefault();
+        if (props.onSubmit) {
+          props.onSubmit(value);
+        }
+      }}
+    >
+      <FormSection title="Resource Type">
+        <div>{value.resourceType}</div>
+      </FormSection>
+      <FormSection title="ID">
+        <div>{value.id}</div>
+      </FormSection>
+      <InlineBackboneElement
+        typeName={value.resourceType}
+        defaultValue={value}
+        outcome={props.outcome}
+        onChange={setValue}
+      />
+    </form>
+  );
+}

--- a/packages/react/src/stories/InlineResourceForm.stories.tsx
+++ b/packages/react/src/stories/InlineResourceForm.stories.tsx
@@ -1,0 +1,122 @@
+import { DrAliceSmith, HomerSimpson, TestOrganization } from '@medplum/mock';
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { Document } from '../Document';
+import { InlineResourceForm } from '../InlineResourceForm';
+
+export default {
+  title: 'Medplum/InlineResourceForm',
+  component: InlineResourceForm,
+} as Meta;
+
+export const Patient = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={HomerSimpson}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const Organization = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={TestOrganization}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const Practitioner = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={DrAliceSmith}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const DiagnosticReport = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={{
+        resourceType: 'DiagnosticReport',
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const DiagnosticReportIssues = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={{
+        resourceType: 'DiagnosticReport',
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+      outcome={{
+        resourceType: 'OperationOutcome',
+        id: 'dabf3927-a936-427e-9320-2ff98b8bea46',
+        issue: [
+          {
+            severity: 'error',
+            code: 'structure',
+            details: {
+              text: 'Missing required property "code"',
+            },
+            expression: ['code'],
+          },
+        ],
+      }}
+    />
+  </Document>
+);
+
+export const Observation = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={{
+        resourceType: 'Observation',
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const Questionnaire = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={{
+        resourceType: 'Questionnaire',
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);
+
+export const Specimen = (): JSX.Element => (
+  <Document>
+    <InlineResourceForm
+      defaultValue={{
+        resourceType: 'Specimen',
+      }}
+      onSubmit={(formData: any) => {
+        console.log('submit', formData);
+      }}
+    />
+  </Document>
+);


### PR DESCRIPTION
For discussion.  In prep for "Foo Provider", experimenting with an "inline edit" form component.

Based on: https://www.patternfly.org/v4/components/inline-edit/design-guidelines/

https://user-images.githubusercontent.com/749094/188023745-9c3c32d7-45f8-40e5-b732-69ac192283fc.mp4

Currently implemented with label on top, value/edit below.  I experimented with label on left, value/edit on right, but that gets messy with larger inputs such as `<HumanNameInput>`, which can be quite wide.  We might need to add more config params to the various input types to keep them smaller and more manageable.  For example, options to only show "first" and "last" name, rather than the full human name spec.

It could also be implemented without the form label at all, and just value+toggle.