### PR TITLE
Fixes #2213 : CLI Global options for authorizeUrl

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -24,7 +24,7 @@ whoami.action(async (options) => {
 async function startLogin(medplum: MedplumClient): Promise<void> {
   await startWebServer(medplum);
 
-  const loginUrl = new URL('/oauth2/authorize', medplum.getBaseUrl());
+  const loginUrl = new URL(medplum.getAuthorizeUrl());
   loginUrl.searchParams.set('client_id', clientId);
   loginUrl.searchParams.set('redirect_uri', redirectUri);
   loginUrl.searchParams.set('scope', 'openid');

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -6,6 +6,7 @@ export async function createMedplumClient(options: MedplumClientOptions): Promis
   const fhirUrlPath = options.fhirUrlPath ?? process.env['MEDPLUM_FHIR_URL_PATH'] ?? '';
   const accessToken = options.accessToken ?? process.env['MEDPLUM_CLIENT_ACCESS_TOKEN'] ?? '';
   const tokenUrl = options.tokenUrl ?? process.env['MEDPLUM_TOKEN_URL'] ?? '';
+  const authorizeUrl = options.authorizeUrl ?? process.env['MEDPLUM_AUTHORIZE_URL'] ?? '';
   const fetchApi = options.fetch ?? fetch;
 
   const medplumClient = new MedplumClient({
@@ -13,6 +14,7 @@ export async function createMedplumClient(options: MedplumClientOptions): Promis
     baseUrl,
     tokenUrl,
     fhirUrlPath,
+    authorizeUrl,
     storage: new FileSystemStorage(),
     onUnauthenticated: onUnauthenticated,
   });

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -6,5 +6,6 @@ export function createMedplumCommand(name: string): Command {
     .option('--client-secret <clientSecret>', 'FHIR server client secret')
     .option('--base-url <baseUrl>', 'FHIR server base url')
     .option('--token-url <tokenUrl>', 'FHIR server token url')
+    .option('--authorize-url <authorizeUrl>', 'FHIR server authorize url')
     .option('--fhir-url-path <fhirUrlPath>', 'FHIR server url path');
 }

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -126,6 +126,14 @@ describe('Client', () => {
     expect(client.getBaseUrl()).toBe('https://x/');
   });
 
+  test('getAuthorizeUrl', () => {
+    const baseUrl = 'https://x';
+    const authorizeUrl = 'https://example.com/custom/authorize';
+    const client = new MedplumClient({ baseUrl, authorizeUrl });
+
+    expect(client.getAuthorizeUrl()).toBe(authorizeUrl);
+  });
+
   test('Restore from localStorage', async () => {
     window.localStorage.setItem(
       'activeLogin',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -603,6 +603,17 @@ export class MedplumClient extends EventTarget {
   }
 
   /**
+   * Returns the current authorize URL.
+   * By default, this is set to `https://api.medplum.com/oauth2/authorize`.
+   * This can be overridden by setting the `authorizeUrl` option when creating the client.
+   * @category HTTP
+   * @returns The current authorize URL.
+   */
+  getAuthorizeUrl(): string {
+    return this.authorizeUrl;
+  }
+
+  /**
    * Clears all auth state including local storage and session storage.
    * @category Authentication
    */


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 74e0da7</samp>

### Summary
🛠️🆕📝

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate the changes to the CLI module that allow using the custom authorize URL option.
2.  🆕 - This emoji represents something new or added, and can be used to indicate the new method `getAuthorizeUrl` in the core module that returns the current authorize URL for the client.
3.  📝 - This emoji represents documentation or writing, and can be used to indicate the new unit test and the JSDoc comments that were added to the core module.
-->
Added support for custom authorize URL in MedplumClient and CLI. The `MedplumClient` class now has a `getAuthorizeUrl` method and an `authorizeUrl` option, and the CLI module can use the `--authorize-url` flag or the `MEDPLUM_AUTHORIZE_URL` environment variable.

> _To use a custom authorize URL_
> _The CLI module got a new tool_
> _A `--authorize-url` option_
> _And a `getAuthorizeUrl` function_
> _That both rely on the `MedplumClient` rule_

### Walkthrough
*  Added `getAuthorizeUrl` method to `MedplumClient` class to return the current authorize URL for OAuth2 authorization ([link](https://github.com/medplum/medplum/pull/2217/files?diff=unified&w=0#diff-858339789c798051d9c13620bffce8ce860e7ad8ba18dba1c8711eb1f7d51a55R606-R616))
*  Updated `startLogin` function in CLI module to use `getAuthorizeUrl` method instead of constructing URL manually ([link](https://github.com/medplum/medplum/pull/2217/files?diff=unified&w=0#diff-d32f5a7975a2c61708cc9e296befdb4732c0c1e1b183b2a8ad326ce4a42c7cafL27-R27))
*  Added `--authorize-url` option to CLI module to allow specifying custom authorize URL as a command line argument ([link](https://github.com/medplum/medplum/pull/2217/files?diff=unified&w=0#diff-f7784b5d582e6d550a96c1d187f2040c05e8b1928e0f0c0d2fbfcea528af05ceR9))
*  Updated `createMedplumClient` function in CLI module to read `authorizeUrl` option from command line arguments or environment variable and pass it to `MedplumClient` constructor ([link](https://github.com/medplum/medplum/pull/2217/files?diff=unified&w=0#diff-80e8d5a02c540100cc38f9c1240d73742010ee4b2f195e615943ac89d67d5bc7R9), [link](https://github.com/medplum/medplum/pull/2217/files?diff=unified&w=0#diff-80e8d5a02c540100cc38f9c1240d73742010ee4b2f195e615943ac89d67d5bc7R17))
*  Added unit test to verify that `getAuthorizeUrl` method returns custom authorize URL if provided in constructor options ([link](https://github.com/medplum/medplum/pull/2217/files?diff=unified&w=0#diff-6ac268cb3fc11e9bb493a4901ab200fce1081e87fdc18580c4d735840b666378R129-R136))

