### PR TITLE
Fixed: Cancel in-progress CI jobs when new commit is pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
 name: Build
+# Limit a single job to run at a time for a given branch/PR to save resources and speed up CI
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ci-build-${{ github.ref_name == 'main' && github.sha || github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,11 @@
 # supported CodeQL languages.
 #
 name: 'CodeQL'
-
+# Limit a single job to run at a time for a given branch/PR to save resources and speed up CI
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ci-build-${{ github.ref_name == 'main' && github.sha || github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches: [main]

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,4 +1,9 @@
 name: Sonar
+# Limit a single job to run at a time for a given branch/PR to save resources and speed up CI
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ci-build-${{ github.ref_name == 'main' && github.sha || github.ref }}
+  cancel-in-progress: true
 on:
   workflow_run:
     workflows: [Build]


### PR DESCRIPTION
Per the [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow), the `concurrency.group` identifiers must be unique per repository, not per workflow as originally assumed.