### PR TITLE
Fixes #2126 - Moved access helpers to core

### DIFF
--- a/packages/core/src/access.test.ts
+++ b/packages/core/src/access.test.ts
@@ -1,0 +1,83 @@
+import { readJson } from '@medplum/definitions';
+import { AccessPolicy, Bundle, SearchParameter } from '@medplum/fhirtypes';
+import { indexSearchParameterBundle, indexStructureDefinitionBundle } from './types';
+import { canReadResourceType, canWriteResource, canWriteResourceType, matchesAccessPolicy } from './access';
+
+const wildcardPolicy: AccessPolicy = {
+  resourceType: 'AccessPolicy',
+  resource: [
+    {
+      resourceType: '*',
+    },
+  ],
+};
+
+const restrictedPolicy: AccessPolicy = {
+  resourceType: 'AccessPolicy',
+  resource: [
+    {
+      resourceType: 'Patient',
+      readonly: true,
+    },
+    {
+      resourceType: 'Observation',
+      readonly: false,
+    },
+    {
+      resourceType: 'Communication',
+      criteria: 'Communication?status=in-progress',
+    },
+    {
+      resourceType: 'Communication',
+      readonly: true,
+      criteria: 'Communication?status=completed',
+    },
+  ],
+};
+
+describe('Access', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+    indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
+  });
+
+  test('canReadResourceType', () => {
+    expect(canReadResourceType(wildcardPolicy, 'Patient')).toBe(true);
+    expect(canReadResourceType(restrictedPolicy, 'Patient')).toBe(true);
+    expect(canReadResourceType(restrictedPolicy, 'Observation')).toBe(true);
+    expect(canReadResourceType(restrictedPolicy, 'Practitioner')).toBe(false);
+  });
+
+  test('canWriteResourceType', () => {
+    expect(canWriteResourceType(wildcardPolicy, 'CapabilityStatement')).toBe(false);
+    expect(canWriteResourceType(wildcardPolicy, 'Login')).toBe(false);
+    expect(canWriteResourceType(wildcardPolicy, 'Patient')).toBe(true);
+
+    expect(canWriteResourceType(restrictedPolicy, 'CapabilityStatement')).toBe(false);
+    expect(canWriteResourceType(restrictedPolicy, 'Login')).toBe(false);
+    expect(canWriteResourceType(restrictedPolicy, 'Patient')).toBe(false);
+    expect(canWriteResourceType(restrictedPolicy, 'Observation')).toBe(true);
+    expect(canWriteResourceType(restrictedPolicy, 'Practitioner')).toBe(false);
+    expect(canWriteResourceType(restrictedPolicy, 'Communication')).toBe(true);
+  });
+
+  test('canWriteResource', () => {
+    expect(canWriteResource(wildcardPolicy, { resourceType: 'Patient' })).toBe(true);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Patient' })).toBe(false);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Observation' })).toBe(true);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication' })).toBe(false);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication', status: 'in-progress' })).toBe(true);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication', status: 'completed' })).toBe(false);
+  });
+
+  test('Legacy compartment case', () => {
+    // Once upon a time, the recommended way to restrict access to a resource was AccessPolicy.compartment
+    // That is now obsolete, becaues you can always use criteria with "_compartment=x"
+    // We still hold onto this for backwards compatibility.
+    const ap: AccessPolicy = { resourceType: 'AccessPolicy', compartment: { reference: '1' } };
+    expect(matchesAccessPolicy(ap, { resourceType: 'Patient', meta: { compartment: [{ reference: '1' }] } }, true));
+    expect(matchesAccessPolicy(ap, { resourceType: 'Patient', meta: { compartment: [{ reference: '2' }] } }, false));
+  });
+});

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -1,0 +1,156 @@
+import { AccessPolicy, AccessPolicyResource, Resource } from '@medplum/fhirtypes';
+import { parseCriteriaAsSearchRequest } from './search/search';
+import { matchesSearchRequest } from './search/match';
+
+/**
+ * Public resource types are in the "public" project.
+ * They are available to all users.
+ */
+export const publicResourceTypes = [
+  'CapabilityStatement',
+  'CompartmentDefinition',
+  'ImplementationGuide',
+  'OperationDefinition',
+  'SearchParameter',
+  'StructureDefinition',
+];
+
+/**
+ * Protected resource types are in the "medplum" project.
+ * Reading and writing is limited to the system account.
+ */
+export const protectedResourceTypes = ['DomainConfiguration', 'JsonWebKey', 'Login', 'User'];
+
+/**
+ * Project admin resource types are special resources that are only
+ * accessible to project administrators.
+ */
+export const projectAdminResourceTypes = ['PasswordChangeRequest', 'Project', 'ProjectMembership'];
+
+/**
+ * Determines if the current user can read the specified resource type.
+ * @param accessPolicy The access policy.
+ * @param resourceType The resource type.
+ * @returns True if the current user can read the specified resource type.
+ */
+export function canReadResourceType(accessPolicy: AccessPolicy, resourceType: string): boolean {
+  if (accessPolicy.resource) {
+    for (const resourcePolicy of accessPolicy.resource) {
+      if (matchesAccessPolicyResourceType(resourcePolicy.resourceType, resourceType)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Determines if the current user can write the specified resource type.
+ * This is a preliminary check before evaluating a write operation in depth.
+ * If a user cannot write a resource type at all, then don't bother looking up previous versions.
+ * @param accessPolicy The access policy.
+ * @param resourceType The resource type.
+ * @returns True if the current user can write the specified resource type.
+ */
+export function canWriteResourceType(accessPolicy: AccessPolicy, resourceType: string): boolean {
+  if (protectedResourceTypes.includes(resourceType)) {
+    return false;
+  }
+  if (publicResourceTypes.includes(resourceType)) {
+    return false;
+  }
+  if (accessPolicy.resource) {
+    for (const resourcePolicy of accessPolicy.resource) {
+      if (matchesAccessPolicyResourceType(resourcePolicy.resourceType, resourceType) && !resourcePolicy.readonly) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Determines if the current user can write the specified resource.
+ * This is a more in-depth check after building the candidate result of a write operation.
+ * @param accessPolicy The access policy.
+ * @param resource The resource.
+ * @returns True if the current user can write the specified resource type.
+ */
+export function canWriteResource(accessPolicy: AccessPolicy, resource: Resource): boolean {
+  const resourceType = resource.resourceType;
+  if (!canWriteResourceType(accessPolicy, resourceType)) {
+    return false;
+  }
+  return matchesAccessPolicy(accessPolicy, resource, false);
+}
+
+/**
+ * Returns true if the resource satisfies the current access policy.
+ * @param accessPolicy The access policy.
+ * @param resource The resource.
+ * @param readonlyMode True if the resource is being read.
+ * @returns True if the resource matches the access policy.
+ */
+export function matchesAccessPolicy(accessPolicy: AccessPolicy, resource: Resource, readonlyMode: boolean): boolean {
+  if (accessPolicy.resource) {
+    for (const resourcePolicy of accessPolicy.resource) {
+      if (matchesAccessPolicyResourcePolicy(resource, resourcePolicy, readonlyMode)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if the resource satisfies the specified access policy resource policy.
+ * @param resource The resource.
+ * @param resourcePolicy One per-resource policy section from the access policy.
+ * @param readonlyMode True if the resource is being read.
+ * @returns True if the resource matches the access policy.
+ */
+function matchesAccessPolicyResourcePolicy(
+  resource: Resource,
+  resourcePolicy: AccessPolicyResource,
+  readonlyMode: boolean
+): boolean {
+  const resourceType = resource.resourceType;
+  if (!matchesAccessPolicyResourceType(resourcePolicy.resourceType, resourceType)) {
+    return false;
+  }
+  if (!readonlyMode && resourcePolicy.readonly) {
+    return false;
+  }
+  if (
+    resourcePolicy.compartment &&
+    !resource.meta?.compartment?.find((c) => c.reference === resourcePolicy.compartment?.reference)
+  ) {
+    // Deprecated - to be removed
+    return false;
+  }
+  if (
+    resourcePolicy.criteria &&
+    !matchesSearchRequest(resource, parseCriteriaAsSearchRequest(resourcePolicy.criteria))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns true if the resource type matches the access policy resource type.
+ * @param accessPolicyResourceType The resource type from the access policy.
+ * @param resourceType The candidate resource resource type.
+ * @returns True if the resource type matches the access policy resource type.
+ */
+function matchesAccessPolicyResourceType(accessPolicyResourceType: string | undefined, resourceType: string): boolean {
+  if (accessPolicyResourceType === resourceType) {
+    return true;
+  }
+  if (accessPolicyResourceType === '*' && !projectAdminResourceTypes.includes(resourceType)) {
+    // Project admin resource types are not allowed to be wildcarded
+    // Project admin resource types must be explicitly included
+    return true;
+  }
+  return false;
+}

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -1,4 +1,4 @@
-import { AccessPolicy, AccessPolicyResource, Resource } from '@medplum/fhirtypes';
+import { AccessPolicy, AccessPolicyResource, Resource, ResourceType } from '@medplum/fhirtypes';
 import { parseCriteriaAsSearchRequest } from './search/search';
 import { matchesSearchRequest } from './search/match';
 
@@ -33,7 +33,7 @@ export const projectAdminResourceTypes = ['PasswordChangeRequest', 'Project', 'P
  * @param resourceType The resource type.
  * @returns True if the current user can read the specified resource type.
  */
-export function canReadResourceType(accessPolicy: AccessPolicy, resourceType: string): boolean {
+export function canReadResourceType(accessPolicy: AccessPolicy, resourceType: ResourceType): boolean {
   if (accessPolicy.resource) {
     for (const resourcePolicy of accessPolicy.resource) {
       if (matchesAccessPolicyResourceType(resourcePolicy.resourceType, resourceType)) {
@@ -52,7 +52,7 @@ export function canReadResourceType(accessPolicy: AccessPolicy, resourceType: st
  * @param resourceType The resource type.
  * @returns True if the current user can write the specified resource type.
  */
-export function canWriteResourceType(accessPolicy: AccessPolicy, resourceType: string): boolean {
+export function canWriteResourceType(accessPolicy: AccessPolicy, resourceType: ResourceType): boolean {
   if (protectedResourceTypes.includes(resourceType)) {
     return false;
   }
@@ -143,7 +143,10 @@ function matchesAccessPolicyResourcePolicy(
  * @param resourceType The candidate resource resource type.
  * @returns True if the resource type matches the access policy resource type.
  */
-function matchesAccessPolicyResourceType(accessPolicyResourceType: string | undefined, resourceType: string): boolean {
+function matchesAccessPolicyResourceType(
+  accessPolicyResourceType: string | undefined,
+  resourceType: ResourceType
+): boolean {
   if (accessPolicyResourceType === resourceType) {
     return true;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './access';
 export * from './base64';
 export * from './bundle';
 export * from './cache';

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -1,7 +1,7 @@
 import { Reference, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { evalFhirPath } from '../fhirpath';
 import { globalSchema } from '../types';
-import { getSearchParameterDetails, SearchParameterType } from './details';
+import { SearchParameterType, getSearchParameterDetails } from './details';
 import { Filter, Operator, SearchRequest } from './search';
 
 /**

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -160,6 +160,16 @@ export function parseSearchDefinition<T extends Resource = Resource>(url: string
   return parseSearchUrl<T>(new URL(url, 'https://example.com/'));
 }
 
+/**
+ * Parses a FHIR criteria string into a SearchRequest.
+ * FHIR criteria strings are found on resources such as Subscription.
+ * @param criteria The FHIR criteria string.
+ * @returns Parsed search definition.
+ */
+export function parseCriteriaAsSearchRequest(criteria: string): SearchRequest {
+  return parseSearchUrl(new URL(criteria, 'https://api.medplum.com/'));
+}
+
 function parseSearchImpl<T extends Resource = Resource>(
   resourceType: T['resourceType'],
   query: [string, string][] | IterableIterator<[string, string]>

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -1,4 +1,4 @@
-import { ProfileResource, resolveId } from '@medplum/core';
+import { ProfileResource, projectAdminResourceTypes, resolveId } from '@medplum/core';
 import {
   AccessPolicy,
   AccessPolicyIpAccessRule,
@@ -8,7 +8,7 @@ import {
   ProjectMembershipAccess,
   Reference,
 } from '@medplum/fhirtypes';
-import { projectAdminResourceTypes, Repository, systemRepo } from './repo';
+import { Repository, systemRepo } from './repo';
 import { applySmartScopes } from './smart';
 
 /**

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -1,9 +1,9 @@
-import { accepted, getResourceTypes } from '@medplum/core';
+import { accepted, getResourceTypes, protectedResourceTypes, publicResourceTypes } from '@medplum/core';
 import { Project, ResourceType } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getConfig } from '../../config';
 import { logger } from '../../logger';
-import { Repository, protectedResourceTypes, publicResourceTypes } from '../repo';
+import { Repository } from '../repo';
 import { BulkExporter } from './utils/bulkexporter';
 
 /**

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2136,7 +2136,7 @@ export class Repository extends BaseRepository implements FhirRepository {
     if (!this.context.accessPolicy) {
       return true;
     }
-    return canReadResourceType(this.context.accessPolicy, resourceType);
+    return canReadResourceType(this.context.accessPolicy, resourceType as ResourceType);
   }
 
   /**
@@ -2159,7 +2159,7 @@ export class Repository extends BaseRepository implements FhirRepository {
     if (!this.context.accessPolicy) {
       return true;
     }
-    return canWriteResourceType(this.context.accessPolicy, resourceType);
+    return canWriteResourceType(this.context.accessPolicy, resourceType as ResourceType);
   }
 
   /**


### PR DESCRIPTION
Refactored access checks so they are available in `@medplum/core`

Examples:

```ts
  test('canReadResourceType', () => {
    expect(canReadResourceType(wildcardPolicy, 'Patient')).toBe(true);
    expect(canReadResourceType(restrictedPolicy, 'Patient')).toBe(true);
    expect(canReadResourceType(restrictedPolicy, 'Observation')).toBe(true);
    expect(canReadResourceType(restrictedPolicy, 'Practitioner')).toBe(false);
  });

  test('canWriteResourceType', () => {
    expect(canWriteResourceType(wildcardPolicy, 'CapabilityStatement')).toBe(false);
    expect(canWriteResourceType(wildcardPolicy, 'Login')).toBe(false);
    expect(canWriteResourceType(wildcardPolicy, 'Patient')).toBe(true);

    expect(canWriteResourceType(restrictedPolicy, 'CapabilityStatement')).toBe(false);
    expect(canWriteResourceType(restrictedPolicy, 'Login')).toBe(false);
    expect(canWriteResourceType(restrictedPolicy, 'Patient')).toBe(false);
    expect(canWriteResourceType(restrictedPolicy, 'Observation')).toBe(true);
    expect(canWriteResourceType(restrictedPolicy, 'Practitioner')).toBe(false);
    expect(canWriteResourceType(restrictedPolicy, 'Communication')).toBe(true);
  });

  test('canWriteResource', () => {
    expect(canWriteResource(wildcardPolicy, { resourceType: 'Patient' })).toBe(true);
    expect(canWriteResource(restrictedPolicy, { resourceType: 'Patient' })).toBe(false);
    expect(canWriteResource(restrictedPolicy, { resourceType: 'Observation' })).toBe(true);
    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication' })).toBe(false);
    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication', status: 'in-progress' })).toBe(true);
    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication', status: 'completed' })).toBe(false);
  });
```

If using `MedplumClient`, you can get the current user's access policy:

```ts
const medplum: MedplumClient = ...;
const accessPolicy = medplum.getAccessPolicy();
```

If using Medplum React components, you can get `MedplumClient` and the current user's access policy:

```ts
export function MyComponent() {
    const medplum = useMedplum();
    const accessPolicy = medplum.getAccessPolicy();

    if (canWriteResource(accessPolicy, myResource)) {
       // Show "Edit" button
    }
}
```
