### PR TITLE
Fixed parsing boolean parameters from SSM parameter store

### DIFF
--- a/packages/server/src/__mocks__/@aws-sdk/client-ssm.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-ssm.ts
@@ -12,6 +12,9 @@ export class SSMClient {
             { Name: 'DatabaseSecrets', Value: 'DatabaseSecretsArn' },
             { Name: 'RedisSecrets', Value: 'RedisSecretsArn' },
             { Name: 'port', Value: '8080' },
+            { Name: 'botCustomFunctionsEnabled', Value: 'true' },
+            { Name: 'logAuditEvents', Value: 'true' },
+            { Name: 'registerEnabled', Value: 'false' },
           ],
         };
       }

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -20,6 +20,9 @@ describe('Config', () => {
     expect(config).toBeDefined();
     expect(config.baseUrl).toBeDefined();
     expect(config.port).toEqual(8080);
+    expect(config.botCustomFunctionsEnabled).toEqual(true);
+    expect(config.logAuditEvents).toEqual(true);
+    expect(config.registerEnabled).toEqual(false);
     expect(getConfig()).toBe(config);
   });
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -153,6 +153,8 @@ async function loadAwsConfig(path: string): Promise<MedplumServerConfig> {
           config['redis'] = await loadAwsSecrets(region, value);
         } else if (key === 'port') {
           config.port = parseInt(value);
+        } else if (key === 'botCustomFunctionsEnabled' || key === 'logAuditEvents' || key === 'registerEnabled') {
+          config[key] = value === 'true';
         } else {
           config[key] = value;
         }


### PR DESCRIPTION
This isn't an imperfect solution.  Ideally we'd have data definitions for each config setting that includes some level of typing.