### PR TITLE
Fixed app security link

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -42,6 +42,8 @@ describe('App', () => {
     });
 
     expect(screen.getByText('Patients')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Security')).toBeInTheDocument();
   });
 
   test('Click profile', async () => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -8,6 +8,7 @@ import {
   IconBuilding,
   IconForms,
   IconId,
+  IconLock,
   IconLockAccess,
   IconMicroscope,
   IconPackages,
@@ -40,16 +41,30 @@ export function App(): JSX.Element {
   );
 }
 
-function userConfigToMenu(config: UserConfiguration | undefined): NavbarMenu[] | undefined {
-  return config?.menu?.map((menu) => ({
-    title: menu.title,
-    links:
-      menu.link?.map((link) => ({
-        label: link.name,
-        href: link.target as string,
-        icon: getIcon(link.target as string),
-      })) || [],
-  }));
+function userConfigToMenu(config: UserConfiguration | undefined): NavbarMenu[] {
+  const result =
+    config?.menu?.map((menu) => ({
+      title: menu.title,
+      links:
+        menu.link?.map((link) => ({
+          label: link.name,
+          href: link.target as string,
+          icon: getIcon(link.target as string),
+        })) || [],
+    })) || [];
+
+  result.push({
+    title: 'Settings',
+    links: [
+      {
+        label: 'Security',
+        href: '/security',
+        icon: <IconLock />,
+      },
+    ],
+  });
+
+  return result;
 }
 
 const resourceTypeToIcon: Record<string, Icon> = {


### PR DESCRIPTION
Regression introduced in https://github.com/medplum/medplum/pull/1899 dropped the "Security" link in the app navbar.