### PR TITLE
Fixed jsdom warning in react test output

### DIFF
--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
@@ -15,7 +15,7 @@ describe('ServiceRequestTimeline', () => {
     await act(async () => {
       render(
         <MemoryRouter>
-          <MedplumProvider medplum={medplum}>
+          <MedplumProvider medplum={medplum} navigate={jest.fn()}>
             <ServiceRequestTimeline {...args} />
           </MedplumProvider>
         </MemoryRouter>


### PR DESCRIPTION
Before: jsdom warning that `window.location.assign()` is not implemented

After: no warnings