### PR TITLE
Gracefully handle malformed UUIDs in _id

### DIFF
--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -11,6 +11,7 @@ export enum SearchParameterType {
   DATE = 'DATE',
   DATETIME = 'DATETIME',
   PERIOD = 'PERIOD',
+  UUID = 'UUID',
 }
 
 export interface SearchParameterDetails {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1004,6 +1004,36 @@ describe('FHIR Repo', () => {
     expect(searchResult2?.entry?.length).toEqual(0);
   });
 
+  test('Non UUID _id', async () => {
+    const searchResult1 = await systemRepo.search({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: '_id',
+          operator: Operator.EQUALS,
+          value: 'x',
+        },
+      ],
+    });
+
+    expect(searchResult1?.entry?.length).toEqual(0);
+  });
+
+  test('Non UUID _compartment', async () => {
+    const searchResult1 = await systemRepo.search({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: '_compartment',
+          operator: Operator.EQUALS,
+          value: 'x',
+        },
+      ],
+    });
+
+    expect(searchResult1?.entry?.length).toEqual(0);
+  });
+
   test('Filter by _project', async () => {
     const project1 = randomUUID();
     const project2 = randomUUID();


### PR DESCRIPTION
In most places where querying by ID, we properly validate the UUID input string.  I.e., read by ID, update by ID, etc.

When using the special `_id` search parameter, we did not correctly validate the UUID string.  For a well formed UUID, everything was fine.  For an invalid UUID, postgres would throw an error.  So rather than empty result, the server threw a 500.

This fixes that by treating malformed UUID's as the special "all zero UUID", which should never match.