### PR TITLE
Fix app in dev mode

### DIFF
--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -68,6 +68,6 @@ export async function initApp(): Promise<void> {
   );
 }
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV !== 'test') {
   initApp().catch(console.error);
 }


### PR DESCRIPTION
This fixes a regression in https://github.com/medplum/medplum/pull/1836

The check for `NODE_ENV === 'production'` should have been `NODE_ENV !== 'test'`

When running in dev mode, `NODE_ENV === 'development'`, so the app does not load at all.