### PR TITLE
Fixes #1630 - reference identifier search

### DIFF
--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -38,6 +38,7 @@ export abstract class LookupTable<T> {
   /**
    * Determines if the search parameter is indexed by this index table.
    * @param searchParam The search parameter.
+   * @param resourceType The resource type.
    * @returns True if the search parameter is indexed.
    */
   abstract isIndexed(searchParam: SearchParameter, resourceType: string): boolean;

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -1,4 +1,5 @@
 import { stringify } from '@medplum/core';
+import { SearchParameter } from '@medplum/fhirtypes';
 
 /**
  * Compares two arrays of objects.
@@ -18,4 +19,28 @@ export function compareArrays(incoming: any[], existing: any[]): boolean {
   }
 
   return true;
+}
+
+/**
+ * Derives an "identifier" search parameter from a reference search parameter.
+ *
+ * FHIR references can have an "identifier" property.
+ *
+ * Any FHIR reference search parameter can be used to search for resources with an identifier.
+ *
+ * However, the FHIR specification does not define an "identifier" search parameter for every resource type.
+ *
+ * This function derives an "identifier" search parameter from a reference search parameter.
+ *
+ * @param inputParam The original reference search parameter.
+ * @returns The derived "identifier" search parameter.
+ */
+export function deriveIdentifierSearchParameter(inputParam: SearchParameter): SearchParameter {
+  return {
+    resourceType: 'SearchParameter',
+    code: inputParam.code + ':identifier',
+    base: inputParam.base,
+    type: 'token',
+    expression: inputParam.expression + '.identifier',
+  };
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -78,6 +78,7 @@ import { AddressTable } from './lookups/address';
 import { HumanNameTable } from './lookups/humanname';
 import { LookupTable } from './lookups/lookuptable';
 import { TokenTable } from './lookups/token';
+import { deriveIdentifierSearchParameter } from './lookups/util';
 import { ValueSetElementTable } from './lookups/valuesetelement';
 import { getPatient } from './patient';
 import { validateReferences } from './references';
@@ -1147,9 +1148,15 @@ export class Repository {
     }
 
     const resourceType = searchRequest.resourceType;
-    const param = getSearchParameter(resourceType, filter.code);
+    let param = getSearchParameter(resourceType, filter.code);
     if (!param || !param.code) {
       throw new OperationOutcomeError(badRequest(`Unknown search parameter: ${filter.code}`));
+    }
+
+    if (filter.operator === FhirOperator.IDENTIFIER) {
+      param = deriveIdentifierSearchParameter(param);
+      filter.code = param.code as string;
+      filter.operator = FhirOperator.EQUALS;
     }
 
     const lookupTable = this.#getLookupTable(resourceType, param);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1128,7 +1128,7 @@ export class Repository {
   }
 
   /**
-   * Adds a single search filter as "WHERE" clause to the query builder.
+   * Builds a single search filter as "WHERE" clause to the query builder.
    * @param selectQuery The select query builder.
    * @param searchRequest The search request.
    * @param filter The search filter.
@@ -1164,6 +1164,21 @@ export class Repository {
       return lookupTable.buildWhere(selectQuery, resourceType, filter);
     }
 
+    // Not any special cases, just a normal search parameter.
+    return this.#buildNormalSearchFilterExpression(resourceType, param, filter);
+  }
+
+  /**
+   * Builds a search filter expression for a normal search parameter.
+   *
+   * Not any special cases, just a normal search parameter.
+   *
+   * @param resourceType The FHIR resource type.
+   * @param param The FHIR search parameter.
+   * @param filter The search filter.
+   * @returns A SQL "WHERE" clause expression.
+   */
+  #buildNormalSearchFilterExpression(resourceType: string, param: SearchParameter, filter: Filter): Expression {
     const details = getSearchParameterDetails(resourceType, param);
     if (filter.operator === FhirOperator.MISSING) {
       return new Condition(details.columnName, filter.value === 'true' ? Operator.EQUALS : Operator.NOT_EQUALS, null);


### PR DESCRIPTION
This PR implements the `:identifier` search modifier.

FHIR references can have an `identifier` property of type `Identifier`. The `:identifier` modifier searches `reference.identifier` with all of the identifier token semantics (`value`, `system|value`, `system`, etc).

For example:

```
GET [base]/Observation?subject:identifier=http://acme.org/fhir/identifier/mrn|123456
```

This is an odd feature, because it is basically an extra `SearchParameter` for every existing `SearchParameter` with `type=reference`.

The implementation here implements exactly that pattern via the new `deriveIdentifierSearchParameter()` utility method.  At "index" time and at "search" time, for every "reference" search parameter, we also allow the derived "identifier" search parameter.