### PR TITLE
Fixes #1486 - Added flag to ClientApplication to disable PKCE

### DIFF
--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -430,6 +430,16 @@
             }]
           },
           {
+            "id" : "ClientApplication.pkceOptional",
+            "path" : "ClientApplication.pkceOptional",
+            "definition" : "Flag to make PKCE optional for this client application. PKCE is required by default for compliance with Smart App Launch. It can be disabled for compatibility with legacy client applications.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "boolean"
+            }]
+          },
+          {
             "id" : "ClientApplication.identityProvider",
             "path" : "ClientApplication.identityProvider",
             "definition" : "Optional external Identity Provider (IdP) for the client application.",

--- a/packages/fhirtypes/dist/ClientApplication.d.ts
+++ b/packages/fhirtypes/dist/ClientApplication.d.ts
@@ -75,6 +75,13 @@ export interface ClientApplication {
   launchUri?: string;
 
   /**
+   * Flag to make PKCE optional for this client application. PKCE is
+   * required by default for compliance with Smart App Launch. It can be
+   * disabled for compatibility with legacy client applications.
+   */
+  pkceOptional?: boolean;
+
+  /**
    * Optional external Identity Provider (IdP) for the client application.
    */
   identityProvider?: IdentityProvider;

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -91,6 +91,8 @@ export async function tryLogin(request: LoginRequest): Promise<Login> {
     client = await systemRepo.readResource<ClientApplication>('ClientApplication', request.clientId);
   }
 
+  validatePkce(request, client);
+
   let launch: SmartAppLaunch | undefined;
   if (request.launchId) {
     launch = await systemRepo.readResource<SmartAppLaunch>('SmartAppLaunch', request.launchId);
@@ -156,6 +158,12 @@ export function validateLoginRequest(request: LoginRequest): void {
   if (!request.scope) {
     throw badRequest('Invalid scope', 'scope');
   }
+}
+
+export function validatePkce(request: LoginRequest, client: ClientApplication | undefined): void {
+  if (client?.pkceOptional) {
+    return;
+  }
 
   if (!request.codeChallenge && request.codeChallengeMethod) {
     throw badRequest('Invalid code challenge', 'code_challenge');
@@ -172,8 +180,6 @@ export function validateLoginRequest(request: LoginRequest): void {
   ) {
     throw badRequest('Invalid code challenge method', 'code_challenge_method');
   }
-
-  return undefined;
 }
 
 async function authenticate(request: LoginRequest, user: User): Promise<void> {


### PR DESCRIPTION
Technically, "code_challenge" is a required param: https://build.fhir.org/ig/HL7/smart-app-launch/app-launch.html#obtain-authorization-code

But it is optional in Epic: https://fhir.epic.com/Documentation?docId=oauth2&section=Embedded-Oauth2-Launch_Access-Token-Request_No_Refresh-Tokens

This PR adds an optional flag to `ClientApplication` to make PKCE optional.