### PR TITLE
Preserve newlines for all strings

### DIFF
--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -86,6 +86,17 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
+  test('Renders string with newline', () => {
+    setup(
+      <ResourcePropertyDisplay
+        property={{ type: [{ code: 'string' }] }}
+        propertyType={PropertyType.string}
+        value={'hello\nworld'}
+      />
+    );
+    expect(screen.getByText('hello world')).toBeInTheDocument();
+  });
+
   test('Renders canonical', () => {
     setup(
       <MemoryRouter>

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -94,7 +94,11 @@ describe('ResourcePropertyDisplay', () => {
         value={'hello\nworld'}
       />
     );
-    expect(screen.getByText('hello world')).toBeInTheDocument();
+    const textElement = screen.getByText('hello world');
+    const lines = textElement.textContent?.split('\n');
+    const numberOfLines = lines?.length || 0;
+    expect(numberOfLines).toBe(2);
+    expect(numberOfLines).not.toBe(1);
   });
 
   test('Renders canonical', () => {

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -59,9 +59,9 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
   switch (propertyType) {
     case PropertyType.boolean:
       return <>{value === undefined ? '' : Boolean(value).toString()}</>;
+    case PropertyType.SystemString:
     case PropertyType.string:
       return <div style={{ whiteSpace: 'pre-wrap' }}>{value}</div>;
-    case PropertyType.SystemString:
     case PropertyType.code:
     case PropertyType.date:
     case PropertyType.integer:

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -59,12 +59,13 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
   switch (propertyType) {
     case PropertyType.boolean:
       return <>{value === undefined ? '' : Boolean(value).toString()}</>;
+    case PropertyType.string:
+      return <div style={{ whiteSpace: 'pre-wrap' }}>{value}</div>;
     case PropertyType.SystemString:
     case PropertyType.code:
     case PropertyType.date:
     case PropertyType.integer:
     case PropertyType.positiveInt:
-    case PropertyType.string:
     case PropertyType.unsignedInt:
     case PropertyType.uri:
     case PropertyType.url:


### PR DESCRIPTION
https://github.com/medplum/medplum/issues/2106

I set it so that all strings will preserve and display newlines. Can change to only OutcomeDesc if needed. 

Tested with "error: not found\ncannot find the value of data in result\nmodules by path line: 44"

Without the 'pre-wrap' 
<img width="892" alt="Screenshot 2023-06-06 at 3 31 01 PM" src="https://github.com/medplum/medplum/assets/6913745/6730788b-598d-4087-853b-bacb9b58c4fd">

With 'pre-wrap'
<img width="916" alt="Screenshot 2023-06-06 at 3 31 48 PM" src="https://github.com/medplum/medplum/assets/6913745/5aa412e6-5613-4fb6-89cc-f0e663f3ca6c">
