### PR TITLE
Use globalThis for default fetch

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2347,26 +2347,17 @@ export class MedplumClient extends EventTarget {
 }
 
 /**
- * Returns the current window if available.
- * All access to the current window should use this to support SSR such as Next.js.
- * @returns The current window or undefined if not available.
- */
-function getWindow(): Window | undefined {
-  return typeof window === 'undefined' ? undefined : window;
-}
-
-/**
  * Returns the default fetch method.
  * The default fetch is currently only available in browser environments.
  * If you want to use SSR such as Next.js, you should pass a custom fetch function.
  * @returns The default fetch function for the current environment.
  */
 function getDefaultFetch(): FetchLike {
-  const window = getWindow();
-  if (!window) {
+  const result = globalThis.fetch;
+  if (!result) {
     throw new Error('Fetch not available in this environment');
   }
-  return window.fetch.bind(window);
+  return result;
 }
 
 /**
@@ -2374,8 +2365,10 @@ function getDefaultFetch(): FetchLike {
  * @category HTTP
  */
 function getWindowOrigin(): string {
-  const window = getWindow();
-  return window ? window.location.protocol + '//' + window.location.host + '/' : '';
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  return window.location.protocol + '//' + window.location.host + '/';
 }
 
 function ensureTrailingSlash(url: string | undefined): string | undefined {


### PR DESCRIPTION
Use `globalThis.fetch` rather than `window.fetch`.  This enables automatic detection of `fetch` on Node.js 18+.

`globalThis`:

> The globalThis property provides a standard way of accessing the global this value (and hence the global object itself) across environments. Unlike similar properties such as window and self, it's guaranteed to work in window and non-window contexts. In this way, you can access the global object in a consistent manner without having to know which environment the code is being run in. To help you remember the name, just remember that in global scope the this value is globalThis.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

Before, to use `MedplumClient` in a Node.js application, we recommended `node-fetch`:

```ts
import { MedplumClient } from '@medplum/core';
import fetch from 'node-fetch';

const medplum = new MedplumClient({ fetch });
```

Node.js 18 added a default `fetch` implementation.  Unfortunately, TypeScript's Node.js 18 type definitions do not include `fetch`, so you have to manually declare the type:

```ts
import { FetchLike, MedplumClient } from '@medplum/core';

declare global {
  var fetch: FetchLike;
}

const medplum = new MedplumClient({ fetch });
```

After this change, you don't need to do any of that.  You can simply use `MedplumClient` as you would expect:

```ts
import { MedplumClient } from '@medplum/core';

const medplum = new MedplumClient();
```