### PR TITLE
Fixed search URL parse bug with multiple filters

### DIFF
--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -98,6 +98,28 @@ describe('Search Utils', () => {
     });
   });
 
+  test('Parse multiple filters same code', () => {
+    //?_count=20&_fields=name,birthDate,gender,address-state,_lastUpdated,id&_lastUpdated=ge2023-04-01T07%3A00%3A00.000Z&_lastUpdated=le2023-05-01T06%3A59%3A59.999Z&_offset=0&_sort=-_lastUpdated
+    const result = parseSearchDefinition(
+      'Patient?_lastUpdated=ge2023-04-01T07%3A00%3A00.000Z&_lastUpdated=le2023-05-01T06%3A59%3A59.999Z'
+    );
+    expect(result).toMatchObject({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: '_lastUpdated',
+          operator: Operator.GREATER_THAN_OR_EQUALS,
+          value: '2023-04-01T07:00:00.000Z',
+        },
+        {
+          code: '_lastUpdated',
+          operator: Operator.LESS_THAN_OR_EQUALS,
+          value: '2023-05-01T06:59:59.999Z',
+        },
+      ],
+    });
+  });
+
   test('Format Patient search', () => {
     const result = formatSearchQuery({
       resourceType: 'Patient',

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -99,7 +99,6 @@ describe('Search Utils', () => {
   });
 
   test('Parse multiple filters same code', () => {
-    //?_count=20&_fields=name,birthDate,gender,address-state,_lastUpdated,id&_lastUpdated=ge2023-04-01T07%3A00%3A00.000Z&_lastUpdated=le2023-05-01T06%3A59%3A59.999Z&_offset=0&_sort=-_lastUpdated
     const result = parseSearchDefinition(
       'Patient?_lastUpdated=ge2023-04-01T07%3A00%3A00.000Z&_lastUpdated=le2023-05-01T06%3A59%3A59.999Z'
     );


### PR DESCRIPTION
The main bug was here:

```ts
  return parseSearchImpl<T>(resourceType, Object.fromEntries(url.searchParams.entries()));
```

`url.searchParams.entries()` returns an array with multiple entries with the same key.

`Object.fromEntries` flattens that into an `Object`, where there can obviously only be one key.

The refactor is to use `url.searchParams.entries()` directly.