### PR TITLE
Make reCAPTCHA optional for new user registration

### DIFF
--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -24,14 +24,21 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
   const [outcome, setOutcome] = useState<OperationOutcome>();
   const issues = getIssuesForExpression(outcome, undefined);
 
-  useEffect(() => initRecaptcha(recaptchaSiteKey), [recaptchaSiteKey]);
+  useEffect(() => {
+    if (recaptchaSiteKey) {
+      initRecaptcha(recaptchaSiteKey);
+    }
+  }, [recaptchaSiteKey]);
 
   return (
     <Form
       style={{ maxWidth: 400 }}
       onSubmit={async (formData: Record<string, string>) => {
         try {
-          const recaptchaToken = await getRecaptcha(recaptchaSiteKey);
+          let recaptchaToken = '';
+          if (recaptchaSiteKey) {
+            recaptchaToken = await getRecaptcha(recaptchaSiteKey);
+          }
           props.handleAuthResponse(
             await medplum.startNewUser({
               projectId: props.projectId,

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -6,9 +6,12 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import * as Recaptcha from '../utils/recaptcha';
 import { RegisterForm, RegisterFormProps } from './RegisterForm';
 
 const recaptchaSiteKey = 'abc';
+const mockrecaptcha = Recaptcha as jest.Mocked<typeof Recaptcha>
+const getRecaptchaSpy = jest.spyOn(mockrecaptcha, 'getRecaptcha');
 
 function mockFetch(url: string, options: any): Promise<any> {
   let status = 404;
@@ -154,9 +157,12 @@ describe('RegisterForm', () => {
     });
   });
 
+  afterEach(() => {    
+    jest.clearAllMocks();
+  });
+
   test('Register new project success', async () => {
     const onSuccess = jest.fn();
-
     await setup({
       type: 'project',
       recaptchaSiteKey,
@@ -200,7 +206,59 @@ describe('RegisterForm', () => {
     });
 
     await waitFor(() => expect(medplum.getProfile()).toBeDefined());
+    expect(getRecaptchaSpy).toHaveBeenCalled();
 
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  test('Register new project success with empty recaptchaSiteKey', async () => {
+    const onSuccess = jest.fn();
+
+    await setup({
+      type: 'project',
+      recaptchaSiteKey: '',
+      onSuccess,
+    });
+
+    expect(screen.getByText('My Register Form')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('First Name', { exact: false }), { target: { value: 'First' } });
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Last Name', { exact: false }), { target: { value: 'Last' } });
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Email', { exact: false }), {
+        target: { value: 'new-user@example.com' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Password', { exact: false }), {
+        target: { value: 'new-password' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create account'));
+    });
+
+    await waitFor(() => screen.getByLabelText('Project Name', { exact: false }));
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Project Name', { exact: false }), { target: { value: 'My Project' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Create project' }));
+    });
+
+    await waitFor(() => expect(medplum.getProfile()).toBeDefined());
+
+    expect(getRecaptchaSpy).not.toBeCalled();
     expect(onSuccess).toHaveBeenCalled();
   });
 

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -10,7 +10,7 @@ import * as Recaptcha from '../utils/recaptcha';
 import { RegisterForm, RegisterFormProps } from './RegisterForm';
 
 const recaptchaSiteKey = 'abc';
-const mockrecaptcha = Recaptcha as jest.Mocked<typeof Recaptcha>
+const mockrecaptcha = Recaptcha as jest.Mocked<typeof Recaptcha>;
 const getRecaptchaSpy = jest.spyOn(mockrecaptcha, 'getRecaptcha');
 
 function mockFetch(url: string, options: any): Promise<any> {
@@ -157,7 +157,7 @@ describe('RegisterForm', () => {
     });
   });
 
-  afterEach(() => {    
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -6,7 +6,7 @@ import { pwnedPassword } from 'hibp';
 import fetch from 'node-fetch';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
-import { loadTestConfig } from '../config';
+import { getConfig, loadTestConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
 import { setupPwnedPasswordMock, setupRecaptchaMock } from '../test.setup';
 import { registerNew } from './register';
@@ -17,9 +17,11 @@ jest.mock('node-fetch');
 const app = express();
 
 describe('New user', () => {
+  let prevRecaptchaSecretKey: string | undefined;
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
+    prevRecaptchaSecretKey = getConfig().recaptchaSecretKey;
   });
 
   afterAll(async () => {
@@ -31,6 +33,7 @@ describe('New user', () => {
     (pwnedPassword as unknown as jest.Mock).mockClear();
     setupPwnedPasswordMock(pwnedPassword as unknown as jest.Mock, 0);
     setupRecaptchaMock(fetch as unknown as jest.Mock, true);
+    getConfig().recaptchaSecretKey = prevRecaptchaSecretKey;
   });
 
   test('Success', async () => {
@@ -332,5 +335,22 @@ describe('New user', () => {
     expect(res2.status).toBe(200);
     expect(res2.body.login).toBeDefined();
     expect(res2.body.code).toBeUndefined();
+  });
+
+  test('Success when config has empty recaptchaSecretKey and missing recaptcha token', async () => {
+    getConfig().recaptchaSecretKey = "";
+    const res = await request(app)
+      .post('/auth/newuser')
+      .type('json')
+      .send({
+        firstName: 'Alexander',
+        lastName: 'Hamilton',
+        email: `alex${randomUUID()}@example.com`,
+        password: 'password!@#',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.login).toBeDefined();
+    expect(res.body.code).toBeUndefined();
   });
 });

--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -338,7 +338,7 @@ describe('New user', () => {
   });
 
   test('Success when config has empty recaptchaSecretKey and missing recaptcha token', async () => {
-    getConfig().recaptchaSecretKey = "";
+    getConfig().recaptchaSecretKey = '';
     const res = await request(app)
       .post('/auth/newuser')
       .type('json')

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -17,7 +17,6 @@ export const newUserValidators = [
   body('lastName').notEmpty().withMessage('Last name is required'),
   body('email').isEmail().withMessage('Valid email address is required'),
   body('password').isLength({ min: 8 }).withMessage('Password must be at least 8 characters'),
-  body('recaptchaToken').notEmpty().withMessage('Recaptcha token is required'),
 ];
 
 /**
@@ -56,9 +55,16 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
     }
   }
 
-  if (!(await verifyRecaptcha(secretKey as string, req.body.recaptchaToken))) {
-    sendOutcome(res, badRequest('Recaptcha failed'));
-    return;
+  if (secretKey) {
+    if (!req.body.recaptchaToken) {
+      sendOutcome(res, badRequest('Recaptcha token is required'));
+      return;
+    }
+
+    if (!(await verifyRecaptcha(secretKey as string, req.body.recaptchaToken))) {
+      sendOutcome(res, badRequest('Recaptcha failed'));
+      return;
+    }
   }
 
   // If the user is a practitioner, then projectId should be undefined

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -61,7 +61,7 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
       return;
     }
 
-    if (!(await verifyRecaptcha(secretKey as string, req.body.recaptchaToken))) {
+    if (!(await verifyRecaptcha(secretKey, req.body.recaptchaToken))) {
       sendOutcome(res, badRequest('Recaptcha failed'));
       return;
     }


### PR DESCRIPTION
- Allow blank/missing recaptchaSecretKey server config setting to make reCAPTCHA optional on server
- Allow blank/missing RECAPTCHA_SITE_KEY app setting to make reCAPTCHA optional on the client

### Tests ###
```
tonylee@tonys-air auth % npm test -- newuser.test.ts      

> @medplum/server@2.0.10 test
> jest --runInBand newuser.test.ts

 PASS  src/auth/newuser.test.ts (5.962 s)
  New user
    ✓ Success (338 ms)
    ✓ Missing recaptcha (6 ms)
    ✓ Incorrect recaptcha (5 ms)
    ✓ Breached password (6 ms)
    ✓ Email already registered (266 ms)
    ✓ Custom recaptcha client success (649 ms)
    ✓ Custom recaptcha client missing access policy (358 ms)
    ✓ Recaptcha site key not found (8 ms)
    ✓ Recaptcha secret key not found (349 ms)
    ✓ Isolated projects (1529 ms)
    ✓ Success when config has empty recaptchaSecretKey and missing recaptcha token (260 ms)

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
Snapshots:   0 total
Time:        6.002 s
Ran all test suites matching /newuser.test.ts/i.
```



```
tonylee@tonys-air auth % npm test -- RegisterForm.test.tsx         

> @medplum/react@2.0.10 test
> jest RegisterForm.test.tsx

 PASS  src/auth/RegisterForm.test.tsx
  RegisterForm
    ✓ Register new project success (370 ms)
    ✓ Register new project success with empty recaptchaSiteKey (106 ms)
    ✓ Register new patient success (79 ms)
    ✓ Google success (55 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        2.499 s, estimated 3 s
Ran all test suites matching /RegisterForm.test.tsx/i.

```