### PR TITLE
Fixed test failure after merge

### DIFF
--- a/packages/cli/src/project.test.ts
+++ b/packages/cli/src/project.test.ts
@@ -12,6 +12,9 @@ jest.mock('fs', () => ({
   existsSync: jest.fn(),
   readFileSync: jest.fn(),
   writeFileSync: jest.fn(),
+  constants: {
+    O_CREAT: 0,
+  },
   promises: {
     readFile: jest.fn(async () => '{}'),
   },


### PR DESCRIPTION
This fixes the current build break:

```
@medplum/cli:test: FAIL src/project.test.ts
@medplum/cli:test:   ● Test suite failed to run
@medplum/cli:test: 
@medplum/cli:test:     TypeError: Cannot destructure property 'O_CREAT' of 'fs.constants' as it is undefined.
@medplum/cli:test: 
@medplum/cli:test:       4 | import { resolve } from 'path';
@medplum/cli:test:       5 | import internal from 'stream';
@medplum/cli:test:     > 6 | import tar from 'tar';
@medplum/cli:test:         | ^
@medplum/cli:test:       7 |
@medplum/cli:test:       8 | interface MedplumConfig {
@medplum/cli:test:       9 |   readonly baseUrl?: string;
@medplum/cli:test: 
@medplum/cli:test:       at Object.<anonymous> (../../node_modules/tar/lib/get-write-flag.js:14:9)
@medplum/cli:test:       at Object.<anonymous> (../../node_modules/tar/lib/unpack.js:48:17)
@medplum/cli:test:       at Object.<anonymous> (../../node_modules/tar/lib/extract.js:5:16)
@medplum/cli:test:       at Object.<anonymous> (../../node_modules/tar/index.js:8:31)
@medplum/cli:test:       at Object.require (src/utils.ts:6:1)
@medplum/cli:test:       at Object.require (src/aws/update-app.ts:9:1)
@medplum/cli:test:       at Object.require (src/aws/index.ts:4:1)
@medplum/cli:test:       at Object.require (src/index.ts:5:1)
@medplum/cli:test:       at Object.require (src/project.test.ts:5:1)
@medplum/cli:test: 
```

It's because https://github.com/medplum/medplum/pull/1932 merged after https://github.com/medplum/medplum/pull/1925 and didn't have all of the necessary `fs` mocks.