### PR TITLE
Fixes #2209 - migrate off CDK RDS instanceProps

### DIFF
--- a/packages/cdk/rollup.config.mjs
+++ b/packages/cdk/rollup.config.mjs
@@ -8,6 +8,7 @@ const external = [
   '@aws-sdk/client-sts',
   'aws-cdk-lib',
   'aws-cdk-lib/aws-ecr',
+  'aws-cdk-lib/aws-rds',
   'cdk',
   'cdk-nag',
   'cdk-serverless-clamscan',

--- a/packages/cdk/src/index.test.ts
+++ b/packages/cdk/src/index.test.ts
@@ -432,4 +432,37 @@ describe('Infra', () => {
     expect(() => main({ config: filename })).not.toThrow();
     unlinkSync(filename);
   });
+
+  test('RDS reader instance', () => {
+    const filename = resolve('./medplum.reader.config.json');
+    writeFileSync(
+      filename,
+      JSON.stringify({
+        name: 'unittest',
+        stackName: 'MedplumReaderStack',
+        accountNumber: '647991932601',
+        region: 'us-east-1',
+        domainName: 'medplum.com',
+        apiPort: 8103,
+        apiDomainName: 'api.medplum.com',
+        apiSslCertArn: 'arn:aws:acm:us-east-1:647991932601:certificate/08bf1daf-3a2b-4cbe-91a0-739b4364a1ec',
+        appDomainName: 'app.medplum.com',
+        appSslCertArn: 'arn:aws:acm:us-east-1:647991932601:certificate/fd21b628-b2c0-4a5d-b4f5-b5c9a6d63b1a',
+        storageBucketName: 'medplum-storage',
+        storageDomainName: 'storage.medplum.com',
+        storageSslCertArn: 'arn:aws:acm:us-east-1:647991932601:certificate/19d85245-0a1d-4bf5-9789-23082b1a15fc',
+        storagePublicKey: '-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----',
+        maxAzs: 2,
+        rdsInstances: 2,
+        desiredServerCount: 1,
+        serverImage: 'medplum/medplum-server:staging',
+        serverMemory: 512,
+        serverCpu: 256,
+      }),
+      { encoding: 'utf-8' }
+    );
+
+    expect(() => main({ config: filename })).not.toThrow();
+    unlinkSync(filename);
+  });
 });


### PR DESCRIPTION
Medplum staging (`rdsInstances = 1`, no readers):

![image](https://github.com/medplum/medplum/assets/749094/a80efb9a-2e27-4116-b1e6-5b7e619a59fb)

Medplum prod (`rdsInstances = 2`):

![image](https://github.com/medplum/medplum/assets/749094/6dfa58c5-ec36-46c4-a409-0683f9635c7c)

So, there is a change, but a minor one.

I did not see an obvious way to add a dependency from the reader instance to the writer instance.  (no `Node` object, so no `addDependency()` method).

And I think that's ok?  I don't think it's necessary from instance1 to have a dependency on instance2 in this case.
