### PR TITLE
Use compatible version strings in peer dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "@medplum/fhirtypes": "0.10.2"
   },
   "peerDependencies": {
-    "pdfmake": "0.2.5"
+    "pdfmake": "^0.2.5"
   },
   "peerDependenciesMeta": {
     "pdfmake": {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "@medplum/core": "0.10.2",
     "@medplum/definitions": "0.10.2",
-    "fast-json-patch": "3.1.1"
+    "fast-json-patch": "^3.1.1"
   },
   "peerDependenciesMeta": {
     "fast-json-patch": {


### PR DESCRIPTION
Peer dependencies should always use `^` to denote "compatible versions".

See: npx npm-check-updates -u --packageFile package.json

(Most peer dependencies already used the `^`, this just fixes the stragglers)