### PR TITLE
Fixed 'restore deleted resource' flow

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -9,6 +9,7 @@ import {
   isGone,
   isNotFound,
   isOk,
+  isOperationOutcome,
   normalizeErrorString,
   notFound,
   notModified,
@@ -66,5 +67,13 @@ describe('Outcomes', () => {
     expect(normalizeErrorString(badRequest('foo'))).toBe('foo');
     expect(normalizeErrorString({ resourceType: 'OperationOutcome' })).toBe('Unknown error');
     expect(normalizeErrorString({ foo: 'bar' })).toBe('{"foo":"bar"}');
+  });
+
+  test('isOperationOutcome', () => {
+    expect(isOperationOutcome(undefined)).toBe(false);
+    expect(isOperationOutcome(null)).toBe(false);
+    expect(isOperationOutcome('foo')).toBe(false);
+    expect(isOperationOutcome({ resourceType: 'Patient' })).toBe(false);
+    expect(isOperationOutcome({ resourceType: 'OperationOutcome' })).toBe(true);
   });
 });

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -137,6 +137,10 @@ export function badRequest(details: string, expression?: string): OperationOutco
   };
 }
 
+export function isOperationOutcome(value: unknown): value is OperationOutcome {
+  return typeof value === 'object' && value !== null && (value as any).resourceType === 'OperationOutcome';
+}
+
 export function isOk(outcome: OperationOutcome): boolean {
   return outcome.id === OK_ID || outcome.id === CREATED_ID || outcome.id === NOT_MODIFIED_ID;
 }
@@ -206,9 +210,8 @@ export function normalizeErrorString(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
   }
-  if (typeof error === 'object' && 'resourceType' in error) {
-    const outcome = error as OperationOutcome;
-    return outcome.issue?.[0]?.details?.text ?? 'Unknown error';
+  if (isOperationOutcome(error)) {
+    return error.issue?.[0]?.details?.text ?? 'Unknown error';
   }
   return JSON.stringify(error);
 }

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -271,6 +271,10 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
         </Panel>
       )}
       {items.map((item) => {
+        if (!item) {
+          // TODO: Handle null history items for deleted versions.
+          return null;
+        }
         const key = `${item.resourceType}/${item.id}/${item.meta?.versionId}`;
         if (item.resourceType === resource.resourceType && item.id === resource.id) {
           return (

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -43,6 +43,7 @@ export * from './MedplumLink/MedplumLink';
 export * from './MedplumProvider/MedplumProvider';
 export * from './MoneyDisplay/MoneyDisplay';
 export * from './MoneyInput/MoneyInput';
+export * from './OperationOutcomeAlert/OperationOutcomeAlert';
 export * from './Panel/Panel';
 export * from './PatientTimeline/PatientTimeline';
 export * from './PlanDefinitionBuilder/PlanDefinitionBuilder';


### PR DESCRIPTION
Fixed a few bugs in the "restore deleted resource" flow

1. The special case for the `gone` `OperationOutcome` got shuffled in some recent refactoring, so the "Restore" dialog wasn't always displayed properly
2. After restoring, the page did not automatically update to show the new version
3. After restoring, the `<ResourceTimeline>` did not correctly handle a "deleted" version
  a. There is still a `TODO` here to show a tombstone for the deleted version.  That's going to require heavier refactoring to handle non-`Resource` items in the timeline though, so punting that to a future PR.
