### PR TITLE
Fix storybook typeahead

### DIFF
--- a/packages/generator/src/storybook.ts
+++ b/packages/generator/src/storybook.ts
@@ -62,6 +62,12 @@ const searchParams = [
   'Encounter-length',
   'Communication-encounter',
   'Media-encounter',
+  'Questionnaire-name',
+  'ActivityDefinition-name',
+  'Schedule-id',
+  'Schedule-identifier',
+  'Task-id',
+  'Task-identifier',
 ];
 
 export function main(): void {

--- a/packages/generator/src/storybook.ts
+++ b/packages/generator/src/storybook.ts
@@ -23,6 +23,9 @@ const resourceTypes = [
   'SpecimenDefinition',
   'ObservationDefinition',
   'Media',
+  'Schedule',
+  'Task',
+  'RequestGroup',
 ];
 
 const properties = [
@@ -64,9 +67,7 @@ const searchParams = [
   'Media-encounter',
   'Questionnaire-name',
   'ActivityDefinition-name',
-  'Schedule-id',
   'Schedule-identifier',
-  'Task-id',
   'Task-identifier',
 ];
 

--- a/packages/mock/src/mocks/searchparameters.json
+++ b/packages/mock/src/mocks/searchparameters.json
@@ -1,6 +1,17 @@
 [
   {
     "resourceType": "SearchParameter",
+    "id": "ActivityDefinition-name",
+    "name": "name",
+    "code": "name",
+    "base": [
+      "ActivityDefinition"
+    ],
+    "type": "string",
+    "expression": "ActivityDefinition.name"
+  },
+  {
+    "resourceType": "SearchParameter",
     "id": "Communication-encounter",
     "name": "encounter",
     "code": "encounter",
@@ -162,6 +173,28 @@
   },
   {
     "resourceType": "SearchParameter",
+    "id": "Questionnaire-name",
+    "name": "name",
+    "code": "name",
+    "base": [
+      "Questionnaire"
+    ],
+    "type": "string",
+    "expression": "Questionnaire.name"
+  },
+  {
+    "resourceType": "SearchParameter",
+    "id": "Schedule-identifier",
+    "name": "identifier",
+    "code": "identifier",
+    "base": [
+      "Schedule"
+    ],
+    "type": "token",
+    "expression": "Schedule.identifier"
+  },
+  {
+    "resourceType": "SearchParameter",
     "id": "ServiceRequest-authored",
     "name": "authored",
     "code": "authored",
@@ -181,5 +214,16 @@
     ],
     "type": "reference",
     "expression": "ServiceRequest.subject"
+  },
+  {
+    "resourceType": "SearchParameter",
+    "id": "Task-identifier",
+    "name": "identifier",
+    "code": "identifier",
+    "base": [
+      "Task"
+    ],
+    "type": "token",
+    "expression": "Task.identifier"
   }
 ]

--- a/packages/mock/src/mocks/structuredefinitions.json
+++ b/packages/mock/src/mocks/structuredefinitions.json
@@ -10737,6 +10737,292 @@
   },
   {
     "resourceType": "StructureDefinition",
+    "id": "Schedule",
+    "name": "Schedule",
+    "type": "Schedule",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Schedule",
+          "path": "Schedule",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Schedule",
+            "min": 0,
+            "max": "*"
+          }
+        },
+        {
+          "id": "Schedule.id",
+          "path": "Schedule.id",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.id",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "http://hl7.org/fhirpath/System.String"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.meta",
+          "path": "Schedule.meta",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.meta",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Meta"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.implicitRules",
+          "path": "Schedule.implicitRules",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.implicitRules",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "uri"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.language",
+          "path": "Schedule.language",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Resource.language",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "code"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.text",
+          "path": "Schedule.text",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "DomainResource.text",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Narrative"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.contained",
+          "path": "Schedule.contained",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "DomainResource.contained",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Resource"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.extension",
+          "path": "Schedule.extension",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "DomainResource.extension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.modifierExtension",
+          "path": "Schedule.modifierExtension",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "DomainResource.modifierExtension",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Extension"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.identifier",
+          "path": "Schedule.identifier",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Schedule.identifier",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Identifier"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.active",
+          "path": "Schedule.active",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Schedule.active",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.serviceCategory",
+          "path": "Schedule.serviceCategory",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Schedule.serviceCategory",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.serviceType",
+          "path": "Schedule.serviceType",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Schedule.serviceType",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.specialty",
+          "path": "Schedule.specialty",
+          "min": 0,
+          "max": "*",
+          "base": {
+            "path": "Schedule.specialty",
+            "min": 0,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.actor",
+          "path": "Schedule.actor",
+          "min": 1,
+          "max": "*",
+          "base": {
+            "path": "Schedule.actor",
+            "min": 1,
+            "max": "*"
+          },
+          "type": [
+            {
+              "code": "Reference",
+              "targetProfile": [
+                "http://hl7.org/fhir/StructureDefinition/Patient",
+                "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                "http://hl7.org/fhir/StructureDefinition/Device",
+                "http://hl7.org/fhir/StructureDefinition/HealthcareService",
+                "http://hl7.org/fhir/StructureDefinition/Location"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "Schedule.planningHorizon",
+          "path": "Schedule.planningHorizon",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Schedule.planningHorizon",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "Period"
+            }
+          ]
+        },
+        {
+          "id": "Schedule.comment",
+          "path": "Schedule.comment",
+          "min": 0,
+          "max": "1",
+          "base": {
+            "path": "Schedule.comment",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "string"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "resourceType": "StructureDefinition",
     "id": "ServiceRequest",
     "name": "ServiceRequest",
     "type": "ServiceRequest",

--- a/packages/react/src/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput.tsx
@@ -6,6 +6,23 @@ import { useMedplum } from './MedplumProvider';
 import { ResourceAvatar } from './ResourceAvatar';
 import { useResource } from './useResource';
 
+/**
+ * Defines which search parameters will be used by the type ahead to search for each resourceType
+ */
+const SEARCH_CODES: Record<string, string> = {
+  Schedule: '_id',
+  Task: '_id',
+  Patient: 'name',
+  Practitioner: 'name',
+  Questionnaire: 'name',
+  ServiceRequest: '_id',
+  DiagnosticReport: '_id',
+  Specimen: '_id',
+  Observation: 'code',
+  RequestGroup: '_id',
+  ActivityDefinition: 'name',
+};
+
 export interface ResourceInputProps<T extends Resource = Resource> {
   readonly resourceType: ResourceType;
   readonly name: string;
@@ -30,10 +47,13 @@ export function ResourceInput<T extends Resource = Resource>(props: ResourceInpu
 
   async function loadValues(input: string): Promise<void> {
     setLoading(true);
-    const resources = await medplum.searchResources(
-      props.resourceType,
-      'name=' + encodeURIComponent(input) + '&_count=10'
-    );
+    const searchCode = SEARCH_CODES[props.resourceType] || 'name';
+    const searchParams = new URLSearchParams({
+      [searchCode]: encodeURIComponent(input),
+      _count: '10',
+    });
+    console.debug(searchParams.toString());
+    const resources = await medplum.searchResources(props.resourceType, searchParams);
     setData(resources.map((resource) => ({ value: getDisplayString(resource), resource })));
     setLoading(false);
   }

--- a/packages/react/src/stories/covid19.ts
+++ b/packages/react/src/stories/covid19.ts
@@ -707,6 +707,7 @@ export const Covid19PCRTest: ActivityDefinition = {
   status: 'active',
   kind: 'ServiceRequest',
   title: 'Order SARS-CoV-2 (COVID-19) RNA panel',
+  name: 'Order SARS-CoV-2 (COVID-19) RNA panel',
   description:
     'Order SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection (Loinc: 94531-1)',
   code: {
@@ -726,6 +727,7 @@ export const Covid19PCRTest: ActivityDefinition = {
 export const Covid19ReviewReport: ActivityDefinition = {
   resourceType: 'ActivityDefinition',
   title: 'Review COVID-19 Report',
+  name: 'Review COVID-19 Report',
   description: 'Review COVID-19 PCR diagnostic results',
   id: 'covid19-review-report',
   status: 'active',


### PR DESCRIPTION
When we moved to a more "correct" version of search in the MockClient, we needed to add some more resources to the generated mock schema to allow the Storybook stories to function correctly.

This PR:
- Adds additional resources to mock structuredefinition.json
- Adds additional search parameters to the mock seachparams.json
- Changes `ResourceInput` to use a lookup table to determine which searchParam to use