### PR TITLE
Use OperationOutcome.issue.diagnostics in error string

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -98,5 +98,17 @@ describe('Outcomes', () => {
         ],
       })
     ).toEqual('error1 (expr1); error2 (expr2)');
+    expect(
+      operationOutcomeToString({
+        resourceType: 'OperationOutcome',
+        issue: [
+          {
+            severity: 'error',
+            code: 'processing',
+            diagnostics: 'Supplied Patient is unknown.',
+          },
+        ],
+      })
+    ).toEqual('Supplied Patient is unknown.');
   });
 });

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -1,4 +1,4 @@
-import { OperationOutcome } from '@medplum/fhirtypes';
+import { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 
 const OK_ID = 'ok';
 const CREATED_ID = 'created';
@@ -268,15 +268,19 @@ export function normalizeErrorString(error: unknown): string {
  * @returns The string representation of the operation outcome.
  */
 export function operationOutcomeToString(outcome: OperationOutcome): string {
-  const strs = [];
-  if (outcome.issue) {
-    for (const issue of outcome.issue) {
-      let issueStr = issue.details?.text || 'Unknown error';
-      if (issue.expression?.length) {
-        issueStr += ` (${issue.expression.join(', ')})`;
-      }
-      strs.push(issueStr);
-    }
-  }
+  const strs = outcome.issue?.map(operationOutcomeIssueToString) ?? [];
   return strs.length > 0 ? strs.join('; ') : 'Unknown error';
+}
+
+/**
+ * Returns a string represenation of the operation outcome issue.
+ * @param issue The operation outcome issue.
+ * @returns The string representation of the operation outcome issue.
+ */
+export function operationOutcomeIssueToString(issue: OperationOutcomeIssue): string {
+  let issueStr = issue.details?.text ?? issue.diagnostics ?? 'Unknown error';
+  if (issue.expression?.length) {
+    issueStr += ` (${issue.expression.join(', ')})`;
+  }
+  return issueStr;
 }


### PR DESCRIPTION
I'm using `MedplumClient` with an external FHIR server, and they put all of the error messages in `OperationOutcome.issue.diagnostics`.

Before:  That resulted in an `OperationOutcomeError` with message "Unknown error".

After: Results in an `OperationOutcomeError` with message "Supplied Patient is unknown."