### PR TITLE
CLI Global Options - Part 1 - bulk commands

### DIFF
--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -1,11 +1,13 @@
 import { MedplumClient, created } from '@medplum/core';
 import { main } from '.';
+import { createMedplumClient } from './util/client';
 
 const testLineOutput = [
   `{"resourceType":"Patient", "id":"1111111"}`,
   `{"resourceType":"Patient", "id":"2222222"}`,
   `{"resourceType":"Patient", "id":"3333333"}`,
 ];
+jest.mock('./util/client');
 jest.mock('child_process');
 jest.mock('http');
 jest.mock('readline', () => ({
@@ -128,6 +130,8 @@ describe('CLI Bulk Commands', () => {
       jest.clearAllMocks();
       medplum = new MedplumClient({ fetch });
 
+      (createMedplumClient as unknown as jest.Mock).mockImplementation(async () => medplum);
+
       console.log = jest.fn();
       console.error = jest.fn();
       process.exit = jest.fn() as never;
@@ -180,10 +184,11 @@ describe('CLI Bulk Commands', () => {
           })),
         };
       });
+      medplum = new MedplumClient({ fetch });
+      (createMedplumClient as unknown as jest.Mock).mockImplementation(async () => medplum);
     });
 
     test('success', async () => {
-      medplum = new MedplumClient({ fetch });
       await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json']);
 
       testLineOutput.forEach((line) => {
@@ -208,7 +213,6 @@ describe('CLI Bulk Commands', () => {
     });
 
     test('success with option numResourcesPerRequest', async () => {
-      medplum = new MedplumClient({ fetch });
       await main(medplum, ['node', 'index.js', 'bulk', 'import', 'Patient.json', '--num-resources-per-request', '1']);
 
       testLineOutput.forEach((line) => {

--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -1,4 +1,4 @@
-import { MedplumClient, created } from '@medplum/core';
+import { created, MedplumClient } from '@medplum/core';
 import { main } from '.';
 import { createMedplumClient } from './util/client';
 

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -3,9 +3,11 @@ import { BundleEntry } from '@medplum/fhirtypes';
 import { createReadStream, writeFile } from 'fs';
 import { resolve } from 'path';
 import { createInterface } from 'readline';
-import { createMedplumClient, MedplumCommand, prettyPrint } from './utils';
+import { createMedplumClient } from './util/client';
+import { createMedplumCommand } from './util/command';
+import { prettyPrint } from './utils';
 
-export const bulk = new MedplumCommand('bulk');
+export const bulk = createMedplumCommand('bulk');
 
 bulk
   .command('export')

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -4,7 +4,7 @@ import { createReadStream, writeFile } from 'fs';
 import { resolve } from 'path';
 import { createInterface } from 'readline';
 import { medplum } from '.';
-import { prettyPrint } from './utils';
+import { getMedplumClient, prettyPrint } from './utils';
 
 export const bulk = new Command('bulk');
 
@@ -19,7 +19,9 @@ bulk
     '-s, --since <since>',
     'optional Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).'
   )
-  .action(async ({ exportLevel, types, since }) => {
+  .action(async (options) => {
+    const { exportLevel, types, since } = options;
+    const medplum = await getMedplumClient(options);
     const response = await medplum.bulkExport(exportLevel, types, since);
     response.output?.forEach(async ({ type, url }) => {
       const fileUrl = new URL(url as string);

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -1,12 +1,11 @@
 import { BundleEntry } from '@medplum/fhirtypes';
-import { Command } from 'commander';
 import { createReadStream, writeFile } from 'fs';
 import { resolve } from 'path';
 import { createInterface } from 'readline';
 import { medplum } from '.';
-import { getMedplumClient, prettyPrint } from './utils';
+import { createMedplumClient, MedplumCommand, prettyPrint } from './utils';
 
-export const bulk = new Command('bulk');
+export const bulk = new MedplumCommand('bulk');
 
 bulk
   .command('export')
@@ -21,7 +20,7 @@ bulk
   )
   .action(async (options) => {
     const { exportLevel, types, since } = options;
-    const medplum = await getMedplumClient(options);
+    const medplum = await createMedplumClient(options);
     const response = await medplum.bulkExport(exportLevel, types, since);
     response.output?.forEach(async ({ type, url }) => {
       const fileUrl = new URL(url as string);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { bulk } from './bulk';
 import { project } from './project';
 import { deleteObject, get, patch, post, put } from './rest';
 import { FileSystemStorage } from './storage';
+import { onUnauthenticated } from './util/client';
 
 export let medplum: MedplumClient;
 
@@ -82,8 +83,4 @@ export async function run(): Promise<void> {
 
 if (require.main === module) {
   run().catch((err) => console.error('Unhandled error:', err));
-}
-
-export function onUnauthenticated(): void {
-  console.log('Unauthenticated: run `npx medplum login` to sign in');
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -84,6 +84,6 @@ if (require.main === module) {
   run().catch((err) => console.error('Unhandled error:', err));
 }
 
-function onUnauthenticated(): void {
+export function onUnauthenticated(): void {
   console.log('Unauthenticated: run `npx medplum login` to sign in');
 }

--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -20,13 +20,32 @@ describe('createMedplumClient', () => {
 
   test('with optional env set', async () => {
     process.env.MEDPLUM_BASE_URL = 'http://example.com';
-    process.env.MEDPLUM_FHIR_URL_PATH = '/fhir/test/path/';
-    process.env.MEDPLUM_CLIENT_ACCESS_TOKEN = 'test_token';
+    process.env.MEDPLUM_FHIR_URL_PATH = 'fhir/test/path/';
+    process.env.MEDPLUM_CLIENT_ACCESS_TOKEN = 'test-access-token';
     process.env.MEDPLUM_TOKEN_URL = 'http://example.com/oauth/token';
     const medplumClient = await createMedplumClient({});
 
     expect(medplumClient.getBaseUrl()).toContain('http://example.com/');
-    expect(medplumClient.getAccessToken()).toBeDefined();
+    expect(medplumClient.getAccessToken()).toBe('test-access-token');
+    expect(medplumClient.fhirUrl('test').toString()).toContain('/fhir/test/path/');
+  });
+
+  test('with global options set', async () => {
+    const options = {
+      baseUrl: 'http://example.com/',
+      fhirPathUrl: '/fhir/test/path/',
+      tokenUrl: 'http://example.com/oauth/token',
+      accessToken: 'test-access-token',
+    };
+    process.env.MEDPLUM_BASE_URL = 'http://example.com';
+    process.env.MEDPLUM_FHIR_URL_PATH = '/fhir/test/path/';
+    process.env.MEDPLUM_CLIENT_ACCESS_TOKEN = 'test_token';
+    process.env.MEDPLUM_TOKEN_URL = 'http://example.com/oauth/token';
+    const medplumClient = await createMedplumClient(options);
+
+    expect(medplumClient.getBaseUrl()).toContain('http://example.com/');
+    expect(medplumClient.getAccessToken()).toBe('test-access-token');
+    expect(medplumClient.fhirUrl('test').toString()).toContain('/fhir/test/path/');
   });
 
   test('setBasicAuth and startClientLogin', async () => {

--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -1,0 +1,51 @@
+import { createMedplumClient } from './client';
+
+jest.mock('node-fetch');
+
+describe('createMedplumClient', () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    process.env = { ...env };
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test('no options and no env set', async () => {
+    const medplumClient = await createMedplumClient({});
+    expect(medplumClient.getBaseUrl()).toContain('https://api.medplum.com/');
+  });
+
+  test('with optional env set', async () => {
+    process.env.MEDPLUM_BASE_URL = 'http://example.com';
+    process.env.MEDPLUM_FHIR_URL_PATH = '/fhir/test/path/';
+    process.env.MEDPLUM_CLIENT_ACCESS_TOKEN = 'test_token';
+    process.env.MEDPLUM_TOKEN_URL = 'http://example.com/oauth/token';
+    const medplumClient = await createMedplumClient({});
+
+    expect(medplumClient.getBaseUrl()).toContain('http://example.com/');
+    expect(medplumClient.getAccessToken()).toBeDefined();
+  });
+
+  test('setBasicAuth and startClientLogin', async () => {
+    const accessToken =
+      'header.' + Buffer.from(JSON.stringify({ cid: 'testclientid' })).toString('base64') + '.signature';
+
+    const fetch = jest.fn(async () => {
+      return {
+        status: 200,
+        ok: true,
+        json: jest.fn(async () => ({
+          access_token: accessToken,
+        })),
+      };
+    });
+    process.env.MEDPLUM_CLIENT_ID = 'testclientid';
+    process.env.MEDPLUM_CLIENT_SECRET = 'secret123';
+    const medplumClient = await createMedplumClient({}, fetch);
+
+    expect(medplumClient.getAccessToken()).toBeDefined();
+  });
+});

--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -1,4 +1,5 @@
-import { createMedplumClient, MedplumClientCommandOptions } from './client';
+import { MedplumClientOptions } from '@medplum/core';
+import { createMedplumClient } from './client';
 
 jest.mock('node-fetch');
 
@@ -31,7 +32,7 @@ describe('createMedplumClient', () => {
   });
 
   test('with global options set', async () => {
-    const options: MedplumClientCommandOptions = {
+    const options: MedplumClientOptions = {
       baseUrl: 'http://example.com/',
       fhirUrlPath: '/fhir/test/path/',
       tokenUrl: 'http://example.com/oauth/token',

--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -8,6 +8,7 @@ describe('createMedplumClient', () => {
 
   beforeEach(() => {
     process.env = { ...env };
+    console.log = jest.fn();
   });
 
   afterEach(() => {
@@ -67,5 +68,21 @@ describe('createMedplumClient', () => {
     const medplumClient = await createMedplumClient({ fetch });
 
     expect(medplumClient.getAccessToken()).toBeDefined();
+  });
+
+  test('Unauthenticated', async () => {
+    const fetch = jest.fn(async () => {
+      return {
+        status: 401,
+      };
+    });
+
+    const medplumClient = await createMedplumClient({ fetch });
+    try {
+      await medplumClient.post('Patient', {});
+      throw new Error('testing');
+    } catch {
+      expect(console.log).toBeCalledWith('Unauthenticated: run `npx medplum login` to sign in');
+    }
   });
 });

--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -1,4 +1,4 @@
-import { createMedplumClient } from './client';
+import { createMedplumClient, MedplumClientCommandOptions } from './client';
 
 jest.mock('node-fetch');
 
@@ -31,9 +31,9 @@ describe('createMedplumClient', () => {
   });
 
   test('with global options set', async () => {
-    const options = {
+    const options: MedplumClientCommandOptions = {
       baseUrl: 'http://example.com/',
-      fhirPathUrl: '/fhir/test/path/',
+      fhirUrlPath: '/fhir/test/path/',
       tokenUrl: 'http://example.com/oauth/token',
       accessToken: 'test-access-token',
     };
@@ -63,7 +63,7 @@ describe('createMedplumClient', () => {
     });
     process.env.MEDPLUM_CLIENT_ID = 'testclientid';
     process.env.MEDPLUM_CLIENT_SECRET = 'secret123';
-    const medplumClient = await createMedplumClient({}, fetch);
+    const medplumClient = await createMedplumClient({ fetch });
 
     expect(medplumClient.getAccessToken()).toBeDefined();
   });

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -1,5 +1,4 @@
 import { MedplumClient } from '@medplum/core';
-import { onUnauthenticated } from '..';
 import { FileSystemStorage } from '../storage';
 
 export async function createMedplumClient(options: any): Promise<MedplumClient> {
@@ -29,4 +28,8 @@ export async function createMedplumClient(options: any): Promise<MedplumClient> 
     await medplumClient.startClientLogin(clientId, clientSecret);
   }
   return medplumClient;
+}
+
+export function onUnauthenticated(): void {
+  console.log('Unauthenticated: run `npx medplum login` to sign in');
 }

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -16,10 +16,10 @@ export async function createMedplumClient(options: MedplumClientCommandOptions):
   const fhirUrlPath = options.fhirUrlPath || process.env['MEDPLUM_FHIR_URL_PATH'] || '';
   const accessToken = options.accessToken || process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
   const tokenUrl = options.tokenUrl || process.env['MEDPLUM_TOKEN_URL'] || '';
-  const fetchOptions = options.fetch || fetch;
+  const fetchApi = options.fetch || fetch;
 
   const medplumClient = new MedplumClient({
-    fetch: fetchOptions,
+    fetch: fetchApi,
     baseUrl,
     tokenUrl,
     fhirUrlPath,

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -1,7 +1,7 @@
-import { MedplumClient } from '@medplum/core';
+import { FetchLike, MedplumClient } from '@medplum/core';
 import { FileSystemStorage } from '../storage';
 
-export async function createMedplumClient(options: any): Promise<MedplumClient> {
+export async function createMedplumClient(options: any, fetch?: FetchLike): Promise<MedplumClient> {
   const baseUrl = options.baseUrl || process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
   const fhirUrlPath = options.fhirUrlPath || process.env['MEDPLUM_FHIR_URL_PATH'] || '';
   const accessToken = options.accessToken || process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -1,0 +1,32 @@
+import { MedplumClient } from '@medplum/core';
+import { onUnauthenticated } from '..';
+import { FileSystemStorage } from '../storage';
+
+export async function createMedplumClient(options: any): Promise<MedplumClient> {
+  const baseUrl = options.baseUrl || process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
+  const fhirUrlPath = options.fhirUrlPath || process.env['MEDPLUM_FHIR_URL_PATH'] || '';
+  const accessToken = options.accessToken || process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
+  const tokenUrl = options.tokenUrl || process.env['MEDPLUM_TOKEN_URL'] || '';
+
+  const medplumClient = new MedplumClient({
+    fetch,
+    baseUrl,
+    tokenUrl,
+    fhirUrlPath,
+    storage: new FileSystemStorage(),
+    onUnauthenticated: onUnauthenticated,
+  });
+
+  if (accessToken) {
+    medplumClient.setAccessToken(accessToken);
+  }
+
+  const clientId = options.clientId || process.env['MEDPLUM_CLIENT_ID'];
+  const clientSecret = options.clientSecret || process.env['MEDPLUM_CLIENT_SECRET'];
+
+  if (clientId && clientSecret) {
+    medplumClient.setBasicAuth(clientId, clientSecret);
+    await medplumClient.startClientLogin(clientId, clientSecret);
+  }
+  return medplumClient;
+}

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -1,22 +1,12 @@
-import { FetchLike, MedplumClient } from '@medplum/core';
+import { MedplumClient, MedplumClientOptions } from '@medplum/core';
 import { FileSystemStorage } from '../storage';
 
-export interface MedplumClientCommandOptions {
-  fetch?: FetchLike;
-  baseUrl?: string;
-  fhirUrlPath?: string;
-  accessToken?: string;
-  tokenUrl?: string;
-  clientId?: string;
-  clientSecret?: string;
-}
-
-export async function createMedplumClient(options: MedplumClientCommandOptions): Promise<MedplumClient> {
-  const baseUrl = options.baseUrl || process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
-  const fhirUrlPath = options.fhirUrlPath || process.env['MEDPLUM_FHIR_URL_PATH'] || '';
-  const accessToken = options.accessToken || process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
-  const tokenUrl = options.tokenUrl || process.env['MEDPLUM_TOKEN_URL'] || '';
-  const fetchApi = options.fetch || fetch;
+export async function createMedplumClient(options: MedplumClientOptions): Promise<MedplumClient> {
+  const baseUrl = options.baseUrl ?? process.env['MEDPLUM_BASE_URL'] ?? 'https://api.medplum.com/';
+  const fhirUrlPath = options.fhirUrlPath ?? process.env['MEDPLUM_FHIR_URL_PATH'] ?? '';
+  const accessToken = options.accessToken ?? process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] ?? '';
+  const tokenUrl = options.tokenUrl ?? process.env['MEDPLUM_TOKEN_URL'] ?? '';
+  const fetchApi = options.fetch ?? fetch;
 
   const medplumClient = new MedplumClient({
     fetch: fetchApi,

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -1,14 +1,25 @@
 import { FetchLike, MedplumClient } from '@medplum/core';
 import { FileSystemStorage } from '../storage';
 
-export async function createMedplumClient(options: any, fetch?: FetchLike): Promise<MedplumClient> {
+export interface MedplumClientCommandOptions {
+  fetch?: FetchLike;
+  baseUrl?: string;
+  fhirUrlPath?: string;
+  accessToken?: string;
+  tokenUrl?: string;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export async function createMedplumClient(options: MedplumClientCommandOptions): Promise<MedplumClient> {
   const baseUrl = options.baseUrl || process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
   const fhirUrlPath = options.fhirUrlPath || process.env['MEDPLUM_FHIR_URL_PATH'] || '';
   const accessToken = options.accessToken || process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
   const tokenUrl = options.tokenUrl || process.env['MEDPLUM_TOKEN_URL'] || '';
+  const fetchOptions = options.fetch || fetch;
 
   const medplumClient = new MedplumClient({
-    fetch,
+    fetch: fetchOptions,
     baseUrl,
     tokenUrl,
     fhirUrlPath,

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -1,0 +1,18 @@
+import { Command } from 'commander';
+
+class MedplumCommand extends Command {
+  createCommand(name: string | undefined): Command {
+    const cmd = new Command(name);
+    cmd.option('--client-id <clientId>', 'FHIR server client id');
+    cmd.option('--client-secret <clientSecret>', 'FHIR server client secret');
+    cmd.option('--base-url <baseUrl>', 'FHIR server base url');
+    cmd.option('--token-url <tokenUrl>', 'FHIR server token url');
+    cmd.option('--fhir-url-path <fhirUrlPath>', 'FHIR server url path');
+
+    return cmd;
+  }
+}
+
+export function createMedplumCommand(name: string): MedplumCommand {
+  return new MedplumCommand(name);
+}

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -3,6 +3,8 @@ import { Command } from 'commander';
 class MedplumCommand extends Command {
   createCommand(name: string | undefined): Command {
     const cmd = new Command(name);
+
+    // global options
     cmd.option('--client-id <clientId>', 'FHIR server client id');
     cmd.option('--client-secret <clientSecret>', 'FHIR server client secret');
     cmd.option('--base-url <baseUrl>', 'FHIR server base url');

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -205,11 +205,11 @@ export async function createMedplumClient(options: any): Promise<MedplumClient> 
 export class MedplumCommand extends Command {
   createCommand(name: string | undefined): Command {
     const cmd = new Command(name);
-    cmd.option('--client-id <clientId>', 'client id');
-    cmd.option('--client-secret <clientSecret>', 'client secret');
-    cmd.option('--base-url <baseUrl>', 'client id');
-    cmd.option('--token-url <tokenUrl>', 'client secret');
-    cmd.option('--fhir-url-path <fhirUrlPath>', 'client secret');
+    cmd.option('--client-id <clientId>', 'FHIR server client id');
+    cmd.option('--client-secret <clientSecret>', 'FHIR server client secret');
+    cmd.option('--base-url <baseUrl>', 'FHIR server base url');
+    cmd.option('--token-url <tokenUrl>', 'FHIR server token url');
+    cmd.option('--fhir-url-path <fhirUrlPath>', 'FHIR server url path');
 
     return cmd;
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -4,9 +4,6 @@ import { existsSync, readFileSync, writeFile } from 'fs';
 import { resolve } from 'path';
 import internal from 'stream';
 import tar from 'tar';
-import { onUnauthenticated } from '.';
-import { FileSystemStorage } from './storage';
-import { Command } from 'commander';
 
 interface MedplumConfig {
   readonly baseUrl?: string;
@@ -171,46 +168,4 @@ export function safeTarExtractor(destinationDir: string): internal.Writable {
       return true;
     },
   });
-}
-
-export async function createMedplumClient(options: any): Promise<MedplumClient> {
-  const baseUrl = options.baseUrl || process.env['MEDPLUM_BASE_URL'] || 'https://api.medplum.com/';
-  const fhirUrlPath = options.fhirUrlPath || process.env['MEDPLUM_FHIR_URL_PATH'] || '';
-  const accessToken = options.accessToken || process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] || '';
-  const tokenUrl = options.tokenUrl || process.env['MEDPLUM_TOKEN_URL'] || '';
-
-  const medplumClient = new MedplumClient({
-    fetch,
-    baseUrl,
-    tokenUrl,
-    fhirUrlPath,
-    storage: new FileSystemStorage(),
-    onUnauthenticated: onUnauthenticated,
-  });
-
-  if (accessToken) {
-    medplumClient.setAccessToken(accessToken);
-  }
-
-  const clientId = options.clientId || process.env['MEDPLUM_CLIENT_ID'];
-  const clientSecret = options.clientSecret || process.env['MEDPLUM_CLIENT_SECRET'];
-
-  if (clientId && clientSecret) {
-    medplumClient.setBasicAuth(clientId, clientSecret);
-    await medplumClient.startClientLogin(clientId, clientSecret);
-  }
-  return medplumClient;
-}
-
-export class MedplumCommand extends Command {
-  createCommand(name: string | undefined): Command {
-    const cmd = new Command(name);
-    cmd.option('--client-id <clientId>', 'FHIR server client id');
-    cmd.option('--client-secret <clientSecret>', 'FHIR server client secret');
-    cmd.option('--base-url <baseUrl>', 'FHIR server base url');
-    cmd.option('--token-url <tokenUrl>', 'FHIR server token url');
-    cmd.option('--fhir-url-path <fhirUrlPath>', 'FHIR server url path');
-
-    return cmd;
-  }
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -112,6 +112,20 @@ export interface MedplumClientOptions {
   clientId?: string;
 
   /**
+   * The client secret.
+   *
+   * Client secret can be used for FHIR Oauth Client Credential flows
+   */
+  clientSecret?: string;
+
+  /**
+   * The OAuth Access Token.
+   *
+   * Access Token used to connect to make request to FHIR servers
+   */
+  accessToken?: string;
+
+  /**
    * Number of resources to store in the cache.
    *
    * Default value is 1000.


### PR DESCRIPTION
Adds optional global options for `bulk` commands. The next step is to follow up with PRs to refactor the remaining CLI commands to support global options.

```shell
npx medplum bulk export -e Group/all --base-url https://sandbox.bcda.cms.gov --fhir-url-path api/v2/ --token-url https://sandbox.bcda.cms.gov/auth/token --client-id {{clientId}} --client-secret {{clientSecret}}

Patient_data_55881_6ec2a601_7178_4785_ba36_db1e6f40684f_ndjson.ndjson is created
Coverage_data_55881_e798f821_0e15_466a_8cd6_39715a0e93ff_ndjson.ndjson is created
ExplanationOfBenefit_data_55881_8e7ff717_b0bb_4d99_abac_4ca57a861542_ndjson.ndjson is created
``` 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e967cab</samp>

### Summary
🧪🛠️🌐

<!--
1.  🧪 - This emoji represents the addition of unit tests for the new utility function and the refactoring of the `bulk` command. It conveys the idea of testing and quality assurance.
2.  🛠️ - This emoji represents the creation of new utility modules and functions that provide common functionality and simplify the code. It conveys the idea of building and improving the codebase.
3.  🌐 - This emoji represents the addition of the `accessToken` option to the `MedplumClient` constructor and the use of environment variables to configure the client. It conveys the idea of connectivity and integration with FHIR servers.
-->
This pull request refactors the `bulk` command of the `cli` package to use a custom `MedplumCommand` class and a `MedplumClient` instance that can be configured with global options and environment variables. It also adds a new utility function `createMedplumClient` to create and mock the `MedplumClient` instance, and a new property `accessToken` to the `MedplumClientOptions` interface. It updates the test cases and the import statements accordingly.

> _We create the Medplum client with global options_
> _We mock the fetch and the console for our tests_
> _We use the Medplum command to simplify our code_
> _We handle the unauthenticated case with a message of doom_

### Walkthrough
*  Added a new utility function `createMedplumClient` to create a `MedplumClient` instance with global options and environment variables ([link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-80e8d5a02c540100cc38f9c1240d73742010ee4b2f195e615943ac89d67d5bc7R1-R36), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-d5acb19f7f25aef929d46e05e464d658e4d47f9d1aa5e71b88f76d4f21fa8574R1-R88))
*  Added a new utility function `onUnauthenticated` to handle the case when the `MedplumClient` instance is unauthenticated and print a message to the console ([link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-80e8d5a02c540100cc38f9c1240d73742010ee4b2f195e615943ac89d67d5bc7R1-R36), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR11), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL86-L89))
*  Added a new utility module `command.ts` that provides a custom `MedplumCommand` class that inherits from `Command` and adds global options for the `MedplumClient` configuration, and a function `createMedplumCommand` to create a `MedplumCommand` instance with a given name ([link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-f7784b5d582e6d550a96c1d187f2040c05e8b1928e0f0c0d2fbfcea528af05ceR1-R20))
*  Modified the `bulk` command to use the new utility functions and classes, and to accept options from the command line or from the environment variables ([link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL1-R10), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL22-R25), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL46-R54), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL67-R80))
*  Modified the `bulk.test.ts` file to mock the `./util/client` module and the `createMedplumClient` function, and to use the same mocked `MedplumClient` instance for testing the `bulk export` and `bulk import` commands ([link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeL1-R3), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeR10), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeR133-R134), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeL183-R191), [link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeL211))
*  Added a new property `accessToken` to the interface `MedplumClientOptions` in `packages/core/src/client.ts` to allow passing an OAuth Access Token as an option to the `MedplumClient` constructor ([link](https://github.com/medplum/medplum/pull/2197/files?diff=unified&w=0#diff-858339789c798051d9c13620bffce8ce860e7ad8ba18dba1c8711eb1f7d51a55R115-R128))

