### PR TITLE
Change typescript target to ES2020

### DIFF
--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "es6",
     "outDir": "dist/esm"
   },
   "exclude": ["**/*.test.ts"]

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "es6",
     "outDir": "dist/esm"
   },
   "exclude": ["**/*.test.ts", "**/*.test.tsx"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "ES2020",
     "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react",


### PR DESCRIPTION
This eliminates the `tslib` shim layer, which appears to cause problems with vitest.