### PR TITLE
Fixing search params in ResourceInput

### DIFF
--- a/packages/react/src/ResourceInput/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.tsx
@@ -21,7 +21,7 @@ const SEARCH_CODES: Record<string, string> = {
   Observation: 'code',
   RequestGroup: '_id',
   ActivityDefinition: 'name',
-  User: 'email',
+  User: 'email:contains',
 };
 
 export interface ResourceInputProps<T extends Resource = Resource> {
@@ -50,7 +50,7 @@ export function ResourceInput<T extends Resource = Resource>(props: ResourceInpu
     setLoading(true);
     const searchCode = SEARCH_CODES[props.resourceType] || 'name';
     const searchParams = new URLSearchParams({
-      [searchCode]: encodeURIComponent(input),
+      [searchCode]: input,
       _count: '10',
     });
 


### PR DESCRIPTION
This pr performs two improvements

- Allow searching for users by partial email (Fixes #1228)
- Don't double-encode all search params as uri string (Fixes #1226)

I can split these up into two pr's if you would like. The changes were so small I didn't think it necessary.