### PR TITLE
chore: Use crypto.randomUUID in @medplum/fhir-router

### DIFF
--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -12,6 +12,7 @@ import {
 } from '@medplum/core';
 import { Bundle, BundleEntry, Reference, Resource } from '@medplum/fhirtypes';
 import { applyPatch, Operation } from 'rfc6902';
+import { randomUUID as generateId } from 'crypto';
 
 /**
  * The FhirRepository interface defines the methods that are required to implement a FHIR repository.
@@ -375,17 +376,3 @@ const sortComparator = <T extends Resource>(a: T, b: T, sortRule: SortRule): num
   const bStr = JSON.stringify(evalFhirPath(expression, b));
   return aStr.localeCompare(bStr) * (sortRule.descending ? -1 : 1);
 };
-
-/**
- * Cross platform random UUID generator
- * Note that this is not intended for production use, but rather for testing
- * This should be replaced when crypto.randomUUID is fully supported
- * See: https://stackoverflow.com/revisions/2117523/28
- * @returns A random UUID.
- */
-const generateId = (): string =>
-  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });


### PR DESCRIPTION
Was poking around in the repository and saw this custom UUID generator. I'm 80% confident that this contribution makes sense but I could have missed something admittedly.

* crypto.randomUUID was released in Node v14.17.0, making the existing comment outdated
* crypto.randomUUID is already used in @medplum/server
* crypto.randomUUID [is now available in a secure context on all modern browsers ](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)(meaning its use in @medplum/mock is fine so long as it's being loaded on `localhost` or `127.0.0.1`)