### PR TITLE
Set default postgres version to 12.9

### DIFF
--- a/packages/infra/src/backend.ts
+++ b/packages/infra/src/backend.ts
@@ -50,7 +50,7 @@ export class BackEnd extends Construct {
     // RDS
     const rdsCluster = new rds.DatabaseCluster(this, 'DatabaseCluster', {
       engine: rds.DatabaseClusterEngine.auroraPostgres({
-        version: rds.AuroraPostgresEngineVersion.VER_12_4,
+        version: rds.AuroraPostgresEngineVersion.VER_12_9,
       }),
       credentials: rds.Credentials.fromGeneratedSecret('clusteradmin'),
       defaultDatabaseName: 'medplum',


### PR DESCRIPTION
AWS Aurora Postgres is configured to automatically perform minor version upgrades, so our production instances are already upgraded.  This is just for new deployments from scratch using CDK.

Ideally there would be a way to specify "12.x".  Or, for CDK unit tests to detect unsupported versions.  Alas, this is the best we can do for now.