### PR TITLE
Fixed urn:uuid: replacement on ifNoneExist match

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@medplum/definitions';
-import { Bundle, Observation, Patient, SearchParameter } from '@medplum/fhirtypes';
+import { Bundle, Observation, Patient, Practitioner, SearchParameter } from '@medplum/fhirtypes';
 import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '../types';
 import { matchesSearchRequest } from './match';
 import { Operator, parseSearchDefinition, SearchRequest } from './search';
@@ -537,5 +537,25 @@ describe('Search matching', () => {
       filters: [{ code: 'identifier', operator: Operator.EQUALS, value: 'foo' }],
     };
     expect(matchesSearchRequest(resource, search2)).toBe(false);
+  });
+
+  test('Identifier with system', () => {
+    const identifier = '1234567890';
+
+    const resource: Practitioner = {
+      resourceType: 'Practitioner',
+      identifier: [
+        {
+          system: 'https://example.com',
+          value: identifier,
+        },
+      ],
+    };
+
+    const search1: SearchRequest = {
+      resourceType: 'Practitioner',
+      filters: [{ code: 'identifier', operator: Operator.EQUALS, value: 'https://example.com|' + identifier }],
+    };
+    expect(matchesSearchRequest(resource, search1)).toBe(true);
   });
 });

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -96,7 +96,11 @@ class BatchProcessor {
         return buildBundleResponse(badRequest('Multiple matches'));
       }
       if (entries.length === 1) {
-        return buildBundleResponse(allOk, entries[0].resource);
+        const matchingResource = entries[0].resource as Resource;
+        if (entry.fullUrl) {
+          this.#addReplacementId(entry.fullUrl, matchingResource);
+        }
+        return buildBundleResponse(allOk, matchingResource);
       }
     }
 


### PR DESCRIPTION
The bug was here:

<img width="447" alt="image" src="https://user-images.githubusercontent.com/749094/220440051-ca35d7d3-5b64-43e8-85bd-816a86815aed.png">

This was a regression introduced in https://github.com/medplum/medplum/pull/1435

The batch execution correctly performed the `ifNoneExist` query.  The result of the query was not added to the "ID's to be replaced", which then left the original `urn:uuid:` in place.

There were tests for `ifNoneExist`, but no tests that used the value in replacement.

The rest of this diff is tests, and improving the `token` search behavior in `MockClient` for tests.