### PR TITLE
Babel config cleanup

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,8 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"],
-  "plugins": [
-    ["@babel/plugin-proposal-class-properties"],
-    ["@babel/plugin-transform-react-jsx"],
-    ["@babel/plugin-transform-runtime"]
-  ]
+  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,6 @@
       ],
       "devDependencies": {
         "@babel/core": "7.20.12",
-        "@babel/plugin-proposal-class-properties": "7.18.6",
-        "@babel/plugin-syntax-dynamic-import": "7.8.3",
-        "@babel/plugin-transform-react-jsx": "7.20.7",
-        "@babel/plugin-transform-regenerator": "7.20.5",
-        "@babel/plugin-transform-runtime": "7.19.6",
         "@babel/preset-env": "7.20.2",
         "@babel/preset-react": "7.18.6",
         "@babel/preset-typescript": "7.18.6",
@@ -59,9 +54,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
-      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.2.tgz",
+      "integrity": "sha512-Fx6tYjk2wKUgLi8uMANZr8GNZx05u44ArIJldn9VxLvolzlJVgHbTUCbwhMd6bcYky178+WUSxPHO3DAtGLWpw==",
       "dev": true
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -18654,9 +18649,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/bonjour-service": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.0.14.tgz",
-      "integrity": "sha512-HIMbgLnk1Vqvs6B4Wq5ep7mxvj9sGz5d1JJyDNSGNIdA/w2MCz6GTjWTdjqOJV1bEPj+6IkxDvWNFKEBxNt4kQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
+      "integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
       "dev": true,
       "dependencies": {
         "array-flatten": "^2.1.2",
@@ -19635,9 +19630,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001442",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+      "version": "1.0.30001444",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
+      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
       "dev": true,
       "funding": [
         {
@@ -20668,9 +20663,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/copy-concurrently": {
@@ -22877,19 +22872,20 @@
       "dev": true
     },
     "node_modules/es-get-iterator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.0",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.1.0",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
         "is-map": "^2.0.2",
         "is-set": "^2.0.2",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -23596,9 +23592,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-1.13.0.tgz",
+      "integrity": "sha512-GTgHqxvbQbNoUfkbdgHMVTY3bXVRJUWkfWEImZ2TPjln6nFlsYvu2fIVGWQmsa3qQ1ck0HwGq8OhS0wPCnsjMw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -24346,9 +24342,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -25217,9 +25213,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -26513,9 +26509,9 @@
       }
     },
     "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -30651,9 +30647,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -32642,9 +32638,9 @@
       }
     },
     "node_modules/npm-check-updates/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -33528,9 +33524,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -37473,9 +37469,9 @@
       "dev": true
     },
     "node_modules/resolve.exports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
+      "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -39926,6 +39922,18 @@
       "integrity": "sha512-3H20QlwQsSm2OvAxWIYhs+j01MzzqwMwGiiO1NQaJYZgJZFPuAbf95/DiKRBSTYIJ2FeGUc+B/6mPGcWP9dO3Q==",
       "dev": true
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/store2": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
@@ -41633,9 +41641,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -45295,9 +45303,9 @@
   },
   "dependencies": {
     "@adobe/css-tools": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
-      "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.2.tgz",
+      "integrity": "sha512-Fx6tYjk2wKUgLi8uMANZr8GNZx05u44ArIJldn9VxLvolzlJVgHbTUCbwhMd6bcYky178+WUSxPHO3DAtGLWpw==",
       "dev": true
     },
     "@algolia/autocomplete-core": {
@@ -59938,9 +59946,9 @@
       }
     },
     "bonjour-service": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.0.14.tgz",
-      "integrity": "sha512-HIMbgLnk1Vqvs6B4Wq5ep7mxvj9sGz5d1JJyDNSGNIdA/w2MCz6GTjWTdjqOJV1bEPj+6IkxDvWNFKEBxNt4kQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
+      "integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
       "dev": true,
       "requires": {
         "array-flatten": "^2.1.2",
@@ -60726,9 +60734,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001442",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+      "version": "1.0.30001444",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
+      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
       "dev": true
     },
     "capture-exit": {
@@ -61506,9 +61514,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "copy-concurrently": {
@@ -63229,19 +63237,20 @@
       "dev": true
     },
     "es-get-iterator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-      "integrity": "sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.0",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.1.0",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
         "is-map": "^2.0.2",
         "is-set": "^2.0.2",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       }
     },
     "es-module-lexer": {
@@ -63756,9 +63765,9 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-1.13.0.tgz",
+      "integrity": "sha512-GTgHqxvbQbNoUfkbdgHMVTY3bXVRJUWkfWEImZ2TPjln6nFlsYvu2fIVGWQmsa3qQ1ck0HwGq8OhS0wPCnsjMw==",
       "dev": true
     },
     "etag": {
@@ -64372,9 +64381,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+          "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -64984,9 +64993,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+          "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -65991,9 +66000,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+          "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -69112,9 +69121,9 @@
       }
     },
     "marked": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true
     },
     "md5.js": {
@@ -70654,9 +70663,9 @@
           "dev": true
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+          "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -71340,9 +71349,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -74265,9 +74274,9 @@
       "dev": true
     },
     "resolve.exports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
+      "integrity": "sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==",
       "dev": true
     },
     "responselike": {
@@ -76240,6 +76249,15 @@
       "integrity": "sha512-3H20QlwQsSm2OvAxWIYhs+j01MzzqwMwGiiO1NQaJYZgJZFPuAbf95/DiKRBSTYIJ2FeGUc+B/6mPGcWP9dO3Q==",
       "dev": true
     },
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "requires": {
+        "internal-slot": "^1.0.4"
+      }
+    },
     "store2": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
@@ -77511,9 +77529,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
+          "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -15,11 +15,6 @@
   ],
   "devDependencies": {
     "@babel/core": "7.20.12",
-    "@babel/plugin-proposal-class-properties": "7.18.6",
-    "@babel/plugin-syntax-dynamic-import": "7.8.3",
-    "@babel/plugin-transform-react-jsx": "7.20.7",
-    "@babel/plugin-transform-regenerator": "7.20.5",
-    "@babel/plugin-transform-runtime": "7.19.6",
     "@babel/preset-env": "7.20.2",
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.18.6",

--- a/packages/cli/babel.config.json
+++ b/packages/cli/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/packages/core/babel.config.json
+++ b/packages/core/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/packages/definitions/babel.config.json
+++ b/packages/definitions/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/packages/generator/babel.config.json
+++ b/packages/generator/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/packages/infra/babel.config.json
+++ b/packages/infra/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/packages/mock/babel.config.json
+++ b/packages/mock/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }

--- a/packages/react/babel.config.json
+++ b/packages/react/babel.config.json
@@ -1,8 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"],
-  "plugins": [
-    ["@babel/plugin-proposal-class-properties"],
-    ["@babel/plugin-transform-react-jsx"],
-    ["@babel/plugin-transform-runtime"]
-  ]
+  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
 }

--- a/packages/server/babel.config.json
+++ b/packages/server/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"],
-  "plugins": [["@babel/plugin-proposal-class-properties"], ["@babel/plugin-transform-runtime"]]
+  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
 }


### PR DESCRIPTION
This removes some Babel plugins that are no longer necessary, and in some cases pure negatives:

- `@babel/plugin-proposal-class-properties` - not using anymore
- `@babel/plugin-syntax-dynamic-import` - not using anymore
- `@babel/plugin-transform-react-jsx` - included automatically with `@babel/preset-react`
- `@babel/plugin-transform-regenerator` - all compile targets now include `await` support, so no longer necessary
- `@babel/plugin-transform-runtime` - all compile targets now include `await` support, so no longer necessary

`@babel/plugin-transform-regenerator` in particular made stack traces much bigger and much uglier.  Every `await` call introduced multiple unnecessary lines in the stack trace, which affects both runtime performance and dev experience.  Much cleaner now.