### PR TITLE
Added option to disable Google auth

### DIFF
--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -14,6 +14,7 @@ import { OperationOutcomeAlert } from '../OperationOutcomeAlert/OperationOutcome
 import { getErrorsForInput, getIssuesForExpression } from '../utils/outcomes';
 
 export interface AuthenticationFormProps extends BaseLoginRequest {
+  readonly disableGoogleAuth?: boolean;
   readonly onForgotPassword?: () => void;
   readonly onRegister?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
@@ -31,7 +32,7 @@ export function AuthenticationForm(props: AuthenticationFormProps): JSX.Element 
 }
 
 export interface EmailFormProps extends BaseLoginRequest {
-  readonly generatePkce?: boolean;
+  readonly disableGoogleAuth?: boolean;
   readonly onRegister?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
   readonly setEmail: (email: string) => void;
@@ -41,7 +42,7 @@ export interface EmailFormProps extends BaseLoginRequest {
 export function EmailForm(props: EmailFormProps): JSX.Element {
   const { setEmail, onRegister, handleAuthResponse, children, ...baseLoginRequest } = props;
   const medplum = useMedplum();
-  const googleClientId = getGoogleClientId(props.googleClientId);
+  const googleClientId = !props.disableGoogleAuth && getGoogleClientId(props.googleClientId);
 
   const isExternalAuth = useCallback(
     async (authMethod: any): Promise<boolean> => {

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -499,6 +499,34 @@ describe('SignInForm', () => {
     expect(props.onRegister).toBeCalled();
   });
 
+  test('Disable Google auth', async () => {
+    const google = {
+      accounts: {
+        id: {
+          initialize: jest.fn(),
+          renderButton: jest.fn(),
+        },
+      },
+    };
+
+    (window as any).google = google;
+
+    const onSuccess = jest.fn();
+
+    await act(async () => {
+      await setup({
+        onSuccess,
+        disableGoogleAuth: true,
+        googleClientId: '123',
+      });
+    });
+
+    await waitFor(() => screen.getByLabelText('Email', { exact: false }));
+    expect(screen.queryByText('Sign in with Google')).toBeNull();
+    expect(google.accounts.id.initialize).not.toHaveBeenCalled();
+    expect(google.accounts.id.renderButton).not.toHaveBeenCalled();
+  });
+
   test('Google success', async () => {
     const clientId = '123';
     let callback: ((response: GoogleCredentialResponse) => void) | undefined = undefined;

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -12,6 +12,7 @@ import { NewProjectForm } from './NewProjectForm';
 export interface SignInFormProps extends BaseLoginRequest {
   readonly login?: string;
   readonly chooseScopes?: boolean;
+  readonly disableGoogleAuth?: boolean;
   readonly onSuccess?: () => void;
   readonly onForgotPassword?: () => void;
   readonly onRegister?: () => void;
@@ -102,6 +103,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
               onForgotPassword={onForgotPassword}
               onRegister={onRegister}
               handleAuthResponse={handleAuthResponse}
+              disableGoogleAuth={props.disableGoogleAuth}
               {...baseLoginRequest}
             >
               {props.children}


### PR DESCRIPTION
You can now pass `disableGoogleAuth` to `<SignInForm>` to disable all Google authentication.

Disabling Google auth is not just a matter of "do not provide `googleClientId`" because the React components automatically use the default publicly available client ID for known hosts (i.e., "localhost:3000").