### PR TITLE
Fixed 'choice of type' regex in additional properties check

### DIFF
--- a/packages/server/src/fhir/schema.test.ts
+++ b/packages/server/src/fhir/schema.test.ts
@@ -429,13 +429,27 @@ describe('FHIR schema', () => {
     }
   });
 
-  test('Patient.multipleBirthBoolean', () => {
-    expect.assertions(1);
-    validateResource({
-      resourceType: 'Patient',
-      multipleBirthBoolean: true,
-    });
-    expect(true).toBeTruthy();
+  test('Choice of type', () => {
+    // Observation.value[x]
+    expect(() =>
+      validateResource({ resourceType: 'Observation', status: 'final', code: { text: 'x' }, valueString: 'xyz' })
+    ).not.toThrow();
+    expect(() =>
+      validateResource({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'x' },
+        valueDateTime: '2020-01-01T00:00:00Z',
+      })
+    ).not.toThrow();
+    expect(() =>
+      validateResource({ resourceType: 'Observation', status: 'final', code: { text: 'x' }, valueXyz: 'xyz' })
+    ).toThrow();
+
+    // Patient.multipleBirth[x] is a choice of boolean or integer
+    expect(() => validateResource({ resourceType: 'Patient', multipleBirthBoolean: true })).not.toThrow();
+    expect(() => validateResource({ resourceType: 'Patient', multipleBirthInteger: 2 })).not.toThrow();
+    expect(() => validateResource({ resourceType: 'Patient', multipleBirthXyz: 'xyz' })).toThrow();
   });
 });
 

--- a/packages/server/src/fhir/schema.test.ts
+++ b/packages/server/src/fhir/schema.test.ts
@@ -428,6 +428,15 @@ describe('FHIR schema', () => {
       console.log(JSON.stringify(outcome, null, 2).substring(0, 1000));
     }
   });
+
+  test('Patient.multipleBirthBoolean', () => {
+    expect.assertions(1);
+    validateResource({
+      resourceType: 'Patient',
+      multipleBirthBoolean: true,
+    });
+    expect(true).toBeTruthy();
+  });
 });
 
 function fail(reason: string): never {

--- a/packages/server/src/fhir/schema.ts
+++ b/packages/server/src/fhir/schema.ts
@@ -230,7 +230,7 @@ export class FhirSchemaValidator<T extends Resource> {
       if (!(key in propertyDefinitions)) {
         // Try to find a "choice of type" property (e.g., "value[x]")
         // TODO: Consolidate this logic with FHIRPath lookup
-        const choiceOfTypeKey = key.replace(/[A-Z].+/, '[x]');
+        const choiceOfTypeKey = key.replace(/[A-Z][a-z]+$/, '[x]');
         if (!(choiceOfTypeKey in propertyDefinitions)) {
           const expression = `${path}.${key}`;
           this.#issues.push(createStructureIssue(expression, `Invalid additional property "${expression}"`));

--- a/packages/server/src/fhir/schema.ts
+++ b/packages/server/src/fhir/schema.ts
@@ -48,6 +48,7 @@ const fhirTypeToJsType: Record<string, string> = {
 
 const baseResourceProperties = new Set<string>([
   // Resource
+  'resourceType',
   'id',
   'meta',
   'implicitRules',

--- a/packages/server/src/fhir/schema.ts
+++ b/packages/server/src/fhir/schema.ts
@@ -1,4 +1,5 @@
 import {
+  capitalize,
   getExtensionValue,
   getTypedPropertyValue,
   IndexedStructureDefinition,
@@ -44,6 +45,23 @@ const fhirTypeToJsType: Record<string, string> = {
   xhtml: 'string',
   'http://hl7.org/fhirpath/System.String': 'string',
 };
+
+const baseResourceProperties = new Set<string>([
+  // Resource
+  'id',
+  'meta',
+  'implicitRules',
+  'language',
+
+  // DomainResource
+  'text',
+  'contained',
+  'extension',
+  'modifierExtension',
+
+  // Other
+  '_baseDefinition',
+]);
 
 export function isResourceType(resourceType: string): boolean {
   const typeSchema = getStructureDefinitions().types[resourceType];
@@ -224,14 +242,11 @@ export class FhirSchemaValidator<T extends Resource> {
   ): void {
     const object = typedValue.value as Record<string, unknown>;
     for (const key of Object.keys(object)) {
-      if (key === 'resourceType' || key === 'id' || key === 'meta' || key === '_baseDefinition') {
+      if (baseResourceProperties.has(key)) {
         continue;
       }
       if (!(key in propertyDefinitions)) {
-        // Try to find a "choice of type" property (e.g., "value[x]")
-        // TODO: Consolidate this logic with FHIRPath lookup
-        const choiceOfTypeKey = key.replace(/[A-Z][a-z]+$/, '[x]');
-        if (!(choiceOfTypeKey in propertyDefinitions)) {
+        if (!isChoiceOfType(key, typedValue, propertyDefinitions)) {
           const expression = `${path}.${key}`;
           this.#issues.push(createStructureIssue(expression, `Invalid additional property "${expression}"`));
         }
@@ -250,4 +265,31 @@ function isIntegerType(propertyType: PropertyType): boolean {
     propertyType === PropertyType.positiveInt ||
     propertyType === PropertyType.unsignedInt
   );
+}
+
+function isChoiceOfType(
+  key: string,
+  typedValue: TypedValue,
+  propertyDefinitions: Record<string, ElementDefinition>
+): boolean {
+  for (const propertyName of Object.keys(propertyDefinitions)) {
+    if (!propertyName.endsWith('[x]')) {
+      continue;
+    }
+    const basePropertyName = propertyName.replace('[x]', '');
+    if (!key.startsWith(basePropertyName)) {
+      continue;
+    }
+    let typedPropertyValue = getTypedPropertyValue(typedValue, propertyName);
+    if (!typedPropertyValue) {
+      continue;
+    }
+    if (Array.isArray(typedPropertyValue)) {
+      typedPropertyValue = typedPropertyValue[0];
+    }
+    if (typedPropertyValue && key === basePropertyName + capitalize(typedPropertyValue.type)) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
The FHIR schema validator choked on `Patient.multipleBirthBoolean`:
* The schema validator checks for invalid additional properties
* For each property, it attempts to find the property in the schema
* If an exact match cannot be found, it looks for a "choice of type" match (i.e., `valueString` matches `value[x]`)
* The matching logic had an error that used regexes and capital letters, which is insufficient

Example cases:
* `Patient.multipleBirthBoolean`
* `Observation.valueDateTime`

This PR implements the "correct" solution, which looks at all choice-of-type properties and valid options.