### PR TITLE
Resource page perf improvements

### DIFF
--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -25,8 +25,24 @@ import { MfaPage } from './MfaPage';
 import { OAuthPage } from './OAuthPage';
 import { RegisterPage } from './RegisterPage';
 import { ResetPasswordPage } from './ResetPasswordPage';
+import { ApplyPage } from './resource/ApplyPage';
+import { AppsPage } from './resource/AppsPage';
+import { BlamePage } from './resource/BlamePage';
+import { BotEditor } from './resource/BotEditor';
+import { BuilderPage } from './resource/BuilderPage';
+import { ChecklistPage } from './resource/ChecklistPage';
+import { DeletePage } from './resource/DeletePage';
+import { DetailsPage } from './resource/DetailsPage';
+import { EditPage } from './resource/EditPage';
+import { HistoryPage } from './resource/HistoryPage';
+import { JsonPage } from './resource/JsonPage';
+import { PreviewPage } from './resource/PreviewPage';
+import { QuestionnaireBotsPage } from './resource/QuestionnaireBotsPage';
+import { ReferenceRangesPage } from './resource/ReferenceRangesPage';
+import { ReportPage } from './resource/ReportPage';
 import { ResourcePage } from './resource/ResourcePage';
 import { ResourceVersionPage } from './resource/ResourceVersionPage';
+import { TimelinePage } from './resource/TimelinePage';
 import { SecurityPage } from './SecurityPage';
 import { SetPasswordPage } from './SetPasswordPage';
 import { SignInPage } from './SignInPage';
@@ -67,8 +83,25 @@ export function AppRoutes(): JSX.Element {
       <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
       <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
       <Route path="/:resourceType/new" element={<CreateResourcePage />} />
-      <Route path="/:resourceType/:id/:tab" element={<ResourcePage />} />
-      <Route path="/:resourceType/:id" element={<ResourcePage />} />
+      <Route path="/:resourceType/:id" element={<ResourcePage />}>
+        <Route index element={<TimelinePage />} />
+        <Route path="apply" element={<ApplyPage />} />
+        <Route path="apps" element={<AppsPage />} />
+        <Route path="blame" element={<BlamePage />} />
+        <Route path="bots" element={<QuestionnaireBotsPage />} />
+        <Route path="builder" element={<BuilderPage />} />
+        <Route path="checklist" element={<ChecklistPage />} />
+        <Route path="delete" element={<DeletePage />} />
+        <Route path="details" element={<DetailsPage />} />
+        <Route path="edit" element={<EditPage />} />
+        <Route path="editor" element={<BotEditor />} />
+        <Route path="history" element={<HistoryPage />} />
+        <Route path="json" element={<JsonPage />} />
+        <Route path="preview" element={<PreviewPage />} />
+        <Route path="report" element={<ReportPage />} />
+        <Route path="ranges" element={<ReferenceRangesPage />} />
+        <Route path="timeline" element={<TimelinePage />} />
+      </Route>
       <Route path="/:resourceType" element={<HomePage />} />
       <Route path="/" element={<HomePage />} />
     </Routes>

--- a/packages/app/src/components/ResourceHeader.test.tsx
+++ b/packages/app/src/components/ResourceHeader.test.tsx
@@ -2,6 +2,7 @@ import { Identifier, Reference, Resource } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import { randomUUID } from 'crypto';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceHeader } from './ResourceHeader';
@@ -22,37 +23,43 @@ describe('ResourceHeader', () => {
   }
 
   test('Renders ID', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
     });
 
-    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText(id)).toBeInTheDocument();
   });
 
   test('Renders single identifier', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'Bundle',
-      id: '123',
+      id,
       identifier: { system: 'abc', value: '456' },
     });
 
-    expect(screen.queryByText('123')).not.toBeInTheDocument();
+    expect(screen.queryByText(id)).not.toBeInTheDocument();
     expect(screen.getByText('abc')).toBeInTheDocument();
     expect(screen.getByText('456')).toBeInTheDocument();
   });
 
   test('Renders identifier array', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       identifier: [
         { system: 'abc', value: '456' },
         { system: 'def', value: '789' },
       ],
     });
 
-    expect(screen.queryByText('123')).not.toBeInTheDocument();
+    expect(screen.queryByText(id)).not.toBeInTheDocument();
     expect(screen.getByText('abc')).toBeInTheDocument();
     expect(screen.getByText('456')).toBeInTheDocument();
     expect(screen.getByText('def')).toBeInTheDocument();
@@ -63,11 +70,11 @@ describe('ResourceHeader', () => {
     await setup({
       resourceType: 'Organization',
       id: '123',
-      name: 'Test Org',
+      name: 'Test Organization',
     });
 
     expect(screen.queryByText('123')).not.toBeInTheDocument();
-    expect(screen.getByText('Test Org')).toBeInTheDocument();
+    expect(screen.getByText('Test Organization')).toBeInTheDocument();
   });
 
   test('Handles reference', async () => {
@@ -81,41 +88,49 @@ describe('ResourceHeader', () => {
   });
 
   test('Handles null identifier', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       identifier: [null as unknown as Identifier],
     });
 
-    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText(id)).toBeInTheDocument();
   });
 
   test('Handles missing identifier system', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       identifier: [{ value: 'abc' }],
     });
 
-    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText(id)).toBeInTheDocument();
     expect(screen.queryByText('abc')).not.toBeInTheDocument();
   });
 
   test('Handles missing identifier value', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       identifier: [{ system: 'abc' }],
     });
 
-    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText(id)).toBeInTheDocument();
     expect(screen.queryByText('abc')).not.toBeInTheDocument();
   });
 
   test('Renders code and category text', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       code: { text: 'TEST_CODE' },
       category: [{ text: 'TEST_CATEGORY' }],
     });
@@ -125,9 +140,11 @@ describe('ResourceHeader', () => {
   });
 
   test('Renders code and category coding', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       code: { coding: [{ display: 'TEST_CODE' }] },
       category: [{ text: 'TEST_CATEGORY' }],
     });
@@ -137,9 +154,11 @@ describe('ResourceHeader', () => {
   });
 
   test('Renders code without display', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       code: { coding: [{ code: 'TEST_CODE' }] },
     });
 
@@ -147,9 +166,11 @@ describe('ResourceHeader', () => {
   });
 
   test('Renders compound code', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'ServiceRequest',
-      id: '123',
+      id,
       code: { coding: [{ display: 'TEST_CODE1' }, { display: 'TEST_CODE2' }] },
       category: [{ text: 'TEST_CATEGORY' }],
     });
@@ -159,13 +180,15 @@ describe('ResourceHeader', () => {
   });
 
   test('Does not render Bot code', async () => {
+    const id = randomUUID();
+
     await setup({
       resourceType: 'Bot',
-      id: '123',
+      id,
       code: 'console.log("Hello World")',
     });
 
-    expect(screen.getByText('123')).toBeInTheDocument();
+    expect(screen.getByText(id)).toBeInTheDocument();
     expect(screen.queryByText('console.log("Hello World")')).toBeNull();
   });
 });

--- a/packages/app/src/resource/ApplyPage.tsx
+++ b/packages/app/src/resource/ApplyPage.tsx
@@ -1,0 +1,20 @@
+import { PlanDefinition, ResourceType } from '@medplum/fhirtypes';
+import { Document, useResource } from '@medplum/react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { PlanDefinitionApplyForm } from './PlanDefinitionApplyForm';
+
+export function ApplyPage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <PlanDefinitionApplyForm planDefinition={resource as PlanDefinition} />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/AppsPage.test.tsx
+++ b/packages/app/src/resource/AppsPage.test.tsx
@@ -1,0 +1,102 @@
+import { MantineProvider } from '@mantine/core';
+import { NotificationsProvider } from '@mantine/notifications';
+import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { readJson } from '@medplum/definitions';
+import { Bundle, SearchParameter } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { ErrorBoundary, MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { Loading } from '../components/Loading';
+
+describe('AppsPage', () => {
+  async function setup(url: string, medplum = new MockClient()): Promise<void> {
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <MemoryRouter initialEntries={[url]} initialIndex={0}>
+            <MantineProvider>
+              <NotificationsProvider>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loading />}>
+                    <AppRoutes />
+                  </Suspense>
+                </ErrorBoundary>
+              </NotificationsProvider>
+            </MantineProvider>
+          </MemoryRouter>
+        </MedplumProvider>
+      );
+    });
+  }
+
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+    indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
+  });
+
+  test('No apps found', async () => {
+    await setup('/Bot/123/apps');
+    await waitFor(() => screen.getByText('No apps found.', { exact: false }));
+
+    expect(screen.getByText('No apps found.', { exact: false })).toBeInTheDocument();
+  });
+
+  test('Patient apps', async () => {
+    await setup('/Patient/123/apps');
+    await waitFor(() => screen.getByText('Apps'));
+
+    expect(screen.getByText('Apps')).toBeInTheDocument();
+    expect(screen.getByText('Vitals')).toBeInTheDocument();
+  });
+
+  test('Patient Smart App Launch', async () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/Patient/123/apps',
+        assign: jest.fn(),
+      },
+      writable: true,
+    });
+
+    await setup('/Patient/123/apps');
+    await waitFor(() => screen.getByText('Apps'));
+
+    expect(screen.getByText('Inferno Client')).toBeInTheDocument();
+    expect(screen.getByText('Client application used for Inferno ONC compliance testing')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Inferno Client'));
+    });
+
+    expect(window.location.assign).toBeCalled();
+  });
+
+  test('Encounter Smart App Launch', async () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/Encounter/123/apps',
+        assign: jest.fn(),
+      },
+      writable: true,
+    });
+
+    await setup('/Encounter/123/apps');
+    await waitFor(() => screen.getByText('Apps'));
+
+    expect(screen.getByText('Inferno Client')).toBeInTheDocument();
+    expect(screen.getByText('Client application used for Inferno ONC compliance testing')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Inferno Client'));
+    });
+
+    expect(window.location.assign).toBeCalled();
+  });
+});

--- a/packages/app/src/resource/BlamePage.tsx
+++ b/packages/app/src/resource/BlamePage.tsx
@@ -1,0 +1,16 @@
+import { ResourceType } from '@medplum/fhirtypes';
+import { Document, ResourceBlame, useMedplum } from '@medplum/react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export function BlamePage(): JSX.Element | null {
+  const medplum = useMedplum();
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const history = medplum.readHistory(resourceType, id).read();
+
+  return (
+    <Document>
+      <ResourceBlame history={history} />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/BuilderPage.test.tsx
+++ b/packages/app/src/resource/BuilderPage.test.tsx
@@ -1,0 +1,64 @@
+import { MantineProvider } from '@mantine/core';
+import { NotificationsProvider } from '@mantine/notifications';
+import { PlanDefinition, Questionnaire } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { ErrorBoundary, MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { Loading } from '../components/Loading';
+
+const medplum = new MockClient();
+
+describe('BuilderPage', () => {
+  async function setup(url: string): Promise<void> {
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <MemoryRouter initialEntries={[url]} initialIndex={0}>
+            <MantineProvider>
+              <NotificationsProvider>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loading />}>
+                    <AppRoutes />
+                  </Suspense>
+                </ErrorBoundary>
+              </NotificationsProvider>
+            </MantineProvider>
+          </MemoryRouter>
+        </MedplumProvider>
+      );
+    });
+  }
+
+  test('PlanDefinition builder', async () => {
+    const planDefinition = await medplum.createResource<PlanDefinition>({
+      resourceType: 'PlanDefinition',
+    });
+
+    await setup(`/PlanDefinition/${planDefinition.id}/builder`);
+    await waitFor(() => screen.getByRole('button', { name: 'Save' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+
+  test('Questionnaire builder', async () => {
+    const questionnaire = await medplum.createResource<Questionnaire>({
+      resourceType: 'Questionnaire',
+    });
+
+    await setup(`/Questionnaire/${questionnaire.id}/builder`);
+    await waitFor(() => screen.getByRole('button', { name: 'Save' }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/resource/BuilderPage.tsx
+++ b/packages/app/src/resource/BuilderPage.tsx
@@ -1,0 +1,44 @@
+import { showNotification } from '@mantine/notifications';
+import { normalizeErrorString } from '@medplum/core';
+import { Resource, ResourceType } from '@medplum/fhirtypes';
+import { Document, PlanDefinitionBuilder, QuestionnaireBuilder, useMedplum } from '@medplum/react';
+import React, { useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { cleanResource } from './utils';
+
+export function BuilderPage(): JSX.Element | null {
+  const medplum = useMedplum();
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const reference = { reference: resourceType + '/' + id };
+
+  const handleSubmit = useCallback(
+    (newResource: Resource): void => {
+      medplum
+        .updateResource(cleanResource(newResource))
+        .then(() => {
+          showNotification({ color: 'green', message: 'Success' });
+        })
+        .catch((err) => {
+          showNotification({ color: 'red', message: normalizeErrorString(err) });
+        });
+    },
+    [medplum]
+  );
+
+  switch (resourceType) {
+    case 'PlanDefinition':
+      return (
+        <Document>
+          <PlanDefinitionBuilder value={reference} onSubmit={handleSubmit} />
+        </Document>
+      );
+    case 'Questionnaire':
+      return (
+        <Document>
+          <QuestionnaireBuilder questionnaire={reference} onSubmit={handleSubmit} />
+        </Document>
+      );
+    default:
+      return null;
+  }
+}

--- a/packages/app/src/resource/ChecklistPage.tsx
+++ b/packages/app/src/resource/ChecklistPage.tsx
@@ -1,0 +1,25 @@
+import { resolveId } from '@medplum/core';
+import { RequestGroup, ResourceType } from '@medplum/fhirtypes';
+import { Document, RequestGroupDisplay, useResource } from '@medplum/react';
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+export function ChecklistPage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+  const navigate = useNavigate();
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <RequestGroupDisplay
+        value={resource as RequestGroup}
+        onStart={(_task, taskInput) => navigate(`/forms/${resolveId(taskInput)}`)}
+        onEdit={(_task, _taskInput, taskOutput) => navigate(`/${taskOutput.reference}}`)}
+      />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/DeletePage.tsx
+++ b/packages/app/src/resource/DeletePage.tsx
@@ -4,17 +4,13 @@ import { normalizeErrorString } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, useMedplum } from '@medplum/react';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
-export interface DeletePageProps {
-  resourceType: ResourceType;
-  id: string;
-}
-
-export function DeletePage(props: DeletePageProps): JSX.Element {
-  const { resourceType, id } = props;
+export function DeletePage(): JSX.Element {
   const medplum = useMedplum();
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
   const navigate = useNavigate();
+
   return (
     <Document>
       <p>Are you sure you want to delete this {resourceType}?</p>

--- a/packages/app/src/resource/DetailsPage.tsx
+++ b/packages/app/src/resource/DetailsPage.tsx
@@ -1,0 +1,19 @@
+import { ResourceType } from '@medplum/fhirtypes';
+import { Document, ResourceTable, useResource } from '@medplum/react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export function DetailsPage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <ResourceTable value={resource} />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/EditPage.test.tsx
+++ b/packages/app/src/resource/EditPage.test.tsx
@@ -1,0 +1,69 @@
+import { MantineProvider } from '@mantine/core';
+import { NotificationsProvider } from '@mantine/notifications';
+import { Practitioner } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { ErrorBoundary, MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { Loading } from '../components/Loading';
+
+const medplum = new MockClient();
+
+describe('EditPage', () => {
+  async function setup(url: string): Promise<void> {
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <MemoryRouter initialEntries={[url]} initialIndex={0}>
+            <MantineProvider>
+              <NotificationsProvider>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loading />}>
+                    <AppRoutes />
+                  </Suspense>
+                </ErrorBoundary>
+              </NotificationsProvider>
+            </MantineProvider>
+          </MemoryRouter>
+        </MedplumProvider>
+      );
+    });
+  }
+
+  test('Edit tab renders', async () => {
+    await setup('/Practitioner/123/edit');
+    await waitFor(() => screen.getByText('Edit'));
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+  });
+
+  test('Submit', async () => {
+    const practitioner = await medplum.createResource<Practitioner>({
+      resourceType: 'Practitioner',
+      name: [{ family: 'Test' }],
+    });
+
+    await setup(`/Practitioner/${practitioner.id}/edit`);
+    expect(screen.getByRole('button', { name: 'OK' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    });
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+
+  test('Delete button on edit page', async () => {
+    await setup('/Practitioner/123/edit');
+    await waitFor(() => screen.getByText('Delete'));
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Delete'));
+    });
+
+    await waitFor(() => screen.getByText('Are you sure you want to delete this Practitioner?'));
+    expect(screen.getByText('Are you sure you want to delete this Practitioner?')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/resource/EditPage.tsx
+++ b/packages/app/src/resource/EditPage.tsx
@@ -1,13 +1,12 @@
-import { Button, Group, JsonInput } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { normalizeErrorString, stringify } from '@medplum/core';
-import { OperationOutcome, ResourceType } from '@medplum/fhirtypes';
-import { Document, Form, OperationOutcomeAlert, useMedplum, useResource } from '@medplum/react';
+import { normalizeErrorString } from '@medplum/core';
+import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
+import { Document, ResourceForm, useMedplum, useResource } from '@medplum/react';
 import React, { useCallback, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { cleanResource } from './utils';
 
-export function JsonPage(): JSX.Element | null {
+export function EditPage(): JSX.Element | null {
   const medplum = useMedplum();
   const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
   const resource = useResource({ reference: resourceType + '/' + id });
@@ -15,9 +14,9 @@ export function JsonPage(): JSX.Element | null {
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
 
   const handleSubmit = useCallback(
-    (formData: Record<string, string>): void => {
+    (newResource: Resource): void => {
       medplum
-        .updateResource(cleanResource(JSON.parse(formData.resource)))
+        .updateResource(cleanResource(newResource))
         .then(() => {
           setOutcome(undefined);
           navigate(`/${resourceType}/${id}/details`);
@@ -30,25 +29,15 @@ export function JsonPage(): JSX.Element | null {
     [medplum, resourceType, id, navigate]
   );
 
+  const handleDelete = useCallback(() => navigate(`/${resourceType}/${id}/delete`), [navigate, resourceType, id]);
+
   if (!resource) {
     return null;
   }
 
   return (
     <Document>
-      {outcome && <OperationOutcomeAlert issues={outcome.issue} />}
-      <Form onSubmit={handleSubmit}>
-        <JsonInput
-          name="resource"
-          data-testid="resource-json"
-          minRows={24}
-          defaultValue={stringify(resource, true)}
-          formatOnBlur
-        />
-        <Group position="right" mt="xl" noWrap>
-          <Button type="submit">OK</Button>
-        </Group>
-      </Form>
+      <ResourceForm defaultValue={resource} onSubmit={handleSubmit} onDelete={handleDelete} outcome={outcome} />
     </Document>
   );
 }

--- a/packages/app/src/resource/HistoryPage.tsx
+++ b/packages/app/src/resource/HistoryPage.tsx
@@ -1,0 +1,16 @@
+import { ResourceType } from '@medplum/fhirtypes';
+import { Document, ResourceHistoryTable, useMedplum } from '@medplum/react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export function HistoryPage(): JSX.Element | null {
+  const medplum = useMedplum();
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const history = medplum.readHistory(resourceType, id).read();
+
+  return (
+    <Document>
+      <ResourceHistoryTable history={history} />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/JsonPage.test.tsx
+++ b/packages/app/src/resource/JsonPage.test.tsx
@@ -1,0 +1,83 @@
+import { MantineProvider } from '@mantine/core';
+import { NotificationsProvider } from '@mantine/notifications';
+import { MockClient } from '@medplum/mock';
+import { ErrorBoundary, MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { Loading } from '../components/Loading';
+
+describe('JsonPage', () => {
+  async function setup(url: string, medplum = new MockClient()): Promise<void> {
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <MemoryRouter initialEntries={[url]} initialIndex={0}>
+            <MantineProvider>
+              <NotificationsProvider>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loading />}>
+                    <AppRoutes />
+                  </Suspense>
+                </ErrorBoundary>
+              </NotificationsProvider>
+            </MantineProvider>
+          </MemoryRouter>
+        </MedplumProvider>
+      );
+    });
+  }
+
+  test('JSON tab renders', async () => {
+    await setup('/Practitioner/123/json');
+    await waitFor(() => screen.getByTestId('resource-json'));
+
+    expect(screen.getByTestId('resource-json')).toBeInTheDocument();
+  });
+
+  test('JSON submit', async () => {
+    await setup('/Practitioner/123/json');
+    await waitFor(() => screen.getByTestId('resource-json'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('resource-json'), {
+        target: { value: '{"resourceType":"Practitioner","id":"123"}' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('OK'));
+    });
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+
+  test('JSON submit with meta', async () => {
+    await setup('/Practitioner/123/json');
+    await waitFor(() => screen.getByTestId('resource-json'));
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('resource-json'), {
+        target: {
+          value: JSON.stringify({
+            resourceType: 'Practitioner',
+            id: '123',
+            meta: {
+              lastUpdated: '2020-01-01T00:00:00.000Z',
+              author: {
+                reference: 'Practitioner/111',
+              },
+            },
+          }),
+        },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('OK'));
+    });
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/resource/PreviewPage.tsx
+++ b/packages/app/src/resource/PreviewPage.tsx
@@ -1,0 +1,29 @@
+import { Alert, Anchor } from '@mantine/core';
+import { ResourceType } from '@medplum/fhirtypes';
+import { Document, QuestionnaireForm, useResource } from '@medplum/react';
+import { IconAlertCircle } from '@tabler/icons-react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export function PreviewPage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <Alert icon={<IconAlertCircle size={16} />} mb="xl">
+        This is just a preview! Access your form here:
+        <br />
+        <Anchor href={`/forms/${id}`}>{`/forms/${id}`}</Anchor>
+      </Alert>
+      <QuestionnaireForm
+        questionnaire={{ reference: resourceType + '/' + id }}
+        onSubmit={() => alert('You submitted the preview')}
+      />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/ReferenceRangesPage.test.tsx
+++ b/packages/app/src/resource/ReferenceRangesPage.test.tsx
@@ -1,0 +1,61 @@
+import { MantineProvider } from '@mantine/core';
+import { NotificationsProvider } from '@mantine/notifications';
+import { ObservationDefinition } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { ErrorBoundary, MedplumProvider } from '@medplum/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React, { Suspense } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { Loading } from '../components/Loading';
+
+const medplum = new MockClient();
+
+describe('ReferenceRangesPage', () => {
+  async function setup(url: string): Promise<void> {
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <MemoryRouter initialEntries={[url]} initialIndex={0}>
+            <MantineProvider>
+              <NotificationsProvider>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loading />}>
+                    <AppRoutes />
+                  </Suspense>
+                </ErrorBoundary>
+              </NotificationsProvider>
+            </MantineProvider>
+          </MemoryRouter>
+        </MedplumProvider>
+      );
+    });
+  }
+
+  test('Renders', async () => {
+    const obsDef = await medplum.createResource<ObservationDefinition>({
+      resourceType: 'ObservationDefinition',
+      code: { text: 'test' },
+    });
+
+    await setup(`/ObservationDefinition/${obsDef.id}/ranges`);
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+
+  test('Submit', async () => {
+    const obsDef = await medplum.createResource<ObservationDefinition>({
+      resourceType: 'ObservationDefinition',
+      code: { text: 'test' },
+    });
+
+    await setup(`/ObservationDefinition/${obsDef.id}/ranges`);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    });
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/resource/ReferenceRangesPage.tsx
+++ b/packages/app/src/resource/ReferenceRangesPage.tsx
@@ -1,0 +1,37 @@
+import { showNotification } from '@mantine/notifications';
+import { normalizeErrorString } from '@medplum/core';
+import { ObservationDefinition, Resource, ResourceType } from '@medplum/fhirtypes';
+import { Document, ReferenceRangeEditor, useMedplum, useResource } from '@medplum/react';
+import React, { useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import { cleanResource } from './utils';
+
+export function ReferenceRangesPage(): JSX.Element | null {
+  const medplum = useMedplum();
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+
+  const handleSubmit = useCallback(
+    (newResource: Resource): void => {
+      medplum
+        .updateResource(cleanResource(newResource))
+        .then(() => {
+          showNotification({ color: 'green', message: 'Success' });
+        })
+        .catch((err) => {
+          showNotification({ color: 'red', message: normalizeErrorString(err) });
+        });
+    },
+    [medplum]
+  );
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <ReferenceRangeEditor onSubmit={handleSubmit} definition={resource as ObservationDefinition} />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/ReportPage.tsx
+++ b/packages/app/src/resource/ReportPage.tsx
@@ -1,0 +1,19 @@
+import { DiagnosticReport, ResourceType } from '@medplum/fhirtypes';
+import { DiagnosticReportDisplay, Document, useResource } from '@medplum/react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export function ReportPage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <DiagnosticReportDisplay value={resource as DiagnosticReport} />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/ResourcePage.test.tsx
+++ b/packages/app/src/resource/ResourcePage.test.tsx
@@ -119,58 +119,6 @@ describe('ResourcePage', () => {
     expect(screen.getByText('Blame')).toBeInTheDocument();
   });
 
-  test('JSON tab renders', async () => {
-    await setup('/Practitioner/123/json');
-    await waitFor(() => screen.getByTestId('resource-json'));
-
-    expect(screen.getByTestId('resource-json')).toBeInTheDocument();
-  });
-
-  test('JSON submit', async () => {
-    await setup('/Practitioner/123/json');
-    await waitFor(() => screen.getByTestId('resource-json'));
-
-    await act(async () => {
-      fireEvent.change(screen.getByTestId('resource-json'), {
-        target: { value: '{"resourceType":"Practitioner","id":"123"}' },
-      });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('OK'));
-    });
-
-    expect(screen.getByTestId('resource-json')).toBeInTheDocument();
-  });
-
-  test('JSON submit with meta', async () => {
-    await setup('/Practitioner/123/json');
-    await waitFor(() => screen.getByTestId('resource-json'));
-
-    await act(async () => {
-      fireEvent.change(screen.getByTestId('resource-json'), {
-        target: {
-          value: JSON.stringify({
-            resourceType: 'Practitioner',
-            id: '123',
-            meta: {
-              lastUpdated: '2020-01-01T00:00:00.000Z',
-              author: {
-                reference: 'Practitioner/111',
-              },
-            },
-          }),
-        },
-      });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('OK'));
-    });
-
-    expect(screen.getByTestId('resource-json')).toBeInTheDocument();
-  });
-
   test('Patient timeline', async () => {
     await setup('/Patient/123/timeline');
     await waitFor(() => screen.getByText('Timeline'));
@@ -296,64 +244,5 @@ describe('ResourcePage', () => {
 
     // Do not open a new browser tab
     expect(window.open).not.toHaveBeenCalled();
-  });
-
-  test('No apps found', async () => {
-    await setup('/Bot/123/apps');
-    await waitFor(() => screen.getByText('No apps found.', { exact: false }));
-
-    expect(screen.getByText('No apps found.', { exact: false })).toBeInTheDocument();
-  });
-
-  test('Patient apps', async () => {
-    await setup('/Patient/123/apps');
-    await waitFor(() => screen.getByText('Apps'));
-
-    expect(screen.getByText('Apps')).toBeInTheDocument();
-    expect(screen.getByText('Vitals')).toBeInTheDocument();
-  });
-
-  test('Patient Smart App Launch', async () => {
-    global.window = Object.create(window);
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
-
-    await setup('/Patient/123/apps');
-    await waitFor(() => screen.getByText('Apps'));
-
-    expect(screen.getByText('Inferno Client')).toBeInTheDocument();
-    expect(screen.getByText('Client application used for Inferno ONC compliance testing')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Inferno Client'));
-    });
-
-    expect(window.location.assign).toBeCalled();
-  });
-
-  test('Encounter Smart App Launch', async () => {
-    global.window = Object.create(window);
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
-
-    await setup('/Encounter/123/apps');
-    await waitFor(() => screen.getByText('Apps'));
-
-    expect(screen.getByText('Inferno Client')).toBeInTheDocument();
-    expect(screen.getByText('Client application used for Inferno ONC compliance testing')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Inferno Client'));
-    });
-
-    expect(window.location.assign).toBeCalled();
   });
 });

--- a/packages/app/src/resource/ResourcePage.test.tsx
+++ b/packages/app/src/resource/ResourcePage.test.tsx
@@ -63,25 +63,6 @@ describe('ResourcePage', () => {
     expect(screen.getByText('Gender')).toBeInTheDocument();
   });
 
-  test('Edit tab renders', async () => {
-    await setup('/Practitioner/123/edit');
-    await waitFor(() => screen.getByText('Edit'));
-    expect(screen.getByText('Edit')).toBeInTheDocument();
-  });
-
-  test('Delete button on edit page', async () => {
-    await setup('/Practitioner/123/edit');
-    await waitFor(() => screen.getByText('Delete'));
-    expect(screen.getByText('Delete')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Delete'));
-    });
-
-    await waitFor(() => screen.getByText('Are you sure you want to delete this Practitioner?'));
-    expect(screen.getByText('Are you sure you want to delete this Practitioner?')).toBeInTheDocument();
-  });
-
   test('Delete button confirm', async () => {
     // Create a practitioner that we can delete
     const medplum = new MockClient();
@@ -136,13 +117,6 @@ describe('ResourcePage', () => {
     await waitFor(() => screen.getByText('Timeline'));
 
     expect(screen.getByText('Timeline')).toBeInTheDocument();
-  });
-
-  test('Questionnaire builder', async () => {
-    await setup('/Questionnaire/123/builder');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeDefined();
   });
 
   test('Questionnaire preview', async () => {

--- a/packages/app/src/resource/TimelinePage.tsx
+++ b/packages/app/src/resource/TimelinePage.tsx
@@ -1,0 +1,19 @@
+import { ResourceType } from '@medplum/fhirtypes';
+import { DefaultResourceTimeline, EncounterTimeline, PatientTimeline, ServiceRequestTimeline } from '@medplum/react';
+import React from 'react';
+import { useParams } from 'react-router-dom';
+
+export function TimelinePage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const reference = { reference: resourceType + '/' + id };
+  switch (resourceType) {
+    case 'Encounter':
+      return <EncounterTimeline encounter={reference} />;
+    case 'Patient':
+      return <PatientTimeline patient={reference} />;
+    case 'ServiceRequest':
+      return <ServiceRequestTimeline serviceRequest={reference} />;
+    default:
+      return <DefaultResourceTimeline resource={reference} />;
+  }
+}

--- a/packages/app/src/resource/utils.ts
+++ b/packages/app/src/resource/utils.ts
@@ -1,0 +1,25 @@
+import { Resource } from '@medplum/fhirtypes';
+
+/**
+ * Cleans a resource of unwanted meta values.
+ * For most users, this will not matter, because meta values are set by the server.
+ * However, some administrative users are allowed to specify some meta values.
+ * The admin use case is sepcial though, and unwanted here on the resource page.
+ * @param resource The input resource.
+ * @returns The cleaned output resource.
+ */
+export function cleanResource(resource: Resource): Resource {
+  let meta = resource.meta;
+  if (meta) {
+    meta = {
+      ...meta,
+      lastUpdated: undefined,
+      versionId: undefined,
+      author: undefined,
+    };
+  }
+  return {
+    ...resource,
+    meta,
+  };
+}

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -536,12 +536,9 @@ export class MedplumClient extends EventTarget {
    * @param resourceType The resource type to invalidate.
    */
   invalidateSearches<K extends ResourceType>(resourceType: K): void {
-    this.#invalidateStartsWith(this.fhirUrl(resourceType).toString());
-  }
-
-  #invalidateStartsWith(prefix: string): void {
+    const url = 'fhir/R4/' + resourceType;
     for (const key of this.#requestCache.keys()) {
-      if (key.startsWith(prefix)) {
+      if (key.endsWith(url) || key.includes(url + '?')) {
         this.#requestCache.delete(key);
       }
     }
@@ -1940,6 +1937,12 @@ export class MedplumClient extends EventTarget {
     }
   }
 
+  /**
+   * Adds a concrete value as the cache entry for the given resource.
+   * This is used in cases where the resource is loaded indirectly.
+   * For example, when a resource is loaded as part of a Bundle.
+   * @param resource The resource to cache.
+   */
   #cacheResource(resource: Resource | undefined): void {
     if (resource?.id) {
       this.#setCacheEntry(

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.tsx
@@ -1,5 +1,5 @@
 import { MedplumClient } from '@medplum/core';
-import { Reference, Resource } from '@medplum/fhirtypes';
+import { Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 import React from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
@@ -11,8 +11,8 @@ export function DefaultResourceTimeline(props: DefaultResourceTimelineProps): JS
   return (
     <ResourceTimeline
       value={props.resource}
-      loadTimelineResources={async (medplum: MedplumClient, resource: Resource) => {
-        return Promise.allSettled([medplum.readHistory(resource.resourceType, resource.id as string)]);
+      loadTimelineResources={async (medplum: MedplumClient, resourceType: ResourceType, id: string) => {
+        return Promise.allSettled([medplum.readHistory(resourceType, id)]);
       }}
     />
   );

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
@@ -1,5 +1,5 @@
-import { createReference, getReferenceString, MedplumClient, ProfileResource } from '@medplum/core';
-import { Attachment, Encounter, Reference } from '@medplum/fhirtypes';
+import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
+import { Attachment, Encounter, Reference, ResourceType } from '@medplum/fhirtypes';
 import React from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
@@ -11,11 +11,11 @@ export function EncounterTimeline(props: EncounterTimelineProps): JSX.Element {
   return (
     <ResourceTimeline
       value={props.encounter}
-      loadTimelineResources={async (medplum: MedplumClient, resource: Encounter) => {
+      loadTimelineResources={async (medplum: MedplumClient, _resourceType: ResourceType, id: string) => {
         return Promise.allSettled([
-          medplum.readHistory('Encounter', resource.id as string),
-          medplum.search('Communication', 'encounter=' + getReferenceString(resource)),
-          medplum.search('Media', 'encounter=' + getReferenceString(resource)),
+          medplum.readHistory('Encounter', id as string),
+          medplum.search('Communication', 'encounter=Encounter/' + id),
+          medplum.search('Media', 'encounter=Encounter/' + id),
         ]);
       }}
       createCommunication={(resource: Encounter, sender: ProfileResource, text: string) => ({

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
@@ -13,7 +13,7 @@ export function EncounterTimeline(props: EncounterTimelineProps): JSX.Element {
       value={props.encounter}
       loadTimelineResources={async (medplum: MedplumClient, _resourceType: ResourceType, id: string) => {
         return Promise.allSettled([
-          medplum.readHistory('Encounter', id as string),
+          medplum.readHistory('Encounter', id),
           medplum.search('Communication', 'encounter=Encounter/' + id),
           medplum.search('Media', 'encounter=Encounter/' + id),
         ]);

--- a/packages/react/src/PatientTimeline/PatientTimeline.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.tsx
@@ -1,5 +1,5 @@
-import { createReference, getReferenceString, MedplumClient, ProfileResource } from '@medplum/core';
-import { Attachment, Patient, Reference } from '@medplum/fhirtypes';
+import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
+import { Attachment, Patient, Reference, ResourceType } from '@medplum/fhirtypes';
 import React, { useCallback } from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
@@ -8,15 +8,15 @@ export interface PatientTimelineProps {
 }
 
 export function PatientTimeline(props: PatientTimelineProps): JSX.Element {
-  const loadTimelineResources = useCallback((medplum: MedplumClient, resource: Patient) => {
+  const loadTimelineResources = useCallback((medplum: MedplumClient, _resourceType: ResourceType, id: string) => {
     return Promise.allSettled([
-      medplum.readHistory('Patient', resource.id as string),
-      medplum.search('Communication', 'subject=' + getReferenceString(resource)),
-      medplum.search('Device', 'patient=' + getReferenceString(resource)),
-      medplum.search('DeviceRequest', 'patient=' + getReferenceString(resource)),
-      medplum.search('DiagnosticReport', 'subject=' + getReferenceString(resource)),
-      medplum.search('Media', 'subject=' + getReferenceString(resource)),
-      medplum.search('ServiceRequest', 'subject=' + getReferenceString(resource)),
+      medplum.readHistory('Patient', id),
+      medplum.search('Communication', 'subject=Patient/' + id),
+      medplum.search('Device', 'patient=Patient/' + id),
+      medplum.search('DeviceRequest', 'patient=Patient/' + id),
+      medplum.search('DiagnosticReport', 'subject=Patient/' + id),
+      medplum.search('Media', 'subject=Patient/' + id),
+      medplum.search('ServiceRequest', 'subject=Patient/' + id),
     ]);
   }, []);
 

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
@@ -1,5 +1,5 @@
-import { createReference, getReferenceString, MedplumClient, ProfileResource } from '@medplum/core';
-import { Attachment, Bundle, Encounter, Resource } from '@medplum/fhirtypes';
+import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
+import { Attachment, Bundle, Encounter, Resource, ResourceType } from '@medplum/fhirtypes';
 import { HomerEncounter, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -11,12 +11,13 @@ const medplum = new MockClient();
 
 async function loadTimelineResources(
   medplum: MedplumClient,
-  resource: Resource
+  resourceType: ResourceType,
+  id: string
 ): Promise<PromiseSettledResult<Bundle>[]> {
   return Promise.allSettled([
-    medplum.readHistory(resource.resourceType, resource.id as string),
-    medplum.search('Communication', 'encounter=' + getReferenceString(resource)),
-    medplum.search('Media', 'encounter=' + getReferenceString(resource)),
+    medplum.readHistory(resourceType, id),
+    medplum.search('Communication', 'encounter=' + resourceType + '/' + id),
+    medplum.search('Media', 'encounter=' + resourceType + '/' + id),
   ]);
 }
 

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.tsx
@@ -1,5 +1,5 @@
-import { createReference, getReferenceString, MedplumClient, ProfileResource } from '@medplum/core';
-import { Attachment, Group, Patient, Reference, ServiceRequest } from '@medplum/fhirtypes';
+import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
+import { Attachment, Group, Patient, Reference, ResourceType, ServiceRequest } from '@medplum/fhirtypes';
 import React from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
@@ -11,12 +11,12 @@ export function ServiceRequestTimeline(props: ServiceRequestTimelineProps): JSX.
   return (
     <ResourceTimeline
       value={props.serviceRequest}
-      loadTimelineResources={async (medplum: MedplumClient, resource: ServiceRequest) => {
+      loadTimelineResources={async (medplum: MedplumClient, _resourceType: ResourceType, id: string) => {
         return Promise.allSettled([
-          medplum.readHistory('ServiceRequest', resource.id as string),
-          medplum.search('Communication', 'based-on=' + getReferenceString(resource)),
-          medplum.search('Media', '_count=100&based-on=' + getReferenceString(resource)),
-          medplum.search('DiagnosticReport', 'based-on=' + getReferenceString(resource)),
+          medplum.readHistory('ServiceRequest', id),
+          medplum.search('Communication', 'based-on=ServiceRequest/' + id),
+          medplum.search('Media', '_count=100&based-on=ServiceRequest/' + id),
+          medplum.search('DiagnosticReport', 'based-on=ServiceRequest/' + id),
         ]);
       }}
       createCommunication={(resource: ServiceRequest, sender: ProfileResource, text: string) => ({

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -1,17 +1,7 @@
-import { MedplumClient } from '@medplum/core';
-import { Device, Reference, Resource } from '@medplum/fhirtypes';
-import { useEffect, useState } from 'react';
+import { deepEquals } from '@medplum/core';
+import { Reference, Resource } from '@medplum/fhirtypes';
+import { useEffect, useRef, useState } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider';
-
-const system: Device = {
-  resourceType: 'Device',
-  id: 'system',
-  deviceName: [
-    {
-      name: 'System',
-    },
-  ],
-};
 
 /**
  * React Hook to use a FHIR reference.
@@ -21,61 +11,50 @@ const system: Device = {
  */
 export function useResource<T extends Resource>(value: Reference<T> | T | undefined): T | undefined {
   const medplum = useMedplum();
-  const [resource, setResource] = useState<T | undefined>(getInitialResource(medplum, value));
+  const referenceRef = useRef<Reference<T> | undefined>(undefined);
+  const resourceRef = useRef<T | undefined>(undefined);
 
+  // Reset the reference and resource
+  referenceRef.current = undefined;
+  resourceRef.current = undefined;
+
+  // Try to convert the value to a reference
+  if (value) {
+    if ('reference' in value) {
+      referenceRef.current = value as Reference<T>;
+    } else if ('resourceType' in value) {
+      resourceRef.current = value;
+      if ('id' in value) {
+        referenceRef.current = { reference: value.resourceType + '/' + value.id };
+      }
+    }
+  }
+
+  // Priority order:
+  // 1. Cached reference
+  // 2. Resource passed in as-is
+  // 3. Undefined
+  const currentResource =
+    (referenceRef.current && medplum.getCachedReference(referenceRef.current)) || resourceRef.current;
+
+  // Keep track of the previous resource
+  // This is used to detect when the resource has changed
+  // We need a React "state" variable to trigger a re-render
+  const [prevResource, setPrevResource] = useState(currentResource);
+
+  // Subscribe to changes to the passed-in value
   useEffect(() => {
-    setResource(getInitialResource(medplum, value));
-  }, [medplum, value]);
-
-  useEffect(() => {
-    let subscribed = true;
-
-    if (!resource && value && 'reference' in value && value.reference) {
+    if (referenceRef.current) {
       medplum
-        .readReference(value as Reference<T>)
-        .then((r) => {
-          if (subscribed) {
-            setResource(r);
+        .readReference(referenceRef.current)
+        .then((newValue) => {
+          if (!deepEquals(newValue, prevResource)) {
+            setPrevResource(newValue);
           }
         })
-        .catch(() => setResource(undefined));
+        .catch(console.error);
     }
+  }, [medplum, value, prevResource]);
 
-    return (() => (subscribed = false)) as () => void;
-  }, [medplum, resource, value]);
-
-  return resource;
-}
-
-/**
- * Returns the initial resource value based on the input value.
- * If the input value is a resource, returns the resource.
- * If the input value is a reference to system, returns the system resource.
- * If the input value is a reference to a resource available in the cache, returns the resource.
- * Otherwise, returns undefined.
- * @param medplum The medplum client.
- * @param value The resource or reference to resource.
- * @returns An initial resource if available; undefined otherwise.
- */
-function getInitialResource<T extends Resource>(
-  medplum: MedplumClient,
-  value: Reference<T> | T | undefined
-): T | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  if ('resourceType' in value) {
-    return value;
-  }
-
-  if ('reference' in value) {
-    if (value.reference === 'system') {
-      return system as T;
-    }
-
-    return medplum.getCachedReference(value);
-  }
-
-  return undefined;
+  return currentResource;
 }

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -18,13 +18,15 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
   referenceRef.current = undefined;
   resourceRef.current = undefined;
 
-  // Try to convert the value to a reference
+  // Try to convert the value to a reference and resource
   if (value) {
     if ('reference' in value) {
+      // If the input is a reference then we can use it as-is
       referenceRef.current = value as Reference<T>;
     } else if ('resourceType' in value) {
       resourceRef.current = value;
       if ('id' in value) {
+        // If the input is a resource with an ID, then we can still create a reference
         referenceRef.current = { reference: value.resourceType + '/' + value.id };
       }
     }
@@ -40,7 +42,7 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
   // Keep track of the previous resource
   // This is used to detect when the resource has changed
   // We need a React "state" variable to trigger a re-render
-  const [prevResource, setPrevResource] = useState(currentResource);
+  const [prevResource, forceRerender] = useState(currentResource);
 
   // Subscribe to changes to the passed-in value
   useEffect(() => {
@@ -49,7 +51,7 @@ export function useResource<T extends Resource>(value: Reference<T> | T | undefi
         .readReference(referenceRef.current)
         .then((newValue) => {
           if (!deepEquals(newValue, prevResource)) {
-            setPrevResource(newValue);
+            forceRerender(newValue);
           }
         })
         .catch(console.error);


### PR DESCRIPTION
Fixes a variety of minor performance issues in `<ResourcePage>` in the app project.

The biggest one is the classic React waterfall problem.  Before, `<ResourcePage>` requested the primary resource at the top level, and then passed it as a prop to the active tab.  And then other requests could get piled on with other nested components.  

<img width="960" alt="image" src="https://user-images.githubusercontent.com/749094/218553202-beee5846-4d2f-47ad-9df3-d0f7e2284f2d.png">

After, the pattern is changed.  `resource` is not passed as a prop.  Each tab component now uses `{resourceType}` and `{id}` from the URL params, which are available immediately.

The great thing about this is that `MedplumClient` "auto batching" combines all of these requests -- from multiple different React components -- and gracefully combines them into a single FHIR batch request.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/749094/218562870-6e7b408d-eeee-4961-b6f8-94cccb3a803a.png">

The next big change is cleaning up some performance debt in `useResource()`.  There were a few problems, notably that the return value of `useResource()` was managed by React `useState()`.  Now the value comes from `medplum.getCachedReference` which will always return the most recent value.  It still uses `useState()` to trigger re-renders on changes.  It still uses `useEffect()` to initiate network requests to fetch the value.

Last but not least, this PR includes a much needed refactoring overhaul of the `<ResourcePage>` tab routing.  Before, it used a mishmash of `if` and `switch` statements to determine the tab contents.  Now it uses `react-router-dom` [nested routes](https://reactrouter.com/en/main/start/overview#nested-routes) for a more maintainable system.