### PR TITLE
Fix TypeScript capitalization

### DIFF
--- a/packages/docs/blog/2023-03-27-fhir-r5.md
+++ b/packages/docs/blog/2023-03-27-fhir-r5.md
@@ -17,7 +17,7 @@ FHIR R5 includes enhancements to the [FHIR specification](/docs/api/fhir/resourc
 
 In the future, we will upgrade our service to support FHIR R5 side by side with R4. This includes ensuring that our solutions comply with the latest FHIR R5 specifications and testing our products for interoperability with other FHIR R5-compliant systems.
 
-We will do this while maintaining our support for FHIR R4 - which most of our customers rely on today. We will use our [Bot](/docs/bots) framework, [Typescript SDK](/docs/sdk) and validation tools to help our customers implement the version of the spec that best suits their business needs.
+We will do this while maintaining our support for FHIR R4 - which most of our customers rely on today. We will use our [Bot](/docs/bots) framework, [TypeScript SDK](/docs/sdk) and validation tools to help our customers implement the version of the spec that best suits their business needs.
 
 We are excited about the potential of FHIR R5 to improve interoperability and enable better healthcare outcomes for patients. We continue to closely monitor industry adoption and compliance requirements and will strive to provide our customers with the most up-to-date solutions to meet their interoperability needs.
 

--- a/packages/docs/blog/2023-04-14-medplum-mitre-talk.md
+++ b/packages/docs/blog/2023-04-14-medplum-mitre-talk.md
@@ -89,7 +89,7 @@ Here's an overview of the system: the core Medplum application, then this is an 
 
 ![Medplum system overview](/img/medplum-overview.svg)
 
-We've invested heavily in the [Typescript SDK](/docs/sdk). And most of our customers and people who are developing on the platform, they're really here. They're writing a white label application on a custom domain, so it's like my `healthcareapp.com`, and they're embedding our SDK. Now, what's notable about this developer paradigm is that.
+We've invested heavily in the [TypeScript SDK](/docs/sdk). And most of our customers and people who are developing on the platform, they're really here. They're writing a white label application on a custom domain, so it's like my `healthcareapp.com`, and they're embedding our SDK. Now, what's notable about this developer paradigm is that.
 
 Right here, this gray box that's running their website is a static JavaScript file. This has no backend and it's meant to be very easy for back to our, the discussion on the labor and labor shortage for somebody who is you know, has a light education in healthcare or they're from a different domain, but they know how to develop apps to help them get productive very quickly.
 

--- a/packages/docs/docs/analytics/index.md
+++ b/packages/docs/docs/analytics/index.md
@@ -24,7 +24,7 @@ When designing your analytics program, it can be useful to consider the followin
 | Ad-hoc clinical reports                               | Retrospective    | FHIR Datastore, including [Bulk](/docs/api/fhir/operations/bulk-fhir.mdx) and Batch APIs |
 | Healthcare standard reports (e.g. HEDIS, CMS Queries) | Retrospective    | Bots for data quality, dashboard apps to monitor                                         |
 | Clinical decision support                             | Prospective      | Bots to produce event driven scores, notifications                                       |
-| Machine Learning, predictive modeling                 | Prospective      | Bots to integrate with ML pipelines, Typescript SDK for dashboarding                     |
+| Machine Learning, predictive modeling                 | Prospective      | Bots to integrate with ML pipelines, TypeScript SDK for dashboarding                     |
 
 ## Ad-Hoc Clinical Reports
 

--- a/packages/docs/docs/api/fhir/operations/patient-everything.md
+++ b/packages/docs/docs/api/fhir/operations/patient-everything.md
@@ -20,5 +20,5 @@ The output of the request is a [FHIR bundle](/docs/api/fhir/resources/bundle) wi
 
 ## Related Documentation
 
-- Refer to [readPatientEverything](/docs/sdk/classes/MedplumClient#readpatienteverything) in the Typescript SDK
-- [Bundle definition](/docs/sdk/classes/MedplumClient#returns-40) in Typescript SDK
+- Refer to [readPatientEverything](/docs/sdk/classes/MedplumClient#readpatienteverything) in the TypeScript SDK
+- [Bundle definition](/docs/sdk/classes/MedplumClient#returns-40) in TypeScript SDK

--- a/packages/docs/docs/auth/index.md
+++ b/packages/docs/docs/auth/index.md
@@ -32,8 +32,8 @@ The following diagram shows an overview of the process. Endpoints are provided t
 
 ## Resources and Reference
 
-- See [authentication functions](./sdk/classes/MedplumClient#authentication) in the Typescript SDK
-- [User profile](./sdk/classes/MedplumClient#user-profile) in the Typescript SDK
+- See [authentication functions](./sdk/classes/MedplumClient#authentication) in the TypeScript SDK
+- [User profile](./sdk/classes/MedplumClient#user-profile) in the TypeScript SDK
 - [OAuth endpoints](./api/oauth) reference
 - [Medplum resources](./api/fhir/medplum) related to authentication and authorization
 - [User registration](https://storybook.medplum.com/?path=/docs/medplum-registerform--basic) react component

--- a/packages/docs/docs/auth/token-exchange.md
+++ b/packages/docs/docs/auth/token-exchange.md
@@ -45,7 +45,7 @@ The client makes a token exchange request to the token endpoint with an extensio
 :::tip Example
 
 <Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="tokenExchange">
       {ExampleCode}
     </MedplumCodeBlock>

--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -106,7 +106,7 @@ import { Patient } from '@medplum/fhirtypes';
 const patient = event.input as Patient;
 ```
 
-This first line casts the contents of event.input of type `Patient`. This allows the rest of the bot code to take advantage of Typescript's strong type system, along with IDE autocomplete and ESLint verification. Medplum provides type definitions for all FHIR resources in the `@medplum/fhirtypes` package.
+This first line casts the contents of event.input of type `Patient`. This allows the rest of the bot code to take advantage of TypeScript's strong type system, along with IDE autocomplete and ESLint verification. Medplum provides type definitions for all FHIR resources in the `@medplum/fhirtypes` package.
 
 ```ts
 const firstName = patient.name?.[0]?.given?.[0];

--- a/packages/docs/docs/bots/bots-in-production.md
+++ b/packages/docs/docs/bots/bots-in-production.md
@@ -14,8 +14,8 @@ Editing bots in the web editor is good for getting started quickly, but as Bots 
 ## This Guide will show you
 
 - How to set up a repository to host the source code for your Bots.
-- Write a new `Bot` in Typescript.
-- Create a new `Bot` resource and link it to your Typescript file.
+- Write a new `Bot` in TypeScript.
+- Create a new `Bot` resource and link it to your TypeScript file.
 - Use the [Medplum Command Line Interface (CLI)](https://github.com/medplum/medplum/tree/main/packages/cli) to create and deploy your Bot to production.
 
 ## Setting up your Repository
@@ -80,7 +80,7 @@ MEDPLUM_BASE_URL=https://api.example.com/
 
 After we've installed dependencies, we can write your Bot in any typescript file under the `src/` directory.
 
-As mentioned in [Bot Basics](./bot-basics), a bot is any Typescript file that contains a `handler` function with the following signature:
+As mentioned in [Bot Basics](./bot-basics), a bot is any TypeScript file that contains a `handler` function with the following signature:
 
 ```ts
 import { MedplumClient, BotEvent } from '@medplum/core';
@@ -124,7 +124,7 @@ First, compile your code:
 npm run build
 ```
 
-This runs the `tsc` compiler to translate your Typescript code to Javascript.
+This runs the `tsc` compiler to translate your TypeScript code to Javascript.
 
 Next, take a look at your `dist/` directory and notice how there is now a file called `my-first-bot.js` with the compiled version of your code.
 
@@ -146,7 +146,7 @@ Next step is to create the bot.
 
 Navigate to the [Project Admin panel](https://app.medplum.com/admin/project) and copy the ID of your project. That will be your `project-id`.
 
-Taking the `source-file` we just created at `src/my-first-bot.ts`, we will use the `bot create` command. In our example 
+Taking the `source-file` we just created at `src/my-first-bot.ts`, we will use the `bot create` command. In our example
 
 ```bash
 npx medplum bot create <bot-name> <project-id> <source-file> <dist-file>
@@ -211,7 +211,7 @@ npx medplum bot deploy *staging*
 
 Running this command does two things:
 
-1. Save the Typescript source to the `code` property of your [`Bot` resource](/docs/api/fhir/medplum/bot)
+1. Save the TypeScript source to the `code` property of your [`Bot` resource](/docs/api/fhir/medplum/bot)
 2. Deploys your compiled Javascript code as an AWS Lambda function with your Medplum deployment.
 
 :::caution Note

--- a/packages/docs/docs/bots/consuming-webhooks.md
+++ b/packages/docs/docs/bots/consuming-webhooks.md
@@ -20,11 +20,11 @@ Once you understand the shape of the data you will consume, write a bot to parse
 
 We recommend writing some [unit tests](/docs/bots/unit-testing-bots) as well, and have several samples provided in `medplum-demo-bots` repo that use our `@medplum/mock` library for testing.
 
-### Using Typescript SDKs in your bot
+### Using TypeScript SDKs in your bot
 
-If the SaaS application that sends webhooks publishes a Typescript SDK, it's straightforward to add it to your bot, to streamline development. Add the package to the `devDependencies` in the `package.json` of your bot repository and install the dependency, and [example from demo bots repo](https://github.com/medplum/medplum-demo-bots/blob/main/package.json) is available. You can then use the Typescript SDK when developing your bot.
+If the SaaS application that sends webhooks publishes a TypeScript SDK, it's straightforward to add it to your bot, to streamline development. Add the package to the `devDependencies` in the `package.json` of your bot repository and install the dependency, and [example from demo bots repo](https://github.com/medplum/medplum-demo-bots/blob/main/package.json) is available. You can then use the TypeScript SDK when developing your bot.
 
-The [Stripe demo bot](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/stripe-bots) uses the Stripe Typescript SDK.
+The [Stripe demo bot](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/stripe-bots) uses the Stripe TypeScript SDK.
 
 ## Creating Access Policies
 

--- a/packages/docs/docs/bots/insurance-eligibility-check.md
+++ b/packages/docs/docs/bots/insurance-eligibility-check.md
@@ -8,7 +8,7 @@ Health insurance eligibility checks are a way to fetch information about a given
 
 Insurance billing is complex, and the fact that there are approximately 300 medical billing companies in the US speaks to that. This example will walk through a very simple eligibility check to demonstrate the concepts and data structures.
 
-_This guide includes an example of a bot written in Typescript, deployed using the [Medplum CLI](https://github.com/medplum/medplum-demo-bots)._
+_This guide includes an example of a bot written in TypeScript, deployed using the [Medplum CLI](https://github.com/medplum/medplum-demo-bots)._
 
 ## This guide will show you
 

--- a/packages/docs/docs/fhir-datastore/index.md
+++ b/packages/docs/docs/fhir-datastore/index.md
@@ -10,5 +10,5 @@ The following reference material can be useful in using the FHIR datastore effec
 
 - [FHIR Resources](/docs/api/fhir/resources/)
 - [FHIR Operations](/docs/api/fhir/operations/)
-- [Typescript SDK Reference](/docs/sdk/)
+- [TypeScript SDK Reference](/docs/sdk/)
 - [FHIR Datastore Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Afhir-datastore) on Github

--- a/packages/docs/docs/fhir-datastore/uploading-files-to-medplum.md
+++ b/packages/docs/docs/fhir-datastore/uploading-files-to-medplum.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 For large files such as videos and images, it can be inconvenient to download contents to the client before uploading to Medplum. In these situations, you can create a [`Media`](../api/fhir/resources/media) resource with a `url` parameter pointing to the location of the content.
 
 <BrowserOnlyTabs groupId="language">
-  <TabItem value="typescript" label="Typescript">
+  <TabItem value="typescript" label="TypeScript">
 
 ```ts
 import { Media } from '@medplum/fhirtypes';

--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -1,6 +1,6 @@
 # Integration
 
-Complex integrations are built by composing [bots](/docs/bots/), [subscriptions](/docs/subscriptions/index.md), [authentication and authorization](/docs/auth/index.md) and the [Typescript SDK](/docs/sdk/).
+Complex integrations are built by composing [bots](/docs/bots/), [subscriptions](/docs/subscriptions/index.md), [authentication and authorization](/docs/auth/index.md) and the [TypeScript SDK](/docs/sdk/).
 
 - [Integration Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aintegration) on Github show the code that powers many of the integrations.
 - [Audit and Logging Features](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Aaudit-logging) show several security and observability integrations.

--- a/packages/docs/docs/search/basic-search.mdx
+++ b/packages/docs/docs/search/basic-search.mdx
@@ -52,7 +52,7 @@ To search for resources, you can simply add search parameters and values as quer
 The [Medplum Client SDK](/docs/sdk/classes/MedplumClient) also provides the `search` helper method, which accepts a `string` or `object`.
 
 <Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchSingle">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -81,7 +81,7 @@ Because iterating over the `Bundle.entry` array is such a common pattern, the Me
 You can perform and AND search by specifying multiple query parameters
 
 <Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchAnd">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -96,7 +96,7 @@ You can perform and AND search by specifying multiple query parameters
 Specifying comma separated values performs an OR operation for that search parameter
 
 <Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchOr">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -117,7 +117,7 @@ The syntax for this kind of search is `[parameter]=[resourceType]/[id]`. You can
 For example, to search for all `Observation` resources that reference a `Patient` with the ID `"1234"`:
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchReference">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -181,7 +181,7 @@ The FHIR spec includes a set of **modifiers** to change the way a specific searc
 For example, search for all `Tasks` where status _is not_ `completed`:
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchNot">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -200,7 +200,7 @@ For example, search for all `Tasks` where status _is not_ `completed`:
 For example, searching for all `Patients` with missing `birthDates`.
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchMissing">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -219,7 +219,7 @@ For example, searching for all `Patients` with missing `birthDates`.
 For example, searching for `Patients` whose name includes the substring `"stein"`
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchContains">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -250,7 +250,7 @@ FHIR provides a mechanism to search for resources that have a value greater or l
 This example shows how to find all `RiskAssessments` with a `probability` greater than 0.8.
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchGreaterThan">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -266,7 +266,7 @@ This example shows how to find all `RiskAssessments` with a `probability` greate
 You can search an inclusive range using an AND search
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchInclusiveRange">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -288,7 +288,7 @@ Because we are specifying the `value-quantity` parameter twice in this query, we
 You can search an exclusive range using an OR search
 
 <Tabs>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchExclusiveRange">
       {ExampleCode}
     </MedplumCodeBlock>

--- a/packages/docs/docs/search/graphql.mdx
+++ b/packages/docs/docs/search/graphql.mdx
@@ -28,7 +28,7 @@ For example, to request a `Patient` by ID:
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="GetPatientByIdTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -69,7 +69,7 @@ To search for a list of `Patient` resources with a specific name and city:
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="SearchPatientsByNameAndCityTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -106,7 +106,7 @@ For example, to retrieve a `DiagnosticReport` and all the `Observation` resource
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="DiagnosticReportWithObservationsTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -143,7 +143,7 @@ In the example below, we first search for a `Patient` by id, and then find all t
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="PatientWithRelatedEncountersTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -174,7 +174,7 @@ FHIR GraphQL supports filtering array properties using field arguments. For exam
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="FilterPatientNameByUseTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -201,7 +201,7 @@ Another common use is to filter an `extension` array by `url`:
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="FilterExtensionByUrlTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -238,7 +238,7 @@ Here is an example of searching for a list of `Patient` resources using the Conn
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="ConnectionApiTS">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -271,7 +271,7 @@ This query searches for a list of `Patients` named `"Eve"`, living in `"Philadel
       {ExampleCode}
     </MedplumCodeBlock>
   </TabItem>
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="PatientsWithReportsTS">
       {ExampleCode}
     </MedplumCodeBlock>

--- a/packages/docs/docs/search/index.md
+++ b/packages/docs/docs/search/index.md
@@ -2,8 +2,8 @@
 
 Search API and SDK supports searching and filtering FHIR resources. There is also support for GraphQL
 
-- [Typescript SDK Search](/docs/sdk/index.md#search) documentation
+- [TypeScript SDK Search](/docs/sdk/index.md#search) documentation
 - [React Search control](/docs/sdk#search)
 - [Searching Linked Objects](/docs/search/basic-search.mdx)
-- [Typescript SDK GraphQL](/docs/sdk/classes/MedplumClient.md#graphql)
+- [TypeScript SDK GraphQL](/docs/sdk/classes/MedplumClient.md#graphql)
 - [Search Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Asearch) on Github

--- a/packages/docs/docs/search/paginated-search.mdx
+++ b/packages/docs/docs/search/paginated-search.mdx
@@ -14,7 +14,7 @@ To set the number of items returned per page, use the `_count` query parameter. 
 Here's an example query that sets the page size to 50:
 
 <Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchCount">
       {ExampleCode}
     </MedplumCodeBlock>
@@ -35,7 +35,7 @@ To set the page offset, or the starting point of the search results, use the `_o
 Here's an example query that sets the page offset to 30:
 
 <Tabs groupId="language">
-  <TabItem value="ts" label="Typescript">
+  <TabItem value="ts" label="TypeScript">
     <MedplumCodeBlock language="ts" selectBlocks="searchOffset">
       {ExampleCode}
     </MedplumCodeBlock>

--- a/packages/docs/sidebars.js
+++ b/packages/docs/sidebars.js
@@ -179,7 +179,7 @@ const sidebars = {
     'api/index',
     {
       type: 'category',
-      label: 'Typescript SDK',
+      label: 'TypeScript SDK',
       link: { type: 'doc', id: 'sdk/index' },
       items: [
         { type: 'doc', id: 'sdk/classes/MedplumClient', label: 'MedplumClient' },

--- a/packages/docs/src/pages/careers.md
+++ b/packages/docs/src/pages/careers.md
@@ -70,7 +70,7 @@ Engineers at Medplum are comfortable working on new products under fluid conditi
 
 - Design, develop, and maintain infrastructure, features and enhancements product for an open source project
 - Collaborate with other engineers to deliver new features and improvements to the product in a highly regulated environment
-- Write clean, maintainable, and efficient code and tests using modern Typescript and React best practices
+- Write clean, maintainable, and efficient code and tests using modern TypeScript and React best practices
 - Contribute to and maintain infrastructure as code for major cloud platforms like AWS, GCP and Microsoft Azure
 - Identify and troubleshoot issues effectively for technical infrastructure
 - Stay up-to-date with the latest advancements in technical infrastructure, performance, security and data management

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -59,7 +59,7 @@ export default function IndexPage(): JSX.Element {
               <div className={styles.cardItem}>
                 <h3>Build with Modern Tools</h3>
                 <p>
-                  Use modern <strong>Typescript</strong>, <strong>React</strong>, and <strong>Node</strong> to build
+                  Use modern <strong>TypeScript</strong>, <strong>React</strong>, and <strong>Node</strong> to build
                   secure, data driven healthcare applications.
                 </p>
                 <a href="https://github.com/medplum/medplum" target="_blank" className={styles.cardButton}>


### PR DESCRIPTION
The [TypeScript branding guidelines](https://www.typescriptlang.org/branding/) recommend using the capital S in the middle of "TypeScript" for consistency with "JavaScript"