### PR TITLE
Fixes #2253 - increase server keep alive timeout

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -38,6 +38,7 @@ export interface MedplumServerConfig {
   registerEnabled?: boolean;
   bcryptHashSalt: number;
   introspectionEnabled?: boolean;
+  keepAliveTimeout?: number;
 }
 
 /**

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -6,7 +6,7 @@ jest.mock('ioredis');
 
 jest.mock('express', () => {
   const original = jest.requireActual('express');
-  const listen = jest.fn();
+  const listen = jest.fn(() => ({}));
   const fn = (): any => {
     const app = original();
     app.listen = listen;
@@ -28,7 +28,7 @@ jest.mock('pg', () => {
       if (sql === 'SELECT "version" FROM "DatabaseMigration"') {
         return { rows: [{ version: 1000000 }] };
       }
-      if (sql === 'SELECT "User"."id", "User"."content" FROM "User" WHERE "deleted"=$1 LIMIT 1') {
+      if (sql === 'SELECT "User"."id", "User"."content" FROM "User" WHERE "User"."deleted"=$1 LIMIT 2') {
         return { rows: [{ id: '1', content: '{}' }] };
       }
       return { rows: [] };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -30,7 +30,8 @@ export async function main(configName: string): Promise<void> {
   loadDataTypes(resourceTypes);
 
   const app = await initApp(express(), config);
-  app.listen(config.port);
+  const server = app.listen(config.port);
+  server.keepAliveTimeout = config.keepAliveTimeout ?? 90000;
   logger.info('Server started on port', config.port);
 }
 


### PR DESCRIPTION
See #2253 

AWS ALB idle timeout is 60 seconds.  Node.js server timeout must be greater than that to avoid 502 Bad Gateway errors.  This PR increases the default keep alive timeout to 90 seconds.