### PR TITLE
Add Non-nullable fields for graphql

### DIFF
--- a/packages/fhir-router/src/graphql/graphql.test.ts
+++ b/packages/fhir-router/src/graphql/graphql.test.ts
@@ -6,8 +6,6 @@ import {
   getReferenceString,
   indexSearchParameterBundle,
   indexStructureDefinitionBundle,
-  serverError,
-  validationError,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import {
@@ -1153,7 +1151,7 @@ describe('GraphQL', () => {
     expect(retrievePatient?.name?.[1].family).toEqual('Smith');
   });
 
-  test('Invalid Mutation', async () => {
+  test('Invalid Update Mutation', async () => {
     const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
       gender: 'female',

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -227,11 +227,10 @@ function buildRootSchema(): GraphQLSchema {
 function buildCreateArgs(resourceType: string): GraphQLFieldConfigArgumentMap {
   const args: GraphQLFieldConfigArgumentMap = {
     res: {
-      type: getGraphQLInputType(resourceType, 'Create'),
+      type: new GraphQLNonNull(getGraphQLInputType(resourceType, 'Create')),
       description: resourceType + ' Create',
     },
   };
-
   return args;
 }
 
@@ -242,7 +241,7 @@ function buildUpdateArgs(resourceType: string): GraphQLFieldConfigArgumentMap {
       description: resourceType + ' ID',
     },
     res: {
-      type: getGraphQLInputType(resourceType, 'Update'),
+      type: new GraphQLNonNull(getGraphQLInputType(resourceType, 'Update')),
       description: resourceType + ' Update',
     },
   };

--- a/packages/fhir-router/src/graphql/output-types.ts
+++ b/packages/fhir-router/src/graphql/output-types.ts
@@ -266,9 +266,12 @@ function buildReverseLookupFields(resourceType: ResourceType, fields: GraphQLFie
 }
 
 function getOutputPropertyType(elementDefinition: ElementDefinition, typeName: string): GraphQLOutputType {
-  const graphqlType = getGraphQLOutputType(typeName);
+  let graphqlType = getGraphQLOutputType(typeName);
   if (elementDefinition.max === '*') {
-    return new GraphQLList(graphqlType);
+    graphqlType = new GraphQLList(graphqlType);
+  }
+  if (elementDefinition.min !== 0 && !elementDefinition.path?.endsWith('[x]')) {
+    graphqlType = new GraphQLNonNull(graphqlType);
   }
   return graphqlType;
 }


### PR DESCRIPTION
From question in discord 

https://discord.com/channels/905144809105260605/1121141361178071152/1121141361178071152

There are some required non-nullable fields in GraphQL FHIR objects however previously we had it optional null for all prior (aside from resourceType). 

This is to add the required fields to the output-type and the `res` argument in the Input types.

Example output type that I console.logged when building the schema 

```
    {
      id: 'Account.coverage.coverage',
      path: 'Account.coverage.coverage',
      short: 'The party(s), such as insurances, that may contribute to the payment of this account',
      definition: 'The party(s) that contribute to payment (or part of) of the charges applied to this account (including self-pay).\n' +
        '\n' +
        'A coverage may only be responsible for specific types of charges, and the sequence of the coverages in the account could be important when processing billing.',
      min: 1,
      max: '1',
      base: { path: 'Account.coverage.coverage', min: 1, max: '1' },
      type: [ { code: 'Reference', targetProfile: [Array] } ],
      constraint: [
        {
          key: 'ele-1',
          severity: 'error',
          human: 'All FHIR elements must have a @value or children',
          expression: 'hasValue() or (children().count() > id.count())',
          xpath: '@value|f:*|h:div',
          source: 'http://hl7.org/fhir/StructureDefinition/Element'
        }
      ],
      isModifier: false,
      isSummary: true,
      mapping: [ { identity: 'rim', map: '.coverage.insurancePolicy.author' } ]
    }

      at log (src/graphql/output-types.ts:276:13)

  console.log
    GraphQLNonNull {
      ofType: GraphQLObjectType {
        name: 'Reference',
        description: 'A reference from one resource to another.',
        isTypeOf: undefined,
        extensions: [Object: null prototype] {},
        astNode: undefined,
        extensionASTNodes: [],
        _fields: [Object: null prototype] {
          resource: [Object],
          id: [Object],
          extension: [Object],
          reference: [Object],
          type: [Object],
          identifier: [Object],
          display: [Object]
        },
        _interfaces: []
      }
    }
```