### PR TITLE
Smart App Launch invalid AUD parameter

### DIFF
--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -129,6 +129,22 @@ describe('OAuth Authorize', () => {
     expect(location.searchParams.get('error')).toEqual('invalid_request');
   });
 
+  test('Invalid audience', async () => {
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: client.id as string,
+      redirect_uri: client.redirectUri as string,
+      scope: 'openid',
+      code_challenge: 'xyz',
+      code_challenge_method: 'plain',
+      aud: 'https://example.com/invalid',
+    });
+    const res = await request(app).get('/oauth2/authorize?' + params.toString());
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.location);
+    expect(location.searchParams.get('error')).toEqual('invalid_request');
+  });
+
   test('Success', async () => {
     const params = new URLSearchParams({
       response_type: 'code',

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -81,6 +81,12 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
     return false;
   }
 
+  const aud = params.aud as string | undefined;
+  if (aud !== undefined && aud !== getConfig().baseUrl + 'fhir/R4') {
+    sendErrorRedirect(res, client.redirectUri as string, 'invalid_request', state);
+    return false;
+  }
+
   const codeChallenge = params.code_challenge;
   if (codeChallenge) {
     const codeChallengeMethod = params.code_challenge_method;


### PR DESCRIPTION
This implements part "9.4 SMART App Launch Error: Invalid AUD Parameter" of "ONC Certification (g)(10) Standardized API".

<img width="957" alt="image" src="https://user-images.githubusercontent.com/749094/200187402-335ddb74-2e0f-4eca-92ca-2312d4a97aa7.png">

https://app.asana.com/0/1201910659736061/1203260945029030/f

