### PR TITLE
Remove Vercel URL rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,15 +23,5 @@
         }
       ]
     }
-  ],
-  "rewrites": [
-    {
-      "source": "/api/:path([^.]+)",
-      "destination": "https://legacy.medplum.com/api/:path"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/index.html"
-    }
   ]
 }


### PR DESCRIPTION
1. Removing legacy `/api/` support, which has been deprecated and unused for 6+ months
2. Removing SPA `index.html` rewrite, which should not be necessary, because Vercel has built-in support for Docusaurus now