### PR TITLE
Allow users to override _total=estimate

### DIFF
--- a/packages/core/src/search/parse.test.ts
+++ b/packages/core/src/search/parse.test.ts
@@ -100,7 +100,7 @@ describe('Search parser', () => {
   test('Parse summary', () => {
     expect(parseSearchRequest('Patient', { _summary: 'true' })).toMatchObject<SearchRequest>({
       resourceType: 'Patient',
-      total: 'estimate',
+      total: 'accurate',
       count: 0,
     });
   });

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -206,7 +206,7 @@ function parseKeyValue(searchRequest: SearchRequest, key: string, value: string)
       break;
 
     case '_summary':
-      searchRequest.total = 'estimate';
+      searchRequest.total = 'accurate';
       searchRequest.count = 0;
       break;
 

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -166,7 +166,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
     medplum
       .search(
         search.resourceType as ResourceType,
-        formatSearchQuery({ ...search, total: 'estimate', fields: undefined })
+        formatSearchQuery({ ...search, total: search.total ?? 'estimate', fields: undefined })
       )
       .then((response) => {
         setState({ ...stateRef.current, searchResponse: response });


### PR DESCRIPTION
2 changes:
1. Change the `_summary` shortcut to use `accurate` rather than `estimate`
2. Allow app users to specify `_total=accurate` to get an accurate count