### PR TITLE
Add onUnauthenticated handling

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,6 +53,15 @@ export async function main(medplumClient: MedplumClient, argv: string[]): Promis
 if (require.main === module) {
   dotenv.config();
   const baseUrl = process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
-  const medplumClient = new MedplumClient({ fetch, baseUrl, storage: new FileSystemStorage() });
+  const medplumClient = new MedplumClient({
+    fetch,
+    baseUrl,
+    storage: new FileSystemStorage(),
+    onUnauthenticated: onUnauthenticated,
+  });
   main(medplumClient, process.argv).catch((err) => console.error('Unhandled error:', err));
+}
+
+function onUnauthenticated(): void {
+  console.log('Unauthenticated: run `npx medplum login` to sign in');
 }

--- a/packages/cli/src/rest.ts
+++ b/packages/cli/src/rest.ts
@@ -17,15 +17,11 @@ get
   .argument('<url>', 'Resource/$id')
   .option('--as-transaction', 'Print out the bundle as a transaction type')
   .action(async (url, options) => {
-    try {
-      const response = await medplum.get(cleanUrl(url));
-      if (options.asTransaction) {
-        prettyPrint(convertToTransactionBundle(response));
-      } else {
-        prettyPrint(response);
-      }
-    } catch (err) {
-      console.log(err);
+    const response = await medplum.get(cleanUrl(url));
+    if (options.asTransaction) {
+      prettyPrint(convertToTransactionBundle(response));
+    } else {
+      prettyPrint(response);
     }
   });
 


### PR DESCRIPTION
If the user is unauthenticated we'll console.log an instruction for them to login via the CLI 

```

jamestouri@Jamess-MacBook-Pro cli % node dist/cjs/index.cjs get 'patient'
Unauthenticated: run `npx medplum login` to sign in
Error: Unauthenticated
jamestouri@Jamess-MacBook-Pro cli %
```