### PR TITLE
Enable custom AWS lambda function names

### DIFF
--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -858,6 +858,17 @@
             }]
           },
           {
+            "id" : "Bot.identifier",
+            "path" : "Bot.identifier",
+            "short" : "An identifier for this bot",
+            "definition" : "An identifier for this bot.",
+            "min" : 0,
+            "max" : "*",
+            "type" : [{
+              "code" : "Identifier"
+            }]
+          },
+          {
             "id" : "Bot.name",
             "path" : "Bot.name",
             "definition" : "A name associated with the Bot.",

--- a/packages/fhirtypes/dist/Bot.d.ts
+++ b/packages/fhirtypes/dist/Bot.d.ts
@@ -4,6 +4,7 @@
  */
 
 import { Attachment } from './Attachment';
+import { Identifier } from './Identifier';
 import { Meta } from './Meta';
 
 /**
@@ -41,6 +42,11 @@ export interface Bot {
    * The base language in which the resource is written.
    */
   language?: string;
+
+  /**
+   * An identifier for this bot.
+   */
+  identifier?: Identifier[];
 
   /**
    * A name associated with the Bot.

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -32,6 +32,7 @@ export interface MedplumServerConfig {
   awsRegion: string;
   botLambdaRoleArn: string;
   botLambdaLayerName: string;
+  botCustomFunctionsEnabled?: boolean;
   logAuditEvents?: boolean;
 }
 

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -191,7 +191,7 @@ describe('Execute', () => {
     const customBot: Bot = {
       resourceType: 'Bot',
       id: '456',
-      identifier: [{ system: 'https://medplum.com/custom-function', value: 'custom' }],
+      identifier: [{ system: 'https://medplum.com/bot-external-function-id', value: 'custom' }],
     };
 
     expect(getLambdaFunctionName(normalBot)).toEqual('medplum-bot-lambda-123');

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -4,8 +4,9 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { registerNew } from '../../auth/register';
-import { loadTestConfig } from '../../config';
+import { getConfig, loadTestConfig } from '../../config';
 import { initTestAuth } from '../../test.setup';
+import { getLambdaFunctionName } from './execute';
 
 const app = express();
 let accessToken: string;
@@ -182,5 +183,24 @@ describe('Execute', () => {
       .send({});
     expect(res3.status).toBe(400);
     expect(res3.body.issue[0].details.text).toEqual('Bots not enabled');
+  });
+
+  test('Get function name', async () => {
+    const config = getConfig();
+    const normalBot: Bot = { resourceType: 'Bot', id: '123' };
+    const customBot: Bot = {
+      resourceType: 'Bot',
+      id: '456',
+      identifier: [{ system: 'https://medplum.com/custom-function', value: 'custom' }],
+    };
+
+    expect(getLambdaFunctionName(normalBot)).toEqual('medplum-bot-lambda-123');
+    expect(getLambdaFunctionName(customBot)).toEqual('medplum-bot-lambda-456');
+
+    // Temporarily enable custom bot support
+    config.botCustomFunctionsEnabled = true;
+    expect(getLambdaFunctionName(normalBot)).toEqual('medplum-bot-lambda-123');
+    expect(getLambdaFunctionName(customBot)).toEqual('custom');
+    config.botCustomFunctionsEnabled = false;
   });
 });

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -1,5 +1,5 @@
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
-import { badRequest, createReference, Hl7Message, resolveId } from '@medplum/core';
+import { badRequest, createReference, getIdentifier, Hl7Message, resolveId } from '@medplum/core';
 import { AuditEvent, Bot, Login, Organization, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { TextDecoder, TextEncoder } from 'util';
@@ -181,9 +181,9 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
  */
 export function getLambdaFunctionName(bot: Bot): string {
   if (getConfig().botCustomFunctionsEnabled) {
-    const customFunction = bot.identifier?.find((id) => id.system === 'https://medplum.com/custom-function');
+    const customFunction = getIdentifier(bot, 'https://medplum.com/bot-external-function-id');
     if (customFunction) {
-      return customFunction.value as string;
+      return customFunction;
     }
   }
 

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -136,7 +136,7 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
   const secrets = Object.fromEntries(project.secret?.map((secret) => [secret.name, secret]) || []);
 
   const client = new LambdaClient({ region: config.awsRegion });
-  const name = `medplum-bot-lambda-${bot.id}`;
+  const name = getLambdaFunctionName(bot);
   const payload = {
     baseUrl: config.baseUrl,
     accessToken,
@@ -170,6 +170,25 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
       logResult: (err as Error).message,
     };
   }
+}
+
+/**
+ * Returns the AWS Lambda function name for the given bot.
+ * By default, the function name is based on the bot ID.
+ * If the bot has a custom function, and the server allows it, then that is used instead.
+ * @param bot The Bot resource.
+ * @returns The AWS Lambda function name.
+ */
+export function getLambdaFunctionName(bot: Bot): string {
+  if (getConfig().botCustomFunctionsEnabled) {
+    const customFunction = bot.identifier?.find((id) => id.system === 'https://medplum.com/custom-function');
+    if (customFunction) {
+      return customFunction.value as string;
+    }
+  }
+
+  // By default, use the bot ID as the Lambda function name
+  return `medplum-bot-lambda-${bot.id}`;
 }
 
 /**


### PR DESCRIPTION
Note that we will not enable this on Medplum's hosted offering.  This should only ever be enabled in self-hosted environments.