### PR TITLE
Added AsyncAutocomplete component

### DIFF
--- a/packages/app/src/components/HeaderSearchInput.test.tsx
+++ b/packages/app/src/components/HeaderSearchInput.test.tsx
@@ -119,6 +119,8 @@ describe('HeaderSearchInput', () => {
       jest.advanceTimersByTime(1000);
     });
 
+    expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
+
     // Press the down arrow
     await act(async () => {
       fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
@@ -129,7 +131,7 @@ describe('HeaderSearchInput', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(screen.getByDisplayValue('Homer Simpson')).toBeDefined();
+    expect(screen.queryByText('Homer Simpson')).not.toBeInTheDocument();
   });
 
   test('Search by UUID', async () => {
@@ -147,6 +149,8 @@ describe('HeaderSearchInput', () => {
       jest.advanceTimersByTime(1000);
     });
 
+    expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
+
     // Press the down arrow
     await act(async () => {
       fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
@@ -157,7 +161,7 @@ describe('HeaderSearchInput', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(screen.getByDisplayValue('Homer Simpson')).toBeDefined();
+    expect(screen.queryByText('Homer Simpson')).not.toBeInTheDocument();
   });
 
   test.each(['Simpson', 'hom sim', 'abc', '9001'])('onChange with %s', async (query) => {

--- a/packages/app/src/components/HeaderSearchInput.tsx
+++ b/packages/app/src/components/HeaderSearchInput.tsx
@@ -3,7 +3,7 @@ import { formatHumanName, getDisplayString, getReferenceString, isUUID } from '@
 import { Patient, ServiceRequest } from '@medplum/fhirtypes';
 import { AsyncAutocomplete, AsyncAutocompleteOption, ResourceAvatar, useMedplum } from '@medplum/react';
 import { IconSearch } from '@tabler/icons';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 export type HeaderSearchTypes = Patient | ServiceRequest;
@@ -56,18 +56,24 @@ export function HeaderSearchInput(): JSX.Element {
   const medplum = useMedplum();
   const location = useLocation();
 
-  async function loadData(input: string, signal: AbortSignal): Promise<HeaderSearchTypes[]> {
-    const query = buildGraphQLQuery(input);
-    const options = { signal };
-    const response = (await medplum.graphql(query, undefined, undefined, options)) as SearchGraphQLResponse;
-    return getResourcesFromResponse(response, input);
-  }
+  const loadData = useCallback(
+    async (input: string, signal: AbortSignal): Promise<HeaderSearchTypes[]> => {
+      const query = buildGraphQLQuery(input);
+      const options = { signal };
+      const response = (await medplum.graphql(query, undefined, undefined, options)) as SearchGraphQLResponse;
+      return getResourcesFromResponse(response, input);
+    },
+    [medplum]
+  );
 
-  function handleSelect(item: HeaderSearchTypes[]): void {
-    if (item.length > 0) {
-      navigate(`/${getReferenceString(item[0])}`);
-    }
-  }
+  const handleSelect = useCallback(
+    (item: HeaderSearchTypes[]): void => {
+      if (item.length > 0) {
+        navigate(`/${getReferenceString(item[0])}`);
+      }
+    },
+    [navigate]
+  );
 
   return (
     <AsyncAutocomplete

--- a/packages/app/src/components/HeaderSearchInput.tsx
+++ b/packages/app/src/components/HeaderSearchInput.tsx
@@ -1,10 +1,10 @@
-import { Autocomplete, AutocompleteItem, createStyles, Group, Loader, Text } from '@mantine/core';
-import { formatHumanName, getDisplayString, isUUID } from '@medplum/core';
+import { createStyles, Group, Text } from '@mantine/core';
+import { formatHumanName, getDisplayString, getReferenceString, isUUID } from '@medplum/core';
 import { Patient, ServiceRequest } from '@medplum/fhirtypes';
-import { ResourceAvatar, useMedplum } from '@medplum/react';
+import { AsyncAutocomplete, AsyncAutocompleteOption, ResourceAvatar, useMedplum } from '@medplum/react';
 import { IconSearch } from '@tabler/icons';
-import React, { forwardRef, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { forwardRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export type HeaderSearchTypes = Patient | ServiceRequest;
 
@@ -38,90 +38,79 @@ interface SearchGraphQLResponse {
   };
 }
 
+function toKey(resource: HeaderSearchTypes): string {
+  return resource.id as string;
+}
+
+function toOption(resource: HeaderSearchTypes): AsyncAutocompleteOption<HeaderSearchTypes> {
+  return {
+    value: resource.id as string,
+    label: getDisplayString(resource),
+    resource,
+  };
+}
+
 export function HeaderSearchInput(): JSX.Element {
   const { classes } = useStyles();
   const navigate = useNavigate();
   const medplum = useMedplum();
-  const [loadingPromise, setLoadingPromise] = useState<Promise<void> | undefined>();
-  const [data, setData] = useState<AutocompleteItem[]>([]);
+  const location = useLocation();
 
-  const currDataRef = useRef<AutocompleteItem[]>();
-  currDataRef.current = data;
-
-  async function loadData(input: string): Promise<void> {
-    const response = (await medplum.graphql(buildGraphQLQuery(input))) as SearchGraphQLResponse;
-    const resources = getResourcesFromResponse(response, input);
-    setData(resources.map((resource) => ({ value: getDisplayString(resource), resource })));
+  async function loadData(input: string, signal: AbortSignal): Promise<HeaderSearchTypes[]> {
+    const query = buildGraphQLQuery(input);
+    const options = { signal };
+    const response = (await medplum.graphql(query, undefined, undefined, options)) as SearchGraphQLResponse;
+    return getResourcesFromResponse(response, input);
   }
 
-  async function handleChange(input: string): Promise<void> {
-    const promise = loadData(input);
-    setLoadingPromise(promise);
-    await promise;
-    setLoadingPromise(undefined);
-  }
-
-  function handleSelect(item: AutocompleteItem): void {
-    setData([]);
-    navigate(`/${item.resource.resourceType}/${item.resource.id}`);
-  }
-
-  async function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): Promise<void> {
-    if (e.key === 'Enter') {
-      // If loading, wait for the next results
-      if (loadingPromise) {
-        await loadingPromise;
-      }
-
-      // Select the first result
-      if (currDataRef.current && currDataRef.current.length > 0) {
-        handleSelect(currDataRef.current[0]);
-      }
+  function handleSelect(item: HeaderSearchTypes[]): void {
+    if (item.length > 0) {
+      navigate(`/${getReferenceString(item[0])}`);
     }
   }
 
   return (
-    <Autocomplete
+    <AsyncAutocomplete
+      key={location.pathname}
       size="sm"
       radius="md"
       className={classes.searchInput}
       icon={<IconSearch size={16} />}
       placeholder="Search"
-      data={data}
       itemComponent={ItemComponent}
-      onChange={handleChange}
-      onItemSubmit={handleSelect}
-      onKeyDown={handleKeyDown}
-      rightSectionWidth={40}
-      rightSection={loadingPromise ? <Loader size={16} /> : null}
-      filter={() => true}
+      toKey={toKey}
+      toOption={toOption}
+      onChange={handleSelect}
+      loadOptions={loadData}
     />
   );
 }
 
-const ItemComponent = forwardRef<HTMLDivElement, any>(({ value, resource, ...others }: any, ref) => {
-  let helpText: string | undefined = undefined;
+const ItemComponent = forwardRef<HTMLDivElement, any>(
+  ({ resource, ...others }: AsyncAutocompleteOption<HeaderSearchTypes>, ref) => {
+    let helpText: string | undefined = undefined;
 
-  if (resource.resourceType === 'Patient') {
-    helpText = resource.birthDate;
-  } else if (resource.resourceType === 'ServiceRequest') {
-    helpText = resource.subject?.display;
+    if (resource.resourceType === 'Patient') {
+      helpText = resource.birthDate;
+    } else if (resource.resourceType === 'ServiceRequest') {
+      helpText = resource.subject?.display;
+    }
+
+    return (
+      <div ref={ref} {...others}>
+        <Group noWrap>
+          <ResourceAvatar value={resource} />
+          <div>
+            <Text>{getDisplayString(resource)}</Text>
+            <Text size="xs" color="dimmed">
+              {helpText}
+            </Text>
+          </div>
+        </Group>
+      </div>
+    );
   }
-
-  return (
-    <div ref={ref} {...others}>
-      <Group noWrap>
-        <ResourceAvatar value={resource} />
-        <div>
-          <Text>{value}</Text>
-          <Text size="xs" color="dimmed">
-            {helpText}
-          </Text>
-        </div>
-      </Group>
-    </div>
-  );
-});
+);
 
 function buildGraphQLQuery(input: string): string {
   const escaped = JSON.stringify(input);

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -1,0 +1,160 @@
+import { Loader, MultiSelect, MultiSelectProps, SelectItem } from '@mantine/core';
+import React, { useEffect, useRef, useState } from 'react';
+import { killEvent } from '../utils/dom';
+
+export interface AsyncAutocompleteOption<T> extends SelectItem {
+  resource: T;
+}
+
+export interface AsyncAutocompleteProps<T>
+  extends Omit<MultiSelectProps, 'data' | 'defaultValue' | 'loadOptions' | 'onChange' | 'onCreate' | 'searchable'> {
+  defaultValue?: T | T[];
+  toKey: (item: T) => string;
+  toOption: (item: T) => AsyncAutocompleteOption<T>;
+  loadOptions: (input: string, signal: AbortSignal) => Promise<T[]>;
+  onChange?: (item: T[]) => void;
+  onCreate?: (input: string) => T;
+}
+
+export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Element {
+  const { defaultValue, toKey, toOption, loadOptions, onChange, onCreate, ...rest } = props;
+  const defaultItems = defaultValue ? (Array.isArray(defaultValue) ? defaultValue : [defaultValue]) : [];
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [lastValue, setLastValue] = useState<string | undefined>(undefined);
+  const [timer, setTimer] = useState<number>();
+  const [abortController, setAbortController] = useState<AbortController>();
+  const [autoSubmit, setAutoSubmit] = useState<boolean>();
+  const [options, setOptions] = useState<AsyncAutocompleteOption<T>[]>(defaultItems?.map(toOption));
+
+  const lastValueRef = useRef<string>();
+  lastValueRef.current = lastValue;
+
+  const timerRef = useRef<number>();
+  timerRef.current = timer;
+
+  const abortControllerRef = useRef<AbortController>();
+  abortControllerRef.current = abortController;
+
+  const autoSubmitRef = useRef<boolean>();
+  autoSubmitRef.current = autoSubmit;
+
+  const optionsRef = useRef<AsyncAutocompleteOption<T>[]>();
+  optionsRef.current = options;
+
+  function handleSearchChange(): void {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      setAbortController(undefined);
+    }
+
+    if (timerRef.current !== undefined) {
+      window.clearTimeout(timerRef.current);
+    }
+
+    const newTimer = window.setTimeout(() => handleTimer(), 100);
+    setTimer(newTimer);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      if (!timerRef.current && !abortControllerRef.current) {
+        killEvent(e);
+        if (options.length > 0) {
+          setOptions(options.slice(0, 1));
+          handleChange([options[0].value]);
+        }
+      } else {
+        // The user pressed enter, but we don't have results yet.
+        // We need to wait for the results to come in.
+        setAutoSubmit(true);
+      }
+    }
+  }
+
+  /**
+   * Handles a timer tick event.
+   * If the contents of the input have changed, sends xhr to the server
+   * for updated contents.
+   */
+  function handleTimer(): void {
+    setTimer(undefined);
+
+    const value = inputRef.current?.value?.trim() || '';
+    if (value === lastValueRef.current) {
+      // Nothing has changed, move on
+      return;
+    }
+
+    setLastValue(value);
+
+    const newAbortController = new AbortController();
+    setAbortController(newAbortController);
+
+    loadOptions(value, newAbortController.signal)
+      .then((newValues: T[]) => {
+        if (!newAbortController.signal.aborted) {
+          setOptions(newValues.map(toOption));
+          setAbortController(undefined);
+          if (autoSubmitRef.current) {
+            if (newValues.length > 0) {
+              emitChange(newValues.slice(0, 1) as T[]);
+            }
+            setAutoSubmit(false);
+          }
+        }
+      })
+      .catch(console.log);
+  }
+
+  function handleChange(values: string[]): void {
+    if (onChange) {
+      const result: T[] = [];
+      for (const value of values) {
+        let item = optionsRef.current?.find((option) => option.value === value)?.resource;
+        if (!item) {
+          item = (onCreate as (input: string) => T)(value);
+        }
+        result.push(item);
+      }
+      emitChange(result);
+    }
+  }
+
+  function emitChange(selectedValues: T[]): void {
+    if (onChange) {
+      onChange(selectedValues);
+    }
+  }
+
+  function handleCreate(input: string): AsyncAutocompleteOption<T> {
+    const option = toOption((onCreate as (input: string) => T)(input));
+    setOptions([...(optionsRef.current as AsyncAutocompleteOption<T>[]), option]);
+    return option;
+  }
+
+  useEffect(() => {
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
+
+  return (
+    <MultiSelect
+      {...rest}
+      ref={inputRef}
+      defaultValue={defaultItems.map(toKey)}
+      searchable
+      onKeyDown={handleKeyDown}
+      onSearchChange={handleSearchChange}
+      data={options}
+      onFocus={handleTimer}
+      onChange={handleChange}
+      onCreate={handleCreate}
+      rightSectionWidth={40}
+      rightSection={abortController ? <Loader size={16} /> : null}
+      filter={(_value: string, selected: boolean) => !selected}
+    />
+  );
+}

--- a/packages/react/src/CodeInput/CodeInput.tsx
+++ b/packages/react/src/CodeInput/CodeInput.tsx
@@ -13,7 +13,8 @@ export interface CodeInputProps {
 export function CodeInput(props: CodeInputProps): JSX.Element {
   const [value, setValue] = useState<string | undefined>(props.defaultValue);
 
-  function handleChange(newValue: ValueSetExpansionContains | undefined): void {
+  function handleChange(newValues: ValueSetExpansionContains[]): void {
+    const newValue = newValues[0];
     const newCode = valueSetElementToCode(newValue);
     setValue(newCode);
     if (props.onChange) {
@@ -23,7 +24,7 @@ export function CodeInput(props: CodeInputProps): JSX.Element {
 
   return (
     <ValueSetAutocomplete
-      property={props.property}
+      elementDefinition={props.property}
       name={props.name}
       placeholder={props.placeholder}
       defaultValue={codeToValueSetElement(value)}

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
@@ -2,8 +2,8 @@ import { CodeableConcept, ElementDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { CodeableConceptInput } from './CodeableConceptInput';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { CodeableConceptInput } from './CodeableConceptInput';
 
 const statusProperty: ElementDefinition = {
   binding: {
@@ -91,10 +91,14 @@ describe('CodeableConceptInput', () => {
       fireEvent.change(input, { target: { value: 'XYZ' } });
     });
 
+    await waitFor(() => screen.getByText('+ Create XYZ'));
+
     // Press down arrow
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
-    });
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
+      });
+    }
 
     // Press "Enter"
     await act(async () => {
@@ -104,7 +108,6 @@ describe('CodeableConceptInput', () => {
     await waitFor(() => screen.getByText('XYZ'));
 
     expect(currValue).toMatchObject({
-      text: 'XYZ',
       coding: [
         {
           code: 'XYZ',

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
@@ -13,8 +13,8 @@ export interface CodeableConceptInputProps {
 export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Element {
   const [value, setValue] = useState<CodeableConcept | undefined>(props.defaultValue);
 
-  function handleChange(newValue: ValueSetExpansionContains | undefined): void {
-    const newConcept = newValue && valueSetElementToCodeableConcept(newValue);
+  function handleChange(newValues: ValueSetExpansionContains[]): void {
+    const newConcept = valueSetElementToCodeableConcept(newValues);
     setValue(newConcept);
     if (props.onChange) {
       props.onChange(newConcept);
@@ -23,7 +23,7 @@ export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Elem
 
   return (
     <ValueSetAutocomplete
-      property={props.property}
+      elementDefinition={props.property}
       name={props.name}
       placeholder={props.placeholder}
       defaultValue={value && codeableConceptToValueSetElement(value)}
@@ -32,23 +32,23 @@ export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Elem
   );
 }
 
-function codeableConceptToValueSetElement(concept: CodeableConcept): ValueSetExpansionContains {
-  return {
-    system: concept.coding?.[0]?.system,
-    code: concept.coding?.[0]?.code,
-    display: concept.coding?.[0]?.display,
-  };
+function codeableConceptToValueSetElement(concept: CodeableConcept): ValueSetExpansionContains[] | undefined {
+  return concept.coding?.map((c) => ({
+    system: c.system,
+    code: c.code,
+    display: c.display,
+  }));
 }
 
-function valueSetElementToCodeableConcept(element: ValueSetExpansionContains): CodeableConcept {
+function valueSetElementToCodeableConcept(elements: ValueSetExpansionContains[]): CodeableConcept | undefined {
+  if (elements.length === 0) {
+    return undefined;
+  }
   return {
-    text: element.display,
-    coding: [
-      {
-        system: element.system,
-        code: element.code,
-        display: element.display,
-      },
-    ],
+    coding: elements.map((e) => ({
+      system: e.system,
+      code: e.code,
+      display: e.display,
+    })),
   };
 }

--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -13,7 +13,8 @@ export interface CodingInputProps {
 export function CodingInput(props: CodingInputProps): JSX.Element {
   const [value, setValue] = useState<Coding | undefined>(props.defaultValue);
 
-  function handleChange(newValue: ValueSetExpansionContains | undefined): void {
+  function handleChange(newValues: ValueSetExpansionContains[]): void {
+    const newValue = newValues[0];
     const newConcept = newValue && valueSetElementToCoding(newValue);
     setValue(newConcept);
     if (props.onChange) {
@@ -23,7 +24,7 @@ export function CodingInput(props: CodingInputProps): JSX.Element {
 
   return (
     <ValueSetAutocomplete
-      property={props.property}
+      elementDefinition={props.property}
       name={props.name}
       placeholder={props.placeholder}
       defaultValue={value && codingToValueSetElement(value)}

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -1,102 +1,65 @@
-import { MultiSelect } from '@mantine/core';
 import { ElementDefinition, ValueSetExpansionContains } from '@medplum/fhirtypes';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
+import {
+  AsyncAutocomplete,
+  AsyncAutocompleteOption,
+  AsyncAutocompleteProps,
+} from '../AsyncAutocomplete/AsyncAutocomplete';
 import { useMedplum } from '../MedplumProvider/MedplumProvider';
 
-export interface ValueSetAutocompleteProps {
-  property: ElementDefinition;
-  name: string;
-  placeholder?: string;
-  defaultValue?: ValueSetExpansionContains;
-  onChange?: (value: ValueSetExpansionContains | undefined) => void;
+export interface ValueSetAutocompleteProps
+  extends Omit<AsyncAutocompleteProps<ValueSetExpansionContains>, 'loadOptions' | 'toKey' | 'toOption'> {
+  elementDefinition: ElementDefinition;
 }
 
-interface ValueSetAutocompleteItem {
-  value: string;
-  label: string;
-  element: ValueSetExpansionContains;
+function toKey(element: ValueSetExpansionContains): string {
+  return element.code as string;
 }
 
-function valueSetElementToAutocompleteItem(element: ValueSetExpansionContains): ValueSetAutocompleteItem {
+function toOption(element: ValueSetExpansionContains): AsyncAutocompleteOption<ValueSetExpansionContains> {
   return {
     value: element.code as string,
     label: getDisplay(element),
-    element,
+    resource: element,
+  };
+}
+
+function createValue(input: string): ValueSetExpansionContains {
+  return {
+    code: input,
+    display: input,
   };
 }
 
 export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Element {
   const medplum = useMedplum();
-  const { property, defaultValue } = props;
-  const [textValues, setTextValues] = useState<string[]>(defaultValue?.code ? [defaultValue.code as string] : []);
+  const { elementDefinition, ...rest } = props;
 
-  const [data, setData] = useState<ValueSetAutocompleteItem[]>(
-    defaultValue?.code ? [valueSetElementToAutocompleteItem(defaultValue)] : []
-  );
+  async function loadValues(input: string, signal: AbortSignal): Promise<ValueSetExpansionContains[]> {
+    const system = elementDefinition.binding?.valueSet as string;
+    const valueSet = await medplum.searchValueSet(system, input, { signal });
+    const valueSetElements = valueSet.expansion?.contains as ValueSetExpansionContains[];
+    const newData: ValueSetExpansionContains[] = [];
 
-  const dataRef = useRef<ValueSetAutocompleteItem[]>();
-  dataRef.current = data;
-
-  const loadValues = useCallback(
-    async (input: string): Promise<void> => {
-      const system = property.binding?.valueSet as string;
-      const valueSet = await medplum.searchValueSet(system, input);
-      const valueSetElements = valueSet.expansion?.contains as ValueSetExpansionContains[];
-      const newData = [...(dataRef.current as ValueSetAutocompleteItem[])];
-
-      for (const valueSetElement of valueSetElements) {
-        if (valueSetElement.code && !newData.some((item) => item.value === valueSetElement.code)) {
-          newData.push(valueSetElementToAutocompleteItem(valueSetElement));
-        }
-      }
-
-      setData(newData);
-    },
-    [medplum, property, dataRef]
-  );
-
-  function handleChange(values: string[]): void {
-    setTextValues(values);
-
-    const textValue = values[0];
-    let currentItem = undefined;
-    if (textValue) {
-      currentItem = (dataRef.current as ValueSetAutocompleteItem[]).find((item) => item.value === values[0]);
-      if (!currentItem) {
-        const newElement = { code: textValue, display: textValue };
-        currentItem = valueSetElementToAutocompleteItem(newElement);
-        setData([...(dataRef.current as ValueSetAutocompleteItem[]), currentItem]);
+    for (const valueSetElement of valueSetElements) {
+      if (valueSetElement.code && !newData.some((item) => item.code === valueSetElement.code)) {
+        newData.push(valueSetElement);
       }
     }
 
-    if (props.onChange) {
-      props.onChange(currentItem?.element);
-    }
+    return newData;
   }
 
-  useEffect(() => {
-    loadValues('').catch(console.log);
-  }, [loadValues]);
-
   return (
-    <MultiSelect
-      data={data}
-      placeholder={props.placeholder}
-      searchable
+    <AsyncAutocomplete
+      {...rest}
       creatable
       clearable
-      value={textValues}
-      filter={(value: string, selected: boolean, item: ValueSetAutocompleteItem) =>
-        !!(
-          textValues.length === 0 &&
-          !selected &&
-          (item.element.display?.toLowerCase().includes(value.toLowerCase().trim()) ||
-            item.element.code?.toLowerCase().includes(value.toLowerCase().trim()))
-        )
-      }
-      onChange={handleChange}
+      toKey={toKey}
+      toOption={toOption}
+      loadOptions={loadValues}
       getCreateLabel={(query) => `+ Create ${query}`}
-      onCreate={(query) => valueSetElementToAutocompleteItem({ code: query, display: query })}
+      onCreate={createValue}
     />
   );
 }

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { ElementDefinition, ValueSetExpansionContains } from '@medplum/fhirtypes';
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   AsyncAutocomplete,
   AsyncAutocompleteOption,
@@ -35,20 +35,23 @@ export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Elem
   const medplum = useMedplum();
   const { elementDefinition, ...rest } = props;
 
-  async function loadValues(input: string, signal: AbortSignal): Promise<ValueSetExpansionContains[]> {
-    const system = elementDefinition.binding?.valueSet as string;
-    const valueSet = await medplum.searchValueSet(system, input, { signal });
-    const valueSetElements = valueSet.expansion?.contains as ValueSetExpansionContains[];
-    const newData: ValueSetExpansionContains[] = [];
+  const loadValues = useCallback(
+    async (input: string, signal: AbortSignal): Promise<ValueSetExpansionContains[]> => {
+      const system = elementDefinition.binding?.valueSet as string;
+      const valueSet = await medplum.searchValueSet(system, input, { signal });
+      const valueSetElements = valueSet.expansion?.contains as ValueSetExpansionContains[];
+      const newData: ValueSetExpansionContains[] = [];
 
-    for (const valueSetElement of valueSetElements) {
-      if (valueSetElement.code && !newData.some((item) => item.code === valueSetElement.code)) {
-        newData.push(valueSetElement);
+      for (const valueSetElement of valueSetElements) {
+        if (valueSetElement.code && !newData.some((item) => item.code === valueSetElement.code)) {
+          newData.push(valueSetElement);
+        }
       }
-    }
 
-    return newData;
-  }
+      return newData;
+    },
+    [medplum, elementDefinition]
+  );
 
   return (
     <AsyncAutocomplete

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,7 @@
 export * from './AddressDisplay/AddressDisplay';
 export * from './AddressInput/AddressInput';
 export * from './AnnotationInput/AnnotationInput';
+export * from './AsyncAutocomplete/AsyncAutocomplete';
 export * from './AttachmentArrayDisplay/AttachmentArrayDisplay';
 export * from './AttachmentArrayInput/AttachmentArrayInput';
 export * from './AttachmentButton/AttachmentButton';


### PR DESCRIPTION
This fixes a few issues:

* Brings back `AbortSignal` support
  * This should fix the barcode scanner + enter bug
* Fixes data loading in `ValueSetAutocomplete` and derivatives (`CodeInput`, `CodingInput`, `CodeableConceptInput`)
* Eliminates unnecessary `$expand` requests on page load
* Mitigates unnecessary requests on fast data entry

Architecturally, this feels much cleaner, as it adds the missing layer between Mantine's `<Autocomplete>` and our custom data fetching autocomplete controls.

We should probably port `<ResourceInput>` in the same way.