### PR TITLE
Fixed pagination bug on project admin pages

### DIFF
--- a/packages/app/src/admin/BotsPage.tsx
+++ b/packages/app/src/admin/BotsPage.tsx
@@ -1,18 +1,13 @@
 import { Group, Title } from '@mantine/core';
-import { MedplumLink, useMedplum } from '@medplum/react';
+import { MedplumLink } from '@medplum/react';
 import React from 'react';
-import { getProjectId } from '../utils';
 import { MemberTable } from './MembersTable';
 
 export function BotsPage(): JSX.Element {
-  const medplum = useMedplum();
-  const projectId = getProjectId(medplum);
-  const result = medplum.get(`admin/projects/${projectId}`).read();
-
   return (
     <>
       <Title>Bots</Title>
-      <MemberTable members={result.members.filter((member: any) => member.role === 'bot')} />
+      <MemberTable resourceType="Bot" fields={['user', 'profile', 'admin', '_lastUpdated']} />
       <Group position="right">
         <MedplumLink to={`/admin/bots/new`}>Create new bot</MedplumLink>
       </Group>

--- a/packages/app/src/admin/ClientsPage.tsx
+++ b/packages/app/src/admin/ClientsPage.tsx
@@ -1,18 +1,13 @@
 import { Group, Title } from '@mantine/core';
-import { MedplumLink, useMedplum } from '@medplum/react';
+import { MedplumLink } from '@medplum/react';
 import React from 'react';
-import { getProjectId } from '../utils';
 import { MemberTable } from './MembersTable';
 
 export function ClientsPage(): JSX.Element {
-  const medplum = useMedplum();
-  const projectId = getProjectId(medplum);
-  const result = medplum.get(`admin/projects/${projectId}`).read();
-
   return (
     <>
       <Title>Clients</Title>
-      <MemberTable members={result.members.filter((member: any) => member.role === 'client')} />
+      <MemberTable resourceType="ClientApplication" fields={['user', 'profile', 'admin', '_lastUpdated']} />
       <Group position="right">
         <MedplumLink to={`/admin/clients/new`}>Create new client</MedplumLink>
       </Group>

--- a/packages/app/src/admin/PatientsPage.tsx
+++ b/packages/app/src/admin/PatientsPage.tsx
@@ -1,18 +1,13 @@
 import { Group, Title } from '@mantine/core';
-import { MedplumLink, useMedplum } from '@medplum/react';
+import { MedplumLink } from '@medplum/react';
 import React from 'react';
-import { getProjectId } from '../utils';
-import { MemberTable, ProjectMember } from './MembersTable';
+import { MemberTable } from './MembersTable';
 
 export function PatientsPage(): JSX.Element {
-  const medplum = useMedplum();
-  const projectId = getProjectId(medplum);
-  const result = medplum.get(`admin/projects/${projectId}`).read();
-
   return (
     <>
       <Title>Patients</Title>
-      <MemberTable members={result.members.filter((member: ProjectMember) => member.role === 'patient')} />
+      <MemberTable resourceType="Patient" fields={['user', 'profile', '_lastUpdated']} />
       <Group position="right">
         <MedplumLink to={`/admin/invite`}>Invite new patient</MedplumLink>
       </Group>

--- a/packages/app/src/admin/ProjectDetailsPage.tsx
+++ b/packages/app/src/admin/ProjectDetailsPage.tsx
@@ -14,7 +14,6 @@ export function ProjectDetailsPage(): JSX.Element {
       <DescriptionList>
         <DescriptionListEntry term="ID">{result.project.id}</DescriptionListEntry>
         <DescriptionListEntry term="Name">{result.project.name}</DescriptionListEntry>
-        <DescriptionListEntry term="Members">{result.members?.length}</DescriptionListEntry>
       </DescriptionList>
     </>
   );

--- a/packages/app/src/admin/ProjectPage.tsx
+++ b/packages/app/src/admin/ProjectPage.tsx
@@ -44,7 +44,7 @@ export function ProjectPage(): JSX.Element {
           </Tabs>
         </ScrollArea>
       </Paper>
-      <Document width={700}>
+      <Document>
         <Outlet />
       </Document>
     </>

--- a/packages/app/src/admin/UsersPage.tsx
+++ b/packages/app/src/admin/UsersPage.tsx
@@ -1,22 +1,13 @@
 import { Group, Title } from '@mantine/core';
-import { MedplumLink, useMedplum } from '@medplum/react';
+import { MedplumLink } from '@medplum/react';
 import React from 'react';
-import { getProjectId } from '../utils';
-import { MemberTable, ProjectMember } from './MembersTable';
+import { MemberTable } from './MembersTable';
 
 export function UsersPage(): JSX.Element {
-  const medplum = useMedplum();
-  const projectId = getProjectId(medplum);
-  const result = medplum.get(`admin/projects/${projectId}`).read();
-  const roles = ['owner', 'admin', 'member'];
-
   return (
     <>
       <Title>Users</Title>
-      <MemberTable
-        members={result.members.filter((member: ProjectMember) => roles.includes(member.role))}
-        showRole={true}
-      />
+      <MemberTable resourceType="Practitioner" fields={['user', 'profile', 'admin', '_lastUpdated']} />
       <Group position="right">
         <MedplumLink to={`/admin/invite`}>Invite new user</MedplumLink>
       </Group>

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -41,12 +41,12 @@ export async function inviteHandler(req: Request, res: Response): Promise<void> 
     return;
   }
 
-  const { profile } = await inviteUser({
+  const { membership } = await inviteUser({
     ...req.body,
     project: res.locals.project,
   });
 
-  res.status(200).json({ profile });
+  res.status(200).json(membership);
 }
 
 export interface InviteRequest {

--- a/packages/server/src/admin/utils.ts
+++ b/packages/server/src/admin/utils.ts
@@ -1,68 +1,19 @@
-import { forbidden, getReferenceString, OperationOutcomeError, Operator } from '@medplum/core';
-import { BundleEntry, Project, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import { forbidden, OperationOutcomeError } from '@medplum/core';
+import { ProjectMembership } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response } from 'express';
-import { systemRepo } from '../fhir/repo';
 
 /**
  * Verifies that the current user is a project admin.
- * Assumes that "projectId" is a path parameter.
- * Assumes that res.locals.user is populated by authenticateToken middleware.
  * @param req The request.
  * @param res The response.
  * @param next The next handler function.
  */
 export async function verifyProjectAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const locals = res.locals;
-  const project = locals.project as Project;
-  const user = locals.membership.user as Reference<User>;
-
-  const bundle = await systemRepo.search<ProjectMembership>({
-    resourceType: 'ProjectMembership',
-    count: 1,
-    filters: [
-      {
-        code: 'project',
-        operator: Operator.EQUALS,
-        value: getReferenceString(project),
-      },
-      {
-        code: 'user',
-        operator: Operator.EQUALS,
-        value: user.reference as string,
-      },
-    ],
-  });
-
-  if (bundle.entry?.length === 0) {
-    next(new OperationOutcomeError(forbidden));
-    return;
-  }
-
-  const membership = bundle.entry?.[0].resource as ProjectMembership;
+  const membership = res.locals.membership as ProjectMembership;
   if (!membership.admin) {
     next(new OperationOutcomeError(forbidden));
     return;
   }
 
   next();
-}
-
-/**
- * Returns the list of project memberships for the specified project.
- * @param projectId The project ID.
- * @returns The list of project memberships.
- */
-export async function getProjectMemberships(projectId: string): Promise<ProjectMembership[]> {
-  const bundle = await systemRepo.search<ProjectMembership>({
-    resourceType: 'ProjectMembership',
-    count: 1000,
-    filters: [
-      {
-        code: 'project',
-        operator: Operator.EQUALS,
-        value: 'Project/' + projectId,
-      },
-    ],
-  });
-  return (bundle.entry as BundleEntry<ProjectMembership>[]).map((entry) => entry.resource as ProjectMembership);
 }

--- a/packages/server/src/auth/login.test.ts
+++ b/packages/server/src/auth/login.test.ts
@@ -226,32 +226,15 @@ describe('Login', () => {
     const id = paths[paths.length - 2];
     const secret = paths[paths.length - 1];
 
-    // Get the project details
-    // Make sure the new member is in the members list
-    // Get the project details and members
-    // 3 members total (1 admin, 1 client, 1 invited)
-    const res3 = await request(app)
-      .get('/admin/projects/' + project.id)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res3.status).toBe(200);
-    expect(res3.body.project).toBeDefined();
-    expect(res3.body.members).toBeDefined();
-    expect(res3.body.members.length).toEqual(3);
-
-    const owner = res3.body.members.find((m: any) => m.role === 'owner');
-    expect(owner).toBeDefined();
-    const member = res3.body.members.find((m: any) => m.role === 'member');
-    expect(member).toBeDefined();
-
     // Get the new membership details
     const res4 = await request(app)
-      .get('/admin/projects/' + project.id + '/members/' + member.id)
+      .get('/admin/projects/' + project.id + '/members/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res4.status).toBe(200);
 
     // Set the new member's access policy
     const res5 = await request(app)
-      .post('/admin/projects/' + project.id + '/members/' + member.id)
+      .post('/admin/projects/' + project.id + '/members/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken)
       .type('json')
       .send({
@@ -264,16 +247,10 @@ describe('Login', () => {
     // Make sure the access policy is set
     // 3 members total (1 admin, 1 client, 1 invited)
     const res6 = await request(app)
-      .get('/admin/projects/' + project.id)
+      .get('/admin/projects/' + project.id + '/members/' + res2.body.id)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res6.status).toBe(200);
-    expect(res6.body.project).toBeDefined();
-    expect(res6.body.members).toBeDefined();
-    expect(res6.body.members.length).toEqual(3);
-
-    const member2 = res6.body.members.find((m: any) => m.role === 'member');
-    expect(member2).toBeDefined();
-    expect(member2.accessPolicy).toBeDefined();
+    expect(res6.body.accessPolicy).toBeDefined();
 
     // Now try to login as the new member
     // First, set the password


### PR DESCRIPTION
On project admin pages, project members were displayed with the `<MemberTable>` component, which did not correctly handle pagination requests under a variety of different circumstances.  This is largely due to the fact the the `/admin/project/members` endpoints did not properly implement pagination themselves.

This PR updates project admin pages to use the normal FHIR `<SearchControl>` component, which includes robust pagination.  This is possible because we recently granted access to project administrators to `ProjectMembership` resources.

![image](https://user-images.githubusercontent.com/749094/223908547-158e5586-f419-479d-b63f-f01a3d91d2e5.png)

Issues for future work:
- Before, there were links for both the "profile" and the "membership", now the row only goes to the membership.
- There are a bunch of predictable sorting requests (first name, last name, email, etc) which are not currently available