### PR TITLE
Fixes #2015 - handle empty strings in name search

### DIFF
--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -90,6 +90,20 @@ describe('HumanName Lookup Table', () => {
     expect(bundleContains(searchResult, patients[2])).toBe(false);
   });
 
+  test('Search with blank name', async () => {
+    const searchResult = await systemRepo.search({
+      resourceType: 'Patient',
+      filters: [
+        {
+          code: 'name',
+          operator: Operator.EQUALS,
+          value: '',
+        },
+      ],
+    });
+    expect(searchResult.entry).toBeDefined();
+  });
+
   test('Multiple names', async () => {
     const name = randomUUID();
     const other = randomUUID();

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -76,6 +76,7 @@ export abstract class LookupTable<T> {
             option
               .trim()
               .split(/\s+/)
+              .filter(Boolean)
               .map((token) => token + ':*')
               .join(' & ')
           )


### PR DESCRIPTION
Postgres tsvector match on ":*" is invalid.  This filters out empty search strings, including in comma separated strings such as "alice,,,,".