### PR TITLE
Generate fhir.schema.json from StructureDefinitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44881,6 +44881,7 @@
         "@medplum/core": "*",
         "@medplum/definitions": "*",
         "@medplum/fhirtypes": "*",
+        "@types/json-schema": "7.0.11",
         "fast-xml-parser": "4.1.2",
         "fhirpath": "3.3.1"
       }
@@ -53131,6 +53132,7 @@
         "@medplum/core": "*",
         "@medplum/definitions": "*",
         "@medplum/fhirtypes": "*",
+        "@types/json-schema": "7.0.11",
         "fast-xml-parser": "4.1.2",
         "fhirpath": "3.3.1"
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -161,7 +161,7 @@ export function indexStructureDefinition(structureDefinition: StructureDefinitio
     elements.forEach((element) => indexType(structureDefinition, element));
 
     // Second pass, build properties
-    elements.forEach((element) => indexProperty(element));
+    elements.forEach((element) => indexProperty(structureDefinition, element));
   }
 }
 
@@ -179,7 +179,13 @@ function indexType(structureDefinition: StructureDefinition, elementDefinition: 
   if (typeCode !== undefined && typeCode !== 'Element' && typeCode !== 'BackboneElement') {
     return;
   }
+
   const parts = path.split('.');
+
+  // Force the first part to be the type name
+  // This is necessary for "SimpleQuantity" and "MoneyQuantity"
+  parts[0] = structureDefinition.name as string;
+
   const typeName = buildTypeName(parts);
   let typeSchema = globalSchema.types[typeName];
 
@@ -200,12 +206,17 @@ function indexType(structureDefinition: StructureDefinition, elementDefinition: 
  * @param element The input ElementDefinition.
  * @see {@link IndexedStructureDefinition} for more details on indexed StructureDefinitions.
  */
-function indexProperty(element: ElementDefinition): void {
+function indexProperty(structureDefinition: StructureDefinition, element: ElementDefinition): void {
   const path = element.path as string;
   const parts = path.split('.');
   if (parts.length === 1) {
     return;
   }
+
+  // Force the first part to be the type name
+  // This is necessary for "SimpleQuantity" and "MoneyQuantity"
+  parts[0] = structureDefinition.name as string;
+
   const typeName = buildTypeName(parts.slice(0, parts.length - 1));
   const typeSchema = globalSchema.types[typeName];
   if (!typeSchema) {

--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -160,7 +160,10 @@
       "JsonWebKey": "#/definitions/JsonWebKey",
       "Bot": "#/definitions/Bot",
       "AccessPolicy": "#/definitions/AccessPolicy",
-      "UserConfiguration": "#/definitions/UserConfiguration"
+      "UserConfiguration": "#/definitions/UserConfiguration",
+      "BulkDataExport": "#/definitions/BulkDataExport",
+      "SmartAppLaunch": "#/definitions/SmartAppLaunch",
+      "DomainConfiguration": "#/definitions/DomainConfiguration"
     }
   },
   "oneOf": [
@@ -628,6 +631,18 @@
     },
     {
       "$ref": "#/definitions/UserConfiguration"
+    },
+    {
+      "$ref": "#/definitions/ProjectMembership"
+    },
+    {
+      "$ref": "#/definitions/BulkDataExport"
+    },
+    {
+      "$ref": "#/definitions/SmartAppLaunch"
+    },
+    {
+      "$ref": "#/definitions/DomainConfiguration"
     }
   ],
   "definitions": {
@@ -1097,6 +1112,18 @@
         },
         {
           "$ref": "#/definitions/UserConfiguration"
+        },
+        {
+          "$ref": "#/definitions/ProjectMembership"
+        },
+        {
+          "$ref": "#/definitions/BulkDataExport"
+        },
+        {
+          "$ref": "#/definitions/SmartAppLaunch"
+        },
+        {
+          "$ref": "#/definitions/DomainConfiguration"
         }
       ]
     },
@@ -61058,7 +61085,7 @@
       "additionalProperties": false
     },
     "Project": {
-      "description": "Medplum project. A Medplum project is the top-level entity for Medplum. A project is an isolated set of resources.",
+      "description": "Encapsulation of resources for a specific project or organization.",
       "properties": {
         "resourceType": {
           "description": "This is a Project resource",
@@ -61096,8 +61123,12 @@
           "description": "Whether this project uses strict FHIR validation.",
           "$ref": "#/definitions/boolean"
         },
+        "checkReferencesOnWrite": {
+          "description": "Whether this project uses referential integrity on write operations such as \u0027create\u0027 and \u0027update\u0027.",
+          "$ref": "#/definitions/boolean"
+        },
         "owner": {
-          "description": "Indicates the user with responsibility for managing the Project.",
+          "description": "The user who owns the project.",
           "$ref": "#/definitions/Reference"
         },
         "features": {
@@ -61124,75 +61155,84 @@
             "$ref": "#/definitions/Project_Site"
           },
           "type": "array"
+        },
+        "ipAccessRule": {
+          "description": "Use IP Access Rules to allowlist, block, and challenge traffic based on the visitor IP address.",
+          "items": {
+            "$ref": "#/definitions/Project_IpAccessRule"
+          },
+          "type": "array"
         }
       },
+      "additionalProperties": false,
       "required": [
-        "name",
-        "owner"
+        "resourceType"
       ]
     },
     "Project_Secret": {
       "description": "Secure environment variable that can be used to store secrets for bots.",
       "properties": {
         "name": {
-          "description": "A name associated with the Project.",
+          "description": "The secret name.",
+          "$ref": "#/definitions/string"
+        },
+        "valueString": {
+          "description": "The secret value.",
           "$ref": "#/definitions/string"
         },
         "valueBoolean": {
-          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^true|false$",
-          "type": "boolean"
+          "description": "The secret value.",
+          "$ref": "#/definitions/boolean"
         },
         "valueDecimal": {
-          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
-          "type": "number"
+          "description": "The secret value.",
+          "$ref": "#/definitions/decimal"
         },
         "valueInteger": {
-          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^-?([0]|([1-9][0-9]*))$",
-          "type": "number"
-        },
-        "valueString": {
-          "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^[ \\r\\n\\t\\S]+$",
-          "type": "string"
+          "description": "The secret value.",
+          "$ref": "#/definitions/integer"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ]
     },
     "Project_Site": {
       "description": "Web application or web site that is associated with the project.",
       "properties": {
         "name": {
-          "description": "A name associated with the Project.",
+          "description": "Friendly name that will make it easy for you to identify the site in the future.",
           "$ref": "#/definitions/string"
         },
         "domain": {
-          "description": "A name associated with the Project.",
+          "description": "The list of domain names associated with the site. User authentication will be restricted to the domains you enter here, plus any subdomains. In other words, a registration for example.com also registers subdomain.example.com. A valid domain requires a host and must not include any path, port, query or fragment.",
           "items": {
             "$ref": "#/definitions/string"
           },
           "type": "array"
         },
         "googleClientId": {
-          "description": "A name associated with the Project.",
+          "description": "The publicly visible Google Client ID for the site. This is used to authenticate users with Google. This value is available in the Google Developer Console.",
           "$ref": "#/definitions/string"
         },
         "googleClientSecret": {
-          "description": "A name associated with the Project.",
+          "description": "The private Google Client Secret for the site. This value is available in the Google Developer Console.",
           "$ref": "#/definitions/string"
         },
         "recaptchaSiteKey": {
-          "description": "A name associated with the Project.",
+          "description": "The publicly visible reCAPTCHA site key. This value is generated when you create a new reCAPTCHA site in the reCAPTCHA admin console. Use this site key in the HTML code your site serves to users.",
           "$ref": "#/definitions/string"
         },
         "recaptchaSecretKey": {
-          "description": "A name associated with the Project.",
+          "description": "The private reCAPTCHA secret key. This value is generated when you create a new reCAPTCHA site in the reCAPTCHA admin console. Use this secret key for communication between your site and reCAPTCHA.",
           "$ref": "#/definitions/string"
         }
       },
+      "additionalProperties": false,
       "required": [
-        "name"
+        "name",
+        "domain"
       ]
     },
     "ProjectMembership": {
@@ -61222,17 +61262,28 @@
           "description": "Project where the memberships are available.",
           "$ref": "#/definitions/Reference"
         },
+        "invitedBy": {
+          "description": "The project administrator who invited the user to the project.",
+          "$ref": "#/definitions/Reference"
+        },
         "user": {
           "description": "User that is granted access to the project.",
           "$ref": "#/definitions/Reference"
         },
         "profile": {
-          "description": "User that is granted access to the project.",
+          "description": "Reference to the resource that represents the user profile within the project.",
           "$ref": "#/definitions/Reference"
         },
         "accessPolicy": {
-          "description": "User that is granted access to the project.",
+          "description": "The access policy for the user within the project memebership.",
           "$ref": "#/definitions/Reference"
+        },
+        "access": {
+          "description": "Extended access configuration using parameterized access policies.",
+          "items": {
+            "$ref": "#/definitions/ProjectMembership_Access"
+          },
+          "type": "array"
         },
         "userConfiguration": {
           "description": "The user configuration for the user within the project memebership such as menu links, saved searches, and features.",
@@ -61243,14 +61294,15 @@
           "$ref": "#/definitions/boolean"
         }
       },
+      "additionalProperties": false,
       "required": [
+        "resourceType",
         "project",
-        "user",
-        "profile"
+        "user"
       ]
     },
     "ClientApplication": {
-      "description": "OAuth client application.",
+      "description": "Medplum client application for automated access.",
       "properties": {
         "resourceType": {
           "description": "This is a ClientApplication resource",
@@ -61268,24 +61320,16 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
         },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
-        },
         "name": {
-          "description": "Human friendly display name that describes the client application.",
+          "description": "A name associated with the ClientApplication.",
           "$ref": "#/definitions/string"
         },
         "description": {
-          "description": "A summary, characterization or explanation of the Client Application.",
+          "description": "A summary, characterization or explanation of the ClientApplication.",
           "$ref": "#/definitions/string"
         },
         "secret": {
@@ -61293,16 +61337,16 @@
           "$ref": "#/definitions/string"
         },
         "jwksUri": {
-          "description": "Optional JWKS URI for public key verification of JWTs issued by the authorization server (client_secret_jwt)",
-          "$ref": "#/definitions/string"
+          "description": "Optional JWKS URI for public key verification of JWTs issued by the authorization server (client_secret_jwt).",
+          "$ref": "#/definitions/uri"
         },
         "redirectUri": {
-          "description": "Redirect URI used when redirecting a client back to the client application.",
-          "$ref": "#/definitions/string"
+          "description": "Optional redirect URI used when redirecting a client back to the client application.",
+          "$ref": "#/definitions/uri"
         },
         "launchUri": {
           "description": "Optional launch URI for SMART EHR launch sequence.",
-          "$ref": "#/definitions/string"
+          "$ref": "#/definitions/uri"
         },
         "pkceOptional": {
           "description": "Flag to make PKCE optional for this client application. PKCE is required by default for compliance with Smart App Launch. It can be disabled for compatibility with legacy client applications.",
@@ -61313,13 +61357,13 @@
           "$ref": "#/definitions/IdentityProvider"
         }
       },
+      "additionalProperties": false,
       "required": [
-        "resourceType",
-        "secret"
+        "resourceType"
       ]
     },
     "User": {
-      "description": "OAuth user.",
+      "description": "Representation of a human user of the system.",
       "properties": {
         "resourceType": {
           "description": "This is a User resource",
@@ -61337,17 +61381,9 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
-        },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
         },
         "firstName": {
           "description": "The first name or given name of the user. This is the value as entered when the user is created. It is used to populate the profile resource.",
@@ -61355,6 +61391,10 @@
         },
         "lastName": {
           "description": "The last name or family name of the user. This is the value as entered when the user is created. It is used to populate the profile resource.",
+          "$ref": "#/definitions/string"
+        },
+        "externalId": {
+          "description": "A String that is an identifier for the resource as defined by the provisioning client.  The \"externalId\" may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain\u0027s identifier of the resource and the identifier used by the service provider.  Each resource MAY include a non-empty \"externalId\" value.  The value of the \"externalId\" attribute is always issued by the provisioning client and MUST NOT be specified by the service provider.  The service provider MUST always interpret the externalId as scoped to the provisioning domain.",
           "$ref": "#/definitions/string"
         },
         "email": {
@@ -61365,25 +61405,36 @@
           "description": "Whether the system has verified that the user has access to the email address.",
           "$ref": "#/definitions/boolean"
         },
+        "admin": {
+          "description": "DEPRECATED",
+          "$ref": "#/definitions/boolean"
+        },
         "passwordHash": {
-          "description": "Encrypted hash of the user's password.",
+          "description": "Encrypted hash of the user\u0027s password.",
           "$ref": "#/definitions/string"
         },
-        "admin": {
-          "description": "Whether this user is a system administrator.",
+        "mfaSecret": {
+          "description": "Shared secret for MFA authenticator applications.",
+          "$ref": "#/definitions/string"
+        },
+        "mfaEnrolled": {
+          "description": "Whether the user has completed MFA enrollment.",
           "$ref": "#/definitions/boolean"
         },
         "project": {
-          "description": "Project where the memberships are available.",
+          "description": "Optional project if the user only exists for the project. This is used for the project-specific user database.",
           "$ref": "#/definitions/Reference"
         }
       },
+      "additionalProperties": false,
       "required": [
-        "email"
+        "resourceType",
+        "firstName",
+        "lastName"
       ]
     },
     "Login": {
-      "description": "OAuth login.",
+      "description": "Login event and session details.",
       "properties": {
         "resourceType": {
           "description": "This is a Login resource",
@@ -61401,20 +61452,20 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
         },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
-        },
         "client": {
           "description": "The client requesting the code.",
+          "$ref": "#/definitions/Reference"
+        },
+        "profileType": {
+          "description": "Optional required profile resource type.",
+          "$ref": "#/definitions/code"
+        },
+        "project": {
+          "description": "Optional required project for the login.",
           "$ref": "#/definitions/Reference"
         },
         "user": {
@@ -61461,6 +61512,10 @@
           "description": "Optional cryptographically random string that your app adds to the initial request and the authorization server includes inside the ID Token, used to prevent token replay attacks.",
           "$ref": "#/definitions/string"
         },
+        "mfaVerified": {
+          "description": "Whether the user has verified using multi-factor authentication (MFA). This will only be set is the user has MFA enabled (see User.mfaEnrolled).",
+          "$ref": "#/definitions/boolean"
+        },
         "granted": {
           "description": "Whether a token has been granted for this login.",
           "$ref": "#/definitions/boolean"
@@ -61469,20 +61524,17 @@
           "description": "Whether this login has been revoked or invalidated.",
           "$ref": "#/definitions/boolean"
         },
-        "compartments": {
-          "description": "Collection of compartments that the user has been granted access.  This is a flattened collection of all ProjectMembership compartments at the time of login.",
-          "items": {
-            "$ref": "#/definitions/Reference"
-          },
-          "type": "array"
-        },
         "admin": {
-          "description": "Whether this login has system administrator privileges.",
+          "description": "DEPRECATED",
           "$ref": "#/definitions/boolean"
         },
         "superAdmin": {
           "description": "Whether this login has super administrator privileges.",
           "$ref": "#/definitions/boolean"
+        },
+        "launch": {
+          "description": "Optional SMART App Launch context for this login.",
+          "$ref": "#/definitions/Reference"
         },
         "remoteAddress": {
           "description": "The Internet Protocol (IP) address of the client or last proxy that sent the request.",
@@ -61492,10 +61544,17 @@
           "description": "The User-Agent request header as sent by the client.",
           "$ref": "#/definitions/string"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "user",
+        "authMethod",
+        "authTime"
+      ]
     },
     "PasswordChangeRequest": {
-      "description": "Password change request for the 'forgot password' flow.",
+      "description": "Password change request for the \u0027forgot password\u0027 flow.",
       "properties": {
         "resourceType": {
           "description": "This is a PasswordChangeRequest resource",
@@ -61513,17 +61572,9 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
-        },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
         },
         "user": {
           "description": "The user requesting the password change.",
@@ -61539,9 +61590,15 @@
         },
         "redirectUri": {
           "description": "Redirect URI used when redirecting a client back to the client application.",
-          "$ref": "#/definitions/string"
+          "$ref": "#/definitions/uri"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "user",
+        "secret"
+      ]
     },
     "JsonWebKey": {
       "description": "A JSON object that represents a cryptographic key. The members of the object represent properties of the key, including its value.",
@@ -61562,17 +61619,9 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
-        },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
         },
         "active": {
           "description": "Whether this key is in active use.",
@@ -61644,7 +61693,11 @@
           "description": "The first CRT coefficient.",
           "$ref": "#/definitions/string"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType"
+      ]
     },
     "Bot": {
       "description": "Bot account for automated actions.",
@@ -61665,17 +61718,16 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
         },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
+        "identifier": {
+          "description": "An identifier for this bot.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
         },
         "name": {
           "description": "A name associated with the Bot.",
@@ -61701,10 +61753,14 @@
           "description": "Optional flag to indicate that the bot should be run as the user.",
           "$ref": "#/definitions/boolean"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType"
+      ]
     },
     "AccessPolicy": {
-      "description": "Access control policy.",
+      "description": "Access Policy for user or user group that defines how entities can or cannot access resources.",
       "properties": {
         "resourceType": {
           "description": "This is a AccessPolicy resource",
@@ -61722,24 +61778,16 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
-        },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
         },
         "name": {
           "description": "A name associated with the AccessPolicy.",
           "$ref": "#/definitions/string"
         },
         "compartment": {
-          "description": "Optional compartment restriction for the user account.",
+          "description": "Optional compartment for newly created resources.  If this field is set, any resources created by a user with this access policy will automatically be included in the specified compartment.",
           "$ref": "#/definitions/Reference"
         },
         "resource": {
@@ -61749,7 +61797,11 @@
           },
           "type": "array"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType"
+      ]
     },
     "AccessPolicy_Resource": {
       "description": "Access details for a resource type.",
@@ -61784,7 +61836,11 @@
           },
           "type": "array"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType"
+      ]
     },
     "UserConfiguration": {
       "description": "User specific configuration for the Medplum application.",
@@ -61805,31 +61861,23 @@
           "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
           "$ref": "#/definitions/uri"
         },
-        "_implicitRules": {
-          "description": "Extensions for implicitRules",
-          "$ref": "#/definitions/Element"
-        },
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
-        },
-        "_language": {
-          "description": "Extensions for language",
-          "$ref": "#/definitions/Element"
         },
         "name": {
           "description": "A name associated with the UserConfiguration.",
           "$ref": "#/definitions/string"
         },
         "menu": {
-          "description": "Optional menu of shortcuts to URLs for quick access.",
+          "description": "Optional menu of shortcuts to URLs.",
           "items": {
             "$ref": "#/definitions/UserConfiguration_Menu"
           },
           "type": "array"
         },
         "search": {
-          "description": "Optional collection of search filters for quick access to preconfigured searches.",
+          "description": "Shortcut links to URLs.",
           "items": {
             "$ref": "#/definitions/UserConfiguration_Search"
           },
@@ -61842,13 +61890,17 @@
           },
           "type": "array"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType"
+      ]
     },
     "UserConfiguration_Menu": {
       "description": "Optional menu of shortcuts to URLs.",
       "properties": {
         "title": {
-          "description": "The resource type.",
+          "description": "Title of the menu.",
           "$ref": "#/definitions/string"
         },
         "link": {
@@ -61858,7 +61910,11 @@
           },
           "type": "array"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "title"
+      ]
     },
     "UserConfiguration_Menu_Link": {
       "description": "Shortcut links to URLs.",
@@ -61869,12 +61925,17 @@
         },
         "target": {
           "description": "The URL target of the link.",
-          "$ref": "#/definitions/string"
+          "$ref": "#/definitions/url"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "target"
+      ]
     },
     "UserConfiguration_Search": {
-      "description": "Optional collection of search filters for quick access to preconfigured searches.",
+      "description": "Shortcut links to URLs.",
       "properties": {
         "name": {
           "description": "The human friendly name of the link.",
@@ -61884,7 +61945,12 @@
           "description": "The rules that the server should use to determine which resources to return.",
           "$ref": "#/definitions/string"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "criteria"
+      ]
     },
     "UserConfiguration_Option": {
       "description": "User options that control the display of the application.",
@@ -61895,30 +61961,29 @@
         },
         "valueBoolean": {
           "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^true|false$",
-          "type": "boolean"
+          "$ref": "#/definitions/boolean"
         },
         "valueCode": {
           "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^[^\\s]+(\\s[^\\s]+)*$",
-          "type": "string"
+          "$ref": "#/definitions/code"
         },
         "valueDecimal": {
           "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?$",
-          "type": "number"
+          "$ref": "#/definitions/decimal"
         },
         "valueInteger": {
           "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^-?([0]|([1-9][0-9]*))$",
-          "type": "number"
+          "$ref": "#/definitions/integer"
         },
         "valueString": {
           "description": "Value of option - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
-          "pattern": "^[ \\r\\n\\t\\S]+$",
-          "type": "string"
+          "$ref": "#/definitions/string"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
     },
     "IdentityProvider": {
       "description": "External Identity Provider (IdP) configuration details.",
@@ -61947,7 +62012,280 @@
           "description": "Optional flag to use the subject field instead of the email field.",
           "$ref": "#/definitions/boolean"
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "authorizeUrl",
+        "tokenUrl",
+        "userInfoUrl",
+        "clientId",
+        "clientSecret"
+      ]
+    },
+    "Project_IpAccessRule": {
+      "description": "Use IP Access Rules to allowlist, block, and challenge traffic based on the visitor IP address.",
+      "properties": {
+        "name": {
+          "description": "Friendly name that will make it easy for you to identify the IP Access Rule in the future.",
+          "$ref": "#/definitions/string"
+        },
+        "value": {
+          "description": "An IP Access rule will apply a certain action to incoming traffic based on the visitor IP address or IP range.",
+          "$ref": "#/definitions/string"
+        },
+        "action": {
+          "description": "Access rule can perform one of the following actions: \"allow\" | \"block\".",
+          "$ref": "#/definitions/string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "action"
+      ]
+    },
+    "ProjectMembership_Access": {
+      "description": "Extended access configuration using parameterized access policies.",
+      "properties": {
+        "policy": {
+          "description": "The base access policy used as a template.  Variables in the template access policy are replaced by the values in the parameter.",
+          "$ref": "#/definitions/Reference"
+        },
+        "parameter": {
+          "description": "User options that control the display of the application.",
+          "items": {
+            "$ref": "#/definitions/ProjectMembership_Access_Parameter"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "policy"
+      ]
+    },
+    "ProjectMembership_Access_Parameter": {
+      "description": "User options that control the display of the application.",
+      "properties": {
+        "name": {
+          "description": "The unique name of the parameter.",
+          "$ref": "#/definitions/code"
+        },
+        "valueString": {
+          "description": "Value of the parameter - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+          "$ref": "#/definitions/string"
+        },
+        "valueReference": {
+          "description": "Value of the parameter - must be one of a constrained set of the data types (see [Extensibility](extensibility.html) for a list).",
+          "$ref": "#/definitions/Reference"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ]
+    },
+    "BulkDataExport": {
+      "description": "User specific configuration for the Medplum application.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a BulkDataExport resource",
+          "const": "BulkDataExport"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/id"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "status": {
+          "description": "The status of the request.",
+          "$ref": "#/definitions/code"
+        },
+        "requestTime": {
+          "description": "Indicates the server\u0027s time when the query is requested.",
+          "$ref": "#/definitions/instant"
+        },
+        "transactionTime": {
+          "description": "Indicates the server\u0027s time when the query is run. The response SHOULD NOT include any resources modified after this instant, and SHALL include any matching resources modified up to and including this instant.",
+          "$ref": "#/definitions/instant"
+        },
+        "request": {
+          "description": "The full URL of the original Bulk Data kick-off request. In the case of a POST request, this URL will not include the request parameters.",
+          "$ref": "#/definitions/uri"
+        },
+        "requiresAccessToken": {
+          "description": "Indicates whether downloading the generated files requires the same authorization mechanism as the $export operation itself.",
+          "$ref": "#/definitions/boolean"
+        },
+        "output": {
+          "description": "An array of file items with one entry for each generated file. If no resources are returned from the kick-off request, the server SHOULD return an empty array.",
+          "items": {
+            "$ref": "#/definitions/BulkDataExport_Output"
+          },
+          "type": "array"
+        },
+        "deleted": {
+          "description": "An array of deleted file items following the same structure as the output array.",
+          "items": {
+            "$ref": "#/definitions/BulkDataExport_Deleted"
+          },
+          "type": "array"
+        },
+        "error": {
+          "description": "Array of message file items following the same structure as the output array.",
+          "items": {
+            "$ref": "#/definitions/BulkDataExport_Error"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "status",
+        "requestTime",
+        "request"
+      ]
+    },
+    "BulkDataExport_Output": {
+      "description": "An array of file items with one entry for each generated file. If no resources are returned from the kick-off request, the server SHOULD return an empty array.",
+      "properties": {
+        "type": {
+          "description": "The FHIR resource type that is contained in the file.",
+          "$ref": "#/definitions/code"
+        },
+        "url": {
+          "description": "The absolute path to the file. The format of the file SHOULD reflect that requested in the _outputFormat parameter of the initial kick-off request.",
+          "$ref": "#/definitions/uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "url"
+      ]
+    },
+    "BulkDataExport_Deleted": {
+      "description": "An array of deleted file items following the same structure as the output array.",
+      "properties": {
+        "type": {
+          "description": "The FHIR resource type that is contained in the file.",
+          "$ref": "#/definitions/code"
+        },
+        "url": {
+          "description": "The absolute path to the file. The format of the file SHOULD reflect that requested in the _outputFormat parameter of the initial kick-off request.",
+          "$ref": "#/definitions/uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "url"
+      ]
+    },
+    "BulkDataExport_Error": {
+      "description": "Array of message file items following the same structure as the output array.",
+      "properties": {
+        "type": {
+          "description": "The FHIR resource type that is contained in the file.",
+          "$ref": "#/definitions/code"
+        },
+        "url": {
+          "description": "The absolute path to the file. The format of the file SHOULD reflect that requested in the _outputFormat parameter of the initial kick-off request.",
+          "$ref": "#/definitions/uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "url"
+      ]
+    },
+    "SmartAppLaunch": {
+      "description": "This resource contains context details for a SMART App Launch.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a SmartAppLaunch resource",
+          "const": "SmartAppLaunch"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/id"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "patient": {
+          "description": "Optional patient indicating that the app was launched in the patient context.",
+          "$ref": "#/definitions/Reference"
+        },
+        "encounter": {
+          "description": "Optional encounter indicating that the app was launched in the encounter context.",
+          "$ref": "#/definitions/Reference"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType"
+      ]
+    },
+    "DomainConfiguration": {
+      "description": "Domain specific configuration for the Medplum application.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a DomainConfiguration resource",
+          "const": "DomainConfiguration"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/id"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "domain": {
+          "description": "Globally unique domain name for this configuration.",
+          "$ref": "#/definitions/uri"
+        },
+        "identityProvider": {
+          "description": "Optional external Identity Provider (IdP) for the domain name.",
+          "$ref": "#/definitions/IdentityProvider"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceType",
+        "domain"
+      ]
     }
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -22,6 +22,7 @@
     "@medplum/core": "*",
     "@medplum/definitions": "*",
     "@medplum/fhirtypes": "*",
+    "@types/json-schema": "7.0.11",
     "fhirpath": "3.3.1",
     "fast-xml-parser": "4.1.2"
   }

--- a/packages/generator/src/jsonschema.ts
+++ b/packages/generator/src/jsonschema.ts
@@ -1,0 +1,222 @@
+import {
+  capitalize,
+  getElementDefinition,
+  globalSchema,
+  indexStructureDefinitionBundle,
+  TypeSchema,
+} from '@medplum/core';
+import { readJson } from '@medplum/definitions';
+import { Bundle, ElementDefinition, ElementDefinitionType } from '@medplum/fhirtypes';
+import { writeFileSync } from 'fs';
+import { JSONSchema6, JSONSchema6Definition } from 'json-schema';
+import { resolve } from 'path';
+import { getValueSetValues } from './valuesets';
+
+// Generate fhir.schema.json
+//
+// The FHIR spec "Downloads" page includes "whole specification", which includes "fhir.schema.json".
+// We extend the "fhir.schema.json" file with Medplum-specific extensions.
+// See: https://hl7.org/fhir/R4/downloads.html
+//
+// This tool *could* be used to generate all of "fhir.schema.json", however -
+// there are a number of inconsistencies in the original version that appear to be the result of
+// evolution rather than intentional design.
+//
+// For example
+//  1. Sometimes the "id" element is defined as a "string" rather than "id" type.
+//  2. Sometimes "resourceType" is a required field
+//  3. Sometimes properties include "pattern" with the regex definition of primitive type.
+//  4. Sometimes properties embed enum values vs use "code".
+//
+// Rather than risk breaking existing tools, we extend the existing schema with Medplum-specific definitions.
+// This allows us to use the existing schema as a starting point, and only add new definitions.
+
+interface FhirSchema extends JSONSchema6 {
+  id: 'http://hl7.org/fhir/json-schema/4.0';
+  discriminator: {
+    propertyName: 'resourceType';
+    mapping: Record<string, string>;
+  };
+  oneOf: JSONSchema6Definition[];
+  definitions: {
+    ResourceList: {
+      oneOf: JSONSchema6Definition[];
+    };
+    [k: string]: JSONSchema6Definition;
+  };
+}
+
+export function main(): void {
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+
+  // Start with the existing schema
+  const fhirSchema = readJson('fhir/r4/fhir.schema.json') as FhirSchema;
+
+  // Then add element types
+  for (const typeSchema of Object.values(globalSchema.types)) {
+    const typeName = buildTypeName((typeSchema.elementDefinition?.path as string).split('.'));
+    if (typeSchema.structureDefinition?.url?.startsWith('https://medplum.com/fhir/StructureDefinition/')) {
+      if (
+        typeName !== 'BackboneElement' &&
+        typeName !== 'Resource' &&
+        typeName !== 'DomainResource' &&
+        typeName !== 'MetadataResource' &&
+        (typeSchema.structureDefinition?.baseDefinition === 'http://hl7.org/fhir/StructureDefinition/DomainResource' ||
+          typeSchema.structureDefinition?.baseDefinition === 'http://hl7.org/fhir/StructureDefinition/Resource') &&
+        typeSchema.structureDefinition.id === typeSchema.elementDefinition.id
+      ) {
+        if (!fhirSchema.discriminator.mapping[typeName]) {
+          fhirSchema.discriminator.mapping[typeName] = `#/definitions/${typeName}`;
+        }
+        if (!fhirSchema.oneOf.find((x) => typeof x === 'object' && x.$ref === `#/definitions/${typeName}`)) {
+          fhirSchema.oneOf.push({ $ref: `#/definitions/${typeName}` });
+        }
+        if (
+          !fhirSchema.definitions.ResourceList.oneOf.find(
+            (x) => typeof x === 'object' && x.$ref === `#/definitions/${typeName}`
+          )
+        ) {
+          fhirSchema.definitions.ResourceList.oneOf.push({ $ref: `#/definitions/${typeName}` });
+        }
+      }
+      fhirSchema.definitions[typeName] = buildElementSchema(typeSchema);
+    }
+  }
+
+  writeFileSync(
+    resolve(__dirname, '../../definitions/dist/fhir/r4/fhir.schema.json'),
+    JSON.stringify(fhirSchema, undefined, 2)
+      .replaceAll("'", '\\u0027')
+      .replaceAll('<', '\\u003c')
+      .replaceAll('=', '\\u003d')
+      .replaceAll('>', '\\u003e'),
+    'utf8'
+  );
+}
+
+function buildElementSchema(typeSchema: TypeSchema): JSONSchema6Definition {
+  const { properties, required } = buildProperties(typeSchema);
+  return {
+    description: getDescription(typeSchema),
+    properties,
+    additionalProperties: false,
+    required,
+  };
+}
+
+function getDescription(typeSchema: TypeSchema): string | undefined {
+  return typeSchema.elementDefinition?.definition;
+}
+
+function buildProperties(typeSchema: TypeSchema): {
+  properties: Record<string, JSONSchema6Definition>;
+  required: string[] | undefined;
+} {
+  const properties: Record<string, JSONSchema6Definition> = {};
+  let required: string[] | undefined = undefined;
+
+  if (
+    (typeSchema.structureDefinition?.baseDefinition === 'http://hl7.org/fhir/StructureDefinition/DomainResource' ||
+      typeSchema.structureDefinition?.baseDefinition === 'http://hl7.org/fhir/StructureDefinition/Resource') &&
+    typeSchema.structureDefinition.id === typeSchema.elementDefinition.id
+  ) {
+    properties['resourceType'] = {
+      description: `This is a ${typeSchema.structureDefinition.name} resource`,
+      const: typeSchema.structureDefinition.name,
+    };
+    required = ['resourceType'];
+  }
+
+  for (const elementName of Object.keys(typeSchema.properties)) {
+    let elementDefinition = typeSchema.properties[elementName];
+
+    if (elementDefinition.contentReference) {
+      const contentReference = elementDefinition.contentReference.substring(1).split('.');
+      const referencePropertyName = contentReference.pop() as string;
+      const referenceTypeName = buildTypeName(contentReference);
+      elementDefinition = getElementDefinition(referenceTypeName, referencePropertyName) as ElementDefinition;
+    }
+
+    for (const elementDefinitionType of elementDefinition.type ?? []) {
+      const propertyName = elementName.replace('[x]', capitalize(elementDefinitionType.code as string));
+      properties[propertyName] = buildPropertySchema(elementDefinition, elementDefinitionType);
+    }
+
+    if (!elementName.includes('[x]') && elementDefinition.min !== 0) {
+      if (!required) {
+        required = [];
+      }
+      required.push(elementName);
+    }
+  }
+
+  return { properties, required };
+}
+
+function buildPropertySchema(
+  elementDefinition: ElementDefinition,
+  elementDefinitionType: ElementDefinitionType
+): JSONSchema6Definition {
+  const result: JSONSchema6Definition = {
+    description: elementDefinition.definition,
+  };
+
+  const enumValues = getEnumValues(elementDefinition);
+
+  if (elementDefinition.max === '*') {
+    result.items = {};
+    if (enumValues) {
+      result.items.enum = enumValues;
+    } else {
+      result.items.$ref = `#/definitions/${getTypeName(elementDefinition, elementDefinitionType)}`;
+    }
+    result.type = 'array';
+  } else {
+    if (enumValues) {
+      result.enum = enumValues;
+    } else {
+      result.$ref = `#/definitions/${getTypeName(elementDefinition, elementDefinitionType)}`;
+    }
+  }
+
+  return result;
+}
+
+function getTypeName(elementDefinition: ElementDefinition, elementDefinitionType: ElementDefinitionType): string {
+  if (elementDefinition.path?.endsWith('.id')) {
+    return 'id';
+  }
+  const code = elementDefinitionType.code as string;
+  return code === 'BackboneElement' || code === 'Element'
+    ? buildTypeName(elementDefinition.path?.split('.') as string[])
+    : code;
+}
+
+function buildTypeName(components: string[]): string {
+  if (components.length === 1) {
+    return components[0];
+  }
+  return components.map(capitalize).join('_');
+}
+
+function getEnumValues(elementDefinition: ElementDefinition): string[] | undefined {
+  if (elementDefinition.binding?.valueSet && elementDefinition.binding.strength === 'required') {
+    if (
+      elementDefinition.binding.valueSet !== 'http://hl7.org/fhir/ValueSet/resource-types|4.0.1' &&
+      elementDefinition.binding.valueSet !== 'http://hl7.org/fhir/ValueSet/all-types|4.0.1' &&
+      elementDefinition.binding.valueSet !== 'http://hl7.org/fhir/ValueSet/defined-types|4.0.1'
+    ) {
+      const values = getValueSetValues(elementDefinition.binding.valueSet);
+      if (values && values.length > 0) {
+        return values;
+      }
+    }
+  }
+  return undefined;
+}
+
+if (require.main === module) {
+  main();
+}

--- a/packages/generator/src/valuesets.ts
+++ b/packages/generator/src/valuesets.ts
@@ -1,0 +1,83 @@
+import { readJson } from '@medplum/definitions';
+import {
+  Bundle,
+  BundleEntry,
+  CodeSystem,
+  CodeSystemConcept,
+  Resource,
+  ValueSet,
+  ValueSetCompose,
+} from '@medplum/fhirtypes';
+
+const valueSets: Map<string, CodeSystem | ValueSet> = new Map();
+
+export function getValueSetValues(url: string): string[] {
+  if (valueSets.size === 0) {
+    loadValueSets();
+  }
+  const result: string[] = [];
+  buildValueSetValues(url, result);
+  return result;
+}
+
+function loadValueSets(): void {
+  const valueSetBundle = readJson('fhir/r4/valuesets.json') as Bundle;
+  for (const entry of valueSetBundle.entry as BundleEntry[]) {
+    const resource = entry.resource as Resource;
+    if (resource.resourceType === 'CodeSystem' || resource.resourceType === 'ValueSet') {
+      valueSets.set(resource.url as string, resource as CodeSystem | ValueSet);
+    }
+  }
+}
+
+function buildValueSetValues(url: string, result: string[]): void {
+  // If the url includes a version, remove it
+  if (url.includes('|')) {
+    url = url.split('|')[0];
+  }
+
+  const resource = valueSets.get(url);
+  if (!resource) {
+    return;
+  }
+
+  if (resource.resourceType === 'ValueSet') {
+    buildValueSetComposeValues(resource.compose, result);
+  }
+
+  if (resource.resourceType === 'CodeSystem') {
+    buildCodeSystemConceptValues(resource.concept, result);
+  }
+}
+
+function buildValueSetComposeValues(compose: ValueSetCompose | undefined, result: string[]): void {
+  if (compose?.include) {
+    for (const include of compose.include) {
+      if (include.concept) {
+        for (const concept of include.concept) {
+          if (concept.code) {
+            result.push(concept.code);
+          }
+        }
+      } else if (include.system) {
+        const includedValues = getValueSetValues(include.system);
+        if (includedValues) {
+          result.push(...includedValues);
+        }
+      }
+    }
+  }
+}
+
+function buildCodeSystemConceptValues(concepts: CodeSystemConcept[] | undefined, result: string[]): void {
+  if (!concepts) {
+    return;
+  }
+
+  for (const concept of concepts) {
+    if (concept.code) {
+      result.push(concept.code);
+    }
+    buildCodeSystemConceptValues(concept.concept, result);
+  }
+}


### PR DESCRIPTION
Generate fhir.schema.json

The FHIR spec "Downloads" page includes "whole specification", which includes "fhir.schema.json". We extend the "fhir.schema.json" file with Medplum-specific extensions. See: https://hl7.org/fhir/R4/downloads.html

This tool *could* be used to generate all of "fhir.schema.json", however - there are a number of inconsistencies in the original version that appear to be the result of evolution rather than intentional design.

For example
 1. Sometimes the "id" element is defined as a "string" rather than "id" type.
 2. Sometimes "resourceType" is a required field
 3. Sometimes properties include "pattern" with the regex definition of primitive type.
 4. Sometimes properties embed enum values vs use "code".

Rather than risk breaking existing tools, we extend the existing schema with Medplum-specific definitions.

This allows us to use the existing schema as a starting point, and only add new definitions.

