### PR TITLE
Remove all uses of User.admin

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -22,6 +22,9 @@ describe('Super Admin routes', () => {
 
     ({ project, client } = await createTestProject());
 
+    // Mark the project as a "Super Admin" project
+    await systemRepo.updateResource({ ...project, superAdmin: true });
+
     const practitioner1 = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
 
     const practitioner2 = await systemRepo.createResource<Practitioner>({ resourceType: 'Practitioner' });
@@ -32,7 +35,6 @@ describe('Super Admin routes', () => {
       lastName: 'Admin',
       email: `super${randomUUID()}@example.com`,
       passwordHash: 'abc',
-      admin: true,
     });
 
     const user2 = await systemRepo.createResource<User>({
@@ -41,7 +43,6 @@ describe('Super Admin routes', () => {
       lastName: 'Admin',
       email: `normie${randomUUID()}@example.com`,
       passwordHash: 'abc',
-      admin: false,
     });
 
     const membership1 = await systemRepo.createResource<ProjectMembership>({
@@ -66,7 +67,7 @@ describe('Super Admin routes', () => {
       membership: createReference(membership1),
       authTime: new Date().toISOString(),
       scope: 'openid',
-      admin: true,
+      superAdmin: true,
     });
 
     const login2 = await systemRepo.createResource<Login>({
@@ -77,7 +78,7 @@ describe('Super Admin routes', () => {
       membership: createReference(membership2),
       authTime: new Date().toISOString(),
       scope: 'openid',
-      admin: false,
+      superAdmin: false,
     });
 
     adminAccessToken = await generateAccessToken({

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -1,5 +1,4 @@
 import { allOk, forbidden } from '@medplum/core';
-import { User } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
 import { sendOutcome } from '../fhir/outcomes';
@@ -19,8 +18,7 @@ superAdminRouter.use(authenticateToken);
 superAdminRouter.post(
   '/valuesets',
   asyncWrap(async (_req: Request, res: Response) => {
-    const user = await systemRepo.readResource<User>('User', res.locals.user);
-    if (!user.admin) {
+    if (!res.locals.login.superAdmin) {
       sendOutcome(res, forbidden);
       return;
     }
@@ -36,8 +34,7 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/structuredefinitions',
   asyncWrap(async (_req: Request, res: Response) => {
-    const user = await systemRepo.readResource<User>('User', res.locals.user);
-    if (!user.admin) {
+    if (!res.locals.login.superAdmin) {
       sendOutcome(res, forbidden);
       return;
     }
@@ -53,8 +50,7 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/searchparameters',
   asyncWrap(async (_req: Request, res: Response) => {
-    const user = await systemRepo.readResource<User>('User', res.locals.user);
-    if (!user.admin) {
+    if (!res.locals.login.superAdmin) {
       sendOutcome(res, forbidden);
       return;
     }
@@ -70,8 +66,7 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/reindex',
   asyncWrap(async (req: Request, res: Response) => {
-    const user = await systemRepo.readResource<User>('User', res.locals.user);
-    if (!user.admin) {
+    if (!res.locals.login.superAdmin) {
       sendOutcome(res, forbidden);
       return;
     }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1878,7 +1878,7 @@ export async function getRepoForLogin(
     project: resolveId(membership.project) as string,
     author: membership.profile as Reference,
     remoteAddress: login.remoteAddress,
-    superAdmin: login.admin || login.superAdmin,
+    superAdmin: login.superAdmin,
     accessPolicy,
     strictMode,
     extendedMode,

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -87,10 +87,10 @@ async function authenticateBasicAuth(req: Request, res: Response, token: string)
 
 async function setupLocals(req: Request, res: Response, login: Login, membership: ProjectMembership): Promise<void> {
   const locals = res.locals;
+  locals.login = login;
   locals.membership = membership;
   locals.user = resolveId(membership.user as Reference<User>);
   locals.profile = membership.profile;
-  locals.scope = login.scope;
   locals.project = await systemRepo.readReference(membership.project as Reference<Project>);
   locals.repo = await getRepoForLogin(login, membership, locals.project.strictMode, isExtendedMode(req));
 }

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -23,19 +23,19 @@ export const userInfoHandler: RequestHandler = asyncWrap(async (_req: Request, r
 
   const profile = await systemRepo.readReference(res.locals.profile as Reference<ProfileResource>);
 
-  if (res.locals.scope.includes('profile')) {
+  if (res.locals.login.scope.includes('profile')) {
     buildProfile(userInfo, profile);
   }
 
-  if (res.locals.scope.includes('email')) {
+  if (res.locals.login.scope.includes('email')) {
     buildEmail(userInfo, profile);
   }
 
-  if (res.locals.scope.includes('phone')) {
+  if (res.locals.login.scope.includes('phone')) {
     buildPhone(userInfo, profile);
   }
 
-  if (res.locals.scope.includes('address')) {
+  if (res.locals.login.scope.includes('address')) {
     buildAddress(userInfo, profile);
   }
 

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -116,7 +116,6 @@ export async function tryLogin(request: LoginRequest): Promise<Login> {
     nonce: request.nonce,
     codeChallenge: request.codeChallenge,
     codeChallengeMethod: request.codeChallengeMethod,
-    admin: user.admin,
     remoteAddress: request.remoteAddress,
     userAgent: request.userAgent,
   });


### PR DESCRIPTION
History:
* A "super admin" user was original identified by `User.admin = true`
* That was suboptimal, because it meant that it always applied to a user account, regardless of project, so a super admin could not use the same `User` for non admin work.  Therefore, they could not use Google auth / 2fa for the same account.
* So, earlier this year, we replaced the model, so "super admin" is identified by `Project.superAdmin = true`
* That allows a user to choose super admin status during the "Choose Profile" stage of login

There were still a handful of code paths that used `User.admin`, notably "Rebuild StructureDefinitions", "Rebuild SearchParameters", etc.  Those are rarely used features, but they do come up from time to time.

This PR removes all uses of `User.admin`.

In a future PR, we can remove the property entirely from schema and type definitions.  That will require a db migration to remove the `admin` property from all `User` objects though.