### PR TITLE
Handler for newpractitioner

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61100,6 +61100,10 @@
           "description": "The default access policy for patients using open registration.",
           "$ref": "#/definitions/Reference"
         },
+        "defaultPractitionerAccessPolicy": {
+          "description": "The default access policy for practitioners using open registration.",
+          "$ref": "#/definitions/Reference"
+        },
         "secret": {
           "description": "Secure environment variable that can be used to store secrets for bots.",
           "items": {

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -142,6 +142,17 @@
             }]
           },
           {
+            "id" : "Project.defaultPractitionerAccessPolicy",
+            "path" : "Project.defaultPractitionerAccessPolicy",
+            "definition" : "The default access policy for practitioners using open registration.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "Reference",
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/AccessPolicy"]
+            }]
+          },
+          {
             "id" : "Project.secret",
             "path" : "Project.secret",
             "definition" : "Secure environment variable that can be used to store secrets for bots.",

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -82,6 +82,11 @@ export interface Project {
   defaultPatientAccessPolicy?: Reference<AccessPolicy>;
 
   /**
+   * The default access policy for practitioners using open registration.
+   */
+  defaultPractitionerAccessPolicy?: Reference<AccessPolicy>;
+
+  /**
    * Secure environment variable that can be used to store secrets for
    * bots.
    */

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -21,7 +21,10 @@
   "devDependencies": {
     "@medplum/definitions": "0.10.0",
     "@medplum/fhirtypes": "0.10.0",
-    "fhirpath": "3.0.0",
-    "fast-xml-parser": "4.0.10"
+    "fast-xml-parser": "4.0.10",
+    "fhirpath": "3.0.0"
+  },
+  "dependencies": {
+    "@medplum/generator": "^0.10.0"
   }
 }

--- a/packages/server/src/auth/newpractitioner.ts
+++ b/packages/server/src/auth/newpractitioner.ts
@@ -1,0 +1,111 @@
+import { badRequest, createReference, formatHumanName, getReferenceString, Operator } from '@medplum/core';
+import { AccessPolicy, HumanName, Login, Practitioner, Project, Reference, User } from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import { createProfile, createProjectMembership } from '../auth/utils';
+import { invalidRequest, sendOutcome } from '../fhir/outcomes';
+import { systemRepo } from '../fhir/repo';
+import { setLoginMembership } from '../oauth/utils';
+
+export const newPractitionerValidators = [
+  body('login').notEmpty().withMessage('Missing login'),
+  body('projectId').notEmpty().withMessage('Project ID is required'),
+];
+
+/**
+ * Handles a HTTP request to /auth/newpractitioner.
+ * Requires a partial login.
+ * @param req The HTTP request.
+ * @param res The HTTP response.
+ */
+export async function newPractitionerHandler(req: Request, res: Response): Promise<void> {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    sendOutcome(res, invalidRequest(errors));
+    return;
+  }
+
+  const login = await systemRepo.readResource<Login>('Login', req.body.login);
+
+  if (login.membership) {
+    sendOutcome(res, badRequest('Login already has a membership'));
+    return;
+  }
+
+  const { projectId } = req.body;
+  const project = await systemRepo.readResource<Project>('Project', projectId);
+  if (!project) {
+    sendOutcome(res, badRequest('Project not found'));
+    return;
+  }
+
+  if (!project.defaultPractitionerAccessPolicy) {
+    sendOutcome(res, badRequest('Project does not allow open registration'));
+    return;
+  }
+
+  const user = await systemRepo.readReference<User>(login.user as Reference<User>);
+  if (!user.project) {
+    sendOutcome(res, badRequest('User must be scoped to the project'));
+    return;
+  }
+
+  const { firstName, lastName, email } = user;
+  let profile = await searchForExistingPractitioner(projectId, email as string);
+  if (!profile) {
+    profile = (await createProfile(
+      project,
+      'Practitioner',
+      firstName as string,
+      lastName as string,
+      email as string
+    )) as Practitioner;
+  }
+  const template = await systemRepo.readReference(project.defaultPractitionerAccessPolicy);
+
+  const policy = await systemRepo.createResource<AccessPolicy>(buildAccessPolicy(template, profile));
+
+  const membership = await createProjectMembership(user, project, profile, createReference(policy));
+
+  // Update the login
+  const updated = await setLoginMembership(login, membership.id as string);
+
+  res.status(200).json({
+    login: updated?.id,
+    code: updated?.code,
+  });
+}
+
+function buildAccessPolicy(template: AccessPolicy, practitioner: Practitioner): AccessPolicy {
+  const templateJson = JSON.stringify(template);
+  const policyJson = templateJson
+    .replaceAll('%practitioner.id', practitioner.id as string)
+    .replaceAll('%practitioner', getReferenceString(practitioner));
+
+  return {
+    ...JSON.parse(policyJson),
+    name: formatHumanName(practitioner.name?.[0] as HumanName) + ' Access Policy',
+  };
+}
+
+async function searchForExistingPractitioner(project: Project, email: string): Promise<Practitioner | undefined> {
+  const bundle = await systemRepo.search<Practitioner>({
+    resourceType: 'Practitioner',
+    filters: [
+      {
+        code: '_project',
+        operator: Operator.EQUALS,
+        value: project.id as string,
+      },
+      {
+        code: 'email',
+        operator: Operator.EQUALS,
+        value: email,
+      },
+    ],
+  });
+  if (bundle.entry && bundle.entry.length > 0) {
+    return bundle.entry[0].resource as Practitioner;
+  }
+  return undefined;
+}

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -7,6 +7,7 @@ import { googleHandler, googleValidators } from './google';
 import { loginHandler, loginValidators } from './login';
 import { meHandler } from './me';
 import { newPatientHandler, newPatientValidators } from './newpatient';
+import { newPractitionerHandler } from './newpractitioner';
 import { newProjectHandler, newProjectValidators } from './newproject';
 import { newUserHandler, newUserValidators } from './newuser';
 import { profileHandler, profileValidators } from './profile';
@@ -25,3 +26,4 @@ authRouter.post('/changepassword', changePasswordValidators, asyncWrap(changePas
 authRouter.post('/resetpassword', resetPasswordValidators, asyncWrap(resetPasswordHandler));
 authRouter.post('/setpassword', setPasswordValidators, asyncWrap(setPasswordHandler));
 authRouter.post('/google', googleValidators, asyncWrap(googleHandler));
+authRouter.post('/newpractitioner', newPatientValidators, asyncWrap(newPractitionerHandler));


### PR DESCRIPTION
This PR pacthes Medplum codebase with a new http handler to allow free signup for a new Practitioner.

Mostly it is a copy of new patient handler. A a design decision, I had to add a `defaultPractitionerAccessPolicy` same as `defaultPatientAccessPolicy`.