### PR TITLE
Removed ECR_REPOSITORY var from build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,6 @@ jobs:
           APP_BUCKET: ${{ secrets.APP_BUCKET }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
           ECS_SERVICE: ${{ secrets.ECS_SERVICE }}
           MEDPLUM_INTROSPECTION_URL: ${{ secrets.MEDPLUM_INTROSPECTION_URL }}


### PR DESCRIPTION
This is a holdover artifact from last year when we published docker images to AWS ECR rather than Docker Hub.