### PR TITLE
Fixes #1883 - publish bot-layer

### DIFF
--- a/packages/bot-layer/README.md
+++ b/packages/bot-layer/README.md
@@ -1,8 +1,27 @@
 # Medplum Bot Layer
 
-Medplum bots can run in [AWS Lambdas]().  When running in lambdas, bots can use [AWS Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) for pre-built dependencies and configuration.
+Medplum bots can run in [AWS Lambdas](https://aws.amazon.com/lambda/). When running in lambdas, bots can use [AWS Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) for pre-built dependencies and configuration.
 
-This package defines the default AWS Lambda Layer.
+This package defines the packages in the default AWS Lambda Layer.
+
+Current packages:
+
+- [`@medplum/core`](https://www.npmjs.com/package/@medplum/core)
+- [`form-data`](https://www.npmjs.com/package/form-data)
+- [`node-fetch`](https://www.npmjs.com/package/node-fetch)
+- [`pdfmake`](https://www.npmjs.com/package/pdfmake)
+- [`ssh2`](https://www.npmjs.com/package/ssh2)
+- [`ssh2-sftp-client`](https://www.npmjs.com/package/ssh2-sftp-client)
+
+## Usage
+
+To use the Medplum Bot Layer in your own Bot packages, add `@medplum/bot-layer` as a dependency:
+
+```bash
+npm i @medplum/bot-layer
+```
+
+## Deployment
 
 For more details on how to build and use, refer to `/scripts/deploy-bot-layer.sh`.
 

--- a/packages/bot-layer/package.json
+++ b/packages/bot-layer/package.json
@@ -22,6 +22,14 @@
   "devDependencies": {
     "@types/node-fetch": "2.6.3"
   },
+  "peerDependencies": {
+    "@medplum/core": "*",
+    "form-data": "^4.0.0",
+    "node-fetch": "^2.6.9",
+    "pdfmake": "^0.2.7",
+    "ssh2": "^1.11.0",
+    "ssh2-sftp-client": "^9.0.4"
+  },
   "keywords": [
     "medplum",
     "aws",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PACKAGES=("cdk" "cli" "core" "definitions" "fhir-router" "fhirtypes" "mock" "react")
+PACKAGES=("bot-layer" "cdk" "cli" "core" "definitions" "fhir-router" "fhirtypes" "mock" "react")
 for package in ${PACKAGES[@]}; do
   echo "Publish $package"
   pushd packages/$package


### PR DESCRIPTION
Initial version published: https://www.npmjs.com/package/@medplum/bot-layer

This updates the readme, sets `peerDependencies`, and adds to our `publish.sh` script.

Quick test:
1. Add dep on `@medplum/bot-layer`
2. `npm i`
3. Dependencies work as expected:

<img width="796" alt="image" src="https://user-images.githubusercontent.com/749094/233801319-9b592abd-65fe-4dc0-a741-4fffdd80fd1f.png">

