### PR TITLE
Fixes #1761  Super admin tool to remove bullmq jobs and repeatable jobs 

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -99,6 +99,20 @@ describe('SuperAdminPage', () => {
     expect(screen.getByText('Done')).toBeInTheDocument();
   });
 
+  test('Remove Bot ID Jobs from Queue', async () => {
+    setup();
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('Bot Id'), { target: { value: 'BotId' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Remove Jobs by Bot ID' }));
+    });
+
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
   test('Force set password', async () => {
     setup();
 

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -42,6 +42,13 @@ export function SuperAdminPage(): JSX.Element {
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err) }));
   }
 
+  function removeBotIdJobsFromQueue(formData: Record<string, string>): void {
+    medplum
+      .post('admin/super/removebotidjobsfromqueue', formData)
+      .then(() => showNotification({ color: 'green', message: 'Done' }))
+      .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err) }));
+  }
+
   function purgeResources(formData: Record<string, string>): void {
     medplum
       .post('admin/super/purge', { ...formData, before: convertLocalToIso(formData.before) })
@@ -128,6 +135,17 @@ export function SuperAdminPage(): JSX.Element {
             <DateTimeInput name="before" placeholder="Before Date" />
           </FormSection>
           <Button type="submit">Purge</Button>
+        </Stack>
+      </Form>
+      <Divider my="lg" />
+      <Title order={2}>Remove Bot ID Jobs from Queue</Title>
+      <p>Remove all queued jobs for a Bot ID</p>
+      <Form onSubmit={removeBotIdJobsFromQueue}>
+        <Stack>
+          <FormSection title="Bot ID">
+            <TextInput name="botId" placeholder="Bot Id" />
+          </FormSection>
+          <Button type="submit">Remove Jobs by Bot ID</Button>
         </Stack>
       </Form>
       <Divider my="lg" />

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -340,4 +340,40 @@ describe('Super Admin routes', () => {
 
     expect(res.status).toBe(200);
   });
+
+  test('Remove Bot Id from Jobs Queue access denied', async () => {
+    const res = await request(app)
+      .post('/admin/super/removebotidjobsfromqueue')
+      .set('Authorization', 'Bearer ' + nonAdminAccessToken)
+      .type('json')
+      .send({
+        botId: 'testBotId',
+      });
+
+    expect(res.status).toBe(403);
+  });
+
+  test('Remove Bot Id from Jobs Queue success', async () => {
+    const res = await request(app)
+      .post('/admin/super/removebotidjobsfromqueue')
+      .set('Authorization', 'Bearer ' + adminAccessToken)
+      .type('json')
+      .send({
+        botId: 'TestBotId',
+      });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('Remove Bot Id from Jobs Queue missing bot id', async () => {
+    const res = await request(app)
+      .post('/admin/super/removebotidjobsfromqueue')
+      .set('Authorization', 'Bearer ' + adminAccessToken)
+      .type('json')
+      .send({
+        botId: '',
+      });
+
+    expect(res.status).toBe(400);
+  });
 });

--- a/packages/server/src/workers/cron.test.ts
+++ b/packages/server/src/workers/cron.test.ts
@@ -135,6 +135,7 @@ describe('Cron Worker', () => {
     queue.getRepeatableJobs.mockImplementation(() => [
       {
         key: `CronJobData:${bot.id}:::* * * * *`,
+        id: bot.id,
       },
     ]);
     await botRepo.updateResource({

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -228,6 +228,7 @@ export async function execBot(job: Job<CronJobData>): Promise<void> {
 export async function removeBullMQJobByKey(botId: string): Promise<void> {
   const previousJobs = (await queue?.getRepeatableJobs())?.filter((p) => p.id === botId) ?? [];
 
+  // There likely should not be more than one repeatable job per bot id.
   for (const p of previousJobs) {
     await queue?.removeRepeatableByKey(p.key);
     logger.debug(`Found a previous job for bot ${botId}, updating...`);

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -225,13 +225,11 @@ export async function execBot(job: Job<CronJobData>): Promise<void> {
   await createAuditEvent(bot, startTime, outcome, logResult);
 }
 
-async function removeBullMQJobByKey(botId: string): Promise<void> {
-  const previousJobs = await queue?.getRepeatableJobs();
-  previousJobs?.map(async (p) => {
-    if (p.key.includes(botId)) {
-      const keyToRemove = p.key;
-      await queue?.removeRepeatableByKey(keyToRemove);
-      logger.debug(`Found a previous job for bot ${botId}, updating...`);
-    }
-  });
+export async function removeBullMQJobByKey(botId: string): Promise<void> {
+  const previousJobs = (await queue?.getRepeatableJobs())?.filter((p) => p.id === botId) ?? [];
+
+  for (const p of previousJobs) {
+    await queue?.removeRepeatableByKey(p.key);
+    logger.debug(`Found a previous job for bot ${botId}, updating...`);
+  }
 }


### PR DESCRIPTION
add endpoint removebotidjobsfromqueue
add remove Job ID from queue to super admin page
update removeBullMQJobByKey to filter for jobs p.id matching the bot id instead of partial matching p.key

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6cc6a6a</samp>

### Summary
🧪🤖🗑️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of a test case for a new feature.
2.  🤖 - This emoji represents robots, automation, or artificial intelligence, and can be used to indicate the addition of a feature related to bot id jobs or cron jobs.
3.  🗑️ - This emoji represents trash, garbage, or deletion, and can be used to indicate the removal of jobs from the queue or the cron schedule.
-->
This pull request adds a new feature for super admins to remove cron jobs by bot id from the queue. It implements a new API endpoint, a new UI component, and some tests for both. It also refactors the `removeBullMQJobByKey` function to use the `id` property of the bot object and to avoid race conditions.

> _Super admins can now clear the queue_
> _Of jobs that belong to a bot id_
> _They use `removeBullMQJobByKey`_
> _And a form with a button and input_
> _To delete cron jobs with a success id_

### Walkthrough
*  Add a new feature to remove bot id jobs from the queue ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-e9fb492809a57eb817e3eb5d9910df8223e6dd212b6f10930b4c09ba1ad82064R141-R151), [link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-cb04462fdffdc85a5b88a42ae35750a7596f503b5aec6f59495352d10a59c307R173-R195), [link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-2d51264bfa2bbbde1add9123c15880bfd4b95b624d2add2c7e2ce87d79ec25edL228-R234))
  * Create a new section in the `SuperAdminPage` component to render a form for entering the bot id and a button for submitting the request ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-e9fb492809a57eb817e3eb5d9910df8223e6dd212b6f10930b4c09ba1ad82064R141-R151))
  * Define a new API endpoint in the `super.ts` module to handle the request and validate the bot id and the super admin permission ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-cb04462fdffdc85a5b88a42ae35750a7596f503b5aec6f59495352d10a59c307R173-R195))
  * Modify the `removeBullMQJobByKey` function in the `cron.ts` module to use the id property instead of the key property to filter the jobs and to use a for loop to await the removal of each job ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-2d51264bfa2bbbde1add9123c15880bfd4b95b624d2add2c7e2ce87d79ec25edL228-R234))
* Add a function to handle the form submission and call the API endpoint and show a notification based on the response ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-e9fb492809a57eb817e3eb5d9910df8223e6dd212b6f10930b4c09ba1ad82064R45-R51))
* Add a test case for the new feature in the `SuperAdminPage.test.tsx` module ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-0a4ff3994d84b1699a01b19275b052f3816dffd98d534ed5f7ddb0ca79ad51b3R102-R115))
* Add the id property to the bot object in the test data in the `cron.test.ts` module ([link](https://github.com/medplum/medplum/pull/1814/files?diff=unified&w=0#diff-99c8f6f5930b08b0e6c7ca9a0aae07f2b68cfdbc13f11a156ef060bdbc7a4d58R138))

