### PR TITLE
Fixes #1829: Expunge test async error

### DIFF
--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { getClient } from '../../database';
-import { createTestProject, initTestAuth, waitFor } from '../../test.setup';
+import { createTestProject, initTestAuth } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { Operator as SqlOperator, SelectQuery } from '../sql';
 import { Expunger } from './expunge';

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -5,7 +5,7 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { getClient } from '../../database';
-import { createTestProject, initTestAuth } from '../../test.setup';
+import { createTestProject, initTestAuth, waitFor } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { Operator as SqlOperator, SelectQuery } from '../sql';
 import { Expunger } from './expunge';
@@ -91,6 +91,7 @@ describe('Expunge', () => {
       .set('X-Medplum', 'extended')
       .send({});
     expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 200));
   });
 
   test('Expunger.expunge() expunges all resource types', async () => {


### PR DESCRIPTION

Before:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/2465773/232917651-bca076e7-5c6a-4bd6-8243-b029dd0a857a.png">


After:
<img width="681" alt="image" src="https://user-images.githubusercontent.com/2465773/232917557-4f38d83c-85bb-45c0-9df7-0d95982c1d14.png">


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9c8dd49</samp>

### Summary
🕒🗑️🧪

<!--
1.  🕒 - This emoji represents the concept of time or delay, which is relevant for the change that adds a 200 milliseconds wait in the test case.
2.  🗑️ - This emoji represents the concept of deletion or expunge, which is the operation that the test case is verifying.
3.  🧪 - This emoji represents the concept of testing or experimentation, which is the context of the change that modifies the test case.
-->
Added a delay in the expunge test case to avoid a race condition. This ensures that the test checks the database state after the expunge operation is done.

> _`expunge` is queued_
> _test must wait for deletion_
> _winter of patience_

### Walkthrough
* Add a delay to the expunge test case to avoid race condition ([link](https://github.com/medplum/medplum/pull/1849/files?diff=unified&w=0#diff-f750e7e7d34f2965a0d321fc6790e2da27f664ce73dd506e56be3a3592401982R94))


