### PR TITLE
Fixes #1770 - S3 bucket policy in multi-region config

### DIFF
--- a/packages/cdk/src/frontend.ts
+++ b/packages/cdk/src/frontend.ts
@@ -11,6 +11,7 @@ import {
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MedplumInfraConfig } from './config';
+import { grantBucketAccessToOriginAccessIdentity } from './oai';
 import { awsManagedRules } from './waf';
 
 /**
@@ -115,7 +116,7 @@ export class FrontEnd extends Construct {
 
       // Origin access identity
       const originAccessIdentity = new cloudfront.OriginAccessIdentity(this, 'OriginAccessIdentity', {});
-      appBucket.grantRead(originAccessIdentity);
+      grantBucketAccessToOriginAccessIdentity(this, appBucket, originAccessIdentity);
 
       // CloudFront distribution
       const distribution = new cloudfront.Distribution(this, 'AppDistribution', {

--- a/packages/cdk/src/oai.ts
+++ b/packages/cdk/src/oai.ts
@@ -1,0 +1,39 @@
+import { aws_cloudfront as cloudfront, aws_iam as iam, aws_s3 as s3 } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+/**
+ * Grants S3 bucket read access to the CloudFront Origin Access Identity (OAI).
+ *
+ * Under normal circumstances, where CDK creates both the S3 bucket and the OAI,
+ * you can achieve this same behavior by simply calling:
+ *
+ *     bucket.grantRead(identity);
+ *
+ * However, if importing an S3 bucket via `s3.Bucket.fromBucketAttributes()`, that does not work.
+ *
+ * See: https://stackoverflow.com/a/60917015
+ *
+ * @param scope The CDK construct scope.
+ * @param bucket The S3 bucket.
+ * @param identity The CloudFront Origin Access Identity.
+ */
+export function grantBucketAccessToOriginAccessIdentity(
+  scope: Construct,
+  bucket: s3.IBucket,
+  identity: cloudfront.OriginAccessIdentity
+): void {
+  const policyStatement = new iam.PolicyStatement();
+  policyStatement.addActions('s3:GetObject*');
+  policyStatement.addActions('s3:GetBucket*');
+  policyStatement.addActions('s3:List*');
+  policyStatement.addResources(bucket.bucketArn);
+  policyStatement.addResources(`${bucket.bucketArn}/*`);
+  policyStatement.addCanonicalUserPrincipal(identity.cloudFrontOriginAccessIdentityS3CanonicalUserId);
+
+  let policy = bucket.policy;
+  if (!policy) {
+    policy = new s3.BucketPolicy(scope, 'Policy', { bucket });
+  }
+
+  policy.document.addStatements(policyStatement);
+}

--- a/packages/cdk/src/storage.ts
+++ b/packages/cdk/src/storage.ts
@@ -11,6 +11,7 @@ import {
 import { ServerlessClamscan } from 'cdk-serverless-clamscan';
 import { Construct } from 'constructs';
 import { MedplumInfraConfig } from './config';
+import { grantBucketAccessToOriginAccessIdentity } from './oai';
 import { awsManagedRules } from './waf';
 
 /**
@@ -101,7 +102,7 @@ export class Storage extends Construct {
 
       // Origin access identity
       const originAccessIdentity = new cloudfront.OriginAccessIdentity(this, 'OriginAccessIdentity', {});
-      storageBucket.grantRead(originAccessIdentity);
+      grantBucketAccessToOriginAccessIdentity(this, storageBucket, originAccessIdentity);
 
       // CloudFront distribution
       const distribution = new cloudfront.Distribution(this, 'StorageDistribution', {


### PR DESCRIPTION
See bug #1770 

The fix is to explicitly define the policy statement and explicitly add them to the S3 bucket policy document as described in this StackOverflow answer:  https://stackoverflow.com/a/60917015

This is a no-op change for deployments hosted in us-east-1:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/749094/230174858-bee9d65a-b1ee-40f4-82fe-d8dec2160276.png">
