### PR TITLE
Set project compartment on Project and ProjectMembership

### DIFF
--- a/packages/server/src/admin/project.test.ts
+++ b/packages/server/src/admin/project.test.ts
@@ -79,6 +79,9 @@ describe('Project Admin routes', () => {
       .get('/admin/projects/' + project.id + '/members/' + member.id)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res4.status).toBe(200);
+    expect(res4.body.resourceType).toEqual('ProjectMembership');
+    expect(res4.body.id).toBeDefined();
+    expect(res4.body.meta.project).toEqual(project.id);
 
     // Try a naughty request using a different resource type
     const res5 = await request(app)

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1643,6 +1643,14 @@ export class Repository {
    * @returns The project ID.
    */
   #getProjectId(resource: Resource): string | undefined {
+    if (resource.resourceType === 'Project') {
+      return resource.id;
+    }
+
+    if (resource.resourceType === 'ProjectMembership') {
+      return resolveId(resource.project);
+    }
+
     if (publicResourceTypes.includes(resource.resourceType)) {
       return undefined;
     }


### PR DESCRIPTION
This is prep work for exposing a limited view of `Project` and `ProjectMembership` to project admin users.

The sequence of events will be:
1. Deploy this PR
2. Run super admin reindex
3. Future PR to expose the resources