### PR TITLE
Fixes #2008 - handle existing s3 bucket policy in cdk

### DIFF
--- a/packages/cdk/src/frontend.ts
+++ b/packages/cdk/src/frontend.ts
@@ -1,13 +1,13 @@
 import {
+  Duration,
+  RemovalPolicy,
   aws_certificatemanager as acm,
   aws_cloudfront as cloudfront,
   aws_cloudfront_origins as origins,
   aws_route53 as route53,
-  aws_route53_targets as targets,
   aws_s3 as s3,
+  aws_route53_targets as targets,
   aws_wafv2 as wafv2,
-  Duration,
-  RemovalPolicy,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { MedplumInfraConfig } from './config';
@@ -116,7 +116,7 @@ export class FrontEnd extends Construct {
 
       // Origin access identity
       const originAccessIdentity = new cloudfront.OriginAccessIdentity(this, 'OriginAccessIdentity', {});
-      grantBucketAccessToOriginAccessIdentity(this, appBucket, originAccessIdentity);
+      grantBucketAccessToOriginAccessIdentity(appBucket, originAccessIdentity);
 
       // CloudFront distribution
       const distribution = new cloudfront.Distribution(this, 'AppDistribution', {

--- a/packages/cdk/src/oai.ts
+++ b/packages/cdk/src/oai.ts
@@ -1,5 +1,4 @@
 import { aws_cloudfront as cloudfront, aws_iam as iam, aws_s3 as s3 } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
 
 /**
  * Grants S3 bucket read access to the CloudFront Origin Access Identity (OAI).
@@ -13,12 +12,10 @@ import { Construct } from 'constructs';
  *
  * See: https://stackoverflow.com/a/60917015
  *
- * @param scope The CDK construct scope.
  * @param bucket The S3 bucket.
  * @param identity The CloudFront Origin Access Identity.
  */
 export function grantBucketAccessToOriginAccessIdentity(
-  scope: Construct,
   bucket: s3.IBucket,
   identity: cloudfront.OriginAccessIdentity
 ): void {
@@ -29,11 +26,5 @@ export function grantBucketAccessToOriginAccessIdentity(
   policyStatement.addResources(bucket.bucketArn);
   policyStatement.addResources(`${bucket.bucketArn}/*`);
   policyStatement.addCanonicalUserPrincipal(identity.cloudFrontOriginAccessIdentityS3CanonicalUserId);
-
-  let policy = bucket.policy;
-  if (!policy) {
-    policy = new s3.BucketPolicy(scope, 'Policy', { bucket });
-  }
-
-  policy.document.addStatements(policyStatement);
+  bucket.addToResourcePolicy(policyStatement);
 }

--- a/packages/cdk/src/storage.ts
+++ b/packages/cdk/src/storage.ts
@@ -1,12 +1,12 @@
 import {
+  Duration,
   aws_certificatemanager as acm,
   aws_cloudfront as cloudfront,
   aws_cloudfront_origins as origins,
   aws_route53 as route53,
-  aws_route53_targets as targets,
   aws_s3 as s3,
+  aws_route53_targets as targets,
   aws_wafv2 as wafv2,
-  Duration,
 } from 'aws-cdk-lib';
 import { ServerlessClamscan } from 'cdk-serverless-clamscan';
 import { Construct } from 'constructs';
@@ -102,7 +102,7 @@ export class Storage extends Construct {
 
       // Origin access identity
       const originAccessIdentity = new cloudfront.OriginAccessIdentity(this, 'OriginAccessIdentity', {});
-      grantBucketAccessToOriginAccessIdentity(this, storageBucket, originAccessIdentity);
+      grantBucketAccessToOriginAccessIdentity(storageBucket, originAccessIdentity);
 
       // CloudFront distribution
       const distribution = new cloudfront.Distribution(this, 'StorageDistribution', {


### PR DESCRIPTION
Explanation from ChatGPT:

----

Both snippets aim to achieve the same thing, which is to add a policy statement to an S3 bucket. However, they approach it in slightly different ways and each has its own implications.

In the first snippet:

```ts
  let policy = bucket.policy;
  if (!policy) {
    policy = new s3.BucketPolicy(scope, 'Policy', { bucket });
  }
  policy.document.addStatements(policyStatement);
```

This code attempts to get the existing policy from the bucket. If it doesn't exist, it creates a new one. Then it adds a new statement to the policy. This approach is more explicit, and allows you to interact with the policy in more detail. However, if the policy already exists on the bucket, trying to create a new one can lead to the error you mentioned.

In the second snippet:

```ts
  bucket.addToResourcePolicy(policyStatement);
```

This code uses the `addToResourcePolicy` method. This method automatically handles the creation or updating of the bucket's policy, which makes it more convenient and less prone to the mentioned error.

So, in your case, where the bucket could potentially already have a policy, the second snippet is likely the better choice. It is more straightforward and handles the existence check and potential creation of the policy automatically, which makes it less error-prone. However, if you need more control or need to interact with the policy in more detail, you might have to use a method similar to the first one, but with additional error handling and checks.