### PR TITLE
Typeguards for `isResource` and `isReference`

### DIFF
--- a/packages/app/src/admin/AccessPolicyInput.tsx
+++ b/packages/app/src/admin/AccessPolicyInput.tsx
@@ -1,4 +1,4 @@
-import { createReference } from '@medplum/core';
+import { createReference, isResource } from '@medplum/core';
 import { AccessPolicy, Reference } from '@medplum/fhirtypes';
 import { ResourceInput } from '@medplum/react';
 import React from 'react';
@@ -17,7 +17,7 @@ export function AccessPolicyInput(props: AccessPolicyInputProps): JSX.Element {
       defaultValue={props.defaultValue}
       placeholder="Access Policy"
       onChange={(newValue) => {
-        if (newValue && 'resourceType' in newValue) {
+        if (isResource(newValue)) {
           props.onChange(createReference(newValue));
         } else {
           props.onChange(undefined);

--- a/packages/app/src/admin/UserConfigurationInput.tsx
+++ b/packages/app/src/admin/UserConfigurationInput.tsx
@@ -1,4 +1,4 @@
-import { createReference } from '@medplum/core';
+import { createReference, isResource } from '@medplum/core';
 import { Reference, UserConfiguration } from '@medplum/fhirtypes';
 import { ResourceInput } from '@medplum/react';
 import React from 'react';
@@ -17,7 +17,7 @@ export function UserConfigurationInput(props: UserConfigurationInputProps): JSX.
       defaultValue={props.defaultValue}
       placeholder="User Configuration"
       onChange={(newValue) => {
-        if (newValue && 'resourceType' in newValue) {
+        if (isResource(newValue)) {
           props.onChange(createReference(newValue));
         } else {
           props.onChange(undefined);

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -1,6 +1,5 @@
-import { Resource } from '@medplum/fhirtypes';
 import { Atom, InfixOperatorAtom, PrefixOperatorAtom } from '../fhirlexer';
-import { PropertyType, TypedValue } from '../types';
+import { isResource, PropertyType, TypedValue } from '../types';
 import { functions } from './functions';
 import {
   booleanToTypedValue,
@@ -68,7 +67,7 @@ export class SymbolAtom implements Atom {
       return undefined;
     }
 
-    if ('resourceType' in input && (input as Resource).resourceType === this.name) {
+    if (isResource(input) && input.resourceType === this.name) {
       return typedValue;
     }
 

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1543,7 +1543,7 @@ export const functions: Record<string, FhirPathFunction> = {
       if (typeof value === 'number') {
         return { type: PropertyType.BackboneElement, value: { namespace: 'System', name: 'Integer' } };
       }
-      if (value && isResource(value)) {
+      if (isResource(value)) {
         return {
           type: PropertyType.BackboneElement,
           value: { namespace: 'FHIR', name: value.resourceType },

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1,6 +1,6 @@
-import { Reference, Resource } from '@medplum/fhirtypes';
+import { Reference } from '@medplum/fhirtypes';
 import { Atom } from '../fhirlexer';
-import { PropertyType, TypedValue } from '../types';
+import { isResource, PropertyType, TypedValue } from '../types';
 import { calculateAge } from '../utils';
 import { DotAtom, SymbolAtom } from './atoms';
 import { parseDateString } from './date';
@@ -1543,10 +1543,10 @@ export const functions: Record<string, FhirPathFunction> = {
       if (typeof value === 'number') {
         return { type: PropertyType.BackboneElement, value: { namespace: 'System', name: 'Integer' } };
       }
-      if (value && typeof value === 'object' && 'resourceType' in value) {
+      if (value && isResource(value)) {
         return {
           type: PropertyType.BackboneElement,
-          value: { namespace: 'FHIR', name: (value as Resource).resourceType },
+          value: { namespace: 'FHIR', name: value.resourceType },
         };
       }
       return { type: PropertyType.BackboneElement, value: null };

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -1,5 +1,5 @@
-import { ElementDefinition, Period, Quantity, Resource } from '@medplum/fhirtypes';
-import { buildTypeName, getElementDefinition, PropertyType, TypedValue } from '../types';
+import { ElementDefinition, Period, Quantity } from '@medplum/fhirtypes';
+import { buildTypeName, getElementDefinition, isResource, PropertyType, TypedValue } from '../types';
 import { capitalize, isEmpty } from '../utils';
 
 /**
@@ -29,8 +29,8 @@ export function toTypedValue(value: unknown): TypedValue {
     return { type: PropertyType.string, value };
   } else if (isQuantity(value)) {
     return { type: PropertyType.Quantity, value };
-  } else if (typeof value === 'object' && 'resourceType' in value) {
-    return { type: (value as Resource).resourceType, value };
+  } else if (isResource(value)) {
+    return { type: value.resourceType, value };
   } else {
     return { type: PropertyType.BackboneElement, value };
   }
@@ -123,7 +123,7 @@ function getTypedPropertyValueWithSchema(
 }
 
 function toTypedValueWithType(value: any, type: string): TypedValue {
-  if (type === 'Resource' && typeof value === 'object' && 'resourceType' in value) {
+  if (type === 'Resource' && isResource(value)) {
     type = value.resourceType;
   }
   return { type, value };
@@ -154,7 +154,7 @@ function getTypedPropertyValueWithoutSchema(
     // Examples:
     // value + valueString = ok, because "string" is valid
     // value + valueDecimal = ok, because "decimal" is valid
-    // id + identifiier = not ok, because "entifier" is not a valid type
+    // id + identifier = not ok, because "entifier" is not a valid type
     // resource + resourceType = not ok, because "type" is not a valid type
     for (const propertyType in PropertyType) {
       const propertyName = path + capitalize(propertyType);

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -8,6 +8,8 @@ import {
   globalSchema,
   indexSearchParameter,
   indexStructureDefinition,
+  isReference,
+  isResource,
   isResourceType,
   TypeSchema,
 } from './types';
@@ -128,5 +130,21 @@ describe('Type Utils', () => {
         },
       } as unknown as TypeSchema)
     ).not.toBeTruthy();
+  });
+
+  test('isResource', () => {
+    expect(isResource(undefined)).toBe(false);
+    expect(isResource('Patient')).toBe(false);
+    expect(isResource({})).toBe(false);
+    expect(isResource({ resourceType: 'Patient' })).toBe(true);
+    expect(isResource({ reference: 'Patient/123' })).toBe(false);
+  });
+
+  test('isReference', () => {
+    expect(isReference(undefined)).toBe(false);
+    expect(isReference('Patient')).toBe(false);
+    expect(isReference({})).toBe(false);
+    expect(isReference({ resourceType: 'Patient' })).toBe(false);
+    expect(isReference({ reference: 'Patient/123' })).toBe(true);
   });
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import {
   Bundle,
   BundleEntry,
   ElementDefinition,
+  Reference,
   Resource,
   SearchParameter,
   StructureDefinition,
@@ -421,6 +422,26 @@ export function getElementDefinition(typeName: string, propertyName: string): El
   }
 
   return property;
+}
+
+/**
+ * Typeguard to validate that an object is a FHIR resource
+ * @param value The object to check
+ * @returns True if the input is of type 'object' and contains property 'resourceType'
+ */
+export function isResource<T extends Resource = Resource>(value: T | Reference<T> | string | undefined): value is T {
+  return typeof value === 'object' && 'resourceType' in value;
+}
+
+/**
+ * Typeguard to validate that an object is a FHIR resource
+ * @param value The object to check
+ * @returns True if the input is of type 'object' and contains property 'reference'
+ */
+export function isReference<T extends Resource>(
+  value: T | Reference<T> | string | undefined
+): value is Reference<T> & { reference: string } {
+  return typeof value === 'object' && 'reference' in value;
 }
 
 /**

--- a/packages/react/src/MedplumLink/MedplumLink.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.tsx
@@ -1,4 +1,5 @@
 import { Anchor, TextProps } from '@mantine/core';
+import { isReference, isResource } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import React from 'react';
 import { useMedplumNavigate } from '../MedplumProvider/MedplumProvider';
@@ -44,9 +45,9 @@ function getHref(to: Resource | Reference | string | undefined): string {
   if (to) {
     if (typeof to === 'string') {
       return getStringHref(to);
-    } else if ('resourceType' in to) {
+    } else if (isResource(to)) {
       return getResourceHref(to);
-    } else if ('reference' in to) {
+    } else if (isReference(to)) {
       return getReferenceHref(to);
     }
   }

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Button, createStyles, NativeSelect, Textarea, TextInput, Title } from '@mantine/core';
-import { globalSchema, IndexedStructureDefinition } from '@medplum/core';
+import { globalSchema, IndexedStructureDefinition, isResource as isResourceType } from '@medplum/core';
 import { Questionnaire, QuestionnaireItem, QuestionnaireItemAnswerOption, Reference } from '@medplum/fhirtypes';
 import React, { useEffect, useRef, useState } from 'react';
 import { Form } from '../Form/Form';
@@ -134,7 +134,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
   const { classes, cx } = useStyles();
   const resource = props.item as Questionnaire;
   const item = props.item as QuestionnaireItem;
-  const isResource = 'resourceType' in props.item;
+  const isResource = isResourceType(props.item);
   const isContainer = isResource || item.type === QuestionnaireItemType.group;
   const linkId = item.linkId ?? '[untitled]';
   const editing = props.selectedKey === props.item.id;

--- a/packages/react/src/useResource/useResource.ts
+++ b/packages/react/src/useResource/useResource.ts
@@ -1,4 +1,4 @@
-import { deepEquals, MedplumClient, normalizeOperationOutcome } from '@medplum/core';
+import { deepEquals, isReference, isResource, MedplumClient, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
 import { useEffect, useRef, useState } from 'react';
 import { useMedplum } from '../MedplumProvider/MedplumProvider';
@@ -73,10 +73,10 @@ function parseValue<T extends Resource>(
     return;
   }
 
-  if ('reference' in value) {
+  if (isReference<T>(value)) {
     // If the input is a reference then we can use it as-is
-    referenceRef.current = value as Reference<T>;
-  } else if ('resourceType' in value) {
+    referenceRef.current = value;
+  } else if (isResource<T>(value)) {
     resourceRef.current = value;
     if ('id' in value) {
       // If the input is a resource with an ID, then we can still create a reference

--- a/packages/server/src/openapi.ts
+++ b/packages/server/src/openapi.ts
@@ -1,3 +1,4 @@
+import { isResource } from '@medplum/core';
 import { Request, Response } from 'express';
 import { JSONSchema4 } from 'json-schema';
 import { ComponentsObject, OpenAPIObject, ReferenceObject, SchemaObject, TagObject } from 'openapi3-ts';
@@ -515,5 +516,5 @@ function buildPatchPath(): any {
 
 function isResourceType(definition: JSONSchema4): boolean {
   const props = definition?.properties;
-  return !!(props && 'resourceType' in props && 'id' in props && 'meta' in props);
+  return !!(props && isResource(props) && 'id' in props && 'meta' in props);
 }

--- a/packages/server/src/openapi.ts
+++ b/packages/server/src/openapi.ts
@@ -516,5 +516,5 @@ function buildPatchPath(): any {
 
 function isResourceType(definition: JSONSchema4): boolean {
   const props = definition?.properties;
-  return !!(props && isResource(props) && 'id' in props && 'meta' in props);
+  return !!(isResource(props) && 'id' in props && 'meta' in props);
 }


### PR DESCRIPTION
I saw a common pattern in our code where we check if `resourceType` or `reference` is in an object, and then casts it. 

This PR takes advantage of Typescript's user-defined type guards to centralize that check in a utility function and eliminate the cast