### PR TITLE
Validate super admin client assigned IDs

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -3445,4 +3445,14 @@ describe('FHIR Repo', () => {
     expect(bundle.entry?.[1]?.resource?.id).toEqual(task3.id);
     expect(bundleContains(bundle, task1)).not.toBeTruthy();
   });
+
+  test('Malformed client assigned ID', async () => {
+    try {
+      await systemRepo.updateResource({ resourceType: 'Patient', id: '123' });
+      throw new Error('expected error');
+    } catch (err) {
+      const outcome = (err as OperationOutcomeError).outcome;
+      expect(outcome.issue?.[0]?.details?.text).toEqual('Invalid id');
+    }
+  });
 });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -497,6 +497,15 @@ export class Repository extends BaseRepository implements FhirRepository {
   }
 
   private async updateResourceImpl<T extends Resource>(resource: T, create: boolean): Promise<T> {
+    const { resourceType, id } = resource;
+    if (!id) {
+      throw new OperationOutcomeError(badRequest('Missing id'));
+    }
+
+    if (!validator.isUUID(id)) {
+      throw new OperationOutcomeError(badRequest('Invalid id'));
+    }
+
     if (this.context.strictMode) {
       validateResource(resource);
       try {
@@ -510,11 +519,6 @@ export class Repository extends BaseRepository implements FhirRepository {
 
     if (this.context.checkReferencesOnWrite) {
       await validateReferences(this, resource);
-    }
-
-    const { resourceType, id } = resource;
-    if (!id) {
-      throw new OperationOutcomeError(badRequest('Missing id'));
     }
 
     if (!this.canWriteResourceType(resourceType)) {


### PR DESCRIPTION
Medplum generally does not support client assigned IDs.  For longer discussion, see: https://github.com/medplum/medplum/discussions/1175

The exception is super admin users (both human and clients), who are allowed to set client assigned IDs - but only UUIDs!

The server was not properly validating that super admin client assigned IDs were actually UUIDs, which led to a Postgres error and a 500.

This PR performs UUID validation, and a more friendly 400.

See https://github.com/medplum/medplum/discussions/1175#discussioncomment-5821443

Thanks @leite08 !