### PR TITLE
Fixed display bugs in ResourceTimeline

### DIFF
--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
@@ -1,10 +1,11 @@
 import { createReference } from '@medplum/core';
+import { DiagnosticReport, Patient } from '@medplum/fhirtypes';
 import { ExampleSubscription, MockClient } from '@medplum/mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { DefaultResourceTimeline, DefaultResourceTimelineProps } from './DefaultResourceTimeline';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { DefaultResourceTimeline, DefaultResourceTimelineProps } from './DefaultResourceTimeline';
 
 const medplum = new MockClient();
 
@@ -37,5 +38,53 @@ describe('DefaultResourceTimeline', () => {
 
     const items = screen.getAllByTestId('timeline-item');
     expect(items).toBeDefined();
+  });
+
+  test('Sorting', async () => {
+    // Sorting has a lot of hidden complexity.
+    // For the "primary resource" of a timeline, we always sort by "lastUpdated" descending.
+    // For other resources, we use a variety of special cases to represent the "natural" order.
+    // Other examples of special cases:
+    //  - DiagnosticReport.issued
+    //  - Media.issued
+    //  - Observation.issued
+    //  - DocumentReference.date
+    // See "sortByDateAndPriority()" for more details.
+
+    const p = await medplum.createResource<Patient>({ resourceType: 'Patient' });
+
+    const dr1 = await medplum.createResource<DiagnosticReport>({
+      resourceType: 'DiagnosticReport',
+      meta: {
+        lastUpdated: '2021-01-01T00:00:00Z',
+      },
+      subject: createReference(p),
+      code: { text: 'test' },
+      issued: '2021-01-01T00:00:00Z',
+      status: 'preliminary',
+    });
+
+    // Take advantage of the fact that MockClient.createResource allows you to set the meta.lastUpdated value.
+    const dr2 = await medplum.createResource<DiagnosticReport>({
+      ...dr1,
+      meta: {
+        lastUpdated: '2021-01-02T00:00:00Z',
+      },
+      status: 'final',
+    });
+
+    await setup({ resource: dr2 });
+
+    const items = screen.getAllByTestId('timeline-item');
+    expect(items).toBeDefined();
+    expect(items.length).toBe(2);
+
+    // Most recent "final" should be on top
+    expect(items[0].textContent).toContain('final');
+
+    // Created item should be on the bototm
+    expect(items[1].textContent).toContain('Created');
+    expect(items[1].textContent).toContain('preliminary');
+    expect(items[1].textContent).not.toContain('final');
   });
 });

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -6,8 +6,23 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider';
 import { useResource } from '../useResource/useResource';
 
 export interface ResourceTableProps {
+  /**
+   * The input value either as a resource or a reference.
+   */
   value: Resource | Reference;
+
+  /**
+   * Optional flag to ignore missing values.
+   * By default, missing values are displayed as empty strings.
+   */
   ignoreMissingValues?: boolean;
+
+  /**
+   * Optional flag to force use the input value.
+   * This is useful when you want to display a specific version of the resource,
+   * and not use the latest version.
+   */
+  forceUseInput?: boolean;
 }
 
 export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
@@ -27,7 +42,10 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
 
   return (
     <BackboneElementDisplay
-      value={{ type: value.resourceType, value }}
+      value={{
+        type: value.resourceType,
+        value: props.forceUseInput ? props.value : value,
+      }}
       ignoreMissingValues={props.ignoreMissingValues}
     />
   );

--- a/packages/react/src/utils/date.ts
+++ b/packages/react/src/utils/date.ts
@@ -3,21 +3,20 @@ import { Resource } from '@medplum/fhirtypes';
 /**
  * Sorts an array of resources in place by meta.lastUpdated ascending.
  * @param resources Array of resources.
+ * @param timelineResource Optional primary resource of a timeline view. If specified, the primary resource will be sorted by meta.lastUpdated descending.
  */
-export function sortByDateAndPriority(resources: Resource[]): void {
-  resources.sort(resourceDateComparator);
-}
-
-function resourceDateComparator(a: Resource, b: Resource): number {
-  const priority1 = getPriorityScore(a);
-  const priority2 = getPriorityScore(b);
-  if (priority1 > priority2) {
-    return 1;
-  }
-  if (priority1 < priority2) {
-    return -1;
-  }
-  return getTime(a) - getTime(b);
+export function sortByDateAndPriority(resources: Resource[], timelineResource?: Resource): void {
+  resources.sort((a: Resource, b: Resource): number => {
+    const priority1 = getPriorityScore(a);
+    const priority2 = getPriorityScore(b);
+    if (priority1 > priority2) {
+      return 1;
+    }
+    if (priority1 < priority2) {
+      return -1;
+    }
+    return getTime(a, timelineResource) - getTime(b, timelineResource);
+  });
 }
 
 function getPriorityScore(resource: Resource): number {
@@ -28,22 +27,26 @@ function getPriorityScore(resource: Resource): number {
   return 0;
 }
 
-function getTime(resource: Resource): number {
-  if (resource.resourceType === 'Communication' && resource.sent) {
-    return new Date(resource.sent).getTime();
-  }
+function getTime(resource: Resource, timelineResource: Resource | undefined): number {
+  if (!isSameResourceType(resource, timelineResource)) {
+    // Only use special case timestamps if not the primary resource of a timeline view.
 
-  if (
-    (resource.resourceType === 'DiagnosticReport' ||
-      resource.resourceType === 'Media' ||
-      resource.resourceType === 'Observation') &&
-    resource.issued
-  ) {
-    return new Date(resource.issued).getTime();
-  }
+    if (resource.resourceType === 'Communication' && resource.sent) {
+      return new Date(resource.sent).getTime();
+    }
 
-  if (resource.resourceType === 'DocumentReference' && resource.date) {
-    return new Date(resource.date).getTime();
+    if (
+      (resource.resourceType === 'DiagnosticReport' ||
+        resource.resourceType === 'Media' ||
+        resource.resourceType === 'Observation') &&
+      resource.issued
+    ) {
+      return new Date(resource.issued).getTime();
+    }
+
+    if (resource.resourceType === 'DocumentReference' && resource.date) {
+      return new Date(resource.date).getTime();
+    }
   }
 
   const dateTime = resource.meta?.lastUpdated;
@@ -51,4 +54,8 @@ function getTime(resource: Resource): number {
     return 0;
   }
   return new Date(dateTime).getTime();
+}
+
+function isSameResourceType(a: Resource, b: Resource | undefined): boolean {
+  return !!b && a.resourceType === b.resourceType && a.id === b.id;
 }


### PR DESCRIPTION
1. Sorting
  a. By default, the `<ResourceTimeline>` sorts by `meta.lastUpdated`
  b. There are some special cases for more natural sorting, such as `Communication.sent` or `DiagnosticReport.issued`
  c. Bug: Those special cases were used, even when looking at that resource, so the history events were not sorted correctly.
2. Created event table
  a. For the first version of a resource, rather than showing a diff, we show `<ResourceTable>` a key/value table of resource properties
  b. A bug was introduced in https://github.com/medplum/medplum/pull/1518 which caused the component to use the most recent value rather than the specific input.
  c. This PR adds a `forceUseInput` prop to say "ignore the cache, display what I gave you".