### PR TITLE
Only set meta.account on resource creation

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -473,11 +473,9 @@ export class Repository {
       resultMeta.project = project;
     }
 
-    if (create) {
-      const account = await this.#getAccount(existing, updated);
-      if (account) {
-        resultMeta.account = account;
-      }
+    const account = await this.#getAccount(existing, updated, create);
+    if (account) {
+      resultMeta.account = account;
     }
 
     resultMeta.compartment = this.#getCompartments(result);
@@ -1595,15 +1593,19 @@ export class Repository {
    * @param resource The FHIR resource.
    * @returns
    */
-  async #getAccount(existing: Resource | undefined, updated: Resource): Promise<Reference | undefined> {
+  async #getAccount(
+    existing: Resource | undefined,
+    updated: Resource,
+    create: boolean
+  ): Promise<Reference | undefined> {
     const account = updated.meta?.account;
     if (account && this.#canWriteMeta()) {
       // If the user specifies an account, allow it if they have permission.
       return account;
     }
 
-    if (this.#context.accessPolicy?.compartment) {
-      // If the user access policy specifies a comparment, then use it as the account.
+    if (create && this.#context.accessPolicy?.compartment) {
+      // If the user access policy specifies a compartment, then use it as the account.
       return this.#context.accessPolicy?.compartment;
     }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -473,9 +473,11 @@ export class Repository {
       resultMeta.project = project;
     }
 
-    const account = await this.#getAccount(existing, updated);
-    if (account) {
-      resultMeta.account = account;
+    if (create) {
+      const account = await this.#getAccount(existing, updated);
+      if (account) {
+        resultMeta.account = account;
+      }
     }
 
     resultMeta.compartment = this.#getCompartments(result);


### PR DESCRIPTION
Previously, the `meta.account` property could be overwritten on every resource update. This caused some problems with a customer, where a customer service update of a resource overwrote the account of a patient, hiding visibility from downstream clients. 

This PR implements what is probably the more correct default behavior. The `meta.account` property is only updated when a resource is created, and then persists throughout updates