### PR TITLE
Resolve redis caching and access policies

### DIFF
--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -173,6 +173,7 @@ describe('Login', () => {
   test('Login with access policy', async () => {
     const adminEmail = `admin${randomUUID()}@example.com`;
     const memberEmail = `member${randomUUID()}@example.com`;
+    const compartment = { reference: `Organization/${randomUUID()}` };
 
     // Register and create a project
     const { project, accessToken } = await registerNew({
@@ -190,12 +191,11 @@ describe('Login', () => {
       .send({
         resourceType: 'AccessPolicy',
         name: 'Test Access Policy',
+        compartment,
         resource: [
           {
             resourceType: 'Patient',
-            compartment: {
-              reference: `Organization/${randomUUID()}`,
-            },
+            compartment,
           },
         ],
       });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1763,9 +1763,6 @@ export class Repository {
     if (publicResourceTypes.includes(resourceType)) {
       return false;
     }
-    if (!this.#context.accessPolicy) {
-      return true;
-    }
     return this.#matchesAccessPolicy(resource, false);
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -262,19 +262,20 @@ export class Repository {
       throw forbidden;
     }
 
-    if (!this.#context.accessPolicy) {
-      const cacheRecord = await getCacheEntry<T>(resourceType, id);
-      if (cacheRecord) {
-        if (
-          !this.#isSuperAdmin() &&
-          this.#context.project !== undefined &&
-          cacheRecord.projectId !== undefined &&
-          cacheRecord.projectId !== this.#context.project
-        ) {
-          throw notFound;
-        }
-        return cacheRecord.resource;
+    const cacheRecord = await getCacheEntry<T>(resourceType, id);
+    if (cacheRecord) {
+      if (
+        !this.#isSuperAdmin() &&
+        this.#context.project !== undefined &&
+        cacheRecord.projectId !== undefined &&
+        cacheRecord.projectId !== this.#context.project
+      ) {
+        throw notFound;
       }
+      if (!this.#matchesAccessPolicy(cacheRecord.resource, true)) {
+        throw notFound;
+      }
+      return cacheRecord.resource;
     }
 
     const client = getClient();
@@ -1765,19 +1766,62 @@ export class Repository {
     if (!this.#context.accessPolicy) {
       return true;
     }
+    return this.#matchesAccessPolicy(resource, false);
+  }
+
+  /**
+   * Returns true if the resource satisfies the current access policy.
+   * @param resource The resource.
+   * @param readonly True if the resource is being read.
+   * @returns True if the resource matches the access policy.
+   */
+  #matchesAccessPolicy(resource: Resource, readonly: boolean): boolean {
+    if (!this.#context.accessPolicy) {
+      return true;
+    }
     if (this.#context.accessPolicy.resource) {
       for (const resourcePolicy of this.#context.accessPolicy.resource) {
-        if (
-          (resourcePolicy.resourceType === resourceType || resourcePolicy.resourceType === '*') &&
-          !resourcePolicy.readonly &&
-          (!resourcePolicy.criteria ||
-            matchesSearchRequest(resource, this.#parseCriteriaAsSearchRequest(resourcePolicy.criteria)))
-        ) {
+        if (this.#matchesAccessPolicyResourcePolicy(resource, resourcePolicy, readonly)) {
           return true;
         }
       }
     }
     return false;
+  }
+
+  /**
+   * Returns true if the resource satisfies the specified access policy resource policy.
+   * @param resource The resource.
+   * @param resourcePolicy One per-resource policy section from the access policy.
+   * @param readonly True if the resource is being read.
+   * @returns True if the resource matches the access policy.
+   */
+  #matchesAccessPolicyResourcePolicy(
+    resource: Resource,
+    resourcePolicy: AccessPolicyResource,
+    readonly: boolean
+  ): boolean {
+    const resourceType = resource.resourceType;
+    if (resourcePolicy.resourceType !== resourceType && resourcePolicy.resourceType !== '*') {
+      return false;
+    }
+    if (!readonly && resourcePolicy.readonly) {
+      return false;
+    }
+    if (
+      resourcePolicy.compartment &&
+      !resource.meta?.compartment?.find((c) => c.reference === resourcePolicy.compartment?.reference)
+    ) {
+      // Deprecated - to be removed
+      return false;
+    }
+    if (
+      resourcePolicy.criteria &&
+      !matchesSearchRequest(resource, this.#parseCriteriaAsSearchRequest(resourcePolicy.criteria))
+    ) {
+      return false;
+    }
+    return true;
   }
 
   /**


### PR DESCRIPTION
Context:
1. We use Redis caching for "read by ID" operations when available
2. AccessPolicy resources define filters/constraints on what a user can read and write
3. Before, the AccessPolicy read filters were only implemented as SQL clauses
4. That meant that we didn't have a clean way to enforce AccessPolicy constraints when reading from Redis
5. So the solution was simply "don't use Redis if the user has an AccessPolicy"
6. That left a lot of low hanging fruit for cache optimization

This PR fixes all of that.  We actually did have most of the machinery to say "does this resource satisfy the current user's access policy".  Just a matter of tying it all together. 