### PR TITLE
Fixes #2176: Target Directory Options for Bulk CLI commands 

### DIFF
--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -157,6 +157,27 @@ describe('CLI Bulk Commands', () => {
         expect.stringMatching('Project_data_55555_aaaaaa_bbbbb_ccc_ddddd_eeeeee_ndjson.ndjson is created')
       );
     });
+
+    test('with --target-directory', async () => {
+      const medplumDownloadSpy = jest.spyOn(medplum, 'download').mockImplementation((): any => {
+        return {
+          text: jest.fn(),
+        };
+      });
+      const testDirectory = 'testtargetdirectory';
+      await main(['node', 'index.js', 'bulk', 'export', '-t', 'Patient', '--target-directory', testDirectory]);
+      expect(medplumDownloadSpy).toBeCalled();
+      expect(console.log).toBeCalledWith(
+        expect.stringMatching(
+          `${testDirectory}/ProjectMembership_storage_20fabdd3_e036_49fc_9260_8a30eaffefb1_498475fe_5eb0_46e5_b9f4_b46943c9719b.ndjson is created`
+        )
+      );
+      expect(console.log).toBeCalledWith(
+        expect.stringMatching(
+          `${testDirectory}/Project_data_55555_aaaaaa_bbbbb_ccc_ddddd_eeeeee_ndjson.ndjson is created`
+        )
+      );
+    });
   });
 
   describe('import', () => {
@@ -215,8 +236,32 @@ describe('CLI Bulk Commands', () => {
       expect(console.log).toBeCalledWith(expect.stringMatching(`"text": "Created"`));
     });
 
-    test('success with option numResourcesPerRequest', async () => {
+    test('success with option --num-resources-per-request', async () => {
       await main(['node', 'index.js', 'bulk', 'import', 'Patient.json', '--num-resources-per-request', '1']);
+
+      testLineOutput.forEach((line) => {
+        const resource = JSON.parse(line);
+        expect(fetch).toBeCalledWith(
+          expect.stringMatching(`/fhir/R4`),
+          expect.objectContaining({
+            body: expect.stringContaining(
+              JSON.stringify({
+                resource: resource,
+                request: {
+                  method: 'POST',
+                  url: resource.resourceType,
+                },
+              })
+            ),
+          })
+        );
+      });
+
+      expect(fetch).toBeCalled();
+    });
+
+    test('success with option --target-directory', async () => {
+      await main(['node', 'index.js', 'bulk', 'import', 'Patient.json', '--target-directory', 'testdirectory']);
 
       testLineOutput.forEach((line) => {
         const resource = JSON.parse(line);

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -55,7 +55,7 @@ bulkImportCommand
     'optional flag to add extensions for missing values in a resource',
     false
   )
-  .option('-d, --target-directory <targetDirectory>', 'optional target directory to import files in the directory')
+  .option('-d, --target-directory <targetDirectory>', 'optional target directory of file to be imported')
   .action(async (fileName, options) => {
     const { numResourcesPerRequest, addExtensionsForMissingValues, targetDirectory } = options;
     const path = resolve(targetDirectory ?? process.cwd(), fileName);

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -23,17 +23,22 @@ bulkExportCommand
     '-s, --since <since>',
     'optional Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).'
   )
+  .option(
+    '-d, --target-directory <targetDirectory>',
+    'optional target directory to save files from the bulk export operations.'
+  )
   .action(async (options) => {
-    const { exportLevel, types, since } = options;
+    const { exportLevel, types, since, targetDirectory } = options;
     const medplum = await createMedplumClient(options);
     const response = await medplum.bulkExport(exportLevel, types, since);
     response.output?.forEach(async ({ type, url }) => {
       const fileUrl = new URL(url as string);
       const data = await medplum.download(url as string);
       const fileName = `${type}_${fileUrl.pathname}`.replace(/[^a-zA-Z0-9]+/g, '_') + '.ndjson';
+      const path = resolve(targetDirectory ?? '', fileName);
 
-      writeFile(`${fileName}`, await data.text(), () => {
-        console.log(`${fileName} is created`);
+      writeFile(`${path}`, await data.text(), () => {
+        console.log(`${path} is created`);
       });
     });
   });
@@ -50,9 +55,10 @@ bulkImportCommand
     'optional flag to add extensions for missing values in a resource',
     false
   )
+  .option('-d, --target-directory <targetDirectory>', 'optional target directory to import files in the directory')
   .action(async (fileName, options) => {
-    const path = resolve(process.cwd(), fileName);
-    const { numResourcesPerRequest, addExtensionsForMissingValues } = options;
+    const { numResourcesPerRequest, addExtensionsForMissingValues, targetDirectory } = options;
+    const path = resolve(targetDirectory ?? process.cwd(), fileName);
     const medplum = await createMedplumClient(options);
 
     await importFile(path, parseInt(numResourcesPerRequest), medplum, addExtensionsForMissingValues);


### PR DESCRIPTION
```shell
 npx medplum bulk export -e Group/all  --base-url https://sandbox.bcda.cms.gov --fhir-url-path api/v2/ --token-url https://sandbox.bcda.cms.gov/auth/token --client-id {{clientId}} --client-secret{{clientSecret}} --target-directory test2
/Users/tonylee/medplum/medplum/test/test2/Patient_data_56391_1fee18b3_ff23_44d3_8668_f9bfd7c04b1b_ndjson.ndjson is created
/Users/tonylee/medplum/medplum/test/test2/Coverage_data_56391_6407f086_aa34_4d40_94fe_0fe31f6a2cff_ndjson.ndjson is created
/Users/tonylee/medplum/medplum/test/test2/ExplanationOfBenefit_data_56391_91221ddc_c7e8_455e_88d8_ab02be32da1a_ndjson.ndjson is created


tonylee@tony-mbp test % npx medplum bulk import --client-id {{clientId}} --client-secret {{clientSecret}} --base-url http://localhost:8103  --add-extensions-for-missing-values --target-directory test2 ExplanationOfBenefit_data_56387_db436439_9577_4aea_b816_76ad70d306f9_ndjson.ndjson
{
  "outcome": {
    "resourceType": "OperationOutcome",
    "id": "created",
    "issue": [
      {
        "severity": "information",
        "code": "informational",
        "details": {
          "text": "Created"
        }
      }
    ]
  },
  "status": "201",
  "location": "ExplanationOfBenefit/bde8196a-10fd-45b4-a18e-adcfc304e751"
}
{
  "outcome": {
    "resourceType": "OperationOutcome",
    "id": "created",
    "issue": [
      {
        "severity": "information",
        "code": "informational",
        "details": {
          "text": "Created"
        }
      }
    ]
  },
  "status": "201",
  "location": "ExplanationOfBenefit/7ea08dd9-a227-496d-aa58-dc3de6986272"
}

``` 


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f15653</samp>

### Summary
🧪📁🐛

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate that the pull request adds or improves some tests for the code.
2.  📁 - This emoji represents a folder, directory, or file system, and can be used to indicate that the pull request adds or modifies a feature related to file management or organization.
3.  🐛 - This emoji represents a bug, error, or mistake, and can be used to indicate that the pull request fixes a typo or a minor issue in the code.
-->
This pull request enhances the bulk export and import commands of the `cli` package by adding a `--target-directory` option. This option lets the user choose a different directory for the files generated or consumed by the commands. The pull request also updates and fixes some tests for these commands in `bulk.test.ts`.

> _Oh we are the CLI crew and we have a job to do_
> _We bulk export and import with a `--target-directory` too_
> _Heave away, haul away, on the count of three we say_
> _We fix the typos and the tests, we make the code shipshape today_

### Walkthrough
* Add new options for bulk export and import commands to specify target directory (`-d` or `--target-directory`) ([link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL26-R31), [link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL53-R61))
* Use target directory option to resolve file paths for writing and reading files in `bulk.ts` ([link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL34-R41), [link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL53-R61))
* Update console.log output to include file paths in `bulk.ts` ([link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-aff1e5d2e9becbf0e02038967adcd4314c1c6588ecca9d825de98d5110a42cafL34-R41))
* Add test cases for bulk export and import commands with target directory option in `bulk.test.ts` ([link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeR160-R180), [link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeR263-R286))
* Fix typo in test description for bulk import command with `--num-resources-per-request` option in `bulk.test.ts` ([link](https://github.com/medplum/medplum/pull/2265/files?diff=unified&w=0#diff-ba0eec9b49430d3db287c8fc6a316004d00df70f9396382fef7d8a1c513824eeL218-R239))

