### PR TITLE
Fixed MockClient to work with new exception handling

### DIFF
--- a/packages/fhir-router/src/fhirrouter.test.ts
+++ b/packages/fhir-router/src/fhirrouter.test.ts
@@ -1,6 +1,14 @@
-import { allOk, badRequest, created, indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import {
+  allOk,
+  badRequest,
+  created,
+  indexSearchParameterBundle,
+  indexStructureDefinitionBundle,
+  notFound,
+} from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, OperationOutcome, SearchParameter } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
 import { FhirRequest, FhirRouter } from './fhirrouter';
 import { FhirRepository, MemoryRepository } from './repo';
 
@@ -100,6 +108,34 @@ describe('FHIR Router', () => {
     );
     expect(res3).toMatchObject(allOk);
     expect(patient3).toBeDefined();
+  });
+
+  test('Read resource by ID not found', async () => {
+    const [res2, patient2] = await router.handleRequest(
+      {
+        method: 'GET',
+        pathname: `/Patient/${randomUUID()}`,
+        body: {},
+        params: {},
+        query: {},
+      },
+      repo
+    );
+    expect(res2).toMatchObject(notFound);
+    expect(patient2).toBeUndefined();
+
+    const [res3, patient3] = await router.handleRequest(
+      {
+        method: 'GET',
+        pathname: `/Patient/${randomUUID()}/_history/${randomUUID()}`,
+        body: {},
+        params: {},
+        query: {},
+      },
+      repo
+    );
+    expect(res3).toMatchObject(notFound);
+    expect(patient3).toBeUndefined();
   });
 
   test('Update incorrect resource type', async () => {

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -1,4 +1,4 @@
-import { allOk, badRequest, created, notFound, parseSearchRequest } from '@medplum/core';
+import { allOk, badRequest, created, normalizeOperationOutcome, notFound, parseSearchRequest } from '@medplum/core';
 import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Operation } from 'rfc6902';
 import { processBatch } from './batch';
@@ -129,6 +129,10 @@ export class FhirRouter {
     }
     const { handler, params } = result;
     req.params = params;
-    return handler(req, repo, this);
+    try {
+      return await handler(req, repo, this);
+    } catch (err) {
+      return [normalizeOperationOutcome(err)];
+    }
   }
 }

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -341,6 +341,19 @@ describe('MockClient', () => {
     }
   });
 
+  test('Read resource after delete', async () => {
+    const client = new MockClient();
+    const patient = await client.createResource<Patient>({ resourceType: 'Patient' });
+    await client.deleteResource('Patient', patient.id as string);
+    try {
+      await client.readResource('Patient', randomUUID());
+      fail('Expected error');
+    } catch (err) {
+      const outcome = (err as OperationOutcomeError).outcome;
+      expect(outcome.id).toEqual('not-found');
+    }
+  });
+
   test('Read history', async () => {
     const client = new MockClient();
     const resource1 = await client.createResource<Patient>({ resourceType: 'Patient' });


### PR DESCRIPTION
This fixes some of the bugs revealed in https://github.com/medplum/medplum/pull/2067

The problem is that the `mockFetch` in `MockClient` was throwing errors rather than returning error responses.  That bypassed some of the error handling in the base `MedplumClient`.

In particular, those unhandled exceptions were misinterpreted as "network errors", which then caused unwanted Mantine notifications.