### PR TITLE
Resource timeline comment button

### DIFF
--- a/packages/react/src/EncounterTimeline.test.tsx
+++ b/packages/react/src/EncounterTimeline.test.tsx
@@ -47,7 +47,7 @@ describe('EncounterTimeline', () => {
 
     // Enter the comment text
     await act(async () => {
-      fireEvent.change(screen.getByTestId('timeline-input'), {
+      fireEvent.change(screen.getByPlaceholderText('Add comment'), {
         target: { value: 'Test comment' },
       });
     });

--- a/packages/react/src/PatientTimeline.test.tsx
+++ b/packages/react/src/PatientTimeline.test.tsx
@@ -49,7 +49,7 @@ describe('PatientTimeline', () => {
 
     // Enter the comment text
     await act(async () => {
-      fireEvent.change(screen.getByTestId('timeline-input'), {
+      fireEvent.change(screen.getByPlaceholderText('Add comment'), {
         target: { value: 'Test comment' },
       });
     });

--- a/packages/react/src/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline.test.tsx
@@ -92,7 +92,7 @@ describe('ResourceTimeline', () => {
 
     // Enter the comment text
     await act(async () => {
-      fireEvent.change(screen.getByTestId('timeline-input'), {
+      fireEvent.change(screen.getByPlaceholderText('Add comment'), {
         target: { value: 'Test comment' },
       });
     });

--- a/packages/react/src/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Loader, Menu, TextInput } from '@mantine/core';
+import { ActionIcon, Group, Loader, Menu, TextInput, UnstyledButton } from '@mantine/core';
 import { getReferenceString, ProfileResource } from '@medplum/core';
 import {
   Attachment,
@@ -11,13 +11,23 @@ import {
   Reference,
   Resource,
 } from '@medplum/fhirtypes';
-import { IconCloudUpload, IconEdit, IconListDetails, IconPin, IconPinnedOff, IconTrash } from '@tabler/icons';
+import {
+  IconCloudUpload,
+  IconEdit,
+  IconListDetails,
+  IconMessage,
+  IconPin,
+  IconPinnedOff,
+  IconTrash,
+} from '@tabler/icons';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { AttachmentButton } from './AttachmentButton';
 import { AttachmentDisplay } from './AttachmentDisplay';
 import { DiagnosticReportDisplay } from './DiagnosticReportDisplay';
 import { Form } from './Form';
 import { useMedplum } from './MedplumProvider';
+import { ResourceAvatar } from './ResourceAvatar';
 import { ResourceDiffTable } from './ResourceDiffTable';
 import { ResourceTable } from './ResourceTable';
 import { Scrollable } from './Scrollable';
@@ -25,8 +35,6 @@ import { Timeline, TimelineItem } from './Timeline';
 import { useResource } from './useResource';
 import { sortByDateAndPriority } from './utils/date';
 
-import { AttachmentButton } from './AttachmentButton';
-import { ResourceAvatar } from './ResourceAvatar';
 import './ResourceTimeline.css';
 
 export interface ResourceTimelineProps<T extends Resource> {
@@ -194,26 +202,21 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
                 }
               }}
             >
-              <Group noWrap>
+              <Group spacing="xs" noWrap>
                 <ResourceAvatar value={sender} />
-                <TextInput
-                  name="text"
-                  data-testid="timeline-input"
-                  ref={inputRef}
-                  size="md"
-                  radius="xl"
-                  rightSectionWidth={40}
-                  rightSection={
-                    <AttachmentButton onUpload={createMedia}>
-                      {(props) => (
-                        <ActionIcon {...props} size={24} radius="xl" color="blue" variant="filled">
-                          <IconCloudUpload size={16} />
-                        </ActionIcon>
-                      )}
-                    </AttachmentButton>
-                  }
-                  placeholder="Add comment"
-                />
+                <TextInput name="text" ref={inputRef} placeholder="Add comment" style={{ width: 300 }} />
+                <UnstyledButton type="submit">
+                  <ActionIcon radius="xl" color="blue" variant="filled">
+                    <IconMessage size={16} />
+                  </ActionIcon>
+                </UnstyledButton>
+                <AttachmentButton onUpload={createMedia}>
+                  {(props) => (
+                    <ActionIcon {...props} radius="xl" color="blue" variant="filled">
+                      <IconCloudUpload size={16} />
+                    </ActionIcon>
+                  )}
+                </AttachmentButton>
               </Group>
             </Form>
           </div>

--- a/packages/react/src/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Loader, Menu, TextInput, UnstyledButton } from '@mantine/core';
+import { ActionIcon, Group, Loader, Menu, TextInput } from '@mantine/core';
 import { getReferenceString, ProfileResource } from '@medplum/core';
 import {
   Attachment,
@@ -205,11 +205,9 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
               <Group spacing="xs" noWrap>
                 <ResourceAvatar value={sender} />
                 <TextInput name="text" ref={inputRef} placeholder="Add comment" style={{ width: 300 }} />
-                <UnstyledButton type="submit">
-                  <ActionIcon radius="xl" color="blue" variant="filled">
-                    <IconMessage size={16} />
-                  </ActionIcon>
-                </UnstyledButton>
+                <ActionIcon type="submit" radius="xl" color="blue" variant="filled">
+                  <IconMessage size={16} />
+                </ActionIcon>
                 <AttachmentButton onUpload={createMedia}>
                   {(props) => (
                     <ActionIcon {...props} radius="xl" color="blue" variant="filled">

--- a/packages/react/src/ServiceRequestTimeline.test.tsx
+++ b/packages/react/src/ServiceRequestTimeline.test.tsx
@@ -49,7 +49,7 @@ describe('ServiceRequestTimeline', () => {
 
     // Enter the comment text
     await act(async () => {
-      fireEvent.change(screen.getByTestId('timeline-input'), {
+      fireEvent.change(screen.getByPlaceholderText('Add comment'), {
         target: { value: 'Test comment' },
       });
     });


### PR DESCRIPTION
Bringing back a dedicated "add comment" button on the resource timeline.  The enter key works to submit, but that doesn't work on mobile.