### PR TITLE
Use projectId rather than compartments

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1277,7 +1277,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    */
   private addProjectFilter(builder: SelectQuery): void {
     if (this.context.project) {
-      builder.where('compartments', Operator.ARRAY_CONTAINS, [this.context.project], 'UUID[]');
+      builder.where('projectId', Operator.EQUALS, this.context.project);
     }
   }
 
@@ -1448,7 +1448,15 @@ export class Repository extends BaseRepository implements FhirRepository {
       return this.buildDateSearchFilter({ type: SearchParameterType.DATETIME, columnName: 'lastUpdated' }, filter);
     }
 
-    if (code === '_compartment' || code === '_project') {
+    if (code === '_project') {
+      return this.buildIdSearchFilter(
+        resourceType,
+        { columnName: 'projectId', type: SearchParameterType.UUID },
+        filter
+      );
+    }
+
+    if (code === '_compartment') {
       return this.buildIdSearchFilter(
         resourceType,
         { columnName: 'compartments', type: SearchParameterType.UUID, array: true },


### PR DESCRIPTION
> **Warning**
> This cannot be deployed as-is!
> This requires a super admin to run the "Rebuild projectId" task.
> Unfortunately that is too slow to run as a database migration (It blocks server startup, and AWS Fargate rejects the server).
> My recommendation is that we do the following:
> 1. Cut a minor release before this PR (i.e., `2.1.0`)
> 2. Write patch notes that after upgrading to `2.1.0`, super admin must run "Rebuild projectId"
> 3. Release this PR

----

This is "Part 1 Step 2" of client assigned IDs: https://github.com/medplum/medplum/discussions/1175#discussioncomment-6235441

In the previous "Part 1 Step 1" (https://github.com/medplum/medplum/pull/2270), we created the `projectId` column and started setting it on all write operations.  We need to do another bulk update operation though to handle all writes that happened concurrently while the previous version was deployed and there were still servers on older versions running and handling requests.

Once the migration runs, `projectId` will be fully populated, and ready for use.

> ### Part 1: Add projectId
> 
> 1. Add `projectId UUID`
>     a. `ALTER TABLE [x] ADD COLUMN "projectId" UUID;`
>     b. Start writing `projectId` on every write operation
>     c. At this point, `projectId` will be a mix of set and not set
> 2. Fully populate `projectId`
>     a. `UPDATE [x] SET "projectId"="compartments"[1];`
>     b. At this point, `projectId` will be fully set
>     c. Start using `projectId`
> 3. Stop setting project ID in `compartments`
> 
> ### Part 2: Adopt v5 UUIDs
> 
> 1. Add `v5uuid UUID`
>     a. In migration, `UPDATE [table] SET v5uuid=uuid_generate_v5(namespace uuid, name text)`
>     b. Add `NOT NULL` constraint to `v5uuid`
>     c. Start populating `v5uuid` on all write operations
>     d. At this point, `id` will be all v4 UUIDs
> 2. Start using `v5uuid` for all ID operations
>     a. Stop using `id` for all ID operations
>     b. At this point, `id` will be all v4 UUIDs
> 3. Start writing `v5uuid` into `id`
>     a. At this point, `id` will be a mix of v4 and v5, so it cannot be used
> 4. Copy all `v5uuid` values into `id`
>     a. `UPDATE [table] SET id=v5uuid`
>     b. Continue writing v5 UUID into both `id` and `v5uuid`
>     c. At this point, `id` should be all v5
> 6. Start using `id`, stop using `v5uuid`
> 7. Drop `v5uuid`
