### PR TITLE
Use transaction client for lookup tables

### DIFF
--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -88,11 +88,11 @@ export class AddressTable extends LookupTable<Address> {
 
     const resourceType = resource.resourceType;
     const resourceId = resource.id as string;
-    const existing = await this.getExistingValues(resourceType, resourceId);
+    const existing = await this.getExistingValues(client, resourceType, resourceId);
 
     if (!compareArrays(addresses, existing)) {
       if (existing.length > 0) {
-        await this.deleteValuesForResource(resource);
+        await this.deleteValuesForResource(client, resource);
       }
 
       const values = [];

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -68,11 +68,11 @@ export class HumanNameTable extends LookupTable<HumanName> {
 
     const resourceType = resource.resourceType;
     const resourceId = resource.id as string;
-    const existing = await this.getExistingValues(resourceType, resourceId);
+    const existing = await this.getExistingValues(client, resourceType, resourceId);
 
     if (!compareArrays(names, existing)) {
       if (existing.length > 0) {
-        await this.deleteValuesForResource(resource);
+        await this.deleteValuesForResource(client, resource);
       }
 
       const values = [];

--- a/packages/server/src/fhir/lookups/valuesetelement.ts
+++ b/packages/server/src/fhir/lookups/valuesetelement.ts
@@ -41,7 +41,7 @@ export class ValueSetElementTable extends LookupTable<ValueSetExpansionContains>
       return;
     }
 
-    await this.deleteValuesForResource(resource);
+    await this.deleteValuesForResource(client, resource);
 
     const values = [];
 


### PR DESCRIPTION
Backporting a bug fix found in https://github.com/medplum/medplum/pull/1350

When inside a postgres transaction, it is important to use the same postgres client.  There were some edge cases in lookup tables where a new client was borrowed from the pool, which could lead to unexpected behavior and/or performance issues.