### PR TITLE
Optimize performance of slow token table join

### DIFF
--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -78,7 +78,11 @@ export abstract class LookupTable<T> {
       }
     }
     subQuery.whereExpr(disjunction);
-    selectQuery.join(joinName, 'id', 'resourceId', subQuery);
+    selectQuery.join(
+      subQuery,
+      joinName,
+      new Condition(new Column(resourceType, 'id'), Operator.EQUALS, new Column(joinName, 'resourceId'))
+    );
     return new Condition(new Column(joinName, columnName), Operator.NOT_EQUALS, null);
   }
 
@@ -95,7 +99,11 @@ export abstract class LookupTable<T> {
     const subQuery = new SelectQuery(tableName)
       .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
       .orderBy('resourceId');
-    selectQuery.join(joinName, 'id', 'resourceId', subQuery);
+    selectQuery.join(
+      subQuery,
+      joinName,
+      new Condition(new Column(resourceType, 'id'), Operator.EQUALS, new Column(joinName, 'resourceId'))
+    );
     selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending);
   }
 

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -60,30 +60,27 @@ export abstract class LookupTable<T> {
     const tableName = this.getTableName(resourceType);
     const joinName = selectQuery.getNextJoinAlias();
     const columnName = this.getColumnName(filter.code);
-    const subQuery = new SelectQuery(tableName)
-      .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
-      .orderBy('resourceId');
+    const joinOnExpression = new Conjunction([
+      new Condition(new Column(resourceType, 'id'), Operator.EQUALS, new Column(joinName, 'resourceId')),
+    ]);
+
     const disjunction = new Disjunction([]);
     for (const option of filter.value.split(',')) {
       if (filter.operator === FhirOperator.EXACT) {
-        disjunction.expressions.push(new Condition(new Column(tableName, columnName), Operator.EQUALS, option?.trim()));
+        disjunction.expressions.push(new Condition(new Column(joinName, columnName), Operator.EQUALS, option?.trim()));
       } else {
         const conjunction = new Conjunction([]);
         for (const chunk of option.split(/\s+/)) {
           conjunction.expressions.push(
-            new Condition(new Column(tableName, columnName), Operator.LIKE, `%${chunk.trim()}%`)
+            new Condition(new Column(joinName, columnName), Operator.LIKE, `%${chunk.trim()}%`)
           );
         }
         disjunction.expressions.push(conjunction);
       }
     }
-    subQuery.whereExpr(disjunction);
-    selectQuery.join(
-      subQuery,
-      joinName,
-      new Condition(new Column(resourceType, 'id'), Operator.EQUALS, new Column(joinName, 'resourceId'))
-    );
-    return new Condition(new Column(joinName, columnName), Operator.NOT_EQUALS, null);
+    joinOnExpression.expressions.push(disjunction);
+    selectQuery.join(tableName, joinName, joinOnExpression);
+    return new Condition(new Column(joinName, 'resourceId'), Operator.NOT_EQUALS, null);
   }
 
   /**
@@ -96,14 +93,12 @@ export abstract class LookupTable<T> {
     const tableName = this.getTableName(resourceType);
     const joinName = selectQuery.getNextJoinAlias();
     const columnName = this.getColumnName(sortRule.code);
-    const subQuery = new SelectQuery(tableName)
-      .raw(`DISTINCT ON ("${tableName}"."resourceId") *`)
-      .orderBy('resourceId');
-    selectQuery.join(
-      subQuery,
-      joinName,
-      new Condition(new Column(resourceType, 'id'), Operator.EQUALS, new Column(joinName, 'resourceId'))
+    const joinOnExpression = new Condition(
+      new Column(resourceType, 'id'),
+      Operator.EQUALS,
+      new Column(joinName, 'resourceId')
     );
+    selectQuery.join(tableName, joinName, joinOnExpression);
     selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending);
   }
 

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -55,4 +55,26 @@ describe('SqlBuilder', () => {
     new SelectQuery('MyTable').column('id').where('name', Operator.NOT_EQUALS, null).buildSql(sql);
     expect(sql.toString()).toBe('SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name" IS NOT NULL');
   });
+
+  test('Select value in subquery with type', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable')
+      .column('id')
+      .where('name', Operator.IN_SUBQUERY, new SelectQuery('MyLookup').column('values'), 'TEXT[]')
+      .buildSql(sql);
+    expect(sql.toString()).toBe(
+      'SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name"=ANY((SELECT "MyLookup"."values" FROM "MyLookup")::TEXT[])'
+    );
+  });
+
+  test('Select value in subquery without type', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable')
+      .column('id')
+      .where('name', Operator.IN_SUBQUERY, new SelectQuery('MyLookup').column('values'))
+      .buildSql(sql);
+    expect(sql.toString()).toBe(
+      'SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name"=ANY(SELECT "MyLookup"."values" FROM "MyLookup")'
+    );
+  });
 });

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -21,6 +21,7 @@ export enum Operator {
   IN = ' IN ',
   ARRAY_CONTAINS = 'ARRAY_CONTAINS',
   TSVECTOR_MATCH = '@@',
+  IN_SUBQUERY = 'IN_SUBQUERY',
 }
 
 export class Column {
@@ -55,6 +56,8 @@ export class Condition implements Expression {
   buildSql(sql: SqlBuilder): void {
     if (this.operator === Operator.ARRAY_CONTAINS) {
       this.buildArrayCondition(sql);
+    } else if (this.operator === Operator.IN_SUBQUERY) {
+      this.buildInSubqueryCondition(sql);
     } else {
       this.buildSimpleCondition(sql);
     }
@@ -70,6 +73,19 @@ export class Condition implements Expression {
     sql.append(']');
     if (this.parameterType) {
       sql.append('::' + this.parameterType);
+    }
+    sql.append(')');
+  }
+
+  protected buildInSubqueryCondition(sql: SqlBuilder): void {
+    sql.appendColumn(this.column);
+    sql.append('=ANY(');
+    if (this.parameterType) {
+      sql.append('(');
+    }
+    (this.parameter as SelectQuery).buildSql(sql);
+    if (this.parameterType) {
+      sql.append(')::' + this.parameterType);
     }
     sql.append(')');
   }
@@ -164,7 +180,11 @@ export class Disjunction extends Connective {
 }
 
 export class Join {
-  constructor(readonly joinName: string, readonly onExpression: Expression, readonly subQuery?: SelectQuery) {}
+  constructor(
+    readonly joinItem: string | SelectQuery,
+    readonly joinAlias: string | undefined,
+    readonly onExpression: Expression
+  ) {}
 }
 
 export class OrderBy {
@@ -300,17 +320,8 @@ export class SelectQuery extends BaseQuery {
     return `T${this.joins.length + 1}`;
   }
 
-  join(joinName: string, leftColumnName: string, joinColumnName: string, subQuery?: SelectQuery): this {
-    this.joinExpr(
-      joinName,
-      new Condition(new Column(this.tableName, leftColumnName), Operator.EQUALS, new Column(joinName, joinColumnName)),
-      subQuery
-    );
-    return this;
-  }
-
-  joinExpr(joinName: string, onExpression: Expression, subQuery?: SelectQuery): this {
-    this.joins.push(new Join(joinName, onExpression, subQuery));
+  join(joinItem: string | SelectQuery, joinAlias: string | undefined, onExpression: Expression): this {
+    this.joins.push(new Join(joinItem, joinAlias, onExpression));
     return this;
   }
 
@@ -397,12 +408,17 @@ export class SelectQuery extends BaseQuery {
 
     for (const join of this.joins) {
       sql.append(' LEFT JOIN ');
-      if (join.subQuery) {
+      if (typeof join.joinItem === 'string') {
+        sql.appendIdentifier(join.joinItem);
+      } else {
         sql.append(' ( ');
-        join.subQuery.buildSql(sql);
+        join.joinItem.buildSql(sql);
         sql.append(' ) ');
       }
-      sql.appendIdentifier(join.joinName);
+      if (join.joinAlias) {
+        sql.append(' AS ');
+        sql.appendIdentifier(join.joinAlias);
+      }
       sql.append(' ON ');
       join.onExpression.buildSql(sql);
     }

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -180,11 +180,7 @@ export class Disjunction extends Connective {
 }
 
 export class Join {
-  constructor(
-    readonly joinItem: string | SelectQuery,
-    readonly joinAlias: string | undefined,
-    readonly onExpression: Expression
-  ) {}
+  constructor(readonly joinItem: string | SelectQuery, readonly joinAlias: string, readonly onExpression: Expression) {}
 }
 
 export class OrderBy {
@@ -320,7 +316,7 @@ export class SelectQuery extends BaseQuery {
     return `T${this.joins.length + 1}`;
   }
 
-  join(joinItem: string | SelectQuery, joinAlias: string | undefined, onExpression: Expression): this {
+  join(joinItem: string | SelectQuery, joinAlias: string, onExpression: Expression): this {
     this.joins.push(new Join(joinItem, joinAlias, onExpression));
     return this;
   }
@@ -415,10 +411,8 @@ export class SelectQuery extends BaseQuery {
         join.joinItem.buildSql(sql);
         sql.append(' ) ');
       }
-      if (join.joinAlias) {
-        sql.append(' AS ');
-        sql.appendIdentifier(join.joinAlias);
-      }
+      sql.append(' AS ');
+      sql.appendIdentifier(join.joinAlias);
       sql.append(' ON ');
       join.onExpression.buildSql(sql);
     }


### PR DESCRIPTION
No change in behavior, just SQL optimization.

This FHIR search led to an outlier slow query:

```
Observation?category:not=https://example.com&status=final&value-quantity:missing=false
```

Before, that translated to this query:

```sql
SELECT "Observation"."id", "Observation"."content" 
FROM "Observation" 
LEFT JOIN  ( 
  SELECT DISTINCT ON ("Observation_Token"."resourceId") * 
  FROM "Observation_Token" 
  WHERE ("Observation_Token"."code"=$1 AND "Observation_Token"."system"=$2) 
  ORDER BY "Observation_Token"."resourceId" ASC ) "T1" 
ON "Observation"."id"="T1"."resourceId" 
WHERE (
  "Observation"."deleted"=$3 
  AND "Observation"."compartments" IS NOT NULL 
  AND "Observation"."compartments"&&ARRAY[$4]::UUID[]) 
  AND "T1"."resourceId" IS NULL 
  AND "Observation"."status"=$5
  AND "valueQuantity" IS NOT NULL
)
ORDER BY "Observation"."lastUpdated"
DESC LIMIT 21
```

Postgres handles the subquery fine for positive matches, but it performed very poorly for negative matches (`:not`).

When the eligible `Observation` rows are >100k and `Observation_Token` rows are >500k, this query take be 10+ seconds.

After, the SQL query is:

```sql
SELECT "Observation"."id", "Observation"."content"
FROM "Observation"
LEFT JOIN "Observation_Token" AS "T1" 
ON (
  "Observation"."id"="T1"."resourceId" 
  AND  "T1"."code"=$1 
  AND "T1"."system"=$2
)
WHERE (
  "Observation"."deleted"=$3 
  AND "Observation"."compartments" IS NOT NULL
  AND "Observation"."compartments"&&ARRAY[$4]::UUID[]) 
  AND "T1"."resourceId" IS NULL 
  AND "Observation"."status"=$5
  AND "valueQuantity" IS NOT NULL
)
ORDER BY "Observation"."lastUpdated"
DESC LIMIT 21
```

And now the query is under 10 _milliseconds_.  This is still a somewhat expensive query, and has more room for improvement, but it is dramatically better than before.