### PR TITLE
Copy .env.defaults to .env if not exists

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,7 +1,12 @@
 /// <reference types="vite/client" />
 import react from '@vitejs/plugin-react';
+import { copyFileSync, existsSync } from 'fs';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+
+if (!existsSync('.env')) {
+  copyFileSync('.env.defaults', '.env');
+}
 
 export default defineConfig({
   envPrefix: ['MEDPLUM_', 'GOOGLE_', 'RECAPTCHA_'],

--- a/packages/graphiql/vite.config.ts
+++ b/packages/graphiql/vite.config.ts
@@ -1,6 +1,11 @@
 /// <reference types="vite/client" />
 import react from '@vitejs/plugin-react';
+import { copyFileSync, existsSync } from 'fs';
 import { defineConfig } from 'vite';
+
+if (!existsSync('.env')) {
+  copyFileSync('.env.defaults', '.env');
+}
 
 export default defineConfig({
   envPrefix: ['MEDPLUM_', 'GOOGLE_', 'RECAPTCHA_'],

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.exclusions=**/node_modules/**,\
   **/coverage/**,\
   **/babel.config.js,\
   **/esbuild.mjs,\
+  **/vite.config.ts,\
   **/test.setup.ts,\
   **/*.stories.tsx,\
   **/jest.sequencer.js,\


### PR DESCRIPTION
On Vite startup:

```ts
if (!existsSync('.env')) {
  copyFileSync('.env.defaults', '.env');
}
```

This is to mimic our previous behavior with Webpack and [`dotenv-webpack`](https://github.com/mrsteele/dotenv-webpack)

Not sure if this is a good idea.  Open to feedback.  I don't see an obvious way to set default `.env` values with Vite.