### PR TITLE
Unify the schema loading flows

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,7 @@
-import { indexSearchParameterBundle, indexStructureDefinitionBundle, loadDataTypes } from '@medplum/core';
-import { readJson } from '@medplum/definitions';
-import { Bundle, SearchParameter, StructureDefinition } from '@medplum/fhirtypes';
 import express from 'express';
 import { initApp } from './app';
 import { loadConfig } from './config';
+import { getStructureDefinitions } from './fhir/structure';
 import { logger } from './logger';
 
 export async function main(configName: string): Promise<void> {
@@ -21,13 +19,7 @@ export async function main(configName: string): Promise<void> {
   const config = await loadConfig(configName);
 
   // Preload the schema
-  const dataTypes = readJson('fhir/r4/profiles-types.json') as Bundle<StructureDefinition>;
-  const resourceTypes = readJson('fhir/r4/profiles-resources.json') as Bundle<StructureDefinition>;
-  indexStructureDefinitionBundle(dataTypes);
-  indexStructureDefinitionBundle(resourceTypes);
-  indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
-  loadDataTypes(dataTypes);
-  loadDataTypes(resourceTypes);
+  getStructureDefinitions();
 
   const app = await initApp(express(), config);
   app.listen(config.port);


### PR DESCRIPTION
FYI @mattwiller 

The new schema validator setup code did not include the custom Medplum types, which caused quite a few warnings.