### PR TITLE
Use sonarcloud-github-action v1.8

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Unzip code coverage'
         run: unzip medplum-code-coverage.zip -d coverage
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@v1.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Sonar currently failing with:

```
INFO: ------------------------------------------------------------------------
INFO: EXECUTION FAILURE
INFO: ------------------------------------------------------------------------
INFO: Total time: 32.201s
ERROR: Error during SonarScanner execution
ERROR: 

The version of node.js (12) you have used to run this analysis is deprecated and we stopped accepting it.
Please update to at least node.js 14. You can find more information here: https://docs.sonarcloud.io/appendices/scanner-environment/

ERROR: 
ERROR: Re-run SonarScanner using the -X switch to enable full debug logging.
INFO: Final Memory: 21M/[77](https://github.com/medplum/medplum/actions/runs/4773885873/jobs/8487228219#step:6:78)M
INFO: ------------------------------------------------------------------------
```

Appears to be affecting everyone: https://community.sonarsource.com/t/sonarsource-sonarcloud-github-action-failing-with-node-js-12-error/89664/2

In that thread, user @leonardfactory suggested rolling back to v1.8.