### PR TITLE
Changed JS hash private fields to TS private

### DIFF
--- a/packages/cli/src/storage.ts
+++ b/packages/cli/src/storage.ts
@@ -4,44 +4,44 @@ import { homedir } from 'os';
 import { resolve } from 'path';
 
 export class FileSystemStorage extends ClientStorage {
-  readonly #dirName: string;
-  readonly #fileName: string;
+  private readonly dirName: string;
+  private readonly fileName: string;
 
   constructor() {
     super();
-    this.#dirName = resolve(homedir(), '.medplum');
-    this.#fileName = resolve(this.#dirName, 'credentials');
+    this.dirName = resolve(homedir(), '.medplum');
+    this.fileName = resolve(this.dirName, 'credentials');
   }
 
   clear(): void {
-    this.#writeFile({});
+    this.writeFile({});
   }
 
   getString(key: string): string | undefined {
-    return this.#readFile()?.[key];
+    return this.readFile()?.[key];
   }
 
   setString(key: string, value: string | undefined): void {
-    const data = this.#readFile() || {};
+    const data = this.readFile() || {};
     if (value) {
       data[key] = value;
     } else {
       delete data[key];
     }
-    this.#writeFile(data);
+    this.writeFile(data);
   }
 
-  #readFile(): Record<string, string> | undefined {
-    if (existsSync(this.#fileName)) {
-      return JSON.parse(readFileSync(this.#fileName, 'utf8'));
+  private readFile(): Record<string, string> | undefined {
+    if (existsSync(this.fileName)) {
+      return JSON.parse(readFileSync(this.fileName, 'utf8'));
     }
     return undefined;
   }
 
-  #writeFile(data: Record<string, string>): void {
-    if (!existsSync(this.#dirName)) {
-      mkdirSync(this.#dirName);
+  private writeFile(data: Record<string, string>): void {
+    if (!existsSync(this.dirName)) {
+      mkdirSync(this.dirName);
     }
-    writeFileSync(this.#fileName, JSON.stringify(data, null, 2), 'utf8');
+    writeFileSync(this.fileName, JSON.stringify(data, null, 2), 'utf8');
   }
 }

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -3,19 +3,19 @@
  * Source: https://stackoverflow.com/a/46432113
  */
 export class LRUCache<T> {
-  readonly #max: number;
-  readonly #cache: Map<string, T>;
+  private readonly max: number;
+  private readonly cache: Map<string, T>;
 
   constructor(max = 10) {
-    this.#max = max;
-    this.#cache = new Map();
+    this.max = max;
+    this.cache = new Map();
   }
 
   /**
    * Deletes all values from the cache.
    */
   clear(): void {
-    this.#cache.clear();
+    this.cache.clear();
   }
 
   /**
@@ -24,10 +24,10 @@ export class LRUCache<T> {
    * @returns The value if found; undefined otherwise.
    */
   get(key: string): T | undefined {
-    const item = this.#cache.get(key);
+    const item = this.cache.get(key);
     if (item) {
-      this.#cache.delete(key);
-      this.#cache.set(key, item);
+      this.cache.delete(key);
+      this.cache.set(key, item);
     }
     return item;
   }
@@ -38,12 +38,12 @@ export class LRUCache<T> {
    * @param val The value to set.
    */
   set(key: string, val: T): void {
-    if (this.#cache.has(key)) {
-      this.#cache.delete(key);
-    } else if (this.#cache.size >= this.#max) {
-      this.#cache.delete(this.#first());
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.max) {
+      this.cache.delete(this.first());
     }
-    this.#cache.set(key, val);
+    this.cache.set(key, val);
   }
 
   /**
@@ -51,7 +51,7 @@ export class LRUCache<T> {
    * @param key The key to delete.
    */
   delete(key: string): void {
-    this.#cache.delete(key);
+    this.cache.delete(key);
   }
 
   /**
@@ -59,11 +59,11 @@ export class LRUCache<T> {
    * @returns The array of keys in the cache.
    */
   keys(): IterableIterator<string> {
-    return this.#cache.keys();
+    return this.cache.keys();
   }
 
-  #first(): string {
+  private first(): string {
     // This works because the Map class maintains ordered keys.
-    return this.#cache.keys().next().value;
+    return this.cache.keys().next().value;
   }
 }

--- a/packages/core/src/eventtarget.ts
+++ b/packages/core/src/eventtarget.ts
@@ -10,21 +10,21 @@ interface Event {
 type EventListener = (e: Event) => void;
 
 export class EventTarget {
-  readonly #listeners: Record<string, EventListener[]>;
+  private readonly listeners: Record<string, EventListener[]>;
 
   constructor() {
-    this.#listeners = {};
+    this.listeners = {};
   }
 
   addEventListener(type: string, callback: EventListener): void {
-    if (!this.#listeners[type]) {
-      this.#listeners[type] = [];
+    if (!this.listeners[type]) {
+      this.listeners[type] = [];
     }
-    this.#listeners[type].push(callback);
+    this.listeners[type].push(callback);
   }
 
   removeEventListeneer(type: string, callback: EventListener): void {
-    const array = this.#listeners[type];
+    const array = this.listeners[type];
     if (!array) {
       return;
     }
@@ -37,7 +37,7 @@ export class EventTarget {
   }
 
   dispatchEvent(event: Event): boolean {
-    const array = this.#listeners[event.type];
+    const array = this.listeners[event.type];
     if (array) {
       array.forEach((listener) => listener.call(this, event));
     }

--- a/packages/core/src/fhirlexer/parse.ts
+++ b/packages/core/src/fhirlexer/parse.ts
@@ -35,16 +35,16 @@ export interface InfixParselet {
 }
 
 export class ParserBuilder {
-  readonly #prefixParselets: Record<string, PrefixParselet> = {};
-  readonly #infixParselets: Record<string, InfixParselet> = {};
+  private readonly prefixParselets: Record<string, PrefixParselet> = {};
+  private readonly infixParselets: Record<string, InfixParselet> = {};
 
   public registerInfix(tokenType: string, parselet: InfixParselet): ParserBuilder {
-    this.#infixParselets[tokenType] = parselet;
+    this.infixParselets[tokenType] = parselet;
     return this;
   }
 
   public registerPrefix(tokenType: string, parselet: PrefixParselet): ParserBuilder {
-    this.#prefixParselets[tokenType] = parselet;
+    this.prefixParselets[tokenType] = parselet;
     return this;
   }
 
@@ -72,27 +72,27 @@ export class ParserBuilder {
   }
 
   public construct(input: Token[]): Parser {
-    return new Parser(input, this.#prefixParselets, this.#infixParselets);
+    return new Parser(input, this.prefixParselets, this.infixParselets);
   }
 }
 
 export class Parser {
-  #tokens: Token[];
-  #prefixParselets: Record<string, PrefixParselet>;
-  #infixParselets: Record<string, InfixParselet>;
+  private tokens: Token[];
+  private prefixParselets: Record<string, PrefixParselet>;
+  private infixParselets: Record<string, InfixParselet>;
 
   constructor(
     tokens: Token[],
     prefixParselets: Record<string, PrefixParselet>,
     infixParselets: Record<string, InfixParselet>
   ) {
-    this.#tokens = tokens;
-    this.#prefixParselets = prefixParselets;
-    this.#infixParselets = infixParselets;
+    this.tokens = tokens;
+    this.prefixParselets = prefixParselets;
+    this.infixParselets = infixParselets;
   }
 
   hasMore(): boolean {
-    return this.#tokens.length > 0;
+    return this.tokens.length > 0;
   }
 
   match(expected: string): boolean {
@@ -107,7 +107,7 @@ export class Parser {
 
   consumeAndParse(precedence = Infinity): Atom {
     const token = this.consume();
-    const prefix = this.#prefixParselets[token.id];
+    const prefix = this.prefixParselets[token.id];
     if (!prefix) {
       throw Error(
         `Parse error at "${token.value}" (line ${token.line}, column ${token.column}). No matching prefix parselet.`
@@ -138,7 +138,7 @@ export class Parser {
   }
 
   consume(expectedId?: string, expectedValue?: string): Token {
-    if (!this.#tokens.length) {
+    if (!this.tokens.length) {
       throw Error('Cant consume unknown more tokens.');
     }
     if (expectedId && this.peek()?.id !== expectedId) {
@@ -151,18 +151,18 @@ export class Parser {
         `Expected "${expectedValue}" but got "${actual.value}" at line ${actual.line} column ${actual.column}.`
       );
     }
-    return this.#tokens.shift() as Token;
+    return this.tokens.shift() as Token;
   }
 
   peek(): Token | undefined {
-    return this.#tokens.length > 0 ? this.#tokens[0] : undefined;
+    return this.tokens.length > 0 ? this.tokens[0] : undefined;
   }
 
   removeComments(): void {
-    this.#tokens = this.#tokens.filter((t) => t.id !== 'Comment');
+    this.tokens = this.tokens.filter((t) => t.id !== 'Comment');
   }
 
   getInfixParselet(token: Token): InfixParselet | undefined {
-    return this.#infixParselets[token.id === 'Symbol' ? token.value : token.id];
+    return this.infixParselets[token.id === 'Symbol' ? token.value : token.id];
   }
 }

--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -34,254 +34,254 @@ export interface TokenizerOptions {
 }
 
 export class Tokenizer {
-  readonly #str: string;
-  readonly #keywords: string[];
-  readonly #operators: string[];
-  readonly #dateTimeLiterals: boolean;
-  readonly #symbolRegex: RegExp;
-  readonly #result: Token[] = [];
-  readonly #pos: Marker = { index: 0, line: 1, column: 0 };
-  readonly #markStack: Marker[] = [];
+  private readonly str: string;
+  private readonly keywords: string[];
+  private readonly operators: string[];
+  private readonly dateTimeLiterals: boolean;
+  private readonly symbolRegex: RegExp;
+  private readonly result: Token[] = [];
+  private readonly pos: Marker = { index: 0, line: 1, column: 0 };
+  private readonly markStack: Marker[] = [];
 
   constructor(str: string, keywords: string[], operators: string[], options?: TokenizerOptions) {
-    this.#str = str;
-    this.#keywords = keywords;
-    this.#operators = operators;
-    this.#dateTimeLiterals = !!options?.dateTimeLiterals;
-    this.#symbolRegex = options?.symbolRegex ?? /[$\w]/;
+    this.str = str;
+    this.keywords = keywords;
+    this.operators = operators;
+    this.dateTimeLiterals = !!options?.dateTimeLiterals;
+    this.symbolRegex = options?.symbolRegex ?? /[$\w]/;
   }
 
   tokenize(): Token[] {
-    while (this.#pos.index < this.#str.length) {
-      const token = this.#consumeToken();
+    while (this.pos.index < this.str.length) {
+      const token = this.consumeToken();
       if (token) {
-        this.#result.push(token);
+        this.result.push(token);
       }
     }
 
-    return this.#result;
+    return this.result;
   }
 
-  #prevToken(): Token | undefined {
-    return this.#result.slice(-1)[0];
+  private prevToken(): Token | undefined {
+    return this.result.slice(-1)[0];
   }
 
-  #peekToken(): Token | undefined {
-    this.#mark();
-    const token = this.#consumeToken();
-    this.#reset();
+  private peekToken(): Token | undefined {
+    this.mark();
+    const token = this.consumeToken();
+    this.reset();
     return token;
   }
 
-  #consumeToken(): Token | undefined {
-    this.#consumeWhitespace();
+  private consumeToken(): Token | undefined {
+    this.consumeWhitespace();
 
-    const c = this.#curr();
+    const c = this.curr();
     if (!c) {
       return undefined;
     }
 
-    this.#mark();
+    this.mark();
 
-    const next = this.#peek();
+    const next = this.peek();
 
     if (c === '/' && next === '*') {
-      return this.#consumeMultiLineComment();
+      return this.consumeMultiLineComment();
     }
 
     if (c === '/' && next === '/') {
-      return this.#consumeSingleLineComment();
+      return this.consumeSingleLineComment();
     }
 
     if (c === "'" || c === '"') {
-      return this.#consumeString(c);
+      return this.consumeString(c);
     }
 
     if (c === '`') {
-      return this.#consumeBacktickSymbol();
+      return this.consumeBacktickSymbol();
     }
 
     if (c === '@') {
-      return this.#consumeDateTime();
+      return this.consumeDateTime();
     }
 
     if (c.match(/\d/)) {
-      return this.#consumeNumber();
+      return this.consumeNumber();
     }
 
     if (c.match(/\w/)) {
-      return this.#consumeSymbol();
+      return this.consumeSymbol();
     }
 
     if (c === '$' && next.match(/\w/)) {
-      return this.#consumeSymbol();
+      return this.consumeSymbol();
     }
 
-    return this.#consumeOperator();
+    return this.consumeOperator();
   }
 
-  #consumeWhitespace(): void {
-    this.#consumeWhile(() => this.#curr().match(/\s/));
+  private consumeWhitespace(): void {
+    this.consumeWhile(() => this.curr().match(/\s/));
   }
 
-  #consumeMultiLineComment(): Token {
-    const start = this.#pos.index;
-    this.#consumeWhile(() => this.#curr() !== '*' || this.#peek() !== '/');
-    this.#advance();
-    this.#advance();
-    return this.#buildToken('Comment', this.#str.substring(start, this.#pos.index));
+  private consumeMultiLineComment(): Token {
+    const start = this.pos.index;
+    this.consumeWhile(() => this.curr() !== '*' || this.peek() !== '/');
+    this.advance();
+    this.advance();
+    return this.buildToken('Comment', this.str.substring(start, this.pos.index));
   }
 
-  #consumeSingleLineComment(): Token {
-    return this.#buildToken(
+  private consumeSingleLineComment(): Token {
+    return this.buildToken(
       'Comment',
-      this.#consumeWhile(() => this.#curr() !== '\n')
+      this.consumeWhile(() => this.curr() !== '\n')
     );
   }
 
-  #consumeString(endChar: string): Token {
-    this.#advance();
-    const result = this.#buildToken(
+  private consumeString(endChar: string): Token {
+    this.advance();
+    const result = this.buildToken(
       'String',
-      this.#consumeWhile(() => this.#prev() === '\\' || this.#curr() !== endChar)
+      this.consumeWhile(() => this.prev() === '\\' || this.curr() !== endChar)
     );
-    this.#advance();
+    this.advance();
     return result;
   }
 
-  #consumeBacktickSymbol(): Token {
-    this.#advance();
-    const result = this.#buildToken(
+  private consumeBacktickSymbol(): Token {
+    this.advance();
+    const result = this.buildToken(
       'Symbol',
-      this.#consumeWhile(() => this.#curr() !== '`')
+      this.consumeWhile(() => this.curr() !== '`')
     );
-    this.#advance();
+    this.advance();
     return result;
   }
 
-  #consumeDateTime(): Token {
-    this.#advance(); // Consume "@"
+  private consumeDateTime(): Token {
+    this.advance(); // Consume "@"
 
-    const start = this.#pos.index;
-    this.#consumeWhile(() => this.#curr().match(/[\d-]/));
+    const start = this.pos.index;
+    this.consumeWhile(() => this.curr().match(/[\d-]/));
 
-    if (this.#curr() === 'T') {
-      this.#advance();
-      this.#consumeWhile(() => this.#curr().match(/[\d:]/));
+    if (this.curr() === 'T') {
+      this.advance();
+      this.consumeWhile(() => this.curr().match(/[\d:]/));
 
-      if (this.#curr() === '.' && this.#peek().match(/\d/)) {
-        this.#advance();
-        this.#consumeWhile(() => this.#curr().match(/\d/));
+      if (this.curr() === '.' && this.peek().match(/\d/)) {
+        this.advance();
+        this.consumeWhile(() => this.curr().match(/\d/));
       }
 
-      if (this.#curr() === 'Z') {
-        this.#advance();
-      } else if (this.#curr() === '+' || this.#curr() === '-') {
-        this.#advance();
-        this.#consumeWhile(() => this.#curr().match(/[\d:]/));
+      if (this.curr() === 'Z') {
+        this.advance();
+      } else if (this.curr() === '+' || this.curr() === '-') {
+        this.advance();
+        this.consumeWhile(() => this.curr().match(/[\d:]/));
       }
     }
 
-    return this.#buildToken('DateTime', this.#str.substring(start, this.#pos.index));
+    return this.buildToken('DateTime', this.str.substring(start, this.pos.index));
   }
 
-  #consumeNumber(): Token {
-    const start = this.#pos.index;
+  private consumeNumber(): Token {
+    const start = this.pos.index;
     let id = 'Number';
-    this.#consumeWhile(() => this.#curr().match(/\d/));
+    this.consumeWhile(() => this.curr().match(/\d/));
 
-    if (this.#curr() === '.' && this.#peek().match(/\d/)) {
-      this.#advance();
-      this.#consumeWhile(() => this.#curr().match(/\d/));
+    if (this.curr() === '.' && this.peek().match(/\d/)) {
+      this.advance();
+      this.consumeWhile(() => this.curr().match(/\d/));
     }
 
-    if (this.#curr() === '-' && this.#dateTimeLiterals) {
+    if (this.curr() === '-' && this.dateTimeLiterals) {
       // Rewind to one character before the start, and then treat as dateTime literal.
-      this.#pos.index = start - 1;
-      return this.#consumeDateTime();
+      this.pos.index = start - 1;
+      return this.consumeDateTime();
     }
 
-    if (this.#curr() === ' ') {
-      if (isUnitToken(this.#peekToken())) {
+    if (this.curr() === ' ') {
+      if (isUnitToken(this.peekToken())) {
         id = 'Quantity';
-        this.#consumeToken();
+        this.consumeToken();
       }
     }
 
-    return this.#buildToken(id, this.#str.substring(start, this.#pos.index));
+    return this.buildToken(id, this.str.substring(start, this.pos.index));
   }
 
-  #consumeSymbol(): Token {
-    const value = this.#consumeWhile(() => this.#curr().match(this.#symbolRegex));
-    if (this.#prevToken()?.value !== '.' && this.#keywords.includes(value)) {
-      return this.#buildToken(value, value);
+  private consumeSymbol(): Token {
+    const value = this.consumeWhile(() => this.curr().match(this.symbolRegex));
+    if (this.prevToken()?.value !== '.' && this.keywords.includes(value)) {
+      return this.buildToken(value, value);
     }
-    return this.#buildToken('Symbol', value);
+    return this.buildToken('Symbol', value);
   }
 
-  #consumeOperator(): Token {
-    const c = this.#curr();
-    const next = this.#peek();
+  private consumeOperator(): Token {
+    const c = this.curr();
+    const next = this.peek();
     const twoCharOp = c + next;
 
-    if (this.#operators.includes(twoCharOp)) {
-      this.#advance();
-      this.#advance();
-      return this.#buildToken(twoCharOp, twoCharOp);
+    if (this.operators.includes(twoCharOp)) {
+      this.advance();
+      this.advance();
+      return this.buildToken(twoCharOp, twoCharOp);
     }
 
-    this.#advance();
-    return this.#buildToken(c, c);
+    this.advance();
+    return this.buildToken(c, c);
   }
 
-  #consumeWhile(condition: () => unknown): string {
-    const start = this.#pos.index;
+  private consumeWhile(condition: () => unknown): string {
+    const start = this.pos.index;
 
-    while (this.#pos.index < this.#str.length && condition()) {
-      this.#advance();
+    while (this.pos.index < this.str.length && condition()) {
+      this.advance();
     }
 
-    return this.#str.substring(start, this.#pos.index);
+    return this.str.substring(start, this.pos.index);
   }
 
-  #curr(): string {
-    return this.#str[this.#pos.index];
+  private curr(): string {
+    return this.str[this.pos.index];
   }
 
-  #prev(): string {
-    return this.#str[this.#pos.index - 1] ?? '';
+  private prev(): string {
+    return this.str[this.pos.index - 1] ?? '';
   }
 
-  #peek(): string {
-    return this.#str[this.#pos.index + 1] ?? '';
+  private peek(): string {
+    return this.str[this.pos.index + 1] ?? '';
   }
 
-  #mark(): void {
-    this.#markStack.push({ ...this.#pos });
+  private mark(): void {
+    this.markStack.push({ ...this.pos });
   }
 
-  #reset(): void {
-    const mark = this.#markStack.pop();
+  private reset(): void {
+    const mark = this.markStack.pop();
     if (!mark) {
       throw new Error('No mark to reset to');
     }
-    this.#pos.index = mark.index;
-    this.#pos.line = mark.line;
-    this.#pos.column = mark.column;
+    this.pos.index = mark.index;
+    this.pos.line = mark.line;
+    this.pos.column = mark.column;
   }
 
-  #advance(): void {
-    this.#pos.index++;
-    if (this.#curr() === '\n') {
-      this.#pos.line++;
-      this.#pos.column = 0;
+  private advance(): void {
+    this.pos.index++;
+    if (this.curr() === '\n') {
+      this.pos.line++;
+      this.pos.column = 0;
     } else {
-      this.#pos.column++;
+      this.pos.column++;
     }
   }
 
-  #buildToken(id: string, value: string): Token {
-    const mark = this.#markStack.pop();
+  private buildToken(id: string, value: string): Token {
+    const mark = this.markStack.pop();
     if (!mark) {
       throw new Error('No mark for token');
     }

--- a/packages/core/src/readablepromise.ts
+++ b/packages/core/src/readablepromise.ts
@@ -5,21 +5,21 @@
  */
 export class ReadablePromise<T> implements Promise<T> {
   readonly [Symbol.toStringTag]: string = 'ReadablePromise';
-  #suspender: Promise<T>;
-  #status: 'pending' | 'error' | 'success' = 'pending';
-  #response: T | undefined;
-  #error: Error | undefined;
+  private suspender: Promise<T>;
+  private status: 'pending' | 'error' | 'success' = 'pending';
+  private response: T | undefined;
+  private error: Error | undefined;
 
   constructor(requestPromise: Promise<T>) {
-    this.#suspender = requestPromise.then(
+    this.suspender = requestPromise.then(
       (res: T) => {
-        this.#status = 'success';
-        this.#response = res;
+        this.status = 'success';
+        this.response = res;
         return res;
       },
       (err: any) => {
-        this.#status = 'error';
-        this.#error = err;
+        this.status = 'error';
+        this.error = err;
         throw err;
       }
     );
@@ -30,7 +30,7 @@ export class ReadablePromise<T> implements Promise<T> {
    * @returns True if the Promise is pending.
    */
   isPending(): boolean {
-    return this.#status === 'pending';
+    return this.status === 'pending';
   }
 
   /**
@@ -38,7 +38,7 @@ export class ReadablePromise<T> implements Promise<T> {
    * @returns True if the Promise resolved successfully.
    */
   isOk(): boolean {
-    return this.#status === 'success';
+    return this.status === 'success';
   }
 
   /**
@@ -49,13 +49,13 @@ export class ReadablePromise<T> implements Promise<T> {
    * @returns The resolved value of the Promise.
    */
   read(): T {
-    switch (this.#status) {
+    switch (this.status) {
       case 'pending':
-        throw this.#suspender;
+        throw this.suspender;
       case 'error':
-        throw this.#error;
+        throw this.error;
       default:
-        return this.#response as T;
+        return this.response as T;
     }
   }
 
@@ -69,7 +69,7 @@ export class ReadablePromise<T> implements Promise<T> {
     onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
   ): Promise<TResult1 | TResult2> {
-    return this.#suspender.then(onfulfilled, onrejected);
+    return this.suspender.then(onfulfilled, onrejected);
   }
 
   /**
@@ -80,7 +80,7 @@ export class ReadablePromise<T> implements Promise<T> {
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null
   ): Promise<T | TResult> {
-    return this.#suspender.catch(onrejected);
+    return this.suspender.catch(onrejected);
   }
 
   /**
@@ -90,6 +90,6 @@ export class ReadablePromise<T> implements Promise<T> {
    * @returns A Promise for the completion of the callback.
    */
   finally(onfinally?: (() => void) | undefined | null): Promise<T> {
-    return this.#suspender.finally(onfinally);
+    return this.suspender.finally(onfinally);
   }
 }

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -8,25 +8,25 @@ import { stringify } from './utils';
  * When Using MedplumClient in the server, it will be backed by the MemoryStorage class.
  */
 export class ClientStorage {
-  readonly #storage: Storage;
+  private readonly storage: Storage;
 
   constructor() {
-    this.#storage = typeof localStorage !== 'undefined' ? localStorage : new MemoryStorage();
+    this.storage = typeof localStorage !== 'undefined' ? localStorage : new MemoryStorage();
   }
 
   clear(): void {
-    this.#storage.clear();
+    this.storage.clear();
   }
 
   getString(key: string): string | undefined {
-    return this.#storage.getItem(key) || undefined;
+    return this.storage.getItem(key) || undefined;
   }
 
   setString(key: string, value: string | undefined): void {
     if (value) {
-      this.#storage.setItem(key, value);
+      this.storage.setItem(key, value);
     } else {
-      this.#storage.removeItem(key);
+      this.storage.removeItem(key);
     }
   }
 
@@ -44,31 +44,31 @@ export class ClientStorage {
  * The MemoryStorage class is a minimal in-memory implementation of the Storage interface.
  */
 export class MemoryStorage implements Storage {
-  #data: Map<string, string>;
+  private data: Map<string, string>;
 
   constructor() {
-    this.#data = new Map<string, string>();
+    this.data = new Map<string, string>();
   }
 
   /**
    * Returns the number of key/value pairs.
    */
   get length(): number {
-    return this.#data.size;
+    return this.data.size;
   }
 
   /**
    * Removes all key/value pairs, if there are any.
    */
   clear(): void {
-    this.#data.clear();
+    this.data.clear();
   }
 
   /**
    * Returns the current value associated with the given key, or null if the given key does not exist.
    */
   getItem(key: string): string | null {
-    return this.#data.get(key) ?? null;
+    return this.data.get(key) ?? null;
   }
 
   /**
@@ -76,9 +76,9 @@ export class MemoryStorage implements Storage {
    */
   setItem(key: string, value: string | null): void {
     if (value) {
-      this.#data.set(key, value);
+      this.data.set(key, value);
     } else {
-      this.#data.delete(key);
+      this.data.delete(key);
     }
   }
 
@@ -86,13 +86,13 @@ export class MemoryStorage implements Storage {
    * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
    */
   removeItem(key: string): void {
-    this.#data.delete(key);
+    this.data.delete(key);
   }
 
   /**
    * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
    */
   key(index: number): string | null {
-    return Array.from(this.#data.keys())[index];
+    return Array.from(this.data.keys())[index];
   }
 }

--- a/packages/generator/src/filebuilder.ts
+++ b/packages/generator/src/filebuilder.ts
@@ -1,13 +1,13 @@
 const DEFAULT_INDENT = ' '.repeat(2);
 
 export class FileBuilder {
-  readonly #indent: string;
-  readonly #b: string[];
+  private readonly indent: string;
+  private readonly b: string[];
   indentCount: number;
 
   constructor(indent = DEFAULT_INDENT, header = true) {
-    this.#indent = indent;
-    this.#b = [];
+    this.indent = indent;
+    this.b = [];
     this.indentCount = 0;
 
     if (header) {
@@ -20,37 +20,37 @@ export class FileBuilder {
   }
 
   newLine(): void {
-    this.#b.push('\n');
+    this.b.push('\n');
   }
 
   appendNoWrap(line: string): void {
-    this.#b.push(this.#indent.repeat(this.indentCount));
-    this.#b.push(line);
-    this.#b.push('\n');
+    this.b.push(this.indent.repeat(this.indentCount));
+    this.b.push(line);
+    this.b.push('\n');
   }
 
   append(line: string): void {
-    const nowrap = this.#indent.repeat(this.indentCount) + line;
+    const nowrap = this.indent.repeat(this.indentCount) + line;
     if (nowrap.length < 160) {
-      this.#b.push(nowrap);
-      this.#b.push('\n');
+      this.b.push(nowrap);
+      this.b.push('\n');
     } else {
       let first = true;
-      for (const wrappedLine of wordWrap(nowrap, 120 - this.#indent.length * this.indentCount)) {
+      for (const wrappedLine of wordWrap(nowrap, 120 - this.indent.length * this.indentCount)) {
         if (first) {
-          this.#b.push(this.#indent.repeat(this.indentCount));
+          this.b.push(this.indent.repeat(this.indentCount));
         } else {
-          this.#b.push(this.#indent.repeat(this.indentCount + 2));
+          this.b.push(this.indent.repeat(this.indentCount + 2));
         }
-        this.#b.push(wrappedLine.trim());
-        this.#b.push('\n');
+        this.b.push(wrappedLine.trim());
+        this.b.push('\n');
         first = false;
       }
     }
   }
 
   toString(): string {
-    return this.#b.join('').replaceAll('\n\n\n', '\n\n');
+    return this.b.join('').replaceAll('\n\n\n', '\n\n');
   }
 }
 

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -10,7 +10,7 @@ import { compareArrays } from './util';
  * Each Address is represented as a separate row in the "Address" table.
  */
 export class AddressTable extends LookupTable<Address> {
-  static readonly #knownParams: Set<string> = new Set<string>([
+  private static readonly knownParams: Set<string> = new Set<string>([
     'individual-address',
     'individual-address-city',
     'individual-address-country',
@@ -76,7 +76,7 @@ export class AddressTable extends LookupTable<Address> {
    * @returns True if the search parameter is an Address parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
-    return AddressTable.#knownParams.has(searchParam.id as string);
+    return AddressTable.knownParams.has(searchParam.id as string);
   }
 
   /**
@@ -87,7 +87,7 @@ export class AddressTable extends LookupTable<Address> {
    * @returns Promise on completion.
    */
   async indexResource(client: PoolClient, resource: Resource): Promise<void> {
-    const addresses = this.#getIncomingAddresses(resource);
+    const addresses = this.getIncomingAddresses(resource);
     if (!addresses || !Array.isArray(addresses)) {
       return;
     }
@@ -123,7 +123,7 @@ export class AddressTable extends LookupTable<Address> {
     }
   }
 
-  #getIncomingAddresses(resource: Resource): Address[] | undefined {
+  private getIncomingAddresses(resource: Resource): Address[] | undefined {
     if (
       resource.resourceType === 'Patient' ||
       resource.resourceType === 'Person' ||

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -10,7 +10,7 @@ import { compareArrays } from './util';
  * Each name is represented as a separate row in the "HumanName" table.
  */
 export class HumanNameTable extends LookupTable<HumanName> {
-  static readonly #knownParams: Set<string> = new Set<string>([
+  private static readonly knownParams: Set<string> = new Set<string>([
     'individual-given',
     'individual-family',
     'Patient-name',
@@ -41,7 +41,7 @@ export class HumanNameTable extends LookupTable<HumanName> {
    * @returns True if the search parameter is an HumanName parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
-    return HumanNameTable.#knownParams.has(searchParam.id as string);
+    return HumanNameTable.knownParams.has(searchParam.id as string);
   }
 
   /**

--- a/packages/server/src/fhir/operations/resourcegraph.test.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.test.ts
@@ -77,6 +77,17 @@ describe('Resource $graph', () => {
 
   describe('Error cases', () => {
     test('Missing Graph Definition', async () => {
+      // Abuse the graph parameter, express will parse it as string array rather than string
+      const graphName = 'g&graph=g';
+      const patient = await createResource({
+        resourceType: 'Patient',
+        name: [{ given: ['Graph'], family: 'Demo' }],
+      } as Patient);
+
+      await getResourceGraph(patient, graphName, 400);
+    });
+
+    test('Missing Graph Definition', async () => {
       const graphName = 'this-graph-doesnt-exist';
       const patient = await createResource({
         resourceType: 'Patient',

--- a/packages/server/src/fhir/operations/resourcegraph.test.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.test.ts
@@ -76,7 +76,7 @@ describe('Resource $graph', () => {
   });
 
   describe('Error cases', () => {
-    test('Missing Graph Definition', async () => {
+    test('Invalid graph parameter', async () => {
       // Abuse the graph parameter, express will parse it as string array rather than string
       const graphName = 'g&graph=g';
       const patient = await createResource({

--- a/packages/server/src/fhir/operations/resourcegraph.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.ts
@@ -284,7 +284,10 @@ async function followSearchLink(
  * @returns The operation parameters if available; otherwise, undefined.
  */
 async function validateQueryParameters(req: Request, res: Response): Promise<GraphDefinition> {
-  const { graph } = req.query as { graph: string };
+  const { graph } = req.query;
+  if (typeof graph !== 'string') {
+    throw new OperationOutcomeError(badRequest('Missing required parameter: graph'));
+  }
 
   const repo = res.locals.repo as Repository;
   const bundle = await repo.search({

--- a/packages/server/src/fhir/references.ts
+++ b/packages/server/src/fhir/references.ts
@@ -16,64 +16,64 @@ export async function validateReferences<T extends Resource>(repo: Repository, r
 }
 
 export class FhirReferenceValidator<T extends Resource> {
-  readonly #issues: OperationOutcomeIssue[];
-  readonly #repo: Repository;
-  readonly #root: T;
+  private readonly issues: OperationOutcomeIssue[];
+  private readonly repo: Repository;
+  private readonly root: T;
 
   constructor(repo: Repository, root: T) {
-    this.#issues = [];
-    this.#repo = repo;
-    this.#root = root;
+    this.issues = [];
+    this.repo = repo;
+    this.root = root;
   }
 
   async validate(): Promise<void> {
-    const resource = this.#root;
+    const resource = this.root;
     const resourceType = resource.resourceType;
-    await this.#validateObject(resourceType, toTypedValue(resource));
+    await this.validateObject(resourceType, toTypedValue(resource));
 
-    if (this.#issues.length > 0) {
+    if (this.issues.length > 0) {
       throw new OperationOutcomeError({
         resourceType: 'OperationOutcome',
         id: randomUUID(),
-        issue: this.#issues,
+        issue: this.issues,
       });
     }
   }
 
-  async #validateObject(path: string, typedValue: TypedValue): Promise<void> {
+  private async validateObject(path: string, typedValue: TypedValue): Promise<void> {
     const object = typedValue.value as Record<string, unknown>;
     for (const key of Object.keys(object)) {
-      await this.#checkProperty(path, key, typedValue);
+      await this.checkProperty(path, key, typedValue);
     }
   }
 
-  async #checkProperty(basePath: string, propertyName: string, typedValue: TypedValue): Promise<void> {
+  private async checkProperty(basePath: string, propertyName: string, typedValue: TypedValue): Promise<void> {
     const path = basePath + '.' + propertyName;
     const value = getTypedPropertyValue(typedValue, propertyName);
     if (Array.isArray(value)) {
       for (const item of value) {
-        await this.#checkPropertyValue(path, item);
+        await this.checkPropertyValue(path, item);
       }
     } else {
-      return this.#checkPropertyValue(path, value as TypedValue);
+      return this.checkPropertyValue(path, value as TypedValue);
     }
   }
 
-  async #checkPropertyValue(path: string, typedValue: TypedValue): Promise<void> {
+  private async checkPropertyValue(path: string, typedValue: TypedValue): Promise<void> {
     if (typedValue.type === PropertyType.Meta) {
       return;
     }
 
     if (typedValue.type === PropertyType.Reference) {
-      return this.#checkReference(path, typedValue.value as Reference);
+      return this.checkReference(path, typedValue.value as Reference);
     }
 
     if (typeof typedValue.value === 'object') {
-      return this.#validateObject(path, typedValue);
+      return this.validateObject(path, typedValue);
     }
   }
 
-  async #checkReference(path: string, reference: Reference): Promise<void> {
+  private async checkReference(path: string, reference: Reference): Promise<void> {
     const refStr = reference.reference;
     if (!refStr) {
       return;
@@ -85,9 +85,9 @@ export class FhirReferenceValidator<T extends Resource> {
     }
 
     try {
-      await this.#repo.readReference(reference);
+      await this.repo.readReference(reference);
     } catch (err) {
-      this.#issues.push(createStructureIssue(path, `Invalid reference: ${path} (${normalizeErrorString(err)})`));
+      this.issues.push(createStructureIssue(path, `Invalid reference: ${path} (${normalizeErrorString(err)})`));
     }
   }
 }


### PR DESCRIPTION
During previous performance exploration (https://github.com/medplum/medplum/pull/1813) we found that using the JavaScript hash `#` private modifier caused measurable performance penalties when used in inner loops.

Because we use a relatively conservative JS version target, the `#` modifier was transpiled to a `WeakMap` with a whole bunch of additional boilerplate code.

In contrast, the TypeScript `private` modifier is only used at compile-time, and does not require transpiling, and does not have any runtime penalty.

There should be no functional changes in this PR.  Everything was done with a handful of search-and-replace calls.

----

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 598085c</samp>

### Summary

No summary available (the operation was too large to complete, the maximum model work limit was reached)



### Walkthrough
No walkthrough available (the operation was too large to complete, the maximum model work limit was reached)

