### PR TITLE
Disable scroll wheel on quantity input

### DIFF
--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -31,7 +31,7 @@ export const ScrollWheelDisabled = (): JSX.Element => (
   <Document>
     <QuantityInput
       name="demo"
-      disableScroll
+      disableWheel
       defaultValue={{
         value: 2,
         unit: 'ng',

--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -33,7 +33,7 @@ export const ScrollWheelDisabled = (): JSX.Element => (
       name="demo"
       disableWheel
       defaultValue={{
-        value: 2,
+        value: 2.2,
         unit: 'ng',
       }}
     />

--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -1,0 +1,41 @@
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { Document } from '../Document/Document';
+import { QuantityInput } from './QuantityInput';
+
+export default {
+  title: 'Medplum/QuantityInput',
+  component: QuantityInput,
+} as Meta;
+
+export const Example = (): JSX.Element => (
+  <Document>
+    <QuantityInput name="demo" />
+  </Document>
+);
+
+export const DefaultValue = (): JSX.Element => (
+  <Document>
+    <QuantityInput
+      name="demo"
+      defaultValue={{
+        value: 10,
+        comparator: '<',
+        unit: 'mg',
+      }}
+    />
+  </Document>
+);
+
+export const ScrollWheelDisabled = (): JSX.Element => (
+  <Document>
+    <QuantityInput
+      name="demo"
+      disableScroll
+      defaultValue={{
+        value: 2,
+        unit: 'ng',
+      }}
+    />
+  </Document>
+);

--- a/packages/react/src/QuantityInput/QuantityInput.test.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.test.tsx
@@ -64,11 +64,11 @@ describe('QuantityInput', () => {
     expect(lastValue).toMatchObject({ comparator: '<', value: 123, unit: 'mg' });
   });
 
-  test('Set value with scroll', async () => {
+  test('Set value with wheel', async () => {
     render(<QuantityInput name="a" defaultValue={{ value: 2.3, unit: 'ng' }} />);
 
     const valueInput = screen.getByPlaceholderText('Value');
-    fireEvent.scroll(valueInput, {
+    fireEvent.wheel(valueInput, {
       deltaY: 100,
     });
     fireEvent.change(valueInput, {
@@ -76,5 +76,16 @@ describe('QuantityInput', () => {
     });
 
     expect(valueInput).toHaveValue(2.4);
+  });
+
+  test('Disable wheel', async () => {
+    render(<QuantityInput name="a" disableWheel defaultValue={{ value: 2.3, unit: 'ng' }} />);
+
+    const valueInput = screen.getByPlaceholderText('Value');
+
+    fireEvent.wheel(valueInput, {
+      deltaY: 100,
+    });
+    expect(valueInput).toHaveValue(2.3);
   });
 });

--- a/packages/react/src/QuantityInput/QuantityInput.test.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.test.tsx
@@ -63,4 +63,18 @@ describe('QuantityInput', () => {
     expect(lastValue).toBeDefined();
     expect(lastValue).toMatchObject({ comparator: '<', value: 123, unit: 'mg' });
   });
+
+  test('Set value with scroll', async () => {
+    render(<QuantityInput name="a" defaultValue={{ value: 2.3, unit: 'ng' }} />);
+
+    const valueInput = screen.getByPlaceholderText('Value');
+    fireEvent.scroll(valueInput, {
+      deltaY: 100,
+    });
+    fireEvent.change(valueInput, {
+      target: { value: '2.4' },
+    });
+
+    expect(valueInput).toHaveValue(2.4);
+  });
 });

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -6,12 +6,11 @@ export interface QuantityInputProps {
   name: string;
   defaultValue?: Quantity;
   onChange?: (value: Quantity) => void;
-  disableScroll?: boolean;
+  disableWheel?: boolean;
 }
 
 export function QuantityInput(props: QuantityInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
-  const disableScroll = !!props.disableScroll;
 
   function setValueWrapper(newValue: Quantity): void {
     setValue(newValue);
@@ -42,7 +41,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
         placeholder="Value"
         defaultValue={value?.value}
         onWheel={(e: WheelEvent<HTMLInputElement>) => {
-          if (disableScroll) {
+          if (props.disableWheel) {
             e.currentTarget.blur();
           }
         }}

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -1,4 +1,4 @@
-import { Group, NativeSelect, NumberInput, TextInput } from '@mantine/core';
+import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Quantity } from '@medplum/fhirtypes';
 import React, { useState, WheelEvent } from 'react';
 
@@ -33,13 +33,14 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
           })
         }
       />
-      <NumberInput
+      <TextInput
         id={props.name}
         name={props.name}
         data-testid={props.name + '-value'}
         type="number"
         placeholder="Value"
         defaultValue={value?.value}
+        step="any"
         onWheel={(e: WheelEvent<HTMLInputElement>) => {
           if (props.disableWheel) {
             e.currentTarget.blur();
@@ -48,7 +49,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
         onChange={(e) => {
           setValueWrapper({
             ...value,
-            value: e,
+            value: tryParseNumber(e.currentTarget.value),
           });
         }}
       />
@@ -65,4 +66,11 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
       />
     </Group>
   );
+}
+
+function tryParseNumber(str: string): number | undefined {
+  if (!str) {
+    return undefined;
+  }
+  return parseFloat(str);
 }

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -1,15 +1,17 @@
-import { Group, NativeSelect, TextInput } from '@mantine/core';
+import { Group, NativeSelect, NumberInput, TextInput } from '@mantine/core';
 import { Quantity } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import React, { useState, WheelEvent } from 'react';
 
 export interface QuantityInputProps {
   name: string;
   defaultValue?: Quantity;
   onChange?: (value: Quantity) => void;
+  disableScroll?: boolean;
 }
 
 export function QuantityInput(props: QuantityInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
+  const disableScroll = !!props.disableScroll;
 
   function setValueWrapper(newValue: Quantity): void {
     setValue(newValue);
@@ -32,20 +34,24 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
           })
         }
       />
-      <TextInput
+      <NumberInput
         id={props.name}
         name={props.name}
         data-testid={props.name + '-value'}
         type="number"
-        step="any"
         placeholder="Value"
-        defaultValue={value?.value?.toString()}
-        onChange={(e) =>
+        defaultValue={value?.value}
+        onWheel={(e: WheelEvent<HTMLInputElement>) => {
+          if (disableScroll) {
+            e.currentTarget.blur();
+          }
+        }}
+        onChange={(e) => {
           setValueWrapper({
             ...value,
-            value: tryParseNumber(e.currentTarget.value),
-          })
-        }
+            value: e,
+          });
+        }}
       />
       <TextInput
         placeholder="Unit"
@@ -60,11 +66,4 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
       />
     </Group>
   );
-}
-
-function tryParseNumber(str: string): number | undefined {
-  if (!str) {
-    return undefined;
-  }
-  return parseFloat(str);
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -320,6 +320,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           name={name}
           defaultValue={initial?.valueQuantity}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue })}
+          disableScroll
         />
       );
     case QuestionnaireItemType.choice:

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -320,7 +320,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           name={name}
           defaultValue={initial?.valueQuantity}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue })}
-          disableScroll
+          disableWheel
         />
       );
     case QuestionnaireItemType.choice:


### PR DESCRIPTION
One of our lab customers gave us feedback that using the scroll wheel over a quantity input sometimes causes them to input incorrect values. This PR adds a prop called `disableWheel` to disable scroll wheel action on the numeric part of the QuantityInput, and enables the prop on the `QuestionnaireForm` component