### PR TITLE
Correct search control icons for fields and filters buttons

### DIFF
--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -304,7 +304,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               compact
               variant={buttonVariant}
               color={buttonColor}
-              leftIcon={<IconFilter size={iconSize} />}
+              leftIcon={<IconColumns size={iconSize} />}
               onClick={() => setState({ ...stateRef.current, fieldEditorVisible: true })}
             >
               Fields
@@ -313,7 +313,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               compact
               variant={buttonVariant}
               color={buttonColor}
-              leftIcon={<IconColumns size={iconSize} />}
+              leftIcon={<IconFilter size={iconSize} />}
               onClick={() => setState({ ...stateRef.current, filterEditorVisible: true })}
             >
               Filters


### PR DESCRIPTION
Before:
<img width="575" alt="image" src="https://user-images.githubusercontent.com/2465773/234168372-c94303cb-2834-4aca-8baa-8b0eb34b59da.png">

After:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/2465773/234168459-c96f0535-87ca-4b31-9aa6-e3cbab545776.png">