### PR TITLE
Minor fixes to build-server-deb.sh

### DIFF
--- a/scripts/build-server-deb.sh
+++ b/scripts/build-server-deb.sh
@@ -88,7 +88,7 @@ Package: $SERVICE_NAME
 Version: $VERSION
 Section: base
 Priority: optional
-Architecture: amd64
+Architecture: all
 Depends: nodejs
 Maintainer: Medplum <hello@medplum.com>
 Description: Medplum FHIR Server
@@ -116,7 +116,7 @@ chmod 755 "$DEBIAN_DIR/postinst"
 chmod 755 "$DEBIAN_DIR/prerm"
 
 # Build the package
-dpkg-deb --build "$TMP_DIR" "$SERVICE_NAME-$VERSION.deb"
+dpkg-deb --build --root-owner-group -Zgzip "$TMP_DIR" "$SERVICE_NAME-$VERSION.deb"
 
 # Cleanup
 rm -rf "$TMP_DIR"


### PR DESCRIPTION
`Architecture: all` - Mark the .deb file as architecture-independent to support other architectures such as `armhf` for raspberry pi.

`--root-owner-group` - Mark all files as "owned by root" by default.

`-Zgzip` - Explicitly use "gzip" compression, because raspberry pi does not support the new "zstd" compression default.