### PR TITLE
Gracefully handle SES failure

### DIFF
--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -68,16 +68,16 @@ export function InvitePage(): JSX.Element {
           </Group>
         </Stack>
       )}
-      {outcome != null && (
+      {outcome && (
         <div data-testid="success">
           <p>User created, email couldn't be sent</p>
-          <p>{outcome.issue?.[0].details?.text}</p>
+          <p>Could not send email. Make sure you have AWS SES set up.</p>
           <p>
             Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
           </p>
         </div>
       )}
-      {success && outcome === undefined && (
+      {success && !outcome && (
         <div data-testid="success">
           <p>User created</p>
           {emailSent && <p>Email sent</p>}

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -77,7 +77,7 @@ export function InvitePage(): JSX.Element {
           </p>
         </div>
       )}
-      {success && outcome == null && (
+      {success && outcome === undefined && (
         <div data-testid="success">
           <p>User created</p>
           {emailSent && <p>Email sent</p>}

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -27,13 +27,14 @@ export function InvitePage(): JSX.Element {
         };
         medplum
           .post('admin/projects/' + projectId + '/invite', body)
+          .then((message) => (message.error ? setOutcome(normalizeOperationOutcome(message.error)) : null))
           .then(() => medplum.get(`admin/projects/${projectId}`, { cache: 'reload' }))
           .then(() => setEmailSent(body.sendEmail))
           .then(() => setSuccess(true))
           .catch((err) => setOutcome(normalizeOperationOutcome(err)));
       }}
     >
-      {!success && (
+      {!success && outcome == null && (
         <Stack>
           <Title>Invite new member</Title>
           <NativeSelect
@@ -67,7 +68,16 @@ export function InvitePage(): JSX.Element {
           </Group>
         </Stack>
       )}
-      {success && (
+      {outcome != null && (
+        <div data-testid="success">
+          <p>User created, email couldn't be sent</p>
+          <p>{outcome.issue?.[0].details?.text}</p>
+          <p>
+            Click <MedplumLink to="/admin/project">here</MedplumLink> to return to the project admin page.
+          </p>
+        </div>
+      )}
+      {success && outcome == null && (
         <div data-testid="success">
           <p>User created</p>
           {emailSent && <p>Email sent</p>}

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -323,4 +323,36 @@ describe('Admin Invite', () => {
     expect(res8.status).toBe(200);
     expect(res8.body.profile.reference).toContain('Patient/');
   });
+
+  test('Email sending error due to SES not being set up', async () => {
+    // AWS is mocked to not be set up
+    SESv2Client.mockImplementation(() => {
+      throw new Error('error');
+    });
+
+    // First, Alice creates a project
+    const aliceRegistration = await registerNew({
+      firstName: 'Alice',
+      lastName: 'Smith',
+      projectName: 'Alice Project',
+      email: `alice${randomUUID()}@example.com`,
+      password: 'password!@#',
+    });
+    const bobEmail = `bob${randomUUID()}@example.com`;
+
+    // Alice invites Bob. Under normal circumstances the email would be sent
+    const res2 = await request(app)
+      .post('/admin/projects/' + aliceRegistration.project.id + '/invite')
+      .set('Authorization', 'Bearer ' + aliceRegistration.accessToken)
+      .send({
+        resourceType: 'Practitioner',
+        firstName: 'Bob',
+        lastName: 'Jones',
+        email: bobEmail,
+      });
+    expect(res2.status).toBe(200);
+    expect(SESv2Client).toHaveBeenCalledTimes(1);
+    expect(res2.body.error).toBe('Could not send email. Make sure you have AWS SES set up.');
+    expect(SendEmailCommand).not.toHaveBeenCalled();
+  });
 });

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -352,7 +352,9 @@ describe('Admin Invite', () => {
       });
     expect(res2.status).toBe(200);
     expect(SESv2Client).toHaveBeenCalledTimes(1);
-    expect(res2.body.error).toBe('Could not send email. Make sure you have AWS SES set up.');
+    expect(res2.body.error.outcome.issue?.[0].details.text).toBe(
+      'Could not send email. Make sure you have AWS SES set up.'
+    );
     expect(SendEmailCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -1,4 +1,4 @@
-import { createReference, Operator, ProfileResource } from '@medplum/core';
+import { badRequest, createReference, OperationOutcomeError, Operator, ProfileResource } from '@medplum/core';
 import {
   AccessPolicy,
   Practitioner,
@@ -48,8 +48,8 @@ export async function inviteHandler(req: Request, res: Response): Promise<void> 
     });
     res.status(200).json(membership);
   } catch (err: any) {
-    logger.info(err.message);
-    res.status(200).json({ error: err.message });
+    logger.info(err);
+    res.status(200).json({ error: err });
   }
 }
 
@@ -102,7 +102,7 @@ export async function inviteUser(
     try {
       await sendInviteEmail(request, user, existingUser, passwordResetUrl);
     } catch (err) {
-      throw new Error('Could not send email. Make sure you have AWS SES set up.');
+      throw new OperationOutcomeError(badRequest('Could not send email. Make sure you have AWS SES set up.'), err);
     }
   }
 

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -47,7 +47,7 @@ export async function inviteHandler(req: Request, res: Response): Promise<void> 
       project: res.locals.project,
     });
     res.status(200).json(membership);
-  } catch (err) {
+  } catch (err: any) {
     logger.info(err.message);
     res.status(200).json({ error: err.message });
   }


### PR DESCRIPTION
Added catch statements in the inviteUser to send an error message. The status will still be 200 to avoid the retry of a server error, and the user will still show that they were invited. 

Wrote a test that mocks the SES client to not be set to see the error message being displayed.

<img width="880" alt="Screen Shot 2023-03-22 at 2 53 13 PM" src="https://user-images.githubusercontent.com/6913745/227067797-633ad256-3861-43f7-90d2-ede44911d67b.png">



https://user-images.githubusercontent.com/6913745/227068961-2a3d1ab9-fc3c-437c-a4fd-e855f325bc83.mov

```
jest --runInBand src/admin/invite.test.ts

 PASS  src/admin/invite.test.ts
  Admin Invite
    ✓ New user to project (499 ms)
    ✓ Existing user to project (503 ms)
    ✓ Existing practitioner to project (351 ms)
    ✓ Access denied (438 ms)
    ✓ Input validation (242 ms)
    ✓ Do not send email (378 ms)
    ✓ Invite by externalId (345 ms)
    ✓ Invite as client (362 ms)
    ✓ Email sending error due to SES not being set up (339 ms)

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        4.742 s
Ran all test suites matching /src\/admin\/invite.test.ts/i.
```

