### PR TITLE
Add _since and _type parameters to system level export

### DIFF
--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -83,15 +83,106 @@ describe('System export', () => {
 
     // Get the export content
     const outputLocation = new URL(output.find((o) => o.type === 'Observation')?.url as string);
-    const res7 = await request(app)
+    const dataRes = await request(app)
       .get(outputLocation.pathname + outputLocation.search)
       .set('Authorization', 'Bearer ' + accessToken);
-    expect(res7.status).toBe(200);
+    expect(dataRes.status).toBe(200);
 
     // Output format is "ndjson", new line delimited JSON
     // However, we only expect one Observation, so we can parse it as JSON
-    const resourceJSON = res7.text.trim().split('\n');
+    const resourceJSON = dataRes.text.trim().split('\n');
     expect(resourceJSON).toHaveLength(1);
     expect(JSON.parse(resourceJSON[0])?.subject?.reference).toEqual(`Patient/${res1.body.id}`);
+  });
+
+  test('Parameters', async () => {
+    const { project } = await createTestProject();
+    expect(project).toBeDefined();
+
+    const accessToken = await initTestAuth();
+    expect(accessToken).toBeDefined();
+
+    const res1 = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+        address: [{ use: 'home', line: ['123 Main St'], city: 'Anywhere', state: 'CA', postalCode: '90210' }],
+        telecom: [
+          { system: 'phone', value: '555-555-5555' },
+          { system: 'email', value: 'alice@example.com' },
+        ],
+      });
+    expect(res1.status).toBe(201);
+
+    // Create observation
+    const res2 = await request(app)
+      .post(`/fhir/R4/Observation`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+        subject: { reference: `Patient/${res1.body.id}` },
+      });
+    expect(res2.status).toBe(201);
+
+    // Create later observation
+    const res3 = await request(app)
+      .post(`/fhir/R4/Observation`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test2' },
+        subject: { reference: `Patient/${res1.body.id}` },
+      });
+    expect(res3.status).toBe(201);
+
+    // Start the export
+    const initRes = await request(app)
+      .post('/fhir/R4/$export')
+      .query({
+        _type: 'Observation',
+        _since: res2.body.meta.lastUpdated,
+      })
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .set('X-Medplum', 'extended')
+      .send({});
+    expect(initRes.status).toBe(202);
+    expect(initRes.headers['content-location']).toBeDefined();
+
+    // Check the export status
+    const contentLocation = new URL(initRes.headers['content-location']);
+
+    let resBody: any;
+    await waitFor(async () => {
+      const statusRes = await request(app)
+        .get(contentLocation.pathname)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(statusRes.status).toBe(200);
+      resBody = statusRes.body;
+    });
+
+    const output = resBody?.output as BulkDataExportOutput[];
+    expect(Object.values(output).map((ex) => ex.type)).toEqual(['Observation']);
+
+    // Get the export content
+    const outputLocation = new URL(output[0]?.url as string);
+    const dataRes = await request(app)
+      .get(outputLocation.pathname + outputLocation.search)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(dataRes.status).toBe(200);
+
+    // Output format is "ndjson", new line delimited JSON
+    // However, we only expect one Observation, so we can parse it as JSON
+    const resourceJSON = dataRes.text.trim().split('\n');
+    expect(resourceJSON).toHaveLength(1);
+    expect(JSON.parse(resourceJSON[0])?.code?.text).toEqual('test2');
   });
 });

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -19,16 +19,19 @@ import { getConfig } from '../../config';
  */
 export async function bulkExportHandler(req: Request, res: Response): Promise<void> {
   const { baseUrl } = getConfig();
+  const query = req.query as Record<string, string | undefined>;
+  const since = query._since;
+  const types = query._type?.split(',');
   const repo = res.locals.repo as Repository;
   const project = res.locals.project as Project;
 
-  const exporter = new BulkExporter(repo, undefined);
+  const exporter = new BulkExporter(repo, since);
   await exporter.start(req.protocol + '://' + req.get('host') + req.originalUrl);
 
   const resourceTypes = getResourceTypes();
 
   for (const resourceType of resourceTypes) {
-    if (!canBeExported(resourceType)) {
+    if (!canBeExported(resourceType) || (types && !types.includes(resourceType))) {
       continue;
     }
     await exportResourceType(exporter, project, resourceType as ResourceType);


### PR DESCRIPTION
Added support for the `_since` and `_type` parameters on the [system level bulk export][export] endpoint.

Also, cleaned up the implementation of the `/$export` operation endpoint by extracting code duplicated with the group export endpoint into utility methods on the `BulkExporter` utility class.

[export]: https://build.fhir.org/ig/HL7/bulk-data/OperationDefinition-export.html