### PR TITLE
Move lint to separate GitHub Action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Cache node modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install
+        run: npm ci
+      - name: Lint
+        run: npm run lint

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,6 +38,3 @@ cp packages/react/coverage/coverage-final.json coverage/packages/coverage-react.
 cp packages/server/coverage/coverage-final.json coverage/packages/coverage-server.json
 npx nyc merge coverage/packages coverage/combined/coverage.json
 npx nyc report -t coverage/combined --report-dir coverage --reporter=lcov
-
-# Lint
-npm run lint


### PR DESCRIPTION
This will run ESLint in parallel to the build for faster feedback, and faster overall build.