### PR TITLE
Fixes #1730 Project delete operations have arbitrary caps Part 1

### DIFF
--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -20,7 +20,13 @@ class Redis {
     this.values.set(key, value);
   }
 
-  async del(key: string): Promise<void> {
+  async del(key: string | string[]): Promise<void> {
+    if (Array.isArray(key)) {
+      key.forEach((k) => {
+        this.values.delete(k);
+      });
+      return;
+    }
     this.values.delete(key);
   }
 

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -8,6 +8,8 @@ import { getClient } from '../../database';
 import { createTestProject, initTestAuth } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { Operator as SqlOperator, SelectQuery } from '../sql';
+import { Expunger } from './expunge';
+import { getRedis } from '../../redis';
 
 const app = express();
 let superAdminAccessToken: string;
@@ -89,9 +91,57 @@ describe('Expunge', () => {
       .set('X-Medplum', 'extended')
       .send({});
     expect(res.status).toBe(200);
+  });
 
-    expect(await existsInDatabase('Project', patient.id)).toBe(false);
-    expect(await existsInDatabase('Project_History', patient.id)).toBe(false);
+  test('Expunger.expunge() expunges all resource types', async () => {
+    //setup
+    const { project, client, membership } = await createTestProject();
+    expect(project).toBeDefined();
+    expect(client).toBeDefined();
+    expect(membership).toBeDefined();
+
+    const patient = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      meta: { project: project.id },
+      name: [{ given: ['Alice'], family: 'Smith' }],
+    });
+    expect(patient).toBeDefined();
+    const patient2 = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      meta: { project: project.id },
+      name: [{ given: ['Bob'], family: 'Smith' }],
+    });
+    const patient3 = await systemRepo.createResource<Patient>({
+      resourceType: 'Patient',
+      meta: { project: project.id },
+      name: [{ given: ['Bob'], family: 'Smith' }],
+    });
+    expect(patient3).toBeDefined();
+
+    const obs = await systemRepo.createResource<Observation>({
+      resourceType: 'Observation',
+      meta: { project: project.id },
+      status: 'final',
+      code: { coding: [{ system: 'http://loinc.org', code: '12345-6' }] },
+      subject: { reference: 'Patient/' + patient.id },
+    });
+    expect(obs).toBeDefined();
+
+    expect(await existsInCache('Project', project.id)).toBe(true);
+    expect(await existsInCache('ClientApplication', client.id)).toBe(true);
+    expect(await existsInCache('ProjectMembership', membership.id)).toBe(true);
+    expect(await existsInCache('Patient', patient.id)).toBe(true);
+    expect(await existsInCache('Patient', patient2.id)).toBe(true);
+    expect(await existsInCache('Patient', patient3.id)).toBe(true);
+    expect(await existsInCache('Observation', obs.id)).toBe(true);
+
+    //execute
+    await new Expunger(systemRepo, project.id as string, 2).expunge();
+
+    //result
+
+    expect(await existsInDatabase('Project', project.id)).toBe(false);
+    expect(await existsInDatabase('Project_History', project.id)).toBe(false);
 
     expect(await existsInDatabase('ClientApplication', client.id)).toBe(false);
     expect(await existsInDatabase('ClientApplication_History', client.id)).toBe(false);
@@ -101,11 +151,28 @@ describe('Expunge', () => {
 
     expect(await existsInDatabase('Patient', patient.id)).toBe(false);
     expect(await existsInDatabase('Patient_History', patient.id)).toBe(false);
+    expect(await existsInDatabase('Patient', patient2.id)).toBe(false);
+    expect(await existsInDatabase('Patient_History', patient2.id)).toBe(false);
+    expect(await existsInDatabase('Patient', patient3.id)).toBe(false);
+    expect(await existsInDatabase('Patient_History', patient3.id)).toBe(false);
 
     expect(await existsInDatabase('Observation', obs.id)).toBe(false);
     expect(await existsInDatabase('Observation_History', obs.id)).toBe(false);
+
+    expect(await existsInCache('Project', project.id)).toBe(false);
+    expect(await existsInCache('ClientApplication', client.id)).toBe(false);
+    expect(await existsInCache('ProjectMembership', membership.id)).toBe(false);
+    expect(await existsInCache('Patient', patient.id)).toBe(false);
+    expect(await existsInCache('Patient', patient2.id)).toBe(false);
+    expect(await existsInCache('Patient', patient3.id)).toBe(false);
+    expect(await existsInCache('Observation', obs.id)).toBe(false);
   });
 });
+
+async function existsInCache(resourceType: string, id: string | undefined): Promise<boolean> {
+  const redis = await getRedis().get(`${resourceType}/${id}`);
+  return !!redis;
+}
 
 async function existsInDatabase(tableName: string, id: string | undefined): Promise<boolean> {
   const rows = await new SelectQuery(tableName).column('id').where('id', SqlOperator.EQUALS, id).execute(getClient());

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -655,6 +655,7 @@ describe('FHIR Repo', () => {
       ],
       count: 100,
     });
+    console.log(bundle);
 
     expect(bundle?.entry?.find((e) => (e.resource as SearchParameter).code === 'name')).toBeDefined();
     expect(bundle?.entry?.find((e) => (e.resource as SearchParameter).code === 'email')).toBeDefined();
@@ -2484,6 +2485,46 @@ describe('FHIR Repo', () => {
     expect(bundle2.entry?.length).toEqual(1);
     expect(bundleContains(bundle2, task1)).toBeTruthy();
     expect(bundleContains(bundle2, task2)).not.toBeTruthy();
+  });
+
+  test('expungeResource forbidden', async () => {
+    const author = 'Practitioner/' + randomUUID();
+
+    const repo = new Repository({
+      project: randomUUID(),
+      extendedMode: true,
+      author: {
+        reference: author,
+      },
+    });
+
+    // Try to expunge as a regular user
+    try {
+      await repo.expungeResource('Patient', new Date().toISOString());
+      fail('Purge should have failed');
+    } catch (err) {
+      expect((err as OperationOutcomeError).outcome).toMatchObject(forbidden);
+    }
+  });
+
+  test('expungeResources forbidden', async () => {
+    const author = 'Practitioner/' + randomUUID();
+
+    const repo = new Repository({
+      project: randomUUID(),
+      extendedMode: true,
+      author: {
+        reference: author,
+      },
+    });
+
+    // Try to expunge as a regular user
+    try {
+      await repo.expungeResources('Patient', [new Date().toISOString()]);
+      fail('Purge should have failed');
+    } catch (err) {
+      expect((err as OperationOutcomeError).outcome).toMatchObject(forbidden);
+    }
   });
 
   test('Purge forbidden', async () => {


### PR DESCRIPTION
- have delete operation be asynchronous
- "crawl" through all resources by resource type without arbitrary limit
- batch sql calls using IN operator of resource ids
- batch delete cachekeys