### PR TITLE
Fixes #1593 - update tsconfig and type exports

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "esnext",
-    "outDir": "dist",
-    "lib": ["esnext", "dom", "dom.iterable"],
-    "noEmit": true
+    "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "./jest.setup.ts"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,8 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run rollup",
-    "rollup": "rollup --config rollup.config.mjs",
+    "build": "npm run clean && tsc --project tsconfig.build.json && rollup --config rollup.config.mjs",
     "test": "jest"
   },
   "devDependencies": {
@@ -28,13 +27,14 @@
       "optional": true
     }
   },
+  "types": "dist/types/index.d.ts",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "types": "dist/esm/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "medplum",

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -35,7 +35,7 @@ export default [
         file: 'dist/cjs/index.min.cjs',
         format: 'umd',
         name: 'medplum.core',
-        plugins: [terser({ sourceMap: true})],
+        plugins: [terser({ sourceMap: true })],
         sourcemapPathTransform,
         globals,
       },
@@ -50,7 +50,7 @@ export default [
       }),
       json(),
       resolve({ extensions }),
-      typescript({ tsconfig: 'tsconfig.cjs.json', resolveJsonModule: true }),
+      typescript({ outDir: 'dist/cjs', declaration: false }),
       {
         buildEnd: () => {
           mkdirSync('./dist/cjs', { recursive: true });
@@ -75,7 +75,7 @@ export default [
       {
         file: 'dist/esm/index.min.mjs',
         format: 'esm',
-        plugins: [terser({ sourceMap: true})],
+        plugins: [terser({ sourceMap: true })],
         sourcemapPathTransform,
       },
     ],
@@ -89,7 +89,7 @@ export default [
       }),
       json(),
       resolve({ extensions }),
-      typescript({ tsconfig: 'tsconfig.esm.json', resolveJsonModule: true }),
+      typescript({ module: 'es6', outDir: 'dist/esm', declaration: false }),
       {
         buildEnd: () => {
           mkdirSync('./dist/esm/node_modules/tslib', { recursive: true });

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "es6",
-    "outDir": "dist/esm"
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "exclude": ["**/*.test.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "lib": ["esnext", "dom"],
-    "emitDeclarationOnly": true,
-    "resolveJsonModule": true
+    "lib": ["esnext", "dom"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist/index.js dist/index.d.ts",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc --project tsconfig.build.json",
     "test": "jest"
   },
   "main": "dist/index.js",

--- a/packages/definitions/tsconfig.build.json
+++ b/packages/definitions/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/definitions/tsconfig.json
+++ b/packages/definitions/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "lib": ["esnext"]
-  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -12,8 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc && npm run rollup",
-    "rollup": "rollup --config rollup.config.mjs",
+    "build": "npm run clean && tsc --project tsconfig.build.json && rollup --config rollup.config.mjs",
     "test": "jest"
   },
   "dependencies": {
@@ -26,11 +25,12 @@
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "medplum",

--- a/packages/fhir-router/rollup.config.mjs
+++ b/packages/fhir-router/rollup.config.mjs
@@ -44,7 +44,7 @@ export default {
   ],
   plugins: [
     resolve({ extensions }),
-    typescript(),
+    typescript({ declaration: false }),
     json(),
     {
       buildEnd: () => {

--- a/packages/fhir-router/tsconfig.build.json
+++ b/packages/fhir-router/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/cjs"
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "exclude": ["**/*.test.ts"]
 }

--- a/packages/fhir-router/tsconfig.json
+++ b/packages/fhir-router/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "lib": ["esnext", "dom"],
-    "emitDeclarationOnly": true,
-    "resolveJsonModule": true
-  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -12,8 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc && npm run rollup",
-    "rollup": "rollup --config rollup.config.mjs",
+    "build": "npm run clean && tsc --project tsconfig.build.json && rollup --config rollup.config.mjs",
     "test": "jest"
   },
   "dependencies": {
@@ -29,11 +28,12 @@
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/types/index.d.ts",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "medplum",

--- a/packages/mock/rollup.config.mjs
+++ b/packages/mock/rollup.config.mjs
@@ -44,7 +44,7 @@ export default {
   ],
   plugins: [
     resolve({ extensions }),
-    typescript(),
+    typescript({ declaration: false }),
     json(),
     {
       buildEnd: () => {

--- a/packages/mock/tsconfig.build.json
+++ b/packages/mock/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/mock/tsconfig.json
+++ b/packages/mock/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "lib": ["esnext", "dom"],
-    "emitDeclarationOnly": true,
-    "resolveJsonModule": true
-  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "clean": "rimraf dist storybook-static",
     "dev": "start-storybook -p 6006",
-    "build": "npm run clean && npm run rollup",
-    "rollup": "rollup --config rollup.config.mjs",
+    "build": "npm run clean && tsc --project tsconfig.build.json && rollup --config rollup.config.mjs",
     "test": "jest",
     "storybook": "build-storybook"
   },
@@ -78,13 +77,12 @@
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/types/index.d.ts",
   "exports": {
-    ".": {
-      "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs"
-    }
+    "types": "./dist/types/index.d.ts",
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
-  "types": "dist/esm/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "medplum",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -59,7 +59,7 @@ export default [
       peerDepsExternal(),
       resolve({ extensions }),
       svgr(),
-      typescript({ tsconfig: 'tsconfig.cjs.json', resolveJsonModule: true }),
+      typescript({ outDir: 'dist/cjs', declaration: false }),
       {
         buildEnd: () => {
           mkdirSync('./dist/cjs', { recursive: true });
@@ -100,7 +100,7 @@ export default [
       peerDepsExternal(),
       resolve({ extensions }),
       svgr(),
-      typescript({ tsconfig: 'tsconfig.esm.json', resolveJsonModule: true }),
+      typescript({ module: 'es6', outDir: 'dist/esm', declaration: false }),
       {
         buildEnd: () => {
           mkdirSync('./dist/esm', { recursive: true });

--- a/packages/react/src/SearchControl/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl/SearchControl.test.tsx
@@ -31,7 +31,7 @@ describe('SearchControl', () => {
   }
 
   test('Renders results', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -55,7 +55,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders _lastUpdated filter', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -78,7 +78,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders empty results', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -102,7 +102,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders choice of type', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Observation',
         fields: ['value[x]'],
@@ -121,7 +121,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders with checkboxes', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -147,7 +147,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders empty results with checkboxes', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -172,7 +172,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders search parameter columns', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         fields: ['id', '_lastUpdated', 'name', 'birthDate', 'active', 'email', 'phone'],
@@ -193,7 +193,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders nested properties', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         fields: ['id', '_lastUpdated', 'name', 'address-city', 'address-state'],
@@ -214,7 +214,7 @@ describe('SearchControl', () => {
   });
 
   test('Renders filters', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         fields: ['id', 'name'],
@@ -239,7 +239,7 @@ describe('SearchControl', () => {
   });
 
   test('Next page button', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         count: 1,
@@ -266,7 +266,7 @@ describe('SearchControl', () => {
   });
 
   test('Next page button without onChange listener', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         count: 1,
@@ -290,7 +290,7 @@ describe('SearchControl', () => {
   });
 
   test('Prev page button', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         count: 1,
@@ -394,7 +394,7 @@ describe('SearchControl', () => {
   });
 
   test('Click on row', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -425,7 +425,7 @@ describe('SearchControl', () => {
   });
 
   test('Aux click on row', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -456,7 +456,7 @@ describe('SearchControl', () => {
   });
 
   test('Field editor onOk', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -486,7 +486,7 @@ describe('SearchControl', () => {
   });
 
   test('Field editor onCancel', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -516,7 +516,7 @@ describe('SearchControl', () => {
   });
 
   test('Filter editor onOk', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -546,7 +546,7 @@ describe('SearchControl', () => {
   });
 
   test('Filter editor onCancel', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -576,7 +576,7 @@ describe('SearchControl', () => {
   });
 
   test('Popup menu and prompt', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -615,7 +615,7 @@ describe('SearchControl', () => {
   });
 
   test('Click all checkbox', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -654,7 +654,7 @@ describe('SearchControl', () => {
   });
 
   test('Click row checkbox', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -697,7 +697,7 @@ describe('SearchControl', () => {
   });
 
   test('Activate popup menu', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         fields: ['id', 'name'],
@@ -741,7 +741,7 @@ describe('SearchControl', () => {
   });
 
   test('Hide toolbar', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [
@@ -769,7 +769,7 @@ describe('SearchControl', () => {
   });
 
   test('Hide filters', async () => {
-    const props = {
+    const props: SearchControlProps = {
       search: {
         resourceType: 'Patient',
         filters: [

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -1,6 +1,6 @@
 import { Button, Menu } from '@mantine/core';
 import { Filter, globalSchema, Operator, SearchRequest } from '@medplum/core';
-import { SearchParameter } from '@medplum/fhirtypes';
+import { ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -39,7 +39,7 @@ describe('SearchPopupMenu', () => {
 
   test('Invalid resource', () => {
     setup({
-      search: { resourceType: 'xyz' },
+      search: { resourceType: 'xyz' as ResourceType },
     });
   });
 
@@ -607,7 +607,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Renders meta.versionId', async () => {
-    const search = {
+    const search: SearchRequest = {
       resourceType: 'Patient',
       fields: ['meta.versionId'],
     };
@@ -627,7 +627,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Renders _lastUpdated', async () => {
-    const search = {
+    const search: SearchRequest = {
       resourceType: 'Patient',
       fields: ['_lastUpdated'],
     };
@@ -650,7 +650,7 @@ describe('SearchPopupMenu', () => {
   });
 
   test('Search parameter choice', async () => {
-    const search = {
+    const search: SearchRequest = {
       resourceType: 'Observation',
       fields: ['value[x]'],
     };
@@ -682,7 +682,7 @@ describe('SearchPopupMenu', () => {
       },
     };
 
-    const search = {
+    const search: SearchRequest = {
       resourceType: 'Observation',
       fields: ['subject'],
     };

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/packages/react/tsconfig.cjs.json
+++ b/packages/react/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs"
-  },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
-}

--- a/packages/react/tsconfig.esm.json
+++ b/packages/react/tsconfig.esm.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "es6",
-    "outDir": "dist/esm"
-  },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
-}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "lib": ["esnext", "dom", "dom.iterable"],
-    "emitDeclarationOnly": true,
-    "resolveJsonModule": true
+    "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc --project tsconfig.build.json",
     "prestart": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node-dev --poll --respawn --transpile-only src/index.ts",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": false
+  },
+  "exclude": ["**/*.test.ts", "src/__mocks__/**/*.ts"]
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,9 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "lib": ["esnext"]
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "src/__mocks__/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react",
@@ -19,7 +19,9 @@
     "noFallthroughCasesInSwitch": false,
     "experimentalDecorators": true,
     "strictPropertyInitialization": true,
-    "allowJs": true
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "noEmit": true
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
1. Only emit TypeScript types once, and always emit to `dist/types`
2. Standardized conventions for `tsconfig.json`:
  a. Use `tsconfig.json` by default for development work - no output to disk, include tests
  b. Use `tsconfig.build.json` when building for publish - output types, exclude tests
3. Always include `"types"` inside `"exports"`, and it should always be the first entry ([order matters?](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing))
4. Because we were previously excluding `*.test.tsx` in the `react` package, this revealed a bunch of TypeScript errors in tests