### PR TITLE
Use db cursors for reindex operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16809,6 +16809,16 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@types/pg-cursor": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.0.tgz",
+      "integrity": "sha512-4Milg/OUqTO2VuPvvRwPxaQTaiVb+bXvSK+ZCwiHjwinbD4/lPqV9AREg8sJAT0cy5ruY38aaajBc2FbdPaKcA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pg": "*"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -35328,6 +35338,14 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
+    "node_modules/pg-cursor": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.7.4.tgz",
+      "integrity": "sha512-CNWwOzTTZ9QvphoOL+Wg/7pmVr9GnAWBjPbuK2FRclrB4A/WRO/ssCJ9BlkzIGmmofK2M/LyokNHgsLSn+fMHA==",
+      "peerDependencies": {
+        "pg": "^8"
+      }
+    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -46775,6 +46793,7 @@
         "nodemailer": "6.8.0",
         "otplib": "12.0.1",
         "pg": "8.8.0",
+        "pg-cursor": "2.7.4",
         "ua-parser-js": "1.0.32",
         "validator": "13.7.0"
       },
@@ -46794,6 +46813,7 @@
         "@types/node": "18.11.9",
         "@types/nodemailer": "6.4.6",
         "@types/pg": "8.6.5",
+        "@types/pg-cursor": "2.7.0",
         "@types/set-cookie-parser": "2.4.2",
         "@types/supertest": "2.0.12",
         "@types/ua-parser-js": "0.7.36",
@@ -52532,6 +52552,7 @@
         "@types/node": "18.11.9",
         "@types/nodemailer": "6.4.6",
         "@types/pg": "8.6.5",
+        "@types/pg-cursor": "2.7.0",
         "@types/set-cookie-parser": "2.4.2",
         "@types/supertest": "2.0.12",
         "@types/ua-parser-js": "0.7.36",
@@ -52558,6 +52579,7 @@
         "openapi3-ts": "3.1.2",
         "otplib": "12.0.1",
         "pg": "8.8.0",
+        "pg-cursor": "2.7.4",
         "set-cookie-parser": "2.5.1",
         "supertest": "6.3.1",
         "ts-node-dev": "2.0.0",
@@ -60063,6 +60085,16 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "@types/pg-cursor": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@types/pg-cursor/-/pg-cursor-2.7.0.tgz",
+      "integrity": "sha512-4Milg/OUqTO2VuPvvRwPxaQTaiVb+bXvSK+ZCwiHjwinbD4/lPqV9AREg8sJAT0cy5ruY38aaajBc2FbdPaKcA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/pg": "*"
       }
     },
     "@types/prettier": {
@@ -74266,6 +74298,12 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "pg-cursor": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.7.4.tgz",
+      "integrity": "sha512-CNWwOzTTZ9QvphoOL+Wg/7pmVr9GnAWBjPbuK2FRclrB4A/WRO/ssCJ9BlkzIGmmofK2M/LyokNHgsLSn+fMHA==",
+      "requires": {}
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,6 +47,7 @@
     "nodemailer": "6.8.0",
     "otplib": "12.0.1",
     "pg": "8.8.0",
+    "pg-cursor": "2.7.4",
     "ua-parser-js": "1.0.32",
     "validator": "13.7.0"
   },
@@ -66,6 +67,7 @@
     "@types/node": "18.11.9",
     "@types/nodemailer": "6.4.6",
     "@types/pg": "8.6.5",
+    "@types/pg-cursor": "2.7.0",
     "@types/set-cookie-parser": "2.4.2",
     "@types/supertest": "2.0.12",
     "@types/ua-parser-js": "0.7.36",

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -590,13 +590,12 @@ export class Repository {
     }
 
     const client = getClient();
-    const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'id' });
+    const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.#addDeletedFilter(builder);
 
-    const rows = await builder.execute(client);
-    for (const { id } of rows) {
-      await this.reindexResource(resourceType, id);
-    }
+    await builder.executeCursor(client, async (row: any) => {
+      await this.#reindexResourceImpl(JSON.parse(row.content) as Resource);
+    });
   }
 
   /**
@@ -612,6 +611,17 @@ export class Repository {
     }
 
     const resource = await this.#readResourceImpl<T>(resourceType, id);
+    return this.#reindexResourceImpl(resource);
+  }
+
+  /**
+   * Internal implementation of reindexing a resource.
+   * This accepts a resource as a parameter, rather than a resource type and ID.
+   * When doing a bulk reindex, this will be more efficient because it avoids unnecessary reads.
+   * @param resource The resource.
+   * @returns The reindexed resource.
+   */
+  async #reindexResourceImpl<T extends Resource>(resource: T): Promise<T> {
     (resource.meta as Meta).compartment = this.#getCompartments(resource);
 
     // Note: We don't try/catch this because if connecting throws an exception.

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -630,8 +630,8 @@ export class Repository {
     const client = await getClient().connect();
     try {
       await client.query('BEGIN');
-      await this.#writeResource(client, resource as T);
-      await this.#writeLookupTables(client, resource as T);
+      await this.#writeResource(client, resource);
+      await this.#writeLookupTables(client, resource);
       await client.query('COMMIT');
     } catch (err) {
       await client.query('ROLLBACK');
@@ -640,7 +640,7 @@ export class Repository {
       client.release();
     }
 
-    return resource as T;
+    return resource;
   }
 
   /**


### PR DESCRIPTION
Context: The FHIR server has a "reindex all" operation that exhaustively reindexes all resources of a certain resource type. This can be run when there are significant changes to indexing logic.

Before: The reindex process used a simple single `SELECT` query to get all resources.  That's impractical when there are 100k+ resources in a single table.

After: The reindex process uses a Postgres cursor to operate in smaller batches.