### PR TITLE
Initial SCIM support

### DIFF
--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -739,6 +739,17 @@
             }]
           },
           {
+            "id" : "ProjectMembership.invitedBy",
+            "path" : "ProjectMembership.invitedBy",
+            "definition" : "The project administrator who invited the user to the project.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "Reference",
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/User"]
+            }]
+          },
+          {
             "id" : "ProjectMembership.user",
             "path" : "ProjectMembership.user",
             "definition" : "User that is granted access to the project.",

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -58,6 +58,11 @@ export interface ProjectMembership {
   project?: Reference<Project>;
 
   /**
+   * The project administrator who invited the user to the project.
+   */
+  invitedBy?: Reference<User>;
+
+  /**
    * User that is granted access to the project.
    */
   user?: Reference<Bot | ClientApplication | User>;

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -59,6 +59,7 @@ export interface InviteRequest {
   readonly accessPolicy?: Reference<AccessPolicy>;
   readonly sendEmail?: boolean;
   readonly password?: string;
+  readonly invitedBy?: Reference<User>;
 }
 
 export async function inviteUser(

--- a/packages/server/src/scim/routes.test.ts
+++ b/packages/server/src/scim/routes.test.ts
@@ -1,8 +1,12 @@
+import { createReference } from '@medplum/core';
+import { AccessPolicy } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
+import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { initTestAuth } from '../test.setup';
+import { systemRepo } from '../fhir/repo';
 
 const app = express();
 let accessToken: string;
@@ -11,7 +15,28 @@ describe('SCIM Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    accessToken = await initTestAuth();
+
+    // First, Alice creates a project
+    const registration = await registerNew({
+      firstName: 'Alice',
+      lastName: 'Smith',
+      projectName: 'Alice Project',
+      email: `alice${randomUUID()}@example.com`,
+      password: 'password!@#',
+    });
+    accessToken = registration.accessToken;
+
+    // Create default access policy
+    const accessPolicy = await systemRepo.createResource<AccessPolicy>({
+      resourceType: 'AccessPolicy',
+      resource: [{ resourceType: 'Patient' }],
+    });
+
+    // Update project with default access policy
+    await systemRepo.updateResource({
+      ...registration.project,
+      defaultPatientAccessPolicy: createReference(accessPolicy),
+    });
   });
 
   afterAll(async () => {
@@ -23,44 +48,70 @@ describe('SCIM Routes', () => {
       .get(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res.status).toBe(200);
+
+    const result = res.body;
+    expect(result.totalResults).toBeDefined();
+    expect(result.Resources).toBeDefined();
   });
 
-  test('Create user', async () => {
+  test('Create and update user', async () => {
+    const res1 = await request(app)
+      .post(`/scim/v2/Users`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        schemas: [
+          'urn:ietf:params:scim:schemas:core:2.0:User',
+          'urn:ietf:params:scim:schemas:extension:medplum:2.0:Patient',
+        ],
+        userName: randomUUID() + '@example.com',
+        name: {
+          givenName: 'SCIM',
+          familyName: 'User',
+        },
+      });
+    expect(res1.status).toBe(201);
+
+    const readResponse = await request(app)
+      .get(`/scim/v2/Users/${res1.body.id}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(readResponse.status).toBe(200);
+    expect(readResponse.body.id).toBe(res1.body.id);
+
+    const searchResponse = await request(app)
+      .get(`/scim/v2/Users`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(searchResponse.status).toBe(200);
+
+    const searchCheck = searchResponse.body.Resources.find((user: any) => user.id === res1.body.id);
+    expect(searchCheck).toBeDefined();
+
+    const updateResponse = await request(app)
+      .put(`/scim/v2/Users/${res1.body.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/json')
+      .send({
+        ...res1.body,
+        externalId: randomUUID(),
+      });
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.externalId).toBeDefined();
+  });
+
+  test('Create missing medplum user type', async () => {
     const res = await request(app)
       .post(`/scim/v2/Users`)
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', 'application/json')
-      .send({});
-    expect(res.status).toBe(200);
-  });
-
-  test('Read user', async () => {
-    const res = await request(app)
-      .get(`/scim/v2/Users/123`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
-  });
-
-  test('Update user', async () => {
-    const res = await request(app)
-      .put(`/scim/v2/Users/123`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/json')
-      .send({});
-    expect(res.status).toBe(200);
-  });
-
-  test('Delete user', async () => {
-    const res = await request(app)
-      .delete(`/scim/v2/Users/123`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
-  });
-
-  test('Patch user', async () => {
-    const res = await request(app)
-      .patch(`/scim/v2/Users/123`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toBe(200);
+      .send({
+        schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        userName: randomUUID() + '@example.com',
+        name: {
+          givenName: 'SCIM',
+          familyName: 'User',
+        },
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.issue[0].details.text).toBe('Missing Medplum user type');
   });
 });

--- a/packages/server/src/scim/routes.ts
+++ b/packages/server/src/scim/routes.ts
@@ -1,32 +1,44 @@
 import { Request, Response, Router } from 'express';
+import { verifyProjectAdmin } from '../admin/utils';
+import { asyncWrap } from '../async';
 import { authenticateToken } from '../oauth/middleware';
+import { createScimUser, readScimUser, searchScimUsers, updateScimUser } from './utils';
 
 export const scimRouter = Router();
 scimRouter.use(authenticateToken);
+scimRouter.use(verifyProjectAdmin);
 
 // SCIM
 // http://www.simplecloud.info/
 
-scimRouter.get('/:resourceType', (_req: Request, res: Response) => {
-  res.sendStatus(200);
-});
+scimRouter.get(
+  '/Users',
+  asyncWrap(async (_req: Request, res: Response) => {
+    const result = await searchScimUsers(res.locals.project);
+    res.status(200).json(result);
+  })
+);
 
-scimRouter.post('/:resourceType', (_req: Request, res: Response) => {
-  res.sendStatus(200);
-});
+scimRouter.post(
+  '/Users',
+  asyncWrap(async (req: Request, res: Response) => {
+    const result = await createScimUser(res.locals.user, res.locals.project, req.body);
+    res.status(201).json(result);
+  })
+);
 
-scimRouter.get('/:resourceType/:id', (_req: Request, res: Response) => {
-  res.sendStatus(200);
-});
+scimRouter.get(
+  '/Users/:id',
+  asyncWrap(async (req: Request, res: Response) => {
+    const result = await readScimUser(res.locals.project, req.params.id);
+    res.status(200).json(result);
+  })
+);
 
-scimRouter.put('/:resourceType/:id', (_req: Request, res: Response) => {
-  res.sendStatus(200);
-});
-
-scimRouter.delete('/:resourceType/:id', (_req: Request, res: Response) => {
-  res.sendStatus(200);
-});
-
-scimRouter.patch('/:resourceType/:id', (_req: Request, res: Response) => {
-  res.sendStatus(200);
-});
+scimRouter.put(
+  '/Users/:id',
+  asyncWrap(async (req: Request, res: Response) => {
+    const result = await updateScimUser(res.locals.project, req.body);
+    res.status(200).json(result);
+  })
+);

--- a/packages/server/src/scim/types.ts
+++ b/packages/server/src/scim/types.ts
@@ -1,0 +1,112 @@
+/**
+ * A complex attribute containing resource metadata.  All "meta"
+ * sub-attributes are assigned by the service provider (have a
+ * "mutability" of "readOnly"), and all of these sub-attributes have
+ * a "returned" characteristic of "default".  This attribute SHALL be
+ * ignored when provided by clients.
+ *
+ * See SCIM 3.1 - Common Attributes
+ * https://www.rfc-editor.org/rfc/rfc7643#section-3.1
+ */
+export interface ScimMeta {
+  resourceType?: string;
+  created?: string;
+  lastModified?: string;
+  location?: string;
+  version?: string;
+}
+
+/**
+ * The components of the user's name.  Service providers MAY return
+ * just the full name as a single string in the formatted
+ * sub-attribute, or they MAY return just the individual component
+ * attributes using the other sub-attributes, or they MAY return
+ * both.  If both variants are returned, they SHOULD be describing
+ * the same name, with the formatted name indicating how the
+ * component attributes should be combined.
+ *
+ * See SCIM 4.1 - User Resource
+ * https://www.rfc-editor.org/rfc/rfc7643#section-4.1
+ */
+export interface ScimName {
+  formatted?: string;
+  familyName?: string;
+  givenName?: string;
+  middleName?: string;
+  honorificPrefix?: string;
+  honorificSuffix?: string;
+}
+
+/**
+ * Phone numbers for the user.  The value SHOULD be specified
+ * according to the format defined in [RFC3966], e.g.,
+ * 'tel:+1-201-555-0123'.  Service providers SHOULD canonicalize the
+ * value according to [RFC3966] format, when appropriate.  The
+ * "display" sub-attribute MAY be used to return the canonicalized
+ * representation of the phone number value.  The sub-attribute
+ * "type" often has typical values of "work", "home", "mobile",
+ * "fax", "pager", and "other" and MAY allow more types to be defined
+ * by the SCIM clients.
+ *
+ * See SCIM 4.1 - User Resource
+ * https://www.rfc-editor.org/rfc/rfc7643#section-4.1
+ */
+export interface ScimPhoneNumber {
+  type?: string;
+  value?: string;
+}
+
+/**
+ * Email addresses for the User.  The value SHOULD be specified
+ * according to [RFC5321].  Service providers SHOULD canonicalize the
+ * value according to [RFC5321], e.g., "bjensen@example.com" instead
+ * of "bjensen@EXAMPLE.COM".  The "display" sub-attribute MAY be used
+ * to return the canonicalized representation of the email value.
+ * The "type" sub-attribute is used to provide a classification
+ * meaningful to the (human) user.  The user interface should
+ * encourage the use of basic values of "work", "home", and "other"
+ * and MAY allow additional type values to be used at the discretion
+ * of SCIM clients.
+ *
+ * See SCIM 4.1 - User Resource
+ * https://www.rfc-editor.org/rfc/rfc7643#section-4.1
+ */
+export interface ScimEmail {
+  type?: string;
+  value?: string;
+  primary?: boolean;
+}
+
+/**
+ * SCIM provides a resource type for "User" resources.  The core schema
+ * for "User" is identified using the following schema URI:
+ * "urn:ietf:params:scim:schemas:core:2.0:User".  The following
+ * attributes are defined in addition to the core schema attributes.
+ *
+ * See SCIM 4.1 - User Resource
+ * https://www.rfc-editor.org/rfc/rfc7643#section-4.1
+ */
+export interface ScimUser {
+  schemas?: string[];
+  id?: string;
+  externalId?: string;
+  userName?: string;
+  meta?: ScimMeta;
+  name?: ScimName;
+  phoneNumbers?: ScimPhoneNumber[];
+  emails?: ScimEmail[];
+}
+
+/**
+ * Responses MUST be identified using the following URI:
+ * "urn:ietf:params:scim:api:messages:2.0:ListResponse".  The following
+ * attributes are defined for responses.
+ *
+ * See SCIM 3.4.2 - List Response
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2
+ */
+export interface ScimListResponse<T> {
+  schemas?: string[];
+  totalResults?: number;
+  Resources: T[];
+}

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -1,0 +1,192 @@
+import { badRequest, forbidden, getReferenceString, OperationOutcomeError, Operator } from '@medplum/core';
+import { BundleEntry, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import { inviteUser } from '../admin/invite';
+import { getConfig } from '../config';
+import { systemRepo } from '../fhir/repo';
+import { ScimListResponse, ScimUser } from './types';
+
+/**
+ * Searches for users in the project.
+ *
+ * See SCIM 3.4.2 - Query Resources
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2
+ *
+ * @param project The project.
+ * @returns List of SCIM users in the project.
+ */
+export async function searchScimUsers(project: Project): Promise<ScimListResponse<ScimUser>> {
+  const memberships = (
+    (
+      await systemRepo.search<ProjectMembership>({
+        resourceType: 'ProjectMembership',
+        filters: [
+          {
+            code: 'project',
+            operator: Operator.EQUALS,
+            value: getReferenceString(project),
+          },
+        ],
+      })
+    ).entry as BundleEntry<ProjectMembership>[]
+  ).map((m) => m.resource as ProjectMembership);
+
+  const users = await systemRepo.readReferences(memberships.map((m) => m.user as Reference<User>));
+  const result = [];
+
+  for (let i = 0; i < memberships.length; i++) {
+    result.push(convertToScimUser(users[i] as User, memberships[i]));
+  }
+
+  return convertToScimListResponse(result);
+}
+
+/**
+ * Creates a user in the project.
+ *
+ * See SCIM 3.3 - Creating Resources
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.3
+ *
+ * @param invitedBy The user who invited the new user.
+ * @param project The project.
+ * @param scimUser The new user definition.
+ * @returns The new user.
+ */
+export async function createScimUser(
+  invitedBy: Reference<User>,
+  project: Project,
+  scimUser: ScimUser
+): Promise<ScimUser> {
+  const resourceType = getScimUserResourceType(scimUser);
+  if (!resourceType) {
+    throw new OperationOutcomeError(badRequest('Missing Medplum user type'));
+  }
+
+  const accessPolicy = project.defaultPatientAccessPolicy;
+  if (!accessPolicy) {
+    throw new OperationOutcomeError(badRequest('Missing defaultPatientAccessPolicy'));
+  }
+
+  const { user, membership } = await inviteUser({
+    project,
+    invitedBy,
+    resourceType,
+    firstName: scimUser.name?.givenName as string,
+    lastName: scimUser.name?.familyName as string,
+    email: scimUser.userName,
+    externalId: scimUser.externalId,
+    sendEmail: false,
+    accessPolicy,
+  });
+
+  return convertToScimUser(user, membership);
+}
+
+/**
+ * Reads an existing user.
+ *
+ * See SCIM 3.4.1 - Retrieve a Known Resource
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.1
+ *
+ * @param project The project.
+ * @param id The user ID.
+ * @returns The user.
+ */
+export async function readScimUser(project: Project, id: string): Promise<ScimUser> {
+  const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', id);
+  if (membership.project?.reference !== getReferenceString(project)) {
+    throw new OperationOutcomeError(forbidden);
+  }
+
+  const user = await systemRepo.readReference<User>(membership.user as Reference<User>);
+  return convertToScimUser(user, membership);
+}
+
+/**
+ * Updates an existing user.
+ *
+ * See SCIM 3.5.1 - Replace a Resource
+ * https://www.rfc-editor.org/rfc/rfc7644#section-3.5.1
+ *
+ * @param project The project.
+ * @param scimUser The updated user definition.
+ * @returns The updated user.
+ */
+export async function updateScimUser(project: Project, scimUser: ScimUser): Promise<ScimUser> {
+  const membership = await systemRepo.readResource<ProjectMembership>('ProjectMembership', scimUser.id as string);
+  if (membership.project?.reference !== getReferenceString(project)) {
+    throw new OperationOutcomeError(forbidden);
+  }
+
+  let user = await systemRepo.readReference<User>(membership.user as Reference<User>);
+  user.firstName = scimUser.name?.givenName as string;
+  user.lastName = scimUser.name?.familyName as string;
+  user.email = scimUser.userName;
+  user.externalId = scimUser.externalId;
+  user = await systemRepo.updateResource(user);
+
+  return convertToScimUser(user, membership);
+}
+
+/**
+ * Returns the Medplum profile resource type from the SCIM definition.
+ *
+ * By default, a SCIM User does not have the equivalent of a FHIR resource type.
+ *
+ * This function looks for the Medplum extension, which contains the resource type.
+ *
+ * @param scimUser The SCIM user definition.
+ * @returns The FHIR profile resource type if found; otherwise, undefined.
+ */
+export function getScimUserResourceType(scimUser: ScimUser): 'Patient' | 'Practitioner' | 'RelatedPerson' | undefined {
+  const resourceType = scimUser.schemas
+    ?.find((x) => x.startsWith('urn:ietf:params:scim:schemas:extension:medplum:2.0:'))
+    ?.split(':')
+    ?.pop();
+  if (resourceType === 'Patient' || resourceType === 'Practitioner' || resourceType === 'RelatedPerson') {
+    return resourceType;
+  }
+  return undefined;
+}
+
+/**
+ * Converts a Medplum user and project membershipt into a SCIM user.
+ * @param user The Medplum user.
+ * @param membership The Medplum project membership.
+ * @returns The SCIM user.
+ */
+export function convertToScimUser(user: User, membership: ProjectMembership): ScimUser {
+  const config = getConfig();
+  const resourceType = membership.profile?.reference?.split('/')?.shift() as string;
+  return {
+    schemas: [
+      'urn:ietf:params:scim:schemas:core:2.0:User',
+      'urn:ietf:params:scim:schemas:extension:medplum:2.0:' + resourceType,
+    ],
+    id: membership.id,
+    meta: {
+      resourceType: 'User',
+      version: membership.meta?.lastUpdated,
+      lastModified: membership.meta?.lastUpdated,
+      location: config.baseUrl + 'scim/2.0/Users/' + membership.id,
+    },
+    userName: user.email,
+    externalId: user.externalId,
+    name: {
+      givenName: user.firstName,
+      familyName: user.lastName,
+    },
+  };
+}
+
+/**
+ * Converts an array of resources into a SCIM ListResponse.
+ * @param Resources The list of resources.
+ * @returns The SCIM ListResponse object.
+ */
+export function convertToScimListResponse<T>(Resources: T[]): ScimListResponse<T> {
+  return {
+    schemas: ['urn:ietf:params:scim:api:messages:2.0:ListResponse'],
+    totalResults: Resources.length,
+    Resources,
+  };
+}


### PR DESCRIPTION
Adding minimal support for SCIM `Users` endpoints.  This is a thin wrapper around our existing project admin capabilities.  The main benefit is that it follows the SCIM standard.  The one net new feature is that it allows admin users to modify `externalId`.

There is a lot of future work here, both in terms of adding more SCIM API support, and also aligning our `User` and `ProjectMembership` object model with SCIM `User`.