### PR TITLE
Fixes #1737 - Set Redis EX flag

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2230,7 +2230,9 @@ async function getCacheEntries(references: Reference[]): Promise<(CacheEntry<Res
 async function setCacheEntry(resource: Resource): Promise<void> {
   await getRedis().set(
     getCacheKey(resource.resourceType, resource.id as string),
-    JSON.stringify({ resource, projectId: resource.meta?.project })
+    JSON.stringify({ resource, projectId: resource.meta?.project }),
+    'EX',
+    24 * 60 * 60 // 24 hours in seconds
   );
 }
 


### PR DESCRIPTION
See: https://github.com/medplum/medplum/issues/1737

AWS Elasticache uses "volatile-lru" by default.

See Redis Eviction Policy: https://redis.io/docs/reference/eviction/

When using "volatile-lru", keys are only evicted the "EX" flag is set: "volatile-lru: Removes least recently used keys with the expire field set to true."

We were not setting the "EX" flag, and therefore Redis would not evict.

There are two ways we could fix:

1. Set the "EX" flag on cached resources.  This makes cached resources eligible for eviction.
2. Change from "volatile-lru" to "allkeys-lru".  This makes all keys, regardless of "EX" flag, eligible for eviction.

I chose to use the "EX" flag option for two reasons:

1. We use Redis for both resource cache and as backing for bullmq.  We don't want bullmq jobs to evict, so "volatile-lru" is better.
2. Changing to "allkeys-lru" would be more disruptive for devops teams, because it requires a non-trivial change to CDK configuration (new Redis policy resources, updated Redis configuration).