### PR TITLE
Create bot from CLI

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -269,25 +269,7 @@ describe('CLI', () => {
   });
 
   test('Create bot success', async () => {
-    const bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
-
-    // (fs.readFileSync as unknown as jest.Mock).mockReturnValue(
-    //   JSON.stringify({
-    //     bots: [
-    //       {
-    //         name: 'hello-world',
-    //         id: 1,
-    //         source: 'src/hello-world.ts',
-    //         dist: 'dist/hello-world.js',
-    //       },
-    //     ],
-    //   })
-    // );
     await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot', '1', 'src/hello-world.ts']);
-
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
-    const check = await medplum.readResource('Bot', bot.id as string);
-    expect(check.code).toBeDefined();
-    expect(check.code).not.toEqual('');
+    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -272,4 +272,11 @@ describe('CLI', () => {
     await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot', '1', 'src/hello-world.ts']);
     expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
   });
+
+  test('Create bot error with lack of commands', async () => {
+    await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot']);
+    expect(console.log).toBeCalledWith(
+      expect.stringMatching('Error: command needs to be npx medplum <new-bot-name> <project-id> <source-file>')
+    );
+  });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -269,15 +269,25 @@ describe('CLI', () => {
   });
 
   test('Create bot success', async () => {
-    (fs.readFileSync as unknown as jest.Mock).mockReturnValue(
-      `import { BotEvent, MedplumClient } from '@medplum/core';
+    const bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
 
-    export async function handler(medplum: MedplumClient, event: BotEvent): Promise<any> {
-      // Your code here
-    }
-    `
-    );
+    // (fs.readFileSync as unknown as jest.Mock).mockReturnValue(
+    //   JSON.stringify({
+    //     bots: [
+    //       {
+    //         name: 'hello-world',
+    //         id: 1,
+    //         source: 'src/hello-world.ts',
+    //         dist: 'dist/hello-world.js',
+    //       },
+    //     ],
+    //   })
+    // );
     await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot', '1', 'src/hello-world.ts']);
+
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    const check = await medplum.readResource('Bot', bot.id as string);
+    expect(check.code).toBeDefined();
+    expect(check.code).not.toEqual('');
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -267,4 +267,17 @@ describe('CLI', () => {
     expect(check.code).toBeDefined();
     expect(check.code).not.toEqual('');
   });
+
+  test('Create bot success', async () => {
+    (fs.readFileSync as unknown as jest.Mock).mockReturnValue(
+      `import { BotEvent, MedplumClient } from '@medplum/core';
+
+    export async function handler(medplum: MedplumClient, event: BotEvent): Promise<any> {
+      // Your code here
+    }
+    `
+    );
+    await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot', '1', 'src/hello-world.ts']);
+    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -215,12 +215,9 @@ async function runBotCommands(medplum: MedplumClient, argv: string[], commands: 
 }
 
 async function createBot(medplum: MedplumClient, argv: string[]): Promise<void> {
-  if (argv.length < 4) {
-    console.log(`Usage: medplum ${argv[2]} <bot-name>`);
-    return;
-  }
   if (argv.length < 6) {
     console.log(`Error: command needs to be npx medplum <new-bot-name> <project-id> <source-file>`);
+    return;
   }
   const botName = argv[3];
   const projectId = argv[4];
@@ -310,7 +307,7 @@ function readFileContents(fileName: string): string | undefined {
 
 function addBotToConfig(botConfig: MedplumBotConfig): void {
   const config = readConfig();
-  config?.bots?.push(botConfig as MedplumBotConfig);
+  config?.bots?.push(botConfig);
   writeFile('medplum.config.json', JSON.stringify(config), () => {
     console.log(`Bot added to config: ${botConfig.id}`);
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { getDisplayString, MedplumClient, normalizeErrorString } from '@medplum/
 import { Bot, OperationOutcome } from '@medplum/fhirtypes';
 import { exec } from 'child_process';
 import dotenv from 'dotenv';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFile } from 'fs';
 import { createServer } from 'http';
 import fetch from 'node-fetch';
 import { platform } from 'os';
@@ -242,8 +242,7 @@ async function createBot(medplum: MedplumClient, argv: string[]): Promise<void> 
     await saveBot(medplum, botConfig as MedplumBotConfig, bot);
     console.log(`Success! Bot created: ${bot.id}`);
 
-    const config = readConfig();
-    config?.bots?.push(botConfig as MedplumBotConfig);
+    addBotToConfig(botConfig);
   } catch (err) {
     console.log('Error while creating new bot ', err);
   }
@@ -307,6 +306,14 @@ function readFileContents(fileName: string): string | undefined {
     return '';
   }
   return readFileSync(path, 'utf8');
+}
+
+function addBotToConfig(botConfig: MedplumBotConfig): void {
+  const config = readConfig();
+  config?.bots?.push(botConfig as MedplumBotConfig);
+  writeFile('medplum.config.json', JSON.stringify(config), () => {
+    console.log(`Bot added to config: ${botConfig.id}`);
+  });
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Adding ability to create a bot from the medplum cli. The expected logic will be 

`npx medplum <bot-name> <project-id> <file-source)`
 
The test coverage is a bit tough and my thought:
- Thinking about creating a `helper` folder for the CLI to make the functions exportable that way we can test them directly. This can allows us to test the helper methods in the cli/index.ts file.  However I wonder how much that'll help.

Any other suggestions on testing this further will be fantastic 
