### PR TITLE
Fixes: #2026 Gateway timeout for System level exports

### DIFF
--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -29,14 +29,14 @@ export async function bulkExportHandler(req: Request, res: Response): Promise<vo
   const exporter = new BulkExporter(repo, since);
   const bulkDataExport = await exporter.start(req.protocol + '://' + req.get('host') + req.originalUrl);
 
-  exportAllResources(exporter, project, types)
+  exportResources(exporter, project, types)
     .then(() => logger.info(`export for ${project.id} is completed`))
     .catch((err) => logger.error(`export for  ${project.id} failed: ${err}`));
   // Send the response
   res.set('Content-Location', `${baseUrl}fhir/R4/bulkdata/export/${bulkDataExport.id}`).status(202).json(accepted);
 }
 
-export async function exportAllResources(
+export async function exportResources(
   exporter: BulkExporter,
   project: Project,
   types: string[] | undefined

--- a/packages/server/src/fhir/operations/utils/bulkexporter.ts
+++ b/packages/server/src/fhir/operations/utils/bulkexporter.ts
@@ -48,7 +48,6 @@ export class BulkExporter {
       request: url,
       requestTime: new Date().toISOString(),
     });
-
     return this.resource;
   }
 

--- a/packages/server/src/fhir/operations/utils/bulkexporter.ts
+++ b/packages/server/src/fhir/operations/utils/bulkexporter.ts
@@ -41,13 +41,15 @@ export class BulkExporter {
     this.since = since;
   }
 
-  async start(url: string): Promise<void> {
+  async start(url: string): Promise<BulkDataExport> {
     this.resource = await this.repo.createResource<BulkDataExport>({
       resourceType: 'BulkDataExport',
       status: 'active',
       request: url,
       requestTime: new Date().toISOString(),
     });
+
+    return this.resource;
   }
 
   async getWriter(resourceType: string): Promise<BulkFileWriter> {


### PR DESCRIPTION
Make system level export be async from request to prevent gateway timeout.

### All initial calls to  `/fhir/R4/$export` will return a status 202. ###
<img width="1062" alt="image" src="https://github.com/medplum/medplum/assets/2465773/2f982aa7-8e43-4df6-aba1-862d8bb6d452">

### Example `in progress` 202 status response from Content Location `fhir/R4/bulkdata/export/20f3d054-7fa5-4955-8962-a279a5859042` ###

<img width="957" alt="image" src="https://github.com/medplum/medplum/assets/2465773/9387f451-2d1a-42f8-9e11-d690e5ad6969">

### `Completed` 200 status response containing output of exported files: ###
<img width="1519" alt="image" src="https://github.com/medplum/medplum/assets/2465773/e4963f8f-519d-4938-8a38-f2c6c6d79db8">


