### PR TITLE
Simple Headless Editable Field, with different stories

### DIFF
--- a/packages/react/src/Field.stories.tsx
+++ b/packages/react/src/Field.stories.tsx
@@ -1,0 +1,81 @@
+import { Meta } from '@storybook/react';
+import * as Field from './Field';
+import React from 'react';
+
+export default {
+  title: 'Medplum/Field',
+  component: Field.Root,
+  args: {
+    editable: true,
+  },
+} as Meta;
+
+const defaultProps: Field.FieldState = {
+  name: 'First Name',
+  value: 'Homer',
+  editable: true,
+  isEditing: false,
+};
+
+export const Basic = (args: any): JSX.Element => <Field.Root {...{ ...defaultProps, ...args }} />;
+
+export const NameToTheLeft = (args: { editable: boolean }): JSX.Element => (
+  <Field.Root {...{ ...defaultProps, ...args }}>
+    <Field.Name />
+    <span>:&nbsp;</span>
+    <Field.Value />
+    <Field.EditToggle />
+  </Field.Root>
+);
+
+export const NameOnTop = (args: { editable: boolean }): JSX.Element => (
+  <Field.Root {...{ ...defaultProps, ...args }}>
+    <b>
+      <Field.Name />
+    </b>
+    <Field.EditToggle />
+    <br />
+    <Field.Value />
+  </Field.Root>
+);
+
+export const Table = (args: { editable: boolean }): JSX.Element => {
+  const data = [
+    {
+      name: 'First Name',
+      value: 'Homer',
+    },
+    {
+      name: 'DOB',
+      value: new Date().toLocaleDateString(),
+    },
+  ];
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((e, i) => (
+          <tr key={i}>
+            <Field.Root {...{ ...e, editable: true, isEditing: false }}>
+              <td>
+                <b>
+                  <Field.Name />
+                </b>
+              </td>
+              <td>
+                <Field.Value />
+                <Field.EditToggle />
+              </td>
+            </Field.Root>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/packages/react/src/Field.tsx
+++ b/packages/react/src/Field.tsx
@@ -1,0 +1,110 @@
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+
+type FieldProps = {
+  name?: string;
+  value: any;
+  editable: boolean;
+  isEditing: boolean;
+  children?: React.ReactNode;
+};
+
+type FieldState = Omit<FieldProps, 'children'> & {
+  setEditing?: (isEditing: boolean) => void;
+};
+
+const defaultState: FieldState = {
+  name: '',
+  value: '',
+  editable: false,
+  isEditing: false,
+};
+
+const FieldStateContext = createContext<FieldState>(defaultState);
+
+// eslint-disable-next-line
+function isFunction(value: any): value is Function {
+  return !!(value && {}.toString.call(value) == '[object Function]');
+}
+function Field(props: FieldProps): JSX.Element {
+  const [isEditing, setEditing] = useState(props.isEditing);
+  const { children, ...rest } = props;
+  return (
+    <FieldStateContext.Provider value={{ ...rest, isEditing, setEditing }}>
+      {children || (
+        <>
+          <FieldName />
+          <FieldValue />
+          <FieldEditToggle />
+        </>
+      )}
+    </FieldStateContext.Provider>
+  );
+}
+
+type RenderChildren<T> = { children?: ReactNode | ((arg: T) => JSX.Element) };
+
+function userRenderFunction<T, Q extends RenderChildren<T>>(data: T, props: Q, defaultValue: ReactNode): ReactNode {
+  if (isFunction(props.children)) {
+    return props.children(data);
+  }
+  if (props.children) {
+    return props.children;
+  }
+  return defaultValue;
+}
+
+function FieldName(props: RenderChildren<Pick<FieldState, 'name'>>): JSX.Element {
+  const { name } = useContext(FieldStateContext);
+  return <>{userRenderFunction({ name }, props, <span>{name}</span>)}</>;
+}
+
+function FieldValue(props: RenderChildren<Pick<FieldState, 'isEditing' | 'value'>>): JSX.Element {
+  const { isEditing, value } = useContext(FieldStateContext);
+  return (
+    <>
+      {userRenderFunction(
+        { isEditing, value },
+        props,
+        isEditing ? <input defaultValue={value} /> : <span>{value}</span>
+      )}
+    </>
+  );
+}
+
+function FieldEditToggle(
+  props: RenderChildren<Pick<FieldState, 'isEditing' | 'setEditing'>> & React.HTMLAttributes<HTMLButtonElement>
+): JSX.Element {
+  const { isEditing, setEditing, editable } = useContext(FieldStateContext);
+  if (!editable) {
+    return <></>;
+  }
+  const defaultStyle = {
+    style: {
+      width: 'clamp(16px, 16px, 32px)',
+      height: 'clamp(16px, 16px, 32px)',
+      margin: '6px',
+    },
+  };
+
+  return (
+    <>
+      {userRenderFunction(
+        { isEditing, setEditing },
+        props,
+        <button
+          {...{ ...defaultStyle, ...props }}
+          onClick={() => {
+            setEditing && setEditing(!isEditing);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+const Root = Field;
+const Name = FieldName;
+const Value = FieldValue;
+const EditToggle = FieldEditToggle;
+export { Root, Name, Value, EditToggle };
+export type { FieldState };


### PR DESCRIPTION
Experimental branch, trying to incorporate the concepts from headless UI libraries like ReachUI, RadixUI, and HeadlessUI into our medplum components. 

Here, I'm experimenting with a simple headless field that can be toggled between display and edit modes. This is purely cosmetic, but I wanted to demonstrate the ability to re-arrange the DOM elements. 

Next step is to see if this  `Field` component can then be a building block for `ResourcePropertyDisplay`, and handle editing multiple different elements

![field](https://user-images.githubusercontent.com/1259236/188115448-e074a9b3-7760-4771-8214-4366ee801056.gif)
