### PR TITLE
**WARNING: SECURITY** [infra] Lets ECS reach ECR

### DIFF
--- a/packages/infra/src/backend.ts
+++ b/packages/infra/src/backend.ts
@@ -213,10 +213,16 @@ export class BackEnd extends Construct {
       },
     });
 
+    const taskDefinitionRole = new iam.Role(this, 'TaskDefinitionRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy')],
+    });
+
     // Task Definitions
     const taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDefinition', {
       memoryLimitMiB: config.serverMemory,
       cpu: config.serverCpu,
+      executionRole: taskDefinitionRole,
       taskRole: taskRole,
     });
 


### PR DESCRIPTION
**THIS PR HAS SECURITY IMPLICATIONS**

**PLEASE THOROUGHLY REVIEW TO DECIDE IF THIS IS SOMETHING YOU WANT IN YOUR INFRA**

This PR allows the ECS container and Fargate agents to access private Amazon ECR repositorys. This change allows the medplum ecs server `TaskDefinition` to point a private ecr repository in the account that hosts the ECS task. Currently if you try to do this, the ECS task creation will fail with an error saying that ECS could not connect to the ECR repository.

- This commit changes the main CDK backend construct to add an IAM Role with the `AmazonECSTaskExecutionRolePolicy` managed policy
- See this guide here for my motivation for adding this policy https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
- This policy provides the following permissions to the task creation agents

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "ecr:GetAuthorizationToken",
        "ecr:BatchCheckLayerAvailability",
        "ecr:GetDownloadUrlForLayer",
        "ecr:BatchGetImage",
        "logs:CreateLogStream",
        "logs:PutLogEvents"
      ],
      "Resource": "*"
    }
  ]
}
```

By default, CDK only provides permissions to create log streams and put log events.

## Motivation

- Allow people self-hosting Medplum on aws infra to use a private aws ecr image as their server image (currently this is not possible)

## Drawbacks

- Wider security surface area
- If this hasn't been a problem for hosted medplum infra so far, it isn't an issue for you