### PR TITLE
CLI login command

### DIFF
--- a/packages/app/src/OAuthPage.tsx
+++ b/packages/app/src/OAuthPage.tsx
@@ -12,6 +12,8 @@ export function OAuthPage(): JSX.Element | null {
     return null;
   }
 
+  const scope = params.get('scope') || 'openid';
+
   function onCode(code: string): void {
     const redirectUrl = new URL(params.get('redirect_uri') as string);
     for (const key of ['scope', 'state', 'nonce']) {
@@ -29,13 +31,13 @@ export function OAuthPage(): JSX.Element | null {
       onForgotPassword={() => navigate('/resetpassword')}
       onRegister={() => navigate('/register')}
       googleClientId={process.env.GOOGLE_CLIENT_ID}
-      clientId={clientId}
-      scope={params.get('scope') || undefined}
+      clientId={clientId || undefined}
+      scope={scope}
       nonce={params.get('nonce') || undefined}
       launch={params.get('launch') || undefined}
       codeChallenge={params.get('code_challenge') || undefined}
       codeChallengeMethod={params.get('code_challenge_method') || undefined}
-      chooseScopes={true}
+      chooseScopes={scope !== 'openid'}
     >
       <Logo size={32} />
       <Title>Sign in to Medplum</Title>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
     "directory": "packages/cli"
   },
   "scripts": {
+    "medplum": "ts-node src/index.ts",
     "clean": "rimraf dist",
     "build": "npm run clean && tsc && rollup --config rollup.config.mjs",
     "test": "jest"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,11 @@
-import { MedplumClient, normalizeErrorString } from '@medplum/core';
+import { getDisplayString, LoginState, MedplumClient, normalizeErrorString } from '@medplum/core';
 import { Bot, OperationOutcome } from '@medplum/fhirtypes';
+import { exec } from 'child_process';
 import dotenv from 'dotenv';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { createServer } from 'http';
 import fetch from 'node-fetch';
+import { homedir, platform } from 'os';
 import { resolve } from 'path';
 
 interface MedplumConfig {
@@ -16,19 +19,132 @@ interface MedplumBotConfig {
   readonly dist?: string;
 }
 
+// const baseUrl = process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
+const baseUrl = 'http://localhost:8103/';
+const clientId = 'medplum-cli';
+const redirectUri = 'http://localhost:9615';
+const credentialsFileName = resolve(homedir(), '.medplum', 'credentials.json');
+
 export async function main(medplum: MedplumClient, argv: string[]): Promise<void> {
   if (argv.length < 3) {
     console.log('Usage: medplum <command>');
     return;
   }
 
+  // Legacy support for MEDPLUM_CLIENT_ID and MEDPLUM_CLIENT_SECRET environment variables
+  const clientId = process.env['MEDPLUM_CLIENT_ID'];
+  const clientSecret = process.env['MEDPLUM_CLIENT_SECRET'];
+  if (clientId && clientSecret) {
+    await medplum.startClientLogin(clientId, clientSecret);
+  }
+
+  // Read credentials from file
+  await readCredentials(medplum);
+
+  medplum.addEventListener('change', async () => {
+    // On changes (such as refresh), save the credentials to file
+    await writeCredentials(medplum);
+  });
+
   const command = argv[2];
-  if (command === 'save-bot') {
-    await runBotCommands(medplum, argv, ['save']);
-  } else if (command === 'deploy-bot') {
-    await runBotCommands(medplum, argv, ['save', 'deploy']);
+  switch (command) {
+    case 'login':
+      await startLogin(medplum);
+      break;
+    case 'me':
+      printMe(medplum);
+      break;
+    case 'save-bot':
+      await runBotCommands(medplum, argv, ['save']);
+      break;
+    case 'deploy-bot':
+      await runBotCommands(medplum, argv, ['save', 'deploy']);
+      break;
+    default:
+      console.log(`Unknown command: ${command}`);
+  }
+}
+
+async function readCredentials(medplum: MedplumClient): Promise<void> {
+  if (existsSync(credentialsFileName)) {
+    const loginState = JSON.parse(readFileSync(credentialsFileName, 'utf8'));
+    await medplum.setActiveLogin(loginState as LoginState);
+  }
+}
+
+async function writeCredentials(medplum: MedplumClient): Promise<void> {
+  const loginState = medplum.getActiveLogin();
+  if (loginState) {
+    writeFileSync(credentialsFileName, JSON.stringify(loginState, null, 2), 'utf8');
+  }
+}
+
+async function startLogin(medplum: MedplumClient): Promise<void> {
+  await startWebServer(medplum);
+
+  const loginUrl = new URL('/oauth2/authorize', baseUrl);
+  loginUrl.searchParams.set('client_id', clientId);
+  loginUrl.searchParams.set('redirect_uri', redirectUri);
+  loginUrl.searchParams.set('scope', 'openid');
+  loginUrl.searchParams.set('response_type', 'code');
+  await openBrowser(loginUrl.toString());
+}
+
+async function startWebServer(medplum: MedplumClient): Promise<void> {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url as string, 'http://localhost:9615');
+    const code = url.searchParams.get('code');
+    if (url.pathname === '/' && code) {
+      try {
+        const profile = await medplum.processCode(code, { clientId, redirectUri });
+        await writeCredentials(medplum);
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end(`Signed in as ${getDisplayString(profile)}. You may close this window.`);
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end(`Error: ${normalizeErrorString(err)}`);
+      } finally {
+        server.close();
+      }
+    } else {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+    }
+  }).listen(9615);
+}
+
+/**
+ * Opens a web browser to the specified URL.
+ * See: https://hasinthaindrajee.medium.com/browser-sso-for-cli-applications-b0be743fa656
+ * @param url The URL to open.
+ */
+async function openBrowser(url: string): Promise<void> {
+  const os = platform();
+  let cmd = undefined;
+  switch (os) {
+    case 'openbsd':
+    case 'linux':
+      cmd = `xdg-open ${url}`;
+      break;
+    case 'darwin':
+      cmd = `open ${url}`;
+      break;
+    case 'win32':
+      cmd = `cmd /c start "" "${url}"`;
+      break;
+    default:
+      throw new Error('Unsupported platform: ' + os);
+  }
+  exec(cmd);
+}
+
+function printMe(medplum: MedplumClient): void {
+  const loginState = medplum.getActiveLogin();
+  if (loginState) {
+    console.log(`Profile: ${loginState.profile?.display} (${loginState.profile?.reference})`);
+    console.log(`Project: ${loginState.project?.display} (${loginState.project?.reference})`);
   } else {
-    console.log(`Unknown command: ${command}`);
+    console.log('Not logged in');
   }
 }
 
@@ -124,9 +240,6 @@ function readFileContents(fileName: string): string | undefined {
 
 if (require.main === module) {
   dotenv.config();
-  const medplum = new MedplumClient({ fetch, baseUrl: process.env['MEDPLUM_BASE_URL'] });
-  medplum
-    .startClientLogin(process.env['MEDPLUM_CLIENT_ID'] as string, process.env['MEDPLUM_CLIENT_SECRET'] as string)
-    .then(() => main(medplum, process.argv))
-    .catch((err) => console.error('Unhandled error:', err));
+  const medplum = new MedplumClient({ fetch, baseUrl });
+  main(medplum, process.argv).catch((err) => console.error('Unhandled error:', err));
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1845,6 +1845,7 @@ export class MedplumClient extends EventTarget {
   }
 
   /**
+   * Returns the current access token.
    * @category Authentication
    */
   getAccessToken(): string | undefined {
@@ -1852,6 +1853,7 @@ export class MedplumClient extends EventTarget {
   }
 
   /**
+   * Sets the current access token.
    * @category Authentication
    */
   setAccessToken(accessToken: string): void {
@@ -2224,14 +2226,15 @@ export class MedplumClient extends EventTarget {
    * Processes an OAuth authorization code.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
    * @param code The authorization code received by URL parameter.
+   * @param loginParams Optional login parameters.
    * @category Authentication
    */
-  processCode(code: string): Promise<ProfileResource> {
+  processCode(code: string, loginParams?: Partial<BaseLoginRequest>): Promise<ProfileResource> {
     const formBody = new URLSearchParams();
     formBody.set('grant_type', 'authorization_code');
-    formBody.set('client_id', this.#clientId as string);
     formBody.set('code', code);
-    formBody.set('redirect_uri', getWindowOrigin());
+    formBody.set('client_id', loginParams?.clientId || (this.#clientId as string));
+    formBody.set('redirect_uri', loginParams?.redirectUri || getWindowOrigin());
 
     if (typeof sessionStorage !== 'undefined') {
       const codeVerifier = sessionStorage.getItem('codeVerifier');

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -1,5 +1,5 @@
 import { badRequest, Operator } from '@medplum/core';
-import { ClientApplication, Project, ResourceType, User } from '@medplum/fhirtypes';
+import { Project, ResourceType, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -8,7 +8,7 @@ import { URL } from 'url';
 import { getConfig } from '../config';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { systemRepo } from '../fhir/repo';
-import { getUserByEmail, GoogleCredentialClaims, tryLogin } from '../oauth/utils';
+import { getClient, getUserByEmail, GoogleCredentialClaims, tryLogin } from '../oauth/utils';
 import { isExternalAuth } from './method';
 import { sendLoginResult } from './utils';
 
@@ -80,7 +80,7 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
   // For OAuth2 flow, check the clientId
   const clientId = req.body.clientId;
   if (clientId) {
-    const client = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+    const client = await getClient(clientId);
     const clientProjectId = client.meta?.project as string;
     if (projectId !== undefined && projectId !== clientProjectId) {
       sendOutcome(res, badRequest('Invalid projectId'));

--- a/packages/server/src/auth/login.ts
+++ b/packages/server/src/auth/login.ts
@@ -1,11 +1,10 @@
 import { badRequest } from '@medplum/core';
-import { ClientApplication, ResourceType } from '@medplum/fhirtypes';
+import { ResourceType } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
-import { systemRepo } from '../fhir/repo';
-import { tryLogin } from '../oauth/utils';
+import { getClient, tryLogin } from '../oauth/utils';
 import { sendLoginResult } from './utils';
 
 export const loginValidators = [
@@ -34,7 +33,7 @@ export async function loginHandler(req: Request, res: Response): Promise<void> {
   // For OAuth2 flow, check the clientId
   const clientId = req.body.clientId;
   if (clientId) {
-    const client = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+    const client = await getClient(clientId);
     const clientProjectId = client.meta?.project as string;
     if (projectId !== undefined && projectId !== clientProjectId) {
       sendOutcome(res, badRequest('Invalid projectId'));

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -7,6 +7,7 @@ import { getConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
 import { logger } from '../logger';
 import { MedplumIdTokenClaims, verifyJwt } from './keys';
+import { getClient } from './utils';
 
 /*
  * Handles the OAuth/OpenID Authorization Endpoint.
@@ -48,7 +49,7 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
   // If these are invalid, then show an error page.
   let client = undefined;
   try {
-    client = await systemRepo.readResource<ClientApplication>('ClientApplication', params.client_id as string);
+    client = await getClient(params.client_id as string);
   } catch (err) {
     res.status(400).send('Client not found');
     return false;

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -7,7 +7,7 @@ import { asyncWrap } from '../async';
 import { getConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
 import { generateSecret, MedplumRefreshTokenClaims, verifyJwt } from './keys';
-import { getAuthTokens, getClientApplicationMembership, revokeLogin, timingSafeEqualStr } from './utils';
+import { getAuthTokens, getClient, getClientApplicationMembership, revokeLogin, timingSafeEqualStr } from './utils';
 
 type ClientIdAndSecret = { error?: string; clientId?: string; clientSecret?: string };
 
@@ -166,7 +166,7 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<voi
   let client: ClientApplication | undefined;
   if (clientId) {
     try {
-      client = await systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+      client = await getClient(clientId);
     } catch (err) {
       sendTokenError(res, 'invalid_request', 'Invalid client');
       return undefined;

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -87,12 +87,30 @@ export interface GoogleCredentialClaims extends JWTPayload {
   readonly picture: string;
 }
 
+/**
+ * Returns the client application by ID.
+ * Handles special cases for "built-in" clients.
+ * @param clientId The client ID.
+ * @returns The client application.
+ */
+export async function getClient(clientId: string): Promise<ClientApplication> {
+  if (clientId === 'medplum-cli') {
+    return {
+      resourceType: 'ClientApplication',
+      id: 'medplum-cli',
+      redirectUri: 'http://localhost:9615',
+      pkceOptional: true,
+    };
+  }
+  return systemRepo.readResource<ClientApplication>('ClientApplication', clientId);
+}
+
 export async function tryLogin(request: LoginRequest): Promise<Login> {
   validateLoginRequest(request);
 
   let client: ClientApplication | undefined;
   if (request.clientId) {
-    client = await systemRepo.readResource<ClientApplication>('ClientApplication', request.clientId);
+    client = await getClient(request.clientId);
   }
 
   validatePkce(request, client);


### PR DESCRIPTION
This adds a new `login` command to the CLI.  Here's how it works.

First, you need to install `@medplum/cli`.  That can either be in your package.json, or globally using `npm i -g @medplum/cli`

Now you can run the command:

```bash
medplum login
```

That does a couple things:
1. Starts up an embedded web server listening for HTTP requests on http://localhost:9615
2. Opens a web browser to the OAuth login flow
3. When the user successfully logs in, the OAuth flow redirects to http://localhost:9615
4. When the embedded web server receives the `code`, it completes the login
5. It then writes the access token to `~/.medplum/credentials`

After that, you can run other commands as yourself:

```bash
$ medplum me
Profile: Cody Ebberson (Practitioner/608d7cd3-419f-41d8-9518-9b151106723c)
Project: Inferno (Project/f4d16028-3de1-4473-bf66-899461b658c6)
```

This will work for other commands as well (`save-bot`, `deploy-bot`, etc).