### PR TITLE
Fix rendering of source JSX for Storybook components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "2.0.15",
+      "version": "2.0.16",
       "workspaces": [
         "packages/*"
       ],
@@ -10375,6 +10375,49 @@
         }
       }
     },
+    "node_modules/@storybook/addon-storysource": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-storysource/-/addon-storysource-7.0.6.tgz",
+      "integrity": "sha512-zhC9UcnZxp3CrxL5XpTTJGDTw0qTdpNGWPWedXaO7vJehf5QP76/mAg/X7y6mnZN9oO9B2CXD3s37IqXLApB+Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.0.6",
+        "@storybook/components": "7.0.6",
+        "@storybook/manager-api": "7.0.6",
+        "@storybook/preview-api": "7.0.6",
+        "@storybook/router": "7.0.6",
+        "@storybook/source-loader": "7.0.6",
+        "@storybook/theming": "7.0.6",
+        "estraverse": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "react-syntax-highlighter": "^15.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-storysource/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/@storybook/addon-toolbars": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-7.0.6.tgz",
@@ -12487,6 +12530,36 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/source-loader": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@storybook/source-loader/-/source-loader-7.0.6.tgz",
+      "integrity": "sha512-WoI8qSEZHgEn4qulFzjaMWNawZVhH1BjYYMpPLhWr9ysSy3o7jkilXyDOw+8k4NyyVmzA0fIo4LA2quGp8ar3Q==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.0",
+        "@storybook/types": "7.0.6",
+        "estraverse": "^5.2.0",
+        "lodash": "^4.17.21",
+        "prettier": "^2.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/source-loader/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/@storybook/store": {
@@ -20907,6 +20980,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
@@ -21536,6 +21622,15 @@
       "dev": true,
       "engines": {
         "node": ">= 14.17"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/formidable": {
@@ -22465,6 +22560,15 @@
       },
       "engines": {
         "node": ">= 14.13.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/history": {
@@ -26610,6 +26714,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "dev": true,
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -32049,6 +32167,22 @@
         }
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
+      "integrity": "sha512-+zq2myprEnQmH5yw6Gqc8lD55QHnpKaU8TOcFeC/Lg/MQSs8UknEA0JC4nTZGFAXC2J2Hyj/ijJ7NlabyPi2gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.27.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/react-textarea-autosize": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
@@ -32369,6 +32503,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "dev": true,
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerate": {
@@ -39182,6 +39340,7 @@
         "@storybook/addon-actions": "7.0.6",
         "@storybook/addon-essentials": "7.0.6",
         "@storybook/addon-links": "7.0.6",
+        "@storybook/addon-storysource": "^7.0.6",
         "@storybook/react": "7.0.6",
         "@storybook/react-webpack5": "7.0.6",
         "@svgr/rollup": "7.0.0",

--- a/packages/react/.storybook/main.js
+++ b/packages/react/.storybook/main.js
@@ -4,7 +4,11 @@ module.exports = {
     '../src/**/*.stories.mdx',
     '../src/**/*.stories.@(js|jsx|ts|tsx)',
   ],
-  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-storysource',
+  ],
   staticDirs: ['../public'],
   framework: {
     name: '@storybook/react-webpack5',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
     "@storybook/addon-actions": "7.0.6",
     "@storybook/addon-essentials": "7.0.6",
     "@storybook/addon-links": "7.0.6",
+    "@storybook/addon-storysource": "^7.0.6",
     "@storybook/react": "7.0.6",
     "@storybook/react-webpack5": "7.0.6",
     "@svgr/rollup": "7.0.0",


### PR DESCRIPTION
Adding the `storysource` addon to correctly render the source code for Storybook components as JSX.  This currently appears to add a bit of extra cruft to the code, but I was unable to configure the addon not to do that.

<img width="998" alt="Screenshot 2023-04-21 at 10 04 49 AM" src="https://user-images.githubusercontent.com/2695901/233694926-0089e8d7-3da2-4d83-98ed-5798329a422c.png">
