### PR TITLE
Add options to executeBatch

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1895,10 +1895,11 @@ export class MedplumClient extends EventTarget {
    * See The FHIR "batch/transaction" section for full details: https://hl7.org/fhir/http.html#transaction
    * @category Batch
    * @param bundle The FHIR batch/transaction bundle.
+   * @param options Optional fetch options.
    * @returns The FHIR batch/transaction response bundle.
    */
-  executeBatch(bundle: Bundle): Promise<Bundle> {
-    return this.post(this.fhirBaseUrl.slice(0, -1), bundle);
+  executeBatch(bundle: Bundle, options: RequestInit = {}): Promise<Bundle> {
+    return this.post(this.fhirBaseUrl.slice(0, -1), bundle, undefined, options);
   }
 
   /**


### PR DESCRIPTION
Fixes #2136

Beyond adding options to executeBatch, I suggested reusing the batch payload on the test to simplify and making it easier to read. But I understand that some teams prefer to have the unit test as isolated as possible from external dependencies, so I'm happy to keep the original structure if preferred.