### PR TITLE
Make Recaptcha optional for Password Reset

### DIFF
--- a/packages/app/src/ResetPasswordPage.test.tsx
+++ b/packages/app/src/ResetPasswordPage.test.tsx
@@ -18,6 +18,9 @@ function setup(): void {
 }
 
 describe('ResetPasswordPage', () => {
+  const origEnv = process.env;
+  const grecaptchaResolved = jest.fn();
+
   beforeAll(() => {
     Object.defineProperty(global, 'grecaptcha', {
       value: {
@@ -25,10 +28,21 @@ describe('ResetPasswordPage', () => {
           callback();
         },
         execute(): Promise<string> {
+          grecaptchaResolved();
           return Promise.resolve('token');
         },
       },
     });
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...origEnv };
+  });
+
+  afterEach(() => {
+    process.env = origEnv;
+    jest.clearAllMocks();
   });
 
   test('Renders', () => {
@@ -36,7 +50,8 @@ describe('ResetPasswordPage', () => {
     expect(screen.getByRole('button', { name: 'Reset password' })).toBeInTheDocument();
   });
 
-  test('Submit success', async () => {
+  test('Submit success with recaptcha site key', async () => {
+    process.env.RECAPTCHA_SITE_KEY = 'recaptchasitekey';
     setup();
 
     await act(async () => {
@@ -48,7 +63,23 @@ describe('ResetPasswordPage', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Reset password' }));
     });
+    expect(grecaptchaResolved).toHaveBeenCalled();
+    expect(screen.getByText('Email sent')).toBeInTheDocument();
+  });
 
+  test('Submit success without recaptcha site key', async () => {
+    setup();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Email *'), {
+        target: { value: 'admin@example.com' },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Reset password' }));
+    });
+    expect(grecaptchaResolved).not.toBeCalled();
     expect(screen.getByText('Email sent')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/ResetPasswordPage.test.tsx
+++ b/packages/app/src/ResetPasswordPage.test.tsx
@@ -68,6 +68,7 @@ describe('ResetPasswordPage', () => {
   });
 
   test('Submit success without recaptcha site key', async () => {
+    process.env.RECAPTCHA_SITE_KEY = '';
     setup();
 
     await act(async () => {

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -9,10 +9,7 @@ import { systemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { verifyRecaptcha } from './utils';
 
-export const resetPasswordValidators = [
-  body('email').isEmail().withMessage('Valid email address is required'),
-  body('recaptchaToken').notEmpty().withMessage('Recaptcha token is required'),
-];
+export const resetPasswordValidators = [body('email').isEmail().withMessage('Valid email address is required')];
 
 export async function resetPasswordHandler(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);
@@ -21,9 +18,18 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
     return;
   }
 
-  if (!(await verifyRecaptcha(getConfig().recaptchaSecretKey as string, req.body.recaptchaToken))) {
-    sendOutcome(res, badRequest('Recaptcha failed'));
-    return;
+  const recaptchaSecretKey = getConfig().recaptchaSecretKey;
+
+  if (recaptchaSecretKey) {
+    if (!req.body.recaptchaToken) {
+      sendOutcome(res, badRequest('Recaptcha token is required'));
+      return;
+    }
+
+    if (!(await verifyRecaptcha(recaptchaSecretKey, req.body.recaptchaToken))) {
+      sendOutcome(res, badRequest('Recaptcha failed'));
+      return;
+    }
   }
 
   const existingBundle = await systemRepo.search<User>({


### PR DESCRIPTION
# Overview #
- update /passwordreset  to allow for recaptchatoken to be optional if server does not have recaptchaSecretKey
- update password reset page to allow for empty RECAPTCHA_SITE_KEY.

## Testing ##
```
% npm test -- src/auth/resetpassword.test.ts

> @medplum/server@2.0.11 test
> jest --runInBand src/auth/resetpassword.test.ts

 PASS  src/auth/resetpassword.test.ts
  Reset Password
    ✓ Blank email address (14 ms)
    ✓ Missing recaptcha (4 ms)
    ✓ Incorrect recaptcha (3 ms)
    ✓ User not found (4 ms)
    ✓ Success (272 ms)
    ✓ Success with no recaptcha secret key and missing recaptchaToken (227 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.457 s
Ran all test suites matching /src\/auth\/resetpassword.test.ts/i.
```
```
% npm test -- src/ResetPasswordPage.test.tsx

> @medplum/app@2.0.11 test
> jest src/ResetPasswordPage.test.tsx

 PASS  src/ResetPasswordPage.test.tsx
  ResetPasswordPage
    ✓ Renders (121 ms)
    ✓ Submit success with recaptcha site key (49 ms)
    ✓ Submit success without recaptcha site key (35 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.015 s
Ran all test suites matching /src\/ResetPasswordPage.test.tsx/i.
```