### PR TITLE
Fixes #1494 - fixed :not token modifier in next URL

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -208,4 +208,13 @@ describe('Search Utils', () => {
       })
     ).toEqual('?url:above=http%3A%2F%2Facme.org');
   });
+
+  test('Format token not', () => {
+    expect(
+      formatSearchQuery({
+        resourceType: 'Condition',
+        filters: [{ code: 'code', operator: Operator.NOT, value: 'x' }],
+      })
+    ).toEqual('?code:not=x');
+  });
 });

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -118,7 +118,10 @@ export class TokenTable extends LookupTable<Token> {
 
     // If the filter is "not equals", then we're looking for ID=null
     // If the filter is "equals", then we're looking for ID!=null
-    const sqlOperator = filter.operator === FhirOperator.NOT_EQUALS ? Operator.EQUALS : Operator.NOT_EQUALS;
+    const sqlOperator =
+      filter.operator === FhirOperator.NOT || filter.operator === FhirOperator.NOT_EQUALS
+        ? Operator.EQUALS
+        : Operator.NOT_EQUALS;
     predicate.expressions.push(new Condition(new Column(joinName, 'resourceId'), sqlOperator, null));
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1976,6 +1976,7 @@ function fhirOperatorToSqlOperator(fhirOperator: FhirOperator): Operator {
   switch (fhirOperator) {
     case FhirOperator.EQUALS:
       return Operator.EQUALS;
+    case FhirOperator.NOT:
     case FhirOperator.NOT_EQUALS:
       return Operator.NOT_EQUALS;
     case FhirOperator.GREATER_THAN:

--- a/packages/server/src/fhir/search/parse.test.ts
+++ b/packages/server/src/fhir/search/parse.test.ts
@@ -21,16 +21,11 @@ describe('FHIR Search Utils', () => {
   });
 
   test('Parse Patient _id:not', () => {
-    try {
-      expect(parseSearchUrl(new URL('https://example.com/fhir/R4/Patient?_id:not=1'))).toMatchObject({
-        resourceType: 'Patient',
-        sortRules: [],
-        filters: [{ code: '_id', operator: Operator.NOT_EQUALS, value: '1' }],
-      });
-    } catch (err) {
-      console.log(err);
-      console.log(JSON.stringify(err, null, 2));
-    }
+    expect(parseSearchUrl(new URL('https://example.com/fhir/R4/Patient?_id:not=1'))).toMatchObject({
+      resourceType: 'Patient',
+      sortRules: [],
+      filters: [{ code: '_id', operator: Operator.NOT, value: '1' }],
+    });
   });
 
   test('Parse Patient name search', () => {
@@ -268,7 +263,7 @@ describe('FHIR Search Utils', () => {
       filters: [
         {
           code: 'email',
-          operator: Operator.NOT_EQUALS,
+          operator: Operator.NOT,
           value: 'alice@example.com',
         },
       ],

--- a/packages/server/src/fhir/search/parse.ts
+++ b/packages/server/src/fhir/search/parse.ts
@@ -37,7 +37,7 @@ const modifierMap: Record<string, Operator> = {
   above: Operator.ABOVE,
   below: Operator.BELOW,
   text: Operator.TEXT,
-  not: Operator.NOT_EQUALS,
+  not: Operator.NOT,
   in: Operator.IN,
   'not-in': Operator.NOT_IN,
   'of-type': Operator.OF_TYPE,


### PR DESCRIPTION
The server project parsed the `:not` param as `NOT_EQUALS` rather than `NOT` which yielded the correct search behavior, but incorrect "next" URL.