### PR TITLE
Added Medplum profile display and signout links to graphiql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20707,6 +20707,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -22365,7 +22366,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -26963,6 +26965,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -27429,7 +27432,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -28495,6 +28499,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -31591,6 +31596,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -33140,6 +33146,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -37245,6 +37252,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -39741,6 +39749,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -43623,6 +43632,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -46275,6 +46285,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -46517,12 +46528,15 @@
       "version": "2.0.5",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@graphiql/react": "0.17.0",
         "@graphiql/toolkit": "0.8.0",
         "@mantine/core": "5.10.5",
         "@mantine/hooks": "5.10.5",
         "@medplum/core": "*",
         "@medplum/fhirtypes": "*",
         "@medplum/react": "*",
+        "@types/react": "18.0.28",
+        "@types/react-dom": "18.0.11",
         "babel-loader": "9.1.2",
         "css-loader": "6.7.3",
         "dotenv-webpack": "8.0.1",
@@ -46536,6 +46550,598 @@
         "style-loader": "3.3.1",
         "worker-loader": "3.0.8"
       }
+    },
+    "packages/graphiql/node_modules/@graphiql/react": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@graphiql/react/-/react-0.17.0.tgz",
+      "integrity": "sha512-mn8FfucLJzFLQQ5OoJ9U1Dvnva1smOxBL89D2TSM2B6mmDyQIRhFXmjzUTPdsqwpauFiqkDaQZiqX7T/ZPrg/w==",
+      "dev": true,
+      "dependencies": {
+        "@graphiql/toolkit": "^0.8.2",
+        "@reach/combobox": "^0.17.0",
+        "@reach/dialog": "^0.17.0",
+        "@reach/listbox": "^0.17.0",
+        "@reach/menu-button": "^0.17.0",
+        "@reach/tooltip": "^0.17.0",
+        "@reach/visually-hidden": "^0.17.0",
+        "clsx": "^1.2.1",
+        "codemirror": "^5.65.3",
+        "codemirror-graphql": "^2.0.4",
+        "copy-to-clipboard": "^3.2.0",
+        "graphql-language-service": "^5.1.2",
+        "markdown-it": "^12.2.0",
+        "set-value": "^4.1.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@graphiql/toolkit": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@graphiql/toolkit/-/toolkit-0.8.2.tgz",
+      "integrity": "sha512-FGtXBYTzcPuwfpaC+0BGeriLD6kwTdcF5xugGvjutk5J93Dgy2vw+SkBdbi1QGzz/jooETi1kEtFeDuWTzIG7Q==",
+      "dev": true,
+      "dependencies": {
+        "@n1ru4l/push-pull-async-iterable-iterator": "^3.1.0",
+        "meros": "^1.1.4"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0",
+        "graphql-ws": ">= 4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        }
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/combobox/-/combobox-0.17.0.tgz",
+      "integrity": "sha512-2mYvU5agOBCQBMdlM4cri+P1BbNwp05P1OuDyc33xJSNiBG7BMy4+ZSHJ0X4fyle6rHwSgCAOCLOeWV1XUYjoQ==",
+      "dev": true,
+      "dependencies": {
+        "@reach/auto-id": "0.17.0",
+        "@reach/descendants": "0.17.0",
+        "@reach/popover": "0.17.0",
+        "@reach/portal": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox/node_modules/@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox/node_modules/@reach/descendants": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+      "integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox/node_modules/@reach/popover": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+      "integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+      "dev": true,
+      "dependencies": {
+        "@reach/portal": "0.17.0",
+        "@reach/rect": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "tabbable": "^4.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox/node_modules/@reach/popover/node_modules/@reach/rect": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox/node_modules/@reach/portal": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/combobox/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dev": true,
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/dialog": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.17.0.tgz",
+      "integrity": "sha512-AnfKXugqDTGbeG3c8xDcrQDE4h9b/vnc27Sa118oQSquz52fneUeX9MeFb5ZEiBJK8T5NJpv7QUTBIKnFCAH5A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/portal": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "react-focus-lock": "^2.5.2",
+        "react-remove-scroll": "^2.4.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/dialog/node_modules/@reach/portal": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/dialog/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dev": true,
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
+      "integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/auto-id": "0.17.0",
+        "@reach/descendants": "0.17.0",
+        "@reach/machine": "0.17.0",
+        "@reach/popover": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/descendants": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+      "integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/machine": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
+      "integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "@xstate/fsm": "1.4.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/popover": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+      "integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+      "dev": true,
+      "dependencies": {
+        "@reach/portal": "0.17.0",
+        "@reach/rect": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "tabbable": "^4.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/popover/node_modules/@reach/portal": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/popover/node_modules/@reach/rect": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/listbox/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dev": true,
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/menu-button/-/menu-button-0.17.0.tgz",
+      "integrity": "sha512-YyuYVyMZKamPtivoEI6D0UEILYH3qZtg4kJzEAuzPmoR/aHN66NZO75Fx0gtjG1S6fZfbiARaCOZJC0VEiDOtQ==",
+      "dev": true,
+      "dependencies": {
+        "@reach/dropdown": "0.17.0",
+        "@reach/popover": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x",
+        "react-is": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/dropdown": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/dropdown/-/dropdown-0.17.0.tgz",
+      "integrity": "sha512-qBTIGInhxtPHtdj4Pl2XZgZMz3e37liydh0xR3qc48syu7g71sL4nqyKjOzThykyfhA3Pb3/wFgsFJKGTSdaig==",
+      "dev": true,
+      "dependencies": {
+        "@reach/auto-id": "0.17.0",
+        "@reach/descendants": "0.17.0",
+        "@reach/popover": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/dropdown/node_modules/@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/dropdown/node_modules/@reach/descendants": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+      "integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/popover": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+      "integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+      "dev": true,
+      "dependencies": {
+        "@reach/portal": "0.17.0",
+        "@reach/rect": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "tabbable": "^4.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/popover/node_modules/@reach/portal": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/popover/node_modules/@reach/rect": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/menu-button/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dev": true,
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/tooltip": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.17.0.tgz",
+      "integrity": "sha512-HP8Blordzqb/Cxg+jnhGmWQfKgypamcYLBPlcx6jconyV5iLJ5m93qipr1giK7MqKT2wlsKWy44ZcOrJ+Wrf8w==",
+      "dev": true,
+      "dependencies": {
+        "@reach/auto-id": "0.17.0",
+        "@reach/portal": "0.17.0",
+        "@reach/rect": "0.17.0",
+        "@reach/utils": "0.17.0",
+        "@reach/visually-hidden": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/tooltip/node_modules/@reach/auto-id": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/tooltip/node_modules/@reach/portal": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+      "dev": true,
+      "dependencies": {
+        "@reach/utils": "0.17.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/tooltip/node_modules/@reach/rect": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+      "dev": true,
+      "dependencies": {
+        "@reach/observe-rect": "1.2.0",
+        "@reach/utils": "0.17.0",
+        "prop-types": "^15.7.2",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/tooltip/node_modules/@reach/utils": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+      "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+      "dev": true,
+      "dependencies": {
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/@graphiql/react/node_modules/@reach/visually-hidden": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
+      "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+      "dev": true,
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || 17.x",
+        "react-dom": "^16.8.0 || 17.x"
+      }
+    },
+    "packages/graphiql/node_modules/codemirror-graphql": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-2.0.4.tgz",
+      "integrity": "sha512-u68lfUJv4hESfIZLJUGSWU2+txNrfoT29EEMxNksDBPXjnF41Ivpp/r8rxJBXigNcDOBmjMfKfs1J4L0Jggwrg==",
+      "dev": true,
+      "dependencies": {
+        "graphql-language-service": "5.1.2"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "6.0.0",
+        "codemirror": "^5.65.3",
+        "graphql": "^15.5.0 || ^16.0.0"
+      }
+    },
+    "packages/graphiql/node_modules/graphql-language-service": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.1.2.tgz",
+      "integrity": "sha512-oeuztbvd7fwKWZ/GCp0voqgctdIL4BDjTkd/phz1jEyH+pfj6inJWKKIkUJPW5ebWHx+mFsZ00wdE6tiCvW2fA==",
+      "dev": true,
+      "dependencies": {
+        "nullthrows": "^1.0.0",
+        "vscode-languageserver-types": "^3.17.1"
+      },
+      "bin": {
+        "graphql": "dist/temp-bin.js"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0"
+      }
+    },
+    "packages/graphiql/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
+    "packages/graphiql/node_modules/tabbable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==",
+      "dev": true
     },
     "packages/infra": {
       "name": "@medplum/infra",
@@ -52991,12 +53597,15 @@
     "@medplum/graphiql": {
       "version": "file:packages/graphiql",
       "requires": {
+        "@graphiql/react": "0.17.0",
         "@graphiql/toolkit": "0.8.0",
         "@mantine/core": "5.10.5",
         "@mantine/hooks": "5.10.5",
         "@medplum/core": "*",
         "@medplum/fhirtypes": "*",
         "@medplum/react": "*",
+        "@types/react": "18.0.28",
+        "@types/react-dom": "18.0.11",
         "babel-loader": "9.1.2",
         "css-loader": "6.7.3",
         "dotenv-webpack": "8.0.1",
@@ -53009,6 +53618,466 @@
         "regenerator-runtime": "0.13.11",
         "style-loader": "3.3.1",
         "worker-loader": "3.0.8"
+      },
+      "dependencies": {
+        "@graphiql/react": {
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/@graphiql/react/-/react-0.17.0.tgz",
+          "integrity": "sha512-mn8FfucLJzFLQQ5OoJ9U1Dvnva1smOxBL89D2TSM2B6mmDyQIRhFXmjzUTPdsqwpauFiqkDaQZiqX7T/ZPrg/w==",
+          "dev": true,
+          "requires": {
+            "@graphiql/toolkit": "^0.8.2",
+            "@reach/combobox": "^0.17.0",
+            "@reach/dialog": "^0.17.0",
+            "@reach/listbox": "^0.17.0",
+            "@reach/menu-button": "^0.17.0",
+            "@reach/tooltip": "^0.17.0",
+            "@reach/visually-hidden": "^0.17.0",
+            "clsx": "^1.2.1",
+            "codemirror": "^5.65.3",
+            "codemirror-graphql": "^2.0.4",
+            "copy-to-clipboard": "^3.2.0",
+            "graphql-language-service": "^5.1.2",
+            "markdown-it": "^12.2.0",
+            "set-value": "^4.1.0"
+          },
+          "dependencies": {
+            "@graphiql/toolkit": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/@graphiql/toolkit/-/toolkit-0.8.2.tgz",
+              "integrity": "sha512-FGtXBYTzcPuwfpaC+0BGeriLD6kwTdcF5xugGvjutk5J93Dgy2vw+SkBdbi1QGzz/jooETi1kEtFeDuWTzIG7Q==",
+              "dev": true,
+              "requires": {
+                "@n1ru4l/push-pull-async-iterable-iterator": "^3.1.0",
+                "meros": "^1.1.4"
+              }
+            },
+            "@reach/combobox": {
+              "version": "0.17.0",
+              "resolved": "https://registry.npmjs.org/@reach/combobox/-/combobox-0.17.0.tgz",
+              "integrity": "sha512-2mYvU5agOBCQBMdlM4cri+P1BbNwp05P1OuDyc33xJSNiBG7BMy4+ZSHJ0X4fyle6rHwSgCAOCLOeWV1XUYjoQ==",
+              "dev": true,
+              "requires": {
+                "@reach/auto-id": "0.17.0",
+                "@reach/descendants": "0.17.0",
+                "@reach/popover": "0.17.0",
+                "@reach/portal": "0.17.0",
+                "@reach/utils": "0.17.0",
+                "prop-types": "^15.7.2",
+                "tiny-warning": "^1.0.3",
+                "tslib": "^2.3.0"
+              },
+              "dependencies": {
+                "@reach/auto-id": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+                  "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/descendants": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+                  "integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/popover": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+                  "integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/portal": "0.17.0",
+                    "@reach/rect": "0.17.0",
+                    "@reach/utils": "0.17.0",
+                    "tabbable": "^4.0.0",
+                    "tslib": "^2.3.0"
+                  },
+                  "dependencies": {
+                    "@reach/rect": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+                      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/observe-rect": "1.2.0",
+                        "@reach/utils": "0.17.0",
+                        "prop-types": "^15.7.2",
+                        "tiny-warning": "^1.0.3",
+                        "tslib": "^2.3.0"
+                      }
+                    }
+                  }
+                },
+                "@reach/portal": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+                  "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/utils": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+                  "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+                  "dev": true,
+                  "requires": {
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                }
+              }
+            },
+            "@reach/dialog": {
+              "version": "0.17.0",
+              "resolved": "https://registry.npmjs.org/@reach/dialog/-/dialog-0.17.0.tgz",
+              "integrity": "sha512-AnfKXugqDTGbeG3c8xDcrQDE4h9b/vnc27Sa118oQSquz52fneUeX9MeFb5ZEiBJK8T5NJpv7QUTBIKnFCAH5A==",
+              "dev": true,
+              "requires": {
+                "@reach/portal": "0.17.0",
+                "@reach/utils": "0.17.0",
+                "prop-types": "^15.7.2",
+                "react-focus-lock": "^2.5.2",
+                "react-remove-scroll": "^2.4.3",
+                "tslib": "^2.3.0"
+              },
+              "dependencies": {
+                "@reach/portal": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+                  "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/utils": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+                  "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+                  "dev": true,
+                  "requires": {
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                }
+              }
+            },
+            "@reach/listbox": {
+              "version": "0.17.0",
+              "resolved": "https://registry.npmjs.org/@reach/listbox/-/listbox-0.17.0.tgz",
+              "integrity": "sha512-AMnH1P6/3VKy2V/nPb4Es441arYR+t4YRdh9jdcFVrCOD6y7CQrlmxsYjeg9Ocdz08XpdoEBHM3PKLJqNAUr7A==",
+              "dev": true,
+              "requires": {
+                "@reach/auto-id": "0.17.0",
+                "@reach/descendants": "0.17.0",
+                "@reach/machine": "0.17.0",
+                "@reach/popover": "0.17.0",
+                "@reach/utils": "0.17.0",
+                "prop-types": "^15.7.2"
+              },
+              "dependencies": {
+                "@reach/auto-id": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+                  "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/descendants": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+                  "integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/machine": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/machine/-/machine-0.17.0.tgz",
+                  "integrity": "sha512-9EHnuPgXzkbRENvRUzJvVvYt+C2jp7PGN0xon7ffmKoK8rTO6eA/bb7P0xgloyDDQtu88TBUXKzW0uASqhTXGA==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "@xstate/fsm": "1.4.0",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/popover": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+                  "integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/portal": "0.17.0",
+                    "@reach/rect": "0.17.0",
+                    "@reach/utils": "0.17.0",
+                    "tabbable": "^4.0.0",
+                    "tslib": "^2.3.0"
+                  },
+                  "dependencies": {
+                    "@reach/portal": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+                      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/utils": "0.17.0",
+                        "tiny-warning": "^1.0.3",
+                        "tslib": "^2.3.0"
+                      }
+                    },
+                    "@reach/rect": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+                      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/observe-rect": "1.2.0",
+                        "@reach/utils": "0.17.0",
+                        "prop-types": "^15.7.2",
+                        "tiny-warning": "^1.0.3",
+                        "tslib": "^2.3.0"
+                      }
+                    }
+                  }
+                },
+                "@reach/utils": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+                  "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+                  "dev": true,
+                  "requires": {
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                }
+              }
+            },
+            "@reach/menu-button": {
+              "version": "0.17.0",
+              "resolved": "https://registry.npmjs.org/@reach/menu-button/-/menu-button-0.17.0.tgz",
+              "integrity": "sha512-YyuYVyMZKamPtivoEI6D0UEILYH3qZtg4kJzEAuzPmoR/aHN66NZO75Fx0gtjG1S6fZfbiARaCOZJC0VEiDOtQ==",
+              "dev": true,
+              "requires": {
+                "@reach/dropdown": "0.17.0",
+                "@reach/popover": "0.17.0",
+                "@reach/utils": "0.17.0",
+                "prop-types": "^15.7.2",
+                "tiny-warning": "^1.0.3",
+                "tslib": "^2.3.0"
+              },
+              "dependencies": {
+                "@reach/dropdown": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/dropdown/-/dropdown-0.17.0.tgz",
+                  "integrity": "sha512-qBTIGInhxtPHtdj4Pl2XZgZMz3e37liydh0xR3qc48syu7g71sL4nqyKjOzThykyfhA3Pb3/wFgsFJKGTSdaig==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/auto-id": "0.17.0",
+                    "@reach/descendants": "0.17.0",
+                    "@reach/popover": "0.17.0",
+                    "@reach/utils": "0.17.0",
+                    "tslib": "^2.3.0"
+                  },
+                  "dependencies": {
+                    "@reach/auto-id": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+                      "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/utils": "0.17.0",
+                        "tslib": "^2.3.0"
+                      }
+                    },
+                    "@reach/descendants": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.17.0.tgz",
+                      "integrity": "sha512-c7lUaBfjgcmKFZiAWqhG+VnXDMEhPkI4kAav/82XKZD6NVvFjsQOTH+v3tUkskrAPV44Yuch0mFW/u5Ntifr7Q==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/utils": "0.17.0",
+                        "tslib": "^2.3.0"
+                      }
+                    }
+                  }
+                },
+                "@reach/popover": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.17.0.tgz",
+                  "integrity": "sha512-yYbBF4fMz4Ml4LB3agobZjcZ/oPtPsNv70ZAd7lEC2h7cvhF453pA+zOBGYTPGupKaeBvgAnrMjj7RnxDU5hoQ==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/portal": "0.17.0",
+                    "@reach/rect": "0.17.0",
+                    "@reach/utils": "0.17.0",
+                    "tabbable": "^4.0.0",
+                    "tslib": "^2.3.0"
+                  },
+                  "dependencies": {
+                    "@reach/portal": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+                      "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/utils": "0.17.0",
+                        "tiny-warning": "^1.0.3",
+                        "tslib": "^2.3.0"
+                      }
+                    },
+                    "@reach/rect": {
+                      "version": "0.17.0",
+                      "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+                      "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+                      "dev": true,
+                      "requires": {
+                        "@reach/observe-rect": "1.2.0",
+                        "@reach/utils": "0.17.0",
+                        "prop-types": "^15.7.2",
+                        "tiny-warning": "^1.0.3",
+                        "tslib": "^2.3.0"
+                      }
+                    }
+                  }
+                },
+                "@reach/utils": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+                  "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+                  "dev": true,
+                  "requires": {
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                }
+              }
+            },
+            "@reach/tooltip": {
+              "version": "0.17.0",
+              "resolved": "https://registry.npmjs.org/@reach/tooltip/-/tooltip-0.17.0.tgz",
+              "integrity": "sha512-HP8Blordzqb/Cxg+jnhGmWQfKgypamcYLBPlcx6jconyV5iLJ5m93qipr1giK7MqKT2wlsKWy44ZcOrJ+Wrf8w==",
+              "dev": true,
+              "requires": {
+                "@reach/auto-id": "0.17.0",
+                "@reach/portal": "0.17.0",
+                "@reach/rect": "0.17.0",
+                "@reach/utils": "0.17.0",
+                "@reach/visually-hidden": "0.17.0",
+                "prop-types": "^15.7.2",
+                "tiny-warning": "^1.0.3",
+                "tslib": "^2.3.0"
+              },
+              "dependencies": {
+                "@reach/auto-id": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.17.0.tgz",
+                  "integrity": "sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/portal": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.17.0.tgz",
+                  "integrity": "sha512-+IxsgVycOj+WOeNPL2NdgooUdHPSY285wCtj/iWID6akyr4FgGUK7sMhRM9aGFyrGpx2vzr+eggbUmAVZwOz+A==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/utils": "0.17.0",
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/rect": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.17.0.tgz",
+                  "integrity": "sha512-3YB7KA5cLjbLc20bmPkJ06DIfXSK06Cb5BbD2dHgKXjUkT9WjZaLYIbYCO8dVjwcyO3GCNfOmPxy62VsPmZwYA==",
+                  "dev": true,
+                  "requires": {
+                    "@reach/observe-rect": "1.2.0",
+                    "@reach/utils": "0.17.0",
+                    "prop-types": "^15.7.2",
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                },
+                "@reach/utils": {
+                  "version": "0.17.0",
+                  "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.17.0.tgz",
+                  "integrity": "sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==",
+                  "dev": true,
+                  "requires": {
+                    "tiny-warning": "^1.0.3",
+                    "tslib": "^2.3.0"
+                  }
+                }
+              }
+            },
+            "@reach/visually-hidden": {
+              "version": "0.17.0",
+              "resolved": "https://registry.npmjs.org/@reach/visually-hidden/-/visually-hidden-0.17.0.tgz",
+              "integrity": "sha512-T6xF3Nv8vVnjVkGU6cm0+kWtvliLqPAo8PcZ+WxkKacZsaHTjaZb4v1PaCcyQHmuTNT/vtTVNOJLG0SjQOIb7g==",
+              "dev": true,
+              "requires": {
+                "prop-types": "^15.7.2",
+                "tslib": "^2.3.0"
+              }
+            }
+          }
+        },
+        "codemirror-graphql": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-2.0.4.tgz",
+          "integrity": "sha512-u68lfUJv4hESfIZLJUGSWU2+txNrfoT29EEMxNksDBPXjnF41Ivpp/r8rxJBXigNcDOBmjMfKfs1J4L0Jggwrg==",
+          "dev": true,
+          "requires": {
+            "graphql-language-service": "5.1.2"
+          }
+        },
+        "graphql-language-service": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-5.1.2.tgz",
+          "integrity": "sha512-oeuztbvd7fwKWZ/GCp0voqgctdIL4BDjTkd/phz1jEyH+pfj6inJWKKIkUJPW5ebWHx+mFsZ00wdE6tiCvW2fA==",
+          "dev": true,
+          "requires": {
+            "nullthrows": "^1.0.0",
+            "vscode-languageserver-types": "^3.17.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true,
+          "peer": true
+        },
+        "tabbable": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
+          "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==",
+          "dev": true
+        }
       }
     },
     "@medplum/infra": {
@@ -63001,6 +64070,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -64285,7 +65355,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "concat-stream": {
       "version": "2.0.0",
@@ -67890,6 +68961,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -68244,7 +69316,8 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -69059,7 +70132,8 @@
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true
     },
     "ignore-walk": {
       "version": "6.0.1",
@@ -71315,6 +72389,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -72564,6 +73639,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -75717,7 +76793,8 @@
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
     },
     "pupa": {
       "version": "3.1.0",
@@ -77601,7 +78678,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "semver-diff": {
       "version": "4.0.0",
@@ -80650,7 +81728,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -82672,7 +83751,8 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
     },
     "yargs": {
       "version": "17.7.1",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -16,12 +16,15 @@
     "build": "npm run clean && cross-env NODE_ENV=production webpack --mode production"
   },
   "devDependencies": {
+    "@graphiql/react": "0.17.0",
     "@graphiql/toolkit": "0.8.0",
     "@mantine/core": "5.10.5",
     "@mantine/hooks": "5.10.5",
     "@medplum/core": "*",
     "@medplum/fhirtypes": "*",
     "@medplum/react": "*",
+    "@types/react": "18.0.28",
+    "@types/react-dom": "18.0.11",
     "babel-loader": "9.1.2",
     "css-loader": "6.7.3",
     "dotenv-webpack": "8.0.1",

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -1,6 +1,7 @@
+import { GraphiQLPlugin } from '@graphiql/react';
 import { FetcherParams, SyncExecutionResult } from '@graphiql/toolkit';
 import { MantineProvider, MantineThemeOverride, Title } from '@mantine/core';
-import { MedplumClient } from '@medplum/core';
+import { getDisplayString, MedplumClient, ProfileResource } from '@medplum/core';
 import { Logo, MedplumProvider, SignInForm, useMedplumProfile } from '@medplum/react';
 import GraphiQL from 'graphiql';
 import React from 'react';
@@ -66,10 +67,27 @@ function fetcher(params: FetcherParams): Promise<SyncExecutionResult> {
   return medplum.graphql(params.query, params.operationName, params.variables);
 }
 
+const medplumPlugin: GraphiQLPlugin = {
+  title: 'Medplum',
+  icon: () => <Logo size={24} />,
+  content: () => (
+    <div>
+      <p>Medplum GraphiQL</p>
+      <p>User: {getDisplayString(medplum.getProfile() as ProfileResource)}</p>
+      <p>Project: {medplum.getActiveLogin()?.project?.display}</p>
+      <p>
+        <a href="#" onClick={() => medplum.signOut().then(() => window.location.reload())}>
+          Sign out
+        </a>
+      </p>
+    </div>
+  ),
+};
+
 function App(): JSX.Element {
   const profile = useMedplumProfile();
   return profile ? (
-    <GraphiQL fetcher={fetcher} defaultQuery={HELP_TEXT} />
+    <GraphiQL fetcher={fetcher} defaultQuery={HELP_TEXT} plugins={[medplumPlugin]} />
   ) : (
     <SignInForm googleClientId={process.env.GOOGLE_CLIENT_ID} onSuccess={() => undefined}>
       <Logo size={32} />


### PR DESCRIPTION
Adding a "Medplum" plugin to GraphiQL that:
1. Shows your current user
2. Shows your current project
3. Shows a link to sign out

https://user-images.githubusercontent.com/749094/222780830-1a21aef3-48b3-435d-ad58-cbcdaa8337eb.mp4

Large diff is due to adding `@graphiql/react` types, which we should have added before anyway.