### PR TITLE
Added explicit extended mode

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1744,6 +1744,8 @@ export class MedplumClient extends EventTarget {
     }
 
     const headers = options.headers as Record<string, string>;
+    headers['X-Medplum'] = 'extended';
+
     if (!headers['Content-Type']) {
       headers['Content-Type'] = FHIR_CONTENT_TYPE;
     }

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -178,6 +178,7 @@ describe('AccessPolicy', () => {
     };
 
     const repo = new Repository({
+      extendedMode: true,
       author: {
         reference: 'Practitioner/123',
       },
@@ -221,6 +222,7 @@ describe('AccessPolicy', () => {
     };
 
     const repo = new Repository({
+      extendedMode: true,
       author: {
         reference: 'Practitioner/123',
       },
@@ -280,6 +282,7 @@ describe('AccessPolicy', () => {
     };
 
     const repo1 = new Repository({
+      extendedMode: true,
       author: {
         reference: 'Practitioner/123',
       },
@@ -287,6 +290,7 @@ describe('AccessPolicy', () => {
     });
 
     const repo2 = new Repository({
+      extendedMode: true,
       author: {
         reference: 'Practitioner/123',
       },
@@ -369,6 +373,7 @@ describe('AccessPolicy', () => {
     };
 
     const repo1 = new Repository({
+      extendedMode: true,
       author: {
         reference: 'Practitioner/123',
       },
@@ -376,6 +381,7 @@ describe('AccessPolicy', () => {
     });
 
     const repo2 = new Repository({
+      extendedMode: true,
       author: {
         reference: 'Practitioner/123',
       },
@@ -491,7 +497,8 @@ describe('AccessPolicy', () => {
     expect(patient).toBeDefined();
 
     // The Patient should have the account value set
-    expect(patient?.meta?.account?.reference).toEqual(account);
+    const patientCheck = await systemRepo.readResource('Patient', patient?.id as string);
+    expect(patientCheck?.meta?.account?.reference).toEqual(account);
 
     // Create an Observation using the ClientApplication
     const observation = await clientRepo.createResource<Observation>({
@@ -506,7 +513,8 @@ describe('AccessPolicy', () => {
     expect(observation).toBeDefined();
 
     // The Observation should have the account value set
-    expect(observation?.meta?.account?.reference).toEqual(account);
+    const observationCheck = await systemRepo.readResource('Observation', observation?.id as string);
+    expect(observationCheck?.meta?.account?.reference).toEqual(account);
 
     // Create a Patient outside of the account
     const patient2 = await systemRepo.createResource<Patient>({

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -39,7 +39,12 @@ export interface BotExecutionResult {
 export const executeHandler = asyncWrap(async (req: Request, res: Response) => {
   const { id } = req.params;
   const repo = res.locals.repo as Repository;
-  const bot = await repo.readResource<Bot>('Bot', id);
+
+  // First read the bot as the user to verify access
+  await repo.readResource<Bot>('Bot', id);
+
+  // Then read the bot as system user to load extended metadata
+  const bot = await systemRepo.readResource<Bot>('Bot', id);
 
   // Execute the bot
   const result = await executeBot({

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -262,6 +262,7 @@ describe('FHIR Repo', () => {
 
     const repo = new Repository({
       project: randomUUID(),
+      extendedMode: true,
       author: {
         reference: author,
       },
@@ -310,6 +311,7 @@ describe('FHIR Repo', () => {
     const clientApp = 'ClientApplication/' + randomUUID();
 
     const repo = new Repository({
+      extendedMode: true,
       author: {
         reference: clientApp,
       },
@@ -327,6 +329,7 @@ describe('FHIR Repo', () => {
     const author = 'Practitioner/' + randomUUID();
 
     const repo = new Repository({
+      extendedMode: true,
       author: {
         reference: author,
       },
@@ -345,6 +348,7 @@ describe('FHIR Repo', () => {
     const fakeAuthor = 'Practitioner/' + randomUUID();
 
     const repo = new Repository({
+      extendedMode: true,
       author: {
         reference: author,
       },
@@ -374,6 +378,7 @@ describe('FHIR Repo', () => {
     // This user does not have an access policy
     // So they can optionally set an account
     const repo = new Repository({
+      extendedMode: true,
       author: {
         reference: author,
       },

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -109,6 +109,15 @@ export interface RepositoryContext {
    * significantly more relaxed.
    */
   strictMode?: boolean;
+
+  /**
+   * Optional flag to include Medplum extended meta fields.
+   * Medplum tracks additional metadata for each resource, such as:
+   * 1) "author" - Reference to the last user who modified the resource.
+   * 2) "project" - Reference to the project that owns the resource.
+   * 3) "account" - Optional reference to a subaccount that owns the resource.
+   */
+  extendedMode?: boolean;
 }
 
 export interface CacheEntry<T extends Resource> {
@@ -177,6 +186,10 @@ export class Repository {
   }
 
   async readResource<T extends Resource>(resourceType: string, id: string): Promise<T> {
+    return this.#removeHiddenFields(await this.#readResourceImpl<T>(resourceType, id));
+  }
+
+  async #readResourceImpl<T extends Resource>(resourceType: string, id: string): Promise<T> {
     if (!id || !validator.isUUID(id)) {
       throw notFound;
     }
@@ -198,7 +211,7 @@ export class Repository {
         ) {
           throw notFound;
         }
-        return this.#removeHiddenFields(cacheRecord.resource);
+        return cacheRecord.resource;
       }
     }
 
@@ -218,7 +231,7 @@ export class Repository {
 
     const resource = JSON.parse(rows[0].content as string) as T;
     await setCacheEntry(resource);
-    return this.#removeHiddenFields(resource);
+    return resource;
   }
 
   async readReference<T extends Resource>(reference: Reference<T>): Promise<T> {
@@ -242,7 +255,7 @@ export class Repository {
    */
   async readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
     try {
-      await this.readResource<T>(resourceType, id);
+      await this.#readResourceImpl<T>(resourceType, id);
     } catch (err) {
       if (!isGone(err as OperationOutcome)) {
         throw err;
@@ -290,7 +303,7 @@ export class Repository {
       throw notFound;
     }
 
-    await this.readResource<T>(resourceType, id);
+    await this.#readResourceImpl<T>(resourceType, id);
 
     const client = getClient();
     const rows = await new SelectQuery(resourceType + '_History')
@@ -390,7 +403,7 @@ export class Repository {
     create: boolean
   ): Promise<T | undefined> {
     try {
-      return await this.readResource<T>(resourceType, id);
+      return await this.#readResourceImpl<T>(resourceType, id);
     } catch (err) {
       if (!err || typeof err !== 'object' || !('resourceType' in err)) {
         throw err;
@@ -485,7 +498,7 @@ export class Repository {
       throw forbidden;
     }
 
-    const resource = await this.readResource<T>(resourceType, id);
+    const resource = await this.#readResourceImpl<T>(resourceType, id);
     await this.#writeResource(resource as T);
     await this.#writeLookupTables(resource as T);
     return resource as T;
@@ -505,11 +518,12 @@ export class Repository {
 
     const resource = await this.readResource<T>(resourceType, id);
     await addSubscriptionJobs(resource);
+    this.#removeHiddenFields(resource);
     return resource as T;
   }
 
   async deleteResource(resourceType: string, id: string): Promise<void> {
-    const resource = await this.readResource(resourceType, id);
+    const resource = await this.#readResourceImpl(resourceType, id);
 
     if (!this.#canWriteResourceType(resourceType)) {
       throw forbidden;
@@ -543,7 +557,7 @@ export class Repository {
   }
 
   async patchResource(resourceType: string, id: string, patch: Operation[]): Promise<Resource> {
-    const resource = await this.readResource(resourceType, id);
+    const resource = await this.#readResourceImpl(resourceType, id);
 
     let patchResult;
     try {
@@ -1455,6 +1469,12 @@ export class Repository {
         this.#removeField(input, field);
       }
     }
+    if (!this.#context.extendedMode) {
+      const meta = input.meta as Meta;
+      meta.author = undefined;
+      meta.project = undefined;
+      meta.account = undefined;
+    }
     return input;
   }
 
@@ -1594,9 +1614,14 @@ function fhirOperatorToSqlOperator(fhirOperator: FhirOperator): Operator {
  * This method ensures that the repository is setup correctly.
  * @param login The user login.
  * @param membership The active project membership.
+ * @param extendedMode Optional flag to enable extended mode for custom Medplum properties.
  * @returns A repository configured for the login details.
  */
-export async function getRepoForLogin(login: Login, membership: ProjectMembership): Promise<Repository> {
+export async function getRepoForLogin(
+  login: Login,
+  membership: ProjectMembership,
+  extendedMode?: boolean
+): Promise<Repository> {
   let accessPolicy: AccessPolicy | undefined = undefined;
 
   if (membership.accessPolicy) {
@@ -1608,12 +1633,14 @@ export async function getRepoForLogin(login: Login, membership: ProjectMembershi
     author: membership.profile as Reference,
     superAdmin: login.admin || login.superAdmin,
     accessPolicy,
+    extendedMode,
   });
 }
 
 export const systemRepo = new Repository({
   superAdmin: true,
   strictMode: true,
+  extendedMode: true,
   author: {
     reference: 'system',
   },

--- a/packages/server/src/oauth/middleware.test.ts
+++ b/packages/server/src/oauth/middleware.test.ts
@@ -148,6 +148,26 @@ describe('Auth middleware', () => {
       });
     expect(res.status).toBe(201);
     expect(res.body.meta).toBeDefined();
+    expect(res.body.meta.project).toBeUndefined();
+  });
+
+  test('Basic auth project with extended mode', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/Patient')
+      .set('Authorization', 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64'))
+      .set('Content-Type', 'application/fhir+json')
+      .set('X-Medplum', 'extended')
+      .send({
+        resourceType: 'Patient',
+        name: [
+          {
+            given: ['Given'],
+            family: 'Family',
+          },
+        ],
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.meta).toBeDefined();
     expect(res.body.meta.project).toBeDefined();
   });
 

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -30,6 +30,7 @@ describe('Subscription Worker', () => {
     });
 
     repo = new Repository({
+      extendedMode: true,
       project: testProject.id,
       author: {
         reference: 'ClientApplication/' + randomUUID(),
@@ -39,6 +40,7 @@ describe('Subscription Worker', () => {
     // Create another project, this one with bots enabled
     const botProjectDetails = await createTestProject();
     botRepo = new Repository({
+      extendedMode: true,
       project: botProjectDetails.project.id,
       author: createReference(botProjectDetails.client),
     });


### PR DESCRIPTION
Context: Medplum adds 3 properties to the FHIR `Meta` type:
* `project` - the project id
* `author` - a `Reference` to the user who created the version
* `account` - an optional `Reference` to the subaccount 

These properties are generally readonly and system assigned.

Historically, we have always included these extra properties in the FHIR meta, and that hasn't caused any issues.

Now we're making a compliance and conformance push.  These extra properties are correctly flagged by most FHIR validators.  We have been able to work around this in the past using `AccessPolicy.hiddenFields`, which removes the properties from the response.

But that's annoying and a bunch of extra work for something that should arguably be the default.

So, this PR hides those fields by default unless you pass in the HTTP Header `X-Medplum: extended`.

The `MedplumClient` class now adds `X-Medplum` by default, so any user of `MedplumClient` should not notice any difference.  For all other clients, the FHIR response should now be more compliant and conformant.