### PR TITLE
Fixed Organization.contact diff bug

### DIFF
--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
@@ -65,6 +65,21 @@ describe('BackboneElementDisplay', () => {
     expect(screen.getByText('Simple Name')).toBeInTheDocument();
   });
 
+  test('Handles name object value', () => {
+    setup({
+      value: {
+        type: 'OrganizationContact',
+        value: {
+          name: {
+            given: ['John'],
+            family: 'Doe',
+          },
+        },
+      },
+    });
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
   test('Not implemented', () => {
     setup({
       value: {

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -24,7 +24,12 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
     return <div>{typeName}&nbsp;not implemented</div>;
   }
 
-  if (typeof value === 'object' && 'name' in value && Object.keys(value).length === 1) {
+  if (
+    typeof value === 'object' &&
+    'name' in value &&
+    Object.keys(value).length === 1 &&
+    typeof value.name === 'string'
+  ) {
     // Special case for common BackboneElement pattern
     // Where there is an object with a single property 'name'
     // Just display the name value.


### PR DESCRIPTION
When rendering `BackboneElement` objects, we have a special case for:
1. Property value is an object
3. Property value only has one child property
2. The one and only child property is "name"

In which case we display the `name` property value rather than a nested table.

The bug is that we did not properly test that `name` was a string.  If, for example, it was a `HumanName`, as in the case of `Organization.contact`, it would attempt to render an object, which causes React to throw.