### PR TITLE
Use rfc6902 in server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25952,11 +25952,6 @@
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "dev": true
     },
-    "node_modules/fast-json-patch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -46306,7 +46301,7 @@
         "@medplum/core": "*",
         "@medplum/definitions": "*",
         "@medplum/fhirtypes": "*",
-        "rfc6902": "^5.0.1"
+        "rfc6902": "5.0.1"
       },
       "devDependencies": {
         "@types/pdfmake": "0.1.21"
@@ -46403,7 +46398,6 @@
         "express": "4.18.2",
         "express-rate-limit": "6.7.0",
         "express-validator": "6.14.3",
-        "fast-json-patch": "3.1.1",
         "graphql": "16.6.0",
         "hibp": "12.0.0",
         "ioredis": "5.3.0",
@@ -46414,6 +46408,7 @@
         "otplib": "12.0.1",
         "pg": "8.9.0",
         "pg-cursor": "2.8.0",
+        "rfc6902": "5.0.1",
         "ua-parser-js": "1.0.33",
         "validator": "13.9.0"
       },
@@ -52674,7 +52669,7 @@
         "@medplum/definitions": "*",
         "@medplum/fhirtypes": "*",
         "@types/pdfmake": "0.1.21",
-        "rfc6902": "^5.0.1"
+        "rfc6902": "5.0.1"
       }
     },
     "@medplum/react": {
@@ -52756,7 +52751,6 @@
         "express": "4.18.2",
         "express-rate-limit": "6.7.0",
         "express-validator": "6.14.3",
-        "fast-json-patch": "3.1.1",
         "graphql": "16.6.0",
         "hibp": "12.0.0",
         "ioredis": "5.3.0",
@@ -52769,6 +52763,7 @@
         "otplib": "12.0.1",
         "pg": "8.9.0",
         "pg-cursor": "2.8.0",
+        "rfc6902": "5.0.1",
         "set-cookie-parser": "2.5.1",
         "supertest": "6.3.3",
         "ts-node-dev": "2.0.0",
@@ -66665,11 +66660,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
       "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
       "dev": true
-    },
-    "fast-json-patch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -292,7 +292,7 @@ export interface BotEvent<T = Resource | Hl7Message | string | Record<string, an
 
 /**
  * JSONPatch patch operation.
- * Compatible with fast-json-patch Operation.
+ * Compatible with fast-json-patch and rfc6902 Operation.
  */
 export interface PatchOperation {
   readonly op: 'add' | 'remove' | 'replace' | 'copy' | 'move' | 'test';

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -20,7 +20,7 @@
     "@medplum/core": "*",
     "@medplum/definitions": "*",
     "@medplum/fhirtypes": "*",
-    "rfc6902": "^5.0.1"
+    "rfc6902": "5.0.1"
   },
   "devDependencies": {
     "@types/pdfmake": "0.1.21"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,7 +37,6 @@
     "express": "4.18.2",
     "express-rate-limit": "6.7.0",
     "express-validator": "6.14.3",
-    "fast-json-patch": "3.1.1",
     "graphql": "16.6.0",
     "hibp": "12.0.0",
     "ioredis": "5.3.0",
@@ -48,6 +47,7 @@
     "otplib": "12.0.1",
     "pg": "8.9.0",
     "pg-cursor": "2.8.0",
+    "rfc6902": "5.0.1",
     "ua-parser-js": "1.0.33",
     "validator": "13.9.0"
   },

--- a/packages/server/src/fhir/batch.ts
+++ b/packages/server/src/fhir/batch.ts
@@ -1,6 +1,6 @@
 import { allOk, badRequest, created, getReferenceString, getStatus, isOk, notFound } from '@medplum/core';
 import { Bundle, BundleEntry, OperationOutcome, Resource } from '@medplum/fhirtypes';
-import { Operation } from 'fast-json-patch';
+import { Operation } from 'rfc6902';
 import { URL } from 'url';
 import { Repository } from './repo';
 import { parseSearchUrl } from './search';

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -1,7 +1,7 @@
 import { allOk, badRequest, created, getStatus } from '@medplum/core';
 import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response, Router } from 'express';
-import { Operation } from 'fast-json-patch';
+import { Operation } from 'rfc6902';
 import { asyncWrap } from '../async';
 import { authenticateToken } from '../oauth/middleware';
 import { processBatch } from './batch';


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/1493

That PR replaced `fast-json-patch` with `rfc6902` in `@medplum/mock`.

This PR replaces `fast-json-patch` with `rfc6902` in `@medplum/server`.