### PR TITLE
Fixes #2130 - use Communication.sent in resource timeline

### DIFF
--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -464,6 +464,7 @@ function CommunicationTimelineItem(props: BaseTimelineItemProps<Communication>):
     <TimelineItem
       resource={props.resource}
       profile={props.resource.sender}
+      dateTime={props.resource.sent}
       padding={true}
       className={className}
       popupMenuItems={<TimelineItemPopupMenu {...props} />}

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -21,6 +21,7 @@ export function Timeline(props: TimelineProps): JSX.Element {
 export interface TimelineItemProps extends PanelProps {
   resource: Resource;
   profile?: Reference;
+  dateTime?: string;
   padding?: boolean;
   popupMenuItems?: React.ReactNode;
 }
@@ -28,6 +29,7 @@ export interface TimelineItemProps extends PanelProps {
 export function TimelineItem(props: TimelineItemProps): JSX.Element {
   const { resource, profile, padding, popupMenuItems, ...others } = props;
   const author = profile ?? resource.meta?.author;
+  const dateTime = props.dateTime ?? resource.meta?.lastUpdated;
 
   return (
     <Panel data-testid="timeline-item" fill={true} {...others}>
@@ -39,7 +41,7 @@ export function TimelineItem(props: TimelineItemProps): JSX.Element {
           </Text>
           <Text size="xs">
             <MedplumLink color="dimmed" to={props.resource}>
-              {formatDateTime(props.resource.meta?.lastUpdated)}
+              {formatDateTime(dateTime)}
             </MedplumLink>
             <Text component="span" color="dimmed" mx={8}>
               &middot;

--- a/packages/react/src/utils/date.test.ts
+++ b/packages/react/src/utils/date.test.ts
@@ -45,4 +45,27 @@ describe('Date utils', () => {
     sortByDateAndPriority(input);
     expect(input).toMatchObject(expected);
   });
+
+  test('Ignore sorting special cases on timeline', () => {
+    // When looking at a particular resource's timeline view,
+    // history events for that resource should not use the sorting special cases
+    const resourceType = 'Communication';
+    const id = '1234';
+    const input: Communication[] = [
+      { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+      { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
+      { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
+      { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
+      { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
+    ];
+    const expected: Communication[] = [
+      { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+      { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
+      { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
+      { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
+      { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
+    ];
+    sortByDateAndPriority(input, input[0]);
+    expect(input).toMatchObject(expected);
+  });
 });

--- a/packages/react/src/utils/date.ts
+++ b/packages/react/src/utils/date.ts
@@ -7,8 +7,8 @@ import { Resource } from '@medplum/fhirtypes';
  */
 export function sortByDateAndPriority(resources: Resource[], timelineResource?: Resource): void {
   resources.sort((a: Resource, b: Resource): number => {
-    const priority1 = getPriorityScore(a);
-    const priority2 = getPriorityScore(b);
+    const priority1 = getPriorityScore(a, timelineResource);
+    const priority2 = getPriorityScore(b, timelineResource);
     if (priority1 > priority2) {
       return 1;
     }
@@ -19,10 +19,14 @@ export function sortByDateAndPriority(resources: Resource[], timelineResource?: 
   });
 }
 
-function getPriorityScore(resource: Resource): number {
-  const priority = (resource as any).priority;
-  if (typeof priority === 'string') {
-    return { stat: 4, asap: 3, urgent: 2 }[priority] || 0;
+function getPriorityScore(resource: Resource, timelineResource: Resource | undefined): number {
+  if (!isSameResourceType(resource, timelineResource)) {
+    // Only use priority if not the primary resource of a timeline view.
+
+    const priority = (resource as any).priority;
+    if (typeof priority === 'string') {
+      return { stat: 4, asap: 3, urgent: 2 }[priority] || 0;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Two changes:
* In the a `<TimelineItem>` for a `Communication` resource, use `Communication.sent` rather than `Communication.meta.lastUpdated`
* Fix sorting bug where `Communication` history versions sorted with `priority` when they shouldn't