### PR TITLE
update default docker image in init script

### DIFF
--- a/packages/infra/src/init.test.ts
+++ b/packages/infra/src/init.test.ts
@@ -54,7 +54,7 @@ test('Init tool success', async () => {
     desiredServerCount: 1,
     serverMemory: 512,
     serverCpu: 256,
-    serverImage: 'medplum/medplum:latest',
+    serverImage: 'medplum/medplum-server:latest',
     storagePublicKey: expect.stringContaining('-----BEGIN PUBLIC KEY-----'),
     apiSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
     appSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',

--- a/packages/infra/src/init.ts
+++ b/packages/infra/src/init.ts
@@ -158,7 +158,7 @@ export async function main(t: readline.Interface): Promise<void> {
   print('You can choose the image to use for the servers.');
   print('Docker images can be loaded from either Docker Hub or AWS ECR.');
   print('The default is the latest Medplum release.');
-  config.serverImage = await ask('Enter the server image:', 'medplum/medplum:latest');
+  config.serverImage = await ask('Enter the server image:', 'medplum/medplum-server:latest');
 
   header('SIGNING KEY');
   print('Medplum uses AWS CloudFront Presigned URLs for binary content such as file uploads.');


### PR DESCRIPTION
Thanks for your work on medplum! The experience of setting up a self-hosted server on AWS was even smoother than I hoped.

I did spend a bit of time trying to figure out why fargate was failing to start. It turns out that the configuration I was using specified a docker image that doesn't exist on docker hub. Modifying the default value in the init script would have saved me some time and confusion.

This PR modifies the image name to match the one I'm using.