### PR TITLE
Fixes #1662 - inline errors in resource form

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeErrorString,
   notFound,
   notModified,
+  operationOutcomeToString,
   tooManyRequests,
   unauthorized,
 } from './outcomes';
@@ -75,5 +76,27 @@ describe('Outcomes', () => {
     expect(isOperationOutcome('foo')).toBe(false);
     expect(isOperationOutcome({ resourceType: 'Patient' })).toBe(false);
     expect(isOperationOutcome({ resourceType: 'OperationOutcome' })).toBe(true);
+  });
+
+  test('operationOutcomeToString', () => {
+    expect(operationOutcomeToString({ resourceType: 'OperationOutcome' })).toEqual('Unknown error');
+    expect(
+      operationOutcomeToString({ resourceType: 'OperationOutcome', issue: [{ details: { text: 'foo' } }] })
+    ).toEqual('foo');
+    expect(
+      operationOutcomeToString({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'foo' }, expression: ['bar'] }],
+      })
+    ).toEqual('foo (bar)');
+    expect(
+      operationOutcomeToString({
+        resourceType: 'OperationOutcome',
+        issue: [
+          { details: { text: 'error1' }, expression: ['expr1'] },
+          { details: { text: 'error2' }, expression: ['expr2'] },
+        ],
+      })
+    ).toEqual('error1 (expr1); error2 (expr2)');
   });
 });

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -205,7 +205,7 @@ export class OperationOutcomeError extends Error {
   readonly outcome: OperationOutcome;
 
   constructor(outcome: OperationOutcome, cause?: unknown) {
-    super(outcome?.issue?.[0].details?.text);
+    super(operationOutcomeToString(outcome));
     this.outcome = outcome;
     this.cause = cause;
   }
@@ -242,7 +242,26 @@ export function normalizeErrorString(error: unknown): string {
     return error.message;
   }
   if (isOperationOutcome(error)) {
-    return error.issue?.[0]?.details?.text ?? 'Unknown error';
+    return operationOutcomeToString(error);
   }
   return JSON.stringify(error);
+}
+
+/**
+ * Returns a string represenation of the operation outcome.
+ * @param outcome The operation outcome.
+ * @returns The string representation of the operation outcome.
+ */
+export function operationOutcomeToString(outcome: OperationOutcome): string {
+  const strs = [];
+  if (outcome.issue) {
+    for (const issue of outcome.issue) {
+      let issueStr = issue.details?.text || 'Unknown error';
+      if (issue.expression?.length) {
+        issueStr += ` (${issue.expression.join(', ')})`;
+      }
+      strs.push(issueStr);
+    }
+  }
+  return strs.length > 0 ? strs.join('; ') : 'Unknown error';
 }

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -47,6 +47,7 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
         }
 
         const [propertyValue, propertyType] = getValueAndType(typedValue, key);
+        const required = property.min !== undefined && property.min > 0;
 
         if (property.type.length === 1 && property.type[0].code === 'boolean') {
           return (
@@ -75,6 +76,7 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
             key={key}
             title={getPropertyDisplayName(key)}
             description={property.definition}
+            withAsterisk={required}
             htmlFor={key}
             outcome={props.outcome}
           >
@@ -83,7 +85,6 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
               name={key}
               defaultValue={propertyValue}
               defaultPropertyType={propertyType}
-              outcome={props.outcome}
               onChange={(newValue: any, propName?: string) => {
                 setValueWrapper(setPropertyValue(value, key, propName ?? key, entry[1], newValue));
               }}

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -5,6 +5,7 @@ export interface CheckboxFormSectionProps {
   htmlFor?: string;
   title?: string;
   description?: string;
+  withAsterisk?: boolean;
   children?: React.ReactNode;
 }
 
@@ -13,7 +14,12 @@ export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Elemen
     <Group noWrap>
       <div>{props.children}</div>
       <div>
-        <Input.Wrapper id={props.htmlFor} label={props.title} description={props.description}>
+        <Input.Wrapper
+          id={props.htmlFor}
+          label={props.title}
+          description={props.description}
+          withAsterisk={props.withAsterisk}
+        >
           {(() => null)()}
         </Input.Wrapper>
       </div>

--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -8,6 +8,7 @@ export interface DateTimeInputProps {
   name?: string;
   placeholder?: string;
   defaultValue?: string;
+  required?: boolean;
   outcome?: OperationOutcome;
   onChange?: (value: string) => void;
 }
@@ -27,6 +28,7 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
       name={props.name}
       data-testid={props.name}
       placeholder={props.placeholder}
+      required={props.required}
       type={getInputType()}
       defaultValue={convertIsoToLocal(props.defaultValue)}
       error={getErrorsForInput(props.outcome, props.name)}

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -7,6 +7,7 @@ export interface FormSectionProps {
   title?: string;
   htmlFor?: string;
   description?: string;
+  withAsterisk?: boolean;
   outcome?: OperationOutcome;
   children?: React.ReactNode;
 }
@@ -17,6 +18,7 @@ export function FormSection(props: FormSectionProps): JSX.Element {
       id={props.htmlFor}
       label={props.title}
       description={props.description}
+      withAsterisk={props.withAsterisk}
       error={getErrorsForInput(props.outcome, props.htmlFor)}
     >
       {props.children}

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -110,6 +110,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
   const propertyType = props.elementDefinitionType.code as PropertyType;
   const name = props.name;
   const value = props.defaultValue;
+  const required = property.min !== undefined && property.min > 0;
 
   switch (propertyType) {
     // 2.24.0.1 Primitive Types
@@ -127,6 +128,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
           name={name}
           data-testid={name}
           defaultValue={value}
+          required={required}
           onChange={(e) => {
             if (props.onChange) {
               props.onChange(e.currentTarget.value);
@@ -143,6 +145,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
           name={name}
           data-testid={name}
           defaultValue={value}
+          required={required}
           onChange={(e) => {
             if (props.onChange) {
               props.onChange(e.currentTarget.value);
@@ -166,6 +169,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
           name={name}
           data-testid={name}
           defaultValue={value}
+          required={required}
           onChange={(e) => {
             if (props.onChange) {
               props.onChange(e.currentTarget.valueAsNumber);
@@ -196,6 +200,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
           name={name}
           data-testid={name}
           defaultValue={value}
+          required={required}
           onChange={(e) => {
             if (props.onChange) {
               props.onChange(e.currentTarget.value);


### PR DESCRIPTION
A bunch of improvements:

1. Show asterisk for required fields
2. Fixed inline error messages on validation errors
3. Include property name in the toast alert on validation errors
4. Include all properties in toast message (not just first one)
5. Fixed React flash of content on validation errors

All around better experience:

![image](https://user-images.githubusercontent.com/749094/225744873-5356c512-a9ce-447d-964d-81538083bd6a.png)
