### PR TITLE
Enable RDS Performance Insights

### DIFF
--- a/packages/infra/src/backend.ts
+++ b/packages/infra/src/backend.ts
@@ -76,6 +76,7 @@ export class BackEnd extends Construct {
           subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
         },
         instanceType: config.rdsInstanceType ? new ec2.InstanceType(config.rdsInstanceType) : undefined,
+        enablePerformanceInsights: true,
       },
       backup: {
         retention: Duration.days(7),


### PR DESCRIPTION
https://aws.amazon.com/rds/performance-insights/

> Amazon RDS Performance Insights is a database performance tuning and monitoring feature that helps you quickly assess the load on your database, and determine when and where to take action. Performance Insights allows non-experts to detect performance problems with an easy-to-understand dashboard that visualizes database load.

This enables the default Performance Insights configuration of 7 days logging.  No extra cost from AWS.