### PR TITLE
Hide Navbar when clicking on the NavbarLinkProps

### DIFF
--- a/packages/app/src/AppNavbar.tsx
+++ b/packages/app/src/AppNavbar.tsx
@@ -133,7 +133,7 @@ function NavbarLink(props: NavbarLinkProps): JSX.Element {
   const isActive = location.pathname === toUrl.pathname && matchesParams(searchParams, toUrl);
 
   return (
-    <Link to={props.to} className={cx(classes.link, { [classes.linkActive]: isActive })}>
+    <Link onClick={props.onClick} className={cx(classes.link, { [classes.linkActive]: isActive })}>
       {props.children}
     </Link>
   );

--- a/packages/app/src/AppNavbar.tsx
+++ b/packages/app/src/AppNavbar.tsx
@@ -121,7 +121,7 @@ export function AppNavbar({ closeNavbar }: AppNavbarProps): JSX.Element {
 
 interface NavbarLinkProps {
   to: string;
-  onClick: (e: React.SyntheticEvent, to: string) => void;
+  onClick: React.MouseEventHandler;
   children: React.ReactNode;
 }
 
@@ -133,7 +133,7 @@ function NavbarLink(props: NavbarLinkProps): JSX.Element {
   const isActive = location.pathname === toUrl.pathname && matchesParams(searchParams, toUrl);
 
   return (
-    <Link onClick={props.onClick} className={cx(classes.link, { [classes.linkActive]: isActive })}>
+    <Link onClick={props.onClick} to={props.to} className={cx(classes.link, { [classes.linkActive]: isActive })}>
       {props.children}
     </Link>
   );


### PR DESCRIPTION
Passed onClick as a prop to Link component

Needed to change type for props to React.MouseEventHandler due to error of 
```
src/AppNavbar.tsx(136,6): error TS2741: Property 'to' is missing in type '{ children: ReactNode; onClick: MouseEventHandler<Element>; className: string; }' but required in type 'LinkProps'.
```

Ran ./scripts/build.sh for testing 

https://user-images.githubusercontent.com/6913745/226490896-6c15dd94-9691-4c1c-b61f-2022e7685749.mov



