### PR TITLE
Prepare cdk package for publishing

### DIFF
--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist cdk.out",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && rollup --config rollup.config.mjs",
     "init": "ts-node src/init.ts",
     "cdk": "cdk",
     "test": "jest"
@@ -26,5 +26,8 @@
     "cdk-nag": "2.22.30",
     "cdk-serverless-clamscan": "2.4.195",
     "constructs": "10.1.272"
+  },
+  "bin": {
+    "medplum-cdk-init": "./dist/cjs/init.cjs"
   }
 }

--- a/packages/cdk/rollup.config.mjs
+++ b/packages/cdk/rollup.config.mjs
@@ -1,0 +1,56 @@
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import { mkdirSync, writeFileSync } from 'fs';
+
+const external = [
+  '@aws-sdk/client-acm',
+  '@aws-sdk/client-ssm',
+  '@aws-sdk/client-sts',
+  'aws-cdk-lib',
+  'aws-cdk-lib/aws-ecr',
+  'cdk',
+  'cdk-nag',
+  'cdk-serverless-clamscan',
+  'constructs',
+];
+
+const extensions = ['.ts'];
+
+const plugins = [
+  resolve({ extensions }),
+  typescript({ outDir: 'dist/cjs', declaration: false }),
+  {
+    buildEnd: () => {
+      mkdirSync('./dist/cjs', { recursive: true });
+      writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}');
+    },
+  },
+];
+
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/cjs/index.cjs',
+        format: 'cjs',
+        sourcemap: true,
+      },
+    ],
+    plugins,
+    external,
+  },
+  {
+    input: 'src/init.ts',
+    output: [
+      {
+        file: 'dist/cjs/init.cjs',
+        format: 'cjs',
+        sourcemap: true,
+        banner: '#!/usr/bin/env node',
+      },
+    ],
+    plugins,
+    external,
+  },
+];

--- a/packages/cdk/src/index.ts
+++ b/packages/cdk/src/index.ts
@@ -63,6 +63,6 @@ export function main(context?: Record<string, string>): void {
   app.synth();
 }
 
-if (process.argv[1].endsWith('index.ts')) {
+if (require.main === module) {
   main();
 }

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -5,4 +5,5 @@ dist/**/*.test.js.map
 src/
 babel.config.json
 jest.config.json
+rollup.config.mjs
 tsconfig.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && rollup --config rollup.config.mjs",
     "test": "jest"
   },
   "dependencies": {
@@ -25,7 +25,7 @@
     "@medplum/mock": "*"
   },
   "bin": {
-    "medplum": "./dist/index.js"
+    "medplum": "./dist/cjs/index.cjs"
   },
   "keywords": [
     "medplum",

--- a/packages/cli/rollup.config.mjs
+++ b/packages/cli/rollup.config.mjs
@@ -1,0 +1,40 @@
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import { mkdirSync, writeFileSync } from 'fs';
+
+const extensions = ['.ts'];
+
+const globals = {
+  '@medplum/core': 'medplum.core',
+  dotenv: 'dotenv',
+  fs: 'fs',
+  'node-fetch': 'fetch',
+  path: 'path',
+};
+
+export default [
+  {
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/cjs/index.cjs',
+        format: 'cjs',
+        name: 'medplum.cli',
+        sourcemap: true,
+        globals,
+        banner: '#!/usr/bin/env node',
+      },
+    ],
+    plugins: [
+      resolve({ extensions }),
+      typescript({ outDir: 'dist/cjs', declaration: false }),
+      {
+        buildEnd: () => {
+          mkdirSync('./dist/cjs', { recursive: true });
+          writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}');
+        },
+      },
+    ],
+    external: Object.keys(globals),
+  },
+];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { MedplumClient, normalizeErrorString } from '@medplum/core';
 import { Bot, OperationOutcome } from '@medplum/fhirtypes';
 import dotenv from 'dotenv';

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -6,6 +6,5 @@ src/
 babel.config.json
 jest.config.json
 rollup.config.mjs
-tsconfig.cjs.json
-tsconfig.esm.json
+tsconfig.build.json
 tsconfig.json

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -11,6 +11,5 @@ storybook-static/
 babel.config.json
 jest.config.json
 rollup.config.mjs
-tsconfig.cjs.json
-tsconfig.esm.json
+tsconfig.build.json
 tsconfig.json


### PR DESCRIPTION
Before:
- Using the Medplum CDK meant cloning the entire Medplum repo, and running commands in special directories
- Running our infra init tool, or running our CDK meant installing all Node.js dependencies for all projects (react, express, typescript, etc)
- No clear config patterns for how to manage infra config files

After:
- We will publish `@medplum/cdk`
- Consumers can create a standalone separate repo with dependencies on `cdk` and `@medplum/cdk`
- Only the necessary dependencies installed
- Create your infra config files in the same directory
- Commit everything to git in standalone repo
- Clear pattern for how to manage config files