### PR TITLE
Project admin auth cleanup

### DIFF
--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -1,21 +1,14 @@
-import { createReference, forbidden } from '@medplum/core';
+import { createReference } from '@medplum/core';
 import { AccessPolicy, ClientApplication, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { Repository, systemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
-import { verifyProjectAdmin } from './utils';
 
 export const createClientValidators = [body('name').notEmpty().withMessage('Client name is required')];
 
 export async function createClientHandler(req: Request, res: Response): Promise<void> {
-  const project = await verifyProjectAdmin(req, res);
-  if (!project) {
-    sendOutcome(res, forbidden);
-    return;
-  }
-
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
     sendOutcome(res, invalidRequest(errors));
@@ -24,7 +17,7 @@ export async function createClientHandler(req: Request, res: Response): Promise<
 
   const client = await createClient(res.locals.repo as Repository, {
     ...req.body,
-    project: project,
+    project: res.locals.project,
   });
 
   res.status(201).json(client);

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -8,7 +8,7 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
+import { addTestUser, setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 
 jest.mock('@aws-sdk/client-sesv2');
 jest.mock('hibp');
@@ -163,14 +163,8 @@ describe('Admin Invite', () => {
       password: 'password!@#',
     });
 
-    // Second, Bob creates a project
-    const bobRegistration = await registerNew({
-      firstName: 'Bob',
-      lastName: 'Jones',
-      projectName: 'Bob Project',
-      email: `bob${randomUUID()}@example.com`,
-      password: 'password!@#',
-    });
+    // Second, Alice invites Bob to project
+    const bobRegistration = await addTestUser(aliceRegistration.project);
 
     // Third, Bob tries to invite Carol to Alice's project
     // In this example, Bob is not an admin of Alice's project

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -90,12 +90,14 @@ export async function initTestAuth(options?: Partial<Project>): Promise<string> 
 
 export async function addTestUser(
   project: Project,
-  accessPolicy: AccessPolicy
+  accessPolicy?: AccessPolicy
 ): Promise<{ user: User; profile: ProfileResource; accessToken: string }> {
-  accessPolicy = await systemRepo.createResource<AccessPolicy>({
-    ...accessPolicy,
-    meta: { project: project.id },
-  });
+  if (accessPolicy) {
+    accessPolicy = await systemRepo.createResource<AccessPolicy>({
+      ...accessPolicy,
+      meta: { project: project.id },
+    });
+  }
 
   const email = randomUUID() + '@example.com';
   const password = randomUUID();
@@ -106,7 +108,8 @@ export async function addTestUser(
     resourceType: 'Patient',
     firstName: 'Bob',
     lastName: 'Jones',
-    accessPolicy: createReference(accessPolicy),
+    accessPolicy: accessPolicy && createReference(accessPolicy),
+    sendEmail: false,
   });
 
   const login = await tryLogin({


### PR DESCRIPTION
This is prep work for the upcoming SCIM API endpoints.  SCIM will only be available to project admins, so all of this work directly applies.

----

Before: Each project admin endpoint duplicated the `verifyProjectAdmin` check

After:  `verifyProjectAdmin` is an express middleware handler, so it can be applied to routes and groups of routes.

Why?

When `verifyProjectAdmin` was first introduced, the user/auth/project model was different, and a single user could admin multiple projects in the same session.  That has not been true for a long time.  Instead, an active session is always associated with a single project.

This also highlights an oddity that project admin API URL's include the project ID (i.e., `/admin/project/123/invite`), which is implicit, because the user's current session  is always associated with a single project.  After this change, the ID in the URL is ignored and unused.