### PR TITLE
Fixed _id:not search

### DIFF
--- a/packages/server/src/fhir/search/parse.test.ts
+++ b/packages/server/src/fhir/search/parse.test.ts
@@ -12,20 +12,25 @@ describe('FHIR Search Utils', () => {
     });
   });
 
-  test('Parse Patient id', () => {
-    expect(parseSearchRequest('Patient', { id: '1' })).toMatchObject({
-      resourceType: 'Patient',
-      sortRules: [],
-      filters: [{ code: '_id', operator: Operator.EQUALS, value: '1' }],
-    });
-  });
-
   test('Parse Patient _id', () => {
     expect(parseSearchRequest('Patient', { _id: '1' })).toMatchObject({
       resourceType: 'Patient',
       sortRules: [],
       filters: [{ code: '_id', operator: Operator.EQUALS, value: '1' }],
     });
+  });
+
+  test('Parse Patient _id:not', () => {
+    try {
+      expect(parseSearchUrl(new URL('https://example.com/fhir/R4/Patient?_id:not=1'))).toMatchObject({
+        resourceType: 'Patient',
+        sortRules: [],
+        filters: [{ code: '_id', operator: Operator.NOT_EQUALS, value: '1' }],
+      });
+    } catch (err) {
+      console.log(err);
+      console.log(JSON.stringify(err, null, 2));
+    }
   });
 
   test('Parse Patient name search', () => {

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -63,8 +63,8 @@ export function parseSearchRequest(
  */
 export function parseSearchUrl(url: URL): SearchRequest {
   let resourceType = url.pathname;
-  if (resourceType.startsWith('/')) {
-    resourceType = resourceType.substring(1);
+  if (resourceType.includes('/')) {
+    resourceType = resourceType.split('/').pop() as string;
   }
   return new SearchParser(resourceType, Object.fromEntries(url.searchParams.entries()));
 }
@@ -106,15 +106,6 @@ class SearchParser implements SearchRequest {
     }
 
     switch (code) {
-      case '_id':
-      case 'id':
-        this.filters.push({
-          code: '_id',
-          operator: Operator.EQUALS,
-          value,
-        });
-        break;
-
       case '_account':
       case '_compartment':
       case '_project':
@@ -123,17 +114,6 @@ class SearchParser implements SearchRequest {
           operator: Operator.EQUALS,
           value,
         });
-        break;
-
-      case '_lastUpdated':
-      case 'meta.lastUpdated':
-        {
-          const parsed = parsePrefix(value);
-          this.filters.push({
-            code: '_lastUpdated',
-            ...parsed,
-          });
-        }
         break;
 
       case '_sort':


### PR DESCRIPTION
Also removing unofficial search parameters `id` and `meta.lastUpdated`, which were never correct.