### PR TITLE
Use --legacy-peer-deps in deploy-bot-layer.sh

### DIFF
--- a/scripts/deploy-bot-layer.sh
+++ b/scripts/deploy-bot-layer.sh
@@ -25,7 +25,7 @@ cp -r packages/bot-layer/fonts tmp/
 cd tmp/nodejs/
 
 # Install dependencies
-npm install --omit=dev --omit=optional
+npm install --legacy-peer-deps --omit=dev --omit=optional
 
 # Go up one directory to the temp directory
 # The zip file must be in the parent directory.


### PR DESCRIPTION
With Rollup 3.0, we need to use `--legacy-peer-deps` for a few build plugins.  This can be removed once all dependencies are fixed.