### PR TITLE
Fix Observation token index

### DIFF
--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -152,6 +152,10 @@ function isIndexed(searchParam: SearchParameter, resourceType: string): boolean 
     return false;
   }
 
+  if (searchParam.code?.endsWith(':identifier')) {
+    return true;
+  }
+
   const details = getSearchParameterDetails(resourceType, searchParam);
   const elementDefinition = details.elementDefinition;
   if (!elementDefinition?.type) {
@@ -321,7 +325,11 @@ function buildSimpleToken(
   system: string | undefined,
   value: string | undefined
 ): void {
-  if (system || value) {
+  // Only add the token if there is a system or a value, and if it is not already in the list.
+  if (
+    (system || value) &&
+    !result.some((token) => token.code === searchParam.code && token.system === system && token.value === value)
+  ) {
     result.push({
       code: searchParam.code as string,
       system,

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -41,6 +41,6 @@ export function deriveIdentifierSearchParameter(inputParam: SearchParameter): Se
     code: inputParam.code + ':identifier',
     base: inputParam.base,
     type: 'token',
-    expression: inputParam.expression + '.identifier',
+    expression: `(${inputParam.expression}).identifier`,
   };
 }


### PR DESCRIPTION
1. ":text" searches were frequently double indexed due to the pattern of duplicate data in `display` and `text`
2. `deriveIdentifierSearchParameter()` did not correctly handle FHIRPath expressions with ` | ` separators, which led to incorrect garbage results for compound search params such as `clinical-patient`
3. Fixing `deriveIdentifierSearchParameter()` revealed a fragile implementation of `getSearchParameterDetails()`