### PR TITLE
Handle base Element types in react components

### DIFF
--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -44,6 +44,9 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
           return null;
         }
         const property = entry[1];
+        if (!property.path) {
+          property.path = typeName + '.' + key;
+        }
         const [propertyValue, propertyType] = getValueAndType(typedValue, key);
         if (
           props.ignoreMissingValues &&

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -93,6 +93,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     case PropertyType.Period:
       return <>{formatPeriod(value)}</>;
     case PropertyType.Quantity:
+    case PropertyType.Duration:
       return <QuantityDisplay value={value} />;
     case PropertyType.Range:
       return <RangeDisplay value={value} />;
@@ -102,6 +103,15 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       return <ReferenceDisplay value={value} link={props.link} />;
     case PropertyType.Timing:
       return <>{formatTiming(value)}</>;
+    case PropertyType.Dosage:
+    case PropertyType.UsageContext:
+      return (
+        <BackboneElementDisplay
+          value={{ type: propertyType, value }}
+          compact={true}
+          ignoreMissingValues={props.ignoreMissingValues}
+        />
+      );
     default:
       if (!property?.path) {
         throw Error(`Displaying property of type ${props.propertyType} requires element definition path`);

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -228,6 +228,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
       return <IdentifierInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Period:
       return <PeriodInput name={name} defaultValue={value} onChange={props.onChange} />;
+    case PropertyType.Duration:
     case PropertyType.Quantity:
       return <QuantityInput name={name} defaultValue={value} onChange={props.onChange} />;
     case PropertyType.Range:
@@ -245,6 +246,16 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
       );
     case PropertyType.Timing:
       return <TimingInput name={name} defaultValue={value} onChange={props.onChange} />;
+    case PropertyType.Dosage:
+    case PropertyType.UsageContext:
+      return (
+        <BackboneElementInput
+          typeName={propertyType}
+          defaultValue={value}
+          onChange={props.onChange}
+          outcome={props.outcome}
+        />
+      );
     default:
       return (
         <BackboneElementInput


### PR DESCRIPTION
Fixes:
* `Dosage` (i.e. `MedicationRequest.dosageInstruction`)
* `Duration` (i.e., `MedicationRequest.dispenseRequest.initialFill.duration`)
* `UsageContext` (i.e., `Questionnaire.useContext`)

Fixed in both `<ResourcePropertyInput>` and `<ResourcePropertyDisplay>`

https://app.asana.com/0/1201910659736061/1202626894569295/f