### PR TITLE
Added restful commands to medplum cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,13 +4,161 @@ The Medplum CLI (Command Line Interface) is a set of command line tools to quick
 
 ## Installation
 
-Add as a dependency:
+Add globally:
+
+```bash
+npm install --global @medplum/cli
+```
+
+Or add as a package dependency:
 
 ```bash
 npm install @medplum/cli
 ```
 
-## Config file
+## Authentication
+
+Use one of these authentication options:
+
+1. Stored credentials in `~/.medplum/credentials`. You can use the `medplum login` command (see below) to automatically create this file.
+2. Client credentials in environment variables `MEDPLUM_CLIENT_ID` and `MEDPLUM_CLIENT_SECRET`. `dotenv` is enabled, so you can store them in a `.env` file.
+
+## Usage
+
+If installed globally, you can use the `medplum` command directly:
+
+```bash
+medplum <command> <args>
+```
+
+If installed as a package dependency, you can use the `medplum` command via `npx`:
+
+```bash
+npx medplum <command> <args>
+```
+
+By default, the `medplum` command uses the Medplum hosted API at "https://api.medplum.com". If you want to use the `medplum` command against your own self-hosted server, you can use the `MEDPLUM_BASE_URL` environment variable. `dotenv` is enabled, so you can store this value in a `.env` file.
+
+### Auth
+
+#### `login`
+
+The `login` command opens a web browser to a Medplum authentication page.
+
+On successful login, the command writes credentials to disk at `~/.medplum/credentials`.
+
+The `medplum` command will then load those credentials on all future runs.
+
+Example:
+
+```bash
+medplum login
+```
+
+#### `whoami`
+
+The `whoami` command displays whether the client is authenticated, and, if so, the name of the current user and current Medplum project.
+
+```bash
+medplum whoami
+```
+
+### RESTful Operations
+
+The `medplum` command can be used as a convenient tool for basic Medplum CRUD and RESTful operations.
+
+While all API endpoints are available to any command line HTTP client such as `curl` or `wget`, there are a few advantages to using the `medplum` command:
+
+1. Authentication and credentials - login once using the `login` command, and the `Authorization` header will be set automatically.
+2. URL prefixes - adds the base URL (i.e., "https://api.medplum.com") and FHIR path prefix (i.e., "fhir/R4/").
+3. Pretty print - formats the JSON with spaces and newlines.
+4. Medplum extended mode - adds the `X-Medplum` HTTP header for private Medplum fields.
+
+#### `get`
+
+Makes an HTTP `GET` request.
+
+```bash
+medplum get <url>
+```
+
+Example: Search for patients:
+
+```bash
+medplum get 'Patient?name=homer'
+```
+
+Example: Read patient by ID:
+
+```bash
+medplum get Patient/$id
+```
+
+#### `post`
+
+Makes an HTTP `POST` request.
+
+```bash
+medplum post <url> <body>
+```
+
+Example: Create a patient:
+
+```bash
+medplum post Patient '{"resourceType":"Patient","name":[{"family":"Simpson"}]}'
+```
+
+Example: Invoke a FHIR operation:
+
+```bash
+medplum post 'Patient/$validate' '{"resourceType":"Patient","name":[{"family":"Simpson"}]}'
+```
+
+#### `put`
+
+Makes an HTTP `PUT` request.
+
+```bash
+medplum put <url> <body>
+```
+
+Example: Update a patient:
+
+```bash
+medplum put Patient/$id '{"resourceType":"Patient","name":[{"family":"Simpson"}]}'
+```
+
+#### `patch`
+
+Makes an HTTP `PATCH` request.
+
+```bash
+medplum patch <url> <body>
+```
+
+Example: Update a patient with [JSONPatch](https://jsonpatch.com/):
+
+```bash
+medplum patch Patient/$id '[{"op":"add","path":"/active","value":[true]}]'
+```
+
+#### `delete`
+
+Makes an HTTP `DELETE` request.
+
+```bash
+medplum delete <url>
+```
+
+Example: Delete patient by ID:
+
+```bash
+medplum delete Patient/$id
+```
+
+### Bots
+
+#### Bots Config file
 
 Create a Medplum config file called `medplum.config.json`:
 
@@ -35,15 +183,7 @@ The `source` property is the file path to the original source. When you "save" t
 
 The `dist` property is the optional file path to the compiled source. If omitted, the command falls back to using the `source` property. When you "deploy" the Bot, the contents of this file will be deployed to the Bot runtime. This file must be JavaScript.
 
-## Usage
-
-Syntax:
-
-```bash
-npx medplum <command> <args>
-```
-
-### save-bot
+#### save-bot
 
 Updates the `code` value on a `Bot` resource
 
@@ -59,7 +199,7 @@ Example:
 npx medplum save-bot hello-world
 ```
 
-### deploy-bot
+#### deploy-bot
 
 Deploys the Bot code
 
@@ -75,11 +215,7 @@ Example:
 npx medplum-deploy-bot <bot name>
 ```
 
-## Authentication
-
-Authentication requires client credentials in environment variables `MEDPLUM_CLIENT_ID` and `MEDPLUM_CLIENT_SECRET`. This supports most use cases, including secrets from CI/CD. `dotenv` is enabled, so you can store them in a `.env` file.
-
-## Example
+## Bots Example
 
 Create a Medplum config file `medplum.config.json`:
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -131,6 +131,11 @@ describe('CLI', () => {
     expect(console.error).toBeCalledWith(expect.stringMatching('Not found'));
   });
 
+  test('Get admin urls', async () => {
+    await main(medplum, ['node', 'index.js', 'get', 'admin/projects/123']);
+    expect(console.log).toBeCalledWith(expect.stringMatching('Project 123'));
+  });
+
   test('Post command', async () => {
     await main(medplum, ['node', 'index.js', 'post', 'Patient', '{ "resourceType": "Patient" }']);
     expect(console.log).toBeCalledWith(expect.stringMatching('Patient'));

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,11 +1,12 @@
-import { MedplumClient } from '@medplum/core';
-import { Bot } from '@medplum/fhirtypes';
+import { createReference, MedplumClient } from '@medplum/core';
+import { Bot, Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import cp from 'child_process';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import http from 'http';
 import { main } from '.';
+import { FileSystemStorage } from './storage';
 
 jest.mock('child_process');
 jest.mock('fs');
@@ -20,6 +21,8 @@ describe('CLI', () => {
     jest.resetModules();
     process.env = { ...env };
     medplum = new MockClient();
+    console.log = jest.fn();
+    console.error = jest.fn();
   });
 
   afterEach(() => {
@@ -27,13 +30,11 @@ describe('CLI', () => {
   });
 
   test('Missing command', async () => {
-    console.log = jest.fn();
     await main(medplum, ['node', 'index.js']);
     expect(console.log).toBeCalledWith('Usage: medplum <command>');
   });
 
   test('Unknown command', async () => {
-    console.log = jest.fn();
     await main(medplum, ['node', 'index.js', 'xyz']);
     expect(console.log).toBeCalledWith('Unknown command: xyz');
   });
@@ -59,35 +60,43 @@ describe('CLI', () => {
     // Start the login
     await main(medplum, ['node', 'index.js', 'login']);
 
-    // Simulate the redirect
+    // Get the handler
     const handler = (http.createServer as unknown as jest.Mock).mock.calls[0][0];
-    const req = { url: '/?code=123' };
-    const res = {
-      writeHead: jest.fn(),
-      end: jest.fn(),
-    };
-    await handler(req, res);
-    expect(res.writeHead).toBeCalledWith(200, { 'Content-Type': 'text/plain' });
-    expect(res.end).toBeCalledWith('Signed in as Alice Smith. You may close this window.');
+
+    // Simulate a favicon.ico request, don't crash
+    const req1 = { url: '/favicon.ico' };
+    const res1 = { writeHead: jest.fn(), end: jest.fn() };
+    await handler(req1, res1);
+    expect(res1.writeHead).toBeCalledWith(404, { 'Content-Type': 'text/plain' });
+    expect(res1.end).toBeCalledWith('Not found');
+
+    // Simulate the redirect
+    const req2 = { url: '/?code=123' };
+    const res2 = { writeHead: jest.fn(), end: jest.fn() };
+    await handler(req2, res2);
+    expect(res2.writeHead).toBeCalledWith(200, { 'Content-Type': 'text/plain' });
+    expect(res2.end).toBeCalledWith('Signed in as Alice Smith. You may close this window.');
     expect(medplum.getActiveLogin()).toBeDefined();
   });
 
   test('Load credentials from disk', async () => {
-    console.log = jest.fn();
+    medplum = new MockClient({ storage: new FileSystemStorage() });
 
     (fs.existsSync as unknown as jest.Mock).mockReturnValue(true);
     (fs.readFileSync as unknown as jest.Mock).mockReturnValue(
       JSON.stringify({
-        accessToken: 'abc',
-        refreshToken: 'xyz',
-        profile: {
-          reference: 'Practitioner/123',
-          display: 'Alice Smith',
-        },
-        project: {
-          reference: 'Project/456',
-          display: 'My Project',
-        },
+        activeLogin: JSON.stringify({
+          accessToken: 'abc',
+          refreshToken: 'xyz',
+          profile: {
+            reference: 'Practitioner/123',
+            display: 'Alice Smith',
+          },
+          project: {
+            reference: 'Project/456',
+            display: 'My Project',
+          },
+        }),
       })
     );
 
@@ -99,14 +108,64 @@ describe('CLI', () => {
     ]);
   });
 
+  test('Delete command', async () => {
+    const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
+    await main(medplum, ['node', 'index.js', 'delete', `Patient/${patient.id}`]);
+    expect(console.log).toBeCalledWith(expect.stringMatching('OK'));
+    try {
+      await medplum.readReference(createReference(patient));
+      throw new Error('Expected error');
+    } catch (err) {
+      expect((err as Error).message).toBe('Not found');
+    }
+  });
+
+  test('Get command', async () => {
+    const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
+    await main(medplum, ['node', 'index.js', 'get', `Patient/${patient.id}`]);
+    expect(console.log).toBeCalledWith(expect.stringMatching(patient.id as string));
+  });
+
+  test('Get not found', async () => {
+    await main(medplum, ['node', 'index.js', 'get', `Patient/${randomUUID()}`]);
+    expect(console.error).toBeCalledWith(expect.stringMatching('Not found'));
+  });
+
+  test('Post command', async () => {
+    await main(medplum, ['node', 'index.js', 'post', 'Patient', '{ "resourceType": "Patient" }']);
+    expect(console.log).toBeCalledWith(expect.stringMatching('Patient'));
+  });
+
+  test('Put command', async () => {
+    const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
+    await main(medplum, [
+      'node',
+      'index.js',
+      'put',
+      `Patient/${patient.id}`,
+      JSON.stringify({ ...patient, gender: 'male' }),
+    ]);
+    expect(console.log).toBeCalledWith(expect.stringMatching('male'));
+  });
+
+  test('Patch command', async () => {
+    const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
+    await main(medplum, [
+      'node',
+      'index.js',
+      'patch',
+      `Patient/${patient.id}`,
+      '[{"op":"add","path":"/active","value":[true]}]',
+    ]);
+    expect(console.log).toBeCalledWith(expect.stringMatching('active'));
+  });
+
   test('Deploy bot missing name', async () => {
-    console.log = jest.fn();
     await main(medplum, ['node', 'index.js', 'deploy-bot']);
     expect(console.log).toBeCalledWith('Usage: medplum deploy-bot <bot-name>');
   });
 
   test('Deploy bot config not found', async () => {
-    console.log = jest.fn();
     const id = randomUUID();
 
     // Setup bot config
@@ -129,7 +188,6 @@ describe('CLI', () => {
   });
 
   test('Deploy bot not found', async () => {
-    console.log = jest.fn();
     const id = randomUUID();
 
     // Setup bot config
@@ -152,8 +210,6 @@ describe('CLI', () => {
   });
 
   test('Save bot success', async () => {
-    console.log = jest.fn();
-
     // Create the bot
     const bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
     expect(bot.code).toBeUndefined();
@@ -181,8 +237,6 @@ describe('CLI', () => {
   });
 
   test('Deploy bot success', async () => {
-    console.log = jest.fn();
-
     // Create the bot
     const bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
     expect(bot.code).toBeUndefined();

--- a/packages/cli/src/storage.test.ts
+++ b/packages/cli/src/storage.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync } from 'fs';
+import os from 'os';
+import { sep } from 'path';
+import { FileSystemStorage } from './storage';
+
+jest.mock('os');
+
+const testHomeDir = mkdtempSync(__dirname + sep + 'storage-');
+
+// unlinkSync
+// existsSync
+// readFileSync
+// writeFileSync
+
+describe('FileSystemStorage', () => {
+  // beforeEach(() => {
+  //   jest.resetModules();
+  //   (os.homedir as unknown as jest.Mock).mockReturnValue(true);
+  // });
+
+  beforeAll(async () => {
+    // const config = await loadTestConfig();
+    // await initApp(app, config);
+    // accessToken = await initTestAuth();
+    (os.homedir as unknown as jest.Mock).mockReturnValue(testHomeDir);
+  });
+
+  afterAll(async () => {
+    // await shutdownApp();
+    rmSync(testHomeDir, { recursive: true, force: true });
+  });
+
+  test('Read and write', async () => {
+    const storage = new FileSystemStorage();
+
+    expect(storage.getString('foo')).toBeUndefined();
+
+    storage.setString('foo', 'bar');
+
+    expect(storage.getString('foo')).toEqual('bar');
+
+    storage.setString('foo', 'baz');
+
+    expect(storage.getString('foo')).toEqual('baz');
+
+    storage.setString('foo', undefined);
+
+    expect(storage.getString('foo')).toBeUndefined();
+
+    storage.clear();
+
+    expect(storage.getString('foo')).toBeUndefined();
+  });
+});

--- a/packages/cli/src/storage.test.ts
+++ b/packages/cli/src/storage.test.ts
@@ -7,26 +7,12 @@ jest.mock('os');
 
 const testHomeDir = mkdtempSync(__dirname + sep + 'storage-');
 
-// unlinkSync
-// existsSync
-// readFileSync
-// writeFileSync
-
 describe('FileSystemStorage', () => {
-  // beforeEach(() => {
-  //   jest.resetModules();
-  //   (os.homedir as unknown as jest.Mock).mockReturnValue(true);
-  // });
-
   beforeAll(async () => {
-    // const config = await loadTestConfig();
-    // await initApp(app, config);
-    // accessToken = await initTestAuth();
     (os.homedir as unknown as jest.Mock).mockReturnValue(testHomeDir);
   });
 
   afterAll(async () => {
-    // await shutdownApp();
     rmSync(testHomeDir, { recursive: true, force: true });
   });
 

--- a/packages/cli/src/storage.ts
+++ b/packages/cli/src/storage.ts
@@ -1,0 +1,57 @@
+import { ClientStorage } from '@medplum/core';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { resolve } from 'path';
+
+export class FileSystemStorage extends ClientStorage {
+  readonly #dirName: string;
+  readonly #fileName: string;
+
+  constructor() {
+    super();
+    this.#dirName = resolve(homedir(), '.medplum');
+    this.#fileName = resolve(this.#dirName, 'credentials');
+  }
+
+  clear(): void {
+    this.#writeFile({});
+  }
+
+  getString(key: string): string | undefined {
+    const data = this.#readFile();
+    return data ? (data[key] as string) : undefined;
+  }
+
+  setString(key: string, value: string | undefined): void {
+    const data = this.#readFile() || {};
+    if (value) {
+      data[key] = value;
+    } else {
+      delete data[key];
+    }
+    this.#writeFile(data);
+  }
+
+  // getObject<T>(key: string): T | undefined {
+  //   const str = this.getString(key);
+  //   return str ? (JSON.parse(str) as T) : undefined;
+  // }
+
+  // setObject<T>(key: string, value: T): void {
+  //   this.setString(key, value ? JSON.stringify(value) : undefined);
+  // }
+
+  #readFile(): Record<string, string> | undefined {
+    if (existsSync(this.#fileName)) {
+      return JSON.parse(readFileSync(this.#fileName, 'utf8'));
+    }
+    return undefined;
+  }
+
+  #writeFile(data: Record<string, string>): void {
+    if (!existsSync(this.#dirName)) {
+      mkdirSync(this.#dirName);
+    }
+    writeFileSync(this.#fileName, JSON.stringify(data, null, 2), 'utf8');
+  }
+}

--- a/packages/cli/src/storage.ts
+++ b/packages/cli/src/storage.ts
@@ -18,8 +18,7 @@ export class FileSystemStorage extends ClientStorage {
   }
 
   getString(key: string): string | undefined {
-    const data = this.#readFile();
-    return data ? (data[key] as string) : undefined;
+    return this.#readFile()?.[key];
   }
 
   setString(key: string, value: string | undefined): void {

--- a/packages/cli/src/storage.ts
+++ b/packages/cli/src/storage.ts
@@ -32,15 +32,6 @@ export class FileSystemStorage extends ClientStorage {
     this.#writeFile(data);
   }
 
-  // getObject<T>(key: string): T | undefined {
-  //   const str = this.getString(key);
-  //   return str ? (JSON.parse(str) as T) : undefined;
-  // }
-
-  // setObject<T>(key: string, value: T): void {
-  //   this.setString(key, value ? JSON.stringify(value) : undefined);
-  // }
-
   #readFile(): Record<string, string> | undefined {
     if (existsSync(this.#fileName)) {
       return JSON.parse(readFileSync(this.#fileName, 'utf8'));

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -137,6 +137,13 @@ export interface MedplumClientOptions {
   fetch?: FetchLike;
 
   /**
+   * Storage implementation.
+   *
+   * Default is window.localStorage (if available), or an in-memory storage implementation.
+   */
+  storage?: ClientStorage;
+
+  /**
    * Create PDF implementation.
    *
    * Default is none, and PDF generation is disabled.
@@ -473,8 +480,8 @@ export class MedplumClient extends EventTarget {
     }
 
     this.#fetch = options?.fetch || getDefaultFetch();
+    this.#storage = options?.storage || new ClientStorage();
     this.#createPdf = options?.createPdf;
-    this.#storage = new ClientStorage();
     this.#requestCache = new LRUCache(options?.resourceCacheSize ?? DEFAULT_RESOURCE_CACHE_SIZE);
     this.#cacheTime = options?.cacheTime ?? DEFAULT_CACHE_TIME;
     this.#baseUrl = ensureTrailingSlash(options?.baseUrl) || DEFAULT_BASE_URL;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,5 +13,6 @@ export * from './schema';
 export * from './search/details';
 export * from './search/match';
 export * from './search/search';
+export * from './storage';
 export * from './types';
 export * from './utils';

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -82,6 +82,7 @@ export class MockClient extends MedplumClient {
     super({
       baseUrl: clientOptions?.baseUrl || 'https://example.com/',
       clientId: clientOptions?.clientId,
+      storage: clientOptions?.storage,
       createPdf: (
         docDefinition: TDocumentDefinitions,
         tableLayouts?: { [name: string]: CustomTableLayout },


### PR DESCRIPTION
See the updated readme for more details: https://github.com/medplum/medplum/blob/2038e46682bd6e9f3b37cca5272005fd7c629e8b/packages/cli/README.md

The primary catalyst for this is a customer feature request for project management capabilities via command line.

Technically, the entire Medplum API is available via HTTP API, so everything is possible via `curl`. But that's not the most customer friendly stance.

In particular, the user has to juggle auth tokens, HTTP headers, and long URL paths.

This PR is pre-work for some additional future convenience methods.  But this PR by itself includes some handy convenience utilities.

You can use the new `medplum` command to perform basic REST operations directly from the command line:

Example: Search for patients:

```bash
medplum get 'Patient?name=homer'
```

Example: Read patient by ID:

```bash
medplum get Patient/$id
```

Example: Create a patient:

```bash
medplum post Patient '{"resourceType":"Patient","name":[{"family":"Simpson"}]}'
```

Example: Invoke a FHIR operation:

```bash
medplum post 'Patient/$validate' '{"resourceType":"Patient","name":[{"family":"Simpson"}]}'
```

Example: Update a patient:

```bash
medplum put Patient/$id '{"resourceType":"Patient","name":[{"family":"Simpson"}]}'
```

Example: Update a patient with [JSONPatch](https://jsonpatch.com/):

```bash
medplum patch Patient/$id '[{"op":"add","path":"/active","value":[true]}]'
```

Example: Delete patient by ID:

```bash
medplum delete Patient/$id
```