### PR TITLE
Updated 'Install on AWS' to only build required packages

### DIFF
--- a/packages/docs/docs/self-hosting/install-on-aws.md
+++ b/packages/docs/docs/self-hosting/install-on-aws.md
@@ -196,7 +196,7 @@ RECAPTCHA_SITE_KEY=***Your reCAPTCHA site key for user verification***
 From the root of the Medplum repo, run:
 
 ```bash
-npm run build
+npm run build -- --filter=@medplum/app
 ```
 
 See the [Build](/docs/contributing/run-the-stack#build) page for more details.


### PR DESCRIPTION
This saves your devops team about 2 minutes by not waiting for the Docusaurus build.