### PR TITLE
support external fhir server auth using startClientLogin

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -43,16 +43,16 @@ describe('CLI', () => {
     process.env = env;
   });
 
-  test('run', () => {
-    run();
+  test('run', async () => {
+    await run();
     expect(process.exit).toBeCalledWith(1);
   });
 
-  test('run with optional env set', () => {
+  test('run with optional env set', async () => {
     process.env.MEDPLUM_BASE_URL = 'http://example.com';
     process.env.MEDPLUM_FHIR_URL_PATH = '/fhir/test/path/';
     process.env.MEDPLUM_CLIENT_ACCESS_TOKEN = 'test_token';
-    run();
+    await run();
     expect(process.exit).toBeCalledWith(1);
   });
 
@@ -73,7 +73,7 @@ describe('CLI', () => {
     process.env.MEDPLUM_CLIENT_ID = '123';
     process.env.MEDPLUM_CLIENT_SECRET = 'abc';
     await main(medplum, ['node', 'index.js', 'whoami']);
-    expect(medplum.getActiveLogin()).toBeDefined();
+    expect(medplum.getAccessToken()).toBeDefined();
   });
 
   test('Login success', async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -64,7 +64,7 @@ export function run(): void {
   const baseUrl = process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
   const fhirUrlPath = process.env['MEDPLUM_FHIR_URL_PATH'] || '';
   const accessToken = process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
-  const tokenUrl = process.env['MEDPLUM_TOKEN_URL'] || 'https://api.medplum.com/';
+  const tokenUrl = process.env['MEDPLUM_TOKEN_URL'] || '';
 
   const medplumClient = new MedplumClient({
     fetch,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,12 @@ export async function main(medplumClient: MedplumClient, argv: string[]): Promis
   medplum = medplumClient;
 
   try {
+    const clientId = process.env['MEDPLUM_CLIENT_ID'];
+    const clientSecret = process.env['MEDPLUM_CLIENT_SECRET'];
+    if (clientId && clientSecret) {
+      medplumClient.setBasicAuth(clientId, clientSecret);
+      await medplumClient.startClientLogin(clientId, clientSecret);
+    }
     const index = new Command('medplum').description('Command to access Medplum CLI');
     index.version(MEDPLUM_VERSION);
 
@@ -70,12 +76,6 @@ export async function run(): Promise<void> {
 
   if (accessToken) {
     medplumClient.setAccessToken(accessToken);
-  }
-  const clientId = process.env['MEDPLUM_CLIENT_ID'];
-  const clientSecret = process.env['MEDPLUM_CLIENT_SECRET'];
-  if (clientId && clientSecret) {
-    medplumClient.setBasicAuth(clientId, clientSecret);
-    await medplumClient.startClientLogin(clientId, clientSecret);
   }
   await main(medplumClient, process.argv);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,8 +18,8 @@ export async function main(medplumClient: MedplumClient, argv: string[]): Promis
   const clientId = process.env['MEDPLUM_CLIENT_ID'];
   const clientSecret = process.env['MEDPLUM_CLIENT_SECRET'];
   if (clientId && clientSecret) {
-    // await medplum.startClientLogin(clientId, clientSecret);
-    await medplum.setBasicAuth(clientId, clientSecret);
+    medplum.setBasicAuth(clientId, clientSecret);
+    await medplum.startClientLogin(clientId, clientSecret);
   }
   try {
     const index = new Command('medplum').description('Command to access Medplum CLI');
@@ -64,12 +64,12 @@ export function run(): void {
   const baseUrl = process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
   const fhirUrlPath = process.env['MEDPLUM_FHIR_URL_PATH'] || '';
   const accessToken = process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
-  // const tokenUrl = process.env['MEDPLUM_TOKEN_URL'] || 'https://api.medplum.com/';
+  const tokenUrl = process.env['MEDPLUM_TOKEN_URL'] || 'https://api.medplum.com/';
 
   const medplumClient = new MedplumClient({
     fetch,
     baseUrl,
-    // tokenUrl,
+    tokenUrl,
     fhirUrlPath,
     storage: new FileSystemStorage(),
     onUnauthenticated: onUnauthenticated,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,8 @@ export async function main(medplumClient: MedplumClient, argv: string[]): Promis
   const clientId = process.env['MEDPLUM_CLIENT_ID'];
   const clientSecret = process.env['MEDPLUM_CLIENT_SECRET'];
   if (clientId && clientSecret) {
-    await medplum.startClientLogin(clientId, clientSecret);
+    // await medplum.startClientLogin(clientId, clientSecret);
+    await medplum.setBasicAuth(clientId, clientSecret);
   }
   try {
     const index = new Command('medplum').description('Command to access Medplum CLI');
@@ -63,10 +64,12 @@ export function run(): void {
   const baseUrl = process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
   const fhirUrlPath = process.env['MEDPLUM_FHIR_URL_PATH'] || '';
   const accessToken = process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
+  // const tokenUrl = process.env['MEDPLUM_TOKEN_URL'] || 'https://api.medplum.com/';
 
   const medplumClient = new MedplumClient({
     fetch,
     baseUrl,
+    // tokenUrl,
     fhirUrlPath,
     storage: new FileSystemStorage(),
     onUnauthenticated: onUnauthenticated,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2032,7 +2032,9 @@ export class MedplumClient extends EventTarget {
     this.storage.setObject('activeLogin', login);
     this.addLogin(login);
     this.refreshPromise = undefined;
-    await this.refreshProfile();
+    if (this.refreshToken) {
+      await this.refreshProfile();
+    }
   }
 
   /**
@@ -2431,7 +2433,6 @@ export class MedplumClient extends EventTarget {
     } else if (this.basicAuth) {
       headers['Authorization'] = 'Basic ' + this.basicAuth;
     }
-
     if (!options.cache) {
       options.cache = 'no-cache';
     }
@@ -2678,6 +2679,7 @@ export class MedplumClient extends EventTarget {
 
     // Verify token has not expired
     const tokenPayload = parseJWTPayload(token);
+
     if (Date.now() >= (tokenPayload.exp as number) * 1000) {
       this.clearActiveLogin();
       throw new Error('Token expired');
@@ -2687,6 +2689,7 @@ export class MedplumClient extends EventTarget {
     // external tokenPayload
     if (tokenPayload.cid) {
       if (tokenPayload.cid === this.clientId) {
+        this.setAccessToken(token);
         return this.setActiveLogin({
           accessToken: token,
           refreshToken: tokens.refresh_token,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2031,6 +2031,9 @@ export class MedplumClient extends EventTarget {
   async setActiveLogin(login: LoginState): Promise<void> {
     this.clearActiveLogin();
     this.accessToken = login.accessToken;
+    if (this.basicAuth) {
+      return;
+    }
     this.refreshToken = login.refreshToken;
     this.storage.setObject('activeLogin', login);
     this.addLogin(login);
@@ -2695,11 +2698,6 @@ export class MedplumClient extends EventTarget {
     } else if (this.clientId && tokenPayload.client_id !== this.clientId) {
       this.clearActiveLogin();
       throw new Error('Token was not issued for this audience');
-    }
-
-    if (this.basicAuth) {
-      this.setAccessToken(token);
-      return;
     }
 
     return this.setActiveLogin({

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2643,21 +2643,16 @@ export class MedplumClient extends EventTarget {
    * @param formBody Token parameters in URL encoded format.
    */
   private async fetchTokens(formBody: URLSearchParams): Promise<ProfileResource> {
-    let options = {};
+    const options = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+      credentials: 'include',
+    };
+    const headers = options.headers as Record<string, string>;
+
     if (this.basicAuth) {
-      options = {
-        method: 'POST',
-        headers: { Authorization: `Basic ${this.basicAuth}` },
-        body: formBody,
-        credentials: 'include',
-      };
-    } else {
-      options = {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: formBody,
-        credentials: 'include',
-      };
+      headers['Authorization'] = `Basic ${this.basicAuth}`;
     }
 
     const response = await this.fetch(this.tokenUrl, options);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2070,9 +2070,6 @@ export class MedplumClient extends EventTarget {
   private async refreshProfile(): Promise<ProfileResource | undefined> {
     this.profilePromise = new Promise((resolve, reject) => {
       if (this.basicAuth) {
-        console.log('do not auth me');
-
-        resolve(false);
         return;
       }
       this.get('auth/me')

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -597,6 +597,9 @@ export class MedplumClient extends EventTarget {
    * @category Authentication
    */
   clearActiveLogin(): void {
+    if (this.basicAuth) {
+      return;
+    }
     this.storage.setString('activeLogin', undefined);
     this.requestCache?.clear();
     this.accessToken = undefined;


### PR DESCRIPTION
Todo before reviews
- [ ] Address comments
- [ ] Unit tests
- [ ] documentation


Use `setBasicAuth` + `startClientLogin` to request access tokens with client id and client secret using basic auth. This is supported by Medplum API and [BCDA](https://bcda.cms.gov/guide.html#try-the-api).


With BCDA credentials:

```
MEDPLUM_BASE_URL=https://sandbox.bcda.cms.gov
MEDPLUM_FHIR_URL_PATH=api/v2/
MEDPLUM_TOKEN_URL=https://sandbox.bcda.cms.gov/auth/token
MEDPLUM_CLIENT_ID={BCDA_CLIENT_ID}
MEDPLUM_CLIENT_SECRET={BCDA_CLIENT_SECRET}
```

```
tonylee@Tony-MBP test % npx medplum bulk export -e Patient
Patient.ndjson is created
Coverage.ndjson is created
ExplanationOfBenefit.ndjson is created
```

With Medplum credentials
```
MEDPLUM_BASE_URL=http://localhost:8103
MEDPLUM_CLIENT_ID={MEDPLUM_CLIENT_ID}
MEDPLUM_CLIENT_SECRET={MEDPLUM_CLIENT_SECRET}
MEDPLUM_FHIR_URL_PATH=
MEDPLUM_TOKEN_URL=
```

```
tonylee@Tony-MBP test % npx medplum bulk export -e Group/70dad8dd-81c2-47c1-a709-1e16f644899e
Patient.ndjson is created
Group.ndjson is created
```