### PR TITLE
Fixes#1959 fix race condition in export test

### DIFF
--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -185,6 +185,7 @@ describe('System export', () => {
       .get(outputLocation.pathname + outputLocation.search)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(dataRes.status).toBe(200);
+
     // Output format is "ndjson", new line delimited JSON
     // However, we only expect one Observation, so we can parse it as JSON
     const resourceJSON = dataRes.text.trim().split('\n');

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -130,35 +130,42 @@ describe('System export', () => {
       });
     expect(res2.status).toBe(201);
 
-    // Create later observation
-    const res3 = await request(app)
-      .post(`/fhir/R4/Observation`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/fhir+json')
-      .send({
-        resourceType: 'Observation',
-        status: 'final',
-        code: { text: 'test2' },
-        subject: { reference: `Patient/${res1.body.id}` },
-      });
-    expect(res3.status).toBe(201);
+    await waitFor(async () => {
+      // Create later observation
+      const res3 = await request(app)
+        .post(`/fhir/R4/Observation`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', 'application/fhir+json')
+        .send({
+          resourceType: 'Observation',
+          status: 'final',
+          code: { text: 'test2' },
+          subject: { reference: `Patient/${res1.body.id}` },
+        });
+      expect(res3.status).toBe(201);
+    });
+    const updatedDate = new Date(res2.body.meta.lastUpdated);
+    updatedDate.setMilliseconds(updatedDate.getMilliseconds() + 1);
 
     // Start the export
-    const initRes = await request(app)
-      .post('/fhir/R4/$export')
-      .query({
-        _type: 'Observation',
-        _since: res2.body.meta.lastUpdated,
-      })
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/fhir+json')
-      .set('X-Medplum', 'extended')
-      .send({});
-    expect(initRes.status).toBe(202);
-    expect(initRes.headers['content-location']).toBeDefined();
+    let initRes: any;
+    await waitFor(async () => {
+      initRes = await request(app)
+        .post('/fhir/R4/$export')
+        .query({
+          _type: 'Observation',
+          _since: updatedDate.toISOString(),
+        })
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', 'application/fhir+json')
+        .set('X-Medplum', 'extended')
+        .send({});
+      expect(initRes.status).toBe(202);
+      expect(initRes.headers['content-location']).toBeDefined();
+    });
 
     // Check the export status
-    const contentLocation = new URL(initRes.headers['content-location']);
+    const contentLocation = new URL(initRes?.headers?.['content-location']);
 
     let resBody: any;
     await waitFor(async () => {
@@ -178,7 +185,6 @@ describe('System export', () => {
       .get(outputLocation.pathname + outputLocation.search)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(dataRes.status).toBe(200);
-
     // Output format is "ndjson", new line delimited JSON
     // However, we only expect one Observation, so we can parse it as JSON
     const resourceJSON = dataRes.text.trim().split('\n');


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3a28f4e</samp>

### Summary
🕒🐛🧪

<!--
1.  🕒 - This emoji represents the use of `waitFor` functions and the addition of a millisecond to the `_since` parameter, which are both related to timing and waiting for certain conditions to be met.
2.  🐛 - This emoji represents the bug fix that the change is intended to achieve, as the test was flaky and sometimes failed due to the timing issues.
3.  🧪 - This emoji represents the test itself, as the change is part of a pull request to fix a test case and improve the reliability of the test suite.
-->
Fix flaky export test by waiting for resources to be indexed and adjusting `_since` parameter.

> _`waitFor` functions_
> _wrap creation and export_
> _avoiding flakiness_

### Walkthrough
* Fix flaky export test by waiting for database transactions and indexing, and adjusting `_since` parameter ([link](https://github.com/medplum/medplum/pull/1962/files?diff=unified&w=0#diff-454070ab471e4a54926cd48d6d4e8e030e3158b06f16797fd9774ed037d467e9L133-R168))


