### PR TITLE
Fixes #2108 - support large file bulk import in CLI

### DIFF
--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -1,7 +1,11 @@
 import { MedplumClient, created } from '@medplum/core';
 import { main } from '.';
 
-const testLineOutput = [`{"resourceType":"Patient", "id":"1111111"}`, `{"resourceType":"Patient", "id":"2222222"}`];
+const testLineOutput = [
+  `{"resourceType":"Patient", "id":"1111111"}`,
+  `{"resourceType":"Patient", "id":"2222222"}`,
+  `{"resourceType":"Patient", "id":"3333333"}`,
+];
 jest.mock('child_process');
 jest.mock('http');
 jest.mock('readline', () => ({
@@ -199,7 +203,7 @@ describe('CLI Bulk Commands', () => {
 
     test('success with option numResourcesPerRequest', async () => {
       medplum = new MedplumClient({ fetch });
-      await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json', '--numResourcesPerRequest', '1']);
+      await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json', '--numResourcesPerRequest', '2']);
 
       testLineOutput.forEach((line) => {
         const resource = JSON.parse(line);

--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -203,7 +203,7 @@ describe('CLI Bulk Commands', () => {
 
     test('success with option numResourcesPerRequest', async () => {
       medplum = new MedplumClient({ fetch });
-      await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json', '--numResourcesPerRequest', '2']);
+      await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json', '--numResourcesPerRequest', '1']);
 
       testLineOutput.forEach((line) => {
         const resource = JSON.parse(line);
@@ -223,7 +223,7 @@ describe('CLI Bulk Commands', () => {
         );
       });
 
-      expect(fetch).toBeCalledTimes(2);
+      expect(fetch).toBeCalledTimes(3);
     });
   });
 });

--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -193,10 +193,33 @@ describe('CLI Bulk Commands', () => {
           })
         );
       });
-
       expect(console.log).toBeCalledWith(expect.stringMatching(`"status": "201"`));
-      expect(console.log).toBeCalledWith(expect.stringMatching(`"type": "transaction-response"`));
       expect(console.log).toBeCalledWith(expect.stringMatching(`"text": "Created"`));
+    });
+
+    test('success with option numResourcesPerRequest', async () => {
+      medplum = new MedplumClient({ fetch });
+      await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json', '--numResourcesPerRequest', '1']);
+
+      testLineOutput.forEach((line) => {
+        const resource = JSON.parse(line);
+        expect(fetch).toBeCalledWith(
+          expect.stringMatching(`/fhir/R4`),
+          expect.objectContaining({
+            body: expect.stringContaining(
+              JSON.stringify({
+                resource: resource,
+                request: {
+                  method: 'POST',
+                  url: resource.resourceType,
+                },
+              })
+            ),
+          })
+        );
+      });
+
+      expect(fetch).toBeCalledTimes(2);
     });
   });
 });

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -35,15 +35,17 @@ bulk
   .argument('<filename>', 'File Name')
   .option(
     '--numResourcesPerRequest <numResourcesPerRequest>',
-    'optional number of resources to import per batch request'
+    'optional number of resources to import per batch request. Defaults to 25.'
   )
   .action(async (fileName, options) => {
     const path = resolve(process.cwd(), fileName);
     const { numResourcesPerRequest } = options;
-    await importFile(path, numResourcesPerRequest);
+
+    const num = numResourcesPerRequest ? parseInt(numResourcesPerRequest) : 25;
+    await importFile(path, num);
   });
 
-async function importFile(path: string, numResourcesPerRequest = 25): Promise<void> {
+async function importFile(path: string, numResourcesPerRequest: number): Promise<void> {
   let entries = [] as BundleEntry[];
   const fileStream = createReadStream(path);
   const rl = createInterface({

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -35,14 +35,14 @@ bulk
   .argument('<filename>', 'File Name')
   .option(
     '--numResourcesPerRequest <numResourcesPerRequest>',
-    'optional number of resources to import per batch request. Defaults to 25.'
+    'optional number of resources to import per batch request. Defaults to 25.',
+    '25'
   )
   .action(async (fileName, options) => {
     const path = resolve(process.cwd(), fileName);
     const { numResourcesPerRequest } = options;
 
-    const num = numResourcesPerRequest ? parseInt(numResourcesPerRequest) : 25;
-    await importFile(path, num);
+    await importFile(path, parseInt(numResourcesPerRequest));
   });
 
 async function importFile(path: string, numResourcesPerRequest: number): Promise<void> {


### PR DESCRIPTION
During importing there might be a size limits on API requests. CLI bulk import command now batches 25 resources per requests. There is an option to override the default value where the batch requests are too large for the server to handle.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4c53697</samp>

### Summary
📄🔢🚀

<!--
1.  📄 - This emoji represents a file or document, which is relevant for the bulk import command that reads from an input file and creates batch entries for each resource.
2.  🔢 - This emoji represents numbers or digits, which is relevant for the new option that specifies how many resources to import per batch request.
3.  🚀 - This emoji represents speed or performance, which is relevant for the refactoring of the command action that improves the efficiency and readability of the code.
-->
Added a new option to the bulk import command to control the batch size and improved the code structure. The option `--numResourcesPerRequest` lets the user specify how many resources to import per request. The code was refactored into two functions: `importFile` and `sendBatchEntries` to handle reading the input file and sending the batch requests.

> _We are the masters of the batch_
> _We import resources with a switch_
> _`--numResourcesPerRequest` is our power_
> _We send the entries and make them cower_

### Walkthrough
*  Add option `--numResourcesPerRequest` to bulk import command ([link](https://github.com/medplum/medplum/pull/2142/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL36-R84))
* Add test case for bulk import command with `--numResourcesPerRequest` set to 2 ([link](https://github.com/medplum/medplum/pull/2142/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeL196-R227))
   * This test uses a mock input file with three patient resources ([link](https://github.com/medplum/medplum/pull/2142/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeL4-R8))

