### PR TITLE
updated readme for selfhosting

### DIFF
--- a/packages/docs/docs/self-hosting/install-on-ubuntu.md
+++ b/packages/docs/docs/self-hosting/install-on-ubuntu.md
@@ -107,7 +107,7 @@ git clone https://github.com/medplum/medplum.git
 Run the build script
 
 ```bash
-./scripts/build.sh
+cd medplum && ./scripts/build.sh
 ```
 
 (This will take a while.  It downloads all dependencies, performs a full build, and runs all tests.)


### PR DESCRIPTION
after cloning the repo the user should first cd into the medplum directory, otherwise the command ./scripts/build.sh will fail