### PR TITLE
Fixes #1250 - client credentials refresh

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2,6 +2,7 @@ import { Bundle, Patient, SearchParameter, StructureDefinition } from '@medplum/
 import { webcrypto } from 'crypto';
 import PdfPrinter from 'pdfmake';
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
+import { URLSearchParams } from 'url';
 import { TextEncoder } from 'util';
 import { MedplumClient, NewPatientRequest, NewProjectRequest, NewUserRequest } from './client';
 import { ProfileResource, stringify } from './utils';
@@ -122,10 +123,14 @@ function mockFetch(url: string, options: any): Promise<any> {
     };
   } else if (method === 'POST' && url.endsWith('oauth2/token')) {
     if (canRefresh) {
+      let clientId = defaultOptions.clientId;
+      if (options.body && options.body.get) {
+        clientId = options.body.get('client_id') || defaultOptions.clientId;
+      }
       result = {
         status: 200,
-        access_token: 'header.' + window.btoa(stringify({ client_id: defaultOptions.clientId })) + '.signature',
-        refresh_token: 'header.' + window.btoa(stringify({ client_id: defaultOptions.clientId })) + '.signature',
+        access_token: 'header.' + window.btoa(stringify({ client_id: clientId })) + '.signature',
+        refresh_token: 'header.' + window.btoa(stringify({ client_id: clientId })) + '.signature',
       };
     } else {
       result = {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -403,6 +403,10 @@ describe('Client', () => {
     const client = new MedplumClient(defaultOptions);
     const result1 = await client.startClientLogin('test-client-id', 'test-client-secret');
     expect(result1).toBeDefined();
+
+    tokenExpired = true;
+    const result2 = await client.get('expired');
+    expect(result2).toBeDefined();
   });
 
   test('HTTP GET', async () => {
@@ -437,7 +441,7 @@ describe('Client', () => {
     await expect(client.processCode(loginResponse.code as string)).rejects.toThrow('Failed to fetch tokens');
 
     const result = client.get('expired');
-    await expect(result).rejects.toThrow('Invalid refresh token');
+    await expect(result).rejects.toThrow('Unauthenticated');
     expect(onUnauthenticated).toBeCalled();
   });
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2031,6 +2031,9 @@ export class MedplumClient extends EventTarget {
    * @returns Promise that resolves to the client profile.
    */
   async startClientLogin(clientId: string, clientSecret: string): Promise<ProfileResource> {
+    this.#clientId = clientId;
+    this.#clientSecret = clientSecret;
+
     const formBody = new URLSearchParams();
     formBody.set('grant_type', 'client_credentials');
     formBody.set('client_id', clientId);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -411,11 +411,12 @@ export class MedplumClient extends EventTarget {
   readonly #requestCache: LRUCache<RequestCacheEntry>;
   readonly #cacheTime: number;
   readonly #baseUrl: string;
-  readonly #clientId: string;
   readonly #authorizeUrl: string;
   readonly #tokenUrl: string;
   readonly #logoutUrl: string;
   readonly #onUnauthenticated?: () => void;
+  #clientId?: string;
+  #clientSecret?: string;
   #accessToken?: string;
   #refreshToken?: string;
   #refreshPromise?: Promise<any>;
@@ -1930,16 +1931,15 @@ export class MedplumClient extends EventTarget {
    * @param contentType The content type of the original request.
    * @param body The body of the original request.
    */
-  async #handleUnauthenticated(method: string, url: string, options: RequestInit): Promise<any> {
-    return this.#refresh()
-      .then(() => this.#request(method, url, options))
-      .catch((error) => {
-        this.clear();
-        if (this.#onUnauthenticated) {
-          this.#onUnauthenticated();
-        }
-        return Promise.reject(error);
-      });
+  #handleUnauthenticated(method: string, url: string, options: RequestInit): Promise<any> {
+    if (this.#refresh()) {
+      return this.#request(method, url, options);
+    }
+    this.clear();
+    if (this.#onUnauthenticated) {
+      this.#onUnauthenticated();
+    }
+    return Promise.reject(new Error('Unauthenticated'));
   }
 
   /**
@@ -1969,7 +1969,7 @@ export class MedplumClient extends EventTarget {
     const url = new URL(this.#authorizeUrl);
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('state', sessionStorage.getItem('pkceState') as string);
-    url.searchParams.set('client_id', this.#clientId);
+    url.searchParams.set('client_id', this.#clientId as string);
     url.searchParams.set('redirect_uri', getBaseUrl());
     url.searchParams.set('code_challenge_method', 'S256');
     url.searchParams.set('code_challenge', sessionStorage.getItem('codeChallenge') as string);
@@ -1984,7 +1984,7 @@ export class MedplumClient extends EventTarget {
   processCode(code: string): Promise<ProfileResource> {
     const formBody = new URLSearchParams();
     formBody.set('grant_type', 'authorization_code');
-    formBody.set('client_id', this.#clientId);
+    formBody.set('client_id', this.#clientId as string);
     formBody.set('code', code);
     formBody.set('redirect_uri', getBaseUrl());
 
@@ -2000,22 +2000,26 @@ export class MedplumClient extends EventTarget {
    * Tries to refresh the auth tokens.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens
    */
-  async #refresh(): Promise<void> {
+  #refresh(): Promise<void> | undefined {
     if (this.#refreshPromise) {
       return this.#refreshPromise;
     }
 
-    if (!this.#refreshToken) {
-      this.clear();
-      throw new Error('Invalid refresh token');
+    if (this.#refreshToken) {
+      const formBody = new URLSearchParams();
+      formBody.set('grant_type', 'refresh_token');
+      formBody.set('client_id', this.#clientId as string);
+      formBody.set('refresh_token', this.#refreshToken);
+      this.#refreshPromise = this.#fetchTokens(formBody);
+      return this.#refreshPromise;
     }
 
-    const formBody = new URLSearchParams();
-    formBody.set('grant_type', 'refresh_token');
-    formBody.set('client_id', this.#clientId);
-    formBody.set('refresh_token', this.#refreshToken);
-    this.#refreshPromise = this.#fetchTokens(formBody);
-    await this.#refreshPromise;
+    if (this.#clientId && this.#clientSecret) {
+      this.#refreshPromise = this.startClientLogin(this.#clientId, this.#clientSecret);
+      return this.#refreshPromise;
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -93,7 +93,6 @@ async function handleClientCredentials(req: Request, res: Response): Promise<voi
     authTime: new Date().toISOString(),
     granted: true,
     scope,
-    refreshSecret: generateSecret(32),
   });
 
   await sendTokenResponse(res, login, membership);


### PR DESCRIPTION
Consider:

```ts
    const medplum = new MedplumClient({ fetch });
    await medplum.startClientLogin(MY_CLIENT_ID, MY_CLIENT_SECRET);
```

Before: After running for more than an hour, it stops working.

After:  It automatically "refreshes" with client ID and secret.  Behind the scenes, it uses `client_credentials` flow, not `refresh_token`.

Also, `client_credentials` no longer includes refresh tokens.  This was incorrect, and is explicitly forbidden in the spec:
* https://www.rfc-editor.org/rfc/rfc6749#section-4.4.3
* https://community.auth0.com/t/how-to-get-refresh-token-with-client-credentials/7028
* https://stackoverflow.com/questions/43340580/oauth-client-credential-flow-refresh-tokens