### PR TITLE
Interim solution for system|code token search

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -6,6 +6,7 @@ import {
   Bundle,
   BundleEntry,
   Communication,
+  DiagnosticReport,
   Encounter,
   Observation,
   OperationOutcome,
@@ -2130,5 +2131,34 @@ describe('FHIR Repo', () => {
     const provenanceEntry = searchResult.entry?.find((entry) => entry.resource?.resourceType === 'Provenance');
     expect(provenanceEntry).toBeDefined();
     expect(provenanceEntry?.search?.mode).toEqual('include');
+  });
+
+  test('DiagnosticReport category with system', async () => {
+    const code = randomUUID();
+    const dr = await systemRepo.createResource<DiagnosticReport>({
+      resourceType: 'DiagnosticReport',
+      status: 'final',
+      code: { coding: [{ code }] },
+      category: [{ coding: [{ system: 'http://loinc.org', code: 'LP217198-3' }] }],
+    });
+
+    const bundle = await systemRepo.search({
+      resourceType: 'DiagnosticReport',
+      filters: [
+        {
+          code: 'code',
+          operator: Operator.EQUALS,
+          value: code,
+        },
+        {
+          code: 'category',
+          operator: Operator.EQUALS,
+          value: 'http://loinc.org|LP217198-3',
+        },
+      ],
+      count: 1,
+    });
+
+    expect(bundleContains(bundle, dr)).toBeTruthy();
   });
 });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1080,7 +1080,12 @@ export class Repository {
     const column = new Column(resourceType, details.columnName);
     const expressions = [];
     for (const valueStr of filter.value.split(',')) {
-      const value = details.type === SearchParameterType.BOOLEAN ? valueStr === 'true' : valueStr;
+      let value: string | boolean = valueStr;
+      if (details.type === SearchParameterType.BOOLEAN) {
+        value = valueStr === 'true';
+      } else if (valueStr.includes('|')) {
+        value = valueStr.split('|').pop() as string;
+      }
       if (details.array) {
         expressions.push(new Condition(column, Operator.ARRAY_CONTAINS, value));
       } else if (filter.operator === FhirOperator.CONTAINS) {


### PR DESCRIPTION
Searching for `DiagnosticReport?category=system|code` is currently broken.

The full correct solution is here: https://github.com/medplum/medplum/pull/891 but it is currently blocked on a backwards compat issue for a live customer.  It should be shipped by end of year.

This PR includes an interim solution.  It is ***not*** spec correct, but it is more correct than the current state.