### PR TITLE
Fixes #1854: Multiple copies of Valuesets and Codesets

### DIFF
--- a/packages/server/src/seeds/valuesets.ts
+++ b/packages/server/src/seeds/valuesets.ts
@@ -21,11 +21,12 @@ export async function createValueSets(): Promise<void> {
 async function deleteExisting(resource: CodeSystem | ValueSet): Promise<void> {
   const bundle = await systemRepo.search({
     resourceType: resource.resourceType,
-    count: 1,
     filters: [{ code: 'url', operator: Operator.EQUALS, value: resource.url as string }],
   });
   if (bundle.entry && bundle.entry.length > 0) {
-    const existing = bundle.entry[0].resource as CodeSystem | ValueSet;
-    await systemRepo.deleteResource(existing.resourceType, existing.id as string);
+    for (const entry of bundle.entry) {
+      const existing = entry.resource as CodeSystem | ValueSet;
+      await systemRepo.deleteResource(existing.resourceType, existing.id as string);
+    }
   }
 }


### PR DESCRIPTION
When importing valuesets and codesets through /admin/super/valuesets as super admin, only one is deleted. There could be edge cases where a database could have multiple copies of valuesets and codesets prior to #1213.


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 02346ad</samp>

### Summary
🗑️🔀🌱

<!--
1.  🗑️ - This emoji represents the deletion of existing resources, as it is a common symbol for trash or garbage.
2.  🔀 - This emoji represents the change from deleting only one resource to deleting multiple resources, as it suggests a switch or a shuffle of the order or number of items.
3.  🌱 - This emoji represents the seed valuesets, as it suggests growth, planting, or initialization of something new.
-->
Fixed a bug in `seeds/valuesets.ts` that could cause duplicate resources with the same url. Improved the `deleteExisting` function to remove all matching resources before seeding.

> _`deleteExisting`_
> _cleans up resources by url_
> _no more duplicates_

### Walkthrough
*  Delete all resources with matching url filter in `deleteExisting` function ([link](https://github.com/medplum/medplum/pull/1868/files?diff=unified&w=0#diff-98d74ef1c9c53ea159fe485a4b17c93c9ae5490e9b7d04df3d3490e4d2a9bdafL24-R30))


 