### PR TITLE
Server config default values

### DIFF
--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -13,7 +13,7 @@ import { logger } from '../logger';
  * @param options The MailComposer options.
  */
 export async function sendEmail(options: Mail.Options): Promise<void> {
-  const sesClient = new SESv2Client({ region: 'us-east-1' });
+  const sesClient = new SESv2Client({ region: getConfig().awsRegion });
   const fromAddress = getConfig().supportEmail;
   const toAddresses = buildAddresses(options.to);
   const ccAddresses = buildAddresses(options.cc);

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -106,7 +106,7 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
     return;
   }
 
-  const client = new LambdaClient({ region: 'us-east-1' });
+  const client = new LambdaClient({ region: getConfig().awsRegion });
   const name = `medplum-bot-lambda-${bot.id}`;
 
   // By default, use the code on the bot

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -110,6 +110,7 @@ export async function isBotEnabled(bot: Bot): Promise<boolean> {
  */
 async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionResult> {
   const { bot, runAs, input, contentType } = request;
+  const config = getConfig();
 
   // Create the Login resource
   const login = await systemRepo.createResource<Login>({
@@ -134,10 +135,10 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
   const project = await systemRepo.readResource<Project>('Project', bot.meta?.project as string);
   const secrets = Object.fromEntries(project.secret?.map((secret) => [secret.name, secret]) || []);
 
-  const client = new LambdaClient({ region: 'us-east-1' });
+  const client = new LambdaClient({ region: config.awsRegion });
   const name = `medplum-bot-lambda-${bot.id}`;
   const payload = {
-    baseUrl: getConfig().baseUrl,
+    baseUrl: config.baseUrl,
     accessToken,
     input: input instanceof Hl7Message ? input.toString() : input,
     contentType,

--- a/packages/server/src/fhir/storage.test.ts
+++ b/packages/server/src/fhir/storage.test.ts
@@ -3,12 +3,17 @@ import { Upload } from '@aws-sdk/lib-storage';
 import { Binary } from '@medplum/fhirtypes';
 import { Request } from 'express';
 import internal, { Readable } from 'stream';
+import { loadTestConfig } from '../config';
 import { getBinaryStorage, initBinaryStorage } from './storage';
 
 jest.mock('@aws-sdk/client-s3');
 jest.mock('@aws-sdk/lib-storage');
 
 describe('Storage', () => {
+  beforeAll(async () => {
+    await loadTestConfig();
+  });
+
   beforeEach(() => {
     (S3Client as unknown as jest.Mock).mockClear();
     (Upload as unknown as jest.Mock).mockClear();

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -4,6 +4,7 @@ import { Binary } from '@medplum/fhirtypes';
 import { createReadStream, createWriteStream, existsSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
 import { Readable } from 'stream';
+import { getConfig } from '../config';
 
 let binaryStorage: BinaryStorage | undefined = undefined;
 
@@ -97,7 +98,7 @@ class S3Storage implements BinaryStorage {
   readonly #bucket: string;
 
   constructor(bucket: string) {
-    this.#client = new S3Client({ region: 'us-east-1' });
+    this.#client = new S3Client({ region: getConfig().awsRegion });
     this.#bucket = bucket;
   }
 


### PR DESCRIPTION
Many of the server config settings are easily derived from other values.  This commit adds default values where possible.

It also adds support for an "awsRegion" setting.  This is still highly experimental, so it is recommended to leave it as the default value of "us-east-1".