### PR TITLE
Fixed total count when joining lookup tables

### DIFF
--- a/packages/server/src/auth/exchange.ts
+++ b/packages/server/src/auth/exchange.ts
@@ -105,9 +105,7 @@ async function getExternalUserInfo(
       },
     });
 
-    const result = await response.json();
-    console.log('user info result', JSON.stringify(result, null, 2));
-    return result;
+    return await response.json();
   } catch (err) {
     logger.warn('Failed to verify code', err);
     throw new OperationOutcomeError(badRequest('Failed to verify code - check your identity provider configuration'));

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -2607,6 +2607,7 @@ describe('FHIR Repo', () => {
 
     const bundle = await systemRepo.search({
       resourceType: 'Patient',
+      total: 'accurate',
       filters: [
         {
           code: 'given',
@@ -2621,6 +2622,7 @@ describe('FHIR Repo', () => {
       ],
     });
     expect(bundle?.entry?.length).toEqual(2);
+    expect(bundle.total).toEqual(2);
     expect(bundleContains(bundle, p1)).toBeTruthy();
     expect(bundleContains(bundle, p2)).not.toBeTruthy();
     expect(bundleContains(bundle, p3)).toBeTruthy();

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -901,7 +901,8 @@ export class Repository {
     const client = getClient();
     const builder = new SelectQuery(resourceType)
       .column({ tableName: resourceType, columnName: 'id' })
-      .column({ tableName: resourceType, columnName: 'content' });
+      .column({ tableName: resourceType, columnName: 'content' })
+      .groupBy({ tableName: resourceType, columnName: 'id' });
 
     this.#addDeletedFilter(builder);
     this.#addSecurityFilters(builder, resourceType);

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -1,4 +1,4 @@
-import { Condition, Negation, Operator, SelectQuery, SqlBuilder } from './sql';
+import { Column, Condition, Negation, Operator, SelectQuery, SqlBuilder } from './sql';
 
 describe('SqlBuilder', () => {
   test('Select', () => {
@@ -76,5 +76,11 @@ describe('SqlBuilder', () => {
     expect(sql.toString()).toBe(
       'SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name"=ANY(SELECT "MyLookup"."values" FROM "MyLookup")'
     );
+  });
+
+  test('Select group by', () => {
+    const sql = new SqlBuilder();
+    new SelectQuery('MyTable').column('id').groupBy('name').groupBy(new Column('MyTable', 'email')).buildSql(sql);
+    expect(sql.toString()).toBe('SELECT "MyTable"."id" FROM "MyTable" GROUP BY "MyTable"."name", "MyTable"."email"');
   });
 });


### PR DESCRIPTION
Regression introduced here: https://github.com/medplum/medplum/pull/1685

The `GROUP BY` was correct in the "get resources" query but not in the "get total count" query.