### PR TITLE
Set status on 0-item QuestionnaireForm

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -240,6 +240,31 @@ describe('QuestionnaireForm', () => {
     expect(answers['q6']).toMatchObject({ valueString: 'initial answer' });
   });
 
+  test('Handles submit (empty)', async () => {
+    const onSubmit = jest.fn();
+
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+      },
+      onSubmit,
+    });
+
+    expect(screen.getByTestId('questionnaire-form')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('OK'));
+    });
+
+    expect(onSubmit).toBeCalled();
+
+    const response = onSubmit.mock.calls[0][0];
+    expect(response.resourceType).toBe('QuestionnaireResponse');
+    expect(response.status).toBe('completed');
+    expect(response.authored).toBeDefined();
+    expect(response.source).toBeDefined();
+  });
+
   each([
     [QuestionnaireItemType.decimal, 'number', '123.456'],
     [QuestionnaireItemType.integer, 'number', '123'],

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -66,7 +66,6 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
   function setItems(newResponseItems: QuestionnaireResponseItem[]): void {
     const newResponse: QuestionnaireResponse = {
       resourceType: 'QuestionnaireResponse',
-      status: 'completed',
       item: newResponseItems,
     };
     setResponse(newResponse);
@@ -88,6 +87,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
             subject: props.subject,
             source: createReference(source as ProfileResource),
             authored: new Date().toISOString(),
+            status: 'completed',
           });
         }
       }}


### PR DESCRIPTION
There was a small bug where the `status` element of the QuestionnaireResponse would not be set on 0-item questionnaires, since `onChange` would never be triggered. 

This only affects projects in "strict mode", which delayed detection of this issue. 