### PR TITLE
Read Provenance by ID

### DIFF
--- a/packages/server/src/fhir/provenance.ts
+++ b/packages/server/src/fhir/provenance.ts
@@ -1,0 +1,40 @@
+import { createReference, ProfileResource } from '@medplum/core';
+import { Provenance, Reference, Resource } from '@medplum/fhirtypes';
+
+/**
+ * Returns a derived Provenance resource for the given resource.
+ *
+ * Provenance
+ * https://www.hl7.org/fhir/provenance.html
+ *
+ * Resource Profile: US Core Provenance Profile
+ * https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-provenance.html
+ *
+ * @param resource The input resource.
+ * @returns The derived Provenance resource.
+ */
+export function resourceToProvenance(resource: Resource): Provenance {
+  const result: Provenance = {
+    resourceType: 'Provenance',
+    // id: `${resource.resourceType}-${resource.id}-${resource.meta?.versionId}`,
+    id: `${resource.resourceType}-${resource.id}`,
+    target: [createReference(resource)],
+    recorded: resource.meta?.lastUpdated,
+    agent: [
+      {
+        who: resource.meta?.author as Reference<ProfileResource> | undefined,
+        onBehalfOf: resource.meta?.account as Reference<ProfileResource> | undefined,
+        type: {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/provenance-participant-type',
+              code: 'author',
+            },
+          ],
+        },
+      },
+    ],
+  };
+  // console.log('GENERATE PROVENANCE', JSON.stringify(result, null, 2));
+  return result;
+}

--- a/packages/server/src/fhir/provenance.ts
+++ b/packages/server/src/fhir/provenance.ts
@@ -14,9 +14,8 @@ import { Provenance, Reference, Resource } from '@medplum/fhirtypes';
  * @returns The derived Provenance resource.
  */
 export function resourceToProvenance(resource: Resource): Provenance {
-  const result: Provenance = {
+  return {
     resourceType: 'Provenance',
-    // id: `${resource.resourceType}-${resource.id}-${resource.meta?.versionId}`,
     id: `${resource.resourceType}-${resource.id}`,
     target: [createReference(resource)],
     recorded: resource.meta?.lastUpdated,
@@ -35,6 +34,4 @@ export function resourceToProvenance(resource: Resource): Provenance {
       },
     ],
   };
-  // console.log('GENERATE PROVENANCE', JSON.stringify(result, null, 2));
-  return result;
 }

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -11,6 +11,7 @@ import {
   Observation,
   OperationOutcome,
   Patient,
+  Provenance,
   Questionnaire,
   QuestionnaireResponse,
   ResourceType,
@@ -2114,6 +2115,12 @@ describe('FHIR Repo', () => {
     const provenanceEntry = searchResult.entry?.find((entry) => entry.resource?.resourceType === 'Provenance');
     expect(provenanceEntry).toBeDefined();
     expect(provenanceEntry?.search?.mode).toEqual('include');
+
+    const provenance = provenanceEntry?.resource as Provenance;
+    expect(provenance.id).toBeDefined();
+
+    const check = await systemRepo.readResource('Provenance', provenance.id as string);
+    expect(check).toBeDefined();
   });
 
   test('DiagnosticReport category with system', async () => {

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -47,7 +47,7 @@ export const logger = {
   },
 
   logAuditEvent(auditEvent: AuditEvent): void {
-    if (process.env.NODE_ENV !== 'test') {
+    if (process.env.NODE_ENV !== 'test' && Date.now() < 0) {
       console.log(JSON.stringify(auditEvent));
     }
   },

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -47,7 +47,7 @@ export const logger = {
   },
 
   logAuditEvent(auditEvent: AuditEvent): void {
-    if (process.env.NODE_ENV !== 'test' && Date.now() < 0) {
+    if (process.env.NODE_ENV !== 'test') {
       console.log(JSON.stringify(auditEvent));
     }
   },


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/1134 we introduced initial support for `_revinclude=Provenance:target`

There were a couple of shortcomings of the first implementation:
- The `Provenance` resources did not include an `id` property
- Obviously without an `id`, you could not read back the `Provenance` by ID
- `Provenance.agent` did not conform the the US Core Profile: https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-provenance.html

This PR fixes those.

Reading by ID requires some extra discussion.  These are derived/synthetic `Provenance` resources.  They are not in the database.  So, to enable this feature, we establish the convention of `Provenance` with `id` in the format `{resourceType}-{id}` is a Provenance for that resource.

For example, if you have `Patient/123` then the derived/synthetic Provenance would be `Provenance/Patient-123`.

This does not prevent users from using `Provenance` resources as normal.  You can still create, read, update, delete, and search for `Provenance` resources like normal.