### PR TITLE
[Bugfix] Show error message on Project > Site

### DIFF
--- a/packages/app/src/admin/SitesPage.tsx
+++ b/packages/app/src/admin/SitesPage.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mantine/core';
 import { IndexedStructureDefinition } from '@medplum/core';
-import { ProjectSite } from '@medplum/fhirtypes';
+import { OperationOutcome, ProjectSite } from '@medplum/fhirtypes';
 import { ResourcePropertyInput, useMedplum } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'react-toastify';
@@ -37,7 +37,13 @@ export function SitesPage(): JSX.Element {
           .post(`admin/projects/${projectId}/sites`, sites)
           .then(() => medplum.get(`admin/projects/${projectId}`, { cache: 'reload' }))
           .then(() => toast.success('Saved'))
-          .catch(console.log);
+          .catch((err) => {
+            const operationOutcome = err as OperationOutcome;
+            // Only show the first error
+            toast.error(
+              `Error ${operationOutcome.issue?.[0].details?.text} ${operationOutcome.issue?.[0].expression?.[0]}`
+            );
+          });
       }}
     >
       <h1>Project Sites</h1>


### PR DESCRIPTION
## Steps to reproduce:

1. Navigate to Project > Sites
2. Omit the "list of domains"
3. Hit Save

**Expected**: Toast error to be shown to understand what may have gone wrong
**Actual**: Toast error not shown


Client-side fix:

Show the first error message and expression as a toast message.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/10590332/193895453-a2e722a4-5ccc-4765-91b3-d988a58895bc.png">
