### PR TITLE
Add server config option for logging AuditEvents

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -171,7 +171,7 @@ describe('Super Admin routes', () => {
       .set('Authorization', 'Bearer ' + nonAdminAccessToken)
       .type('json')
       .send({
-        resourceType: 'Patient',
+        resourceType: 'PaymentNotice',
       });
 
     expect(res.status).toBe(403);
@@ -183,7 +183,7 @@ describe('Super Admin routes', () => {
       .set('Authorization', 'Bearer ' + adminAccessToken)
       .type('json')
       .send({
-        resourceType: 'Patient',
+        resourceType: 'PaymentNotice',
       });
 
     expect(res.status).toBe(200);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -62,6 +62,7 @@ describe('App', () => {
   });
 
   test('Internal Server Error', async () => {
+    console.log = jest.fn();
     const app = express();
     app.get('/throw', () => {
       throw new Error('Error');
@@ -71,6 +72,7 @@ describe('App', () => {
     const res = await request(app).get('/throw');
     expect(res.status).toBe(500);
     expect(res.body).toMatchObject({ msg: 'Internal Server Error' });
+    expect(console.log).toHaveBeenCalled();
     await shutdownApp();
   });
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -31,6 +31,7 @@ export interface MedplumServerConfig {
   allowedOrigins?: string;
   botLambdaRoleArn: string;
   botLambdaLayerName: string;
+  logAuditEvents?: boolean;
 }
 
 /**

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,4 +1,5 @@
 import { AuditEvent } from '@medplum/fhirtypes';
+import { getConfig } from './config';
 
 /*
  * Once upon a time, we used Winston, and that was fine.
@@ -16,7 +17,7 @@ export enum LogLevel {
 }
 
 export const logger = {
-  level: process.env.NODE_ENV === 'test' ? LogLevel.NONE : LogLevel.INFO,
+  level: process.env.NODE_ENV === 'test' ? LogLevel.ERROR : LogLevel.INFO,
 
   error(...args: any[]): void {
     if (logger.level >= LogLevel.ERROR) {
@@ -47,7 +48,7 @@ export const logger = {
   },
 
   logAuditEvent(auditEvent: AuditEvent): void {
-    if (process.env.NODE_ENV !== 'test') {
+    if (getConfig().logAuditEvents) {
       console.log(JSON.stringify(auditEvent));
     }
   },

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -2,7 +2,6 @@ import { resolveId, unauthorized } from '@medplum/core';
 import { ClientApplication, Login, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response } from 'express';
 import { getRepoForLogin, systemRepo } from '../fhir/repo';
-import { logger } from '../logger';
 import { MedplumAccessTokenClaims, verifyJwt } from './keys';
 import { getClientApplicationMembership, timingSafeEqualStr } from './utils';
 
@@ -44,7 +43,6 @@ async function authenticateBearerToken(req: Request, res: Response, token: strin
     const membership = await systemRepo.readReference<ProjectMembership>(login.membership);
     await setupLocals(req, res, login, membership);
   } catch (err) {
-    logger.error('verify error', err);
     throw unauthorized;
   }
 }


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/1025 we started logging AuditEvents for all RESTful operations.  That is an important feature for regulated prod environments.  It was way too noisy for dev environments.  I found myself frequently manually disabling it by commenting it out.  This PR makes it a server config setting.

It also cleans up a couple other cases of logs leaking during tests.