### PR TITLE
Create-Bot CLI fix and add to documentation

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -269,14 +269,24 @@ describe('CLI', () => {
   });
 
   test('Create bot success', async () => {
-    await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot', '1', 'src/hello-world.ts']);
+    await main(medplum, [
+      'node',
+      'index.js',
+      'create-bot',
+      'test-bot',
+      '1',
+      'src/hello-world.ts',
+      'dist/src/hello-world.ts',
+    ]);
     expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
   });
 
   test('Create bot error with lack of commands', async () => {
     await main(medplum, ['node', 'index.js', 'create-bot', 'test-bot']);
     expect(console.log).toBeCalledWith(
-      expect.stringMatching('Error: command needs to be npx medplum <new-bot-name> <project-id> <source-file>')
+      expect.stringMatching(
+        'Error: command needs to be npx medplum <new-bot-name> <project-id> <source-file> <dist-file>'
+      )
     );
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -214,26 +214,28 @@ async function runBotCommands(medplum: MedplumClient, argv: string[], commands: 
 }
 
 async function createBot(medplum: MedplumClient, argv: string[]): Promise<void> {
-  if (argv.length < 6) {
-    console.log(`Error: command needs to be npx medplum <new-bot-name> <project-id> <source-file>`);
+  if (argv.length < 7) {
+    console.log(`Error: command needs to be npx medplum <new-bot-name> <project-id> <source-file> <dist-file>`);
     return;
   }
   const botName = argv[3];
   const projectId = argv[4];
   const sourceFile = argv[5];
+  const distFile = argv[6];
 
   try {
     const body = {
       name: botName,
       description: '',
     };
-    const newBot = await medplum.post('admin/projects/' + projectId + '/invite', body);
+    const newBot = await medplum.post('admin/projects/' + projectId + '/bot', body);
     const bot = await medplum.readResource('Bot', newBot.id);
 
     const botConfig = {
       name: botName,
       id: newBot.id,
       source: sourceFile,
+      dist: distFile,
     };
     await saveBot(medplum, botConfig as MedplumBotConfig, bot);
     console.log(`Success! Bot created: ${bot.id}`);

--- a/packages/docs/docs/bots/bots-in-production.md
+++ b/packages/docs/docs/bots/bots-in-production.md
@@ -117,15 +117,8 @@ Running this command does the following:
 If you see an error, try running the command again. If it fails after 3 tries, please [**submit a bug report**](https://github.com/medplum/medplum/issues/new) or [**contact us on Discord**](https://discord.gg/UBAWwvrVeN)
 :::
 
-## Linking your code to a Bot Resource (Skip ahead if you created your bot on the CLI)
 
-If you prefer to create the bot on the Medplum App, you can follow the instructions on the [Bot Basics tutorial](./bot-basics/#creating-a-bot) to create a new Bot resource.
-
-Then the next step will be to create a [`Bot` resource](/docs/api/fhir/medplum/bot) using the Medplum App and link your code to the resource.
-
-Next, we need to tell the [Medplum CLI](https://github.com/medplum/medplum/tree/main/packages/cli) which `.ts` and `.js` files are associated with the resource by editing the `medplum.config.json` field.
-
-Open the the file `medplum.config.json` and add the following entry to the `bots` array.
+After creating the bot, you should go to `medplum.config.json` and you should see the new bot added in the bottom of the file. It should look like this: 
 
 ```js
 {

--- a/packages/docs/docs/bots/bots-in-production.md
+++ b/packages/docs/docs/bots/bots-in-production.md
@@ -16,7 +16,7 @@ Editing bots in the web editor is good for getting started quickly, but as Bots 
 - How to set up a repository to host the source code for your Bots.
 - Write a new `Bot` in Typescript.
 - Create a new `Bot` resource and link it to your Typescript file.
-- Use the [Medplum Command Line Interface (CLI)](https://github.com/medplum/medplum/tree/main/packages/cli) to deploy your Bot to production.
+- Use the [Medplum Command Line Interface (CLI)](https://github.com/medplum/medplum/tree/main/packages/cli) to create and deploy your Bot to production.
 
 ## Setting up your Repository
 
@@ -94,11 +94,34 @@ ls dist
 
 ```
 
-## Linking your code to a Bot Resource
+## Creating your Bot 
 
-The next step will be to create a [`Bot` resource](/docs/api/fhir/medplum/bot) using the Medplum App and link your code to the resource.
+Next step is to create the bot. 
 
-First, we'll have to create the resource in the Medplum App. If you haven't already done so, follow the instructions on the [Bot Basics tutorial](./bot-basics/#creating-a-bot) to create a new Bot resource.
+Navigate to the [Project Admin panel](https://app.medplum.com/admin/project) and copy the ID of your project. That will be your `project-id`. 
+
+Taking the `source-file` we just created at `src/my-first-bot.ts`, we will use the `create-bot` command. In our example 
+
+```bash
+npx medplum create-bot <bot-name> <project-id> <source-file> <dist-file>
+```
+
+Running this command does the following:
+
+1. Creates the Bot resource 
+2. Creates a ProjectMembership resource that connects it to a project
+3. Saves the bot to the associated project in the Medplum database
+4. Adds a bot entry to the `medplum.config.json` file in the `bots` array
+
+:::caution Note
+If you see an error, try running the command again. If it fails after 3 tries, please [**submit a bug report**](https://github.com/medplum/medplum/issues/new) or [**contact us on Discord**](https://discord.gg/UBAWwvrVeN)
+:::
+
+## Linking your code to a Bot Resource (Skip ahead if you created your bot on the CLI)
+
+If you prefer to create the bot on the Medplum App, you can follow the instructions on the [Bot Basics tutorial](./bot-basics/#creating-a-bot) to create a new Bot resource.
+
+Then the next step will be to create a [`Bot` resource](/docs/api/fhir/medplum/bot) using the Medplum App and link your code to the resource.
 
 Next, we need to tell the [Medplum CLI](https://github.com/medplum/medplum/tree/main/packages/cli) which `.ts` and `.js` files are associated with the resource by editing the `medplum.config.json` field.
 


### PR DESCRIPTION
The create-bot command had an error in the endpoint, and we are now requiring developers to add a <dist-file> in their command. Tested locally and the output shows:
```
Update bot code.....
Success! New bot version: 44e89f17-6939-486c-8ab0-a38a3c8d3166
Success! Bot created: bf1ca89c-f790-44ab-8125-f87ab34a459c
Bot added to config: bf1ca89c-f790-44ab-8125-f87ab34a459c
```

The medplum.config.json shows 

```
    {
      "name": "newbot2",
      "id": "bf1ca89c-f790-44ab-8125-f87ab34a459c",
      "source": "src/examples/hello-patient.ts",
      "dist": "dist/src/examples/hello-patient.ts"
    }
  ]
```

And in app.medplum.com we see the bot created:
<img width="971" alt="Screenshot 2023-04-05 at 11 14 44 AM" src="https://user-images.githubusercontent.com/6913745/230172171-1594b4aa-a18d-4144-810c-e23666e3ae02.png">

