### PR TITLE
Fix Repos Sync with Multiple Examples 

### DIFF
--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Update listening repos, create PR, and clean up
         if: env.changed_paths != ''
         run: |
-          ./scripts/update-example-changes.sh ${{ secrets.SYNC_REPO_TOKEN }} ${{ env.changed_paths }}
+          ./scripts/update-example-changes.sh "${{ secrets.SYNC_REPO_TOKEN }}" "${{ env.changed_paths }}"


### PR DESCRIPTION
When iterating through the changed_arrays, every directory after the initial one was being treated as command rather than a string, so I needed to put quotes in the parameters of the .yml file when passing it.

Tested with 3 projects, 2 existing and 1 new one

```
Run ./scripts/update-example-changes.sh "***" "examples/james-goodbye/;examples/james-hello/;examples/james-test-other/;"
Changed paths array: examples/james-goodbye/ examples/james-hello/ examples/james-test-other/
Created new repo: https://github.com/medplum/james-goodbye
Cloning into 'james-goodbye'...
warning: redirecting to https://github.com/medplum/james-goodbye.git/
warning: You appear to have cloned an empty repository.
[main (root-commit) 2efbba2] Merge from main repo: Merge pull request #6 from medplum/james-pr
 2 files changed, 2 insertions(+)
 create mode 100644 LICENSE.txt
 create mode 100644 the-james.ts
warning: redirecting to https://github.com/medplum/james-goodbye.git/
To https://github.com/medplum/james-goodbye.git
 * [new branch]      main -> main
Cloning into 'james-hello'...
warning: redirecting to https://github.com/medplum/james-hello.git/
[main 2d02a[14](https://github.com/medplum/test-sync-repo/actions/runs/5137510181/jobs/9245691596#step:5:15)] Merge from main repo: Merge pull request #6 from medplum/james-pr
 1 file changed, 1 insertion(+)
warning: redirecting to https://github.com/medplum/james-hello.git/
remote: Resolving deltas:   0% (0/1)        
remote: Resolving deltas: 100% (1/1)        
remote: Resolving deltas: 100% (1/1), completed with 1 local object.        
To https://github.com/medplum/james-hello.git
   8f37fab..2d02a14  main -> main
Cloning into 'james-test-other'...
warning: redirecting to https://github.com/medplum/james-test-other.git/
[main cec9e11] Merge from main repo: Merge pull request #6 from medplum/james-pr
 1 file changed, 1 insertion(+), 1 deletion(-)
warning: redirecting to https://github.com/medplum/james-test-other.git/
remote: Resolving deltas:   0% (0/1)        
remote: Resolving deltas: 100% (1/1)        
remote: Resolving deltas: 100% (1/1), completed with 1 local object.        
To https://github.com/medplum/james-test-other.git
   d0c1c4c..cec9e11  main -> main
```
<img width="1237" alt="Screenshot 2023-05-31 at 1 43 48 PM" src="https://github.com/medplum/medplum/assets/6913745/824cceae-247a-4c45-9c4e-364bb0d50eef">

Tested with 1 change out of the 3 projects and that was merged as well
