### PR TITLE
Fixes #1328 - Added getExtension() helper function

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -14,6 +14,7 @@ import {
   getDateProperty,
   getDisplayString,
   getExtensionValue,
+  getExtension,
   getIdentifier,
   getImageSrc,
   getQuestionnaireAnswers,
@@ -296,6 +297,27 @@ describe('Core Utils', () => {
     };
     expect(getExtensionValue(resource, 'http://example.com')).toBe('xyz');
     expect(getExtensionValue(resource, 'http://example.com', 'key1')).toBe('value1');
+  });
+
+  test('Get extension object', () => {
+    const resource: Patient = {
+      resourceType: 'Patient',
+      extension: [
+        {
+          url: 'http://example.com',
+          valueString: 'xyz',
+          extension: [
+            {
+              url: 'key1',
+              valueString: 'value1',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getExtension(resource, 'http://example.com')).toBe(resource?.extension?.[0]);
+    expect(getExtension(resource, 'http://example.com', 'key1')).toBe(resource?.extension?.[0]?.extension?.[0]);
   });
 
   test('Stringify', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -307,6 +307,24 @@ export function getExtensionValue(resource: any, ...urls: string[]): string | un
 }
 
 /**
+ * Returns an extension by extension URLs.
+ * @param resource The base resource.
+ * @param urls Array of extension URLs. Each entry represents a nested extension.
+ * @returns The extension object if found; undefined otherwise.
+ */
+export function getExtension(resource: any, ...urls: string[]): Extension | undefined {
+  // Let curr be the current resource or extension. Extensions can be nested.
+  let curr: any = resource;
+
+  // For each of the urls, try to find a matching nested extension.
+  for (let i = 0; i < urls.length && curr; i++) {
+    curr = (curr?.extension as Extension[] | undefined)?.find((e) => e.url === urls[i]);
+  }
+
+  return curr as Extension | undefined;
+}
+
+/**
  * FHIR JSON stringify.
  * Removes properties with empty string values.
  * Removes objects with zero properties.


### PR DESCRIPTION
Added a helper function for retrieving a nested FHIR Extension based on a collection of nested string URLs (based on the existing getExtensionValue() function) and a supporting unit test.