### PR TITLE
Flagging "Abnormal" in the DiagnosticReportDisplay

### DIFF
--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -225,5 +225,5 @@ function ReferenceRangeDisplay(props: ReferenceRangeProps): JSX.Element | null {
  */
 function isCritical(observation: Observation): boolean {
   const code = observation.interpretation?.[0]?.coding?.[0]?.code;
-  return code === 'AA' || code === 'LL' || code === 'HH' || code === 'RR';
+  return code === 'AA' || code === 'LL' || code === 'HH' || code === 'A';
 }


### PR DESCRIPTION
Some customers have confirmed that "RR" should not be used as an interpretation, but rather we should be using and highlighting the code "Abnormal"