### PR TITLE
Expose /api/ subdirectory

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -16,6 +16,18 @@ describe('App', () => {
     await shutdownApp();
   });
 
+  test('Use /api/', async () => {
+    const app = express();
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    const res = await request(app).get('/api/');
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBeDefined();
+    expect(res.headers['content-security-policy']).toBeDefined();
+    expect(res.headers['referrer-policy']).toBeDefined();
+    await shutdownApp();
+  });
+
   test('Get HTTPS config', async () => {
     const app = express();
     const config = await loadTestConfig();

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -2,7 +2,7 @@ import { badRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import compression from 'compression';
 import cors from 'cors';
-import { Express, json, NextFunction, Request, Response, text, urlencoded } from 'express';
+import { Express, json, NextFunction, Request, Response, Router, text, urlencoded } from 'express';
 import { adminRouter } from './admin';
 import { asyncWrap } from './async';
 import { authRouter } from './auth';
@@ -134,19 +134,24 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
       type: ['x-application/hl7-v2+er7'],
     })
   );
-  app.get('/', (_req, res) => res.sendStatus(200));
-  app.get('/robots.txt', (_req, res) => res.type('text/plain').send('User-agent: *\nDisallow: /'));
-  app.get('/healthcheck', asyncWrap(healthcheckHandler));
-  app.get('/openapi.json', openApiHandler);
-  app.use('/.well-known/', wellKnownRouter);
-  app.use('/admin/', adminRouter);
-  app.use('/auth/', authRouter);
-  app.use('/dicom/PS3/', dicomRouter);
-  app.use('/email/v1/', emailRouter);
-  app.use('/fhir/R4/', fhirRouter);
-  app.use('/oauth2/', oauthRouter);
-  app.use('/scim/v2/', scimRouter);
-  app.use('/storage/', storageRouter);
+
+  const apiRouter = Router();
+  apiRouter.get('/', (_req, res) => res.sendStatus(200));
+  apiRouter.get('/robots.txt', (_req, res) => res.type('text/plain').send('User-agent: *\nDisallow: /'));
+  apiRouter.get('/healthcheck', asyncWrap(healthcheckHandler));
+  apiRouter.get('/openapi.json', openApiHandler);
+  apiRouter.use('/.well-known/', wellKnownRouter);
+  apiRouter.use('/admin/', adminRouter);
+  apiRouter.use('/auth/', authRouter);
+  apiRouter.use('/dicom/PS3/', dicomRouter);
+  apiRouter.use('/email/v1/', emailRouter);
+  apiRouter.use('/fhir/R4/', fhirRouter);
+  apiRouter.use('/oauth2/', oauthRouter);
+  apiRouter.use('/scim/v2/', scimRouter);
+  apiRouter.use('/storage/', storageRouter);
+
+  app.use('/api/', apiRouter);
+  app.use('/', apiRouter);
   app.use(errorHandler);
   return app;
 }


### PR DESCRIPTION
(This is all working backwards from some pending improvements to the "file upload" flow)

Before:
* Server is available at `api.example.com`
* App is available at `app.example.com`
* JavaScript code running in `app.example.com` makes HTTPS requests to `api.example.com`
* Because that is cross-domain, the requests are CORS requests, and therefore the browser does all of the CORS stuff

Why that is suboptimal:
* Every HTTP request has a "preflight OPTIONS request", which means we basically double the number of HTTP requests
* That apparently can cause issues with `XMLHttpRequest`
* It also requires an open CORS policy, which some servers may not want to implement

What would be better:
* If the app could be hosted in way such that `app.example.com/api/` proxies to `api.example.com`, you can avoid all of CORS
* This eliminates the double HTTP request problem
* This also enables a no-CORS configuration

In this PR:
* Update `server` to support API routes at both `/` and `/api/`
* Update the `app` CloudFront CDK configuration to proxy `/api/` to `api.example.com`

This is deployed on https://app.staging.medplum.com/ and works as desired.
