### PR TITLE
Clarify use of Quantities in RangeDisplay component

### DIFF
--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -309,6 +309,7 @@ test('Format timing', () => {
 });
 
 test('Format Range', () => {
+  expect(formatRange(undefined)).toBe('');
   expect(formatRange({})).toBe('');
   expect(formatRange({ low: {}, high: {} })).toBe('');
 
@@ -337,6 +338,9 @@ test('Format Range', () => {
   expect(formatRange({ low: { value: 20, unit: 'mg/dL' }, high: { value: 30, unit: 'mg/dL' } })).toBe('20 - 30 mg/dL');
   expect(formatRange({ low: { value: 20, unit: '%' }, high: { value: 30, unit: '%' } })).toBe('20 - 30%');
   expect(formatRange({ low: { value: 0, unit: '%' }, high: { value: 100, unit: '%' } })).toBe('0 - 100%');
+
+  // Edge case where quantity contains invalid comparator
+  expect(formatRange({ high: { value: 20, unit: 'mg/dL', comparator: '<=' } })).toBe('<= 20 mg/dL');
 });
 
 test('Format Quantity', () => {

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -292,7 +292,7 @@ export function formatTiming(timing: Timing | undefined): string {
 }
 
 /**
- * Returns a human-readable string for a FHIR Range datatype, taking into account comparators and one-sided ranges
+ * Returns a human-readable string for a FHIR Range datatype, taking into account one-sided ranges
  * @param range A FHIR Range element
  * @param exclusive If true, one-sided ranges will be rendered with the '>' or '<' bounds rather than '>=' or '<='
  * @returns A human-readable string representation of the Range

--- a/packages/react/src/RangeDisplay/RangeDisplay.stories.tsx
+++ b/packages/react/src/RangeDisplay/RangeDisplay.stories.tsx
@@ -57,19 +57,3 @@ export const LowOnly = (): JSX.Element => (
     />
   </Document>
 );
-
-export const WithComparator = (): JSX.Element => (
-  <Document>
-    <RangeDisplay
-      value={
-        {
-          low: {
-            comparator: '>',
-            value: 10,
-            unit: 'mg',
-          },
-        } as Range
-      }
-    />
-  </Document>
-);


### PR DESCRIPTION
Fixes #1679 

The FHIR [`Range`](http://hl7.org/fhir/R4/datatypes.html#Range) data type uses `SimpleQuantity` variants for the range endpoints, which forbids use of the `comparator` field.  References to using Quantity values with a comparator in a Range have been removed.