### PR TITLE
Fixes #1684 - duplicate matches in lookup table match

### DIFF
--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -340,6 +340,7 @@ export class SelectQuery extends BaseQuery {
     this.#buildSelect(sql);
     this.#buildFrom(sql);
     this.buildConditions(sql);
+    this.#buildGroupBy(sql);
     this.#buildOrderBy(sql);
 
     if (this.limit_ > 0) {
@@ -418,12 +419,27 @@ export class SelectQuery extends BaseQuery {
     }
   }
 
+  #buildGroupBy(sql: SqlBuilder): void {
+    if (this.joins.length > 0) {
+      sql.append(' GROUP BY ');
+      sql.appendIdentifier(this.tableName);
+      sql.append('.');
+      sql.appendIdentifier('id');
+    }
+  }
+
   #buildOrderBy(sql: SqlBuilder): void {
     let first = true;
 
     for (const orderBy of this.orderBys) {
       sql.append(first ? ' ORDER BY ' : ', ');
+      if (orderBy.column.tableName && orderBy.column.tableName !== this.tableName) {
+        sql.append('MIN(');
+      }
       sql.appendColumn(orderBy.column);
+      if (orderBy.column.tableName && orderBy.column.tableName !== this.tableName) {
+        sql.append(')');
+      }
       sql.append(orderBy.descending ? ' DESC' : ' ASC');
       first = false;
     }


### PR DESCRIPTION
Added `GROUP BY "ServiceRequest"."id"` to queries with joins.

Original query:

```sql
SELECT "ServiceRequest"."id", "ServiceRequest"."content" 
FROM "ServiceRequest" 
LEFT JOIN "ServiceRequest_Token" AS "T1" 
ON ("ServiceRequest"."id"="T1"."resourceId" AND "T1"."code"=$1 AND "T1"."value"=$2) 
WHERE ("ServiceRequest"."deleted"=$3 AND "T1"."resourceId" IS NOT NULL) 
LIMIT 21
```

Working query:

```sql
SELECT "ServiceRequest"."id", "ServiceRequest"."content" 
FROM "ServiceRequest"
LEFT JOIN "ServiceRequest_Token" AS "T1"
ON ("ServiceRequest"."id"="T1"."resourceId" AND "T1"."code"=$1 AND "T1"."value"=$2)
WHERE ("ServiceRequest"."deleted"=$3 AND "T1"."resourceId" IS NOT NULL) 
GROUP BY "ServiceRequest"."id" 
LIMIT 21
```
