### PR TITLE
Fixes #1798 Navigate to all FHIR resource Types

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -93,11 +93,6 @@ describe('App', () => {
   test('Resource Type Search', async () => {
     await setup();
 
-    // open app navbar
-    await act(async () => {
-      fireEvent.click(screen.getByTitle('Medplum Logo'));
-    });
-
     const input = screen.getByPlaceholderText('Navigate by Resource Type') as HTMLInputElement;
     expect(input.value).toBe('');
 

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -134,4 +134,50 @@ describe('App', () => {
     expect(screen.getByText('Test Display')).toBeDefined();
     expect(resultInput?.value).toBe('test-code');
   });
+
+  test('Resource Type Search clear result', async () => {
+    await setup();
+
+    const comboboxes = screen.getAllByRole('combobox');
+
+    let resultInput: HTMLInputElement | undefined = undefined;
+    const input = screen.getByPlaceholderText('Navigate by Resource Type') as HTMLInputElement;
+
+    for (const combobox of comboboxes) {
+      const element = combobox.querySelector(`input[name="resourceType"]`) as HTMLInputElement;
+      if (element) {
+        resultInput = element;
+        break;
+      }
+    }
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Test' } });
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Press the down arrow
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
+    });
+
+    // Press "Enter"
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    expect(screen.getByText('Test Display')).toBeDefined();
+    expect(resultInput?.value).toBe('test-code');
+
+    //click on search clear button
+    const button = screen.getAllByRole('button').find((el) => el.getAttribute('class')?.includes('mantine-CloseButton-root')) as HTMLElement;
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(resultInput?.value).toBe('');
+  });
 });

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,7 +1,4 @@
 import { MantineProvider } from '@mantine/core';
-import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
-import { readJson } from '@medplum/definitions';
-import { Bundle, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -95,10 +95,9 @@ describe('App', () => {
   test('Resource Type Search', async () => {
     await setup();
 
-    const comboboxes = screen
-      .getAllByRole('combobox');
+    const comboboxes = screen.getAllByRole('combobox');
 
-    let resultInput:HTMLInputElement|undefined = undefined;
+    let resultInput: HTMLInputElement | undefined = undefined;
     const input = screen.getByPlaceholderText('Navigate by Resource Type') as HTMLInputElement;
 
     for (const combobox of comboboxes) {
@@ -108,7 +107,6 @@ describe('App', () => {
         break;
       }
     }
-   
     // Enter random text
     await act(async () => {
       fireEvent.change(input, { target: { value: 'Different' } });

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -98,7 +98,7 @@ describe('App', () => {
     const comboboxes = screen.getAllByRole('combobox');
 
     let resultInput: HTMLInputElement | undefined = undefined;
-    const input = screen.getByPlaceholderText('Navigate by Resource Type') as HTMLInputElement;
+    const input = screen.getByPlaceholderText('Resource Type') as HTMLInputElement;
 
     for (const combobox of comboboxes) {
       const element = combobox.querySelector(`input[name="resourceType"]`) as HTMLInputElement;
@@ -133,53 +133,5 @@ describe('App', () => {
 
     expect(screen.getByText('Test Display')).toBeDefined();
     expect(resultInput?.value).toBe('test-code');
-  });
-
-  test('Resource Type Search clear result', async () => {
-    await setup();
-
-    const comboboxes = screen.getAllByRole('combobox');
-
-    let resultInput: HTMLInputElement | undefined = undefined;
-    const input = screen.getByPlaceholderText('Navigate by Resource Type') as HTMLInputElement;
-
-    for (const combobox of comboboxes) {
-      const element = combobox.querySelector(`input[name="resourceType"]`) as HTMLInputElement;
-      if (element) {
-        resultInput = element;
-        break;
-      }
-    }
-
-    await act(async () => {
-      fireEvent.change(input, { target: { value: 'Test' } });
-    });
-
-    // Wait for the drop down
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    // Press the down arrow
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
-    });
-
-    // Press "Enter"
-    await act(async () => {
-      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    });
-
-    expect(screen.getByText('Test Display')).toBeDefined();
-    expect(resultInput?.value).toBe('test-code');
-
-    //click on search clear button
-    const button = screen
-      .getAllByRole('button')
-      .find((el) => el.getAttribute('class')?.includes('mantine-CloseButton-root')) as HTMLElement;
-    await act(async () => {
-      fireEvent.click(button);
-    });
-    expect(resultInput?.value).toBe('');
   });
 });

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -26,12 +26,6 @@ async function setup(url = '/'): Promise<void> {
 }
 
 describe('App', () => {
-  // beforeAll(() => {
-  //   indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
-  //   indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
-  //   indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
-  // });
-
   beforeEach(() => {
     jest.useFakeTimers();
   });

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -174,7 +174,9 @@ describe('App', () => {
     expect(resultInput?.value).toBe('test-code');
 
     //click on search clear button
-    const button = screen.getAllByRole('button').find((el) => el.getAttribute('class')?.includes('mantine-CloseButton-root')) as HTMLElement;
+    const button = screen
+      .getAllByRole('button')
+      .find((el) => el.getAttribute('class')?.includes('mantine-CloseButton-root')) as HTMLElement;
     await act(async () => {
       fireEvent.click(button);
     });

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -89,4 +89,22 @@ describe('App', () => {
     const completedLink = screen.getByText('Completed Orders');
     expect(activeLink.parentElement?.className).not.toEqual(completedLink.parentElement?.className);
   });
+
+  test('Resource Type Search', async () => {
+    await setup();
+
+    // open app navbar
+    await act(async () => {
+      fireEvent.click(screen.getByTitle('Medplum Logo'));
+    });
+
+    const input = screen.getByPlaceholderText('Navigate by Resource Type') as HTMLInputElement;
+    expect(input.value).toBe('');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Account' } });
+    });
+
+    expect(input.value).toBe('Account');
+  });
 });

--- a/packages/app/src/AppNavbar.tsx
+++ b/packages/app/src/AppNavbar.tsx
@@ -101,8 +101,9 @@ export function AppNavbar({ closeNavbar }: AppNavbarProps): JSX.Element {
     <Navbar width={{ sm: 250 }} p="xs">
       <Navbar.Section>
         <CodeInput
+          key={window.location.pathname}
           name="resourceType"
-          placeholder="Navigate by Resource Type"
+          placeholder="Resource Type"
           property={{
             binding: {
               valueSet: 'http://hl7.org/fhir/ValueSet/resource-types',
@@ -110,8 +111,9 @@ export function AppNavbar({ closeNavbar }: AppNavbarProps): JSX.Element {
           }}
           onChange={(newValue) => navigateResourceType(newValue)}
           creatable={false}
-          maxSelectedValues={1}
-          clearSearchOnChange={false}
+          maxSelectedValues={0}
+          clearSearchOnChange={true}
+          clearable={false}
         />
       </Navbar.Section>
       <Navbar.Section grow>

--- a/packages/app/src/AppNavbar.tsx
+++ b/packages/app/src/AppNavbar.tsx
@@ -102,7 +102,7 @@ export function AppNavbar({ closeNavbar }: AppNavbarProps): JSX.Element {
       <Navbar.Section>
         <CodeInput
           name="resourceType"
-          placeholder="Resource Type..."
+          placeholder="Navigate by Resource Type"
           property={{
             binding: {
               valueSet: 'http://hl7.org/fhir/ValueSet/resource-types',

--- a/packages/app/src/AppNavbar.tsx
+++ b/packages/app/src/AppNavbar.tsx
@@ -1,5 +1,5 @@
 import { createStyles, getStylesRef, Navbar, Space, Text } from '@mantine/core';
-import { useMedplumContext } from '@medplum/react';
+import { CodeInput, useMedplumContext } from '@medplum/react';
 import {
   Icon,
   IconBrandAsana,
@@ -91,8 +91,29 @@ export function AppNavbar({ closeNavbar }: AppNavbarProps): JSX.Element {
     }
   }
 
+  function navigateResourceType(resourceType: string | undefined): void {
+    if (resourceType) {
+      navigate(`/${resourceType}`);
+    }
+  }
+
   return (
     <Navbar width={{ sm: 250 }} p="xs">
+      <Navbar.Section>
+        <CodeInput
+          name="resourceType"
+          placeholder="Resource Type..."
+          property={{
+            binding: {
+              valueSet: 'http://hl7.org/fhir/ValueSet/resource-types',
+            },
+          }}
+          onChange={(newValue) => navigateResourceType(newValue)}
+          creatable={false}
+          maxSelectedValues={1}
+          clearSearchOnChange={false}
+        />
+      </Navbar.Section>
       <Navbar.Section grow>
         {config?.menu?.map((menu, index) => (
           <React.Fragment key={`menu-${index}-${config?.menu?.length}`}>

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -107,7 +107,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
       if (e.key === 'Enter') {
         if (!timerRef.current && !abortControllerRef.current) {
           killEvent(e);
-          if (optionsRef.current && optionsRef.current.length > 0 && creatable !== false) {
+          if (optionsRef.current && optionsRef.current.length > 0) {
             setOptions(optionsRef.current.slice(0, 1));
             handleChange([optionsRef.current[0].value]);
           }
@@ -118,7 +118,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
         }
       }
     },
-    [creatable, handleChange]
+    [handleChange]
   );
 
   const handleCreate = useCallback(

--- a/packages/react/src/CodeInput/CodeInput.test.tsx
+++ b/packages/react/src/CodeInput/CodeInput.test.tsx
@@ -79,7 +79,7 @@ describe('CodeInput', () => {
   });
 
   test('Searches for results with creatable set to false', async () => {
-    await setup(<CodeInput property={statusProperty} name="test" creatable={false} />);
+    await setup(<CodeInput property={statusProperty} name="test" creatable={false} clearable={false} />);
 
     const input = screen.getByRole('searchbox') as HTMLInputElement;
 

--- a/packages/react/src/CodeInput/CodeInput.test.tsx
+++ b/packages/react/src/CodeInput/CodeInput.test.tsx
@@ -77,4 +77,32 @@ describe('CodeInput', () => {
 
     expect(screen.getByText('Test Display')).toBeDefined();
   });
+
+  test('Searches for results with creatable set to false', async () => {
+    await setup(<CodeInput property={statusProperty} name="test" creatable={false} />);
+
+    const input = screen.getByRole('searchbox') as HTMLInputElement;
+
+    // Enter random text
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Test' } });
+    });
+
+    // Wait for the drop down
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    // Press the down arrow
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
+    });
+
+    // Press "Enter"
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    });
+
+    expect(screen.getByText('Test Display')).toBeDefined();
+  });
 });

--- a/packages/react/src/CodeInput/CodeInput.tsx
+++ b/packages/react/src/CodeInput/CodeInput.tsx
@@ -11,6 +11,7 @@ export interface CodeInputProps {
   creatable?: boolean;
   maxSelectedValues?: number;
   clearSearchOnChange?: boolean;
+  clearable?: boolean;
 }
 
 export function CodeInput(props: CodeInputProps): JSX.Element {
@@ -35,6 +36,7 @@ export function CodeInput(props: CodeInputProps): JSX.Element {
       creatable={props.creatable}
       maxSelectedValues={props.maxSelectedValues}
       clearSearchOnChange={props.clearSearchOnChange}
+      clearable={props.clearable}
     />
   );
 }

--- a/packages/react/src/CodeInput/CodeInput.tsx
+++ b/packages/react/src/CodeInput/CodeInput.tsx
@@ -8,6 +8,9 @@ export interface CodeInputProps {
   placeholder?: string;
   defaultValue?: string;
   onChange?: (value: string | undefined) => void;
+  creatable?: boolean;
+  maxSelectedValues?: number;
+  clearSearchOnChange?: boolean;
 }
 
 export function CodeInput(props: CodeInputProps): JSX.Element {
@@ -29,6 +32,9 @@ export function CodeInput(props: CodeInputProps): JSX.Element {
       placeholder={props.placeholder}
       defaultValue={codeToValueSetElement(value)}
       onChange={handleChange}
+      creatable={props.creatable}
+      maxSelectedValues={props.maxSelectedValues}
+      clearSearchOnChange={props.clearSearchOnChange}
     />
   );
 }

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -10,6 +10,7 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider';
 export interface ValueSetAutocompleteProps
   extends Omit<AsyncAutocompleteProps<ValueSetExpansionContains>, 'loadOptions' | 'toKey' | 'toOption'> {
   elementDefinition: ElementDefinition;
+  creatable?: boolean;
 }
 
 function toKey(element: ValueSetExpansionContains): string {
@@ -36,7 +37,7 @@ function createValue(input: string): ValueSetExpansionContains {
  */
 export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Element {
   const medplum = useMedplum();
-  const { elementDefinition, ...rest } = props;
+  const { elementDefinition, creatable, ...rest } = props;
 
   const loadValues = useCallback(
     async (input: string, signal: AbortSignal): Promise<ValueSetExpansionContains[]> => {
@@ -44,7 +45,6 @@ export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Elem
       const valueSet = await medplum.searchValueSet(system, input, { signal });
       const valueSetElements = valueSet.expansion?.contains as ValueSetExpansionContains[];
       const newData: ValueSetExpansionContains[] = [];
-
       for (const valueSetElement of valueSetElements) {
         if (valueSetElement.code && !newData.some((item) => item.code === valueSetElement.code)) {
           newData.push(valueSetElement);
@@ -59,13 +59,13 @@ export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Elem
   return (
     <AsyncAutocomplete
       {...rest}
-      creatable
+      creatable={creatable ?? true}
       clearable
       toKey={toKey}
       toOption={toOption}
       loadOptions={loadValues}
-      getCreateLabel={(query) => `+ Create ${query}`}
       onCreate={createValue}
+      getCreateLabel={creatable === false ? undefined : (query: any) => `+ Create ${query}`}
     />
   );
 }

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -11,6 +11,7 @@ export interface ValueSetAutocompleteProps
   extends Omit<AsyncAutocompleteProps<ValueSetExpansionContains>, 'loadOptions' | 'toKey' | 'toOption'> {
   elementDefinition: ElementDefinition;
   creatable?: boolean;
+  clearable?: boolean;
 }
 
 function toKey(element: ValueSetExpansionContains): string {
@@ -37,7 +38,7 @@ function createValue(input: string): ValueSetExpansionContains {
  */
 export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Element {
   const medplum = useMedplum();
-  const { elementDefinition, creatable, ...rest } = props;
+  const { elementDefinition, creatable, clearable, ...rest } = props;
 
   const loadValues = useCallback(
     async (input: string, signal: AbortSignal): Promise<ValueSetExpansionContains[]> => {
@@ -60,7 +61,7 @@ export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Elem
     <AsyncAutocomplete
       {...rest}
       creatable={creatable ?? true}
-      clearable
+      clearable={clearable ?? true}
       toKey={toKey}
       toOption={toOption}
       loadOptions={loadValues}


### PR DESCRIPTION

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/2465773/232859283-97777461-0564-47c1-8b34-9f8d5462e61c.png">


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f0ab917</samp>

### Summary
🧪🔎✨

<!--
1.  🧪 This emoji represents testing, and it can be used for the first and second changes, which add or improve test cases for the CodeInput and App components.
2.  🔎 This emoji represents searching, and it can be used for the third change, which adds a CodeInput component to the AppNavbar that enables searching and navigating to resource types from a value set.
3.  ✨ This emoji represents enhancement, and it can be used for the fourth, fifth, and sixth changes, which add new props and features to the AsyncAutocomplete, CodeInput, and ValueSetAutocomplete components, respectively.
-->
This pull request adds and improves features for searching and selecting resource types from value sets in the app and react packages. It introduces a `CodeInput` component that allows creating and clearing values, and uses it in the `AsyncAutocomplete` and `ValueSetAutocomplete` components. It also fixes some bugs and enhances the testing of the `App` and `CodeInput` components.

> _We are the masters of the code_
> _We create and clear with ease_
> _We search and navigate the nodes_
> _We test and fix with expertise_

### Walkthrough
*  Implement resource type search feature in `AppNavbar` component ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-7286cd06e8095cc6ab0286912f9c49f1af1a19c76248fc453d86f8e00d9ec71dL2-R2), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-7286cd06e8095cc6ab0286912f9c49f1af1a19c76248fc453d86f8e00d9ec71dL94-R118))
*  Add and pass creatable prop to `AsyncAutocomplete` component to control creating new values from input ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-68b6db61ad5c98fd329a4d7755b9a54275fbbdb7592d8a60c7dfd9ac26a70042L17-R21), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-68b6db61ad5c98fd329a4d7755b9a54275fbbdb7592d8a60c7dfd9ac26a70042L93-R102), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-68b6db61ad5c98fd329a4d7755b9a54275fbbdb7592d8a60c7dfd9ac26a70042R158))
*  Add and pass creatable, maxSelectedValues, clearSearchOnChange, and clearable props to `CodeInput` component to customize its behavior ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-d0ec7b7051fa2e7a49958cd96a7110f8798012ca6b9cb75d02e86536f9085f3cR11-R14), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-d0ec7b7051fa2e7a49958cd96a7110f8798012ca6b9cb75d02e86536f9085f3cR36-R39))
*  Add and pass creatable and clearable props to `ValueSetAutocomplete` component to customize its behavior ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-2d8c8c95fe05082ed9b021050b244d55355f42150eabec28f1f1d3a013eadb87R13-R14), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-2d8c8c95fe05082ed9b021050b244d55355f42150eabec28f1f1d3a013eadb87L39-R41), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-2d8c8c95fe05082ed9b021050b244d55355f42150eabec28f1f1d3a013eadb87L47))
*  Modify `App.test.tsx` to use fake timers for testing asynchronous components ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-0a8b6bde29271c8e59b2c74b2058cecd61881f8d8dcb965b48f5769c4211e6b5L2-L4), [link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-0a8b6bde29271c8e59b2c74b2058cecd61881f8d8dcb965b48f5769c4211e6b5L29-R36))
*  Add test case for resource type search feature in `App.test.tsx` ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-0a8b6bde29271c8e59b2c74b2058cecd61881f8d8dcb965b48f5769c4211e6b5R94-R136))
*  Add test case for `CodeInput` component with creatable prop set to false ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-e6c3b1192fcc45eb5996645bc6a21916be2a5e783e2c1417ef9533f501bc2475R80-R107))
*  Remove an empty line from `ValueSetAutocomplete` component ([link](https://github.com/medplum/medplum/pull/1844/files?diff=unified&w=0#diff-2d8c8c95fe05082ed9b021050b244d55355f42150eabec28f1f1d3a013eadb87L62-R69))

