### PR TITLE
Verify Client provided ProjectId and custom recaptchaSiteKey

### DIFF
--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -277,7 +277,7 @@ describe('Google Auth', () => {
     expect(res2.status).toBe(200);
   });
 
-  test('Custom Google client wrong project', async () => {
+  test('Custom Google client wrong projectId', async () => {
     const email = `google-client${randomUUID()}@example.com`;
     const password = 'password!@#';
     const googleClientId = 'google-client-id-' + randomUUID();
@@ -342,7 +342,7 @@ describe('Google Auth', () => {
     expect(res.body.code).toBeDefined();
   });
 
-  test('Custom Google client wrong project', async () => {
+  test('ClientId with incorrect projectId', async () => {
     const email = `google-client${randomUUID()}@example.com`;
     const password = 'password!@#';
 

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -39,7 +39,7 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
     // If the recaptcha site key is not the main Medplum recaptcha site key,
     // then it must be associated with a Project.
     // The user can only authenticate with that project.
-    project = await getProjectByRecaptchaSiteKey(recaptchaSiteKey);
+    project = await getProjectByRecaptchaSiteKey(recaptchaSiteKey, req.body.projectId as string | undefined);
     if (!project) {
       sendOutcome(res, badRequest('Invalid recaptchaSiteKey'));
       return;
@@ -124,17 +124,30 @@ export async function createUser(request: NewUserRequest): Promise<User> {
   return result;
 }
 
-async function getProjectByRecaptchaSiteKey(recaptchaSiteKey: string): Promise<Project | undefined> {
+async function getProjectByRecaptchaSiteKey(
+  recaptchaSiteKey: string,
+  projectId: string | undefined
+): Promise<Project | undefined> {
+  const filters = [
+    {
+      code: 'recaptcha-site-key',
+      operator: Operator.EQUALS,
+      value: recaptchaSiteKey,
+    },
+  ];
+
+  if (projectId) {
+    filters.push({
+      code: '_id',
+      operator: Operator.EQUALS,
+      value: projectId,
+    });
+  }
+
   const bundle = await systemRepo.search<Project>({
     resourceType: 'Project',
     count: 1,
-    filters: [
-      {
-        code: 'recaptcha-site-key',
-        operator: Operator.EQUALS,
-        value: recaptchaSiteKey,
-      },
-    ],
+    filters,
   });
   return bundle.entry && bundle.entry.length > 0 ? bundle.entry[0].resource : undefined;
 }


### PR DESCRIPTION
# Overview #

- New user registration was breaking for projects having duplicate recaptchaSiteKey
- If projectId is provided, search projects by projectId and recaptchaSiteKey

### Tests ###
```
 PASS  src/auth/newuser.test.ts (6.59 s)
  New user
    ✓ Success (341 ms)
    ✓ Missing recaptcha (7 ms)
    ✓ Incorrect recaptcha (6 ms)
    ✓ Breached password (6 ms)
    ✓ Email already registered (280 ms)
    ✓ Custom recaptcha client success (662 ms)
    ✓ Custom recaptcha client with incorrect project ID (349 ms)
    ✓ Custom recaptcha client missing access policy (352 ms)
    ✓ Recaptcha site key not found (5 ms)
    ✓ Recaptcha secret key not found (353 ms)
    ✓ Isolated projects (1537 ms)
    ✓ Success when config has empty recaptchaSecretKey and missing recaptcha token (265 ms)

Test Suites: 1 passed, 1 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        6.631 s
```