### PR TITLE
Add global context for eval

### DIFF
--- a/packages/core/src/fhirlexer/parse.ts
+++ b/packages/core/src/fhirlexer/parse.ts
@@ -1,7 +1,8 @@
 import { TypedValue } from '../types';
 import { Token } from './tokenize';
+
 export interface AtomContext {
-  parent: AtomContext | undefined;
+  parent?: AtomContext;
   variables: Record<string, TypedValue>;
 }
 export interface Atom {

--- a/packages/core/src/fhirlexer/parse.ts
+++ b/packages/core/src/fhirlexer/parse.ts
@@ -1,14 +1,17 @@
 import { TypedValue } from '../types';
 import { Token } from './tokenize';
-
+export interface AtomContext {
+  parent: AtomContext | undefined;
+  variables: Record<string, TypedValue>;
+}
 export interface Atom {
-  eval(context: TypedValue[]): TypedValue[];
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[];
 }
 
 export abstract class PrefixOperatorAtom implements Atom {
   constructor(public readonly operator: string, public readonly child: Atom) {}
 
-  abstract eval(context: TypedValue[]): TypedValue[];
+  abstract eval(context: AtomContext, input: TypedValue[]): TypedValue[];
 
   toString(): string {
     return `${this.operator}(${this.child.toString()})`;
@@ -18,7 +21,7 @@ export abstract class PrefixOperatorAtom implements Atom {
 export abstract class InfixOperatorAtom implements Atom {
   constructor(public readonly operator: string, public readonly left: Atom, public readonly right: Atom) {}
 
-  abstract eval(context: TypedValue[]): TypedValue[];
+  abstract eval(context: AtomContext, input: TypedValue[]): TypedValue[];
 
   toString(): string {
     return `${this.left.toString()} ${this.operator} ${this.right.toString()}`;

--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -11,10 +11,7 @@ describe('Atoms', () => {
   beforeAll(() => {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
-    context = {
-      parent: undefined,
-      variables: {},
-    };
+    context = { variables: {} };
   });
 
   test('LiteralAtom', () => {

--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -3,11 +3,18 @@ import { Bundle, Observation } from '@medplum/fhirtypes';
 import { indexStructureDefinitionBundle, PropertyType } from '../types';
 import { LiteralAtom, SymbolAtom } from './atoms';
 import { evalFhirPath, parseFhirPath } from './parse';
+import { AtomContext } from '../fhirlexer';
+
+let context: AtomContext;
 
 describe('Atoms', () => {
   beforeAll(() => {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    context = {
+      parent: undefined,
+      variables: {},
+    };
   });
 
   test('LiteralAtom', () => {
@@ -34,7 +41,7 @@ describe('Atoms', () => {
 
   test('EmptySetAtom', () => {
     const atom = parseFhirPath('{}');
-    expect(atom.eval([])).toEqual([]);
+    expect(atom.eval(context, [])).toEqual([]);
     expect(atom.toString()).toEqual('{}');
   });
 

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -1,4 +1,4 @@
-import { Atom, InfixOperatorAtom, PrefixOperatorAtom } from '../fhirlexer';
+import { Atom, AtomContext, InfixOperatorAtom, PrefixOperatorAtom } from '../fhirlexer';
 import { PropertyType, TypedValue, isResource } from '../types';
 import { functions } from './functions';
 import {
@@ -13,16 +13,15 @@ import {
   toJsBoolean,
   toTypedValue,
 } from './utils';
-
 export class FhirPathAtom implements Atom {
   constructor(public readonly original: string, public readonly child: Atom) {}
 
-  eval(context: TypedValue[]): TypedValue[] {
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
     try {
-      if (context.length > 0) {
-        return context.map((e) => this.child.eval([e])).flat();
+      if (input.length > 0) {
+        return input.map((e) => this.child.eval(context, [e])).flat();
       } else {
-        return this.child.eval([]);
+        return this.child.eval(context, []);
       }
     } catch (error) {
       throw new Error(`FhirPathError on "${this.original}": ${error}`);
@@ -51,11 +50,11 @@ export class LiteralAtom implements Atom {
 
 export class SymbolAtom implements Atom {
   constructor(public readonly name: string) {}
-  eval(context: TypedValue[]): TypedValue[] {
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
     if (this.name === '$this') {
-      return context;
+      return input;
     }
-    return context.flatMap((e) => this.evalValue(e)).filter((e) => e?.value !== undefined) as TypedValue[];
+    return input.flatMap((e) => this.evalValue(e)).filter((e) => e?.value !== undefined) as TypedValue[];
   }
 
   private evalValue(typedValue: TypedValue): TypedValue[] | TypedValue | undefined {
@@ -91,8 +90,8 @@ export class UnaryOperatorAtom extends PrefixOperatorAtom {
     super(operator, child);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    return this.impl(this.child.eval(context));
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    return this.impl(this.child.eval(context, input));
   }
 
   toString(): string {
@@ -105,8 +104,8 @@ export class AsAtom extends InfixOperatorAtom {
     super('as', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    return functions.ofType(this.left.eval(context), this.right);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    return functions.ofType(context, this.left.eval(context, input), this.right);
   }
 }
 
@@ -120,12 +119,12 @@ export class ArithemticOperatorAtom extends InfixOperatorAtom {
     super(operator, left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftEvalResult = this.left.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftEvalResult = this.left.eval(context, input);
     if (leftEvalResult.length !== 1) {
       return [];
     }
-    const rightEvalResult = this.right.eval(context);
+    const rightEvalResult = this.right.eval(context, input);
     if (rightEvalResult.length !== 1) {
       return [];
     }
@@ -149,9 +148,9 @@ export class ConcatAtom extends InfixOperatorAtom {
     super('&', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     const result = [...leftValue, ...rightValue];
     if (result.length > 0 && result.every((e) => typeof e.value === 'string')) {
       return [{ type: PropertyType.string, value: result.map((e) => e.value as string).join('') }];
@@ -165,9 +164,9 @@ export class ContainsAtom extends InfixOperatorAtom {
     super('contains', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     return booleanToTypedValue(leftValue.some((e) => e.value === rightValue[0].value));
   }
 }
@@ -177,9 +176,9 @@ export class InAtom extends InfixOperatorAtom {
     super('in', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     return booleanToTypedValue(rightValue.some((e) => e.value === leftValue[0].value));
   }
 }
@@ -189,8 +188,8 @@ export class DotAtom extends InfixOperatorAtom {
     super('.', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    return this.right.eval(this.left.eval(context));
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    return this.right.eval(context, this.left.eval(context, input));
   }
 
   toString(): string {
@@ -203,9 +202,9 @@ export class UnionAtom extends InfixOperatorAtom {
     super('|', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftResult = this.left.eval(context);
-    const rightResult = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftResult = this.left.eval(context, input);
+    const rightResult = this.right.eval(context, input);
     return removeDuplicates([...leftResult, ...rightResult]);
   }
 }
@@ -215,9 +214,9 @@ export class EqualsAtom extends InfixOperatorAtom {
     super('=', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     return fhirPathArrayEquals(leftValue, rightValue);
   }
 }
@@ -227,9 +226,9 @@ export class NotEqualsAtom extends InfixOperatorAtom {
     super('!=', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     return fhirPathNot(fhirPathArrayEquals(leftValue, rightValue));
   }
 }
@@ -239,9 +238,9 @@ export class EquivalentAtom extends InfixOperatorAtom {
     super('~', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     return fhirPathArrayEquivalent(leftValue, rightValue);
   }
 }
@@ -251,9 +250,9 @@ export class NotEquivalentAtom extends InfixOperatorAtom {
     super('!~', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     return fhirPathNot(fhirPathArrayEquivalent(leftValue, rightValue));
   }
 }
@@ -263,8 +262,8 @@ export class IsAtom extends InfixOperatorAtom {
     super('is', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
     if (leftValue.length !== 1) {
       return [];
     }
@@ -284,9 +283,9 @@ export class AndAtom extends InfixOperatorAtom {
     super('and', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
-    const rightValue = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
+    const rightValue = this.right.eval(context, input);
     if (leftValue[0]?.value === true && rightValue[0]?.value === true) {
       return booleanToTypedValue(true);
     }
@@ -302,13 +301,13 @@ export class OrAtom extends InfixOperatorAtom {
     super('or', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftValue = this.left.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftValue = this.left.eval(context, input);
     if (toJsBoolean(leftValue)) {
       return leftValue;
     }
 
-    const rightValue = this.right.eval(context);
+    const rightValue = this.right.eval(context, input);
     if (toJsBoolean(rightValue)) {
       return rightValue;
     }
@@ -328,9 +327,9 @@ export class XorAtom extends InfixOperatorAtom {
     super('xor', left, right);
   }
 
-  eval(context: TypedValue[]): TypedValue[] {
-    const leftResult = this.left.eval(context);
-    const rightResult = this.right.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const leftResult = this.left.eval(context, input);
+    const rightResult = this.right.eval(context, input);
     if (leftResult.length === 0 && rightResult.length === 0) {
       return [];
     }
@@ -348,12 +347,12 @@ export class XorAtom extends InfixOperatorAtom {
 
 export class FunctionAtom implements Atom {
   constructor(public readonly name: string, public readonly args: Atom[]) {}
-  eval(context: TypedValue[]): TypedValue[] {
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
     const impl = functions[this.name];
     if (!impl) {
       throw new Error('Unrecognized function: ' + this.name);
     }
-    return impl(context, ...this.args);
+    return impl(context, input, ...this.args);
   }
 
   toString(): string {
@@ -363,8 +362,8 @@ export class FunctionAtom implements Atom {
 
 export class IndexerAtom implements Atom {
   constructor(public readonly left: Atom, public readonly expr: Atom) {}
-  eval(context: TypedValue[]): TypedValue[] {
-    const evalResult = this.expr.eval(context);
+  eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    const evalResult = this.expr.eval(context, input);
     if (evalResult.length !== 1) {
       return [];
     }
@@ -372,7 +371,7 @@ export class IndexerAtom implements Atom {
     if (typeof index !== 'number') {
       throw new Error(`Invalid indexer expression: should return integer}`);
     }
-    const leftResult = this.left.eval(context);
+    const leftResult = this.left.eval(context, input);
     if (!(index in leftResult)) {
       return [];
     }

--- a/packages/core/src/fhirpath/functions.test.ts
+++ b/packages/core/src/fhirpath/functions.test.ts
@@ -1,13 +1,18 @@
 import { Patient } from '@medplum/fhirtypes';
-import { Atom } from '../fhirlexer';
+import { Atom, AtomContext } from '../fhirlexer';
 import { PropertyType, TypedValue } from '../types';
 import { createReference, getReferenceString } from '../utils';
 import { LiteralAtom } from './atoms';
 import { FhirPathFunction, functions } from './functions';
 import { booleanToTypedValue, toTypedValue } from './utils';
 
+const context = {
+  parent: undefined,
+  variables: {},
+};
+
 const isEven: Atom = {
-  eval: (num: TypedValue[]) => booleanToTypedValue((num[0].value as number) % 2 === 0),
+  eval: (context: AtomContext, num: TypedValue[]) => booleanToTypedValue((num[0].value as number) % 2 === 0),
 };
 
 const TYPED_TRUE = toTypedValue(true);
@@ -34,488 +39,493 @@ describe('FHIRPath functions', () => {
   // 5.1 Existence
 
   test('empty', () => {
-    expect(functions.empty([])).toEqual([TYPED_TRUE]);
-    expect(functions.empty([TYPED_1])).toEqual([TYPED_FALSE]);
-    expect(functions.empty([TYPED_1, TYPED_2])).toEqual([TYPED_FALSE]);
+    expect(functions.empty(context, [])).toEqual([TYPED_TRUE]);
+    expect(functions.empty(context, [TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.empty(context, [TYPED_1, TYPED_2])).toEqual([TYPED_FALSE]);
   });
 
   test('exists', () => {
-    expect(functions.exists([])).toEqual([TYPED_FALSE]);
-    expect(functions.exists([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(functions.exists([TYPED_1, TYPED_2])).toEqual([TYPED_TRUE]);
-    expect(functions.exists([], isEven)).toEqual([TYPED_FALSE]);
-    expect(functions.exists([TYPED_1], isEven)).toEqual([TYPED_FALSE]);
-    expect(functions.exists([TYPED_1, TYPED_2], isEven)).toEqual([TYPED_TRUE]);
+    expect(functions.exists(context, [])).toEqual([TYPED_FALSE]);
+    expect(functions.exists(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(functions.exists(context, [TYPED_1, TYPED_2])).toEqual([TYPED_TRUE]);
+    expect(functions.exists(context, [], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.exists(context, [TYPED_1], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.exists(context, [TYPED_1, TYPED_2], isEven)).toEqual([TYPED_TRUE]);
   });
 
   test('all', () => {
-    expect(functions.all([], isEven)).toEqual([TYPED_TRUE]);
-    expect(functions.all([TYPED_1], isEven)).toEqual([TYPED_FALSE]);
-    expect(functions.all([TYPED_2], isEven)).toEqual([TYPED_TRUE]);
-    expect(functions.all([TYPED_1, TYPED_2], isEven)).toEqual([TYPED_FALSE]);
-    expect(functions.all([TYPED_2, TYPED_4], isEven)).toEqual([TYPED_TRUE]);
+    expect(functions.all(context, [], isEven)).toEqual([TYPED_TRUE]);
+    expect(functions.all(context, [TYPED_1], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.all(context, [TYPED_2], isEven)).toEqual([TYPED_TRUE]);
+    expect(functions.all(context, [TYPED_1, TYPED_2], isEven)).toEqual([TYPED_FALSE]);
+    expect(functions.all(context, [TYPED_2, TYPED_4], isEven)).toEqual([TYPED_TRUE]);
   });
 
   test('allTrue', () => {
-    expect(functions.allTrue([])).toEqual([TYPED_TRUE]);
-    expect(functions.allTrue([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.allTrue([TYPED_FALSE])).toEqual([TYPED_FALSE]);
-    expect(functions.allTrue([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
-    expect(functions.allTrue([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.allTrue([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allTrue(context, [])).toEqual([TYPED_TRUE]);
+    expect(functions.allTrue(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.allTrue(context, [TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allTrue(context, [TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allTrue(context, [TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.allTrue(context, [TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
   });
 
   test('anyTrue', () => {
-    expect(functions.anyTrue([])).toEqual([TYPED_FALSE]);
-    expect(functions.anyTrue([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.anyTrue([TYPED_FALSE])).toEqual([TYPED_FALSE]);
-    expect(functions.anyTrue([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.anyTrue([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.anyTrue([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyTrue(context, [])).toEqual([TYPED_FALSE]);
+    expect(functions.anyTrue(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyTrue(context, [TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyTrue(context, [TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyTrue(context, [TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyTrue(context, [TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
   });
 
   test('allFalse', () => {
-    expect(functions.allFalse([])).toEqual([TYPED_TRUE]);
-    expect(functions.allFalse([TYPED_TRUE])).toEqual([TYPED_FALSE]);
-    expect(functions.allFalse([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.allFalse([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
-    expect(functions.allFalse([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_FALSE]);
-    expect(functions.allFalse([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.allFalse(context, [])).toEqual([TYPED_TRUE]);
+    expect(functions.allFalse(context, [TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.allFalse(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.allFalse(context, [TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.allFalse(context, [TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.allFalse(context, [TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
   });
 
   test('anyFalse', () => {
-    expect(functions.anyFalse([])).toEqual([TYPED_FALSE]);
-    expect(functions.anyFalse([TYPED_TRUE])).toEqual([TYPED_FALSE]);
-    expect(functions.anyFalse([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.anyFalse([TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.anyFalse([TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_FALSE]);
-    expect(functions.anyFalse([TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyFalse(context, [])).toEqual([TYPED_FALSE]);
+    expect(functions.anyFalse(context, [TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyFalse(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyFalse(context, [TYPED_TRUE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.anyFalse(context, [TYPED_TRUE, TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.anyFalse(context, [TYPED_FALSE, TYPED_FALSE])).toEqual([TYPED_TRUE]);
   });
 
   test('count', () => {
-    expect(functions.count([])).toEqual([TYPED_0]);
-    expect(functions.count([TYPED_1])).toEqual([TYPED_1]);
-    expect(functions.count([TYPED_1, TYPED_2])).toEqual([TYPED_2]);
+    expect(functions.count(context, [])).toEqual([TYPED_0]);
+    expect(functions.count(context, [TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.count(context, [TYPED_1, TYPED_2])).toEqual([TYPED_2]);
   });
 
   test('distinct', () => {
-    expect(functions.distinct([])).toEqual([]);
-    expect(functions.distinct([TYPED_1])).toEqual([TYPED_1]);
-    expect(functions.distinct([TYPED_1, TYPED_2])).toEqual([TYPED_1, TYPED_2]);
-    expect(functions.distinct([TYPED_1, TYPED_1])).toEqual([TYPED_1]);
-    expect(functions.distinct([TYPED_A])).toEqual([TYPED_A]);
-    expect(functions.distinct([TYPED_A, TYPED_B])).toEqual([TYPED_A, TYPED_B]);
-    expect(functions.distinct([TYPED_A, TYPED_A])).toEqual([TYPED_A]);
+    expect(functions.distinct(context, [])).toEqual([]);
+    expect(functions.distinct(context, [TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.distinct(context, [TYPED_1, TYPED_2])).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.distinct(context, [TYPED_1, TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.distinct(context, [TYPED_A])).toEqual([TYPED_A]);
+    expect(functions.distinct(context, [TYPED_A, TYPED_B])).toEqual([TYPED_A, TYPED_B]);
+    expect(functions.distinct(context, [TYPED_A, TYPED_A])).toEqual([TYPED_A]);
   });
 
   test('isDistinct', () => {
-    expect(functions.isDistinct([])).toEqual([TYPED_TRUE]);
-    expect(functions.isDistinct([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(functions.isDistinct([TYPED_1, TYPED_2])).toEqual([TYPED_TRUE]);
-    expect(functions.isDistinct([TYPED_1, TYPED_1])).toEqual([TYPED_FALSE]);
-    expect(functions.isDistinct([TYPED_A])).toEqual([TYPED_TRUE]);
-    expect(functions.isDistinct([TYPED_A, TYPED_B])).toEqual([TYPED_TRUE]);
-    expect(functions.isDistinct([TYPED_A, TYPED_A])).toEqual([TYPED_FALSE]);
+    expect(functions.isDistinct(context, [])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct(context, [TYPED_1, TYPED_2])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct(context, [TYPED_1, TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.isDistinct(context, [TYPED_A])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct(context, [TYPED_A, TYPED_B])).toEqual([TYPED_TRUE]);
+    expect(functions.isDistinct(context, [TYPED_A, TYPED_A])).toEqual([TYPED_FALSE]);
   });
 
   // 5.2. Filtering and projection
 
   test('where', () => {
-    expect(functions.where([], isEven)).toEqual([]);
-    expect(functions.where([TYPED_1], isEven)).toEqual([]);
-    expect(functions.where([TYPED_1, TYPED_2], isEven)).toEqual([TYPED_2]);
-    expect(functions.where([TYPED_1, TYPED_2, TYPED_3, TYPED_4], isEven)).toEqual([TYPED_2, TYPED_4]);
+    expect(functions.where(context, [], isEven)).toEqual([]);
+    expect(functions.where(context, [TYPED_1], isEven)).toEqual([]);
+    expect(functions.where(context, [TYPED_1, TYPED_2], isEven)).toEqual([TYPED_2]);
+    expect(functions.where(context, [TYPED_1, TYPED_2, TYPED_3, TYPED_4], isEven)).toEqual([TYPED_2, TYPED_4]);
   });
 
   // 5.3 Subsetting
 
   test('single', () => {
-    expect(functions.single([])).toEqual([]);
-    expect(functions.single([TYPED_1])).toEqual([TYPED_1]);
-    expect(() => functions.single([TYPED_1, TYPED_2])).toThrowError('Expected input length one for single()');
+    expect(functions.single(context, [])).toEqual([]);
+    expect(functions.single(context, [TYPED_1])).toEqual([TYPED_1]);
+    expect(() => functions.single(context, [TYPED_1, TYPED_2])).toThrowError('Expected input length one for single()');
   });
 
   test('first', () => {
-    expect(functions.first([])).toEqual([]);
-    expect(functions.first([TYPED_1])).toEqual([TYPED_1]);
-    expect(functions.first([TYPED_1, TYPED_2])).toEqual([TYPED_1]);
-    expect(functions.first([TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_1]);
-    expect(functions.first([TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_1]);
+    expect(functions.first(context, [])).toEqual([]);
+    expect(functions.first(context, [TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.first(context, [TYPED_1, TYPED_2])).toEqual([TYPED_1]);
+    expect(functions.first(context, [TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_1]);
+    expect(functions.first(context, [TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_1]);
   });
 
   test('last', () => {
-    expect(functions.last([])).toEqual([]);
-    expect(functions.last([TYPED_1])).toEqual([TYPED_1]);
-    expect(functions.last([TYPED_1, TYPED_2])).toEqual([TYPED_2]);
-    expect(functions.last([TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_3]);
-    expect(functions.last([TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_4]);
+    expect(functions.last(context, [])).toEqual([]);
+    expect(functions.last(context, [TYPED_1])).toEqual([TYPED_1]);
+    expect(functions.last(context, [TYPED_1, TYPED_2])).toEqual([TYPED_2]);
+    expect(functions.last(context, [TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_3]);
+    expect(functions.last(context, [TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_4]);
   });
 
   test('tail', () => {
-    expect(functions.tail([])).toEqual([]);
-    expect(functions.tail([TYPED_1])).toEqual([]);
-    expect(functions.tail([TYPED_1, TYPED_2])).toEqual([TYPED_2]);
-    expect(functions.tail([TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_2, TYPED_3]);
-    expect(functions.tail([TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_2, TYPED_3, TYPED_4]);
+    expect(functions.tail(context, [])).toEqual([]);
+    expect(functions.tail(context, [TYPED_1])).toEqual([]);
+    expect(functions.tail(context, [TYPED_1, TYPED_2])).toEqual([TYPED_2]);
+    expect(functions.tail(context, [TYPED_1, TYPED_2, TYPED_3])).toEqual([TYPED_2, TYPED_3]);
+    expect(functions.tail(context, [TYPED_1, TYPED_2, TYPED_3, TYPED_4])).toEqual([TYPED_2, TYPED_3, TYPED_4]);
   });
 
   test('skip', () => {
     const nonNumber: Atom = { eval: () => [TYPED_XYZ] };
-    expect(() => functions.skip([TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
+    expect(() => functions.skip(context, [TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
       'Expected a number for skip(num)'
     );
 
     const num0: Atom = { eval: () => [TYPED_0] };
-    expect(functions.skip([], num0)).toEqual([]);
-    expect(functions.skip([TYPED_1], num0)).toEqual([TYPED_1]);
-    expect(functions.skip([TYPED_1, TYPED_2], num0)).toEqual([TYPED_1, TYPED_2]);
-    expect(functions.skip([TYPED_1, TYPED_2, TYPED_3], num0)).toEqual([TYPED_1, TYPED_2, TYPED_3]);
+    expect(functions.skip(context, [], num0)).toEqual([]);
+    expect(functions.skip(context, [TYPED_1], num0)).toEqual([TYPED_1]);
+    expect(functions.skip(context, [TYPED_1, TYPED_2], num0)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.skip(context, [TYPED_1, TYPED_2, TYPED_3], num0)).toEqual([TYPED_1, TYPED_2, TYPED_3]);
 
     const num1: Atom = { eval: () => [TYPED_1] };
-    expect(functions.skip([], num1)).toEqual([]);
-    expect(functions.skip([TYPED_1], num1)).toEqual([]);
-    expect(functions.skip([TYPED_1, TYPED_2], num1)).toEqual([TYPED_2]);
-    expect(functions.skip([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_2, TYPED_3]);
+    expect(functions.skip(context, [], num1)).toEqual([]);
+    expect(functions.skip(context, [TYPED_1], num1)).toEqual([]);
+    expect(functions.skip(context, [TYPED_1, TYPED_2], num1)).toEqual([TYPED_2]);
+    expect(functions.skip(context, [TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_2, TYPED_3]);
 
     const num2: Atom = { eval: () => [TYPED_2] };
-    expect(functions.skip([], num2)).toEqual([]);
-    expect(functions.skip([TYPED_1], num2)).toEqual([]);
-    expect(functions.skip([TYPED_1, TYPED_2], num2)).toEqual([]);
-    expect(functions.skip([TYPED_1, TYPED_2, TYPED_3], num2)).toEqual([TYPED_3]);
+    expect(functions.skip(context, [], num2)).toEqual([]);
+    expect(functions.skip(context, [TYPED_1], num2)).toEqual([]);
+    expect(functions.skip(context, [TYPED_1, TYPED_2], num2)).toEqual([]);
+    expect(functions.skip(context, [TYPED_1, TYPED_2, TYPED_3], num2)).toEqual([TYPED_3]);
   });
 
   test('take', () => {
     const nonNumber: Atom = { eval: () => [TYPED_XYZ] };
-    expect(() => functions.take([TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
+    expect(() => functions.take(context, [TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
       'Expected a number for take(num)'
     );
 
     const num0: Atom = { eval: () => [TYPED_0] };
-    expect(functions.take([], num0)).toEqual([]);
-    expect(functions.take([TYPED_1], num0)).toEqual([]);
-    expect(functions.take([TYPED_1, TYPED_2], num0)).toEqual([]);
-    expect(functions.take([TYPED_1, TYPED_2, TYPED_3], num0)).toEqual([]);
+    expect(functions.take(context, [], num0)).toEqual([]);
+    expect(functions.take(context, [TYPED_1], num0)).toEqual([]);
+    expect(functions.take(context, [TYPED_1, TYPED_2], num0)).toEqual([]);
+    expect(functions.take(context, [TYPED_1, TYPED_2, TYPED_3], num0)).toEqual([]);
 
     const num1: Atom = { eval: () => [TYPED_1] };
-    expect(functions.take([], num1)).toEqual([]);
-    expect(functions.take([TYPED_1], num1)).toEqual([TYPED_1]);
-    expect(functions.take([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1]);
-    expect(functions.take([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1]);
+    expect(functions.take(context, [], num1)).toEqual([]);
+    expect(functions.take(context, [TYPED_1], num1)).toEqual([TYPED_1]);
+    expect(functions.take(context, [TYPED_1, TYPED_2], num1)).toEqual([TYPED_1]);
+    expect(functions.take(context, [TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1]);
 
     const num2: Atom = { eval: () => [TYPED_2] };
-    expect(functions.take([], num2)).toEqual([]);
-    expect(functions.take([TYPED_1], num2)).toEqual([TYPED_1]);
-    expect(functions.take([TYPED_1, TYPED_2], num2)).toEqual([TYPED_1, TYPED_2]);
-    expect(functions.take([TYPED_1, TYPED_2, TYPED_3], num2)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.take(context, [], num2)).toEqual([]);
+    expect(functions.take(context, [TYPED_1], num2)).toEqual([TYPED_1]);
+    expect(functions.take(context, [TYPED_1, TYPED_2], num2)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.take(context, [TYPED_1, TYPED_2, TYPED_3], num2)).toEqual([TYPED_1, TYPED_2]);
   });
 
   test('intersect', () => {
-    expect(functions.intersect([], undefined as unknown as Atom)).toEqual([]);
-    expect(functions.intersect([], null as unknown as Atom)).toEqual([]);
+    expect(functions.intersect(context, [], undefined as unknown as Atom)).toEqual([]);
+    expect(functions.intersect(context, [], null as unknown as Atom)).toEqual([]);
 
     const num1: Atom = { eval: () => [TYPED_1] };
-    expect(functions.intersect([], num1)).toEqual([]);
-    expect(functions.intersect([TYPED_1], num1)).toEqual([TYPED_1]);
-    expect(functions.intersect([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1]);
-    expect(functions.intersect([TYPED_1, TYPED_1, TYPED_3], num1)).toEqual([TYPED_1]);
+    expect(functions.intersect(context, [], num1)).toEqual([]);
+    expect(functions.intersect(context, [TYPED_1], num1)).toEqual([TYPED_1]);
+    expect(functions.intersect(context, [TYPED_1, TYPED_2], num1)).toEqual([TYPED_1]);
+    expect(functions.intersect(context, [TYPED_1, TYPED_1, TYPED_3], num1)).toEqual([TYPED_1]);
   });
 
   test('exclude', () => {
-    expect(functions.exclude([], undefined as unknown as Atom)).toEqual([]);
-    expect(functions.exclude([], null as unknown as Atom)).toEqual([]);
+    expect(functions.exclude(context, [], undefined as unknown as Atom)).toEqual([]);
+    expect(functions.exclude(context, [], null as unknown as Atom)).toEqual([]);
 
     const num1: Atom = { eval: () => [TYPED_1] };
-    expect(functions.exclude([], num1)).toEqual([]);
-    expect(functions.exclude([TYPED_1], num1)).toEqual([]);
-    expect(functions.exclude([TYPED_1, TYPED_2], num1)).toEqual([TYPED_2]);
-    expect(functions.exclude([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_2, TYPED_3]);
+    expect(functions.exclude(context, [], num1)).toEqual([]);
+    expect(functions.exclude(context, [TYPED_1], num1)).toEqual([]);
+    expect(functions.exclude(context, [TYPED_1, TYPED_2], num1)).toEqual([TYPED_2]);
+    expect(functions.exclude(context, [TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_2, TYPED_3]);
   });
 
   // 5.4. Combining
 
   test('union', () => {
-    expect(functions.union([], undefined as unknown as Atom)).toEqual([]);
-    expect(functions.union([], null as unknown as Atom)).toEqual([]);
+    expect(functions.union(context, [], undefined as unknown as Atom)).toEqual([]);
+    expect(functions.union(context, [], null as unknown as Atom)).toEqual([]);
 
     const num1: Atom = { eval: () => [TYPED_1] };
-    expect(functions.union([], num1)).toEqual([TYPED_1]);
-    expect(functions.union([TYPED_1], num1)).toEqual([TYPED_1]);
-    expect(functions.union([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1, TYPED_2]);
-    expect(functions.union([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1, TYPED_2, TYPED_3]);
+    expect(functions.union(context, [], num1)).toEqual([TYPED_1]);
+    expect(functions.union(context, [TYPED_1], num1)).toEqual([TYPED_1]);
+    expect(functions.union(context, [TYPED_1, TYPED_2], num1)).toEqual([TYPED_1, TYPED_2]);
+    expect(functions.union(context, [TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1, TYPED_2, TYPED_3]);
   });
 
   test('combine', () => {
-    expect(functions.combine([], undefined as unknown as Atom)).toEqual([]);
-    expect(functions.combine([], null as unknown as Atom)).toEqual([]);
+    expect(functions.combine(context, [], undefined as unknown as Atom)).toEqual([]);
+    expect(functions.combine(context, [], null as unknown as Atom)).toEqual([]);
 
     const num1: Atom = { eval: () => [TYPED_1] };
-    expect(functions.combine([], num1)).toEqual([TYPED_1]);
-    expect(functions.combine([TYPED_1], num1)).toEqual([TYPED_1, TYPED_1]);
-    expect(functions.combine([TYPED_1, TYPED_2], num1)).toEqual([TYPED_1, TYPED_2, TYPED_1]);
-    expect(functions.combine([TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1, TYPED_2, TYPED_3, TYPED_1]);
+    expect(functions.combine(context, [], num1)).toEqual([TYPED_1]);
+    expect(functions.combine(context, [TYPED_1], num1)).toEqual([TYPED_1, TYPED_1]);
+    expect(functions.combine(context, [TYPED_1, TYPED_2], num1)).toEqual([TYPED_1, TYPED_2, TYPED_1]);
+    expect(functions.combine(context, [TYPED_1, TYPED_2, TYPED_3], num1)).toEqual([TYPED_1, TYPED_2, TYPED_3, TYPED_1]);
   });
 
   // 5.5. Conversion
 
   test('iif', () => {
-    expect(functions.iif([], LITERAL_TRUE, LITERAL_X)).toEqual([TYPED_X]);
-    expect(functions.iif([], LITERAL_FALSE, LITERAL_X)).toEqual([]);
-    expect(functions.iif([], LITERAL_TRUE, LITERAL_X, LITERAL_Y)).toEqual([TYPED_X]);
-    expect(functions.iif([], LITERAL_FALSE, LITERAL_X, LITERAL_Y)).toEqual([TYPED_Y]);
+    expect(functions.iif(context, [], LITERAL_TRUE, LITERAL_X)).toEqual([TYPED_X]);
+    expect(functions.iif(context, [], LITERAL_FALSE, LITERAL_X)).toEqual([]);
+    expect(functions.iif(context, [], LITERAL_TRUE, LITERAL_X, LITERAL_Y)).toEqual([TYPED_X]);
+    expect(functions.iif(context, [], LITERAL_FALSE, LITERAL_X, LITERAL_Y)).toEqual([TYPED_Y]);
   });
 
   test('toBoolean', () => {
-    expect(functions.toBoolean([])).toEqual([]);
-    expect(functions.toBoolean([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.toBoolean([TYPED_FALSE])).toEqual([TYPED_FALSE]);
-    expect(functions.toBoolean([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(() => functions.toBoolean([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toBoolean([toTypedValue('true')])).toEqual([TYPED_TRUE]);
-    expect(functions.toBoolean([toTypedValue('false')])).toEqual([TYPED_FALSE]);
-    expect(functions.toBoolean([toTypedValue('xyz')])).toEqual([]);
-    expect(functions.toBoolean([toTypedValue({})])).toEqual([]);
+    expect(functions.toBoolean(context, [])).toEqual([]);
+    expect(functions.toBoolean(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.toBoolean(context, [TYPED_FALSE])).toEqual([TYPED_FALSE]);
+    expect(functions.toBoolean(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.toBoolean(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toBoolean(context, [toTypedValue('true')])).toEqual([TYPED_TRUE]);
+    expect(functions.toBoolean(context, [toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.toBoolean(context, [toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toBoolean(context, [toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToBoolean', () => {
-    expect(functions.convertsToBoolean([])).toEqual([]);
-    expect(functions.convertsToBoolean([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToBoolean([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToBoolean([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(() => functions.convertsToBoolean([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToBoolean([toTypedValue('true')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToBoolean([toTypedValue('false')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToBoolean([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToBoolean([toTypedValue({})])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToBoolean(context, [])).toEqual([]);
+    expect(functions.convertsToBoolean(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToBoolean(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToBoolean(context, [toTypedValue('true')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean(context, [toTypedValue('false')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToBoolean(context, [toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToBoolean(context, [toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toInteger', () => {
-    expect(functions.toInteger([])).toEqual([]);
-    expect(functions.toInteger([TYPED_TRUE])).toEqual([TYPED_1]);
-    expect(functions.toInteger([TYPED_FALSE])).toEqual([TYPED_0]);
-    expect(functions.toInteger([TYPED_0])).toEqual([TYPED_0]);
-    expect(functions.toInteger([TYPED_1])).toEqual([TYPED_1]);
-    expect(() => functions.toInteger([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toInteger([toTypedValue('1')])).toEqual([TYPED_1]);
-    expect(functions.toInteger([toTypedValue('true')])).toEqual([]);
-    expect(functions.toInteger([toTypedValue('false')])).toEqual([]);
-    expect(functions.toInteger([toTypedValue('xyz')])).toEqual([]);
-    expect(functions.toInteger([toTypedValue({})])).toEqual([]);
+    expect(functions.toInteger(context, [])).toEqual([]);
+    expect(functions.toInteger(context, [TYPED_TRUE])).toEqual([TYPED_1]);
+    expect(functions.toInteger(context, [TYPED_FALSE])).toEqual([TYPED_0]);
+    expect(functions.toInteger(context, [TYPED_0])).toEqual([TYPED_0]);
+    expect(functions.toInteger(context, [TYPED_1])).toEqual([TYPED_1]);
+    expect(() => functions.toInteger(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toInteger(context, [toTypedValue('1')])).toEqual([TYPED_1]);
+    expect(functions.toInteger(context, [toTypedValue('true')])).toEqual([]);
+    expect(functions.toInteger(context, [toTypedValue('false')])).toEqual([]);
+    expect(functions.toInteger(context, [toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toInteger(context, [toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToInteger', () => {
-    expect(functions.convertsToInteger([])).toEqual([]);
-    expect(functions.convertsToInteger([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToInteger([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToInteger([TYPED_0])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToInteger([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(() => functions.convertsToInteger([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToInteger([toTypedValue('1')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToInteger([toTypedValue('true')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToInteger([toTypedValue('false')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToInteger([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToInteger([toTypedValue({})])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger(context, [])).toEqual([]);
+    expect(functions.convertsToInteger(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger(context, [TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToInteger(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToInteger(context, [toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToInteger(context, [toTypedValue('true')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger(context, [toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger(context, [toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToInteger(context, [toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toDate', () => {
-    expect(functions.toDate([])).toEqual([]);
-    expect(() => functions.toDate([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toDate([toTypedValue('2020-01-01')])).toEqual([{ type: PropertyType.date, value: '2020-01-01' }]);
-    expect(functions.toDate([TYPED_1])).toEqual([]);
-    expect(functions.toDate([TYPED_TRUE])).toEqual([]);
+    expect(functions.toDate(context, [])).toEqual([]);
+    expect(() => functions.toDate(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toDate(context, [toTypedValue('2020-01-01')])).toEqual([
+      { type: PropertyType.date, value: '2020-01-01' },
+    ]);
+    expect(functions.toDate(context, [TYPED_1])).toEqual([]);
+    expect(functions.toDate(context, [TYPED_TRUE])).toEqual([]);
   });
 
   test('convertsToDate', () => {
-    expect(functions.convertsToDate([])).toEqual([]);
-    expect(() => functions.convertsToDate([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToDate([toTypedValue('2020-01-01')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDate([TYPED_1])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToDate([TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDate(context, [])).toEqual([]);
+    expect(() => functions.convertsToDate(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToDate(context, [toTypedValue('2020-01-01')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDate(context, [TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDate(context, [TYPED_TRUE])).toEqual([TYPED_FALSE]);
   });
 
   test('toDateTime', () => {
-    expect(functions.toDateTime([])).toEqual([]);
-    expect(() => functions.toDateTime([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toDateTime([toTypedValue('2020-01-01')])).toEqual([
+    expect(functions.toDateTime(context, [])).toEqual([]);
+    expect(() => functions.toDateTime(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toDateTime(context, [toTypedValue('2020-01-01')])).toEqual([
       { type: PropertyType.dateTime, value: '2020-01-01' },
     ]);
-    expect(functions.toDateTime([toTypedValue('2020-01-01T12:00:00Z')])).toEqual([
+    expect(functions.toDateTime(context, [toTypedValue('2020-01-01T12:00:00Z')])).toEqual([
       { type: PropertyType.dateTime, value: '2020-01-01T12:00:00.000Z' },
     ]);
-    expect(functions.toDateTime([TYPED_1])).toEqual([]);
-    expect(functions.toDateTime([TYPED_TRUE])).toEqual([]);
+    expect(functions.toDateTime(context, [TYPED_1])).toEqual([]);
+    expect(functions.toDateTime(context, [TYPED_TRUE])).toEqual([]);
   });
 
   test('convertsToDateTime', () => {
-    expect(functions.convertsToDateTime([])).toEqual([]);
-    expect(() => functions.convertsToDateTime([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToDateTime([toTypedValue('2020-01-01')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDateTime([toTypedValue('2020-01-01T12:00:00Z')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDateTime([TYPED_1])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToDateTime([TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDateTime(context, [])).toEqual([]);
+    expect(() => functions.convertsToDateTime(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToDateTime(context, [toTypedValue('2020-01-01')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDateTime(context, [toTypedValue('2020-01-01T12:00:00Z')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDateTime(context, [TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDateTime(context, [TYPED_TRUE])).toEqual([TYPED_FALSE]);
   });
 
   test('toDecimal', () => {
-    expect(functions.toDecimal([])).toEqual([]);
-    expect(functions.toDecimal([TYPED_TRUE])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
-    expect(functions.toDecimal([TYPED_FALSE])).toEqual([{ type: PropertyType.decimal, value: 0 }]);
-    expect(functions.toDecimal([TYPED_0])).toEqual([{ type: PropertyType.decimal, value: 0 }]);
-    expect(functions.toDecimal([TYPED_1])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
-    expect(() => functions.toDecimal([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toDecimal([toTypedValue('1')])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
-    expect(functions.toDecimal([toTypedValue('true')])).toEqual([]);
-    expect(functions.toDecimal([toTypedValue('false')])).toEqual([]);
-    expect(functions.toDecimal([toTypedValue('xyz')])).toEqual([]);
-    expect(functions.toDecimal([toTypedValue({})])).toEqual([]);
+    expect(functions.toDecimal(context, [])).toEqual([]);
+    expect(functions.toDecimal(context, [TYPED_TRUE])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
+    expect(functions.toDecimal(context, [TYPED_FALSE])).toEqual([{ type: PropertyType.decimal, value: 0 }]);
+    expect(functions.toDecimal(context, [TYPED_0])).toEqual([{ type: PropertyType.decimal, value: 0 }]);
+    expect(functions.toDecimal(context, [TYPED_1])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
+    expect(() => functions.toDecimal(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toDecimal(context, [toTypedValue('1')])).toEqual([{ type: PropertyType.decimal, value: 1 }]);
+    expect(functions.toDecimal(context, [toTypedValue('true')])).toEqual([]);
+    expect(functions.toDecimal(context, [toTypedValue('false')])).toEqual([]);
+    expect(functions.toDecimal(context, [toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toDecimal(context, [toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToDecimal', () => {
-    expect(functions.convertsToDecimal([])).toEqual([]);
-    expect(functions.convertsToDecimal([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDecimal([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDecimal([TYPED_0])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDecimal([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(() => functions.convertsToDecimal([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToDecimal([toTypedValue('1')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToDecimal([toTypedValue('true')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToDecimal([toTypedValue('false')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToDecimal([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToDecimal([toTypedValue({})])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal(context, [])).toEqual([]);
+    expect(functions.convertsToDecimal(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal(context, [TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToDecimal(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToDecimal(context, [toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToDecimal(context, [toTypedValue('true')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal(context, [toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal(context, [toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToDecimal(context, [toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toQuantity', () => {
-    expect(functions.toQuantity([])).toEqual([]);
-    expect(functions.toQuantity([toTypedValue({ value: 123, unit: 'mg' })])).toEqual([
+    expect(functions.toQuantity(context, [])).toEqual([]);
+    expect(functions.toQuantity(context, [toTypedValue({ value: 123, unit: 'mg' })])).toEqual([
       toTypedValue({ value: 123, unit: 'mg' }),
     ]);
-    expect(functions.toQuantity([TYPED_TRUE])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
-    expect(functions.toQuantity([TYPED_FALSE])).toEqual([toTypedValue({ value: 0, unit: '1' })]);
-    expect(functions.toQuantity([TYPED_0])).toEqual([toTypedValue({ value: 0, unit: '1' })]);
-    expect(functions.toQuantity([TYPED_1])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
-    expect(() => functions.toQuantity([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toQuantity([toTypedValue('1')])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
-    expect(functions.toQuantity([toTypedValue('true')])).toEqual([]);
-    expect(functions.toQuantity([toTypedValue('false')])).toEqual([]);
-    expect(functions.toQuantity([toTypedValue('xyz')])).toEqual([]);
-    expect(functions.toQuantity([toTypedValue({})])).toEqual([]);
+    expect(functions.toQuantity(context, [TYPED_TRUE])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
+    expect(functions.toQuantity(context, [TYPED_FALSE])).toEqual([toTypedValue({ value: 0, unit: '1' })]);
+    expect(functions.toQuantity(context, [TYPED_0])).toEqual([toTypedValue({ value: 0, unit: '1' })]);
+    expect(functions.toQuantity(context, [TYPED_1])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
+    expect(() => functions.toQuantity(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toQuantity(context, [toTypedValue('1')])).toEqual([toTypedValue({ value: 1, unit: '1' })]);
+    expect(functions.toQuantity(context, [toTypedValue('true')])).toEqual([]);
+    expect(functions.toQuantity(context, [toTypedValue('false')])).toEqual([]);
+    expect(functions.toQuantity(context, [toTypedValue('xyz')])).toEqual([]);
+    expect(functions.toQuantity(context, [toTypedValue({})])).toEqual([]);
   });
 
   test('convertsToQuantity', () => {
-    expect(functions.convertsToQuantity([])).toEqual([]);
-    expect(functions.convertsToQuantity([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToQuantity([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToQuantity([TYPED_0])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToQuantity([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(() => functions.convertsToQuantity([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToQuantity([toTypedValue('1')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToQuantity([toTypedValue('true')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToQuantity([toTypedValue('false')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToQuantity([toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToQuantity([toTypedValue({})])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity(context, [])).toEqual([]);
+    expect(functions.convertsToQuantity(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity(context, [TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(() => functions.convertsToQuantity(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToQuantity(context, [toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToQuantity(context, [toTypedValue('true')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity(context, [toTypedValue('false')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity(context, [toTypedValue('xyz')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToQuantity(context, [toTypedValue({})])).toEqual([TYPED_FALSE]);
   });
 
   test('toString', () => {
     const toString = functions.toString as unknown as FhirPathFunction;
-    expect(toString([])).toEqual([]);
-    expect(() => toString([null as unknown as TypedValue])).toThrow();
-    expect(() => toString([undefined as unknown as TypedValue])).toThrow();
-    expect(() => toString([TYPED_1, TYPED_2])).toThrow();
-    expect(toString([TYPED_TRUE])).toEqual([toTypedValue('true')]);
-    expect(toString([TYPED_FALSE])).toEqual([toTypedValue('false')]);
-    expect(toString([TYPED_0])).toEqual([toTypedValue('0')]);
-    expect(toString([TYPED_1])).toEqual([toTypedValue('1')]);
-    expect(toString([toTypedValue(null)])).toEqual([]);
-    expect(toString([toTypedValue(undefined)])).toEqual([]);
-    expect(toString([toTypedValue('1')])).toEqual([toTypedValue('1')]);
-    expect(toString([toTypedValue('true')])).toEqual([toTypedValue('true')]);
-    expect(toString([toTypedValue('false')])).toEqual([toTypedValue('false')]);
-    expect(toString([toTypedValue('xyz')])).toEqual([toTypedValue('xyz')]);
+    expect(toString(context, [])).toEqual([]);
+    expect(() => toString(context, [null as unknown as TypedValue])).toThrow();
+    expect(() => toString(context, [undefined as unknown as TypedValue])).toThrow();
+    expect(() => toString(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(toString(context, [TYPED_TRUE])).toEqual([toTypedValue('true')]);
+    expect(toString(context, [TYPED_FALSE])).toEqual([toTypedValue('false')]);
+    expect(toString(context, [TYPED_0])).toEqual([toTypedValue('0')]);
+    expect(toString(context, [TYPED_1])).toEqual([toTypedValue('1')]);
+    expect(toString(context, [toTypedValue(null)])).toEqual([]);
+    expect(toString(context, [toTypedValue(undefined)])).toEqual([]);
+    expect(toString(context, [toTypedValue('1')])).toEqual([toTypedValue('1')]);
+    expect(toString(context, [toTypedValue('true')])).toEqual([toTypedValue('true')]);
+    expect(toString(context, [toTypedValue('false')])).toEqual([toTypedValue('false')]);
+    expect(toString(context, [toTypedValue('xyz')])).toEqual([toTypedValue('xyz')]);
   });
 
   test('convertsToString', () => {
-    expect(functions.convertsToString([])).toEqual([]);
-    expect(() => functions.convertsToString([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToString([TYPED_TRUE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([TYPED_FALSE])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([TYPED_0])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([TYPED_1])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([toTypedValue('1')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([toTypedValue('true')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([toTypedValue('false')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([toTypedValue('xyz')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToString([toTypedValue({})])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [])).toEqual([]);
+    expect(() => functions.convertsToString(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToString(context, [TYPED_TRUE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [TYPED_FALSE])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [TYPED_0])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [TYPED_1])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [toTypedValue('1')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [toTypedValue('true')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [toTypedValue('false')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [toTypedValue('xyz')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToString(context, [toTypedValue({})])).toEqual([TYPED_TRUE]);
   });
 
   test('toTime', () => {
-    expect(functions.toTime([])).toEqual([]);
-    expect(() => functions.toTime([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.toTime([toTypedValue('12:00:00')])).toEqual([
+    expect(functions.toTime(context, [])).toEqual([]);
+    expect(() => functions.toTime(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.toTime(context, [toTypedValue('12:00:00')])).toEqual([
       { type: PropertyType.time, value: 'T12:00:00.000Z' },
     ]);
-    expect(functions.toTime([toTypedValue('T12:00:00')])).toEqual([
+    expect(functions.toTime(context, [toTypedValue('T12:00:00')])).toEqual([
       { type: PropertyType.time, value: 'T12:00:00.000Z' },
     ]);
-    expect(functions.toTime([toTypedValue('foo')])).toEqual([]);
-    expect(functions.toTime([TYPED_1])).toEqual([]);
-    expect(functions.toTime([TYPED_TRUE])).toEqual([]);
+    expect(functions.toTime(context, [toTypedValue('foo')])).toEqual([]);
+    expect(functions.toTime(context, [TYPED_1])).toEqual([]);
+    expect(functions.toTime(context, [TYPED_TRUE])).toEqual([]);
   });
 
   test('convertsToTime', () => {
-    expect(functions.convertsToTime([])).toEqual([]);
-    expect(() => functions.convertsToTime([TYPED_1, TYPED_2])).toThrow();
-    expect(functions.convertsToTime([toTypedValue('12:00:00')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToTime([toTypedValue('T12:00:00')])).toEqual([TYPED_TRUE]);
-    expect(functions.convertsToTime([toTypedValue('foo')])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToTime([TYPED_1])).toEqual([TYPED_FALSE]);
-    expect(functions.convertsToTime([TYPED_TRUE])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToTime(context, [])).toEqual([]);
+    expect(() => functions.convertsToTime(context, [TYPED_1, TYPED_2])).toThrow();
+    expect(functions.convertsToTime(context, [toTypedValue('12:00:00')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToTime(context, [toTypedValue('T12:00:00')])).toEqual([TYPED_TRUE]);
+    expect(functions.convertsToTime(context, [toTypedValue('foo')])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToTime(context, [TYPED_1])).toEqual([TYPED_FALSE]);
+    expect(functions.convertsToTime(context, [TYPED_TRUE])).toEqual([TYPED_FALSE]);
   });
 
   // 5.6. String Manipulation.
 
   test('indexOf', () => {
-    expect(functions.indexOf([TYPED_APPLE], new LiteralAtom(toTypedValue('a')))).toEqual([TYPED_0]);
+    expect(functions.indexOf(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('a')))).toEqual([TYPED_0]);
   });
 
   test('substring', () => {
-    expect(functions.substring([], new LiteralAtom(toTypedValue(0)))).toEqual([]);
-    expect(() => functions.substring([TYPED_1], new LiteralAtom(toTypedValue(0)))).toThrow();
-    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(-1)))).toEqual([]);
-    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(6)))).toEqual([]);
-    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(0)))).toEqual([TYPED_APPLE]);
-    expect(functions.substring([TYPED_APPLE], new LiteralAtom(toTypedValue(2)))).toEqual([toTypedValue('ple')]);
+    expect(functions.substring(context, [], new LiteralAtom(toTypedValue(0)))).toEqual([]);
+    expect(() => functions.substring(context, [TYPED_1], new LiteralAtom(toTypedValue(0)))).toThrow();
+    expect(functions.substring(context, [TYPED_APPLE], new LiteralAtom(toTypedValue(-1)))).toEqual([]);
+    expect(functions.substring(context, [TYPED_APPLE], new LiteralAtom(toTypedValue(6)))).toEqual([]);
+    expect(functions.substring(context, [TYPED_APPLE], new LiteralAtom(toTypedValue(0)))).toEqual([TYPED_APPLE]);
+    expect(functions.substring(context, [TYPED_APPLE], new LiteralAtom(toTypedValue(2)))).toEqual([
+      toTypedValue('ple'),
+    ]);
   });
 
   test('startsWith', () => {
-    expect(functions.startsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_TRUE]);
-    expect(functions.startsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_FALSE]);
+    expect(functions.startsWith(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_TRUE]);
+    expect(functions.startsWith(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_FALSE]);
   });
 
   test('endsWith', () => {
-    expect(functions.endsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_FALSE]);
-    expect(functions.endsWith([TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_TRUE]);
+    expect(functions.endsWith(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_FALSE]);
+    expect(functions.endsWith(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_TRUE]);
   });
 
   test('contains', () => {
-    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_TRUE]);
-    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_TRUE]);
-    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('ppl')))).toEqual([TYPED_TRUE]);
-    expect(functions.contains([TYPED_APPLE], new LiteralAtom(toTypedValue('xyz')))).toEqual([TYPED_FALSE]);
+    expect(functions.contains(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('app')))).toEqual([TYPED_TRUE]);
+    expect(functions.contains(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('ple')))).toEqual([TYPED_TRUE]);
+    expect(functions.contains(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('ppl')))).toEqual([TYPED_TRUE]);
+    expect(functions.contains(context, [TYPED_APPLE], new LiteralAtom(toTypedValue('xyz')))).toEqual([TYPED_FALSE]);
   });
 
   test('upper', () => {
-    expect(functions.upper([toTypedValue('apple')])).toEqual([toTypedValue('APPLE')]);
-    expect(functions.upper([toTypedValue('Apple')])).toEqual([toTypedValue('APPLE')]);
-    expect(functions.upper([toTypedValue('APPLE')])).toEqual([toTypedValue('APPLE')]);
+    expect(functions.upper(context, [toTypedValue('apple')])).toEqual([toTypedValue('APPLE')]);
+    expect(functions.upper(context, [toTypedValue('Apple')])).toEqual([toTypedValue('APPLE')]);
+    expect(functions.upper(context, [toTypedValue('APPLE')])).toEqual([toTypedValue('APPLE')]);
   });
 
   test('lower', () => {
-    expect(functions.lower([TYPED_APPLE])).toEqual([TYPED_APPLE]);
-    expect(functions.lower([toTypedValue('Apple')])).toEqual([TYPED_APPLE]);
-    expect(functions.lower([toTypedValue('APPLE')])).toEqual([TYPED_APPLE]);
+    expect(functions.lower(context, [TYPED_APPLE])).toEqual([TYPED_APPLE]);
+    expect(functions.lower(context, [toTypedValue('Apple')])).toEqual([TYPED_APPLE]);
+    expect(functions.lower(context, [toTypedValue('APPLE')])).toEqual([TYPED_APPLE]);
   });
 
   test('replace', () => {
     expect(
       functions.replace(
+        context,
         [toTypedValue('banana')],
         new LiteralAtom(toTypedValue('nana')),
         new LiteralAtom(toTypedValue('tman'))
@@ -524,12 +534,13 @@ describe('FHIRPath functions', () => {
   });
 
   test('matches', () => {
-    expect(functions.matches([TYPED_APPLE], new LiteralAtom(TYPED_A))).toEqual([TYPED_TRUE]);
+    expect(functions.matches(context, [TYPED_APPLE], new LiteralAtom(TYPED_A))).toEqual([TYPED_TRUE]);
   });
 
   test('replaceMatches', () => {
     expect(
       functions.replaceMatches(
+        context,
         [toTypedValue('banana')],
         new LiteralAtom(toTypedValue('nana')),
         new LiteralAtom(toTypedValue('tman'))
@@ -538,27 +549,27 @@ describe('FHIRPath functions', () => {
   });
 
   test('length', () => {
-    expect(functions.length([toTypedValue('')])).toEqual([TYPED_0]);
-    expect(functions.length([toTypedValue('x')])).toEqual([TYPED_1]);
-    expect(functions.length([toTypedValue('xy')])).toEqual([TYPED_2]);
-    expect(functions.length([toTypedValue('xyz')])).toEqual([TYPED_3]);
+    expect(functions.length(context, [toTypedValue('')])).toEqual([TYPED_0]);
+    expect(functions.length(context, [toTypedValue('x')])).toEqual([TYPED_1]);
+    expect(functions.length(context, [toTypedValue('xy')])).toEqual([TYPED_2]);
+    expect(functions.length(context, [toTypedValue('xyz')])).toEqual([TYPED_3]);
   });
 
   test('toChars', () => {
-    expect(functions.toChars([toTypedValue('')])).toEqual([]);
-    expect(functions.toChars([toTypedValue('x')])).toEqual([TYPED_X]);
-    expect(functions.toChars([toTypedValue('xy')])).toEqual([TYPED_X, TYPED_Y]);
-    expect(functions.toChars([toTypedValue('xyz')])).toEqual([TYPED_X, TYPED_Y, TYPED_Z]);
+    expect(functions.toChars(context, [toTypedValue('')])).toEqual([]);
+    expect(functions.toChars(context, [toTypedValue('x')])).toEqual([TYPED_X]);
+    expect(functions.toChars(context, [toTypedValue('xy')])).toEqual([TYPED_X, TYPED_Y]);
+    expect(functions.toChars(context, [toTypedValue('xyz')])).toEqual([TYPED_X, TYPED_Y, TYPED_Z]);
   });
 
   // 5.7. Math
 
   test('abs', () => {
-    expect(() => functions.abs([toTypedValue('xyz')])).toThrow();
-    expect(functions.abs([])).toEqual([]);
-    expect(functions.abs([toTypedValue(-1)])).toEqual([TYPED_1]);
-    expect(functions.abs([TYPED_0])).toEqual([TYPED_0]);
-    expect(functions.abs([TYPED_1])).toEqual([TYPED_1]);
+    expect(() => functions.abs(context, [toTypedValue('xyz')])).toThrow();
+    expect(functions.abs(context, [])).toEqual([]);
+    expect(functions.abs(context, [toTypedValue(-1)])).toEqual([TYPED_1]);
+    expect(functions.abs(context, [TYPED_0])).toEqual([TYPED_0]);
+    expect(functions.abs(context, [TYPED_1])).toEqual([TYPED_1]);
   });
 
   // 5.8. Tree navigation
@@ -566,20 +577,21 @@ describe('FHIRPath functions', () => {
   // 5.9. Utility functions
 
   test('now', () => {
-    expect(functions.now([])[0]).toBeDefined();
+    expect(functions.now(context, [])[0]).toBeDefined();
   });
 
   test('timeOfDay', () => {
-    expect(functions.timeOfDay([])[0]).toBeDefined();
+    expect(functions.timeOfDay(context, [])[0]).toBeDefined();
   });
 
   test('today', () => {
-    expect(functions.today([])[0]).toBeDefined();
+    expect(functions.today(context, [])[0]).toBeDefined();
   });
 
   test('between', () => {
     expect(
       functions.between(
+        context,
         [],
         new LiteralAtom(toTypedValue('2000-01-01')),
         new LiteralAtom(toTypedValue('2020-01-01')),
@@ -594,6 +606,7 @@ describe('FHIRPath functions', () => {
 
     expect(() =>
       functions.between(
+        context,
         [],
         new LiteralAtom(toTypedValue('xxxx-xx-xx')),
         new LiteralAtom(toTypedValue('2020-01-01')),
@@ -603,6 +616,7 @@ describe('FHIRPath functions', () => {
 
     expect(() =>
       functions.between(
+        context,
         [],
         new LiteralAtom(toTypedValue('2020-01-01')),
         new LiteralAtom(toTypedValue('xxxx-xx-xx')),
@@ -612,6 +626,7 @@ describe('FHIRPath functions', () => {
 
     expect(() =>
       functions.between(
+        context,
         [],
         new LiteralAtom(toTypedValue('2000-01-01')),
         new LiteralAtom(toTypedValue('2020-01-01')),
@@ -631,39 +646,39 @@ describe('FHIRPath functions', () => {
     };
 
     // Canonical string resolves to patient-like with resourceType and id
-    expect(functions.resolve([toTypedValue(getReferenceString(patient))])).toEqual([
+    expect(functions.resolve(context, [toTypedValue(getReferenceString(patient))])).toEqual([
       toTypedValue({ resourceType: 'Patient', id: '123' }),
     ]);
 
     // Reference resolves to patient-like with resourceType and id
-    expect(functions.resolve([toTypedValue(createReference(patient))])).toEqual([
+    expect(functions.resolve(context, [toTypedValue(createReference(patient))])).toEqual([
       toTypedValue({ resourceType: 'Patient', id: '123' }),
     ]);
 
     // Number resolves to nothing
-    expect(functions.resolve([toTypedValue(123)])).toEqual([]);
+    expect(functions.resolve(context, [toTypedValue(123)])).toEqual([]);
 
     // Reference with embedded resource resolves to resource
     // We don't normally use embeded resources, except in GraphQL queries
-    expect(functions.resolve([toTypedValue({ reference: getReferenceString(patient), resource: patient })])).toEqual([
-      toTypedValue(patient),
-    ]);
+    expect(
+      functions.resolve(context, [toTypedValue({ reference: getReferenceString(patient), resource: patient })])
+    ).toEqual([toTypedValue(patient)]);
 
     // Identifier references with a "type" should resolve to patient search reference
     expect(
-      functions.resolve([
+      functions.resolve(context, [
         { type: PropertyType.Reference, value: { type: 'Patient', identifier: patient.identifier?.[0] } },
       ])
     ).toEqual([toTypedValue({ resourceType: 'Patient' })]);
 
     // Identifier references without a "type" resolves to nothing
     expect(
-      functions.resolve([{ type: PropertyType.Reference, value: { identifier: patient.identifier?.[0] } }])
+      functions.resolve(context, [{ type: PropertyType.Reference, value: { identifier: patient.identifier?.[0] } }])
     ).toEqual([]);
   });
 
   test('as', () => {
-    expect(functions.as([toTypedValue({ resourceType: 'Patient', id: '123' })])).toEqual([
+    expect(functions.as(context, [toTypedValue({ resourceType: 'Patient', id: '123' })])).toEqual([
       toTypedValue({ resourceType: 'Patient', id: '123' }),
     ]);
   });
@@ -671,9 +686,11 @@ describe('FHIRPath functions', () => {
   // 12. Formal Specifications
 
   test('type', () => {
-    expect(functions.type([TYPED_TRUE])).toEqual([toTypedValue({ namespace: 'System', name: 'Boolean' })]);
-    expect(functions.type([toTypedValue(123)])).toEqual([toTypedValue({ namespace: 'System', name: 'Integer' })]);
-    expect(functions.type([toTypedValue({ resourceType: 'Patient', id: '123' })])).toEqual([
+    expect(functions.type(context, [TYPED_TRUE])).toEqual([toTypedValue({ namespace: 'System', name: 'Boolean' })]);
+    expect(functions.type(context, [toTypedValue(123)])).toEqual([
+      toTypedValue({ namespace: 'System', name: 'Integer' }),
+    ]);
+    expect(functions.type(context, [toTypedValue({ resourceType: 'Patient', id: '123' })])).toEqual([
       toTypedValue({ namespace: 'FHIR', name: 'Patient' }),
     ]);
   });

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1101,6 +1101,14 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the input string starts with the given prefix.
+   *
+   * If prefix is the empty string (''), the result is true.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#startswithprefix-string-boolean
    * @param context The evaluation context.
    * @param input The input collection.
    * @param prefixAtom The prefix substring to test.
@@ -1112,6 +1120,14 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the input string ends with the given suffix.
+   *
+   * If suffix is the empty string (''), the result is true.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#endswithsuffix-string-boolean
    * @param context The evaluation context.
    * @param input The input collection.
    * @param suffixAtom The suffix substring to test.
@@ -1123,6 +1139,14 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the given substring is a substring of the input string.
+   *
+   * If substring is the empty string (''), the result is true.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#containssubstring-string-boolean
    * @param context The evaluation context.
    * @param input The input collection.
    * @param substringAtom The substring to test.
@@ -1134,6 +1158,11 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns the input string with all characters converted to upper case.
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#upper-string
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns The string converted to upper case.
@@ -1144,6 +1173,12 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns the input string with all characters converted to lower case.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#lower-string
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns The string converted to lower case.
@@ -1156,6 +1191,12 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the input string with all instances of pattern replaced with substitution. If the substitution is the empty string (''),
    * instances of pattern are removed from the result. If pattern is the empty string (''), every character in the input string is
    * surrounded by the substitution, e.g. 'abc'.replace('','x') becomes 'xaxbxcx'.
+   *
+   * If the input collection, pattern, or substitution are empty, the result is empty ({ }).
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#replacepattern-string-substitution-string-string
    * @param context The evaluation context.
    * @param input The input collection.
    * @param patternAtom The pattern to search for.
@@ -1174,6 +1215,12 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the value matches the given regular expression. Regular expressions should function consistently, regardless of any culture- and locale-specific settings in the environment, should be case-sensitive, use 'single line' mode and allow Unicode characters.
+   *
+   * If the input collection or regex are empty, the result is empty ({ }).
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#matchesregex-string-boolean
    * @param context The evaluation context.
    * @param input The input collection.
    * @param regexAtom The regular expression atom.
@@ -1185,6 +1232,12 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Matches the input using the regular expression in regex and replaces each match with the substitution string. The substitution may refer to identified match groups in the regular expression.
+   *
+   * If the input collection, regex, or substitution are empty, the result is empty ({ }).
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * See: https://hl7.org/fhirpath/#replacematchesregex-string-substitution-string-string
    * @param context The evaluation context.
    * @param input The input collection.
    * @param regexAtom The regular expression atom.

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -49,10 +49,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * for where(criteria).exists().
    *
    * See: https://hl7.org/fhirpath/#existscriteria-expression-boolean
-   *
    * @param context The evaluation context.
-   * @param input
-   * @param criteria
+   * @param input The input collection.
+   * @param criteria The evaluation criteria.
    * @returns True if the collection has unknown elements, and false otherwise.
    */
   exists: (context: AtomContext, input: TypedValue[], criteria?: Atom): TypedValue[] => {
@@ -70,7 +69,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#allcriteria-expression-boolean
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param criteria The evaluation criteria.
@@ -86,7 +84,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#alltrue-boolean
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if all the items are true.
@@ -105,7 +102,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If all the items are false, or if the input is empty ({ }), the result is false.
    *
    * See: https://hl7.org/fhirpath/#anytrue-boolean
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if unknown of the items are true.
@@ -125,7 +121,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#allfalse-boolean
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if all the items are false.
@@ -144,7 +139,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If all the items are true, or if the input is empty ({ }), the result is false.
    *
    * See: https://hl7.org/fhirpath/#anyfalse-boolean
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if for every element in the input collection, criteria evaluates to true.
@@ -189,7 +183,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns 0 when the input collection is empty.
    *
    * See: https://hl7.org/fhirpath/#count-integer
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
@@ -209,7 +202,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * preserved in the result.
    *
    * See: https://hl7.org/fhirpath/#distinct-collection
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
@@ -230,7 +222,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * as defined below.
    *
    * See: https://hl7.org/fhirpath/#isdistinct-boolean
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
@@ -256,7 +247,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * consistent with singleton evaluation of collections behavior.
    *
    * See: https://hl7.org/fhirpath/#wherecriteria-expression-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param criteria The condition atom.
@@ -322,7 +312,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * about cardinality is violated at run-time.
    *
    * See: https://hl7.org/fhirpath/#single-collection
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The single item in the input if there is just one item.
@@ -339,7 +328,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * This function is equivalent to item[0], so it will return an empty collection if the input collection has no items.
    *
    * See: https://hl7.org/fhirpath/#first-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing only the first item in the input collection.
@@ -367,7 +355,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Will return an empty collection if the input collection has no items, or only one item.
    *
    * See: https://hl7.org/fhirpath/#tail-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing all but the first item in the input collection.
@@ -383,7 +370,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If num is less than or equal to zero, the input collection is simply returned.
    *
    * See: https://hl7.org/fhirpath/#skipnum-integer-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param num The atom representing the number of elements to skip.
@@ -410,7 +396,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * take returns an empty collection.
    *
    * See: https://hl7.org/fhirpath/#takenum-integer-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param num The atom representing the number of elements to take.
@@ -495,6 +480,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * In other words, this function returns the distinct list of elements from both inputs.
    *
    * See: http://hl7.org/fhirpath/#unionother-collection
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param other The atom representing the collection of elements to merge.
    * @returns A collection containing the elements that represent the union of both collections.
@@ -591,15 +577,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#toboolean-boolean
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The input converted to boolean value.
    */
-  toBoolean: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toBoolean: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (typeof value === 'boolean') {
       return [{ type: PropertyType.boolean, value }];
     }
@@ -664,16 +650,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tointeger-integer
-   *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The string representation of the input.
    */
-  toInteger: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toInteger: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (typeof value === 'number') {
       return [{ type: PropertyType.integer, value }];
     }
@@ -700,7 +685,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstointeger-boolean
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the input can be converted to an integer.
@@ -727,15 +711,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#todate-date
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The value converted to a date if possible; otherwise empty array.
    */
-  toDate: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toDate: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (typeof value === 'string' && value.match(/^\d{4}(-\d{2}(-\d{2})?)?/)) {
       return [{ type: PropertyType.date, value: parseDateString(value) }];
     }
@@ -785,7 +769,7 @@ export const functions: Record<string, FhirPathFunction> = {
  * If the input collection is empty, the result is empty.
 
  * See: https://hl7.org/fhirpath/#todatetime-datetime
- *
+ * @param context The evaluation context.
  * @param input
  * @returns
  */
@@ -813,6 +797,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodatetime-boolean
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the item can be converted to a dateTime.
    */
@@ -837,16 +822,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#decimal-conversion-functions
-   *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The value converted to a decimal if possible; otherwise empty array.
    */
-  toDecimal: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toDecimal: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (typeof value === 'number') {
       return [{ type: PropertyType.decimal, value }];
     }
@@ -872,7 +856,6 @@ export const functions: Record<string, FhirPathFunction> = {
  * If the input collection is empty, the result is empty.
 
  * See: https://hl7.org/fhirpath/#convertstodecimal-boolean
- *
  * @param context The evaluation context.
  * @param input The input collection.
  * @returns
@@ -894,16 +877,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one of the above types, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#quantity-conversion-functions
-   *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The value converted to a quantity if possible; otherwise empty array.
    */
-  toQuantity: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toQuantity: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput( input, 1);
     if (isQuantity(value)) {
       return [{ type: PropertyType.Quantity, value }];
     }
@@ -938,7 +920,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the unit argument is provided, it must be the string representation of a UCUM code (or a FHIRPath calendar duration keyword), and is used to determine whether the input quantity can be converted to the given unit, according to the unit conversion rules specified by UCUM. If the input quantity can be converted, the result is true, otherwise, the result is false.
    *
    * See: https://hl7.org/fhirpath/#convertstoquantityunit-string-boolean
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the item can be converted to a quantity.
@@ -962,16 +943,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one of the above types, the result is false.
    *
    * See: https://hl7.org/fhirpath/#tostring-string
-   *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The string representation of the input.
    */
-  toString: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toString: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (value === null || value === undefined) {
       return [];
     }
@@ -997,7 +977,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tostring-string
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the item can be converted to a string
@@ -1025,15 +1004,15 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#totime-time
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The value converted to a time if possible; otherwise empty array.
    */
-  toTime: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toTime: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (typeof value === 'string') {
       const match = value.match(/^T?(\d{2}(:\d{2}(:\d{2})?)?)/);
       if (match) {
@@ -1055,6 +1034,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstotime-boolean
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the item can be converted to a time.
    */
@@ -1081,7 +1061,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#indexofsubstring-string-integer
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param searchStringAtom The substring to search for.
@@ -1101,7 +1080,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If an empty length is provided, the behavior is the same as if length had not been provided.
    *
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param startAtom The start index atom.
@@ -1124,7 +1102,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the input string starts with the given prefix.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param prefixAtom The prefix substring to test.
@@ -1136,7 +1113,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the input string ends with the given suffix.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param suffixAtom The suffix substring to test.
@@ -1148,7 +1124,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the given substring is a substring of the input string.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param substringAtom The substring to test.
@@ -1171,7 +1146,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns the input string with all characters converted to lower case.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns The string converted to lower case.
@@ -1184,7 +1158,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the input string with all instances of pattern replaced with substitution. If the substitution is the empty string (''),
    * instances of pattern are removed from the result. If pattern is the empty string (''), every character in the input string is
    * surrounded by the substitution, e.g. 'abc'.replace('','x') becomes 'xaxbxcx'.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param patternAtom The pattern to search for.
@@ -1203,7 +1176,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns true when the value matches the given regular expression. Regular expressions should function consistently, regardless of any culture- and locale-specific settings in the environment, should be case-sensitive, use 'single line' mode and allow Unicode characters.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param regexAtom The regular expression atom.
@@ -1215,7 +1187,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Matches the input using the regular expression in regex and replaces each match with the substitution string. The substitution may refer to identified match groups in the regular expression.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param regexAtom The regular expression atom.
@@ -1233,7 +1204,6 @@ export const functions: Record<string, FhirPathFunction> = {
   },
 
   /**
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns The index of the substring.
@@ -1246,7 +1216,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the list of characters in the input string. If the input collection is empty ({ }), the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tochars-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns Array of characters.
@@ -1267,7 +1236,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#abs-integer-decimal-quantity
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1284,7 +1252,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#ceiling-integer
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1303,7 +1270,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#exp-decimal
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1320,7 +1286,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#floor-integer
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1339,7 +1304,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#ln-decimal
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1360,7 +1324,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#logbase-decimal-decimal
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param baseAtom The logarithm base.
@@ -1380,7 +1343,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#powerexponent-integer-decimal-integer-decimal
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param expAtom The exponent power.
@@ -1402,7 +1364,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#roundprecision-integer-decimal
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1423,7 +1384,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
    *
    * See: https://hl7.org/fhirpath/#sqrt-decimal
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1440,7 +1400,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#truncate-integer
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing the result.
@@ -1472,7 +1431,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * function unchanged.
    *
    * See: https://hl7.org/fhirpath/#tracename-string-projection-expression-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @param nameAtom The log name.
@@ -1712,7 +1670,7 @@ function applyStringFunc<T>(
   if (input.length === 0) {
     return [];
   }
-  const [{ value }] = validateInput(context, input, 1);
+  const [{ value }] = validateInput(input, 1);
   if (typeof value !== 'string') {
     throw new Error('String function cannot be called with non-string');
   }
@@ -1735,7 +1693,7 @@ function applyMathFunc(
   if (input.length === 0) {
     return [];
   }
-  const [{ value }] = validateInput(context, input, 1);
+  const [{ value }] = validateInput(input, 1);
   const quantity = isQuantity(value);
   const numberInput = quantity ? value.value : value;
   if (typeof numberInput !== 'number') {
@@ -1747,7 +1705,7 @@ function applyMathFunc(
   return [{ type, value: returnValue }];
 }
 
-function validateInput(context: AtomContext, input: TypedValue[], count: number): TypedValue[] {
+function validateInput(input: TypedValue[], count: number): TypedValue[] {
   if (input.length !== count) {
     throw new Error(`Expected ${count} arguments`);
   }

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -751,27 +751,27 @@ export const functions: Record<string, FhirPathFunction> = {
     return booleanToTypedValue(functions.toDate(context, input).length === 1);
   },
 
-/**
- * If the input collection contains a single item, this function will return a single datetime if:
- *   1) the item is a DateTime
- *   2) the item is a Date, in which case the result is a DateTime with the year, month, and day of the Date, and the time components empty (not set to zero)
- *   3) the item is a String and is convertible to a DateTime
- *
- * If the item is not one of the above types, the result is empty.
- *
- * If the item is a String, but the string is not convertible to a DateTime (using the format YYYY-MM-DDThh:mm:ss.fff(+|-)hh:mm), the result is empty.
- *
- * If the item contains a partial datetime (e.g. '2012-01-01T10:00'), the result is a partial datetime.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
-
- * See: https://hl7.org/fhirpath/#todatetime-datetime
- * @param _context The evaluation context.
- * @param input The input collection.
- * @returns The value converted to a datetime if possible; otherwise empty array.
- */
+  /**
+   * If the input collection contains a single item, this function will return a single datetime if:
+   *   1) the item is a DateTime
+   *   2) the item is a Date, in which case the result is a DateTime with the year, month, and day of the Date, and the time components empty (not set to zero)
+   *   3) the item is a String and is convertible to a DateTime
+   *
+   * If the item is not one of the above types, the result is empty.
+   *
+   * If the item is a String, but the string is not convertible to a DateTime (using the format YYYY-MM-DDThh:mm:ss.fff(+|-)hh:mm), the result is empty.
+   *
+   * If the item contains a partial datetime (e.g. '2012-01-01T10:00'), the result is a partial datetime.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#todatetime-datetime
+   * @param _context The evaluation context.
+   * @param input The input collection.
+   * @returns The value converted to a datetime if possible; otherwise empty array.
+   */
   toDateTime: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
@@ -842,23 +842,23 @@ export const functions: Record<string, FhirPathFunction> = {
     return [];
   },
 
-/**
- * If the input collection contains a single item, this function will true if:
- *   1) the item is an Integer or Decimal
- *   2) the item is a String and is convertible to a Decimal
- *   3) the item is a Boolean
- *
- * If the item is not one of the above types, or is not convertible to a Decimal (using the regex format (\\+|-)?\d+(\.\d+)?), the result is false.
- *
- * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
- *
- * If the input collection is empty, the result is empty.
-
- * See: https://hl7.org/fhirpath/#convertstodecimal-boolean
- * @param context The evaluation context.
- * @param input The input collection.
- * @returns The value converted to a decimal if possible; otherwise empty array.
- */
+  /**
+   * If the input collection contains a single item, this function will true if:
+   *   1) the item is an Integer or Decimal
+   *   2) the item is a String and is convertible to a Decimal
+   *   3) the item is a Boolean
+   *
+   * If the item is not one of the above types, or is not convertible to a Decimal (using the regex format (\\+|-)?\d+(\.\d+)?), the result is false.
+   *
+   * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
+   *
+   * If the input collection is empty, the result is empty.
+   *
+   * See: https://hl7.org/fhirpath/#convertstodecimal-boolean
+   * @param context The evaluation context.
+   * @param input The input collection.
+   * @returns The value converted to a decimal if possible; otherwise empty array.
+   */
   convertsToDecimal: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -341,7 +341,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * Will return an empty collection if the input collection has no items.
    *
    * See: https://hl7.org/fhirpath/#last-collection
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns A collection containing only the last item in the input collection.
@@ -752,7 +751,7 @@ export const functions: Record<string, FhirPathFunction> = {
     return booleanToTypedValue(functions.toDate(context, input).length === 1);
   },
 
-  /**
+/**
  * If the input collection contains a single item, this function will return a single datetime if:
  *   1) the item is a DateTime
  *   2) the item is a Date, in which case the result is a DateTime with the year, month, and day of the Date, and the time components empty (not set to zero)
@@ -770,8 +769,8 @@ export const functions: Record<string, FhirPathFunction> = {
 
  * See: https://hl7.org/fhirpath/#todatetime-datetime
  * @param _context The evaluation context.
- * @param input
- * @returns
+ * @param input The input collection.
+ * @returns The value converted to a datetime if possible; otherwise empty array.
  */
   toDateTime: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
@@ -843,7 +842,7 @@ export const functions: Record<string, FhirPathFunction> = {
     return [];
   },
 
-  /**
+/**
  * If the input collection contains a single item, this function will true if:
  *   1) the item is an Integer or Decimal
  *   2) the item is a String and is convertible to a Decimal
@@ -858,7 +857,7 @@ export const functions: Record<string, FhirPathFunction> = {
  * See: https://hl7.org/fhirpath/#convertstodecimal-boolean
  * @param context The evaluation context.
  * @param input The input collection.
- * @returns
+ * @returns The value converted to a decimal if possible; otherwise empty array.
  */
   convertsToDecimal: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
@@ -1063,7 +1062,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * See: https://hl7.org/fhirpath/#indexofsubstring-string-integer
    * @param context The evaluation context.
    * @param input The input collection.
-   * @param searchStringAtom The substring to search for.
+   * @param substringAtom The substring to search for.
    * @returns The index of the substring.
    */
   indexOf: (context: AtomContext, input: TypedValue[], substringAtom: Atom): TypedValue[] => {
@@ -1135,7 +1134,6 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * Returns the input string with all characters converted to upper case.
-   *
    * @param context The evaluation context.
    * @param input The input collection.
    * @returns The string converted to upper case.
@@ -1621,7 +1619,6 @@ export const functions: Record<string, FhirPathFunction> = {
    * https://hl7.org/fhirpath/modelinfo.xsd
    *
    * See: https://hl7.org/fhirpath/#model-information
-   *
    * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The type of the input value.

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -31,11 +31,11 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns true if the input collection is empty ({ }) and false otherwise.
    *
    * See: https://hl7.org/fhirpath/#empty-boolean
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if the input collection is empty ({ }) and false otherwise.
    */
-  empty: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  empty: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     return booleanToTypedValue(input.length === 0);
   },
 
@@ -87,11 +87,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#alltrue-boolean
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if all the items are true.
    */
-  allTrue: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  allTrue: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     for (const value of input) {
       if (!value.value) {
         return booleanToTypedValue(false);
@@ -106,11 +106,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#anytrue-boolean
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if unknown of the items are true.
    */
-  anyTrue: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  anyTrue: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     for (const value of input) {
       if (value.value) {
         return booleanToTypedValue(true);
@@ -126,11 +126,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#allfalse-boolean
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if all the items are false.
    */
-  allFalse: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  allFalse: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     for (const value of input) {
       if (value.value) {
         return booleanToTypedValue(false);
@@ -145,11 +145,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#anyfalse-boolean
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns True if for every element in the input collection, criteria evaluates to true.
    */
-  anyFalse: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  anyFalse: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     for (const value of input) {
       if (!value.value) {
         return booleanToTypedValue(true);
@@ -190,11 +190,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#count-integer
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
-  count: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  count: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     return [{ type: PropertyType.integer, value: input.length }];
   },
 
@@ -210,11 +210,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#distinct-collection
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
-  distinct: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  distinct: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     const result: TypedValue[] = [];
     for (const value of input) {
       if (!result.some((e) => e.value === value.value)) {
@@ -276,6 +276,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * the input collection is empty ({ }), the result is empty as well.
    *
    * See: http://hl7.org/fhirpath/#selectprojection-expression-collection
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param criteria The condition atom.
    * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
@@ -300,11 +301,12 @@ export const functions: Record<string, FhirPathFunction> = {
    * must resolve to the name of a type in a model
    *
    * See: http://hl7.org/fhirpath/#oftypetype-type-specifier-collection
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @param criteria The condition atom.
    * @returns A collection containing only those elements in the input collection that are of the given type or a subclass thereof.
    */
-  ofType: (context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
+  ofType: (_context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
     return input.filter((e) => e.type === (criteria as SymbolAtom).name);
   },
 
@@ -321,11 +323,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#single-collection
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The single item in the input if there is just one item.
    */
-  single: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  single: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length > 1) {
       throw new Error('Expected input length one for single()');
     }
@@ -434,6 +436,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * Order of items is not guaranteed to be preserved in the result of this function.
    *
    * See: http://hl7.org/fhirpath/#intersectother-collection-collection
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param other The atom representing the collection of elements to intersect.
    * @returns A collection containing the elements that are in both collections.
@@ -459,6 +462,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * e.g. (1 | 2 | 3).exclude(2) returns (1 | 3).
    *
    * See: http://hl7.org/fhirpath/#excludeother-collection-collection
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param other The atom representing the collection of elements to exclude.
    * @returns A collection containing the elements that are in the input collection but not the other collection.
@@ -511,6 +515,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * There is no expectation of order in the resulting collection.
    *
    * See: http://hl7.org/fhirpath/#combineother-collection-collection
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param other The atom representing the collection of elements to merge.
    * @returns A collection containing the elements that represent the combination of both collections including duplicates.
@@ -544,6 +549,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * true-result should only be evaluated if the criterion evaluates to true,
    * and otherwise-result should only be evaluated otherwise. For implementations,
    * this means delaying evaluation of the arguments.
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param criterion The atom representing the conditional.
    * @param trueResult The atom to be used if the conditional evaluates to true.
@@ -585,6 +591,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#toboolean-boolean
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns The input converted to boolean value.
    */
@@ -629,6 +636,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: http://hl7.org/fhirpath/#convertstoboolean-boolean
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the input can be converted to boolean.
    */
@@ -719,6 +727,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#todate-date
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns The value converted to a date if possible; otherwise empty array.
    */
@@ -748,6 +757,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodate-boolean
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the item can be converted to a date.
    */
@@ -1015,6 +1025,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#totime-time
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns The value converted to a time if possible; otherwise empty array.
    */
@@ -1509,6 +1520,7 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * IBM FHIR issue: https://github.com/IBM/FHIR/issues/1014
    * IBM FHIR PR: https://github.com/IBM/FHIR/pull/1023
+   * @param context The evaluation context.
    * @param input The input collection.
    * @param startAtom The start date/time.
    * @param endAtom The end date/time.
@@ -1550,11 +1562,12 @@ export const functions: Record<string, FhirPathFunction> = {
    * For implementations with compile-time typing, this requires special-case
    * handling when processing the argument to treat it as a type specifier rather
    * than an identifier expression:
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @param typeAtom The desired type.
    * @returns True if the input element is of the desired type.
    */
-  is: (context: AtomContext, input: TypedValue[], typeAtom: Atom): TypedValue[] => {
+  is: (_context: AtomContext, input: TypedValue[], typeAtom: Atom): TypedValue[] => {
     let typeName = '';
     if (typeAtom instanceof SymbolAtom) {
       typeName = typeAtom.name;
@@ -1575,6 +1588,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * 6.5.3. not() : Boolean
    *
    * Returns true if the input collection evaluates to false, and false if it evaluates to true. Otherwise, the result is empty ({ }):
+   * @param context The evaluation context.
    * @param input The input collection.
    * @returns True if the input evaluates to false.
    */
@@ -1590,11 +1604,11 @@ export const functions: Record<string, FhirPathFunction> = {
   /**
    * For each item in the collection, if it is a string that is a uri (or canonical or url), locate the target of the reference, and add it to the resulting collection. If the item does not resolve to a resource, the item is ignored and nothing is added to the output collection.
    * The items in the collection may also represent a Reference, in which case the Reference.reference is resolved.
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The resolved resource.
    */
-  resolve: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  resolve: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     return input
       .map((e) => {
         const value = e.value;
@@ -1627,10 +1641,11 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * The as operator can be used to treat a value as a specific type.
+   * @param _context The evaluation context.
    * @param input The input value.
    * @returns The value as the specific type.
    */
-  as: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  as: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     return input;
   },
 
@@ -1649,11 +1664,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * See: https://hl7.org/fhirpath/#model-information
    *
-   * @param context The evaluation context.
+   * @param _context The evaluation context.
    * @param input The input collection.
    * @returns The type of the input value.
    */
-  type: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  type: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     return input.map(({ value }) => {
       if (typeof value === 'boolean') {
         return { type: PropertyType.BackboneElement, value: { namespace: 'System', name: 'Boolean' } };

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -769,15 +769,15 @@ export const functions: Record<string, FhirPathFunction> = {
  * If the input collection is empty, the result is empty.
 
  * See: https://hl7.org/fhirpath/#todatetime-datetime
- * @param context The evaluation context.
+ * @param _context The evaluation context.
  * @param input
  * @returns
  */
-  toDateTime: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
+  toDateTime: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput(context, input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (typeof value === 'string' && value.match(/^\d{4}(-\d{2}(-\d{2})?)?/)) {
       return [{ type: PropertyType.dateTime, value: parseDateString(value) }];
     }
@@ -885,7 +885,7 @@ export const functions: Record<string, FhirPathFunction> = {
     if (input.length === 0) {
       return [];
     }
-    const [{ value }] = validateInput( input, 1);
+    const [{ value }] = validateInput(input, 1);
     if (isQuantity(value)) {
       return [{ type: PropertyType.Quantity, value }];
     }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -1,5 +1,5 @@
 import { Quantity } from '@medplum/fhirtypes';
-import { Atom, AtomContext, InfixParselet, Parser, ParserBuilder, PrefixParselet } from '../fhirlexer';
+import { Atom, InfixParselet, Parser, ParserBuilder, PrefixParselet } from '../fhirlexer';
 import { PropertyType, TypedValue } from '../types';
 import {
   AndAtom,
@@ -254,13 +254,8 @@ export function evalFhirPath(expression: string, input: unknown): unknown[] {
 export function evalFhirPathTyped(
   expression: string,
   input: TypedValue[],
-  context: AtomContext | undefined = undefined
+  context?: Record<string, TypedValue>
 ): TypedValue[] {
-  if (!context) {
-    context = {
-      parent: undefined,
-      variables: {},
-    };
-  }
-  return parseFhirPath(expression).eval(context, input);
+  const variableInput = context ? context : {};
+  return parseFhirPath(expression).eval({ variables: variableInput }, input);
 }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -248,12 +248,19 @@ export function evalFhirPath(expression: string, input: unknown): unknown[] {
  * Evaluates a FHIRPath expression against a resource or other object.
  * @param expression The FHIRPath expression to parse.
  * @param input The resource or object to evaluate the expression against.
+ * @param context The context to use when evaluating the expression.
  * @returns The result of the FHIRPath expression against the resource or object.
  */
-export function evalFhirPathTyped(expression: string, input: TypedValue[]): TypedValue[] {
-  const context: AtomContext = {
-    parent: undefined,
-    variables: {},
-  };
+export function evalFhirPathTyped(
+  expression: string,
+  input: TypedValue[],
+  context: AtomContext | undefined = undefined
+): TypedValue[] {
+  if (!context) {
+    context = {
+      parent: undefined,
+      variables: {},
+    };
+  }
   return parseFhirPath(expression).eval(context, input);
 }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -248,14 +248,14 @@ export function evalFhirPath(expression: string, input: unknown): unknown[] {
  * Evaluates a FHIRPath expression against a resource or other object.
  * @param expression The FHIRPath expression to parse.
  * @param input The resource or object to evaluate the expression against.
- * @param context The context to use when evaluating the expression.
+ * @param variables A map of variables for eval input.
  * @returns The result of the FHIRPath expression against the resource or object.
  */
 export function evalFhirPathTyped(
   expression: string,
   input: TypedValue[],
-  context?: Record<string, TypedValue>
+  variables?: Record<string, TypedValue>
 ): TypedValue[] {
-  const variableInput = context ? context : {};
+  const variableInput = variables ? variables : {};
   return parseFhirPath(expression).eval({ variables: variableInput }, input);
 }

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -1,5 +1,5 @@
 import { Quantity } from '@medplum/fhirtypes';
-import { Atom, InfixParselet, Parser, ParserBuilder, PrefixParselet } from '../fhirlexer';
+import { Atom, AtomContext, InfixParselet, Parser, ParserBuilder, PrefixParselet } from '../fhirlexer';
 import { PropertyType, TypedValue } from '../types';
 import {
   AndAtom,
@@ -251,5 +251,9 @@ export function evalFhirPath(expression: string, input: unknown): unknown[] {
  * @returns The result of the FHIRPath expression against the resource or object.
  */
 export function evalFhirPathTyped(expression: string, input: TypedValue[]): TypedValue[] {
-  return parseFhirPath(expression).eval(input);
+  const context: AtomContext = {
+    parent: undefined,
+    variables: {},
+  };
+  return parseFhirPath(expression).eval(context, input);
 }

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -108,25 +108,6 @@ export async function createAuditEvent(
   });
 }
 
-export function shouldTriggerJob(subscription: Subscription): boolean {
-  const criteria = getExtension(subscription, 'https://medplum.com/fhir/StructureDefinition/fhir-path-criteria')
-  if (!criteria) {
-    return true;
-  }
-
-  let previous = '';
-  let next; 
-  
-  if (!previous) {
-    return true;
-  }
-  if (previous !== next) {
-    return true;
-  }
-  
-  return false;
-}
-
 export function isJobSuccessful(subscription: Subscription, status: number): boolean {
   const successCodes = getExtension(
     subscription,

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -108,6 +108,25 @@ export async function createAuditEvent(
   });
 }
 
+export function shouldTriggerJob(subscription: Subscription): boolean {
+  const criteria = getExtension(subscription, 'https://medplum.com/fhir/StructureDefinition/fhir-path-criteria')
+  if (!criteria) {
+    return true;
+  }
+
+  let previous = '';
+  let next; 
+  
+  if (!previous) {
+    return true;
+  }
+  if (previous !== next) {
+    return true;
+  }
+  
+  return false;
+}
+
 export function isJobSuccessful(subscription: Subscription, status: number): boolean {
   const successCodes = getExtension(
     subscription,


### PR DESCRIPTION
We need to evaluate an expression that takes in two inputs. The first step is to add a global variable `context` 

https://github.com/medplum/medplum/issues/1931