### PR TITLE
Fixed graphql Extension list field args

### DIFF
--- a/packages/fhir-router/src/graphql.test.ts
+++ b/packages/fhir-router/src/graphql.test.ts
@@ -940,6 +940,6 @@ describe('GraphQL', () => {
     const check3 = data.PatientList.find((p: any) => p.id === p3.id);
     expect(check3).toBeDefined();
     expect(check3.extension).toHaveLength(1);
-    expect(check3.extension[0]).toMatchObject(patient.extension?.[1] as Extension);
+    expect(check3.extension[0]).toMatchObject(p3.extension?.[1] as Extension);
   });
 });

--- a/packages/fhir-router/src/graphql.ts
+++ b/packages/fhir-router/src/graphql.ts
@@ -588,8 +588,8 @@ function resolveTypeByReference(resource: Resource | undefined): string | undefi
  * @implements {GraphQLFieldResolver}
  */
 async function resolveField(source: any, args: any, _ctx: GraphQLContext, info: GraphQLResolveInfo): Promise<any> {
-  const fieldValue = source[info.fieldName];
-  if (!args) {
+  const fieldValue = source?.[info.fieldName];
+  if (!args || !fieldValue) {
     return fieldValue;
   }
 

--- a/packages/fhir-router/src/graphql.ts
+++ b/packages/fhir-router/src/graphql.ts
@@ -346,19 +346,46 @@ function buildListPropertyFieldArgs(fieldTypeName: string): GraphQLFieldConfigAr
       for (const fieldKey of Object.keys(fieldTypeSchema.properties)) {
         const fieldElementDefinition = getElementDefinition(fieldTypeName, fieldKey) as ElementDefinition;
         for (const type of fieldElementDefinition.type as ElementDefinitionType[]) {
-          if (type.code === 'code' || type.code === 'string') {
-            const fieldName = fieldKey.replace('[x]', capitalize(type.code as string));
-            fieldArgs[fieldName] = {
-              type: GraphQLString,
-              description: fieldElementDefinition.short,
-            };
-          }
+          buildListPropertyFieldArg(fieldArgs, fieldKey, fieldElementDefinition, type);
         }
       }
     }
   }
 
   return fieldArgs;
+}
+
+/**
+ * Builds a field argument for a list property.
+ * @param fieldArgs The output argument map.
+ * @param fieldKey The key of the field.
+ * @param elementDefinition The FHIR element definition of the field.
+ * @param elementDefinitionType The FHIR element definition type of the field.
+ */
+function buildListPropertyFieldArg(
+  fieldArgs: GraphQLFieldConfigArgumentMap,
+  fieldKey: string,
+  elementDefinition: ElementDefinition,
+  elementDefinitionType: ElementDefinitionType
+): void {
+  const baseType = elementDefinitionType.code as string;
+  const fieldName = fieldKey.replace('[x]', capitalize(baseType));
+  switch (baseType) {
+    case 'canonical':
+    case 'code':
+    case 'id':
+    case 'oid':
+    case 'string':
+    case 'uri':
+    case 'url':
+    case 'uuid':
+    case 'http://hl7.org/fhirpath/System.String':
+      fieldArgs[fieldName] = {
+        type: GraphQLString,
+        description: elementDefinition.short,
+      };
+      break;
+  }
 }
 
 /**

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -62,7 +62,7 @@ const theme: MantineThemeOverride = {
 
 function fetcher(params: FetcherParams): Promise<SyncExecutionResult> {
   if (params.operationName === 'IntrospectionQuery') {
-    return fetch('/schema/schema-v2.json').then((res) => res.json());
+    return fetch('/schema/schema-v3.json').then((res) => res.json());
   }
   return medplum.graphql(params.query, params.operationName, params.variables);
 }


### PR DESCRIPTION
This is regarding GraphQL "List Field Arguments"

* Spec: https://hl7.org/fhir/R4/graphql.html#list
* First implementation: https://github.com/medplum/medplum/pull/1896

I tried using it on a FHIR `Extension` property, but the `Extension.url` was unrecognized because it is type `http://hl7.org/fhirpath/System.String`.

Before: We only supported `code` and `string`

After: We support

```ts
    case 'canonical':
    case 'code':
    case 'id':
    case 'oid':
    case 'string':
    case 'uri':
    case 'url':
    case 'uuid':
    case 'http://hl7.org/fhirpath/System.String':
```