### PR TITLE
Added Specimen collection dates to DiagnosticReportDisplay

### DIFF
--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
@@ -1,5 +1,5 @@
-import { createReference } from '@medplum/core';
-import { Observation, Reference } from '@medplum/fhirtypes';
+import { createReference, deepClone } from '@medplum/core';
+import { Observation, Reference, Specimen } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport } from '@medplum/mock';
 import { Meta } from '@storybook/react';
 import React, { useEffect, useState } from 'react';
@@ -41,6 +41,25 @@ export const WithCategories = (): JSX.Element => {
   return (
     <Document>
       <DiagnosticReportDisplay value={ExampleReport} />
+    </Document>
+  );
+};
+
+export const MultipleSpecimens = (): JSX.Element => {
+  const report = deepClone(HomerDiagnosticReport);
+  report.specimen = [HomerDiagnosticReport.specimen?.[0], HomerDiagnosticReport.specimen?.[0]] as Reference<Specimen>[];
+
+  return (
+    <Document>
+      <DiagnosticReportDisplay value={report} />
+    </Document>
+  );
+};
+
+export const HideSpecimenInfo = (): JSX.Element => {
+  return (
+    <Document>
+      <DiagnosticReportDisplay hideSpecimenInfo value={HomerDiagnosticReport} />
     </Document>
   );
 };

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
@@ -12,6 +12,7 @@ const syntheaReport: DiagnosticReport = {
   resourceType: 'DiagnosticReport',
   id: 'e508a0f9-17f1-49a9-8151-0e21cb19098f',
   status: 'final',
+  specimen: HomerDiagnosticReport.specimen,
   category: [
     {
       coding: [
@@ -123,8 +124,8 @@ describe('DiagnosticReportDisplay', () => {
       setup({ value: ExampleReport });
     });
 
-    expect(screen.getByText('Test Organization')).toBeDefined();
-    expect(screen.getByText('Alice Smith')).toBeDefined();
+    expect(screen.getByText('Test Organization')).not.toBeNull();
+    expect(screen.getByText('Alice Smith')).not.toBeNull();
   });
 
   test('Renders observation category', async () => {
@@ -145,7 +146,7 @@ describe('DiagnosticReportDisplay', () => {
     await act(async () => {
       setup({ value: ExampleReport });
     });
-    expect(screen.getByText('Previously reported as 167 mg/dL on 2/3/2023, 8:40:14 PM')).toBeDefined();
+    expect(screen.getByText('Previously reported as 167 mg/dL on 2/3/2023, 8:40:14 PM')).not.toBeNull();
   });
 
   test('Hide observation note', async () => {
@@ -156,5 +157,30 @@ describe('DiagnosticReportDisplay', () => {
       setup({ value: ExampleReport, hideObservationNotes: true });
     });
     expect(screen.queryByText('Previously reported as 167 mg/dL on 2/3/2023, 8:40:14 PM')).toBeNull();
+  });
+
+  test('Renders specimen note', async () => {
+    await act(async () => {
+      setup({ value: syntheaReport });
+    });
+
+    expect(screen.queryByText('Specimen hemolyzed. Results may be affected.')).not.toBeNull();
+    expect(screen.queryByText('Specimen lipemic. Results may be affected.')).not.toBeNull();
+  });
+
+  test('Renders specimen collected time', async () => {
+    await act(async () => {
+      setup({ value: syntheaReport });
+    });
+
+    expect(screen.queryByText('Collected:')).not.toBeNull();
+  });
+
+  test('Renders hide specimen info', async () => {
+    await act(async () => {
+      setup({ value: syntheaReport, hideSpecimenInfo: true });
+    });
+
+    expect(screen.queryByText('Collected:')).toBeNull();
   });
 });

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -87,7 +87,7 @@ export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JS
   return (
     <Stack>
       <Title>Diagnostic Report</Title>
-      {DiagnosticReportHeader(diagnosticReport)}
+      <DiagnosticReportHeader value={diagnosticReport} />
       {!props.hideSpecimenInfo && SpecimenInfo(specimens)}
       {diagnosticReport.result && (
         <ObservationTable hideObservationNotes={props.hideObservationNotes} value={diagnosticReport.result} />
@@ -97,21 +97,25 @@ export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JS
   );
 }
 
-function DiagnosticReportHeader(diagnosticReport: DiagnosticReport): JSX.Element {
+interface DiagnosticReportHeaderProps {
+  value: DiagnosticReport;
+}
+
+function DiagnosticReportHeader({ value }: DiagnosticReportHeaderProps): JSX.Element {
   return (
     <Group mt="md" spacing={30}>
-      {diagnosticReport.subject && (
+      {value.subject && (
         <div>
           <Text size="xs" transform="uppercase" color="dimmed">
             Subject
           </Text>
           <Text>
-            <ResourceBadge value={diagnosticReport.subject} link={true} />
+            <ResourceBadge value={value.subject} link={true} />
           </Text>
         </div>
       )}
-      {diagnosticReport.resultsInterpreter &&
-        diagnosticReport.resultsInterpreter.map((interpreter) => (
+      {value.resultsInterpreter &&
+        value.resultsInterpreter.map((interpreter) => (
           <div key={interpreter.reference}>
             <Text size="xs" transform="uppercase" color="dimmed">
               Interpreter
@@ -121,8 +125,8 @@ function DiagnosticReportHeader(diagnosticReport: DiagnosticReport): JSX.Element
             </Text>
           </div>
         ))}
-      {diagnosticReport.performer &&
-        diagnosticReport.performer.map((performer) => (
+      {value.performer &&
+        value.performer.map((performer) => (
           <div key={performer.reference}>
             <Text size="xs" transform="uppercase" color="dimmed">
               Performer
@@ -132,20 +136,20 @@ function DiagnosticReportHeader(diagnosticReport: DiagnosticReport): JSX.Element
             </Text>
           </div>
         ))}
-      {diagnosticReport.issued && (
+      {value.issued && (
         <div>
           <Text size="xs" transform="uppercase" color="dimmed">
             Issued
           </Text>
-          <Text>{formatDateTime(diagnosticReport.issued)}</Text>
+          <Text>{formatDateTime(value.issued)}</Text>
         </div>
       )}
-      {diagnosticReport.status && (
+      {value.status && (
         <div>
           <Text size="xs" transform="uppercase" color="dimmed">
             Status
           </Text>
-          <Text>{capitalize(diagnosticReport.status)}</Text>
+          <Text>{capitalize(value.status)}</Text>
         </div>
       )}
     </Group>

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -65,7 +65,12 @@ export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JS
 
   useEffect(() => {
     if (diagnosticReport?.specimen) {
-      Promise.all(diagnosticReport.specimen.map((ref) => medplum.readReference(ref)))
+      Promise.allSettled(diagnosticReport.specimen.map((ref) => medplum.readReference(ref)))
+        .then((outcomes) =>
+          outcomes
+            .filter((outcome) => outcome.status === 'fulfilled')
+            .map((outcome) => (outcome as PromiseFulfilledResult<Specimen>).value)
+        )
         .then(setSpecimens)
         .catch(console.error);
     }

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -1,4 +1,4 @@
-import { createStyles, Group, Stack, Text, Title } from '@mantine/core';
+import { createStyles, Group, List, Stack, Text, Title } from '@mantine/core';
 import { capitalize, formatDateTime, formatObservationValue } from '@medplum/core';
 import {
   Annotation,
@@ -7,10 +7,12 @@ import {
   ObservationComponent,
   ObservationReferenceRange,
   Reference,
+  Specimen,
 } from '@medplum/fhirtypes';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { CodeableConceptDisplay } from '../CodeableConceptDisplay/CodeableConceptDisplay';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
+import { useMedplum } from '../MedplumProvider/MedplumProvider';
 import { NoteDisplay } from '../NoteDisplay/NoteDisplay';
 import { RangeDisplay } from '../RangeDisplay/RangeDisplay';
 import { ReferenceDisplay } from '../ReferenceDisplay/ReferenceDisplay';
@@ -48,17 +50,32 @@ const useStyles = createStyles((theme) => ({
 export interface DiagnosticReportDisplayProps {
   value?: DiagnosticReport | Reference<DiagnosticReport>;
   hideObservationNotes?: boolean;
+  hideSpecimenInfo?: boolean;
 }
 
+DiagnosticReportDisplay.defaultProps = {
+  hideObservationNotes: false,
+  hideSpecimenInfo: false,
+} as DiagnosticReportDisplayProps;
+
 export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JSX.Element | null {
+  const medplum = useMedplum();
   const diagnosticReport = useResource(props.value);
-  const specimen = useResource(diagnosticReport?.specimen?.[0]);
+  const [specimens, setSpecimens] = useState<Specimen[]>();
+
+  useEffect(() => {
+    if (diagnosticReport?.specimen) {
+      Promise.all(diagnosticReport.specimen.map((ref) => medplum.readReference(ref)))
+        .then(setSpecimens)
+        .catch(console.error);
+    }
+  }, [medplum, diagnosticReport]);
 
   if (!diagnosticReport) {
     return null;
   }
 
-  const specimenNotes: Annotation[] = specimen?.note || [];
+  const specimenNotes: Annotation[] = specimens?.flatMap((spec) => spec.note || []) || [];
 
   if (diagnosticReport.presentedForm && diagnosticReport.presentedForm.length > 0) {
     const pf = diagnosticReport.presentedForm[0];
@@ -70,60 +87,92 @@ export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JS
   return (
     <Stack>
       <Title>Diagnostic Report</Title>
-      <Group mt="md" spacing={30}>
-        {diagnosticReport.subject && (
-          <div>
-            <Text size="xs" transform="uppercase" color="dimmed">
-              Subject
-            </Text>
-            <Text>
-              <ResourceBadge value={diagnosticReport.subject} link={true} />
-            </Text>
-          </div>
-        )}
-        {diagnosticReport.resultsInterpreter &&
-          diagnosticReport.resultsInterpreter.map((interpreter) => (
-            <div key={interpreter.reference}>
-              <Text size="xs" transform="uppercase" color="dimmed">
-                Interpreter
-              </Text>
-              <Text>
-                <ResourceBadge value={interpreter} link={true} />
-              </Text>
-            </div>
-          ))}
-        {diagnosticReport.performer &&
-          diagnosticReport.performer.map((performer) => (
-            <div key={performer.reference}>
-              <Text size="xs" transform="uppercase" color="dimmed">
-                Performer
-              </Text>
-              <Text>
-                <ResourceBadge value={performer} link={true} />
-              </Text>
-            </div>
-          ))}
-        {diagnosticReport.issued && (
-          <div>
-            <Text size="xs" transform="uppercase" color="dimmed">
-              Issued
-            </Text>
-            <Text>{formatDateTime(diagnosticReport.issued)}</Text>
-          </div>
-        )}
-        {diagnosticReport.status && (
-          <div>
-            <Text size="xs" transform="uppercase" color="dimmed">
-              Status
-            </Text>
-            <Text>{capitalize(diagnosticReport.status)}</Text>
-          </div>
-        )}
-      </Group>
+      {DiagnosticReportHeader(diagnosticReport)}
+      {!props.hideSpecimenInfo && SpecimenInfo(specimens)}
       {diagnosticReport.result && (
         <ObservationTable hideObservationNotes={props.hideObservationNotes} value={diagnosticReport.result} />
       )}
       {specimenNotes.length > 0 && <NoteDisplay value={specimenNotes} />}
+    </Stack>
+  );
+}
+
+function DiagnosticReportHeader(diagnosticReport: DiagnosticReport): JSX.Element {
+  return (
+    <Group mt="md" spacing={30}>
+      {diagnosticReport.subject && (
+        <div>
+          <Text size="xs" transform="uppercase" color="dimmed">
+            Subject
+          </Text>
+          <Text>
+            <ResourceBadge value={diagnosticReport.subject} link={true} />
+          </Text>
+        </div>
+      )}
+      {diagnosticReport.resultsInterpreter &&
+        diagnosticReport.resultsInterpreter.map((interpreter) => (
+          <div key={interpreter.reference}>
+            <Text size="xs" transform="uppercase" color="dimmed">
+              Interpreter
+            </Text>
+            <Text>
+              <ResourceBadge value={interpreter} link={true} />
+            </Text>
+          </div>
+        ))}
+      {diagnosticReport.performer &&
+        diagnosticReport.performer.map((performer) => (
+          <div key={performer.reference}>
+            <Text size="xs" transform="uppercase" color="dimmed">
+              Performer
+            </Text>
+            <Text>
+              <ResourceBadge value={performer} link={true} />
+            </Text>
+          </div>
+        ))}
+      {diagnosticReport.issued && (
+        <div>
+          <Text size="xs" transform="uppercase" color="dimmed">
+            Issued
+          </Text>
+          <Text>{formatDateTime(diagnosticReport.issued)}</Text>
+        </div>
+      )}
+      {diagnosticReport.status && (
+        <div>
+          <Text size="xs" transform="uppercase" color="dimmed">
+            Status
+          </Text>
+          <Text>{capitalize(diagnosticReport.status)}</Text>
+        </div>
+      )}
+    </Group>
+  );
+}
+
+function SpecimenInfo(specimens: Specimen[] | undefined): JSX.Element {
+  return (
+    <Stack spacing={'xs'}>
+      <Title order={2} size="h6">
+        Specimens
+      </Title>
+
+      <List type="ordered">
+        {specimens?.map((specimen, index) => (
+          <List.Item ml={'sm'} key={`specimen-${specimen.id}-${index}`}>
+            <Group spacing={20}>
+              <Group spacing={5}>
+                <Text fw={500}>Collected:</Text> {formatDateTime(specimen.collection?.collectedDateTime)}
+              </Group>
+              <Group spacing={5}>
+                <Text fw={500}>Received:</Text> {formatDateTime(specimen.receivedTime)}
+              </Group>
+            </Group>
+          </List.Item>
+        ))}
+      </List>
     </Stack>
   );
 }
@@ -151,7 +200,7 @@ export function ObservationTable(props: ObservationTableProps): JSX.Element {
       <tbody>
         {props.value?.map((observation, index) => (
           <ObservationRow
-            key={`obs-${index}-${observation.id}`}
+            key={`obs-${observation.id}-${index}`}
             hideObservationNotes={props.hideObservationNotes}
             value={observation}
           />


### PR DESCRIPTION
This PR adds specimen collection and receipt times to the `DiagnosticReportDisplay` component, to help lab staff quickly identifier missing dates