### PR TITLE
Allow extra URL path content with Bot execute

### DIFF
--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -233,4 +233,14 @@ describe('Execute', () => {
     expect(res.status).toBe(200);
     expect(res.body.foo).toBe('bar');
   });
+
+  test('POST request with extra path', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Bot/${bot.id}/$execute/RequestGroup`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send({ foo: 'bar' });
+    expect(res.status).toBe(200);
+    expect(res.body.foo).toBe('bar');
+  });
 });

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -90,10 +90,14 @@ protectedRoutes.get('/ValueSet/([$]|%24)expand', expandOperator);
 protectedRoutes.get('/:resourceType/([$]|%24)csv', asyncWrap(csvHandler));
 
 // Bot $execute operation
-protectedRoutes.get('/Bot/([$]|%24)execute', executeHandler);
-protectedRoutes.get('/Bot/:id/([$]|%24)execute', executeHandler);
-protectedRoutes.post('/Bot/([$]|%24)execute', executeHandler);
-protectedRoutes.post('/Bot/:id/([$]|%24)execute', executeHandler);
+const botPaths = [
+  '/Bot/([$]|%24)execute',
+  '/Bot/:id/([$]|%24)execute',
+  '/Bot/([$]|%24)execute/*',
+  '/Bot/:id/([$]|%24)execute/*',
+];
+protectedRoutes.get(botPaths, executeHandler);
+protectedRoutes.post(botPaths, executeHandler);
 
 // Bot $deploy operation
 protectedRoutes.post('/Bot/:id/([$]|%24)deploy', deployHandler);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -90,6 +90,7 @@ protectedRoutes.get('/ValueSet/([$]|%24)expand', expandOperator);
 protectedRoutes.get('/:resourceType/([$]|%24)csv', asyncWrap(csvHandler));
 
 // Bot $execute operation
+// Allow extra path content after the "$execute" to support external callers who append path info
 const botPaths = [
   '/Bot/([$]|%24)execute',
   '/Bot/:id/([$]|%24)execute',


### PR DESCRIPTION
One of our integration partners appends paths to the webhook callback URL.  So, for example, if you create a subscription with the callback URL `https://example.com/Bot/123/$execute`, the actual requested URL could be `https://example.com/Bot/123/$execute/RequestGroup`.

This PR allows extra content after the `$execute` portion of the URL.