### PR TITLE
Move sync-repos logic to .sh files

### DIFF
--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Update listening repos, create PR, and clean up
         if: env.changed_paths != ''
         run: |
-          ./scripts/update-example-changes.sh ${{ secrets.PERSONAL_ACCESS_TOKEN }} ${{ env.changed_paths }}
+          ./scripts/update-example-changes.sh ${{ secrets.SYNC_REPO_TOKEN }} ${{ env.changed_paths }}

--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -17,62 +17,16 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set script permissions
+        run: |
+          chmod +x ./scripts/check-changes.sh
+          chmod +x ./scripts/update-example-changes.sh
       - name: Check for changes in specified path
         id: check_changes
         run: |
-          changed_paths=""
-          for path in examples/*/; do
-            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} -- "${path}*")
-            if [ -n "$CHANGED_FILES" ]; then
-              changed_paths+="$path;"
-            fi
-          done
-          echo "changed_paths=$changed_paths" >> $GITHUB_ENV
+          echo "GITHUB_ENV=$GITHUB_ENV" >> $GITHUB_ENV
+          ./scripts/check-changes.sh ${{ github.event.before }} ${{ github.event.after }}
       - name: Update listening repos, create PR, and clean up
         if: env.changed_paths != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # This separates the strings with ; to turn it into an array
-          IFS=';' read -ra changed_paths_array <<< "${{ env.changed_paths }}"
-          echo "Changed paths array: ${changed_paths_array[@]}"
-
-          # Configure Git
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
-          for path in "${changed_paths_array[@]}"; do
-            # Store the current working directory
-            initial_working_directory=$(pwd)
-
-            # Extract the folder name from the path
-            folder_name=$(basename $path)
-
-            # Check if the listening repo exists
-            repo="https://$GITHUB_TOKEN:@github.com/medplum/${folder_name}.git"
-            REPO_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/medplum/${folder_name}")
-
-            # If the repo does not exist, create a new repo
-            if [ $REPO_STATUS -eq 404 ]; then
-              CREATE_REPO_PAYLOAD="{\"name\": \"${folder_name}\", \"default_branch\": \"main\"}"
-              CREATE_REPO_RESPONSE=$(curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -H "Accept: application/vnd.github+json" --data "$CREATE_REPO_PAYLOAD" "https://api.github.com/orgs/medplum/repos")
-              echo "Created new repo: $(echo $CREATE_REPO_RESPONSE | jq -r '.html_url')"
-            fi
-
-            # Clone the corresponding listening repo
-            git clone "$repo"
-
-            # Copy changed files to the listening repo
-            rsync -a --delete --exclude .git/ --exclude tsconfig.json "${initial_working_directory}/${path%}"/ ${folder_name}/
-            cp LICENSE.txt ${folder_name}/
-
-            # Commit and push changes to the listening repo
-            cd ${folder_name}
-            git add .
-            git commit -m "Update from main medplum repo"
-            git push origin main
-
-            # Cleanup: Remove the cloned repo folder and delete the local branch
-            cd ..
-            rm -rf ${folder_name}
-          done
+          ./scripts/update-example-changes.sh ${{ secrets.PERSONAL_ACCESS_TOKEN }} ${{ env.changed_paths }}

--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Check for changes in specified path
         id: check_changes
         run: |
-          echo "GITHUB_ENV=$GITHUB_ENV" >> $GITHUB_ENV
-          ./scripts/check-changes.sh ${{ github.event.before }} ${{ github.event.after }}
+          echo "changed_paths=$(./scripts/check-changes.sh ${{ github.event.before }} ${{ github.event.after }})" >> $GITHUB_ENV
       - name: Update listening repos, create PR, and clean up
         if: env.changed_paths != ''
         run: |

--- a/scripts/check-changes.sh
+++ b/scripts/check-changes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+before_merge=$1
+after_merge=$2
+
+changed_paths=""
+for path in examples/*/; do
+  CHANGED_FILES=$(git diff --name-only $before_merge $after_merge -- "${path}*")
+  if [ -n "$CHANGED_FILES" ]; then
+    changed_paths+="$path;"
+  fi
+done
+echo "changed_paths=$changed_paths" >> $GITHUB_ENV

--- a/scripts/check-changes.sh
+++ b/scripts/check-changes.sh
@@ -10,4 +10,4 @@ for path in examples/*/; do
     changed_paths+="$path;"
   fi
 done
-echo "changed_paths=$changed_paths" >> $GITHUB_ENV
+echo $changed_paths

--- a/scripts/update-example-changes.sh
+++ b/scripts/update-example-changes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-personal_access_token=$1
+sync_repo_token=$1
 changed_paths=$2
 
 # This separates the strings with ; to turn it into an array
@@ -19,13 +19,13 @@ for path in "${changed_paths_array[@]}"; do
   folder_name=$(basename $path)
 
   # Check if the listening repo exists
-  repo="https://$personal_access_token:@github.com/medplum/${folder_name}.git"
-  REPO_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token $personal_access_token" "https://api.github.com/repos/medplum/${folder_name}")
+  repo="https://$sync_repo_token:@github.com/medplum/${folder_name}.git"
+  REPO_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token $sync_repo_token" "https://api.github.com/repos/medplum/${folder_name}")
 
   # If the repo does not exist, create a new repo
   if [ $REPO_STATUS -eq 404 ]; then
     CREATE_REPO_PAYLOAD="{\"name\": \"${folder_name}\", \"default_branch\": \"main\"}"
-    CREATE_REPO_RESPONSE=$(curl -s -X POST -H "Authorization: token $personal_access_token" -H "Content-Type: application/json" -H "Accept: application/vnd.github+json" --data "$CREATE_REPO_PAYLOAD" "https://api.github.com/orgs/medplum/repos")
+    CREATE_REPO_RESPONSE=$(curl -s -X POST -H "Authorization: token $sync_repo_token" -H "Content-Type: application/json" -H "Accept: application/vnd.github+json" --data "$CREATE_REPO_PAYLOAD" "https://api.github.com/orgs/medplum/repos")
     echo "Created new repo: $(echo $CREATE_REPO_RESPONSE | jq -r '.html_url')"
   fi
 

--- a/scripts/update-example-changes.sh
+++ b/scripts/update-example-changes.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+personal_access_token=$1
+changed_paths=$2
+
+# This separates the strings with ; to turn it into an array
+IFS=';' read -ra changed_paths_array <<< "$changed_paths"
+echo "Changed paths array: ${changed_paths_array[@]}"
+
+# Configure Git
+git config --global user.name "github-actions[bot]"
+git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+for path in "${changed_paths_array[@]}"; do
+  # Store the current working directory
+  initial_working_directory=$(pwd)
+
+  # Extract the folder name from the path
+  folder_name=$(basename $path)
+
+  # Check if the listening repo exists
+  repo="https://$personal_access_token:@github.com/medplum/${folder_name}.git"
+  REPO_STATUS=$(curl -s -o /dev/null -I -w "%{http_code}" -H "Authorization: token $personal_access_token" "https://api.github.com/repos/medplum/${folder_name}")
+
+  # If the repo does not exist, create a new repo
+  if [ $REPO_STATUS -eq 404 ]; then
+    CREATE_REPO_PAYLOAD="{\"name\": \"${folder_name}\", \"default_branch\": \"main\"}"
+    CREATE_REPO_RESPONSE=$(curl -s -X POST -H "Authorization: token $personal_access_token" -H "Content-Type: application/json" -H "Accept: application/vnd.github+json" --data "$CREATE_REPO_PAYLOAD" "https://api.github.com/orgs/medplum/repos")
+    echo "Created new repo: $(echo $CREATE_REPO_RESPONSE | jq -r '.html_url')"
+  fi
+
+  # Clone the corresponding listening repo
+  git clone "$repo"
+
+  # Copy changed files to the listening repo
+  rsync -a --delete --exclude .git/ --exclude tsconfig.json "${initial_working_directory}/${path%}"/ ${folder_name}/
+
+  # Copy the LICENSE file to the listening repo
+  cp LICENSE.txt ${folder_name}/
+
+  # Commit and push changes to the listening repo
+  cd ${folder_name}
+  git add .
+  git commit -m "Update from main medplum repo"
+  git push origin main
+
+  # Cleanup: Remove the cloned repo folder and delete the local branch
+  cd ..
+  rm -rf ${folder_name}
+done


### PR DESCRIPTION
Cleaning up the sync repos to make it a lot more readable 

Created a test repo for it 

Github actions 
<img width="1356" alt="Screenshot 2023-05-15 at 10 50 46 AM" src="https://github.com/medplum/medplum/assets/6913745/e96e82d4-c886-4d56-9818-daa18b0bba5e">


And the listening repo
<img width="968" alt="Screenshot 2023-05-15 at 10 50 59 AM" src="https://github.com/medplum/medplum/assets/6913745/6126f09d-a874-4e5e-80b6-85113f081728">
