### PR TITLE
Fixes #1951: Add a QuestionnaireResponse tab to the Questionnaire resource page

### DIFF
--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -101,7 +101,7 @@ export function AppRoutes(): JSX.Element {
           <Route path="history" element={<HistoryPage />} />
           <Route path="json" element={<JsonPage />} />
           <Route path="preview" element={<PreviewPage />} />
-          <Route path="questionnaireresponse" element={<QuestionnaireResponsePage />} />
+          <Route path="responses" element={<QuestionnaireResponsePage />} />
           <Route path="report" element={<ReportPage />} />
           <Route path="ranges" element={<ReferenceRangesPage />} />
           <Route path="timeline" element={<TimelinePage />} />

--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -48,6 +48,7 @@ import { SecurityPage } from './SecurityPage';
 import { SetPasswordPage } from './SetPasswordPage';
 import { SignInPage } from './SignInPage';
 import { SmartSearchPage } from './SmartSearchPage';
+import { QuestionnaireResponsePage } from './resource/QuestionnaireResponsePage';
 
 export function AppRoutes(): JSX.Element {
   return (
@@ -100,6 +101,7 @@ export function AppRoutes(): JSX.Element {
           <Route path="history" element={<HistoryPage />} />
           <Route path="json" element={<JsonPage />} />
           <Route path="preview" element={<PreviewPage />} />
+          <Route path="questionnaireresponse" element={<QuestionnaireResponsePage />} />
           <Route path="report" element={<ReportPage />} />
           <Route path="ranges" element={<ReferenceRangesPage />} />
           <Route path="timeline" element={<TimelinePage />} />

--- a/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
@@ -77,7 +77,7 @@ describe('QuestionnaireResponsePage', () => {
     });
 
     await act(async () => {
-      fireEvent.keyDown(screen.getByRole('button', { name: 'Last Updated' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Sort Newest to Oldest' }));
     });
 
     expect(screen.getByText(`${response1.id}`)).toBeInTheDocument();

--- a/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
@@ -37,7 +37,7 @@ describe('QuestionnaireResponsePage', () => {
       setup(`/Questionnaire/${questionnaire.id}`);
     });
 
-    const questionnaireResponseTab = screen.getByRole('tab', { name: 'QuestionnaireResponse' });
+    const questionnaireResponseTab = screen.getByRole('tab', { name: 'Responses' });
 
     // click on questionnaire response tab
     await act(async () => {
@@ -68,7 +68,7 @@ describe('QuestionnaireResponsePage', () => {
 
     // load questionnaire response page
     await act(async () => {
-      setup(`/Questionnaire/${questionnaire.id}/questionnaireresponse`);
+      setup(`/Questionnaire/${questionnaire.id}/responses`);
     });
 
     // click on a questionnaire response

--- a/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
@@ -1,0 +1,40 @@
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
+import { getReferenceString } from '@medplum/core';
+
+const medplum = new MockClient();
+
+describe('QuestionnaireResponsePage', () => {
+  function setup(url: string): void {
+    render(
+      <MedplumProvider medplum={medplum}>
+        <MemoryRouter initialEntries={[url]} initialIndex={0}>
+          <AppRoutes />
+        </MemoryRouter>
+      </MedplumProvider>
+    );
+  }
+
+  test('Renders', async () => {
+    const questionnaire = await medplum.createResource<Questionnaire>({
+      resourceType: 'Questionnaire',
+      status: 'active',
+    });
+
+    const response1 = await medplum.createResource<QuestionnaireResponse>({
+      resourceType: 'QuestionnaireResponse',
+      status: 'completed',
+      questionnaire: getReferenceString(questionnaire),
+    });
+    await act(async () => {
+      setup(`/Questionnaire/${questionnaire.id}/questionnaireresponse`);
+    });
+
+    expect(screen.getByText(`${response1.id}`)).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
@@ -71,7 +71,7 @@ describe('QuestionnaireResponsePage', () => {
       setup(`/Questionnaire/${questionnaire.id}/questionnaireresponse`);
     });
 
-    // click on a question response
+    // click on a questionnaire response
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Last Updated' }));
     });

--- a/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
@@ -1,6 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
@@ -31,8 +31,53 @@ describe('QuestionnaireResponsePage', () => {
       status: 'completed',
       questionnaire: getReferenceString(questionnaire),
     });
+
+    // load questionnaire page
+    await act(async () => {
+      setup(`/Questionnaire/${questionnaire.id}`);
+    });
+
+    const questionnaireResponseTab = screen.getByRole('tab', { name: 'QuestionnaireResponse' });
+
+    // click on questionnaire response tab
+    await act(async () => {
+      fireEvent.click(questionnaireResponseTab);
+    });
+
+    expect(screen.getByText(`${response1.id}`)).toBeInTheDocument();
+
+    // click on a question response
+    await act(async () => {
+      fireEvent.click(screen.getByText(`${response1.id}`));
+    });
+
+    expect(screen.getByLabelText(`Actions for QuestionnaireResponse/${response1.id}`));
+  });
+
+  test('Renders test changes', async () => {
+    const questionnaire = await medplum.createResource<Questionnaire>({
+      resourceType: 'Questionnaire',
+      status: 'active',
+    });
+
+    const response1 = await medplum.createResource<QuestionnaireResponse>({
+      resourceType: 'QuestionnaireResponse',
+      status: 'completed',
+      questionnaire: getReferenceString(questionnaire),
+    });
+
+    // load questionnaire response page
     await act(async () => {
       setup(`/Questionnaire/${questionnaire.id}/questionnaireresponse`);
+    });
+
+    // click on a question response
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Last Updated' }));
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Last Updated' }));
     });
 
     expect(screen.getByText(`${response1.id}`)).toBeInTheDocument();

--- a/packages/app/src/resource/QuestionnaireResponsePage.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.tsx
@@ -5,18 +5,13 @@ import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function QuestionnaireResponsePage(): JSX.Element | null {
-  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
-  const resource = useResource({ reference: resourceType + '/' + id });
+  const { id } = useParams() as { resourceType: ResourceType; id: string };
   const navigate = useNavigate();
   const [search, setSearch] = useState<SearchRequest>({
     resourceType: 'QuestionnaireResponse',
     filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/' + id }],
     fields: ['id', '_lastUpdated'],
   });
-
-  if (!resource) {
-    return null;
-  }
 
   return (
     <Document>

--- a/packages/app/src/resource/QuestionnaireResponsePage.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.tsx
@@ -1,11 +1,10 @@
 import { Operator, SearchRequest } from '@medplum/core';
-import { ResourceType } from '@medplum/fhirtypes';
 import { Document, MemoizedSearchControl } from '@medplum/react';
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function QuestionnaireResponsePage(): JSX.Element | null {
-  const { id } = useParams() as { resourceType: ResourceType; id: string };
+  const { id } = useParams() as { id: string };
   const navigate = useNavigate();
   const [search, setSearch] = useState<SearchRequest>({
     resourceType: 'QuestionnaireResponse',

--- a/packages/app/src/resource/QuestionnaireResponsePage.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.tsx
@@ -1,6 +1,6 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
-import { Document, MemoizedSearchControl, useResource } from '@medplum/react';
+import { Document, MemoizedSearchControl } from '@medplum/react';
 import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/packages/app/src/resource/QuestionnaireResponsePage.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.tsx
@@ -1,0 +1,32 @@
+import { Operator, SearchRequest } from '@medplum/core';
+import { ResourceType } from '@medplum/fhirtypes';
+import { Document, MemoizedSearchControl, useResource } from '@medplum/react';
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+export function QuestionnaireResponsePage(): JSX.Element | null {
+  const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
+  const resource = useResource({ reference: resourceType + '/' + id });
+  const navigate = useNavigate();
+  const [search, setSearch] = useState<SearchRequest>({
+    resourceType: 'QuestionnaireResponse',
+    filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/' + id }],
+    fields: ['id', '_lastUpdated'],
+  });
+
+  if (!resource) {
+    return null;
+  }
+
+  return (
+    <Document>
+      <MemoizedSearchControl
+        search={search}
+        onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
+        onChange={(e) => setSearch(e.definition)}
+        hideFilters
+        hideToolbar
+      />
+    </Document>
+  );
+}

--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -25,7 +25,7 @@ function getTabs(resourceType: string): string[] {
   }
 
   if (resourceType === 'Questionnaire') {
-    result.push('Preview', 'Builder', 'Bots', 'QuestionnaireResponse');
+    result.push('Preview', 'Builder', 'Bots', 'Responses');
   }
 
   if (resourceType === 'DiagnosticReport') {

--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -25,7 +25,7 @@ function getTabs(resourceType: string): string[] {
   }
 
   if (resourceType === 'Questionnaire') {
-    result.push('Preview', 'Builder', 'Bots');
+    result.push('Preview', 'Builder', 'Bots', 'QuestionnaireResponse');
   }
 
   if (resourceType === 'DiagnosticReport') {


### PR DESCRIPTION

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8794c74</samp>

### Summary
📝🗂️📊

<!--
1.  📝 - This emoji represents the creation of a new module and component for the `QuestionnaireResponsePage`.
2.  🗂️ - This emoji represents the modification of the `ResourcePage` component to add a new tab for the `QuestionnaireResponse` resource type.
3.  📊 - This emoji represents the addition of a new feature to the app: the ability to view questionnaire responses.
-->
This pull request adds a new feature to the app: the ability to view questionnaire responses for a given questionnaire resource. It creates a new component `QuestionnaireResponsePage` and a new route in `AppRoutes`, and adds a new tab to the `ResourcePage` component.

> _`QuestionnaireResponse` is the key to your doom_
> _You can't escape the data that they consume_
> _They fetch and display your secrets in a table_
> _You're just a resource, a reference, a label_

### Walkthrough
*  Add `QuestionnaireResponsePage` component to render a table of questionnaire responses for a given questionnaire resource ([link](https://github.com/medplum/medplum/pull/1963/files?diff=unified&w=0#diff-32982533cd91cd9f0eee834e803d26de4f95ee2c7472e16d46089b61d38278c7R51), [link](https://github.com/medplum/medplum/pull/1963/files?diff=unified&w=0#diff-32982533cd91cd9f0eee834e803d26de4f95ee2c7472e16d46089b61d38278c7R104), [link](https://github.com/medplum/medplum/pull/1963/files?diff=unified&w=0#diff-e94be48af691436a1e90080d573db7683eec6f2de4a99e868625bff01f17be3cR1-R32))
*  Update `ResourcePage` component to include a `QuestionnaireResponse` tab for `Questionnaire` resources ([link](https://github.com/medplum/medplum/pull/1963/files?diff=unified&w=0#diff-d89fa3aa8cb41394175dec409b85e6606ff495c9c83857e9191cd4f967f5d62cL28-R28))

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/2465773/235604314-0ca5a65f-3acd-4c9b-8647-4e9e56b453b4.png">

