### PR TITLE
Fixed stale state bug in useResource

### DIFF
--- a/packages/react/src/useResource/useResource.test.tsx
+++ b/packages/react/src/useResource/useResource.test.tsx
@@ -1,8 +1,8 @@
 import { createReference } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
-import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
 import { useResource } from './useResource';
@@ -72,5 +72,32 @@ describe('useResource', () => {
     const el = screen.getByTestId('test-component');
     expect(el).toBeInTheDocument();
     expect(el.innerHTML).toBe('');
+  });
+
+  test('Responds to value change', () => {
+    function TestComponentWrapper(): JSX.Element {
+      const [id, setId] = useState('123');
+      return (
+        <>
+          <button onClick={() => setId('456')}>Click</button>
+          <TestComponent value={{ id, resourceType: 'ServiceRequest' }} />
+        </>
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <TestComponentWrapper />
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+
+    const el = screen.getByTestId('test-component');
+    expect(el).toBeInTheDocument();
+    expect(el.innerHTML).toContain('123');
+
+    fireEvent.click(screen.getByText('Click'));
+    expect(el.innerHTML).toContain('456');
   });
 });

--- a/packages/react/src/useResource/useResource.test.tsx
+++ b/packages/react/src/useResource/useResource.test.tsx
@@ -1,5 +1,5 @@
 import { createReference } from '@medplum/core';
-import { Reference, Resource } from '@medplum/fhirtypes';
+import { Reference, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { useState } from 'react';
@@ -99,5 +99,37 @@ describe('useResource', () => {
 
     fireEvent.click(screen.getByText('Click'));
     expect(el.innerHTML).toContain('456');
+  });
+
+  test('Responds to value edit', () => {
+    function TestComponentWrapper(): JSX.Element {
+      const [resource, setResource] = useState<ServiceRequest>({
+        id: '123',
+        meta: { versionId: '1' },
+        resourceType: 'ServiceRequest',
+        status: 'draft',
+      });
+      return (
+        <>
+          <button onClick={() => setResource((sr) => ({ ...sr, status: 'active' }))}>Click</button>
+          <TestComponent value={resource} />
+        </>
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>
+          <TestComponentWrapper />
+        </MedplumProvider>
+      </MemoryRouter>
+    );
+
+    const el = screen.getByTestId('test-component');
+    expect(el).toBeInTheDocument();
+    expect(el.innerHTML).not.toContain('active');
+
+    fireEvent.click(screen.getByText('Click'));
+    expect(el.innerHTML).toContain('active');
   });
 });

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -24,6 +24,10 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
   const [resource, setResource] = useState<T | undefined>(getInitialResource(medplum, value));
 
   useEffect(() => {
+    setResource(getInitialResource(medplum, value));
+  }, [medplum, value]);
+
+  useEffect(() => {
     let subscribed = true;
 
     if (!resource && value && 'reference' in value && value.reference) {


### PR DESCRIPTION
**The Problem**
The `resource` state variable is initially set based on the `value` prop sent to the `useResource` hook. However, this is only set on the _first_ render of the component calling `useResource`. If the component renders again with a different value for `value`, the `resource` state will not be updated. 

This was manifesting in a number of places through the Medplum App, where clicking on links would update the url in the address bar, but would not force a re-render of components.

**Solution**
An additional call to useEffect to reset the state in response to the prop. 
ref: https://stackoverflow.com/questions/54865764/react-usestate-does-not-reload-state-from-props