### PR TITLE
Revert clear cache on submit questionnaire

### DIFF
--- a/packages/app/src/FormPage.test.tsx
+++ b/packages/app/src/FormPage.test.tsx
@@ -44,7 +44,7 @@ describe('FormPage', () => {
   });
 
   test('Patient subject', async () => {
-    await setup('/forms/123?subject=Patient/123&clearCache=true');
+    await setup('/forms/123?subject=Patient/123&');
     await waitFor(() => screen.getByText('First question'));
 
     expect(screen.getByText('First question')).toBeInTheDocument();

--- a/packages/app/src/FormPage.tsx
+++ b/packages/app/src/FormPage.tsx
@@ -20,7 +20,6 @@ export function FormPage(): JSX.Element {
   const location = useLocation();
   const queryParams = Object.fromEntries(new URLSearchParams(location.search).entries()) as Record<string, string>;
   const subjectParam = queryParams.subject;
-  const clearCache = queryParams.clearCache === 'true';
   const medplum = useMedplum();
   const [loading, setLoading] = useState<boolean>(true);
   const [questionnaire, setQuestionnaire] = useState<Questionnaire | undefined>();
@@ -158,9 +157,6 @@ export function FormPage(): JSX.Element {
           })
         );
       }
-    }
-    if (clearCache) {
-      medplum.invalidateAll();
     }
     setResult(responses);
   }

--- a/packages/app/src/resource/AppsPage.tsx
+++ b/packages/app/src/resource/AppsPage.tsx
@@ -74,7 +74,7 @@ export function AppsPage(): JSX.Element | null {
       {questionnaires.map((questionnaire) => (
         <div key={questionnaire.id}>
           <Title order={3}>
-            <MedplumLink to={`/forms/${questionnaire?.id}?subject=${getReferenceString(resource)}&clearCache=true`}>
+            <MedplumLink to={`/forms/${questionnaire?.id}?subject=${getReferenceString(resource)}`}>
               {questionnaire.title || questionnaire.name}
             </MedplumLink>
           </Title>


### PR DESCRIPTION
Changes were introduced here: https://github.com/medplum/medplum/pull/2044

Everything was functional, but users noticed performance impact, so rolling back.

Kepping the `medplum.invalidateAll();` method in `MedplumClient`.