### PR TITLE
AuditEvents for restful operations

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -57,6 +57,7 @@ import {
   ReadInteraction,
   SearchInteraction,
   UpdateInteraction,
+  VreadInteraction,
 } from '../util/auditevent';
 import { addBackgroundJobs } from '../workers';
 import { addSubscriptionJobs } from '../workers/subscription';
@@ -369,10 +370,10 @@ export class Repository {
       }
 
       const result = this.#removeHiddenFields(JSON.parse(rows[0].content as string));
-      this.#logEvent(HistoryInteraction, AuditEventOutcome.Success, undefined, result);
+      this.#logEvent(VreadInteraction, AuditEventOutcome.Success, undefined, result);
       return result;
     } catch (err) {
-      this.#logEvent(HistoryInteraction, AuditEventOutcome.MinorFailure, err);
+      this.#logEvent(VreadInteraction, AuditEventOutcome.MinorFailure, err);
       throw err;
     }
   }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1655,7 +1655,16 @@ export class Repository {
     if (search) {
       query = search.resourceType + formatSearchQuery(search);
     }
-    logRestfulEvent(subtype, this.#context.author, this.#context.remoteAddress, outcome, outcomeDesc, resource, query);
+    logRestfulEvent(
+      subtype,
+      this.#context.project as string,
+      this.#context.author,
+      this.#context.remoteAddress,
+      outcome,
+      outcomeDesc,
+      resource,
+      query
+    );
   }
 }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1639,8 +1639,22 @@ export class Repository {
       // Don't log system events.
       return;
     }
-    const outcomeDesc = normalizeErrorString(description);
-    const query = search ? formatSearchQuery(search) : undefined;
+    if (resource && publicResourceTypes.includes(resource.resourceType)) {
+      // Don't log public events.
+      return;
+    }
+    if (search && publicResourceTypes.includes(search.resourceType)) {
+      // Don't log public events.
+      return;
+    }
+    let outcomeDesc: string | undefined = undefined;
+    if (description) {
+      outcomeDesc = normalizeErrorString(description);
+    }
+    let query: string | undefined = undefined;
+    if (search) {
+      query = search.resourceType + formatSearchQuery(search);
+    }
     logRestfulEvent(subtype, this.#context.author, this.#context.remoteAddress, outcome, outcomeDesc, resource, query);
   }
 }
@@ -1740,6 +1754,7 @@ export async function getRepoForLogin(
   return new Repository({
     project: resolveId(membership.project) as string,
     author: membership.profile as Reference,
+    remoteAddress: login.remoteAddress,
     superAdmin: login.admin || login.superAdmin,
     accessPolicy,
     strictMode,

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -13,6 +13,7 @@ import {
   isGone,
   isNotFound,
   isOk,
+  normalizeErrorString,
   notFound,
   Operator as FhirOperator,
   resolveId,
@@ -45,6 +46,18 @@ import { getConfig } from '../config';
 import { getClient } from '../database';
 import { logger } from '../logger';
 import { getRedis } from '../redis';
+import {
+  AuditEventOutcome,
+  AuditEventSubtype,
+  CreateInteraction,
+  DeleteInteraction,
+  HistoryInteraction,
+  logRestfulEvent,
+  PatchInteraction,
+  ReadInteraction,
+  SearchInteraction,
+  UpdateInteraction,
+} from '../util/auditevent';
 import { addBackgroundJobs } from '../workers';
 import { addSubscriptionJobs } from '../workers/subscription';
 import { validateResourceWithJsonSchema } from './jsonschema';
@@ -80,6 +93,8 @@ export interface RepositoryContext {
    * This value will be included in every resource as meta.author.
    */
   author: Reference;
+
+  remoteAddress?: string;
 
   /**
    * The current project reference.
@@ -176,17 +191,31 @@ export class Repository {
   }
 
   async createResource<T extends Resource>(resource: T): Promise<T> {
-    return this.#updateResourceImpl(
-      {
-        ...resource,
-        id: randomUUID(),
-      },
-      true
-    );
+    try {
+      const result = await this.#updateResourceImpl(
+        {
+          ...resource,
+          id: randomUUID(),
+        },
+        true
+      );
+      this.#logEvent(CreateInteraction, AuditEventOutcome.Success, undefined, result);
+      return result;
+    } catch (err) {
+      this.#logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
+    }
   }
 
   async readResource<T extends Resource>(resourceType: string, id: string): Promise<T> {
-    return this.#removeHiddenFields(await this.#readResourceImpl<T>(resourceType, id));
+    try {
+      const result = this.#removeHiddenFields(await this.#readResourceImpl<T>(resourceType, id));
+      this.#logEvent(ReadInteraction, AuditEventOutcome.Success, undefined, result);
+      return result;
+    } catch (err) {
+      this.#logEvent(ReadInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
+    }
   }
 
   async #readResourceImpl<T extends Resource>(resourceType: string, id: string): Promise<T> {
@@ -255,87 +284,108 @@ export class Repository {
    */
   async readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
     try {
-      await this.#readResourceImpl<T>(resourceType, id);
-    } catch (err) {
-      if (!isGone(err as OperationOutcome)) {
-        throw err;
+      let resource: T | undefined = undefined;
+      try {
+        resource = await this.#readResourceImpl<T>(resourceType, id);
+      } catch (err) {
+        if (!isGone(err as OperationOutcome)) {
+          throw err;
+        }
       }
-    }
 
-    const client = getClient();
-    const rows = await new SelectQuery(resourceType + '_History')
-      .column('versionId')
-      .column('id')
-      .column('content')
-      .column('lastUpdated')
-      .where('id', Operator.EQUALS, id)
-      .orderBy('lastUpdated', true)
-      .limit(100)
-      .execute(client);
+      const client = getClient();
+      const rows = await new SelectQuery(resourceType + '_History')
+        .column('versionId')
+        .column('id')
+        .column('content')
+        .column('lastUpdated')
+        .where('id', Operator.EQUALS, id)
+        .orderBy('lastUpdated', true)
+        .limit(100)
+        .execute(client);
 
-    const entries: BundleEntry<T>[] = [];
+      const entries: BundleEntry<T>[] = [];
 
-    for (const row of rows) {
-      const resource = row.content ? this.#removeHiddenFields(JSON.parse(row.content as string)) : undefined;
-      const outcome: OperationOutcome = row.content
-        ? allOk
-        : {
-            resourceType: 'OperationOutcome',
-            id: 'gone',
-            issue: [
-              {
-                severity: 'error',
-                code: 'deleted',
-                details: {
-                  text: 'Deleted on ' + row.lastUpdated,
+      for (const row of rows) {
+        const resource = row.content ? this.#removeHiddenFields(JSON.parse(row.content as string)) : undefined;
+        const outcome: OperationOutcome = row.content
+          ? allOk
+          : {
+              resourceType: 'OperationOutcome',
+              id: 'gone',
+              issue: [
+                {
+                  severity: 'error',
+                  code: 'deleted',
+                  details: {
+                    text: 'Deleted on ' + row.lastUpdated,
+                  },
                 },
-              },
-            ],
-          };
-      entries.push({
-        fullUrl: this.#getFullUrl(resourceType, row.id),
-        request: {
-          method: 'GET',
-          url: `${resourceType}/${row.id}/_history/${row.versionId}`,
-        },
-        response: {
-          status: getStatus(outcome).toString(),
-          outcome,
-        },
-        resource,
-      });
-    }
+              ],
+            };
+        entries.push({
+          fullUrl: this.#getFullUrl(resourceType, row.id),
+          request: {
+            method: 'GET',
+            url: `${resourceType}/${row.id}/_history/${row.versionId}`,
+          },
+          response: {
+            status: getStatus(outcome).toString(),
+            outcome,
+          },
+          resource,
+        });
+      }
 
-    return {
-      resourceType: 'Bundle',
-      type: 'history',
-      entry: entries,
-    };
+      this.#logEvent(HistoryInteraction, AuditEventOutcome.Success, undefined, resource);
+      return {
+        resourceType: 'Bundle',
+        type: 'history',
+        entry: entries,
+      };
+    } catch (err) {
+      this.#logEvent(HistoryInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
+    }
   }
 
   async readVersion<T extends Resource>(resourceType: string, id: string, vid: string): Promise<T> {
-    if (!validator.isUUID(vid)) {
-      throw notFound;
+    try {
+      if (!validator.isUUID(vid)) {
+        throw notFound;
+      }
+
+      await this.#readResourceImpl<T>(resourceType, id);
+
+      const client = getClient();
+      const rows = await new SelectQuery(resourceType + '_History')
+        .column('content')
+        .where('id', Operator.EQUALS, id)
+        .where('versionId', Operator.EQUALS, vid)
+        .execute(client);
+
+      if (rows.length === 0) {
+        throw notFound;
+      }
+
+      const result = this.#removeHiddenFields(JSON.parse(rows[0].content as string));
+      this.#logEvent(HistoryInteraction, AuditEventOutcome.Success, undefined, result);
+      return result;
+    } catch (err) {
+      this.#logEvent(HistoryInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
     }
-
-    await this.#readResourceImpl<T>(resourceType, id);
-
-    const client = getClient();
-    const rows = await new SelectQuery(resourceType + '_History')
-      .column('content')
-      .where('id', Operator.EQUALS, id)
-      .where('versionId', Operator.EQUALS, vid)
-      .execute(client);
-
-    if (rows.length === 0) {
-      throw notFound;
-    }
-
-    return this.#removeHiddenFields(JSON.parse(rows[0].content as string));
   }
 
   async updateResource<T extends Resource>(resource: T): Promise<T> {
-    return this.#updateResourceImpl(resource, false);
+    try {
+      const result = await this.#updateResourceImpl(resource, false);
+      this.#logEvent(UpdateInteraction, AuditEventOutcome.Success, undefined, result);
+      return result;
+    } catch (err) {
+      this.#logEvent(UpdateInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
+    }
   }
 
   async #updateResourceImpl<T extends Resource>(resource: T, create: boolean): Promise<T> {
@@ -537,89 +587,108 @@ export class Repository {
   }
 
   async deleteResource(resourceType: string, id: string): Promise<void> {
-    const resource = await this.#readResourceImpl(resourceType, id);
+    try {
+      const resource = await this.#readResourceImpl(resourceType, id);
 
-    if (!this.#canWriteResourceType(resourceType)) {
-      throw forbidden;
-    }
+      if (!this.#canWriteResourceType(resourceType)) {
+        throw forbidden;
+      }
 
-    await deleteCacheEntry(resourceType, id);
+      await deleteCacheEntry(resourceType, id);
 
-    const client = getClient();
-    const lastUpdated = new Date();
-    const content = '';
-    const columns: Record<string, any> = {
-      id,
-      lastUpdated,
-      deleted: true,
-      compartments: this.#getCompartments(resource),
-      content,
-    };
-
-    await new InsertQuery(resourceType, [columns]).mergeOnConflict(true).execute(client);
-
-    await new InsertQuery(resourceType + '_History', [
-      {
+      const client = getClient();
+      const lastUpdated = new Date();
+      const content = '';
+      const columns: Record<string, any> = {
         id,
-        versionId: randomUUID(),
         lastUpdated,
+        deleted: true,
+        compartments: this.#getCompartments(resource),
         content,
-      },
-    ]).execute(client);
+      };
 
-    await this.#deleteFromLookupTables(resource);
+      await new InsertQuery(resourceType, [columns]).mergeOnConflict(true).execute(client);
+
+      await new InsertQuery(resourceType + '_History', [
+        {
+          id,
+          versionId: randomUUID(),
+          lastUpdated,
+          content,
+        },
+      ]).execute(client);
+
+      await this.#deleteFromLookupTables(resource);
+      this.#logEvent(DeleteInteraction, AuditEventOutcome.Success, undefined, resource);
+    } catch (err) {
+      this.#logEvent(DeleteInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
+    }
   }
 
   async patchResource(resourceType: string, id: string, patch: Operation[]): Promise<Resource> {
-    const resource = await this.#readResourceImpl(resourceType, id);
-
-    let patchResult;
     try {
-      patchResult = applyPatch(resource, patch, true);
-    } catch (err) {
-      const patchError = err as JsonPatchError;
-      const message = patchError.message?.split('\n')?.[0] || 'JSONPatch error';
-      throw badRequest(message);
-    }
+      const resource = await this.#readResourceImpl(resourceType, id);
 
-    const patchedResource = patchResult.newDocument;
-    return this.updateResource(patchedResource);
+      let patchResult;
+      try {
+        patchResult = applyPatch(resource, patch, true);
+      } catch (err) {
+        const patchError = err as JsonPatchError;
+        const message = patchError.message?.split('\n')?.[0] || 'JSONPatch error';
+        throw badRequest(message);
+      }
+
+      const patchedResource = patchResult.newDocument;
+      const result = await this.#updateResourceImpl(patchedResource, false);
+      this.#logEvent(PatchInteraction, AuditEventOutcome.Success, undefined, result);
+      return result;
+    } catch (err) {
+      this.#logEvent(PatchInteraction, AuditEventOutcome.MinorFailure, err);
+      throw err;
+    }
   }
 
   async search<T extends Resource>(searchRequest: SearchRequest): Promise<Bundle<T>> {
-    const resourceType = searchRequest.resourceType;
-    validateResourceType(resourceType);
+    try {
+      const resourceType = searchRequest.resourceType;
+      validateResourceType(resourceType);
 
-    if (!this.#canReadResourceType(resourceType)) {
-      throw forbidden;
+      if (!this.#canReadResourceType(resourceType)) {
+        throw forbidden;
+      }
+
+      // Ensure that "count" is set.
+      // Count is an optional field.  From this point on, it is safe to assume it is a number.
+      if (searchRequest.count === undefined) {
+        searchRequest.count = DEFAULT_SEARCH_COUNT;
+      } else if (searchRequest.count > maxSearchResults) {
+        searchRequest.count = maxSearchResults;
+      }
+
+      let entry = undefined;
+      let hasMore = false;
+      if (searchRequest.count > 0) {
+        ({ entry, hasMore } = await this.#getSearchEntries<T>(searchRequest));
+      }
+
+      let total = undefined;
+      if (searchRequest.total === 'estimate' || searchRequest.total === 'accurate') {
+        total = await this.#getTotalCount(searchRequest);
+      }
+
+      this.#logEvent(SearchInteraction, AuditEventOutcome.Success, undefined, undefined, searchRequest);
+      return {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry,
+        total,
+        link: this.#getSearchLinks(searchRequest, hasMore),
+      };
+    } catch (err) {
+      this.#logEvent(SearchInteraction, AuditEventOutcome.MinorFailure, err, undefined, searchRequest);
+      throw err;
     }
-
-    // Ensure that "count" is set.
-    // Count is an optional field.  From this point on, it is safe to assume it is a number.
-    if (searchRequest.count === undefined) {
-      searchRequest.count = DEFAULT_SEARCH_COUNT;
-    } else if (searchRequest.count > maxSearchResults) {
-      searchRequest.count = maxSearchResults;
-    }
-
-    let entry = undefined;
-    let hasMore = false;
-    if (searchRequest.count > 0) {
-      ({ entry, hasMore } = await this.#getSearchEntries<T>(searchRequest));
-    }
-
-    let total = undefined;
-    if (searchRequest.total === 'estimate' || searchRequest.total === 'accurate') {
-      total = await this.#getTotalCount(searchRequest);
-    }
-
-    return {
-      resourceType: 'Bundle',
-      type: 'searchset',
-      entry,
-      total,
-      link: this.#getSearchLinks(searchRequest, hasMore),
-    };
   }
 
   /**
@@ -1549,6 +1618,30 @@ export class Repository {
   #isAdminClient(): boolean {
     const { adminClientId } = getConfig();
     return !!adminClientId && this.#context.author.reference === 'ClientApplication/' + adminClientId;
+  }
+
+  /**
+   * Logs an AuditEvent for a restful operation.
+   * @param subtype The AuditEvent subtype.
+   * @param outcome The AuditEvent outcome.
+   * @param description The description.  Can be a string, object, or Error.  Will be normalized to a string.
+   * @param resource Optional resource to associate with the AuditEvent.
+   * @param search Optional search parameters to associate with the AuditEvent.
+   */
+  #logEvent(
+    subtype: AuditEventSubtype,
+    outcome: AuditEventOutcome,
+    description?: unknown,
+    resource?: Resource,
+    search?: SearchRequest
+  ): void {
+    if (this.#context.author.reference === 'system') {
+      // Don't log system events.
+      return;
+    }
+    const outcomeDesc = normalizeErrorString(description);
+    const query = search ? formatSearchQuery(search) : undefined;
+    logRestfulEvent(subtype, this.#context.author, this.#context.remoteAddress, outcome, outcomeDesc, resource, query);
   }
 }
 

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,3 +1,5 @@
+import { AuditEvent } from '@medplum/fhirtypes';
+
 /*
  * Once upon a time, we used Winston, and that was fine.
  * Then the log4j fiasco happened, and everyone started auditing logging libraries.
@@ -42,5 +44,11 @@ export const logger = {
 
   log(level: string, ...args: any[]): void {
     console.log(level, new Date().toISOString(), ...args);
+  },
+
+  logAuditEvent(auditEvent: AuditEvent): void {
+    if (process.env.NODE_ENV !== 'test') {
+      console.log(JSON.stringify(auditEvent));
+    }
   },
 };

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -12,6 +12,7 @@ import bcrypt from 'bcryptjs';
 import { timingSafeEqual } from 'crypto';
 import { JWTPayload } from 'jose';
 import { systemRepo } from '../fhir/repo';
+import { AuditEventOutcome, logAuthEvent, LoginEvent } from '../util/auditevent';
 import { generateAccessToken, generateIdToken, generateRefreshToken, generateSecret } from './keys';
 
 export interface LoginRequest {
@@ -255,6 +256,8 @@ export async function setLoginMembership(login: Login, membershipId: string): Pr
   if (project.features?.includes('google-auth-required') && login.authMethod !== 'google') {
     throw badRequest('Google authentication is required');
   }
+
+  logAuthEvent(LoginEvent, project.id as string, membership.profile, login.remoteAddress, AuditEventOutcome.Success);
 
   // Everything checks out, update the login
   return systemRepo.updateResource<Login>({

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -147,16 +147,18 @@ export enum AuditEventOutcome {
 
 export function logAuthEvent(
   subtype: AuditEventSubtype,
+  projectId: string,
   who: Reference | undefined,
   remoteAddress: string | undefined,
   outcome: AuditEventOutcome,
   outcomeDesc?: string
 ): void {
-  logAuditEvent(UserAuthenticationEvent, subtype, who, remoteAddress, outcome, outcomeDesc);
+  logAuditEvent(UserAuthenticationEvent, subtype, projectId, who, remoteAddress, outcome, outcomeDesc);
 }
 
 export function logRestfulEvent(
   subtype: AuditEventSubtype,
+  projectId: string,
   who: Reference | undefined,
   remoteAddress: string | undefined,
   outcome: AuditEventOutcome,
@@ -164,12 +166,23 @@ export function logRestfulEvent(
   resource?: Resource,
   searchQuery?: string
 ): void {
-  logAuditEvent(RestfulOperationType, subtype, who, remoteAddress, outcome, outcomeDesc, resource, searchQuery);
+  logAuditEvent(
+    RestfulOperationType,
+    subtype,
+    projectId,
+    who,
+    remoteAddress,
+    outcome,
+    outcomeDesc,
+    resource,
+    searchQuery
+  );
 }
 
 export function logAuditEvent(
   type: AuditEventType,
   subtype: AuditEventSubtype,
+  projectId: string,
   who: Reference | undefined,
   remoteAddress: string | undefined,
   outcome: AuditEventOutcome,
@@ -194,6 +207,9 @@ export function logAuditEvent(
 
   const auditEvent: AuditEvent = {
     resourceType: 'AuditEvent',
+    meta: {
+      project: projectId,
+    },
     type,
     subtype: [subtype],
     action: AuditEventActionLookup[subtype.code as string],

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -1,3 +1,138 @@
+import { createReference } from '@medplum/core';
+import {
+  AuditEventAgentNetwork,
+  AuditEventEntity,
+  Coding,
+  Practitioner,
+  Reference,
+  Resource,
+} from '@medplum/fhirtypes';
+import { getConfig } from '../config';
+import { logger } from '../logger';
+
+/*
+ * This file includes a collection of utility functions for working with AuditEvents.
+ *
+ * AuditEvent is a versatile resource that can be used to record a variety of events.
+ * However, for core logging, we want to use a consistent set of event types.
+ * This file includes a collection of best practices derived from examples from the HL7 FHIR website.
+ */
+
+/**
+ * DICOM code system.
+ * See: https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html
+ */
+export const DicomCodeSystem = 'http://dicom.nema.org/resources/ontology/DCM';
+
+/**
+ * AuditEvent type code system.
+ * See: https://www.hl7.org/fhir/valueset-audit-event-type.html
+ */
+export const AuditEventTypeCodeSystem = 'http://terminology.hl7.org/CodeSystem/audit-event-type';
+
+/**
+ * RESTful operation code system.
+ * See: https://hl7.org/fhir/codesystem-restful-interaction.html
+ */
+export const RestfulActionCodeSystem = 'http://hl7.org/fhir/restful-interaction';
+
+/**
+ * User authentication event type.
+ * See examples:
+ * Login: https://www.hl7.org/fhir/audit-event-example-login.json.html
+ * Logout: https://www.hl7.org/fhir/audit-event-example-logout.json.html
+ */
+export const UserAuthenticationEvent: Coding = {
+  system: DicomCodeSystem,
+  code: '110114',
+  display: 'User Authentication',
+};
+
+/**
+ * RESTful operation event type.
+ * See examples:
+ * vread: https://www.hl7.org/fhir/audit-event-example-vread.json.html
+ */
+export const RestfulOperationType: Coding = {
+  system: 'http://terminology.hl7.org/CodeSystem/audit-event-type',
+  code: 'rest',
+  display: 'Restful Operation',
+};
+
+/*
+ * UserAuthentication subtypes.
+ * See: https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html
+ */
+
+export const LoginEvent: Coding = { system: DicomCodeSystem, code: '110122', display: 'Login' };
+export const LogoutEvent: Coding = { system: DicomCodeSystem, code: '110123', display: 'Logout' };
+
+/*
+ * Restful interactions.
+ * See: https://hl7.org/fhir/codesystem-restful-interaction.html
+ */
+export const RestfulInteractions = {
+  read: { system: RestfulActionCodeSystem, code: 'read', display: 'read' },
+};
+
+export const ReadInteraction: Coding = { system: RestfulActionCodeSystem, code: 'read', display: 'read' };
+export const VreadInteraction: Coding = { system: RestfulActionCodeSystem, code: 'vread', display: 'vread' };
+export const UpdateInteraction: Coding = { system: RestfulActionCodeSystem, code: 'update', display: 'update' };
+export const PatchInteraction: Coding = { system: RestfulActionCodeSystem, code: 'patch', display: 'patch' };
+export const DeleteInteraction: Coding = { system: RestfulActionCodeSystem, code: 'delete', display: 'delete' };
+export const HistoryInteraction: Coding = { system: RestfulActionCodeSystem, code: 'history', display: 'history' };
+export const CreateInteraction: Coding = { system: RestfulActionCodeSystem, code: 'create', display: 'create' };
+export const SearchInteraction: Coding = { system: RestfulActionCodeSystem, code: 'search', display: 'search' };
+export const BatchInteraction: Coding = { system: RestfulActionCodeSystem, code: 'batch', display: 'batch' };
+export const TransactionInteraction: Coding = {
+  system: RestfulActionCodeSystem,
+  code: 'transaction',
+  display: 'transaction',
+};
+export const OperationInteraction: Coding = {
+  system: RestfulActionCodeSystem,
+  code: 'operation',
+  display: 'operation',
+};
+
+export type AuditEventType = typeof UserAuthenticationEvent | typeof RestfulOperationType;
+
+export type AuditEventSubtype =
+  | typeof LoginEvent
+  | typeof LogoutEvent
+  | typeof ReadInteraction
+  | typeof VreadInteraction
+  | typeof UpdateInteraction
+  | typeof PatchInteraction
+  | typeof DeleteInteraction
+  | typeof HistoryInteraction
+  | typeof CreateInteraction
+  | typeof SearchInteraction
+  | typeof TransactionInteraction
+  | typeof BatchInteraction
+  | typeof OperationInteraction;
+
+/**
+ * AuditEvent action code.
+ * See: https://www.hl7.org/fhir/valueset-audit-event-action.html
+ */
+export enum AuditEventAction {
+  Create = 'C',
+  Read = 'R',
+  Update = 'U',
+  Delete = 'D',
+  Execute = 'E',
+}
+
+const AuditEventActionLookup: Record<string, 'C' | 'R' | 'U' | 'D' | 'E'> = {
+  create: 'C',
+  read: 'R',
+  vread: 'R',
+  history: 'R',
+  search: 'R',
+  update: 'U',
+};
+
 /**
  * AuditEvent outcome code.
  * See: https://www.hl7.org/fhir/valueset-audit-event-outcome.html
@@ -7,4 +142,73 @@ export enum AuditEventOutcome {
   MinorFailure = '4',
   SeriousFailure = '8',
   MajorFailure = '12',
+}
+
+export function logAuthEvent(
+  subtype: AuditEventSubtype,
+  who: Reference | undefined,
+  remoteAddress: string | undefined,
+  outcome: AuditEventOutcome,
+  outcomeDesc?: string
+): void {
+  logAuditEvent(UserAuthenticationEvent, subtype, who, remoteAddress, outcome, outcomeDesc);
+}
+
+export function logRestfulEvent(
+  subtype: AuditEventSubtype,
+  who: Reference | undefined,
+  remoteAddress: string | undefined,
+  outcome: AuditEventOutcome,
+  outcomeDesc?: string,
+  resource?: Resource,
+  searchQuery?: string
+): void {
+  logAuditEvent(RestfulOperationType, subtype, who, remoteAddress, outcome, outcomeDesc, resource, searchQuery);
+}
+
+export function logAuditEvent(
+  type: AuditEventType,
+  subtype: AuditEventSubtype,
+  who: Reference | undefined,
+  remoteAddress: string | undefined,
+  outcome: AuditEventOutcome,
+  outcomeDesc?: string,
+  resource?: Resource,
+  searchQuery?: string
+): void {
+  const config = getConfig();
+
+  let entity: AuditEventEntity[] | undefined = undefined;
+  if (resource) {
+    entity = [{ what: createReference(resource) }];
+  }
+  if (searchQuery) {
+    entity = [{ query: searchQuery }];
+  }
+
+  let network: AuditEventAgentNetwork | undefined = undefined;
+  if (remoteAddress) {
+    network = { address: remoteAddress, type: '2' };
+  }
+
+  const auditEvent = {
+    resourceType: 'AuditEvent',
+    type,
+    subtype: [subtype],
+    action: AuditEventActionLookup[subtype.code as string],
+    recorded: new Date().toISOString(),
+    source: { observer: { identifier: { value: config.baseUrl } } },
+    agent: [
+      {
+        who: who as Reference<Practitioner>,
+        requestor: true,
+        network,
+      },
+    ],
+    outcome,
+    outcomeDesc,
+    entity,
+  };
+
+  logger.info(JSON.stringify(auditEvent));
 }

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -1,5 +1,6 @@
 import { createReference } from '@medplum/core';
 import {
+  AuditEvent,
   AuditEventAgentNetwork,
   AuditEventEntity,
   Coding,
@@ -191,7 +192,7 @@ export function logAuditEvent(
     network = { address: remoteAddress, type: '2' };
   }
 
-  const auditEvent = {
+  const auditEvent: AuditEvent = {
     resourceType: 'AuditEvent',
     type,
     subtype: [subtype],
@@ -210,5 +211,5 @@ export function logAuditEvent(
     entity,
   };
 
-  logger.info(JSON.stringify(auditEvent));
+  logger.logAuditEvent(auditEvent);
 }


### PR DESCRIPTION
This includes more verbose logging of restful operations using `AuditEvent` resources.

While we already store FHIR history for all resources for all time, we did not store read operations in a structured way.

These `AuditEvent` resources are not stored in the database.  They only go to the logger.  For our prod servers, that means they go to CloudWatch logs.

A significant portion of the diff is whitespace changes, because many of the top-level calls in `repo.ts` are wrapped in new `try`/`catch` blocks.