### PR TITLE
GraphiQL use static schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ packages/definitions/dist/**/*.js.map
 packages/definitions/dist/**/*.d.ts
 packages/generator/dist/
 packages/graphiql/dist/
+packages/graphiql/public/
 packages/infra/dist/
 packages/mock/dist/
 packages/seeder/dist/

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -1,3 +1,32 @@
-## Medplum GraphiQL
+# Medplum GraphiQL
 
 This is the code for [https://graphiql.medplum.com](https://graphiql.medplum.com)
+
+## Schema
+
+The FHIR GraphQL schema is approximately 40 MB of compact JSON. It is large, and computationally expensive. The Medplum production servers disable GraphQL schema queries to reduce the risk of service interruption.
+
+However, GraphiQL needs the schema for helpful functionality such as tooltips and autocomplete.
+
+To use GraphiQL on localhost, you need a copy of the schema "introspection query" response in the `public/schema` directory.
+
+The easy way is to simply copy the publicly hosted schema:
+
+```bash
+mkdir -p public/schema
+cd public/schema
+wget https://graphiql.medplum.com/schema/schema-v1.json
+```
+
+The harder way is to regenerate the schema from the current GraphQL model.
+
+1. Make sure your Medplum user account has access to GraphQL schema/introspection queries
+2. Disable the `operationName === 'IntrospectionQuery'` guard in `src/index.tsx`
+3. Start the GraphiQL dev server
+4. Open the GraphiQL app in your web browser
+5. Use your web browser "Network" tools to find the introspection query
+6. Save the output of that request as "schema-x.json"
+7. Update `src/index.tsx` with the new schema filename
+8. Re-enable the `operationName === 'IntrospectionQuery'` guard in `src/index.tsx`
+
+TODO: Automate these steps

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -1,9 +1,11 @@
+import { FetcherParams, SyncExecutionResult } from '@graphiql/toolkit';
 import { MantineProvider, MantineThemeOverride, Title } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { Logo, MedplumProvider, SignInForm, useMedplumProfile } from '@medplum/react';
 import GraphiQL from 'graphiql';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+
 import 'regenerator-runtime/runtime.js';
 
 import 'graphiql/graphiql.css';
@@ -57,13 +59,17 @@ const theme: MantineThemeOverride = {
   },
 };
 
+function fetcher(params: FetcherParams): Promise<SyncExecutionResult> {
+  if (params.operationName === 'IntrospectionQuery') {
+    return fetch('/schema/schema-v1.json').then((res) => res.json());
+  }
+  return medplum.graphql(params.query, params.operationName, params.variables);
+}
+
 function App(): JSX.Element {
   const profile = useMedplumProfile();
   return profile ? (
-    <GraphiQL
-      fetcher={async (params) => medplum.graphql(params.query, params.operationName, params.variables)}
-      defaultQuery={HELP_TEXT}
-    />
+    <GraphiQL fetcher={fetcher} defaultQuery={HELP_TEXT} />
   ) : (
     <SignInForm googleClientId={process.env.GOOGLE_CLIENT_ID} onSuccess={() => undefined}>
       <Logo size={32} />

--- a/packages/graphiql/webpack.config.js
+++ b/packages/graphiql/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = (env, argv) => ({
   devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].[contenthash].js',
+    filename: 'js/[name].[contenthash].js',
   },
   module: {
     rules: [
@@ -54,9 +54,9 @@ module.exports = (env, argv) => ({
   ],
   devServer: {
     hot: true,
-    // bypass simple localhost CORS restrictions by setting
-    // these to 127.0.0.1 in /etc/hosts
-    allowedHosts: ['local.test.com', 'graphiql.com'],
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
   },
   optimization: {
     usedExports: true,

--- a/scripts/deploy-graphiql.sh
+++ b/scripts/deploy-graphiql.sh
@@ -1,32 +1,51 @@
 #!/usr/bin/env bash
 
 pushd packages/graphiql
-aws s3 cp dist/ s3://medplum-docs/graphiql/ \
-  --region us-east-1 \
-  --recursive \
-  --cache-control "public, max-age=31536000" \
-  --exclude "*.html" \
-  --exclude "*.css" \
-  --exclude "*.js"
-aws s3 cp dist/ s3://medplum-docs/graphiql/ \
+
+# No cache
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --region us-east-1 \
   --recursive \
   --content-type "text/html" \
   --cache-control "no-cache" \
   --exclude "*" \
   --include "*.html"
-aws s3 cp dist/ s3://medplum-docs/graphiql/ \
+
+# Cache forever
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --region us-east-1 \
   --recursive \
   --content-type "text/css" \
-  --cache-control "no-cache" \
+  --cache-control "public, max-age=31536000" \
   --exclude "*" \
   --include "*.css"
-aws s3 cp dist/ s3://medplum-docs/graphiql/ \
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --region us-east-1 \
   --recursive \
   --content-type "application/javascript" \
-  --cache-control "no-cache" \
+  --cache-control "public, max-age=31536000" \
   --exclude "*" \
   --include "*.js"
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
+  --region us-east-1 \
+  --recursive \
+  --content-type "application/json" \
+  --cache-control "public, max-age=31536000" \
+  --exclude "*" \
+  --include "*.json" \
+  --include "*.css.map" \
+  --include "*.js.map"
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
+  --region us-east-1 \
+  --recursive \
+  --content-type "text/plain" \
+  --cache-control "public, max-age=31536000" \
+  --exclude "*" \
+  --include "*.txt"
+
 popd


### PR DESCRIPTION
Part of https://app.asana.com/0/1201910659736061/1202865485101500/f

This is live at https://graphiql.medplum.com

Notes:
* The big challenge here is juggling a 40 MB schema file that is difficult to generate
* My original plan was to host the schema separately (i.e., static.medplum.com), but CORS became a mess
* So, instead, I decided to host the schema together with the graphiql web app
* Due to the complexity of generating the schema, I decided it was out of scope to make it work with Vercel hosting
* So, instead, I fell back to AWS S3/CloudFront, so we have more control over the storage and caching
