### PR TITLE
Use postgres explain hack for fast 'estimate' count

### DIFF
--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -31,6 +31,7 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 import { Container } from '../Container/Container';
 import { useMedplum } from '../MedplumProvider/MedplumProvider';
+import { SearchExportDialog } from '../SearchExportDialog/SearchExportDialog';
 import { SearchFieldEditor } from '../SearchFieldEditor/SearchFieldEditor';
 import { SearchFilterEditor } from '../SearchFilterEditor/SearchFilterEditor';
 import { SearchFilterValueDialog } from '../SearchFilterValueDialog/SearchFilterValueDialog';
@@ -39,7 +40,6 @@ import { SearchPopupMenu } from '../SearchPopupMenu/SearchPopupMenu';
 import { isCheckboxCell, killEvent } from '../utils/dom';
 import { getFieldDefinitions } from './SearchControlField';
 import { addFilter, buildFieldNameString, getOpString, renderValue, setPage } from './SearchUtils';
-import { SearchExportDialog } from '../SearchExportDialog/SearchExportDialog';
 
 export class SearchChangeEvent extends Event {
   readonly definition: SearchRequest;
@@ -166,7 +166,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
     medplum
       .search(
         search.resourceType as ResourceType,
-        formatSearchQuery({ ...search, total: 'accurate', fields: undefined })
+        formatSearchQuery({ ...search, total: 'estimate', fields: undefined })
       )
       .then((response) => {
         setState({ ...stateRef.current, searchResponse: response });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1223,7 +1223,7 @@ export class Repository extends BaseRepository implements FhirRepository {
     const rows = await builder.execute(client);
     for (const row of rows) {
       const queryPlan = row['QUERY PLAN'];
-      const match = /rows=([\d]+)/.exec(queryPlan);
+      const match = /rows=(\d+)/.exec(queryPlan);
       if (match) {
         return parseInt(match[1]);
       }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -9,6 +9,7 @@ import {
   FhirFilterConnective,
   FhirFilterExpression,
   FhirFilterNegation,
+  Operator as FhirOperator,
   Filter,
   forbidden,
   formatSearchQuery,
@@ -16,6 +17,7 @@ import {
   getSearchParameterDetails,
   getStatus,
   gone,
+  IncludeTarget,
   isGone,
   isNotFound,
   isOk,
@@ -25,7 +27,6 @@ import {
   normalizeOperationOutcome,
   notFound,
   OperationOutcomeError,
-  Operator as FhirOperator,
   parseFilterParameter,
   parseSearchUrl,
   PropertyType,
@@ -39,7 +40,6 @@ import {
   toTypedValue,
   validateResource,
   validateResourceType,
-  IncludeTarget,
 } from '@medplum/core';
 import { BaseRepository, FhirRepository } from '@medplum/fhir-router';
 import {
@@ -925,8 +925,10 @@ export class Repository extends BaseRepository implements FhirRepository {
       }
 
       let total = undefined;
-      if (searchRequest.total === 'estimate' || searchRequest.total === 'accurate') {
-        total = await this.getTotalCount(searchRequest);
+      if (searchRequest.total === 'accurate') {
+        total = await this.getAccurateCount(searchRequest);
+      } else if (searchRequest.total === 'estimate') {
+        total = await this.getEstimateCount(searchRequest);
       }
 
       this.logEvent(SearchInteraction, AuditEventOutcome.Success, undefined, undefined, searchRequest);
@@ -1183,7 +1185,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * @param searchRequest The search request.
    * @returns The total number of matching results.
    */
-  private async getTotalCount(searchRequest: SearchRequest): Promise<number> {
+  private async getAccurateCount(searchRequest: SearchRequest): Promise<number> {
     const client = getClient();
     const builder = new SelectQuery(searchRequest.resourceType);
     this.addDeletedFilter(builder);
@@ -1198,6 +1200,35 @@ export class Repository extends BaseRepository implements FhirRepository {
 
     const rows = await builder.execute(client);
     return rows[0].count as number;
+  }
+
+  /**
+   * Returns the estimated number of matching results for a search request.
+   * This ignores page number and page size.
+   * This uses the estimated row count technique as described here: https://wiki.postgresql.org/wiki/Count_estimate
+   * @param searchRequest The search request.
+   * @returns The total number of matching results.
+   */
+  private async getEstimateCount(searchRequest: SearchRequest): Promise<number> {
+    const client = getClient();
+    const builder = new SelectQuery(searchRequest.resourceType);
+    this.addDeletedFilter(builder);
+    this.addSecurityFilters(builder, searchRequest.resourceType);
+    this.addSearchFilters(builder, searchRequest);
+    builder.raw(`DISTINCT "${searchRequest.resourceType}"."id"`);
+    builder.explain = true;
+
+    // See: https://wiki.postgresql.org/wiki/Count_estimate
+    // This parses the query plan to find the estimated number of rows.
+    const rows = await builder.execute(client);
+    for (const row of rows) {
+      const queryPlan = row['QUERY PLAN'];
+      const match = /rows=([\d]+)/.exec(queryPlan);
+      if (match) {
+        return parseInt(match[1]);
+      }
+    }
+    return 0;
   }
 
   /**

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -271,6 +271,7 @@ export class SqlBuilder {
 export abstract class BaseQuery {
   readonly tableName: string;
   readonly predicate: Conjunction;
+  explain = false;
 
   constructor(tableName: string) {
     this.tableName = tableName;
@@ -360,6 +361,9 @@ export class SelectQuery extends BaseQuery {
   }
 
   buildSql(sql: SqlBuilder): void {
+    if (this.explain) {
+      sql.append('EXPLAIN ');
+    }
     sql.append('SELECT ');
     this.buildDistinctOn(sql);
     this.buildColumns(sql);


### PR DESCRIPTION
By default, FHIR search does not include the `total` count.  In the query string params, you can pass in `_total` with value of `none`, `estimate`, or `accurate`.

Before, we treated `estimate` and `accurate` as the same, both using a Postgres `COUNT` query.  Unfortunately, counts are slow in Postgres.

In this PR, we use the Postgres "Count Estimate" hack of inspecting the output of an `EXPLAIN` query.  The technique is described here: https://wiki.postgresql.org/wiki/Count_estimate  It is dramatically faster (typically ~1ms response time vs 20ms+ for an accurate count).

On that page, see the note about `ANALYZE` and "autovacuum".  AWS Aurora Postgres has autovacuuming enabled by default with reasonable (?) defaults: https://aws.amazon.com/blogs/database/understanding-autovacuum-in-amazon-rds-for-postgresql-environments/