### PR TITLE
Add Bot as entity in Subscription AuditEvent

### DIFF
--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -266,6 +266,7 @@ async function createAuditEvent(bot: Bot, outcome: AuditEventOutcome, outcomeDes
     entity: [
       {
         what: createReference(bot),
+        role: { code: '9', display: 'Subscriber' },
       },
     ],
     outcome,

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -537,6 +537,7 @@ describe('Subscription Worker', () => {
     const auditEvent = bundle.entry?.[0]?.resource as AuditEvent;
     expect(auditEvent.outcomeDesc).toEqual('Bots not enabled');
     expect(auditEvent.period).toBeDefined();
+    expect(auditEvent.entity).toHaveLength(3);
   });
 
   test('Execute bot subscriptions', async () => {
@@ -800,5 +801,6 @@ describe('Subscription Worker', () => {
     const auditEvent = bundle?.entry?.[0].resource as AuditEvent;
     expect(auditEvent.meta?.account).toBeDefined();
     expect(auditEvent.meta?.account?.reference).toEqual(account.reference);
+    expect(auditEvent.entity).toHaveLength(2);
   });
 });


### PR DESCRIPTION
There are two ways to invoke a Bot:
1. Calling the `/$execute` endpoint directly
2. Via FHIR `Subscription` with the bot as the destination

These involve two slightly different code paths.  One of the differences in the two code paths is how `AuditEvent` resources are created.

1. For `/$execute` executions, the Bot was included in the `AuditEvent.entity` list
2. For `Subscription` executions, the Bot was ***not*** included

This led to awkward inconsistency when debugging.

This PR fixes that, and makes sure the Bot is always included in the `AuditEvent`.