### PR TITLE
Gracefully handle database disconnect

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config';
+import { getClient } from './database';
 
 describe('App', () => {
   test('Get HTTP config', async () => {
@@ -73,6 +74,21 @@ describe('App', () => {
     expect(res.status).toBe(500);
     expect(res.body).toMatchObject({ msg: 'Internal Server Error' });
     expect(console.log).toHaveBeenCalled();
+    await shutdownApp();
+  });
+
+  test('Database disconnect', async () => {
+    const app = express();
+    const config = await loadTestConfig();
+    await initApp(app, config);
+
+    // Mock database disconnect
+    // Error should be logged, but should not crash the server
+    console.log = jest.fn();
+    const error = new Error('Mock database disconnect');
+    getClient().emit('error', error);
+    expect(console.log).toHaveBeenCalledWith('ERROR', expect.anything(), 'Database connection error', error);
+
     await shutdownApp();
   });
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -21,6 +21,10 @@ export async function initDatabase(config: MedplumDatabaseConfig): Promise<void>
     password: config.password,
   });
 
+  pool.on('error', (err) => {
+    logger.error('Database connection error', err);
+  });
+
   let client: PoolClient | undefined;
   try {
     client = await pool.connect();

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -48,6 +48,10 @@ jest.mock('pg', () => {
       return (await this.connect()).query(sql);
     }
 
+    on(): void {
+      // Nothing to do
+    }
+
     end(): void {
       // Nothing to do
     }


### PR DESCRIPTION
Before, a database disconnect caused an unrecoverable failure.

After, you can repeatedly stop and restart Postgres, and the server gracefully reconnects.