### PR TITLE
Workaround for JsonInput deserialization bug

### DIFF
--- a/packages/app/src/resource/JsonPage.tsx
+++ b/packages/app/src/resource/JsonPage.tsx
@@ -44,6 +44,7 @@ export function JsonPage(): JSX.Element | null {
           minRows={24}
           defaultValue={stringify(resource, true)}
           formatOnBlur
+          deserialize={JSON.parse}
         />
         <Group position="right" mt="xl" noWrap>
           <Button type="submit">OK</Button>

--- a/packages/app/src/resource/utils.ts
+++ b/packages/app/src/resource/utils.ts
@@ -4,7 +4,7 @@ import { Resource } from '@medplum/fhirtypes';
  * Cleans a resource of unwanted meta values.
  * For most users, this will not matter, because meta values are set by the server.
  * However, some administrative users are allowed to specify some meta values.
- * The admin use case is sepcial though, and unwanted here on the resource page.
+ * The admin use case is special though, and unwanted here on the resource page.
  * @param resource The input resource.
  * @returns The cleaned output resource.
  */


### PR DESCRIPTION
Mantine 6.0 introduced a custom serializers/deserializers for the JsonInput component. However, they introduced a bug where they use `JSON.stringify` rather `JSON.parse` for their deserializer.

https://github.com/mantinedev/mantine/commit/d536a2a3c10c6224cf901edd3065f265c2c90b38

This PR works around that bug but explicitly passing in `JSON.parse` as a custom deserializer