### PR TITLE
Panel spacing cleanup

### DIFF
--- a/packages/react/src/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.stories.tsx
@@ -1,6 +1,6 @@
-import { Paper } from '@mantine/core';
 import { Meta } from '@storybook/react';
 import React from 'react';
+import { Panel } from '../Panel/Panel';
 import { DescriptionList, DescriptionListEntry } from './DescriptionList';
 
 export default {
@@ -9,11 +9,11 @@ export default {
 } as Meta;
 
 export const Basic = (): JSX.Element => (
-  <Paper m="xl" p="xl" shadow="xl">
+  <Panel>
     <DescriptionList>
       <DescriptionListEntry term="Term 1">Value 1</DescriptionListEntry>
       <DescriptionListEntry term="Term 2">Value 2</DescriptionListEntry>
       <DescriptionListEntry term="Term 3">Value 3</DescriptionListEntry>
     </DescriptionList>
-  </Paper>
+  </Panel>
 );

--- a/packages/react/src/Panel/Panel.tsx
+++ b/packages/react/src/Panel/Panel.tsx
@@ -3,22 +3,31 @@ import React from 'react';
 
 export interface PanelStylesParams {
   width?: number;
+  fill?: boolean;
 }
 
-const useStyles = createStyles((theme, { width }: PanelStylesParams) => ({
+const useStyles = createStyles((theme, { width, fill }: PanelStylesParams) => ({
   paper: {
     maxWidth: width,
     margin: `${theme.spacing.xl}px auto`,
-    padding: theme.spacing.lg,
+    padding: fill ? 0 : theme.spacing.md,
     '@media (max-width: 800px)': {
-      paddingLeft: 8,
-      paddingRight: 8,
+      padding: fill ? 0 : 8,
+    },
+    '& img': {
+      width: '100%',
+      maxWidth: '100%',
+    },
+    '& video': {
+      width: '100%',
+      maxWidth: '100%',
     },
   },
 }));
 
 export interface PanelProps extends PaperProps {
   width?: number;
+  fill?: boolean;
 }
 
 const defaultProps: Partial<PanelProps> = {
@@ -28,8 +37,12 @@ const defaultProps: Partial<PanelProps> = {
 };
 
 export function Panel(props: PanelProps): JSX.Element {
-  const { className, children, width, unstyled, ...others } = useComponentDefaultProps('Panel', defaultProps, props);
-  const { classes, cx } = useStyles({ width }, { name: 'Panel', unstyled });
+  const { className, children, width, fill, unstyled, ...others } = useComponentDefaultProps(
+    'Panel',
+    defaultProps,
+    props
+  );
+  const { classes, cx } = useStyles({ width, fill }, { name: 'Panel', unstyled });
 
   return (
     <Paper className={cx(classes.paper, className)} {...others}>

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Center, createStyles, Group, Loader, Menu, Paper, ScrollArea, TextInput } from '@mantine/core';
+import { ActionIcon, Center, createStyles, Group, Loader, Menu, ScrollArea, TextInput } from '@mantine/core';
 import { showNotification, updateNotification } from '@mantine/notifications';
 import { getReferenceString, normalizeErrorString, ProfileResource } from '@medplum/core';
 import {
@@ -30,6 +30,7 @@ import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { DiagnosticReportDisplay } from '../DiagnosticReportDisplay/DiagnosticReportDisplay';
 import { Form } from '../Form/Form';
 import { useMedplum } from '../MedplumProvider/MedplumProvider';
+import { Panel } from '../Panel/Panel';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceDiffTable } from '../ResourceDiffTable/ResourceDiffTable';
 import { ResourceTable } from '../ResourceTable/ResourceTable';
@@ -237,7 +238,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
   return (
     <Timeline>
       {props.createCommunication && (
-        <Paper m="lg" p="sm" shadow="xs" radius="sm" withBorder>
+        <Panel>
           <Form
             testid="timeline-form"
             onSubmit={(formData: Record<string, string>) => {
@@ -274,7 +275,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
               </AttachmentButton>
             </Group>
           </Form>
-        </Paper>
+        </Panel>
       )}
       {items.map((item) => {
         if (item.resourceType === resource.resourceType && item.id === resource.id) {

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -30,8 +30,8 @@ export function TimelineItem(props: TimelineItemProps): JSX.Element {
   const author = profile ?? resource.meta?.author;
 
   return (
-    <Panel data-testid="timeline-item" {...others}>
-      <Group position="apart" spacing={8}>
+    <Panel data-testid="timeline-item" fill={true} {...others}>
+      <Group position="apart" spacing={8} mx="xs" my="sm">
         <ResourceAvatar value={author} link={true} size="md" />
         <div style={{ flex: 1 }}>
           <Text size="sm">
@@ -61,7 +61,7 @@ export function TimelineItem(props: TimelineItemProps): JSX.Element {
         )}
       </Group>
       <ErrorBoundary>
-        {padding && <div style={{ padding: '2px 16px 16px 16px' }}>{props.children}</div>}
+        {padding && <div style={{ padding: '0 16px 16px 16px' }}>{props.children}</div>}
         {!padding && <>{props.children}</>}
       </ErrorBoundary>
     </Panel>


### PR DESCRIPTION
Background and context:

Mantine provides a number of layout utilities:
* [Box](https://mantine.dev/core/box/) - thin wrapper around `<div>`
* [Container](https://mantine.dev/core/container/) -  basic layout element, it centers content horizontally and adds horizontal padding from theme.
* [Paper](https://mantine.dev/core/paper/) - renders white (or theme.colors.dark[7] for dark theme) background with shadow, border-radius and padding from theme.

By necessity, Mantine layout utilities are quite unopinionated and general purpose.  Medplum provides additional layout utility components:

* [Container](https://github.com/medplum/medplum/blob/main/packages/react/src/Container/Container.tsx) - More opinionated version of Mantine's Container.  Has dynamic horizontal padding for better mobile layout.  Medplum App only uses Medplum Container, never Mantine Container.
* [Panel](https://github.com/medplum/medplum/blob/main/packages/react/src/Panel/Panel.tsx) - More opinionated version of Mantine's Paper.  Medplum App uses both Mantiner Paper (for general purpose surfaces) and Medplum Panel (for any case where you want the default border, shadow, radius, and padding).
* [Document](https://github.com/medplum/medplum/blob/main/packages/react/src/Document/Document.tsx) - Just `<Container><Panel /></Container>`, which ends up being a common pattern.  This could be considered for deprecation.

This PR makes those patterns consistent.  You can see evidence of the inconsistences in mobile view:

![image](https://user-images.githubusercontent.com/749094/205357687-4065b123-539a-48e1-bf90-7a4bd55e674b.png)

