### PR TITLE
Support general Task actions in PlanDefinition apply

### DIFF
--- a/packages/react/src/PlanDefinitionBuilder.tsx
+++ b/packages/react/src/PlanDefinitionBuilder.tsx
@@ -267,6 +267,13 @@ function ActionEditor(props: ActionEditorProps): JSX.Element {
           onChange={(newValue) => changeProperty('title', newValue)}
         />
       </FormSection>
+      <FormSection title="Description" htmlFor={`actionDescription-${action.id}`}>
+        <Input
+          name={`actionDescription-${action.id}`}
+          defaultValue={action.description}
+          onChange={(newValue) => changeProperty('description', newValue)}
+        />
+      </FormSection>
       <FormSection
         title="Type of Action"
         description="The type of the action to be performed."

--- a/packages/react/src/RequestGroupDisplay.tsx
+++ b/packages/react/src/RequestGroupDisplay.tsx
@@ -42,6 +42,7 @@ export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Elemen
             <div className="medplum-request-group-task-checkmark">{task?.status === 'completed' ? '🗹' : '☐'}</div>
             <div className="medplum-request-group-task-details">
               <div className="medplum-request-group-task-title">{action.title}</div>
+              {action.description && <div>{action.description}</div>}
               <div>
                 Last edited by&nbsp;
                 <ResourceName value={task?.meta?.author as Reference} />

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -183,7 +183,7 @@ describe('PlanDefinition apply', () => {
     expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Missing subject parameter');
   });
 
-  test('Unsupported action type', async () => {
+  test('General task', async () => {
     const res2 = await request(app)
       .post(`/fhir/R4/PlanDefinition`)
       .set('Authorization', 'Bearer ' + accessToken)
@@ -194,7 +194,7 @@ describe('PlanDefinition apply', () => {
         status: 'active',
         action: [
           {
-            definitionCanonical: 'UnsupportedResourceType',
+            description: 'do the thing',
           },
         ],
       });
@@ -223,7 +223,6 @@ describe('PlanDefinition apply', () => {
           },
         ],
       });
-    expect(res4.status).toBe(400);
-    expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Unsupported action type');
+    expect(res4.status).toBe(200);
   });
 });

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,4 +1,4 @@
-import { allOk, badRequest, createReference, getReferenceString, OperationOutcomeError } from '@medplum/core';
+import { allOk, badRequest, createReference, getReferenceString, ProfileResource } from '@medplum/core';
 import {
   CareTeam,
   Device,
@@ -16,6 +16,7 @@ import {
   RequestGroupAction,
   Resource,
   Task,
+  TaskInput,
 } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { sendOutcome } from '../outcomes';
@@ -49,6 +50,7 @@ interface PlanDefinitionApplyParameters {
 export async function planDefinitionApplyHandler(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
   const repo = res.locals.repo as Repository;
+  const profile = res.locals.profile as Reference<ProfileResource>;
 
   const planDefinition = await repo.readResource<PlanDefinition>('PlanDefinition', id);
 
@@ -60,7 +62,7 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
   const actions: RequestGroupAction[] = [];
   if (planDefinition.action) {
     for (const action of planDefinition.action) {
-      actions.push(await createAction(repo, params, action));
+      actions.push(await createAction(repo, profile, params, action));
     }
   }
 
@@ -109,7 +111,7 @@ async function validateParameters(req: Request, res: Response): Promise<PlanDefi
 }
 
 /**
- * Creates a RequestGroup action for the given PlanDefinition action.
+ * Creates a Task and RequestGroup action for the given PlanDefinition action.
  * @param repo The repository configured for the current user.
  * @param params The apply operation parameters (subject, etc).
  * @param action The PlanDefinition action.
@@ -117,17 +119,18 @@ async function validateParameters(req: Request, res: Response): Promise<PlanDefi
  */
 async function createAction(
   repo: Repository,
+  requester: Reference<ProfileResource>,
   params: PlanDefinitionApplyParameters,
   action: PlanDefinitionAction
 ): Promise<RequestGroupAction> {
   if (action.definitionCanonical?.startsWith('Questionnaire/')) {
-    return createQuestionnaireTask(repo, params, action);
+    return createQuestionnaireTask(repo, requester, params, action);
   }
-  throw new OperationOutcomeError(badRequest('Unsupported action type'));
+  return createTask(repo, requester, params, action);
 }
 
 /**
- * Creates a RequestGroup action for a Questionnaire.
+ * Creates a Task and RequestGroup action to complete a Questionnaire.
  * @param repo The repository configured for the current user.
  * @param params The apply operation parameters (subject, etc).
  * @param action The PlanDefinition action.
@@ -135,26 +138,48 @@ async function createAction(
  */
 async function createQuestionnaireTask(
   repo: Repository,
+  requester: Reference<ProfileResource>,
   params: PlanDefinitionApplyParameters,
   action: PlanDefinitionAction
+): Promise<RequestGroupAction> {
+  return createTask(repo, requester, params, action, [
+    {
+      type: {
+        text: 'Questionnaire',
+      },
+      valueReference: {
+        display: action.title,
+        reference: action.definitionCanonical,
+      },
+    },
+  ]);
+}
+
+/**
+ * Creates a Task and RequestGroup action for a PlanDefinition action.
+ * @param repo The repository configured for the current user.
+ * @param requester The requester profile.
+ * @param params The apply operation parameters (subject, etc).
+ * @param action The PlanDefinition action.
+ * @param input Optional input details.
+ * @return The RequestGroup action.
+ */
+async function createTask(
+  repo: Repository,
+  requester: Reference<ProfileResource>,
+  params: PlanDefinitionApplyParameters,
+  action: PlanDefinitionAction,
+  input?: TaskInput[] | undefined
 ): Promise<RequestGroupAction> {
   const task = await repo.createResource<Task>({
     resourceType: 'Task',
     intent: 'order',
     status: 'requested',
     authoredOn: new Date().toISOString(),
+    requester,
     owner: createReference(params.subject),
-    input: [
-      {
-        type: {
-          text: 'Questionnaire',
-        },
-        valueReference: {
-          display: action.title,
-          reference: action.definitionCanonical,
-        },
-      },
-    ],
+    description: action.description,
+    input,
   });
 
   return {

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -89,7 +89,7 @@ async function setupLocals(req: Request, res: Response, login: Login, membership
   const locals = res.locals;
   locals.membership = membership;
   locals.user = resolveId(membership.user as Reference<User>);
-  locals.profile = membership.profile?.reference;
+  locals.profile = membership.profile;
   locals.scope = login.scope;
   locals.project = await systemRepo.readReference(membership.project as Reference<Project>);
   locals.repo = await getRepoForLogin(login, membership, locals.project.strictMode, isExtendedMode(req));

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -7,6 +7,7 @@ import {
   getReferenceString,
   ProfileResource,
 } from '@medplum/core';
+import { Reference } from '@medplum/fhirtypes';
 import { Request, RequestHandler, Response } from 'express';
 import { asyncWrap } from '../async';
 import { systemRepo } from '../fhir/repo';
@@ -20,11 +21,7 @@ export const userInfoHandler: RequestHandler = asyncWrap(async (_req: Request, r
     sub: res.locals.user,
   };
 
-  const resource = await systemRepo.readReference({
-    reference: res.locals.profile,
-  });
-
-  const profile = resource as ProfileResource;
+  const profile = await systemRepo.readReference(res.locals.profile as Reference<ProfileResource>);
 
   if (res.locals.scope.includes('profile')) {
     buildProfile(userInfo, profile);


### PR DESCRIPTION
Before:  PlanDefinition "apply" only supported Questionnaire actions

Now:  PlanDefinition "apply" falls back to a generic Task without inputs for unrecognized action types

Bonus:  Added "Description" to the PlanDefinition action editor