### PR TITLE
Fix total count for search by Reference.identifier

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -2348,6 +2348,15 @@ describe('FHIR Repo', () => {
     expect(bundle2.entry?.length).toEqual(2);
     expect(bundleContains(bundle2, c1)).toBeTruthy();
     expect(bundleContains(bundle2, c2)).toBeTruthy();
+
+    // Search with count
+    const bundle3 = await systemRepo.search(
+      parseSearchDefinition(`Condition?code=${code}&subject:identifier=mrn|123456&_total=accurate`)
+    );
+    expect(bundle3.entry?.length).toEqual(1);
+    expect(bundle3.total).toBe(1);
+    expect(bundleContains(bundle3, c1)).toBeTruthy();
+    expect(bundleContains(bundle3, c2)).not.toBeTruthy();
   });
 
   test('Purge forbidden', async () => {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1102,14 +1102,14 @@ export class Repository {
    * @param predicate The predicate conjunction.
    * @param searchRequest The search request.
    */
-  #addSearchFilters(selectQuery: SelectQuery, searchRequest: Readonly<SearchRequest>): void {
+  #addSearchFilters(selectQuery: SelectQuery, searchRequest: SearchRequest): void {
     const expr = this.#buildSearchExpression(selectQuery, searchRequest);
     if (expr) {
       selectQuery.predicate.expressions.push(expr);
     }
   }
 
-  #buildSearchExpression(selectQuery: SelectQuery, searchRequest: Readonly<SearchRequest>): Expression | undefined {
+  #buildSearchExpression(selectQuery: SelectQuery, searchRequest: SearchRequest): Expression | undefined {
     const expressions: Expression[] = [];
     if (searchRequest.filters) {
       for (const filter of searchRequest.filters) {
@@ -1136,8 +1136,8 @@ export class Repository {
    */
   #buildSearchFilterExpression(
     selectQuery: SelectQuery,
-    searchRequest: Readonly<SearchRequest>,
-    filter: Readonly<Filter>
+    searchRequest: SearchRequest,
+    filter: Filter
   ): Expression | undefined {
     if (typeof filter.value !== 'string') {
       throw new OperationOutcomeError(badRequest('Search filter value must be a string'));
@@ -1371,7 +1371,7 @@ export class Repository {
    * @param builder The client query builder.
    * @param searchRequest The search request.
    */
-  #addSortRules(builder: SelectQuery, searchRequest: Readonly<SearchRequest>): void {
+  #addSortRules(builder: SelectQuery, searchRequest: SearchRequest): void {
     searchRequest.sortRules?.forEach((sortRule) => this.#addOrderByClause(builder, searchRequest, sortRule));
   }
 
@@ -1381,7 +1381,7 @@ export class Repository {
    * @param searchRequest The search request.
    * @param sortRule The sort rule.
    */
-  #addOrderByClause(builder: SelectQuery, searchRequest: Readonly<SearchRequest>, sortRule: Readonly<SortRule>): void {
+  #addOrderByClause(builder: SelectQuery, searchRequest: SearchRequest, sortRule: SortRule): void {
     if (sortRule.code === '_lastUpdated') {
       builder.orderBy('lastUpdated', !!sortRule.descending);
       return;

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1102,14 +1102,14 @@ export class Repository {
    * @param predicate The predicate conjunction.
    * @param searchRequest The search request.
    */
-  #addSearchFilters(selectQuery: SelectQuery, searchRequest: SearchRequest): void {
+  #addSearchFilters(selectQuery: SelectQuery, searchRequest: Readonly<SearchRequest>): void {
     const expr = this.#buildSearchExpression(selectQuery, searchRequest);
     if (expr) {
       selectQuery.predicate.expressions.push(expr);
     }
   }
 
-  #buildSearchExpression(selectQuery: SelectQuery, searchRequest: SearchRequest): Expression | undefined {
+  #buildSearchExpression(selectQuery: SelectQuery, searchRequest: Readonly<SearchRequest>): Expression | undefined {
     const expressions: Expression[] = [];
     if (searchRequest.filters) {
       for (const filter of searchRequest.filters) {
@@ -1136,8 +1136,8 @@ export class Repository {
    */
   #buildSearchFilterExpression(
     selectQuery: SelectQuery,
-    searchRequest: SearchRequest,
-    filter: Filter
+    searchRequest: Readonly<SearchRequest>,
+    filter: Readonly<Filter>
   ): Expression | undefined {
     if (typeof filter.value !== 'string') {
       throw new OperationOutcomeError(badRequest('Search filter value must be a string'));
@@ -1156,8 +1156,11 @@ export class Repository {
 
     if (filter.operator === FhirOperator.IDENTIFIER) {
       param = deriveIdentifierSearchParameter(param);
-      filter.code = param.code as string;
-      filter.operator = FhirOperator.EQUALS;
+      filter = {
+        ...filter,
+        code: param.code as string,
+        operator: FhirOperator.EQUALS,
+      };
     }
 
     const lookupTable = this.#getLookupTable(resourceType, param);
@@ -1368,7 +1371,7 @@ export class Repository {
    * @param builder The client query builder.
    * @param searchRequest The search request.
    */
-  #addSortRules(builder: SelectQuery, searchRequest: SearchRequest): void {
+  #addSortRules(builder: SelectQuery, searchRequest: Readonly<SearchRequest>): void {
     searchRequest.sortRules?.forEach((sortRule) => this.#addOrderByClause(builder, searchRequest, sortRule));
   }
 
@@ -1378,7 +1381,7 @@ export class Repository {
    * @param searchRequest The search request.
    * @param sortRule The sort rule.
    */
-  #addOrderByClause(builder: SelectQuery, searchRequest: SearchRequest, sortRule: SortRule): void {
+  #addOrderByClause(builder: SelectQuery, searchRequest: Readonly<SearchRequest>, sortRule: Readonly<SortRule>): void {
     if (sortRule.code === '_lastUpdated') {
       builder.orderBy('lastUpdated', !!sortRule.descending);
       return;


### PR DESCRIPTION
When the Medplum App makes a search call, it includes the `_total=accurate` search parameter to get the total count of resources. 

There was a bug in the code block handling the `reference:identifer` that would mutate the `SearchRequest` object. 

```
if (filter.operator === FhirOperator.IDENTIFIER) {
    param = deriveIdentifierSearchParameter(param);
    filter.code = param.code as string,
    filter.operator = FhirOperator.EQUALS,
 }
```

This only becomes a problem when `getTotalCount()` is invoked in the same API call, because changing `filter.code` to `<param>:identifer` causes this to be treated as an invalid search parameter