### PR TITLE
Listening repos to have more descriptive messaging in their commits

### DIFF
--- a/scripts/update-example-changes.sh
+++ b/scripts/update-example-changes.sh
@@ -11,6 +11,13 @@ echo "Changed paths array: ${changed_paths_array[@]}"
 git config --global user.name "github-actions[bot]"
 git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+# Get the SHA of the latest commit
+latest_commit_sha=$(git rev-parse HEAD)
+# Get the commit message of the latest commit
+commit_message=$(git log --format=%B -n 1 $latest_commit_sha)
+# Get the first line of the commit message
+formatted_title=$(echo "$commit_message" | head -n 1)
+
 for path in "${changed_paths_array[@]}"; do
   # Store the current working directory
   initial_working_directory=$(pwd)
@@ -41,7 +48,7 @@ for path in "${changed_paths_array[@]}"; do
   # Commit and push changes to the listening repo
   cd ${folder_name}
   git add .
-  git commit -m "Update from main medplum repo"
+  git commit -m "Merge from main repo: ${formatted_title}"
   git push origin main
 
   # Cleanup: Remove the cloned repo folder and delete the local branch


### PR DESCRIPTION
https://github.com/medplum/medplum/issues/2011

When merging to main in the test repo 
<img width="1067" alt="Screenshot 2023-05-19 at 1 56 44 PM" src="https://github.com/medplum/medplum/assets/6913745/5d000d63-5992-4f1d-9d27-e8b911d6c71e">


The github actions will find the most recent commit and take the first line of the message
<img width="552" alt="Screenshot 2023-05-19 at 1 57 28 PM" src="https://github.com/medplum/medplum/assets/6913745/51d34d0c-0fad-4590-bded-8a2748d53535">

The listening repo will have the merge changes with a descriptive title from the branch
<img width="1291" alt="Screenshot 2023-05-19 at 1 57 43 PM" src="https://github.com/medplum/medplum/assets/6913745/374cc671-a044-4660-9440-5df2e25a24f5">



Here is an example when a follow up branch was merged
<img width="621" alt="Screenshot 2023-05-19 at 1 59 21 PM" src="https://github.com/medplum/medplum/assets/6913745/1ffb26f1-9c79-4509-b465-b7412250641b">

