### PR TITLE
Add "Category" and "Status" fields to the DiagnosticReportDisplay component

### DIFF
--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -349,6 +349,7 @@ export const HomerMedia: Media = {
 export const HomerObservation1: Observation = {
   resourceType: 'Observation',
   id: '1',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -362,6 +363,7 @@ export const HomerObservation1: Observation = {
 export const HomerObservation2: Observation = {
   resourceType: 'Observation',
   id: '2',
+  status: 'corrected',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -385,6 +387,7 @@ export const HomerObservation2: Observation = {
 export const HomerObservation3: Observation = {
   resourceType: 'Observation',
   id: '3',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -408,6 +411,7 @@ export const HomerObservation3: Observation = {
 export const HomerObservation4: Observation = {
   resourceType: 'Observation',
   id: '4',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -442,6 +446,7 @@ export const HomerObservation4: Observation = {
 export const HomerObservation5: Observation = {
   resourceType: 'Observation',
   id: '5',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -460,6 +465,7 @@ export const HomerObservation5: Observation = {
 export const HomerObservation6: Observation = {
   resourceType: 'Observation',
   id: '6',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -488,6 +494,7 @@ export const HomerObservation6: Observation = {
 export const HomerObservation7: Observation = {
   resourceType: 'Observation',
   id: '7',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',
@@ -520,6 +527,7 @@ export const HomerObservation7: Observation = {
 export const HomerObservation8: Observation = {
   resourceType: 'Observation',
   id: '8',
+  status: 'final',
   subject: {
     reference: 'Patient/123',
     display: 'Homer Simpson',

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
@@ -1,9 +1,11 @@
 import { HomerDiagnosticReport } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { DiagnosticReportDisplay } from './DiagnosticReportDisplay';
 import { Document } from '../Document/Document';
-
+import { CreatinineObservation, ExampleReport } from '../stories/referenceLab';
+import { useMedplum } from '../MedplumProvider/MedplumProvider';
+import { createReference } from '@medplum/core';
 export default {
   title: 'Medplum/DiagnosticReportDisplay',
   component: DiagnosticReportDisplay,
@@ -14,3 +16,29 @@ export const Simple = (): JSX.Element => (
     <DiagnosticReportDisplay value={HomerDiagnosticReport} />
   </Document>
 );
+
+export const WithCategories = (): JSX.Element => {
+  const medplum = useMedplum();
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    (async (): Promise<boolean> => {
+      const obs = await medplum.createResource(CreatinineObservation);
+      ExampleReport.result = [createReference(obs)];
+      await medplum.updateResource(ExampleReport);
+      return true;
+    })()
+      .then(setLoaded)
+      .catch(console.log);
+  }, [medplum]);
+
+  if (!loaded) {
+    return <></>;
+  }
+
+  return (
+    <Document>
+      <DiagnosticReportDisplay value={ExampleReport} />
+    </Document>
+  );
+};

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
@@ -1,10 +1,12 @@
+import { createReference } from '@medplum/core';
 import { DiagnosticReport } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport, MockClient } from '@medplum/mock';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { DiagnosticReportDisplay, DiagnosticReportDisplayProps } from './DiagnosticReportDisplay';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { CreatinineObservation, ExampleReport } from '../stories/referenceLab';
+import { DiagnosticReportDisplay, DiagnosticReportDisplayProps } from './DiagnosticReportDisplay';
 
 const syntheaReport: DiagnosticReport = {
   resourceType: 'DiagnosticReport',
@@ -88,6 +90,9 @@ describe('DiagnosticReportDisplay', () => {
     expect(screen.getByText('Specimen lipemic. Results may be affected.', { exact: false })).toBeDefined();
     expect(screen.getByText('Critical high')).toBeInTheDocument();
     expect(screen.getByText('Critical high')).toHaveStyle('background:');
+    expect(screen.getAllByText('final')).toHaveLength(7);
+    expect(screen.getAllByText('corrected')).toHaveLength(1);
+    screen.getAllByText('final').forEach((badge) => expect(badge).toHaveClass('mantine-Badge-inner'));
   });
 
   test('Renders by reference', async () => {
@@ -108,5 +113,16 @@ describe('DiagnosticReportDisplay', () => {
     });
     expect(screen.getByText('Diagnostic Report')).toBeDefined();
     expect(screen.getByText('Hello world')).toBeDefined();
+  });
+
+  test('Renders observation category', async () => {
+    const obs = await medplum.createResource(CreatinineObservation);
+    ExampleReport.result = [createReference(obs)];
+    await medplum.updateResource(ExampleReport);
+    await act(async () => {
+      setup({ value: ExampleReport });
+    });
+    expect(screen.getByText('Diagnostic Report')).toBeDefined();
+    expect(screen.getByText('Day 2')).toBeDefined();
   });
 });

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -12,6 +12,7 @@ import { CodeableConceptDisplay } from '../CodeableConceptDisplay/CodeableConcep
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { RangeDisplay } from '../RangeDisplay/RangeDisplay';
 import { ResourceBadge } from '../ResourceBadge/ResourceBadge';
+import { StatusBadge } from '../StatusBadge/StatusBadge';
 import { useResource } from '../useResource/useResource';
 
 const useStyles = createStyles((theme) => ({
@@ -44,6 +45,7 @@ export interface DiagnosticReportDisplayProps {
 export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JSX.Element | null {
   const diagnosticReport = useResource(props.value);
   const specimen = useResource(diagnosticReport?.specimen?.[0]);
+
   if (!diagnosticReport) {
     return null;
   }
@@ -125,6 +127,8 @@ export function ObservationTable(props: ObservationTableProps): JSX.Element {
           <th>Value</th>
           <th>Reference Range</th>
           <th>Interpretation</th>
+          <th>Category</th>
+          <th>Status</th>
         </tr>
       </thead>
       <tbody>
@@ -167,6 +171,18 @@ function ObservationRow(props: ObservationRowProps): JSX.Element | null {
           <CodeableConceptDisplay value={observation.interpretation[0]} />
         )}
       </td>
+      <td>
+        {observation.category && observation.category.length > 0 && (
+          <ul>
+            {observation.category.map((concept) => (
+              <li>
+                <CodeableConceptDisplay value={concept} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </td>
+      <td>{observation.status && <StatusBadge status={observation.status} />}</td>
     </tr>
   );
 }

--- a/packages/react/src/StatusBadge/StatusBadge.tsx
+++ b/packages/react/src/StatusBadge/StatusBadge.tsx
@@ -9,7 +9,7 @@ import React from 'react';
  * draft, active, retired, unknown
  *
  * Observation status: https://www.hl7.org/fhir/valueset-observation-status.html
- * registered, preliminary, final, amended, cancelled, entered-in-error, unknown
+ * registered, preliminary, final, amended,  corrected, cancelled, entered-in-error, unknown
  *
  * DiagnosticReport status: https://hl7.org/fhir/valueset-diagnostic-report-status.html
  * registered, preliminary, final, amended, corrected, appended, cancelled, entered-in-error, unknown
@@ -34,6 +34,7 @@ const statusToColor: Record<string, DefaultMantineColor> = {
   preliminary: 'blue',
   final: 'green',
   amended: 'yellow',
+  corrected: 'yellow',
   cancelled: 'red',
   requested: 'blue',
   received: 'blue',

--- a/packages/react/src/stories/referenceLab.ts
+++ b/packages/react/src/stories/referenceLab.ts
@@ -1,4 +1,5 @@
-import { ObservationDefinition } from '@medplum/fhirtypes';
+import { createReference } from '@medplum/core';
+import { DiagnosticReport, Observation, ObservationDefinition } from '@medplum/fhirtypes';
 
 export const TestosteroneDefinition: ObservationDefinition = {
   resourceType: 'ObservationDefinition',
@@ -552,4 +553,100 @@ export const HDLDefinition: ObservationDefinition = {
       },
     },
   ],
+};
+
+export const CreatinineObservation: Observation = {
+  id: 'obs-1',
+  resourceType: 'Observation',
+  status: 'final',
+  category: [{ text: 'Kidney' }, { text: 'Day 2' }],
+  code: {
+    coding: [
+      {
+        system: 'https://intranet.aumc.nl/labtestcodes',
+        code: '20005',
+        display: 'Creatinine(Serum)',
+      },
+    ],
+  },
+  subject: {
+    reference: 'Patient/f201',
+    display: 'Roel',
+  },
+  issued: '2013-04-04T14:34:00+01:00',
+  performer: [
+    {
+      reference: 'Practitioner/f202',
+      display: 'Luigi Maas',
+    },
+  ],
+  valueQuantity: {
+    value: 122,
+    unit: 'umol/L',
+    system: 'http://snomed.info/sct',
+    code: '258814008',
+  },
+  interpretation: [
+    {
+      coding: [
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation',
+          code: 'H',
+        },
+      ],
+    },
+  ],
+  referenceRange: [
+    {
+      low: {
+        value: 64,
+      },
+      high: {
+        value: 104,
+      },
+      type: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/referencerange-meaning',
+            code: 'normal',
+            display: 'Normal Range',
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const ExampleReport: DiagnosticReport = {
+  resourceType: 'DiagnosticReport',
+  id: 'report-1',
+  status: 'final',
+  category: [
+    {
+      coding: [
+        {
+          system: 'http://snomed.info/sct',
+          code: '15220000',
+          display: 'Laboratory test',
+        },
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/v2-0074',
+          code: 'LAB',
+        },
+      ],
+    },
+  ],
+  subject: {
+    reference: 'Patient/f201',
+    display: 'Roel',
+  },
+  issued: '2013-03-11T10:28:00+01:00',
+  performer: [
+    {
+      reference: 'Organization/f201',
+      display: 'AUMC',
+    },
+  ],
+  result: [createReference(CreatinineObservation)],
+  conclusion: 'All observations within normal limits',
 };


### PR DESCRIPTION
This PR adds two new columns to DiagnosticReportDisplay - "Category" and "status". 

These were requested by a customer, to make it easier for their lab team to finalize lab results without having to click on each individual observation. 