### PR TITLE
Make resource history optional in ResourceTimeline component

### DIFF
--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -226,7 +226,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
     });
   }
 
-  if (!resource || !history) {
+  if (!resource) {
     return (
       <Center style={{ width: '100%', height: '100%' }}>
         <Loader />


### PR DESCRIPTION
In earlier versions of the `<ResourceTimeline>` component, resource history was more integral.  Now it's completely optional.  This allows a developer to create a timeline view without any history diff elements.