### PR TITLE
Added 'send email' option to invite page

### DIFF
--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -58,13 +58,13 @@ describe('InvitePage', () => {
     expect(screen.getByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.change(screen.getByLabelText('First Name'), {
+      fireEvent.change(screen.getByLabelText('First Name *'), {
         target: { value: 'George' },
       });
-      fireEvent.change(screen.getByLabelText('Last Name'), {
+      fireEvent.change(screen.getByLabelText('Last Name *'), {
         target: { value: 'Washington' },
       });
-      fireEvent.change(screen.getByLabelText('Email'), {
+      fireEvent.change(screen.getByLabelText('Email *'), {
         target: { value: 'george@example.com' },
       });
     });
@@ -74,6 +74,7 @@ describe('InvitePage', () => {
     });
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
+    expect(screen.getByText('Email sent')).toBeInTheDocument();
   });
 
   test('Submit with access policy', async () => {
@@ -83,13 +84,13 @@ describe('InvitePage', () => {
     expect(screen.getByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
-      fireEvent.change(screen.getByLabelText('First Name'), {
+      fireEvent.change(screen.getByLabelText('First Name *'), {
         target: { value: 'George' },
       });
-      fireEvent.change(screen.getByLabelText('Last Name'), {
+      fireEvent.change(screen.getByLabelText('Last Name *'), {
         target: { value: 'Washington' },
       });
-      fireEvent.change(screen.getByLabelText('Email'), {
+      fireEvent.change(screen.getByLabelText('Email *'), {
         target: { value: 'george@example.com' },
       });
     });
@@ -133,13 +134,13 @@ describe('InvitePage', () => {
       fireEvent.change(screen.getByLabelText('Role'), {
         target: { value: 'Patient' },
       });
-      fireEvent.change(screen.getByLabelText('First Name'), {
+      fireEvent.change(screen.getByLabelText('First Name *'), {
         target: { value: 'Peggy' },
       });
-      fireEvent.change(screen.getByLabelText('Last Name'), {
+      fireEvent.change(screen.getByLabelText('Last Name *'), {
         target: { value: 'Patient' },
       });
-      fireEvent.change(screen.getByLabelText('Email'), {
+      fireEvent.change(screen.getByLabelText('Email *'), {
         target: { value: 'peggypatient@example.com' },
       });
     });
@@ -149,5 +150,35 @@ describe('InvitePage', () => {
     });
 
     expect(screen.getByTestId('success')).toBeInTheDocument();
+  });
+
+  test('Do not send email', async () => {
+    await setup('/admin/invite');
+    await waitFor(() => screen.getByText('Invite'));
+
+    expect(screen.getByText('Invite')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('First Name *'), {
+        target: { value: 'George' },
+      });
+      fireEvent.change(screen.getByLabelText('Last Name *'), {
+        target: { value: 'Washington' },
+      });
+      fireEvent.change(screen.getByLabelText('Email *'), {
+        target: { value: 'george@example.com' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Send email'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Invite'));
+    });
+
+    expect(screen.getByTestId('success')).toBeInTheDocument();
+    expect(screen.queryByText('Email sent')).not.toBeInTheDocument();
   });
 });

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, NativeSelect, Stack, TextInput, Title } from '@mantine/core';
+import { Button, Checkbox, Group, NativeSelect, Stack, TextInput, Title } from '@mantine/core';
 import { AccessPolicy, OperationOutcome, Reference } from '@medplum/fhirtypes';
 import { Form, FormSection, getErrorsForInput, MedplumLink, useMedplum } from '@medplum/react';
 import React, { useState } from 'react';
@@ -8,94 +8,73 @@ import { AccessPolicyInput } from './AccessPolicyInput';
 export function InvitePage(): JSX.Element {
   const medplum = useMedplum();
   const projectId = getProjectId(medplum);
-  const [resourceType, setResourceType] = useState<string>('Practitioner');
-  const [firstName, setFirstName] = useState<string>('');
-  const [lastName, setLastName] = useState<string>('');
-  const [email, setEmail] = useState<string>('');
   const [accessPolicy, setAccessPolicy] = useState<Reference<AccessPolicy>>();
   const [outcome, setOutcome] = useState<OperationOutcome>();
+  const [emailSent, setEmailSent] = useState(false);
   const [success, setSuccess] = useState(false);
 
   return (
-    <>
-      <Title>Invite new member</Title>
-      <Form
-        onSubmit={() => {
-          const body = {
-            resourceType,
-            firstName,
-            lastName,
-            email,
-            accessPolicy,
-          };
-          medplum
-            .post('admin/projects/' + projectId + '/invite', body)
-            .then(() => medplum.get(`admin/projects/${projectId}`, { cache: 'reload' }))
-            .then(() => setSuccess(true))
-            .catch(setOutcome);
-        }}
-      >
-        {!success && (
-          <Stack>
-            <FormSection title="Role" htmlFor="resourceType" outcome={outcome}>
-              <NativeSelect
-                id="resourceType"
-                name="resourceType"
-                defaultValue="Practitioner"
-                data={['Practitioner', 'Patient', 'RelatedPerson']}
-                onChange={(e) => setResourceType(e.currentTarget.value)}
-                error={getErrorsForInput(outcome, 'resourceType')}
-              />
-            </FormSection>
-            <FormSection title="First Name" htmlFor="firstName" outcome={outcome}>
-              <TextInput
-                id="firstName"
-                name="firstName"
-                type="text"
-                required={true}
-                autoFocus={true}
-                onChange={(e) => setFirstName(e.currentTarget.value)}
-                error={getErrorsForInput(outcome, 'firstName')}
-              />
-            </FormSection>
-            <FormSection title="Last Name" htmlFor="lastName" outcome={outcome}>
-              <TextInput
-                id="lastName"
-                name="lastName"
-                type="text"
-                required={true}
-                onChange={(e) => setLastName(e.currentTarget.value)}
-                error={getErrorsForInput(outcome, 'lastName')}
-              />
-            </FormSection>
-            <FormSection title="Email" htmlFor="email" outcome={outcome}>
-              <TextInput
-                id="email"
-                name="email"
-                type="email"
-                required={true}
-                onChange={(e) => setEmail(e.currentTarget.value)}
-                error={getErrorsForInput(outcome, 'email')}
-              />
-            </FormSection>
-            <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
-              <AccessPolicyInput name="accessPolicy" onChange={setAccessPolicy} />
-            </FormSection>
-            <Group position="right">
-              <Button type="submit">Invite</Button>
-            </Group>
-          </Stack>
-        )}
-        {success && (
-          <div data-testid="success">
-            <p>User created</p>
-            <p>Email sent</p>
-            <p>
-              Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
-            </p>
-          </div>
-        )}
-      </Form>
-    </>
+    <Form
+      onSubmit={(formData: Record<string, string>) => {
+        const body = {
+          resourceType: formData.resourceType,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          email: formData.email,
+          sendEmail: formData.sendEmail === 'on',
+          accessPolicy,
+        };
+        medplum
+          .post('admin/projects/' + projectId + '/invite', body)
+          .then(() => medplum.get(`admin/projects/${projectId}`, { cache: 'reload' }))
+          .then(() => setEmailSent(body.sendEmail))
+          .then(() => setSuccess(true))
+          .catch(setOutcome);
+      }}
+    >
+      {!success && (
+        <Stack>
+          <Title>Invite new member</Title>
+          <NativeSelect
+            name="resourceType"
+            label="Role"
+            defaultValue="Practitioner"
+            data={['Practitioner', 'Patient', 'RelatedPerson']}
+            error={getErrorsForInput(outcome, 'resourceType')}
+          />
+          <TextInput
+            name="firstName"
+            label="First Name"
+            required={true}
+            autoFocus={true}
+            error={getErrorsForInput(outcome, 'firstName')}
+          />
+          <TextInput name="lastName" label="Last Name" required={true} error={getErrorsForInput(outcome, 'lastName')} />
+          <TextInput
+            name="email"
+            type="email"
+            label="Email"
+            required={true}
+            error={getErrorsForInput(outcome, 'email')}
+          />
+          <FormSection title="Access Policy" htmlFor="accessPolicy" outcome={outcome}>
+            <AccessPolicyInput name="accessPolicy" onChange={setAccessPolicy} />
+          </FormSection>
+          <Checkbox name="sendEmail" label="Send email" defaultChecked={true} />
+          <Group position="right">
+            <Button type="submit">Invite</Button>
+          </Group>
+        </Stack>
+      )}
+      {success && (
+        <div data-testid="success">
+          <p>User created</p>
+          {emailSent && <p>Email sent</p>}
+          <p>
+            Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
+          </p>
+        </div>
+      )}
+    </Form>
   );
 }

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -218,4 +218,32 @@ describe('Admin Invite', () => {
     expect(SESv2Client).not.toHaveBeenCalled();
     expect(SendEmailCommand).not.toHaveBeenCalled();
   });
+
+  test('Do not send email', async () => {
+    // First, Alice creates a project
+    const { project, accessToken } = await registerNew({
+      firstName: 'Alice',
+      lastName: 'Smith',
+      projectName: 'Alice Project',
+      email: `alice${randomUUID()}@example.com`,
+      password: 'password!@#',
+    });
+
+    // Second, Alice invites Bob to the project
+    const bobEmail = `bob${randomUUID()}@example.com`;
+    const res2 = await request(app)
+      .post('/admin/projects/' + project.id + '/invite')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: bobEmail,
+        sendEmail: false,
+      });
+
+    expect(res2.status).toBe(200);
+    expect(SESv2Client).toHaveBeenCalledTimes(0);
+    expect(SendEmailCommand).toHaveBeenCalledTimes(0);
+  });
 });


### PR DESCRIPTION
Before:  We always sent email

After: We send email by default, with option to skip.

This helps sidestep server errors if SES is not configured correctly.