### PR TITLE
Add/Update Overview Pages for Tutorials and API sections

### DIFF
--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -6,8 +6,10 @@ sidebar_position: 0
 
 Welcome to the Medplum API documentation!
 
-**Storing Healthcare Data**: Our [**TypeScript SDK**](./sdk/classes/MedplumClient) provides a powerful, type-safe library to create and store healthcare data in the Medplum CDR.
+**Storing Healthcare Data:** Our [**TypeScript SDK**](./sdk/classes/MedplumClient) provides a powerful, type-safe library to create and store healthcare data in the Medplum CDR.
 
-**Building Healthcare Apps**: If you're building a [**React**](https://reactjs.org/) app with Medplum, our [**React Components**](./api/react-components) can give you building blocks to get you started.
+**Building Healthcare Apps:** If you're building a [**React**](https://reactjs.org/) app with Medplum, our [**React Components**](./api/react-components) can give you building blocks to get you started.
 
-**FHIR Data Model**: For documentation on all the FHIR Resources that Medplum supports, check out our [**FHIR API docs**](./api/fhir) (and if you're asking yourself, "_What's FHIR?_", check out our [FHIR Basics page](/docs/fhir-basics.md) )
+**OAuth2:** If you are using Medplum as an identity-provider, [**OAuth**](./api/oauth) documents the endpoints supplied by the Medplum server to complete the [OAuth2 Auth Code Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow).
+
+**FHIR Data Model**: For documentation on all the FHIR Resources that Medplum supports, check out our [**FHIR API docs**](./api/fhir). If you're asking yourself, "_What's FHIR?_", check out our [FHIR Basics page](/docs/fhir-basics.md)

--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -3,3 +3,11 @@ sidebar_position: 0
 ---
 
 # API Overview
+
+Welcome to the Medplum API documentation!
+
+**Storing Healthcare Data**: Our [**TypeScript SDK**](./sdk/classes/MedplumClient) provides a powerful, type-safe library to create and store healthcare data in the Medplum CDR.
+
+**Building Healthcare Apps**: If you're building a [**React**](https://reactjs.org/) app with Medplum, our [**React Components**](./api/react-components) can give you building blocks to get you started.
+
+**FHIR Data Model**: For documentation on all the FHIR Resources that Medplum supports, check out our [**FHIR API docs**](./api/fhir) (and if you're asking yourself, "_What's FHIR?_", check out our [FHIR Basics page](/docs/fhir-basics.md) )

--- a/packages/docs/docs/tutorials/bots/intro.md
+++ b/packages/docs/docs/tutorials/bots/intro.md
@@ -5,7 +5,7 @@ slug: /tutorials/bots
 
 # Intro
 
-If you have never heard of Medplum Bots, we encourage you to read the intro material in the [Bot Guide](./bots).
+If you have never heard of Medplum Bots, we encourage you to read the intro material in the [**Bot Guide**](./bots/bot-basics).
 
 Medplum bots are functions that execute when triggered. They are similar to AWS Lambda functions, and in Medplum we make them easy to write and deploy and trigger with [FHIR Subscriptions](./api-basics/publish-and-subscribe). For the purpose of the tutorials found in this section, it's important to understand that **Bots drive many of the major integrations that you see in Medplum**.
 

--- a/packages/docs/docs/tutorials/index.md
+++ b/packages/docs/docs/tutorials/index.md
@@ -1,15 +1,20 @@
 ---
-sidebar_label: Getting Started
+sidebar_label: Medplum Tutorials
 sidebar_position: 1
 ---
 
-# Getting Started
+# Medplum Tutorials
 
-Welcome to the Medplum tutorials!
+Welcome to the Medplum tutorials! This section contains various guides on how to use the Medplum platform to rapidly develop compliant, scalable healthcare apps.
 
-The [Medplum App](./tutorials/app) section is a good place to learn about the basics of setting up a your Medplum project,
-registering new users, and manipulating data.
+**Setting up your environment:** The [**Medplum App**](./tutorials/app) section is a good place to learn about the basics of setting up a your Medplum Project, registering new users, and manipulating data.
 
-If you're looking to learn about the Medplum API, start with the [API Basics](./tutorials/api-basics/create-fhir-data) section.
+**Storing Healthcare Data:** If you're looking to learn about the Medplum API for storing and retrieving clinical data, start with the [**API Basics**](./tutorials/api-basics/create-fhir-data) section.
 
-If you're building front-end healthcare apps, take a a look our [UI Component Examples](./tutorials/ui-components)
+**Building front-end apps:** If you're building front-end healthcare apps for patients or providers, take a a look our [**UI Component Tutorials**](./tutorials/ui-components).
+
+**Security:** Medplum offers a number of security features that app builders need, including OAuth2 endpoints, and Access Controls. The [**Authentication & Security**](./tutorials/security) section has more details.
+
+**Integrations & Workflow Automation:** The [**Medplum Bots**](./tutorials/bots) section covers how developers can use Medplum's offers developer-friendly tools to automate complex medical workflows and integrate with 3rd-party services.
+
+**Self-Hosting:** By default, Medplum's cloud-based service provides each customer with isolated, cost-effective environments for their data. If your application requires you to host your own infrastructure, you can refer to the [**Self-Hosting**](./tutorials/self-hosting) tutorials on how to set up your own infrastructure.

--- a/packages/docs/docs/tutorials/index.md
+++ b/packages/docs/docs/tutorials/index.md
@@ -13,7 +13,7 @@ Welcome to the Medplum tutorials! This section contains various guides on how to
 
 **Building front-end apps:** If you're building front-end healthcare apps for patients or providers, take a a look our [**UI Component Tutorials**](./tutorials/ui-components).
 
-**Security:** Medplum offers a number of security features that app builders need, including OAuth2 endpoints, and Access Controls. The [**Authentication & Security**](./tutorials/security) section has more details.
+**Security:** Medplum offers a number of security features that app builders need, including OAuth2 endpoints, and Access Controls. The [**Authentication & Security**](./tutorials/authentication-and-security) section has more details.
 
 **Integrations & Workflow Automation:** The [**Medplum Bots**](./tutorials/bots) section covers how developers can use Medplum's offers developer-friendly tools to automate complex medical workflows and integrate with 3rd-party services.
 


### PR DESCRIPTION
Added some more prose / structure to the overview pages for the "Tutorials" and "API" Sections of the docs:

![image](https://user-images.githubusercontent.com/1259236/190947199-c536888b-4be8-4397-ab86-b8c281f382b0.png)

![image](https://user-images.githubusercontent.com/1259236/190947215-9c769be1-06b9-462a-8119-a162b4044eab.png)
