### PR TITLE
Caching improvements in MedplumClient

### DIFF
--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -90,7 +90,6 @@ export function ResourcePage(): JSX.Element {
   const medplum = useMedplum();
   const [value, setValue] = useState<Resource | undefined>();
   const [historyBundle, setHistoryBundle] = useState<Bundle | undefined>();
-  const [questionnaires, setQuestionnaires] = useState<Bundle<Questionnaire> | undefined>();
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
 
   function handleError(error: unknown): void {
@@ -126,10 +125,6 @@ export function ResourcePage(): JSX.Element {
   useEffect(() => {
     medplum.readResource(resourceType, id).then(setValue).catch(handleError);
     medplum.readHistory(resourceType, id).then(setHistoryBundle).catch(handleError);
-    medplum
-      .search('Questionnaire', 'subject-type=' + resourceType)
-      .then(setQuestionnaires)
-      .catch(handleError);
   }, [medplum, resourceType, id]);
 
   if (outcome && isGone(outcome)) {
@@ -154,7 +149,6 @@ export function ResourcePage(): JSX.Element {
       id={id}
       value={value}
       historyBundle={historyBundle}
-      questionnaires={questionnaires}
       onSubmit={onSubmit}
       outcome={outcome}
     />
@@ -166,7 +160,6 @@ interface ResourcePageBodyProps {
   id: string;
   value: Resource;
   historyBundle: Bundle;
-  questionnaires: Bundle<Questionnaire> | undefined;
   onSubmit: (newResource: Resource) => void;
   outcome: OperationOutcome | undefined;
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1594,6 +1594,7 @@ export class MedplumClient extends EventTarget {
    * @returns The result of the delete operation.
    */
   deleteResource(resourceType: ResourceType, id: string): Promise<any> {
+    this.#deleteCacheEntry(this.fhirUrl(resourceType, id).toString());
     this.invalidateSearches(resourceType);
     return this.delete(this.fhirUrl(resourceType, id));
   }
@@ -1925,6 +1926,16 @@ export class MedplumClient extends EventTarget {
   #setCacheEntry(key: string, value: ReadablePromise<any>): void {
     if (this.#cacheTime > 0) {
       this.#requestCache.set(key, { requestTime: Date.now(), value });
+    }
+  }
+
+  /**
+   * Deletes a cache entry.
+   * @param key The cache key to delete.
+   */
+  #deleteCacheEntry(key: string): void {
+    if (this.#cacheTime > 0) {
+      this.#requestCache.delete(key);
     }
   }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -904,7 +904,31 @@ export class MedplumClient extends EventTarget {
     query?: URLSearchParams | string,
     options: RequestInit = {}
   ): ReadablePromise<Bundle<ExtractResource<K>>> {
-    return this.get(this.fhirSearchUrl(resourceType, query), options);
+    const url = this.fhirSearchUrl(resourceType, query);
+    const cacheKey = url.toString() + '-search';
+    const cached = this.#getCacheEntry(cacheKey, options);
+    if (cached) {
+      return cached.value;
+    }
+    const promise = new ReadablePromise(
+      (async () => {
+        const bundle = await this.get<Bundle<ExtractResource<K>>>(url, options);
+        if (bundle.entry) {
+          for (const entry of bundle.entry) {
+            const resource = entry.resource;
+            if (resource?.id) {
+              this.#setCacheEntry(
+                this.fhirUrl(resourceType, resource.id).toString(),
+                new ReadablePromise(Promise.resolve(resource))
+              );
+            }
+          }
+        }
+        return bundle;
+      })()
+    );
+    this.#setCacheEntry(cacheKey, promise);
+    return promise;
   }
 
   /**
@@ -1116,12 +1140,20 @@ export class MedplumClient extends EventTarget {
    * @param resourceType The FHIR resource type.
    * @returns Promise to a schema with the requested resource type.
    */
-  async requestSchema(resourceType: string): Promise<IndexedStructureDefinition> {
+  requestSchema(resourceType: string): Promise<IndexedStructureDefinition> {
     if (resourceType in globalSchema.types) {
-      return globalSchema;
+      return Promise.resolve(globalSchema);
     }
 
-    const query = `{
+    const cacheKey = resourceType + '-requestSchema';
+    const cached = this.#getCacheEntry(cacheKey, undefined);
+    if (cached) {
+      return cached.value;
+    }
+
+    const promise = new ReadablePromise<IndexedStructureDefinition>(
+      (async () => {
+        const query = `{
       StructureDefinitionList(name: "${resourceType}") {
         name,
         description,
@@ -1151,17 +1183,21 @@ export class MedplumClient extends EventTarget {
       }
     }`.replace(/\s+/g, ' ');
 
-    const response = (await this.graphql(query)) as SchemaGraphQLResponse;
+        const response = (await this.graphql(query)) as SchemaGraphQLResponse;
 
-    for (const structureDefinition of response.data.StructureDefinitionList) {
-      indexStructureDefinition(structureDefinition);
-    }
+        for (const structureDefinition of response.data.StructureDefinitionList) {
+          indexStructureDefinition(structureDefinition);
+        }
 
-    for (const searchParameter of response.data.SearchParameterList) {
-      indexSearchParameter(searchParameter);
-    }
+        for (const searchParameter of response.data.SearchParameterList) {
+          indexSearchParameter(searchParameter);
+        }
 
-    return globalSchema;
+        return globalSchema;
+      })()
+    );
+    this.#setCacheEntry(cacheKey, promise);
+    return promise;
   }
 
   /**


### PR DESCRIPTION
1. Cache and reuse request promises for "get schema".  Normally this would have worked automatically, because this exact behavior is implemented for all GET requests.  The difference is that we use GraphQL for schema requests because we only want a small subset of the `StructureDefinition` and `SearchParameter` resources.  Therefore, these requests were not cached.  The real problem is that `app.medplum.com` would often make 2-3 requests for the same resource type, which is just inefficient.  That probably could be fixed at the `app` level, but easier to fix it globally at the `MedplumClient` level.
2. After a search, cache the individual resources so that subsequent `readResource` operations will return instantly.  The most obvious application of this is going from the search results page to the resource details page.  Then the resource will be available immediately.
3. Remove an unused `Questionnaire` search.  It looks like when we refactored the "Apps" page, this query became redundant.