### PR TITLE
Fixes #1379 - Node.js 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # It depends on medplum-server.tar.gz which is created by scripts/deploy-server.sh.
 # This is a production ready image.
 # It does not include any development dependencies.
-FROM node:16-slim
+FROM node:18-slim
 ENV NODE_ENV production
 WORKDIR /usr/src/medplum
 ADD ./medplum-server.tar.gz ./

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "engines": {
     "npm": ">=8.0.0",
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "build": "turbo run build",

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -19,7 +19,7 @@ import { sendOutcome } from '../outcomes';
 import { Repository, systemRepo } from '../repo';
 import { isBotEnabled } from './execute';
 
-const LAMBDA_RUNTIME = 'nodejs16.x';
+const LAMBDA_RUNTIME = 'nodejs18.x';
 
 const LAMBDA_HANDLER = 'index.handler';
 

--- a/scripts/deploy-bot-layer.sh
+++ b/scripts/deploy-bot-layer.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ -z "${BOT_LAYER_NAME}" ]]; then
+  echo "BOT_LAYER_NAME is missing"
+  exit 1
+fi
+
+
 # Fail on error
 set -e
 
@@ -37,10 +43,10 @@ zip -r -q medplum-bot-layer.zip .
 # Publish the bot layer
 aws lambda publish-layer-version \
   --region us-east-1 \
-  --layer-name "medplum-bot-layer" \
+  --layer-name "$BOT_LAYER_NAME" \
   --description "Medplum Bot Layer" \
   --license-info "Apache-2.0" \
-  --compatible-runtimes "nodejs16.x" \
+  --compatible-runtimes "nodejs18.x" \
   --zip-file fileb://medplum-bot-layer.zip
 
 # Pop back to original directory


### PR DESCRIPTION
Node 16 (our current target) is no longer the "Active LTS", and is in "Maintenance LTS".  Node 16 will end-of-life in September 2023.

Node 18 was initially released in April 2022, and was promoted to "Active LTS" in October 2022.  It will remain the "Active LTS" version until October 2023, and will continue to receive maintenance until April 2025.

https://nodejs.dev/en/about/releases/

AWS released Node 18 support in Nov 2022: https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/

There are actually 3 separate "upgrade" decision points:
1. Server
2. AWS Lambda Bot Layer
3. Medplum CLI tools

All client side libs (`@medplum/core`, `@medplum/react`, etc) should be unaffected.

Reasons to upgrade:
* General good hygiene
* Node 18 includes `fetch` support, so we can drop the `node-fetch` dependency

Reasons not to upgrade (yet):
* It will be a burden for anyone who wants to stick with older versions
* For Medplum CLI in particular, this could be a breaking change