### PR TITLE
Fixed loading AWS config settings outside of us-east-1

### DIFF
--- a/packages/server/src/__mocks__/@aws-sdk/client-secrets-manager.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-secrets-manager.ts
@@ -1,0 +1,15 @@
+export class GetSecretValueCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class SecretsManagerClient {
+  async send(command: any): Promise<any> {
+    if (command instanceof GetSecretValueCommand) {
+      return {
+        SecretString: JSON.stringify({ host: 'host', port: 123 }),
+      };
+    }
+
+    return undefined;
+  }
+}

--- a/packages/server/src/__mocks__/@aws-sdk/client-ssm.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-ssm.ts
@@ -1,0 +1,23 @@
+export class GetParametersByPathCommand {
+  constructor(public readonly input: any) {}
+}
+
+export class SSMClient {
+  async send(command: any): Promise<any> {
+    if (command instanceof GetParametersByPathCommand) {
+      if (command.input.Path === 'test') {
+        return {
+          Parameters: [
+            { Name: 'baseUrl', Value: 'https://www.example.com/' },
+            { Name: 'DatabaseSecrets', Value: 'DatabaseSecretsArn' },
+            { Name: 'RedisSecrets', Value: 'RedisSecretsArn' },
+            { Name: 'port', Value: '8080' },
+          ],
+        };
+      }
+      throw new Error('Parameters not found');
+    }
+
+    return undefined;
+  }
+}

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -75,7 +75,7 @@ export function getConfig(): MedplumServerConfig {
  * @returns The loaded configuration.
  */
 export async function loadConfig(configName: string): Promise<MedplumServerConfig> {
-  const [configType, configPath] = configName.split(':', 2);
+  const [configType, configPath] = splitOnce(configName, ':');
   switch (configType) {
     case 'file':
       cachedConfig = await loadFileConfig(configPath);
@@ -124,7 +124,7 @@ async function loadFileConfig(path: string): Promise<MedplumServerConfig> {
 async function loadAwsConfig(path: string): Promise<MedplumServerConfig> {
   let region = DEFAULT_AWS_REGION;
   if (path.includes(':')) {
-    [region, path] = path.split(':', 2);
+    [region, path] = splitOnce(path, ':');
   }
 
   const client = new SSMClient({ region });
@@ -194,4 +194,9 @@ function addDefaults(config: MedplumServerConfig): MedplumServerConfig {
   config.awsRegion = config.awsRegion || DEFAULT_AWS_REGION;
   config.botLambdaLayerName = config.botLambdaLayerName || 'medplum-bot-layer';
   return config;
+}
+
+function splitOnce(value: string, delimiter: string): [string, string] {
+  const index = value.indexOf(delimiter);
+  return [value.substring(0, index), value.substring(index + 1)];
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -86,7 +86,8 @@ export async function loadConfig(configName: string): Promise<MedplumServerConfi
     default:
       throw new Error('Unrecognized config type: ' + configType);
   }
-  return addDefaults(cachedConfig);
+  cachedConfig = addDefaults(cachedConfig);
+  return cachedConfig;
 }
 
 /**


### PR DESCRIPTION
Fixed loading AWS config settings outside of us-east-1

The standard Medplum Docker image takes one parameter: a string that represents where to load config settings.

The string can either start with "file:" for a config file on the local file system, or "aws:" for AWS Parameter Store params.

Before, the "aws:" code path always assumed us-east-1.  Then we introduced partial support for "aws:region:" for outside of us-east-1.  Unfortunately there was an untested bug in how the string split works.

This PR fixes the string parse and adds testing.