### PR TITLE
Bring back sourcemaps

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
+      outDir: 'dist/assets',
       registerType: 'autoUpdate',
       injectRegister: null,
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'masked-icon.svg'],
@@ -43,4 +44,7 @@ export default defineConfig({
     port: 3000,
   },
   publicDir: 'static',
+  build: {
+    sourcemap: true,
+  },
 });

--- a/packages/cdk/esbuild.mjs
+++ b/packages/cdk/esbuild.mjs
@@ -13,6 +13,7 @@ const options = {
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,
+  sourcemap: true,
   external: [
     '@aws-sdk/client-acm',
     '@aws-sdk/client-ssm',

--- a/packages/cli/esbuild.mjs
+++ b/packages/cli/esbuild.mjs
@@ -13,6 +13,7 @@ const options = {
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,
+  sourcemap: true,
   external: [
     '@aws-sdk/client-acm',
     '@aws-sdk/client-cloudformation',

--- a/packages/core/esbuild.mjs
+++ b/packages/core/esbuild.mjs
@@ -18,6 +18,7 @@ const options = {
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,
+  sourcemap: true,
   define: {
     'process.env.NODE_ENV': '"production"',
     'process.env.MEDPLUM_VERSION': `"${medplumVersion}"`,

--- a/packages/fhir-router/esbuild.mjs
+++ b/packages/fhir-router/esbuild.mjs
@@ -13,6 +13,7 @@ const options = {
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,
+  sourcemap: true,
   external: ['@medplum/core', 'dataloader', 'rfc6902'],
 };
 

--- a/packages/graphiql/vite.config.ts
+++ b/packages/graphiql/vite.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
   server: {
     port: 8080,
   },
+  build: {
+    sourcemap: true,
+  },
 });

--- a/packages/mock/esbuild.mjs
+++ b/packages/mock/esbuild.mjs
@@ -13,6 +13,7 @@ const options = {
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,
+  sourcemap: true,
   external: ['@medplum/core', '@medplum/fhir-router', 'rfc6902'],
 };
 

--- a/packages/react/esbuild.mjs
+++ b/packages/react/esbuild.mjs
@@ -17,6 +17,7 @@ const options = {
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,
+  sourcemap: true,
   define: {
     'process.env.NODE_ENV': '"production"',
     'process.env.GOOGLE_AUTH_ORIGINS': `"${process.env.GOOGLE_AUTH_ORIGINS}"`,


### PR DESCRIPTION
There was a dev-experience regression in https://github.com/medplum/medplum/pull/2298 where we stopped producing sourcemaps.

That meant stacktraces were bad, worse than useless, because it would basically dump the entire minified JS file in your terminal.

After this changes, the stack traces refer to original TypeScript files and line numbers again.