### PR TITLE
Added more HL7 parsing utils

### DIFF
--- a/packages/core/src/hl7.test.ts
+++ b/packages/core/src/hl7.test.ts
@@ -1,10 +1,6 @@
-import { Hl7Message } from './hl7';
+import { Hl7Message, Hl7Segment } from './hl7';
 
 describe('HL7', () => {
-  test('Unsupported encoding', () => {
-    expect(() => Hl7Message.parse('MSH_^~\\&|')).toThrow();
-  });
-
   test('Minimal', () => {
     const text = 'MSH|^~\\&';
     const msg = Hl7Message.parse(text);
@@ -44,26 +40,26 @@ PV1||O|168 ~219~C~PMA^^^^^^^^^||||277^ALLEN MYLASTNAME^BONNIE^^^^|||||||||| ||26
     expect(msg.segments[2].name).toBe('NK1');
     expect(msg.segments[3].name).toBe('PV1');
 
-    const msh = msg.get('MSH');
+    const msh = msg.get('MSH') as Hl7Segment;
     expect(msh).toBeDefined();
-    expect(msh?.get(2).toString()).toBe('EPIC');
-    expect(msh?.get(3).toString()).toBe('EPICADT');
+    expect(msh.get(2).toString()).toBe('EPIC');
+    expect(msh.get(3).toString()).toBe('EPICADT');
 
-    const pid = msg.get('PID');
+    const pid = msg.get('PID') as Hl7Segment;
     expect(pid).toBeDefined();
-    expect(pid?.get(2).get(0)).toBe('0493575');
-    expect(pid?.get(2).toString()).toBe('0493575^^^2^ID 1');
+    expect(pid.get(2).get(0)).toBe('0493575');
+    expect(pid.get(2).toString()).toBe('0493575^^^2^ID 1');
 
-    const nk1 = msg.get('NK1');
+    const nk1 = msg.get('NK1') as Hl7Segment;
     expect(nk1).toBeDefined();
-    expect(nk1?.get(2).get(0)).toBe('ROE');
-    expect(nk1?.get(2).get(1)).toBe('MARIE');
-    expect(nk1?.get(2).toString()).toBe('ROE^MARIE^^^^');
+    expect(nk1.get(2).get(0)).toBe('ROE');
+    expect(nk1.get(2).get(1)).toBe('MARIE');
+    expect(nk1.get(2).toString()).toBe('ROE^MARIE^^^^');
 
-    const pv1 = msg.get('PV1');
+    const pv1 = msg.get('PV1') as Hl7Segment;
     expect(pv1).toBeDefined();
-    expect(pv1?.get(2).get(0)).toBe('O');
-    expect(pv1?.get(2).toString()).toBe('O');
+    expect(pv1.get(2).get(0)).toBe('O');
+    expect(pv1.get(2).toString()).toBe('O');
   });
 
   test('QBP_Q11', () => {
@@ -78,10 +74,10 @@ RCP|I|1|R^^HL70394`;
     expect(msg.segments[1].name).toBe('QPD');
     expect(msg.segments[2].name).toBe('RCP');
 
-    const msh = msg.get('MSH');
+    const msh = msg.get('MSH') as Hl7Segment;
     expect(msh).toBeDefined();
-    expect(msh?.get(2).toString()).toBe('cobas® pro');
-    expect(msh?.get(4).toString()).toBe('host');
+    expect(msh.get(2).toString()).toBe('cobas® pro');
+    expect(msh.get(4).toString()).toBe('host');
   });
 
   test('OUL_R22', () => {
@@ -113,14 +109,14 @@ OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other·Supplemental^I
     expect(msg.segments[2].name).toBe('SPM');
     expect(msg.get(0)).toEqual(msg.get('MSH'));
 
-    const pid = msg.get('PID');
+    const pid = msg.get('PID') as Hl7Segment;
     expect(pid).toBeDefined();
-    expect(pid?.toString()).toBe('PID|||||^^^^^^U|||U');
+    expect(pid.toString()).toBe('PID|||||^^^^^^U|||U');
 
-    const msh = msg.get('MSH');
+    const msh = msg.get('MSH') as Hl7Segment;
     expect(msh).toBeDefined();
-    expect(msh?.get(2).toString()).toBe('cobas pro');
-    expect(msh?.get(4).toString()).toBe('host');
+    expect(msh.get(2)?.toString()).toBe('cobas pro');
+    expect(msh.get(4)?.toString()).toBe('host');
 
     const obxs = msg.getAll('OBX');
     expect(obxs).toBeDefined();
@@ -132,5 +128,69 @@ OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other·Supplemental^I
       expect(obx.get(1).toString()).toBe(i.toString());
       i++;
     }
+  });
+
+  test('Non-standard encoding', () => {
+    const text =
+      'MSH_^~\\&_Main_XYZ_iFW_ABC_20160915003015__ACK_9B38584D_P_2.6.1_\r' +
+      'MSA_AA_9B38584D_Everything was okay dokay!_';
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(2);
+    expect(msg.toString()).toBe(text);
+
+    const msa = msg.get('MSA') as Hl7Segment;
+    expect(msa).toBeDefined();
+    expect(msa.get(1).toString()).toBe('AA');
+    expect(msa.get(2).toString()).toBe('9B38584D');
+    expect(msa.get(3).toString()).toBe('Everything was okay dokay!');
+  });
+
+  test('Sub-field values', () => {
+    const text =
+      'MSH|^~\\&|cobas pro||Host||20220812155051+0900||OUL^R22^OUL_R22|2019|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-29^IHE\r' +
+      'PID|||||^^^^^^U|||U\r' +
+      'SPM|1|140799&BARCODE||SERPLAS^^99ROC|||||||P^^HL70369|||~~~~|||||||||||||SC^^99ROC\r' +
+      'SAC|||140799^BARCODE|||||||50036|1||||||||||||||||||^1^:^1\r' +
+      'OBR|1|""||10020^^99ROC|||||||\r' +
+      'ORC|SC||||CM\r' +
+      'TQ1|||||||||R^^HL70485\r' +
+      'OBX|1|NM|10020^10020^99ROC^^^IHELAW|1|112|ng/dL^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|2|CE|10020^10020^99ROC^^^IHELAW|1|^^99ROC|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'TCD|10020^^99ROC|^1^:^1\r' +
+      'INV|1310020|OK^^HL70383~CURRENT^^99ROC|ASY|24308|1|19||||||20230831||||620931\r' +
+      'INV|1018448|OK^^HL70383~CURRENT^^99ROC|PRC|12854|1|1||||||20231130||||620127\r' +
+      'OBX|3|DTM|PT^Pipetting_Time^99ROC^S_OTHER^Other Supplemental^IHELAW|1|20220812151841|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|4|EI|CalibrationID^CalibrationID^99ROC^S_OTHER^Other Supplemental^IHELAW|1|1081|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|5|EI|QCTID^QC Test ID^99ROC^S_OTHER^Other Supplemental^IHELAW|1|19132~19112~19092|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|6|CE|QCSTATE^QC Status^99ROC^S_OTHER^Other Supplemental^IHELAW|1|1^^99ROC|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|7|ST|TR_TECHNICALLIMIT^TR_TECHNICALLIMIT^99ROC^S_OTHER^Other Supplemental^IHELAW|1|2.50 - 1500|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|8|ST|TR_REPEATLIMIT^TR_REPEATLIMIT^99ROC^S_OTHER^Other Supplemental^IHELAW|1|-9999900 - |||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other Supplemental^IHELAW|1|-9999900 - |||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|10|NM|10020_EFS^10020_EFS^99ROC^S_RAW^Raw Supplemental^IHELAW|1|42399.210|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|11|NM|10020_EFV^10020_EFV^99ROC^S_RAW^Raw Supplemental^IHELAW|1|-116.3324|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|12|NM|10020_EFC^10020_EFC^99ROC^S_RAW^Raw Supplemental^IHELAW|1|254.4396|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|13|NM|10020_PMT^10020_PMT^99ROC^S_RAW^Raw Supplemental^IHELAW|1|13773|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT';
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(23);
+    expect(msg.toString()).toBe(text);
+
+    // Test sub-components with the "&" separator
+    const spm = msg.get('SPM') as Hl7Segment;
+    expect(spm.get(2).get(0)).toEqual('140799&BARCODE');
+    expect(spm.get(2).get(0, 0)).toEqual('140799');
+    expect(spm.get(2).get(0, 1)).toEqual('BARCODE');
+
+    // Test repetition with the "~" separator
+    const obx = msg.get('OBX') as Hl7Segment;
+    expect(obx.get(18).toString()).toEqual('e801^ROCHE~2037-06^ROCHE~1^ROCHE');
+    expect(obx.get(18).get(0)).toEqual('e801');
+    expect(obx.get(18).get(0, 0, 0)).toEqual('e801');
+    expect(obx.get(18).get(1, 0, 0)).toEqual('ROCHE');
+    expect(obx.get(18).get(0, 0, 1)).toEqual('2037-06');
+    expect(obx.get(18).get(1, 0, 1)).toEqual('ROCHE');
   });
 });

--- a/packages/core/src/hl7.test.ts
+++ b/packages/core/src/hl7.test.ts
@@ -1,6 +1,15 @@
-import { Hl7Message, Hl7Segment } from './hl7';
+import { Hl7Field, Hl7Message, Hl7Segment } from './hl7';
 
 describe('HL7', () => {
+  test('Unsupported encoding', () => {
+    expect(() => Hl7Message.parse('xyz')).toThrow();
+  });
+
+  test('Default context', () => {
+    expect(Hl7Segment.parse('MSA|AA|123').toString()).toBe('MSA|AA|123');
+    expect(Hl7Field.parse('x1^x2^x3~y1^y2^y3').toString()).toBe('x1^x2^x3~y1^y2^y3');
+  });
+
   test('Minimal', () => {
     const text = 'MSH|^~\\&';
     const msg = Hl7Message.parse(text);

--- a/packages/core/src/hl7.ts
+++ b/packages/core/src/hl7.ts
@@ -1,21 +1,65 @@
 import { isStringArray } from './utils';
 
-export const SEGMENT_SEPARATOR = '\r';
-export const FIELD_SEPARATOR = '|';
-export const COMPONENT_SEPARATOR = '^';
+/**
+ * The Hl7Context class represents the parsing context for an HL7 message.
+ *
+ * MSH-1:
+ * https://hl7-definition.caristix.com/v2/HL7v2.6/Fields/MSH.1
+ *
+ * MSH-2:
+ * https://hl7-definition.caristix.com/v2/HL7v2.6/Fields/MSH.2
+ *
+ * See this tutorial on MSH, and why it's a bad idea to use anything other than the default values:
+ * https://www.hl7soup.com/HL7TutorialMSH.html
+ */
+export class Hl7Context {
+  constructor(
+    public readonly segmentSeparator = '\r',
+    public readonly fieldSeparator = '|',
+    public readonly componentSeparator = '^',
+    public readonly repetitionSeparator = '~',
+    public readonly escapeCharacter = '\\',
+    public readonly subcomponentSeparator = '&'
+  ) {}
+
+  /**
+   * Returns the MSH-2 field value based on the configured separators.
+   * @returns The HL7 MSH-2 field value.
+   */
+  getMsh2(): string {
+    return (
+      this.fieldSeparator +
+      this.componentSeparator +
+      this.repetitionSeparator +
+      this.escapeCharacter +
+      this.subcomponentSeparator
+    );
+  }
+}
 
 /**
  * The Hl7Message class represents one HL7 message.
  * A message is a collection of segments.
- * Note that we do not strictly parse messages, and only use default delimeters.
  */
 export class Hl7Message {
+  readonly context: Hl7Context;
   readonly segments: Hl7Segment[];
 
-  constructor(segments: Hl7Segment[]) {
+  /**
+   * Creates a new HL7 message.
+   * @param segments The HL7 segments.
+   * @param context Optional HL7 parsing context.
+   */
+  constructor(segments: Hl7Segment[], context = new Hl7Context()) {
+    this.context = context;
     this.segments = segments;
   }
 
+  /**
+   * Returns an HL7 segment by index or by name.
+   * @param index The HL7 segment index or name.
+   * @returns The HL7 segment if found; otherwise, undefined.
+   */
   get(index: number | string): Hl7Segment | undefined {
     if (typeof index === 'number') {
       return this.segments[index];
@@ -23,14 +67,27 @@ export class Hl7Message {
     return this.segments.find((s) => s.name === index);
   }
 
+  /**
+   * Returns all HL7 segments of a given name.
+   * @param name The HL7 segment name.
+   * @returns An array of HL7 segments with the specified name.
+   */
   getAll(name: string): Hl7Segment[] {
     return this.segments.filter((s) => s.name === name);
   }
 
+  /**
+   * Returns the HL7 message as a string.
+   * @returns The HL7 message as a string.
+   */
   toString(): string {
-    return this.segments.map((s) => s.toString()).join(SEGMENT_SEPARATOR);
+    return this.segments.map((s) => s.toString()).join(this.context.segmentSeparator);
   }
 
+  /**
+   * Returns an HL7 "ACK" (acknowledgement) message for this message.
+   * @returns The HL7 "ACK" message.
+   */
   buildAck(): Hl7Message {
     const now = new Date();
     const msh = this.get('MSH');
@@ -42,31 +99,50 @@ export class Hl7Message {
     const versionId = msh?.get(12)?.toString() || '2.5.1';
 
     return new Hl7Message([
-      new Hl7Segment([
-        'MSH',
-        '^~\\&',
-        receivingApp,
-        receivingFacility,
-        sendingApp,
-        sendingFacility,
-        now.toISOString(),
-        '',
-        'ACK',
-        now.getTime().toString(),
-        'P',
-        versionId,
-      ]),
-      new Hl7Segment(['MSA', 'AA', controlId, 'OK']),
+      new Hl7Segment(
+        [
+          'MSH',
+          this.context.getMsh2(),
+          receivingApp,
+          receivingFacility,
+          sendingApp,
+          sendingFacility,
+          now.toISOString(),
+          '',
+          'ACK',
+          now.getTime().toString(),
+          'P',
+          versionId,
+        ],
+        this.context
+      ),
+      new Hl7Segment(['MSA', 'AA', controlId, 'OK'], this.context),
     ]);
   }
 
+  /**
+   * Parses an HL7 message string into an Hl7Message object.
+   * @param text The HL7 message text.
+   * @returns The parsed HL7 message.
+   */
   static parse(text: string): Hl7Message {
-    if (!text.startsWith('MSH|^~\\&')) {
+    if (!text.startsWith('MSH')) {
       const err = new Error('Invalid HL7 message');
       (err as any).type = 'entity.parse.failed';
       throw err;
     }
-    return new Hl7Message(text.split(/[\r\n]+/).map((line) => Hl7Segment.parse(line)));
+    const context = new Hl7Context(
+      '\r',
+      text.charAt(3), // Field separator, recommended "|"
+      text.charAt(4), // Component separator, recommended "^"
+      text.charAt(5), // Repetition separator, recommended "~"
+      text.charAt(6), // Escape character, recommended "\"
+      text.charAt(7) // Subcomponent separator, recommended "&"
+    );
+    return new Hl7Message(
+      text.split(/[\r\n]+/).map((line) => Hl7Segment.parse(line, context)),
+      context
+    );
   }
 }
 
@@ -74,55 +150,111 @@ export class Hl7Message {
  * The Hl7Segment class represents one HL7 segment.
  * A segment is a collection of fields.
  * The name field is the first field.
- * Note that we do not strictly parse messages, and only use default delimeters.
  */
 export class Hl7Segment {
+  readonly context: Hl7Context;
   readonly name: string;
   readonly fields: Hl7Field[];
 
-  constructor(fields: Hl7Field[] | string[]) {
+  /**
+   * Creates a new HL7 segment.
+   * @param fields The HL7 fields.
+   * @param context Optional HL7 parsing context.
+   */
+  constructor(fields: Hl7Field[] | string[], context = new Hl7Context()) {
+    this.context = context;
     if (isStringArray(fields)) {
       this.fields = fields.map((f) => Hl7Field.parse(f));
     } else {
       this.fields = fields;
     }
-    this.name = this.fields[0].components[0];
+    this.name = this.fields[0].components[0][0];
   }
 
+  /**
+   * Returns an HL7 field by index.
+   * @param index The HL7 field index.
+   * @returns The HL7 field.
+   */
   get(index: number): Hl7Field {
     return this.fields[index];
   }
 
+  /**
+   * Returns the HL7 segment as a string.
+   * @returns The HL7 segment as a string.
+   */
   toString(): string {
-    return this.fields.map((f) => f.toString()).join(FIELD_SEPARATOR);
+    return this.fields.map((f) => f.toString()).join(this.context.fieldSeparator);
   }
 
-  static parse(text: string): Hl7Segment {
-    return new Hl7Segment(text.split(FIELD_SEPARATOR).map((f) => Hl7Field.parse(f)));
+  /**
+   * Parses an HL7 segment string into an Hl7Segment object.
+   * @param text The HL7 segment text.
+   * @param context Optional HL7 parsing context.
+   * @returns The parsed HL7 segment.
+   */
+  static parse(text: string, context = new Hl7Context()): Hl7Segment {
+    return new Hl7Segment(
+      text.split(context.fieldSeparator).map((f) => Hl7Field.parse(f, context)),
+      context
+    );
   }
 }
 
 /**
  * The Hl7Field class represents one HL7 field.
  * A field is a collection of components.
- * Note that we do not strictly parse messages, and only use default delimeters.
  */
 export class Hl7Field {
-  readonly components: string[];
+  readonly context: Hl7Context;
+  readonly components: string[][];
 
-  constructor(components: string[]) {
+  /**
+   * Creates a new HL7 field.
+   * @param components The HL7 components.
+   * @param context Optional HL7 parsing context.
+   */
+  constructor(components: string[][], context = new Hl7Context()) {
+    this.context = context;
     this.components = components;
   }
 
-  get(index: number): string {
-    return this.components[index];
+  /**
+   * Returns an HL7 component by index.
+   * @param component The component index.
+   * @param subcomponent Optional subcomponent index.
+   * @param repetition Optional repetition index.
+   * @returns The string value of the specified component.
+   */
+  get(component: number, subcomponent?: number, repetition = 0): string {
+    let value = this.components[repetition][component] || '';
+
+    if (subcomponent !== undefined) {
+      value = value.split(this.context.subcomponentSeparator)[subcomponent] || '';
+    }
+
+    return value;
   }
 
+  /**
+   * Returns the HL7 field as a string.
+   * @returns The HL7 field as a string.
+   */
   toString(): string {
-    return this.components.join(COMPONENT_SEPARATOR);
+    return this.components.map((r) => r.join(this.context.componentSeparator)).join(this.context.repetitionSeparator);
   }
 
-  static parse(text: string): Hl7Field {
-    return new Hl7Field(text.split(COMPONENT_SEPARATOR));
+  /**
+   * Parses an HL7 field string into an Hl7Field object.
+   * @param text The HL7 field text.
+   * @param context Optional HL7 parsing context.
+   * @returns The parsed HL7 field.
+   */
+  static parse(text: string, context = new Hl7Context()): Hl7Field {
+    return new Hl7Field(
+      text.split(context.repetitionSeparator).map((r) => r.split(context.componentSeparator)),
+      context
+    );
   }
 }


### PR DESCRIPTION
* Support non-standard MSH-1 and MSH-2 segment characters
* Helpers for subcomponent parsing
* Helpers for repetition parsing
* Comments and documentation