### PR TITLE
CDK error handling and warnings in init tool

### DIFF
--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -15,7 +15,7 @@
     "build": "npm run clean && tsc && rollup --config rollup.config.mjs",
     "init": "ts-node src/init.ts",
     "cdk": "cdk",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@aws-sdk/client-acm": "3.287.0",

--- a/packages/cdk/src/__mocks__/@aws-sdk/client-acm.ts
+++ b/packages/cdk/src/__mocks__/@aws-sdk/client-acm.ts
@@ -11,18 +11,30 @@ export class RequestCertificateCommand {
 }
 
 export class ACMClient {
+  constructor(readonly config?: any) {}
+
   async send(command: any): Promise<any> {
     if (command instanceof ListCertificatesCommand) {
+      if (this.config?.region === 'us-bad-1') {
+        throw new Error('Invalid region');
+      }
       return {
         CertificateSummaryList: [
           {
             DomainName: 'example.com',
+          },
+          {
+            CertificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789013',
+            DomainName: 'api.existing.example.com',
           },
         ],
       };
     }
 
     if (command instanceof RequestCertificateCommand) {
+      if (this.config?.region === 'us-bad-1') {
+        throw new Error('Invalid region');
+      }
       return {
         CertificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
       };

--- a/packages/cdk/src/__mocks__/@aws-sdk/client-sts.ts
+++ b/packages/cdk/src/__mocks__/@aws-sdk/client-sts.ts
@@ -3,8 +3,13 @@ export class GetCallerIdentityCommand {
 }
 
 export class STSClient {
+  constructor(readonly config?: any) {}
+
   async send(command: any): Promise<any> {
     if (command instanceof GetCallerIdentityCommand) {
+      if (this.config?.region === 'us-bad-1') {
+        throw new Error('Invalid region');
+      }
       return {};
     }
 

--- a/packages/cdk/src/init.test.ts
+++ b/packages/cdk/src/init.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { readFileSync, unlinkSync } from 'fs';
+import { readFileSync, unlinkSync, writeFileSync } from 'fs';
 import readline from 'readline';
 import { main } from './init';
 
@@ -60,6 +60,130 @@ test('Init tool success', async () => {
     serverImage: 'medplum/medplum-server:latest',
     storagePublicKey: expect.stringContaining('-----BEGIN PUBLIC KEY-----'),
     apiSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+    appSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+    storageSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+  });
+  unlinkSync(filename);
+});
+
+test('Overwrite existing file', async () => {
+  const filename = `test-${randomUUID()}.json`;
+  writeFileSync(filename, '{}', 'utf8');
+
+  await main(
+    mockReadline(
+      'foo',
+      filename,
+      'y', // Yes, overwrite
+      'us-east-1',
+      'account-123',
+      'TestStack',
+      'test.example.com',
+      'support@example.com',
+      '', // default API domain
+      '', // default app domain
+      '', // default storage domain
+      '', // default storage bucket
+      '', // default availability zones
+      'y', // Yes, create a database
+      '', // default database instances
+      '', // default server instances
+      '', // default server memory
+      '', // default server cpu
+      '', // default server image
+      'y', // Yes, request api certificate
+      '', // default DNS validation
+      'y', // Yes, request app certificate
+      '', // default DNS validation
+      'y', // Yes, request storage certificate
+      '', // default DNS validation
+      'y' // Yes, write to Parameter Store
+    )
+  );
+
+  const config = JSON.parse(readFileSync(filename, 'utf8'));
+  expect(config).toMatchObject({
+    apiPort: 8103,
+    name: 'foo',
+    region: 'us-east-1',
+    accountNumber: 'account-123',
+    stackName: 'TestStack',
+    domainName: 'test.example.com',
+    apiDomainName: 'api.test.example.com',
+    appDomainName: 'app.test.example.com',
+    storageDomainName: 'storage.test.example.com',
+    storageBucketName: 'medplum-foo-storage',
+    maxAzs: 2,
+    rdsInstances: 1,
+    desiredServerCount: 1,
+    serverMemory: 512,
+    serverCpu: 256,
+    serverImage: 'medplum/medplum-server:latest',
+    storagePublicKey: expect.stringContaining('-----BEGIN PUBLIC KEY-----'),
+    apiSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+    appSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+    storageSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+  });
+  unlinkSync(filename);
+});
+
+test('Invalid AWS credentials', async () => {
+  const filename = `test-${randomUUID()}.json`;
+
+  console.log = jest.fn();
+
+  await main(
+    mockReadline(
+      'foo',
+      filename,
+      'us-bad-1', // Special fake region for mock clients
+      'account-123',
+      'TestStack',
+      'test.example.com',
+      'support@example.com',
+      '', // default API domain
+      '', // default app domain
+      '', // default storage domain
+      '', // default storage bucket
+      '', // default availability zones
+      'y', // Yes, create a database
+      '', // default database instances
+      '', // default server instances
+      '', // default server memory
+      '', // default server cpu
+      '', // default server image
+      'y', // Yes, request api certificate
+      '', // default DNS validation
+      'y', // Yes, request app certificate
+      '', // default DNS validation
+      'y', // Yes, request storage certificate
+      '', // default DNS validation
+      'y' // Yes, write to Parameter Store
+    )
+  );
+
+  expect(console.log).toHaveBeenCalledWith('Warning: Unable to get AWS account ID', 'Invalid region');
+
+  const config = JSON.parse(readFileSync(filename, 'utf8'));
+  expect(config).toMatchObject({
+    apiPort: 8103,
+    name: 'foo',
+    region: 'us-bad-1',
+    accountNumber: 'account-123',
+    stackName: 'TestStack',
+    domainName: 'test.example.com',
+    apiDomainName: 'api.test.example.com',
+    appDomainName: 'app.test.example.com',
+    storageDomainName: 'storage.test.example.com',
+    storageBucketName: 'medplum-foo-storage',
+    maxAzs: 2,
+    rdsInstances: 1,
+    desiredServerCount: 1,
+    serverMemory: 512,
+    serverCpu: 256,
+    serverImage: 'medplum/medplum-server:latest',
+    storagePublicKey: expect.stringContaining('-----BEGIN PUBLIC KEY-----'),
+    apiSslCertArn: 'TODO',
     appSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
     storageSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
   });
@@ -180,10 +304,75 @@ test('Do not request SSL certs', async () => {
   unlinkSync(filename);
 });
 
+test('Existing SSL certificates', async () => {
+  const filename = `test-${randomUUID()}.json`;
+
+  await main(
+    mockReadline(
+      'foo',
+      filename,
+      'us-east-1',
+      'account-123',
+      'TestStack',
+      'existing.example.com',
+      'support@example.com',
+      '', // default API domain
+      '', // default app domain
+      '', // default storage domain
+      '', // default storage bucket
+      '', // default availability zones
+      'y', // Yes, create a database
+      '', // default database instances
+      '', // default server instances
+      '', // default server memory
+      '', // default server cpu
+      '', // default server image
+      'y', // Yes, request api certificate
+      '', // default DNS validation
+      'y', // Yes, request app certificate
+      '', // default DNS validation
+      'y', // Yes, request storage certificate
+      '', // default DNS validation
+      'y' // Yes, write to Parameter Store
+    )
+  );
+
+  const config = JSON.parse(readFileSync(filename, 'utf8'));
+  expect(config).toMatchObject({
+    apiPort: 8103,
+    name: 'foo',
+    region: 'us-east-1',
+    accountNumber: 'account-123',
+    stackName: 'TestStack',
+    domainName: 'existing.example.com',
+    apiDomainName: 'api.existing.example.com',
+    appDomainName: 'app.existing.example.com',
+    storageDomainName: 'storage.existing.example.com',
+    storageBucketName: 'medplum-foo-storage',
+    maxAzs: 2,
+    rdsInstances: 1,
+    desiredServerCount: 1,
+    serverMemory: 512,
+    serverCpu: 256,
+    serverImage: 'medplum/medplum-server:latest',
+    storagePublicKey: expect.stringContaining('-----BEGIN PUBLIC KEY-----'),
+    apiSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789013',
+    appSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+    storageSslCertArn: 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012',
+  });
+  unlinkSync(filename);
+});
+
 function mockReadline(...answers: string[]): readline.Interface {
   const result = { write: jest.fn(), question: jest.fn() };
+  const debug = false;
   for (const answer of answers) {
-    result.question.mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(answer));
+    result.question.mockImplementationOnce((q: string, cb: (answer: string) => void) => {
+      if (debug) {
+        console.log(q, answer);
+      }
+      cb(answer);
+    });
   }
   return result as unknown as readline.Interface;
 }

--- a/packages/cdk/src/init.ts
+++ b/packages/cdk/src/init.ts
@@ -373,13 +373,13 @@ async function listCertificates(region: string): Promise<CertificateSummary[]> {
  *
  * 1. If the certificate already exists, return the ARN.
  * 2. If the certificate does not exist, and the user wants to create a new certificate, create it and return the ARN.
- * 3. If the certificate does not exist, and the user does not want to create a new certificate, return "TODO".
+ * 3. If the certificate does not exist, and the user does not want to create a new certificate, return a placeholder.
  *
  * @param config In-progress config settings.
  * @param allCerts List of all existing certificates.
  * @param region The AWS region where the certificate is needed.
  * @param certName The name of the certificate (api, app, or storage).
- * @returns The ARN of the certificate or "TODO" if a new certificate is needed.
+ * @returns The ARN of the certificate or placeholder if a new certificate is needed.
  */
 async function processCert(
   config: MedplumInfraConfig,

--- a/packages/cdk/src/init.ts
+++ b/packages/cdk/src/init.ts
@@ -10,7 +10,7 @@ import { MedplumInfraConfig } from './config';
 let terminal: readline.Interface;
 
 export async function main(t: readline.Interface): Promise<void> {
-  const config = { apiPort: 8103 } as MedplumInfraConfig;
+  const config = { apiPort: 8103, region: 'us-east-1' } as MedplumInfraConfig;
   terminal = t;
   header('MEDPLUM');
   print('This tool prepares the necessary prerequisites for deploying Medplum in your AWS account.');
@@ -339,11 +339,16 @@ function writeConfig(configFileName: string, config: MedplumInfraConfig): void {
  * @param region The AWS region.
  * @returns The AWS account ID.
  */
-async function getAccountId(region: string): Promise<string> {
-  const client = new STSClient({ region });
-  const command = new GetCallerIdentityCommand({});
-  const response = await client.send(command);
-  return response.Account as string;
+async function getAccountId(region: string): Promise<string | undefined> {
+  try {
+    const client = new STSClient({ region });
+    const command = new GetCallerIdentityCommand({});
+    const response = await client.send(command);
+    return response.Account as string;
+  } catch (err) {
+    console.log('Warning: Unable to get AWS account ID', (err as Error).message);
+  }
+  return undefined;
 }
 
 /**

--- a/packages/cdk/src/init.ts
+++ b/packages/cdk/src/init.ts
@@ -7,6 +7,13 @@ import { resolve } from 'path';
 import readline from 'readline';
 import { MedplumInfraConfig } from './config';
 
+type MedplumDomainType = 'api' | 'app' | 'storage';
+type MedplumDomainSetting = `${MedplumDomainType}DomainName`;
+type MedplumDomainCertSetting = `${MedplumDomainType}SslCertArn`;
+
+const getDomainSetting = (domain: MedplumDomainType): MedplumDomainSetting => `${domain}DomainName`;
+const getDomainCertSetting = (domain: MedplumDomainType): MedplumDomainCertSetting => `${domain}SslCertArn`;
+
 let terminal: readline.Interface;
 
 export async function main(t: readline.Interface): Promise<void> {
@@ -185,31 +192,6 @@ export async function main(t: readline.Interface): Promise<void> {
   const allCerts = await listAllCertificates(config.region);
   print('Found ' + allCerts.length + ' certificate(s).');
 
-  const doCert = async (region: string, certName: 'api' | 'app' | 'storage'): Promise<boolean> => {
-    const subdomain = config[(certName + 'DomainName') as 'apiDomainName' | 'appDomainName' | 'storageDomainName'];
-    const setting = (certName + 'SslCertArn') as 'apiSslCertArn' | 'appSslCertArn' | 'storageSslCertArn';
-    const existingCert = allCerts.find(
-      (cert) => cert.CertificateArn?.includes(region) && cert.DomainName === subdomain
-    );
-    let arn = 'TODO';
-    print('');
-    if (existingCert) {
-      print(`Found existing certificate for "${subdomain}".`);
-      arn = existingCert.CertificateArn as string;
-    } else {
-      print(`No existing certificate found for "${subdomain}".`);
-      if (await yesOrNo('Do you want to create a new certificate?')) {
-        arn = await requestCert(region, subdomain);
-      } else {
-        print(`Please certificate ARN in the config file in the "${setting}" setting.`);
-      }
-    }
-    print('Certificate ARN: ' + arn);
-    config[setting] = arn;
-    writeConfig(configFileName, config);
-    return true;
-  };
-
   // Process certificates for each subdomain
   // Note: The "api" certificate must be created in the same region as the API
   // Note: The "app" and "storage" certificates must be created in us-east-1
@@ -218,9 +200,10 @@ export async function main(t: readline.Interface): Promise<void> {
     { region: 'us-east-1', certName: 'app' },
     { region: 'us-east-1', certName: 'storage' },
   ] as const) {
-    if (!(await doCert(region, certName))) {
-      return;
-    }
+    print('');
+    const arn = await processCert(config, allCerts, region, certName);
+    config[getDomainCertSetting(certName)] = arn;
+    writeConfig(configFileName, config);
   }
 
   header('AWS PARAMETER STORE');
@@ -347,8 +330,8 @@ async function getAccountId(region: string): Promise<string | undefined> {
     return response.Account as string;
   } catch (err) {
     console.log('Warning: Unable to get AWS account ID', (err as Error).message);
+    return undefined;
   }
-  return undefined;
 }
 
 /**
@@ -374,10 +357,52 @@ async function listAllCertificates(region: string): Promise<CertificateSummary[]
  * @returns The list of AWS Certificates.
  */
 async function listCertificates(region: string): Promise<CertificateSummary[]> {
-  const client = new ACMClient({ region });
-  const command = new ListCertificatesCommand({ MaxItems: 1000 });
-  const response = await client.send(command);
-  return response.CertificateSummaryList as CertificateSummary[];
+  try {
+    const client = new ACMClient({ region });
+    const command = new ListCertificatesCommand({ MaxItems: 1000 });
+    const response = await client.send(command);
+    return response.CertificateSummaryList as CertificateSummary[];
+  } catch (err) {
+    console.log('Warning: Unable to list certificates', (err as Error).message);
+    return [];
+  }
+}
+
+/**
+ * Processes a required certificate.
+ *
+ * 1. If the certificate already exists, return the ARN.
+ * 2. If the certificate does not exist, and the user wants to create a new certificate, create it and return the ARN.
+ * 3. If the certificate does not exist, and the user does not want to create a new certificate, return "TODO".
+ *
+ * @param config In-progress config settings.
+ * @param allCerts List of all existing certificates.
+ * @param region The AWS region where the certificate is needed.
+ * @param certName The name of the certificate (api, app, or storage).
+ * @returns The ARN of the certificate or "TODO" if a new certificate is needed.
+ */
+async function processCert(
+  config: MedplumInfraConfig,
+  allCerts: CertificateSummary[],
+  region: string,
+  certName: 'api' | 'app' | 'storage'
+): Promise<string> {
+  const domainName = config[getDomainSetting(certName)];
+  const existingCert = allCerts.find((cert) => cert.CertificateArn?.includes(region) && cert.DomainName === domainName);
+  if (existingCert) {
+    print(`Found existing certificate for "${domainName}" in "${region}.`);
+    return existingCert.CertificateArn as string;
+  }
+
+  print(`No existing certificate found for "${domainName}" in "${region}.`);
+  if (!(await yesOrNo('Do you want to request a new certificate?'))) {
+    print(`Please add your certificate ARN to the config file in the "${getDomainCertSetting(certName)}" setting.`);
+    return 'TODO';
+  }
+
+  const arn = await requestCert(region, domainName);
+  print('Certificate ARN: ' + arn);
+  return arn;
 }
 
 /**
@@ -387,14 +412,23 @@ async function listCertificates(region: string): Promise<CertificateSummary[]> {
  * @returns The AWS Certificate ARN on success, or undefined on failure.
  */
 async function requestCert(region: string, domain: string): Promise<string> {
-  const validationMethod = await choose('Validate certificate using DNS or email validation?', ['dns', 'email'], 'dns');
-  const client = new ACMClient({ region });
-  const command = new RequestCertificateCommand({
-    DomainName: domain,
-    ValidationMethod: validationMethod.toUpperCase(),
-  });
-  const response = await client.send(command);
-  return response.CertificateArn as string;
+  try {
+    const validationMethod = await choose(
+      'Validate certificate using DNS or email validation?',
+      ['dns', 'email'],
+      'dns'
+    );
+    const client = new ACMClient({ region });
+    const command = new RequestCertificateCommand({
+      DomainName: domain,
+      ValidationMethod: validationMethod.toUpperCase(),
+    });
+    const response = await client.send(command);
+    return response.CertificateArn as string;
+  } catch (err) {
+    console.log('Error: Unable to request certificate', (err as Error).message);
+    return 'TODO';
+  }
 }
 
 /**
@@ -462,12 +496,7 @@ async function writeParameters(region: string, prefix: string, params: Record<st
 }
 
 if (require.main === module) {
-  main(
-    readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    })
-  )
+  main(readline.createInterface({ input: process.stdin, output: process.stdout }))
     .then(() => process.exit(0))
     .catch((err) => {
       console.error((err as Error).message);


### PR DESCRIPTION
* Handle errors if no AWS access
  * No access to get identity
  * No access to list certificates
  * No access to request a certificate
* On errors, put "TODO" placeholders in the config file
* Option to use "email" or "dns" verification for new SSL certificates