### PR TITLE
Add CDK dependencies between Fargate, RDS, and Redis

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -300,6 +300,12 @@ export class BackEnd extends Construct {
       securityGroups: [fargateSecurityGroup],
     });
 
+    // Add dependencies - make sure Fargate service is created after RDS and Redis
+    if (rdsCluster) {
+      fargateService.node.addDependency(rdsCluster);
+    }
+    fargateService.node.addDependency(redisCluster);
+
     // Load Balancer Target Group
     const targetGroup = new elbv2.ApplicationTargetGroup(this, 'TargetGroup', {
       vpc: vpc,


### PR DESCRIPTION
Before: CDK would instantiate Fargate, RDS, and Redis all simultaneously.  That meant that Fargate could start before RDS and Redis were ready, which would lead to noisy logs and alerts.

After: Set a dependency so that Fargate "DependsOn" RDS and Redis, and will not start until they are ready.

This is deployed on staging:

<img width="720" alt="image" src="https://user-images.githubusercontent.com/749094/224810734-8ad65b67-1b21-43dd-862e-6aae7416cdb6.png">
