### PR TITLE
Bugfix: useResource makes incorrect fetch when called with resource with id

### DIFF
--- a/packages/react/src/useResource/useResource.test.tsx
+++ b/packages/react/src/useResource/useResource.test.tsx
@@ -150,7 +150,7 @@ describe('useResource', () => {
 
   test('Responds to value edit after cache', async () => {
     function TestComponentWrapper(): JSX.Element {
-      // Call useResource with a reference to fille the cache
+      // Call useResource with a reference to fill the cache
       useResource({ reference: 'ServiceRequest/123' });
       const [resource, setResource] = useState<ServiceRequest>({
         resourceType: 'ServiceRequest',

--- a/packages/react/src/useResource/useResource.test.tsx
+++ b/packages/react/src/useResource/useResource.test.tsx
@@ -119,6 +119,7 @@ describe('useResource', () => {
       const [resource, setResource] = useState<ServiceRequest>({
         resourceType: 'ServiceRequest',
         status: 'draft',
+        id: '123',
       });
       return (
         <>

--- a/packages/react/src/useResource/useResource.test.tsx
+++ b/packages/react/src/useResource/useResource.test.tsx
@@ -123,7 +123,9 @@ describe('useResource', () => {
       });
       return (
         <>
-          <button onClick={() => setResource((sr) => ({ ...sr, status: 'active' }))}>Click</button>
+          <button onClick={() => setResource((sr) => ({ ...sr, status: sr.status === 'active' ? 'draft' : 'active' }))}>
+            Click
+          </button>
           <TestComponent value={resource} />
         </>
       );
@@ -138,7 +140,52 @@ describe('useResource', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Click'));
     });
-
     expect(el.innerHTML).toContain('active');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Click'));
+    });
+    expect(el.innerHTML).not.toContain('active');
+  });
+
+  test('Responds to value edit after cache', async () => {
+    function TestComponentWrapper(): JSX.Element {
+      // Call useResource with a reference to fille the cache
+      useResource({ reference: 'ServiceRequest/123' });
+      const [resource, setResource] = useState<ServiceRequest>({
+        resourceType: 'ServiceRequest',
+        status: 'draft',
+        id: '123',
+      });
+
+      return (
+        <>
+          <button
+            onClick={() => {
+              setResource((sr) => ({ ...sr, status: sr.status === 'active' ? 'draft' : 'active' }));
+            }}
+          >
+            Click
+          </button>
+          <TestComponent value={resource} />
+        </>
+      );
+    }
+
+    await setup(<TestComponentWrapper />);
+
+    const el = screen.getByTestId('test-component');
+    expect(el).toBeInTheDocument();
+    expect(el.innerHTML).not.toContain('active');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Click'));
+    });
+    expect(el.innerHTML).toContain('active');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Click'));
+    });
+    expect(el.innerHTML).not.toContain('active');
   });
 });

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -36,7 +36,7 @@ export function useResource<T extends Resource>(
   useEffect(() => {
     if (resourceRef.current) {
       if (!deepEquals(prevResource, currentResource)) {
-        forceRerender(currentResource);
+        forceRerender(resourceRef.current);
       }
     } else if (referenceRef.current && referenceRef.current.reference !== lastRequestedRef.current) {
       lastRequestedRef.current = referenceRef.current.reference;
@@ -82,10 +82,6 @@ function parseValue<T extends Resource>(
     referenceRef.current = value as Reference<T>;
   } else if ('resourceType' in value) {
     resourceRef.current = value;
-    if ('id' in value) {
-      // If the input is a resource with an ID, then we can still create a reference
-      referenceRef.current = { reference: value.resourceType + '/' + value.id };
-    }
   }
 }
 

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -34,7 +34,11 @@ export function useResource<T extends Resource>(
 
   // Subscribe to changes to the passed-in value
   useEffect(() => {
-    if (referenceRef.current && referenceRef.current.reference !== lastRequestedRef.current) {
+    if (resourceRef.current) {
+      if (!deepEquals(prevResource, value)) {
+        forceRerender(currentResource);
+      }
+    } else if (referenceRef.current && referenceRef.current.reference !== lastRequestedRef.current) {
       lastRequestedRef.current = referenceRef.current.reference;
       medplum
         .readReference(referenceRef.current)

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -35,7 +35,7 @@ export function useResource<T extends Resource>(
   // Subscribe to changes to the passed-in value
   useEffect(() => {
     if (resourceRef.current) {
-      if (!deepEquals(prevResource, value)) {
+      if (!deepEquals(prevResource, currentResource)) {
         forceRerender(currentResource);
       }
     } else if (referenceRef.current && referenceRef.current.reference !== lastRequestedRef.current) {
@@ -53,7 +53,7 @@ export function useResource<T extends Resource>(
           }
         });
     }
-  }, [medplum, prevResource, value, setOutcome]);
+  }, [medplum, prevResource, currentResource, setOutcome]);
 
   return currentResource;
 }


### PR DESCRIPTION
Before: 
calling `useResource({resourceType: 'ServiceRequest', id: '123'})` would always fetch from the server, even if the resource had been modified on the client.

After: 
If calling with a resource that has been modified client-side, re-render if `deepEquals` fails