### PR TITLE
Poll status follow Location header

### DIFF
--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -1,7 +1,7 @@
 import { created, MedplumClient } from '@medplum/core';
 import { main } from '.';
-import { getUnsupportedExtension } from './utils';
 import { createMedplumClient } from './util/client';
+import { getUnsupportedExtension } from './utils';
 
 const testLineOutput = [
   `{"resourceType":"Patient", "id":"1111111"}`,
@@ -51,6 +51,7 @@ describe('CLI Bulk Commands', () => {
         if (url.includes('/$export?_since=200')) {
           return {
             status: 200,
+            headers: { get: () => 'application/fhir+json' },
             json: jest.fn(async () => {
               return {
                 resourceType: 'OperationOutcome',
@@ -90,6 +91,7 @@ describe('CLI Bulk Commands', () => {
             headers: {
               get(name: string): string | undefined {
                 return {
+                  'content-type': 'application/fhir+json',
                   'content-location': 'bulkdata/id/status',
                 }[name];
               },
@@ -102,6 +104,7 @@ describe('CLI Bulk Commands', () => {
             count++;
             return {
               status: 202,
+              headers: { get: () => 'application/fhir+json' },
               json: jest.fn(async () => {
                 return {};
               }),
@@ -111,6 +114,7 @@ describe('CLI Bulk Commands', () => {
 
         return {
           status: 200,
+          headers: { get: () => 'application/fhir+json' },
           json: jest.fn(async () => ({
             transactionTime: '2023-05-18T22:55:31.280Z',
             request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
@@ -182,6 +186,7 @@ describe('CLI Bulk Commands', () => {
       fetch = jest.fn(async () => {
         return {
           status: 200,
+          headers: { get: () => 'application/fhir+json' },
           json: jest.fn(async () => ({
             resourceType: 'Bundle',
             type: 'transaction-response',

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1777,6 +1777,7 @@ describe('Client', () => {
   test('setAccessToken', async () => {
     const fetch = jest.fn(async () => ({
       status: 200,
+      headers: { get: () => 'application/fhir+json' },
       json: async () => ({ resourceType: 'Patient' }),
     }));
 
@@ -1941,6 +1942,7 @@ describe('Client', () => {
       }
       return {
         status: 200,
+        headers: { get: () => 'application/fhir+json' },
         json: async () => ({ resourceType: 'Patient' }),
       };
     });
@@ -1968,8 +1970,10 @@ describe('Client', () => {
   });
 
   test('Log non-JSON response', async () => {
+    // Handle the ugly case where server returns JSON header but non-JSON body
     const fetch = jest.fn(async () => ({
       status: 200,
+      headers: { get: () => 'application/json' },
       json: () => Promise.reject(new Error('Not JSON')),
     }));
     console.error = jest.fn();
@@ -1992,6 +1996,7 @@ describe('Client', () => {
         if (url.includes('/$export?_since=200')) {
           return {
             status: 200,
+            headers: { get: () => 'application/fhir+json' },
             json: jest.fn(async () => {
               return {
                 resourceType: 'OperationOutcome',
@@ -2031,6 +2036,7 @@ describe('Client', () => {
             headers: {
               get(name: string): string | undefined {
                 return {
+                  'content-type': 'application/fhir+json',
                   'content-location': 'bulkdata/id/status',
                 }[name];
               },
@@ -2052,6 +2058,7 @@ describe('Client', () => {
 
         return {
           status: 200,
+          headers: { get: () => 'application/fhir+json' },
           json: jest.fn(async () => ({
             transactionTime: '2023-05-18T22:55:31.280Z',
             request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
@@ -2137,7 +2144,7 @@ describe('Client', () => {
             };
           }),
           headers: {
-            get: jest.fn(),
+            get: (key: string) => (key === 'content-type' ? 'application/fhir+json' : null),
           },
         };
       });

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -106,6 +106,7 @@ function mockFetch(url: string, options: any): Promise<any> {
   return Promise.resolve({
     status,
     ok: status < 400,
+    headers: { get: () => 'application/fhir+json' },
     json: () => Promise.resolve(response),
   });
 }

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -154,6 +154,7 @@ function mockFetch(url: string, options: any): Promise<any> {
   return Promise.resolve({
     status,
     ok: status < 400,
+    headers: { get: () => 'application/fhir+json' },
     json: () => Promise.resolve(response),
   });
 }


### PR DESCRIPTION
Handles the following situation:
- Start an async request using `Prefer: respond-async`
- Server responds with HTTP 202 Accepted and a `Content-Location` header
- Poll on the `Content-Location`
- Response turns to HTTP 201 Created with either a `Content-Location` or `Location` header
- Follow it all the way