### PR TITLE
Disable Workbox plugin in dev mode

### DIFF
--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -7,7 +7,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
 
-if ('serviceWorker' in navigator) {
+if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('/service-worker.js')

--- a/packages/app/webpack.config.js
+++ b/packages/app/webpack.config.js
@@ -75,12 +75,12 @@ export default (env, argv) => ({
         },
       ]
     }),
-    new WorkboxPlugin.GenerateSW({
+    argv.mode === 'production' && new WorkboxPlugin.GenerateSW({
       clientsClaim: true,
       skipWaiting: true,
       maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
     }),
-  ],
+  ].filter((p) => !!p),
   module: {
     rules: [
       {


### PR DESCRIPTION
This disables the [workbox plugin](https://developer.chrome.com/docs/workbox/modules/workbox-webpack-plugin/) in dev mode.  It just doesn't play nice with webpack hot module reloading, and leads to too many warnings.