### PR TITLE
Add non-null requirements to values in GraphQL array types

### DIFF
--- a/packages/fhir-router/src/graphql/input-types.ts
+++ b/packages/fhir-router/src/graphql/input-types.ts
@@ -6,6 +6,7 @@ import {
   GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLList,
+  GraphQLNonNull,
   GraphQLString,
 } from 'graphql';
 import { typeCache } from './utils';
@@ -78,7 +79,10 @@ function buildInputPropertyField(
   };
 
   if (elementDefinition.max === '*') {
-    fieldConfig.type = new GraphQLList(getGraphQLInputType(typeName, nameSuffix));
+    fieldConfig.type = new GraphQLList(new GraphQLNonNull(getGraphQLInputType(typeName, nameSuffix)));
+  }
+  if (elementDefinition.min !== 0 && !elementDefinition.path?.endsWith('[x]')) {
+    fieldConfig.type = new GraphQLNonNull(fieldConfig.type);
   }
 
   const propertyName = key.replace('[x]', capitalize(elementDefinitionType.code as string));

--- a/packages/fhir-router/src/graphql/output-types.ts
+++ b/packages/fhir-router/src/graphql/output-types.ts
@@ -268,7 +268,7 @@ function buildReverseLookupFields(resourceType: ResourceType, fields: GraphQLFie
 function getOutputPropertyType(elementDefinition: ElementDefinition, typeName: string): GraphQLOutputType {
   let graphqlType = getGraphQLOutputType(typeName);
   if (elementDefinition.max === '*') {
-    graphqlType = new GraphQLList(graphqlType);
+    graphqlType = new GraphQLList(new GraphQLNonNull(graphqlType));
   }
   if (elementDefinition.min !== 0 && !elementDefinition.path?.endsWith('[x]')) {
     graphqlType = new GraphQLNonNull(graphqlType);


### PR DESCRIPTION
In response to requiring Arrays to be non-null values, we will also require the elements in an array to be non-null as well