### PR TITLE
More eslint cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,9 +109,17 @@
         "error",
         "always"
       ],
-      "jsdoc/check-tag-names": 0,
+      "jsdoc/check-tag-names": [
+        "error",
+        {
+          "definedTags": [
+            "category",
+            "experimental",
+            "ts-ignore"
+          ]
+        }
+      ],
       "jsdoc/require-jsdoc": 0,
-      "jsdoc/tag-lines": 0,
       "prefer-promise-reject-errors": "error"
     },
     "ignorePatterns": [

--- a/packages/cdk/src/oai.ts
+++ b/packages/cdk/src/oai.ts
@@ -11,7 +11,6 @@ import { aws_cloudfront as cloudfront, aws_iam as iam, aws_s3 as s3 } from 'aws-
  * However, if importing an S3 bucket via `s3.Bucket.fromBucketAttributes()`, that does not work.
  *
  * See: https://stackoverflow.com/a/60917015
- *
  * @param bucket The S3 bucket.
  * @param identity The CloudFront Origin Access Identity.
  */

--- a/packages/cli/src/aws/describe.ts
+++ b/packages/cli/src/aws/describe.ts
@@ -2,7 +2,6 @@ import { getStackByTag, printStackDetails } from './utils';
 
 /**
  * The AWS "describe" command prints details about a Medplum CloudFormation stack.
- *
  * @param tag The Medplum stack tag.
  */
 export async function describeStacksCommand(tag: string): Promise<void> {

--- a/packages/cli/src/aws/init.ts
+++ b/packages/cli/src/aws/init.ts
@@ -409,7 +409,6 @@ async function listCertificates(region: string): Promise<CertificateSummary[]> {
  * 1. If the certificate already exists, return the ARN.
  * 2. If the certificate does not exist, and the user wants to create a new certificate, create it and return the ARN.
  * 3. If the certificate does not exist, and the user does not want to create a new certificate, return a placeholder.
- *
  * @param config In-progress config settings.
  * @param allCerts List of all existing certificates.
  * @param region The AWS region where the certificate is needed.
@@ -476,7 +475,6 @@ async function requestCert(region: string, domain: string): Promise<string> {
  *   3. It must be a 2048-bit key pair.
  *
  * See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs
- *
  * @returns A new signing key.
  */
 function generateSigningKey(): { publicKey: string; privateKey: string; passphrase: string } {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -142,7 +142,6 @@ function escapeRegex(str: string): string {
  * Expanding archive files without controlling resource consumption is security-sensitive
  *
  * See: https://sonarcloud.io/organizations/medplum/rules?open=typescript%3AS5042&rule_key=typescript%3AS5042
- *
  * @param destinationDir The destination directory where all files will be extracted.
  * @returns A tar file extractor.
  */

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -645,7 +645,6 @@ export class MedplumClient extends EventTarget {
    * This is a lower level method for custom requests.
    * For common operations, we recommend using higher level methods
    * such as `readResource()`, `search()`, etc.
-   *
    * @category HTTP
    * @param url The target URL.
    * @param options Optional fetch options.
@@ -688,7 +687,6 @@ export class MedplumClient extends EventTarget {
    * This is a lower level method for custom requests.
    * For common operations, we recommend using higher level methods
    * such as `createResource()`.
-   *
    * @category HTTP
    * @param url The target URL.
    * @param body The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
@@ -714,7 +712,6 @@ export class MedplumClient extends EventTarget {
    * This is a lower level method for custom requests.
    * For common operations, we recommend using higher level methods
    * such as `updateResource()`.
-   *
    * @category HTTP
    * @param url The target URL.
    * @param body The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
@@ -740,7 +737,6 @@ export class MedplumClient extends EventTarget {
    * This is a lower level method for custom requests.
    * For common operations, we recommend using higher level methods
    * such as `patchResource()`.
-   *
    * @category HTTP
    * @param url The target URL.
    * @param operations Array of JSONPatch operations.
@@ -762,7 +758,6 @@ export class MedplumClient extends EventTarget {
    * This is a lower level method for custom requests.
    * For common operations, we recommend using higher level methods
    * such as `deleteResource()`.
-   *
    * @category HTTP
    * @param url The target URL.
    * @param options Optional fetch options.
@@ -780,7 +775,6 @@ export class MedplumClient extends EventTarget {
    * This method is part of the two different user registration flows:
    * 1) New Practitioner and new Project
    * 2) New Patient registration
-   *
    * @category Authentication
    * @param newUserRequest Register request including email and password.
    * @returns Promise to the authentication response.
@@ -798,7 +792,6 @@ export class MedplumClient extends EventTarget {
    * Initiates a new project flow.
    *
    * This requires a partial login from `startNewUser` or `startNewGoogleUser`.
-   *
    * @param newProjectRequest Register request including email and password.
    * @returns Promise to the authentication response.
    */
@@ -810,7 +803,6 @@ export class MedplumClient extends EventTarget {
    * Initiates a new patient flow.
    *
    * This requires a partial login from `startNewUser` or `startNewGoogleUser`.
-   *
    * @param newPatientRequest Register request including email and password.
    * @returns Promise to the authentication response.
    */
@@ -1032,7 +1024,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @category Search
    * @param resourceType The FHIR resource type.
    * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1080,7 +1071,6 @@ export class MedplumClient extends EventTarget {
    * The return value is the resource, if available; otherwise, undefined.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @category Search
    * @param resourceType The FHIR resource type.
    * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1122,7 +1112,6 @@ export class MedplumClient extends EventTarget {
    * The return value is an array of resources.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @category Search
    * @param resourceType The FHIR resource type.
    * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1163,7 +1152,6 @@ export class MedplumClient extends EventTarget {
    *  }
    * }
    * ```
-   *
    * @category Search
    * @param resourceType The FHIR resource type.
    * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1193,7 +1181,6 @@ export class MedplumClient extends EventTarget {
   /**
    * Searches a ValueSet resource using the "expand" operation.
    * See: https://www.hl7.org/fhir/operation-valueset-expand.html
-   *
    * @category Search
    * @param system The ValueSet system url.
    * @param filter The search string.
@@ -1251,7 +1238,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "read" operation for full details: https://www.hl7.org/fhir/http.html#read
-   *
    * @category Read
    * @param resourceType The FHIR resource type.
    * @param id The resource ID.
@@ -1280,7 +1266,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "read" operation for full details: https://www.hl7.org/fhir/http.html#read
-   *
    * @category Read
    * @param reference The FHIR reference object.
    * @param options Optional fetch options.
@@ -1393,7 +1378,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "history" operation for full details: https://www.hl7.org/fhir/http.html#history
-   *
    * @category Read
    * @param resourceType The FHIR resource type.
    * @param id The resource ID.
@@ -1419,7 +1403,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "vread" operation for full details: https://www.hl7.org/fhir/http.html#vread
-   *
    * @category Read
    * @param resourceType The FHIR resource type.
    * @param id The resource ID.
@@ -1447,7 +1430,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "patient-everything" operation for full details: https://hl7.org/fhir/operation-patient-everything.html
-   *
    * @category Read
    * @param id The Patient Id
    * @param options Optional fetch options.
@@ -1476,7 +1458,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
-   *
    * @category Create
    * @param resource The FHIR resource to create.
    * @returns The result of the create operation.
@@ -1523,7 +1504,6 @@ export class MedplumClient extends EventTarget {
    * The query parameter only contains the search parameters (what would be in the URL following the "?").
    *
    * See the FHIR "conditional create" operation for full details: https://www.hl7.org/fhir/http.html#ccreate
-   *
    * @category Create
    * @param resource The FHIR resource to create.
    * @param query The search query for an equivalent resource (should not include resource type or "?").
@@ -1550,7 +1530,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
-   *
    * @category Create
    * @param data The binary data to upload.
    * @param filename Optional filename for the binary.
@@ -1628,7 +1607,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the pdfmake document definition for full details: https://pdfmake.github.io/docs/0.1/document-definition-object/
-   *
    * @category Media
    * @param docDefinition The PDF document definition.
    * @param filename Optional filename for the PDF binary resource.
@@ -1653,7 +1631,6 @@ export class MedplumClient extends EventTarget {
    * Creates a FHIR `Communication` resource with the provided data content.
    *
    * This is a convenience method to handle commmon cases where a `Communication` resource is created with a `payload`.
-   *
    * @category Create
    * @param resource The FHIR resource to comment on.
    * @param text The text of the comment.
@@ -1709,7 +1686,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "update" operation for full details: https://www.hl7.org/fhir/http.html#update
-   *
    * @category Write
    * @param resource The FHIR resource to update.
    * @returns The result of the update operation.
@@ -1750,7 +1726,6 @@ export class MedplumClient extends EventTarget {
    * See the FHIR "update" operation for full details: https://www.hl7.org/fhir/http.html#patch
    *
    * See the JSONPatch specification for full details: https://tools.ietf.org/html/rfc6902
-   *
    * @category Write
    * @param resourceType The FHIR resource type.
    * @param id The resource ID.
@@ -1776,7 +1751,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "delete" operation for full details: https://www.hl7.org/fhir/http.html#delete
-   *
    * @category Delete
    * @param resourceType The FHIR resource type.
    * @param id The resource ID.
@@ -1801,7 +1775,6 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "$validate" operation for full details: https://www.hl7.org/fhir/resource-operation-validate.html
-   *
    * @param resource The FHIR resource.
    * @returns The validate operation outcome.
    */
@@ -1987,7 +1960,6 @@ export class MedplumClient extends EventTarget {
    * See the GraphQL documentation for more details: https://graphql.org/learn/
    *
    * See the FHIR GraphQL documentation for FHIR specific details: https://www.hl7.org/fhir/graphql.html
-   *
    * @category Read
    * @param query The GraphQL query.
    * @param operationName Optional GraphQL operation name.
@@ -2177,7 +2149,6 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Performs Bulk Data Export operation request flow. See The FHIR "Bulk Data Export" for full details: https://build.fhir.org/ig/HL7/bulk-data/export.html#bulk-data-export
-   *
    * @param exportLevel Optional export level. Defaults to system level export. 'Group/:id' - Group of Patients, 'Patient' - All Patients.
    * @param resourceTypes A string of comma-delimited FHIR resource types.
    * @param since Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).
@@ -2639,7 +2610,6 @@ export class MedplumClient extends EventTarget {
    * // Example Search
    * await medplum.searchResources('Patient')
    * ```
-   *
    * @category Authentication
    * @param clientId The client ID.
    * @param clientSecret The client secret.

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -31,7 +31,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns true if the input collection is empty ({ }) and false otherwise.
    *
    * See: https://hl7.org/fhirpath/#empty-boolean
-   *
    * @param input The input collection.
    * @returns True if the input collection is empty ({ }) and false otherwise.
    */
@@ -49,7 +48,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * for where(criteria).exists().
    *
    * See: https://hl7.org/fhirpath/#existscriteria-expression-boolean
-   *
    * @param input The input collection.
    * @param criteria Optional criteria applied to the collection.
    * @returns True if the collection has unknown elements, and false otherwise.
@@ -69,7 +67,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#allcriteria-expression-boolean
-   *
    * @param input The input collection.
    * @param criteria The evaluation criteria.
    * @returns True if for every element in the input collection, criteria evaluates to true.
@@ -84,7 +81,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#alltrue-boolean
-   *
    * @param input The input collection.
    * @returns True if all the items are true.
    */
@@ -102,7 +98,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If all the items are false, or if the input is empty ({ }), the result is false.
    *
    * See: https://hl7.org/fhirpath/#anytrue-boolean
-   *
    * @param input The input collection.
    * @returns True if unknown of the items are true.
    */
@@ -121,7 +116,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#allfalse-boolean
-   *
    * @param input The input collection.
    * @returns True if all the items are false.
    */
@@ -139,7 +133,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If all the items are true, or if the input is empty ({ }), the result is false.
    *
    * See: https://hl7.org/fhirpath/#anyfalse-boolean
-   *
    * @param input The input collection.
    * @returns True if for every element in the input collection, criteria evaluates to true.
    */
@@ -183,7 +176,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns 0 when the input collection is empty.
    *
    * See: https://hl7.org/fhirpath/#count-integer
-   *
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
@@ -202,7 +194,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * preserved in the result.
    *
    * See: https://hl7.org/fhirpath/#distinct-collection
-   *
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
@@ -222,7 +213,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * as defined below.
    *
    * See: https://hl7.org/fhirpath/#isdistinct-boolean
-   *
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
@@ -247,7 +237,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * consistent with singleton evaluation of collections behavior.
    *
    * See: https://hl7.org/fhirpath/#wherecriteria-expression-collection
-   *
    * @param input The input collection.
    * @param criteria The condition atom.
    * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
@@ -266,7 +255,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * the input collection is empty ({ }), the result is empty as well.
    *
    * See: http://hl7.org/fhirpath/#selectprojection-expression-collection
-   *
    * @param input The input collection.
    * @param criteria The condition atom.
    * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
@@ -291,7 +279,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * must resolve to the name of a type in a model
    *
    * See: http://hl7.org/fhirpath/#oftypetype-type-specifier-collection
-   *
    * @param input The input collection.
    * @param criteria The condition atom.
    * @returns A collection containing only those elements in the input collection that are of the given type or a subclass thereof.
@@ -312,7 +299,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * about cardinality is violated at run-time.
    *
    * See: https://hl7.org/fhirpath/#single-collection
-   *
    * @param input The input collection.
    * @returns The single item in the input if there is just one item.
    */
@@ -328,7 +314,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * This function is equivalent to item[0], so it will return an empty collection if the input collection has no items.
    *
    * See: https://hl7.org/fhirpath/#first-collection
-   *
    * @param input The input collection.
    * @returns A collection containing only the first item in the input collection.
    */
@@ -341,7 +326,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Will return an empty collection if the input collection has no items.
    *
    * See: https://hl7.org/fhirpath/#last-collection
-   *
    * @param input The input collection.
    * @returns A collection containing only the last item in the input collection.
    */
@@ -354,7 +338,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Will return an empty collection if the input collection has no items, or only one item.
    *
    * See: https://hl7.org/fhirpath/#tail-collection
-   *
    * @param input The input collection.
    * @returns A collection containing all but the first item in the input collection.
    */
@@ -369,7 +352,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If num is less than or equal to zero, the input collection is simply returned.
    *
    * See: https://hl7.org/fhirpath/#skipnum-integer-collection
-   *
    * @param input The input collection.
    * @param num The atom representing the number of elements to skip.
    * @returns A collection containing all but the first item in the input collection.
@@ -395,7 +377,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * take returns an empty collection.
    *
    * See: https://hl7.org/fhirpath/#takenum-integer-collection
-   *
    * @param input The input collection.
    * @param num The atom representing the number of elements to take.
    * @returns A collection containing the first num items in the input collection.
@@ -420,7 +401,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Order of items is not guaranteed to be preserved in the result of this function.
    *
    * See: http://hl7.org/fhirpath/#intersectother-collection-collection
-   *
    * @param input The input collection.
    * @param other The atom representing the collection of elements to intersect.
    * @returns A collection containing the elements that are in both collections.
@@ -446,7 +426,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * e.g. (1 | 2 | 3).exclude(2) returns (1 | 3).
    *
    * See: http://hl7.org/fhirpath/#excludeother-collection-collection
-   *
    * @param input The input collection.
    * @param other The atom representing the collection of elements to exclude.
    * @returns A collection containing the elements that are in the input collection but not the other collection.
@@ -479,7 +458,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * In other words, this function returns the distinct list of elements from both inputs.
    *
    * See: http://hl7.org/fhirpath/#unionother-collection
-   *
    * @param input The input collection.
    * @param other The atom representing the collection of elements to merge.
    * @returns A collection containing the elements that represent the union of both collections.
@@ -500,7 +478,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * There is no expectation of order in the resulting collection.
    *
    * See: http://hl7.org/fhirpath/#combineother-collection-collection
-   *
    * @param input The input collection.
    * @param other The atom representing the collection of elements to merge.
    * @returns A collection containing the elements that represent the combination of both collections including duplicates.
@@ -534,7 +511,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * true-result should only be evaluated if the criterion evaluates to true,
    * and otherwise-result should only be evaluated otherwise. For implementations,
    * this means delaying evaluation of the arguments.
-   *
    * @param input The input collection.
    * @param criterion The atom representing the conditional.
    * @param trueResult The atom to be used if the conditional evaluates to true.
@@ -570,7 +546,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#toboolean-boolean
-   *
    * @param input The input collection.
    * @returns The input converted to boolean value.
    */
@@ -615,7 +590,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: http://hl7.org/fhirpath/#convertstoboolean-boolean
-   *
    * @param input The input collection.
    * @returns True if the input can be converted to boolean.
    */
@@ -643,7 +617,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tointeger-integer
-   *
    * @param input The input collection.
    * @returns The string representation of the input.
    */
@@ -678,7 +651,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstointeger-boolean
-   *
    * @param input The input collection.
    * @returns True if the input can be converted to an integer.
    */
@@ -704,7 +676,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#todate-date
-   *
    * @param input The input collection.
    * @returns The value converted to a date if possible; otherwise empty array.
    */
@@ -734,7 +705,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodate-boolean
-   *
    * @param input The input collection.
    * @returns True if the item can be converted to a date.
    */
@@ -762,7 +732,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#todatetime-datetime
-   *
    * @param input The input collection.
    * @returns The value converted to a dateTime if possible; otherwise empty array.
    */
@@ -790,7 +759,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodatetime-boolean
-   *
    * @param input The input collection.
    * @returns True if the item can be converted to a dateTime.
    */
@@ -815,7 +783,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#decimal-conversion-functions
-   *
    * @param input The input collection.
    * @returns The value converted to a decimal if possible; otherwise empty array.
    */
@@ -849,7 +816,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodecimal-boolean
-   *
    * @param input The input collection.
    * @returns True if the item can be converted to a decimal.
    */
@@ -870,7 +836,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one of the above types, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#quantity-conversion-functions
-   *
    * @param input The input collection.
    * @returns The value converted to a quantity if possible; otherwise empty array.
    */
@@ -913,7 +878,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the unit argument is provided, it must be the string representation of a UCUM code (or a FHIRPath calendar duration keyword), and is used to determine whether the input quantity can be converted to the given unit, according to the unit conversion rules specified by UCUM. If the input quantity can be converted, the result is true, otherwise, the result is false.
    *
    * See: https://hl7.org/fhirpath/#convertstoquantityunit-string-boolean
-   *
    * @param input The input collection.
    * @returns True if the item can be converted to a quantity.
    */
@@ -936,7 +900,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one of the above types, the result is false.
    *
    * See: https://hl7.org/fhirpath/#tostring-string
-   *
    * @param input The input collection.
    * @returns The string representation of the input.
    */
@@ -970,7 +933,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tostring-string
-   *
    * @param input The input collection.
    * @returns True if the item can be converted to a string
    */
@@ -997,7 +959,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#totime-time
-   *
    * @param input The input collection.
    * @returns The value converted to a time if possible; otherwise empty array.
    */
@@ -1027,7 +988,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstotime-boolean
-   *
    * @param input The input collection.
    * @returns True if the item can be converted to a time.
    */
@@ -1054,7 +1014,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#indexofsubstring-string-integer
-   *
    * @param input The input collection.
    * @param searchStringAtom The substring to search for.
    * @returns The index of the substring.
@@ -1073,7 +1032,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If an empty length is provided, the behavior is the same as if length had not been provided.
    *
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-   *
    * @param input The input collection.
    * @param startAtom The start index atom.
    * @param lengthAtom Optional length atom.
@@ -1102,7 +1060,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#startswithprefix-string-boolean
-   *
    * @param input The input collection.
    * @param prefixAtom The prefix substring to test.
    * @returns True if the input string starts with the given prefix string.
@@ -1121,7 +1078,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#endswithsuffix-string-boolean
-   *
    * @param input The input collection.
    * @param suffixAtom The suffix substring to test.
    * @returns True if the input string ends with the given suffix string.
@@ -1140,7 +1096,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#containssubstring-string-boolean
-   *
    * @param input The input collection.
    * @param substringAtom The substring to test.
    * @returns True if the input string contains the given substring.
@@ -1157,7 +1112,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#upper-string
-   *
    * @param input The input collection.
    * @returns The string converted to upper case.
    */
@@ -1173,7 +1127,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#lower-string
-   *
    * @param input The input collection.
    * @returns The string converted to lower case.
    */
@@ -1191,7 +1144,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#replacepattern-string-substitution-string-string
-   *
    * @param input The input collection.
    * @param patternAtom The pattern to search for.
    * @param substitionAtom The substition to replace with.
@@ -1214,7 +1166,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#matchesregex-string-boolean
-   *
    * @param input The input collection.
    * @param regexAtom The regular expression atom.
    * @returns True if the input string matches the given regular expression.
@@ -1231,7 +1182,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#replacematchesregex-string-substitution-string-string
-   *
    * @param input The input collection.
    * @param regexAtom The regular expression atom.
    * @param substitionAtom The substition to replace with.
@@ -1247,7 +1197,6 @@ export const functions: Record<string, FhirPathFunction> = {
   },
 
   /**
-   *
    * @param input The input collection.
    * @returns The index of the substring.
    */
@@ -1259,7 +1208,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the list of characters in the input string. If the input collection is empty ({ }), the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tochars-collection
-   *
    * @param input The input collection.
    * @returns Array of characters.
    */
@@ -1279,7 +1227,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#abs-integer-decimal-quantity
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1295,7 +1242,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#ceiling-integer
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1313,7 +1259,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#exp-decimal
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1329,7 +1274,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#floor-integer
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1347,7 +1291,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#ln-decimal
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1367,7 +1310,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#logbase-decimal-decimal
-   *
    * @param input The input collection.
    * @param baseAtom The logarithm base.
    * @returns A collection containing the result.
@@ -1386,7 +1328,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#powerexponent-integer-decimal-integer-decimal
-   *
    * @param input The input collection.
    * @param expAtom The exponent power.
    * @returns A collection containing the result.
@@ -1407,7 +1348,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#roundprecision-integer-decimal
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1427,7 +1367,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
    *
    * See: https://hl7.org/fhirpath/#sqrt-decimal
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1443,7 +1382,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#truncate-integer
-   *
    * @param input The input collection.
    * @returns A collection containing the result.
    */
@@ -1474,7 +1412,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * function unchanged.
    *
    * See: https://hl7.org/fhirpath/#tracename-string-projection-expression-collection
-   *
    * @param input The input collection.
    * @param nameAtom The log name.
    * @returns The input collection.
@@ -1488,7 +1425,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the current date and time, including timezone offset.
    *
    * See: https://hl7.org/fhirpath/#now-datetime
-   *
    * @returns The current dateTime.
    */
   now: (): TypedValue[] => {
@@ -1499,7 +1435,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the current time.
    *
    * See: https://hl7.org/fhirpath/#timeofday-time
-   *
    * @returns The current time string.
    */
   timeOfDay: (): TypedValue[] => {
@@ -1510,7 +1445,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the current date.
    *
    * See: https://hl7.org/fhirpath/#today-date
-   *
    * @returns The current date string.
    */
   today: (): TypedValue[] => {
@@ -1524,7 +1458,6 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * IBM FHIR issue: https://github.com/IBM/FHIR/issues/1014
    * IBM FHIR PR: https://github.com/IBM/FHIR/pull/1023
-   *
    * @param input The input collection.
    * @param startAtom The start date/time.
    * @param endAtom The end date/time.
@@ -1560,7 +1493,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * For implementations with compile-time typing, this requires special-case
    * handling when processing the argument to treat it as a type specifier rather
    * than an identifier expression:
-   *
    * @param input The input collection.
    * @param typeAtom The desired type.
    * @returns True if the input element is of the desired type.
@@ -1586,7 +1518,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * 6.5.3. not() : Boolean
    *
    * Returns true if the input collection evaluates to false, and false if it evaluates to true. Otherwise, the result is empty ({ }):
-   *
    * @param input The input collection.
    * @returns True if the input evaluates to false.
    */
@@ -1659,7 +1590,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * https://hl7.org/fhirpath/modelinfo.xsd
    *
    * See: https://hl7.org/fhirpath/#model-information
-   *
    * @param input The input collection.
    * @returns The type of the input value.
    */

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -78,7 +78,6 @@ const baseResourceProperties = new Set<string>([
  * const medplum = new MedplumClient();
  * await medplum.requestSchema('Patient');
  * ```
- *
  * @param resourceType The candidate resource type string.
  * @returns True if the resource type is a valid FHIR resource type.
  */
@@ -121,7 +120,6 @@ export function isResourceType(resourceType: string): boolean {
  * const medplum = new MedplumClient();
  * await medplum.requestSchema('Patient');
  * ```
- *
  * @param resourceType The candidate resource type string.
  */
 export function validateResourceType(resourceType: string): void {
@@ -163,7 +161,6 @@ export function validateResourceType(resourceType: string): void {
  * const medplum = new MedplumClient();
  * await medplum.requestSchema('Patient');
  * ```
- *
  * @param resource The candidate resource.
  */
 export function validateResource<T extends Resource>(resource: T): void {
@@ -369,7 +366,6 @@ export class FhirSchemaValidator<T extends Resource> {
    *   2) a JSON property with _ prepended to the name of the element, which, if present, contains the value's id and/or extensions
    *
    * See: https://hl7.org/fhir/json.html#primitive
-   *
    * @param path The path to the property
    * @param key The key in the current typed value.
    * @param typedValue The current typed value.
@@ -438,7 +434,6 @@ function isChoiceOfType(
  * Recursively checks for null values in an object.
  *
  * Note that "null" is a special value in JSON that is not allowed in FHIR.
- *
  * @param value Input value of any type.
  * @param path Path string to the value for OperationOutcome.
  * @param issues Output list of issues.

--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -31,7 +31,6 @@ export interface SearchParameterDetails {
  *   1) The "date" type includes "date", "datetime", and "period".
  *   2) The "token" type includes enums and booleans.
  *   3) Arrays/multiple values are not reflected at all.
- *
  * @param resourceType The root resource type.
  * @param searchParam The search parameter.
  * @returns The search parameter type details.

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -57,7 +57,6 @@ export interface SliceDiscriminator {
 /**
  * Parses a StructureDefinition resource into an internal schema better suited for
  * programmatic validation and usage in internal systems
- *
  * @param sd The StructureDefinition resource to parse
  * @returns The parsed schema for the given resource type
  * @experimental

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -286,7 +286,6 @@ function buildQuestionnaireAnswerItems(
  * If multiple identifiers exist with the same system, the first one is returned.
  *
  * If the system is not found, then returns undefined.
- *
  * @param resource The resource to check.
  * @param system The identifier system.
  * @returns The identifier value if found; otherwise undefined.
@@ -466,7 +465,6 @@ function deepEqualsObject(
  *
  * See: https://web.dev/structured-clone/
  * See: https://stackoverflow.com/questions/40488190/how-is-structured-clone-algorithm-different-from-deep-copy
- *
  * @param input The input to clone.
  * @returns A deep clone of the input.
  */

--- a/packages/examples/src/tutorials/api-basics/publish-and-subscribe.ts
+++ b/packages/examples/src/tutorials/api-basics/publish-and-subscribe.ts
@@ -34,7 +34,6 @@ await medplum.startClientLogin(MY_CLIENT_ID, MY_CLIENT_SECRET);
  * We will use this in the "conditional create".
  * When creating an order, and if you don't know if the patient exists,
  * you can use this MRN to check.
- *
  * @param patientMrn The patient medical record number (MRN).
  */
 async function createServiceRequest(patientMrn: string): Promise<void> {
@@ -82,7 +81,6 @@ await createServiceRequest('MRN1234');
 // start-block create-specimen
 /**
  * Creates a Specimen for a given ServiceRequest
- *
  * @param serviceRequestId The ServiceRequest ID.
  */
 async function createSpecimenForServiceRequest(serviceRequestId: string): Promise<void> {

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -18,7 +18,6 @@ import { HttpMethod } from './urlrouter';
  * Processes a FHIR batch request.
  *
  * See: https://www.hl7.org/fhir/http.html#transaction
- *
  * @param router The FHIR router.
  * @param repo The FHIR repository.
  * @param bundle The input bundle.

--- a/packages/fhir-router/src/graphql.ts
+++ b/packages/fhir-router/src/graphql.ts
@@ -129,7 +129,6 @@ interface ConnectionEdge {
  * Handles FHIR GraphQL requests.
  *
  * See: https://www.hl7.org/fhir/graphql.html
- *
  * @param req The request details.
  * @param repo The current user FHIR repository.
  * @param router The router for router options.
@@ -186,7 +185,6 @@ export async function graphqlHandler(
  * Introspection queries ask for the schema, which is expensive.
  *
  * See: https://graphql.org/learn/introspection/
- *
  * @param query The GraphQL query.
  * @returns True if the query is an introspection query.
  */
@@ -347,7 +345,6 @@ function buildPropertyField(
  *   4. All properties of the list element type.
  *
  * See: https://hl7.org/fhir/R4/graphql.html#list
- *
  * @param fieldTypeName The type name of the field.
  * @returns The arguments for the field.
  */
@@ -442,7 +439,6 @@ function buildListPropertyFieldArg(
  * (except that the "id" argument is prohibited here as nonsensical).
  *
  * See: https://www.hl7.org/fhir/graphql.html#reverse
- *
  * @param resourceType The resource type to build fields for.
  * @param fields The fields object to add fields to.
  */

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -26,7 +26,6 @@ export interface FhirRepository {
    * Creates a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#create
-   *
    * @param resource The FHIR resource to create.
    * @returns The created resource.
    */
@@ -36,7 +35,6 @@ export interface FhirRepository {
    * Reads a FHIR resource by ID.
    *
    * See: https://www.hl7.org/fhir/http.html#read
-   *
    * @param resourceType The FHIR resource type.
    * @param id The FHIR resource ID.
    * @returns The FHIR resource.
@@ -47,7 +45,6 @@ export interface FhirRepository {
    * Reads a FHIR resource by reference.
    *
    * See: https://www.hl7.org/fhir/http.html#read
-   *
    * @param reference The FHIR reference.
    * @returns The FHIR resource.
    */
@@ -57,7 +54,6 @@ export interface FhirRepository {
    * Reads a collection of FHIR resources by reference.
    *
    * See: https://www.hl7.org/fhir/http.html#read
-   *
    * @param references The FHIR references.
    * @returns The FHIR resources.
    */
@@ -69,7 +65,6 @@ export interface FhirRepository {
    * Results are sorted with oldest versions last
    *
    * See: https://www.hl7.org/fhir/http.html#history
-   *
    * @param resourceType The FHIR resource type.
    * @param id The FHIR resource ID.
    * @returns Operation outcome and a history bundle.
@@ -80,7 +75,6 @@ export interface FhirRepository {
    * Reads a FHIR resource version.
    *
    * See: https://www.hl7.org/fhir/http.html#vread
-   *
    * @param resourceType The FHIR resource type.
    * @param id The FHIR resource ID.
    * @param vid The FHIR resource version ID.
@@ -91,7 +85,6 @@ export interface FhirRepository {
    * Updates a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#update
-   *
    * @param resource The FHIR resource to update.
    * @returns The updated resource.
    */
@@ -101,7 +94,6 @@ export interface FhirRepository {
    * Deletes a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#delete
-   *
    * @param resourceType The FHIR resource type.
    * @param id The FHIR resource ID.
    */
@@ -111,7 +103,6 @@ export interface FhirRepository {
    * Patches a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#patch
-   *
    * @param resourceType The FHIR resource type.
    * @param id The FHIR resource ID.
    * @param patch The JSONPatch operations.
@@ -123,7 +114,6 @@ export interface FhirRepository {
    * Searches for FHIR resources.
    *
    * See: https://www.hl7.org/fhir/http.html#search
-   *
    * @param searchRequest The FHIR search request.
    * @returns The search results.
    */
@@ -137,7 +127,6 @@ export interface FhirRepository {
    * The return value is the resource, if available; otherwise, undefined.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @param searchRequest The FHIR search request.
    * @returns Promise to the first search result or undefined.
    */
@@ -151,7 +140,6 @@ export interface FhirRepository {
    * The return value is an array of resources.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @param searchRequest The FHIR search request.
    * @returns Promise to the array of search results.
    */
@@ -163,7 +151,6 @@ export abstract class BaseRepository {
    * Searches for FHIR resources.
    *
    * See: https://www.hl7.org/fhir/http.html#search
-   *
    * @param searchRequest The FHIR search request.
    * @returns The search results.
    */
@@ -177,7 +164,6 @@ export abstract class BaseRepository {
    * The return value is the resource, if available; otherwise, undefined.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @param searchRequest The FHIR search request.
    * @returns Promise to the first search result or undefined.
    */
@@ -194,7 +180,6 @@ export abstract class BaseRepository {
    * The return value is an array of resources.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   *
    * @param searchRequest The FHIR search request.
    * @returns Promise to the array of search results.
    */

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -29,7 +29,6 @@ export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {
 
   /**
    * Processes a single file.
-   *
    * @param file The file descriptor.
    */
   function processFile(file: File): void {

--- a/packages/react/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react/src/MedplumProvider/MedplumProvider.tsx
@@ -25,7 +25,6 @@ export interface MedplumContext {
  * Medplum context includes:
  *   1) medplum - Medplum client library
  *   2) profile - The current user profile (if signed in)
- *
  * @param props The MedplumProvider React props.
  * @returns The MedplumProvider React node.
  */

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -238,7 +238,6 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
 
   /**
    * Handles a click on a order row.
-   *
    * @param e The click event.
    * @param resource The FHIR resource.
    */

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -84,7 +84,6 @@ const operatorNames: Record<Operator, string> = {
 
 /**
  * Sets the array of filters.
- *
  * @param definition The original search request.
  * @param filters The new filters.
  * @returns The updated search request.
@@ -109,7 +108,6 @@ export function clearFilters(definition: SearchRequest): SearchRequest {
 
 /**
  * Clears all of the filters on a certain field.
- *
  * @param definition The original search request.
  * @param code The field key name to clear filters.
  * @returns The updated search request.
@@ -123,7 +121,6 @@ export function clearFiltersOnField(definition: SearchRequest, code: string): Se
 
 /**
  * Adds a filter.
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @param op The operation key name.
@@ -153,7 +150,6 @@ export function addFilter(
 
 /**
  * Adds a field.
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -176,7 +172,6 @@ export function addField(definition: SearchRequest, field: string): SearchReques
 
 /**
  * Deletes a filter at the specified index.
- *
  * @param definition The original search request.
  * @param index The filter index.
  * @returns The updated search request.
@@ -196,7 +191,6 @@ export function deleteFilter(definition: SearchRequest, index: number): SearchRe
 
 /**
  * Adds a filter that constrains the specified field to "yesterday".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -207,7 +201,6 @@ export function addYesterdayFilter(definition: SearchRequest, field: string): Se
 
 /**
  * Adds a filter that constrains the specified field to "today".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -218,7 +211,6 @@ export function addTodayFilter(definition: SearchRequest, field: string): Search
 
 /**
  * Adds a filter that constrains the specified field to "tomorrow".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -233,7 +225,6 @@ export function addTomorrowFilter(definition: SearchRequest, field: string): Sea
  * "Today" would be 0.
  * "Yesterday" would be -1.
  * "Tomorrow" would be 1.
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @param delta The number of days from this day.
@@ -253,7 +244,6 @@ function addDayFilter(definition: SearchRequest, field: string, delta: number): 
 
 /**
  * Adds a filter that constrains the specified field to "last month".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -264,7 +254,6 @@ export function addLastMonthFilter(definition: SearchRequest, field: string): Se
 
 /**
  * Adds a filter that constrains the specified field to "this month".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -275,7 +264,6 @@ export function addThisMonthFilter(definition: SearchRequest, field: string): Se
 
 /**
  * Adds a filter that constrains the specified field to "next month".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -290,7 +278,6 @@ export function addNextMonthFilter(definition: SearchRequest, field: string): Se
  * "This month" would be 0.
  * "Last month" would be -1.
  * "Next month" would be 1.
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @param delta The number of months from this month.
@@ -313,7 +300,6 @@ function addMonthFilter(definition: SearchRequest, field: string, delta: number)
 
 /**
  * Adds a filter that constrains the specified field to the year to date.
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @returns The updated search request.
@@ -331,7 +317,6 @@ export function addYearToDateFilter(definition: SearchRequest, field: string): S
 
 /**
  * Adds a filter for a date between two dates (inclusive of both dates).
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @param d1 The start date.
@@ -347,7 +332,6 @@ export function addDateFilterBetween(definition: SearchRequest, field: string, d
 
 /**
  * Adds a filter for a date before a certain date/time.
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @param op The date/time operation.
@@ -360,7 +344,6 @@ function addDateFilterImpl(definition: SearchRequest, field: string, op: Operato
 
 /**
  * Adds a filter that constrains the specified field to "missing".
- *
  * @param definition The original search request.
  * @param field The field key name.
  * @param value Optional boolean value. Default is true.
@@ -372,7 +355,6 @@ export function addMissingFilter(definition: SearchRequest, field: string, value
 
 /**
  * Sets the offset (starting at zero).
- *
  * @param definition The original search request.
  * @param offset The offset number.
  * @returns The updated search request.
@@ -403,7 +385,6 @@ export function setPage(definition: SearchRequest, page: number): SearchRequest 
 /**
  * Sorts the search by the specified key, and optional direction.
  * Direction defaults to ascending ('asc') if not specified.
- *
  * @param definition The original search request.
  * @param sort The sort key.
  * @param desc Optional descending flag. Default is false.
@@ -429,7 +410,6 @@ export function setSort(definition: SearchRequest, sort: string, desc?: boolean)
  * Toggles the sort of the search by key.
  * If the search is already sorted by the key, reverses the direction.
  * If the search is not sorted by the key, sort in ascending order.
- *
  * @param definition The original search request.
  * @param key The field key name.
  * @returns The updated search request.
@@ -470,7 +450,6 @@ export function getSearchOperators(searchParam: SearchParameter): Operator[] | u
 
 /**
  * Returns a string representing the operation.
- *
  * @param op The operation code.
  * @returns A display string for the operation.
  */

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -25,7 +25,6 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
   /**
    * Handles a key down event on the "available" field.
    * If the user presses enter, it is a shortcut for the "Add" button.
-   *
    * @param e The keyboard event.
    */
   function handleAvailableKeyDown(e: React.KeyboardEvent): void {
@@ -45,7 +44,6 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
   /**
    * Handles a key down event on the "available" field.
    * If the user presses enter, it is a shortcut for the "Add" button.
-   *
    * @param e The keyboard event.
    */
   function handleSelectedKeyDown(e: React.KeyboardEvent): void {

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -29,7 +29,6 @@ export interface SignInFormProps extends BaseLoginRequest {
  * 3) Choose profile - If the user has multiple profiles, prompt to choose one
  * 4) Choose scope - If the user has multiple scopes, prompt to choose one
  * 5) Success - Return to the caller with either a code or a redirect
- *
  * @param props The SignInForm React props.
  * @returns The SignInForm React node.
  */

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -95,7 +95,6 @@ binaryRouter.get(
  *
  * Unfortunately body-parser will always write the content to a temporary file on local disk.
  * That is not acceptable for multi gigabyte files, which could easily fill up the disk.
- *
  * @param req The HTTP request.
  * @returns The content stream.
  */

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -56,7 +56,6 @@ export class AddressTable extends LookupTable<Address> {
    *   address-postalcode | postalCode
    *   address-state      | state
    *   addrses-use        | use
-   *
    * @param code The search parameter code.
    * @returns The column name.
    */

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -31,7 +31,6 @@ export function compareArrays(incoming: any[], existing: any[]): boolean {
  * However, the FHIR specification does not define an "identifier" search parameter for every resource type.
  *
  * This function derives an "identifier" search parameter from a reference search parameter.
- *
  * @param inputParam The original reference search parameter.
  * @returns The derived "identifier" search parameter.
  */

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -35,7 +35,6 @@ interface EvaluateMeasureParameters {
  * 4. location parameter
  *
  * See: https://hl7.org/fhir/measure-operation-evaluate-measure.html
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -233,7 +233,6 @@ export function getLambdaFunctionName(bot: Bot): string {
  * so we attempt to scrub away all of that extra metadata.
  *
  * See: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html
- *
  * @param logResult The raw log result from the AWS lambda event.
  * @returns The parsed log result.
  */

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -14,7 +14,6 @@ import { BulkExporter } from './utils/bulkexporter';
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html
  * See: https://hl7.org/fhir/R4/async.html
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */

--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -9,7 +9,6 @@ import { logger } from '../../logger';
  * Handles an expunge request.
  *
  * Endpoint: [fhir base]/[resourceType]/[id]/$expunge
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */

--- a/packages/server/src/fhir/operations/groupexport.ts
+++ b/packages/server/src/fhir/operations/groupexport.ts
@@ -15,7 +15,6 @@ import { BulkExporter } from './utils/bulkexporter';
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html
  * See: https://hl7.org/fhir/R4/async.html
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -43,7 +43,6 @@ interface PlanDefinitionApplyParameters {
  * The operation converts a PlanDefinition to a RequestGroup.
  *
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */

--- a/packages/server/src/fhir/operations/projectclone.ts
+++ b/packages/server/src/fhir/operations/projectclone.ts
@@ -10,7 +10,6 @@ import { sendResponse } from '../routes';
  * Handles a Project clone request.
  *
  * Endpoint: [fhir base]/Project/[id]/$clone
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */

--- a/packages/server/src/fhir/operations/resourcegraph.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.ts
@@ -31,7 +31,6 @@ import { sendResponse } from '../routes';
  * The operation fetches all the data related to this resources as defined by a GraphDefinition resource
  *
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- *
  * @param req The HTTP request.
  * @param res The HTTP response.
  */
@@ -240,7 +239,6 @@ async function followCanonicalElements(
 /**
  * Fetches all resources referenced by this GraphDefinition link,
  * where the link is specified using search parameters
- *
  * @param repo The repository object for fetching data
  * @param resource The resource for which this GraphDefinition is being applied
  * @param link A link element defined in the GraphDefinition

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -385,7 +385,6 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Results are sorted with oldest versions last
    *
    * See: https://www.hl7.org/fhir/http.html#history
-   *
    * @param resourceType The FHIR resource type.
    * @param id The FHIR resource ID.
    * @returns Operation outcome and a history bundle.
@@ -1038,7 +1037,6 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Returns bundle entries for the resources that are included in the search result.
    *
    * See documentation on _include: https://hl7.org/fhir/R4/search.html#include
-   *
    * @param include The include parameter.
    * @param resources The base search result resources.
    * @returns The bundle entries for the included resources.
@@ -1093,7 +1091,6 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Returns bundle entries for the resources that are reverse included in the search result.
    *
    * See documentation on _revinclude: https://hl7.org/fhir/R4/search.html#revinclude
-   *
    * @param revInclude The revInclude parameter.
    * @param resources The base search result resources.
    * @returns The bundle entries for the reverse included resources.
@@ -1390,7 +1387,6 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Builds a search filter expression for a normal search parameter.
    *
    * Not any special cases, just a normal search parameter.
-   *
    * @param resourceType The FHIR resource type.
    * @param param The FHIR search parameter.
    * @param filter The search filter.
@@ -1419,7 +1415,6 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Returns true if the search parameter code is a special search parameter.
    *
    * See: https://www.hl7.org/fhir/search.html#all
-   *
    * @param selectQuery The select query builder.
    * @param searchRequest The overall search request.
    * @param filter The search filter.

--- a/packages/server/src/fhir/rewrite.ts
+++ b/packages/server/src/fhir/rewrite.ts
@@ -34,7 +34,6 @@ export enum RewriteMode {
  *
  * Uses the repository to verify that the referenced resources exist and that
  * the current user has permission to read them.
- *
  * @param mode The mode to use when rewriting the attachments.
  * @param repo The repository configured for the current user.
  * @param input The input value (object, array, or primitive).
@@ -172,7 +171,6 @@ class Rewriter {
  *   3) Presigned URL (https://storage.medplum.com/binary/123/456?Signature=...)
  *
  * When comparing two binary URLs, we want to compare the binary ID and version ID.
- *
  * @param url The input URL.
  * @returns The normalized binary ID and version ID.
  */

--- a/packages/server/src/fhir/signer.ts
+++ b/packages/server/src/fhir/signer.ts
@@ -7,7 +7,6 @@ import { getConfig } from '../config';
  *
  * Reference:
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_cloudfront_signer.html
- *
  * @param binary Binary resource.
  * @returns Presigned URL to access the binary data.
  */

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -128,7 +128,6 @@ class S3Storage implements BinaryStorage {
    *
    * Learn more:
    * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
-   *
    * @param binary The binary resource destination.
    * @param filename Optional binary filename.
    * @param contentType Optional binary content type.

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -386,7 +386,6 @@ export async function exchangeExternalAuthToken(
  * 3. Form body (client_secret_post)
  *
  * See SMART "token_endpoint_auth_methods_supported"
- *
  * @param req The HTTP request.
  * @returns The client ID and secret on success, or an error message on failure.
  */
@@ -421,7 +420,6 @@ async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
  * 2. https://www.hl7.org/fhir/smart-app-launch/example-backend-services.html#step-2-discovery
  * 3. https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/csimg/obtaining-access-token-using-self-signed-client-assertion.html
  * 4. https://darutk.medium.com/oauth-2-0-client-authentication-4b5f929305d4
- *
  * @param clientAssertiontype The client assertion type.
  * @param clientAssertion The client assertion JWT.
  * @returns The parsed client ID and secret on success, or an error message on failure.

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -660,7 +660,6 @@ export async function getUserByEmailWithoutProject(email: string): Promise<User 
  * The built-in function timingSafeEqual requires that buffers are equal length.
  * Per the discussion here: https://github.com/nodejs/node/issues/17178
  * That is considered ok, and does not invalidate the protection from timing attack.
- *
  * @param a First string.
  * @param b Second string.
  * @returns True if the strings are equal.

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -10,7 +10,6 @@ import { ScimListResponse, ScimUser } from './types';
  *
  * See SCIM 3.4.2 - Query Resources
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2
- *
  * @param project The project.
  * @returns List of SCIM users in the project.
  */
@@ -42,7 +41,6 @@ export async function searchScimUsers(project: Project): Promise<ScimListRespons
  *
  * See SCIM 3.3 - Creating Resources
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.3
- *
  * @param invitedBy The user who invited the new user.
  * @param project The project.
  * @param scimUser The new user definition.
@@ -83,7 +81,6 @@ export async function createScimUser(
  *
  * See SCIM 3.4.1 - Retrieve a Known Resource
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.1
- *
  * @param project The project.
  * @param id The user ID.
  * @returns The user.
@@ -103,7 +100,6 @@ export async function readScimUser(project: Project, id: string): Promise<ScimUs
  *
  * See SCIM 3.5.1 - Replace a Resource
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.5.1
- *
  * @param project The project.
  * @param scimUser The updated user definition.
  * @returns The updated user.
@@ -136,7 +132,6 @@ export async function updateScimUser(project: Project, scimUser: ScimUser): Prom
  *
  * See SCIM 3.4.1 - Retrieve a Known Resource
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.1
- *
  * @param project The project.
  * @param id The user ID.
  * @returns The user.
@@ -156,7 +151,6 @@ export async function deleteScimUser(project: Project, id: string): Promise<void
  * By default, a SCIM User does not have the equivalent of a FHIR resource type.
  *
  * This function looks for the Medplum extension, which contains the resource type.
- *
  * @param scimUser The SCIM user definition.
  * @returns The FHIR profile resource type if found; otherwise, undefined.
  */

--- a/packages/server/src/util/cloudwatch.ts
+++ b/packages/server/src/util/cloudwatch.ts
@@ -103,7 +103,6 @@ export class CloudWatchLogger {
    * This method takes the full queue and splits it into acceptable batches.
    *
    * In the common case, one call to processEvents will result in one call to putEvents.
-   *
    * @param logEvents All of the events in the queue at the time of the timer.
    */
   private async processEvents(logEvents: LogEvent[]): Promise<void> {
@@ -135,7 +134,6 @@ export class CloudWatchLogger {
    * Uploads a batch of events to CloudWatch logs.
    *
    * T?his method assumes that the PutLogEvents constraints are satisfied.
-   *
    * @param logEvents Batch of events for single call to PutLogEvents.
    */
   private async putEvents(logEvents: LogEvent[]): Promise<void> {

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -94,7 +94,6 @@ export function getDownloadQueue(): Queue<DownloadJobData> | undefined {
  * at that moment in time.  For each matching download, we enqueue the job.
  * The only purpose of the job is to make the outbound HTTP request,
  * not to re-evaluate the download.
- *
  * @param resource The resource that was created or updated.
  */
 export async function addDownloadJobs(resource: Resource): Promise<void> {
@@ -119,7 +118,6 @@ export async function addDownloadJobs(resource: Resource): Promise<void> {
  *  1) They refer to a fully qualified fhir/R4/Binary/ endpoint.
  *  2) They refer to the Medplum storage URL.
  *  3) They refer to a Binary in canonical form (i.e., "Binary/123").
- *
  * @param url The Media content URL.
  * @returns True if the URL is an external URL.
  */

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -109,7 +109,6 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
  * at that moment in time.  For each matching subscription, we enqueue the job.
  * The only purpose of the job is to make the outbound HTTP request,
  * not to re-evaluate the subscription.
- *
  * @param resource The resource that was created or updated.
  * @param context The background job context.
  */


### PR DESCRIPTION
Before: `jsdoc/check-tag-names` was disabled
After: `jsdoc/check-tag-names` is enabled with exceptions for `@category`, `@experimental`, and `@ts-ignore`

Before: `jsdoc/tag-lines` was disabled
After: `jsdoc/tag-lines` is enabled and all of the unwanted blank lines are deleted
