### PR TITLE
Added searchResources and searchOne helpers to FhirRepository

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -987,7 +987,7 @@ export class MedplumClient extends EventTarget {
    * @param resourceType The FHIR resource type.
    * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
    * @param options Optional fetch options.
-   * @returns Promise to the search result bundle.
+   * @returns Promise to the first search result.
    */
   searchOne<K extends ResourceType>(
     resourceType: K,
@@ -1029,7 +1029,7 @@ export class MedplumClient extends EventTarget {
    * @param resourceType The FHIR resource type.
    * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
    * @param options Optional fetch options.
-   * @returns Promise to the search result bundle.
+   * @returns Promise to the array of search results.
    */
   searchResources<K extends ResourceType>(
     resourceType: K,

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -111,10 +111,10 @@ const PREFIX_OPERATORS: Record<string, Operator> = {
  * @param query The collection of query string parameters.
  * @returns A parsed SearchRequest.
  */
-export function parseSearchRequest(
-  resourceType: ResourceType,
+export function parseSearchRequest<T extends Resource = Resource>(
+  resourceType: T['resourceType'],
   query: Record<string, string[] | string | undefined>
-): SearchRequest {
+): SearchRequest<T> {
   return parseSearchImpl(resourceType, query);
 }
 
@@ -123,9 +123,9 @@ export function parseSearchRequest(
  * @param url The search URL.
  * @returns A parsed SearchRequest.
  */
-export function parseSearchUrl(url: URL): SearchRequest {
+export function parseSearchUrl<T extends Resource = Resource>(url: URL): SearchRequest<T> {
   const resourceType = url.pathname.split('/').filter(Boolean).pop() as ResourceType;
-  return parseSearchImpl(resourceType, Object.fromEntries(url.searchParams.entries()));
+  return parseSearchImpl<T>(resourceType, Object.fromEntries(url.searchParams.entries()));
 }
 
 /**
@@ -133,15 +133,15 @@ export function parseSearchUrl(url: URL): SearchRequest {
  * @param url The URL to parse.
  * @returns Parsed search definition.
  */
-export function parseSearchDefinition(url: string): SearchRequest {
-  return parseSearchUrl(new URL(url, 'https://example.com/'));
+export function parseSearchDefinition<T extends Resource = Resource>(url: string): SearchRequest<T> {
+  return parseSearchUrl<T>(new URL(url, 'https://example.com/'));
 }
 
-function parseSearchImpl(
-  resourceType: ResourceType,
+function parseSearchImpl<T extends Resource = Resource>(
+  resourceType: T['resourceType'],
   query: Record<string, string[] | string | undefined>
-): SearchRequest {
-  const searchRequest: SearchRequest = {
+): SearchRequest<T> {
+  const searchRequest: SearchRequest<T> = {
     resourceType,
   };
 

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -1,10 +1,10 @@
-import { ResourceType, SearchParameter } from '@medplum/fhirtypes';
+import { Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { globalSchema } from '../types';
 
 export const DEFAULT_SEARCH_COUNT = 20;
 
-export interface SearchRequest {
-  readonly resourceType: ResourceType;
+export interface SearchRequest<T extends Resource = Resource> {
+  readonly resourceType: T['resourceType'];
   filters?: Filter[];
   sortRules?: SortRule[];
   offset?: number;

--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -1,11 +1,25 @@
-import { badRequest, notFound, OperationOutcomeError } from '@medplum/core';
-import { Observation, Patient } from '@medplum/fhirtypes';
+import {
+  badRequest,
+  indexSearchParameterBundle,
+  indexStructureDefinitionBundle,
+  notFound,
+  OperationOutcomeError,
+  parseSearchDefinition,
+} from '@medplum/core';
+import { readJson } from '@medplum/definitions';
+import { Bundle, Observation, Patient, SearchParameter } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { MemoryRepository } from './repo';
 
 const repo = new MemoryRepository();
 
 describe('MemoryRepository', () => {
+  beforeAll(async () => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
+  });
+
   test('Create resource', async () => {
     const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
     expect(patient.id).toBeDefined();
@@ -66,7 +80,35 @@ describe('MemoryRepository', () => {
     expect(bundle.entry).toHaveLength(1);
   });
 
+  test('searchResources helper', async () => {
+    const family = randomUUID();
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
+    const resources = await repo.searchResources<Patient>(parseSearchDefinition('Patient?family=' + family));
+    expect(resources).toHaveLength(1);
+    expect(resources[0].id).toBe(patient.id);
+
+    const emptyResources = await repo.searchResources<Patient>(parseSearchDefinition('Patient?family=' + randomUUID()));
+    expect(emptyResources).toHaveLength(0);
+  });
+
+  test('searchOne helper', async () => {
+    const family = randomUUID();
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
+    const resource = await repo.searchOne<Patient>(parseSearchDefinition('Patient?family=' + family));
+    expect(resource?.id).toBe(patient.id);
+
+    const emptyResource = await repo.searchOne<Patient>(parseSearchDefinition('Patient?family=' + randomUUID()));
+    expect(emptyResource).toBeUndefined();
+  });
+
   test('Sort unknown search parameter', async () => {
-    // todo
+    for (let i = 0; i < 10; i++) {
+      await repo.createResource<Patient>({ resourceType: 'Patient' });
+    }
+
+    // Mock repository silently ignores unknown search parameters
+    // This is different than the real server environment, which will throw an error
+    const bundle = await repo.search({ resourceType: 'Patient', sortRules: [{ code: 'xyz' }] });
+    expect(bundle.entry).toBeDefined();
   });
 });

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -1,5 +1,5 @@
 import { getReferenceString, Operator, ProfileResource } from '@medplum/core';
-import { BundleEntry, Login, ProjectMembership, Reference, User, UserConfiguration } from '@medplum/fhirtypes';
+import { Login, ProjectMembership, Reference, User, UserConfiguration } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { UAParser } from 'ua-parser-js';
 import { systemRepo } from '../fhir/repo';
@@ -73,7 +73,7 @@ async function getUserConfiguration(membership: ProjectMembership): Promise<User
 }
 
 async function getSessions(user: User): Promise<UserSession[]> {
-  const logins = await systemRepo.search<Login>({
+  const logins = await systemRepo.searchResources<Login>({
     resourceType: 'Login',
     filters: [
       {
@@ -90,8 +90,7 @@ async function getSessions(user: User): Promise<UserSession[]> {
   });
 
   const result = [];
-  for (const e of logins.entry as BundleEntry<Login>[]) {
-    const login = e.resource as Login;
+  for (const login of logins) {
     if (!login.membership || login.revoked) {
       continue;
     }

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -1,5 +1,5 @@
 import { allOk, badRequest, createReference, Operator } from '@medplum/core';
-import { BundleEntry, PasswordChangeRequest, User } from '@medplum/fhirtypes';
+import { PasswordChangeRequest, User } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { getConfig } from '../config';
@@ -26,7 +26,7 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
     return;
   }
 
-  const existingBundle = await systemRepo.search<User>({
+  const user = await systemRepo.searchOne<User>({
     resourceType: 'User',
     filters: [
       {
@@ -37,12 +37,10 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
     ],
   });
 
-  if ((existingBundle.entry as BundleEntry[]).length === 0) {
+  if (!user) {
     sendOutcome(res, badRequest('User not found', 'email'));
     return;
   }
-
-  const user = existingBundle?.entry?.[0]?.resource as User;
 
   const url = await resetPassword(user);
 

--- a/packages/server/src/fhir/operations/csv.ts
+++ b/packages/server/src/fhir/operations/csv.ts
@@ -6,15 +6,7 @@ import {
   isResourceType,
   parseSearchRequest,
 } from '@medplum/core';
-import {
-  Address,
-  BundleEntry,
-  CodeableConcept,
-  ContactPoint,
-  HumanName,
-  Reference,
-  ResourceType,
-} from '@medplum/fhirtypes';
+import { Address, CodeableConcept, ContactPoint, HumanName, Reference, ResourceType } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { sendOutcome } from '../outcomes';
 import { Repository } from '../repo';
@@ -58,19 +50,19 @@ export async function csvHandler(req: Request, res: Response): Promise<void> {
   const repo = res.locals.repo as Repository;
   const searchRequest = parseSearchRequest(resourceType, query);
   searchRequest.count = 10000;
-  const bundle = await repo.search(searchRequest);
+  const resources = await repo.searchResources(searchRequest);
   const output: string[][] = [];
 
   // Header row
   output.push(columnNames);
 
   // For each resource...
-  for (const entry of bundle.entry as BundleEntry[]) {
+  for (const resource of resources) {
     const row: string[] = [];
 
     // For each column...
     for (const expression of expressions) {
-      const values = evalFhirPath(expression, entry.resource);
+      const values = evalFhirPath(expression, resource);
       if (values.length > 0) {
         row.push(csvEscape(values[0]));
       } else {

--- a/packages/server/src/fhir/operations/resourcegraph.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.ts
@@ -219,11 +219,10 @@ async function followCanonicalElements(
     if (url in resourceCache) {
       results.push(resourceCache[url]);
     } else {
-      const bundle = await repo.search({
+      const linkedResources = await repo.searchResources({
         resourceType: target.type,
         filters: [{ code: 'url', operator: Operator.EQUALS, value: url }],
       });
-      const linkedResources = bundle?.entry?.map((entry) => entry.resource).filter((e) => !!e) as Resource[];
       if (linkedResources?.length > 1) {
         logger.warn(`Warning: Found more than 1 resource with canonical URL ${url}`);
       }
@@ -268,11 +267,9 @@ async function followSearchLink(
     searchRequest.count = Math.max(parseCardinality(link.max), 5000);
 
     // Run the search and add the results to the `results` array
-    const bundle = await repo.search(searchRequest);
-    if (bundle && bundle.entry) {
-      const resources = bundle.entry.map((entry) => entry.resource).filter((e): e is Resource => !!e);
+    const resources = await repo.searchResources(searchRequest);
+    if (resources) {
       resources.forEach((res) => addToCache(res, resourceCache));
-
       results.push(...resources);
     }
   }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -36,6 +36,7 @@ import {
   validateResource,
   validateResourceType,
 } from '@medplum/core';
+import { BaseRepository, FhirRepository } from '@medplum/fhir-router';
 import {
   AccessPolicy,
   AccessPolicyResource,
@@ -216,10 +217,11 @@ const maxSearchResults = 1000;
  * It is a thin layer on top of the database.
  * Repository instances should be created per author and project.
  */
-export class Repository {
+export class Repository extends BaseRepository implements FhirRepository {
   readonly #context: RepositoryContext;
 
   constructor(context: RepositoryContext) {
+    super();
     this.#context = context;
     if (!this.#context.author?.reference) {
       throw new Error('Invalid author reference');

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -101,16 +101,16 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     throw new Error('Missing issuer');
   }
 
-  const searchResult = await systemRepo.search({
+  const searchResult = await systemRepo.searchResources<JsonWebKey>({
     resourceType: 'JsonWebKey',
     filters: [{ code: 'active', operator: Operator.EQUALS, value: 'true' }],
   });
 
   let jsonWebKeys: JsonWebKey[] | undefined;
 
-  if (searchResult?.entry && searchResult.entry.length > 0) {
-    logger.info(`Loaded ${searchResult.entry.length} key(s) from the database`);
-    jsonWebKeys = searchResult.entry.map((entry) => entry.resource as JsonWebKey);
+  if (searchResult.length > 0) {
+    logger.info(`Loaded ${searchResult.length} key(s) from the database`);
+    jsonWebKeys = searchResult;
   } else {
     // Generate a key pair
     // https://github.com/panva/jose/blob/HEAD/docs/functions/util_generate_key_pair.generatekeypair.md

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -11,7 +11,6 @@ import {
 } from '@medplum/core';
 import {
   AccessPolicy,
-  BundleEntry,
   ClientApplication,
   Login,
   Project,
@@ -312,13 +311,11 @@ export async function getMembershipsForLogin(login: Login): Promise<ProjectMembe
     });
   }
 
-  const bundle = await systemRepo.search<ProjectMembership>({
+  let memberships = await systemRepo.searchResources<ProjectMembership>({
     resourceType: 'ProjectMembership',
     count: 100,
     filters,
   });
-
-  let memberships = (bundle.entry as BundleEntry<ProjectMembership>[]).map((e) => e.resource as ProjectMembership);
 
   const profileType = login.profileType;
   if (profileType) {

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -11,7 +11,6 @@ import {
 import {
   AuditEvent,
   Bot,
-  BundleEntry,
   Practitioner,
   ProjectMembership,
   Reference,
@@ -212,7 +211,7 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
   if (!project) {
     return [];
   }
-  const bundle = await systemRepo.search<Subscription>({
+  return systemRepo.searchResources<Subscription>({
     resourceType: 'Subscription',
     count: 1000,
     filters: [
@@ -228,7 +227,6 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
       },
     ],
   });
-  return (bundle.entry as BundleEntry<Subscription>[]).map((e) => e.resource as Subscription);
 }
 
 /**


### PR DESCRIPTION
This is a 100% pure refactoring / cleanup PR.

By default, `search()` calls return a FHIR `Bundle`.  `Bundle` is a wrapper type.  The meat of the results is inside `Bundle.entry`.  `Bundle` also includes a bunch of metadata (total count, next/previous links, etc).  However, in the common case, you just want the `entry` values.

In `MedplumClient` we have 2 extremely handy convenience methods: `searchResources` and `searchOne`.  Where the normal `search()` method returns a FHIR `Bundle`, `searchResources` returns a simple `Resource[]` array and `searchOne` returns a single `Resource`.

In the server, we did not have those convenience methods, and so we ended up doing a lot of `bundle.entry?.map(...)` calls.

This PR finally gets around to adding the convenience methods, and using it in a bunch of places.  I don't think I found all of them, so there might be some ongoing opportunities to replace `search() + map()` with `searchResources()`.