### PR TITLE
Fixes #1332 - Multi-platform Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - uses: docker/setup-buildx-action@v2
       - name: Build Project
         run: ./scripts/build.sh
         env:
@@ -65,9 +66,6 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Login to Amazon ECR
-        if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
-        uses: aws-actions/amazon-ecr-login@v1
       - name: Login to Docker Hub
         if: github.repository == 'medplum/medplum' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@
 # It depends on medplum-server.tar.gz which is created by scripts/deploy-server.sh.
 # This is a production ready image.
 # It does not include any development dependencies.
+
+# Builds multiarch docker images
+# https://docs.docker.com/build/building/multi-platform/
+# https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
+
+# Supported architectures:
+# linux/amd64, linux/arm64, linux/arm/v7
+# https://github.com/docker-library/official-images#architectures-other-than-amd64
+
 FROM node:18-slim
 ENV NODE_ENV production
 WORKDIR /usr/src/medplum

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "root",
+  "version": "2.0.1",
   "engines": {
     "npm": ">=8.0.0",
     "node": ">=18.0.0"

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -45,3 +45,30 @@ npm run dev
 npm run build
 ```
 
+## Docker
+
+Medplum recommends Docker images for production deployment.
+
+The `../scripts/deploy-server.sh` script does the following:
+
+1. Creates a `.tar.gz` file with all files necessary to seed the Docker image
+2. Runs `docker build` to build the Docker images
+3. Runs `docker
+
+#### Troubleshooting
+
+Medplum uses the `buildx` command, which is currently an "experimental" Docker feature.
+
+First, make sure that experimental features are enabled.
+
+You may encounter the following error:
+
+```
+ERROR: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
+```
+
+If so, create a new multiarch driver:
+
+```bash
+docker buildx create --name multiarch --driver docker-container --use
+```


### PR DESCRIPTION
Enables "multi arch" / "multi platform" Docker images

After, new architectures will be available on Docker Hub:

![image](https://user-images.githubusercontent.com/749094/216841102-ed47fd24-debb-45ee-971d-54463d29b817.png)

This only downside is that this is slower than a single architecture (adds about 5 min to deploy).

Currently building "linux/amd64, linux/arm64, linux/arm/v7".  We could also build "linux/ppc64le" and/or "linux/s390x", as Node supports them, but that seems unnecessary and speculative.  Easy to change later too.

See:

- https://docs.docker.com/build/building/multi-platform/
- https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/

Other drive-by fixes:
- Removed ECR deploys, which we have not used for over 2 months
- Excluded ".cjs.map" and ".mjs.map" sourcemap files from Docker images (we already excluded ".js.map")
- Use single command for Docker "build and push"
- Additional Docker tag for "version" (in addition to "latest" and git sha)