### PR TITLE
Fixes #2306 - remove console.log from export tests due to race conditions

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -12,7 +12,7 @@ import { generateAccessToken } from '../oauth/keys';
 import { createSearchParameters } from '../seeds/searchparameters';
 import { createStructureDefinitions } from '../seeds/structuredefinitions';
 import { createValueSets } from '../seeds/valuesets';
-import { createTestProject } from '../test.setup';
+import { createTestProject, waitForAsyncJob } from '../test.setup';
 
 jest.mock('../seeds/valuesets');
 jest.mock('../seeds/structuredefinitions');
@@ -138,7 +138,7 @@ describe('Super Admin routes', () => {
 
     expect(res.status).toEqual(202);
     expect(res.headers['content-location']).toBeDefined();
-    await waitForAsyncJob(res.headers['content-location']);
+    await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken);
   });
 
   test('Rebuild ValueSetElements as super admin with respond-async error', async () => {
@@ -193,7 +193,7 @@ describe('Super Admin routes', () => {
 
     expect(res.status).toEqual(202);
     expect(res.headers['content-location']).toBeDefined();
-    await waitForAsyncJob(res.headers['content-location']);
+    await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken);
   });
 
   test('Rebuild StructureDefinitions as super admin with respond-async error', async () => {
@@ -248,7 +248,7 @@ describe('Super Admin routes', () => {
 
     expect(res.status).toEqual(202);
     expect(res.headers['content-location']).toBeDefined();
-    await waitForAsyncJob(res.headers['content-location']);
+    await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken);
   });
 
   test('Rebuild searchparameters as super admin with respond-async error', async () => {
@@ -327,7 +327,7 @@ describe('Super Admin routes', () => {
 
     expect(res.status).toEqual(202);
     expect(res.headers['content-location']).toBeDefined();
-    await waitForAsyncJob(res.headers['content-location']);
+    await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken);
   });
 
   test('Reindex with respond-async error', async () => {
@@ -571,24 +571,6 @@ describe('Super Admin routes', () => {
 
     expect(res1.status).toEqual(202);
     expect(res1.headers['content-location']).toBeDefined();
-    await waitForAsyncJob(res1.headers['content-location']);
+    await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken);
   });
 });
-
-async function waitForAsyncJob(contentLocation: string): Promise<void> {
-  for (let i = 0; i < 10; i++) {
-    const res = await request(app)
-      .get(new URL(contentLocation).pathname)
-      .set('Authorization', 'Bearer ' + adminAccessToken);
-    if (res.status !== 202) {
-      return;
-    }
-    await sleep(1000);
-  }
-  throw new Error('Async job did not complete');
-}
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -4,12 +4,10 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { createTestProject, initTestAuth, waitFor } from '../../test.setup';
+import { createTestProject, initTestAuth, waitFor, waitForJob } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { exportResourceType } from './export';
 import { BulkExporter } from './utils/bulkexporter';
-
-jest.mock('../../logger');
 
 const app = express();
 
@@ -113,6 +111,7 @@ describe('Export', () => {
       .send({});
     expect(initRes.status).toBe(202);
     expect(initRes.headers['content-location']).toBeDefined();
+    await waitForJob(app, initRes.headers['content-location'], accessToken);
   });
 
   test('Patient Export Accepted with GET', async () => {
@@ -127,6 +126,7 @@ describe('Export', () => {
       .send({});
     expect(initRes.status).toBe(202);
     expect(initRes.headers['content-location']).toBeDefined();
+    await waitForJob(app, initRes.headers['content-location'], accessToken);
   });
 
   test('exportResourceType iterating through paginated search results', async () => {

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { createTestProject, initTestAuth, waitFor, waitForJob } from '../../test.setup';
+import { createTestProject, initTestAuth, waitFor, waitForAsyncJob } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { exportResourceType } from './export';
 import { BulkExporter } from './utils/bulkexporter';
@@ -111,7 +111,7 @@ describe('Export', () => {
       .send({});
     expect(initRes.status).toBe(202);
     expect(initRes.headers['content-location']).toBeDefined();
-    await waitForJob(app, initRes.headers['content-location'], accessToken);
+    await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
   });
 
   test('Patient Export Accepted with GET', async () => {
@@ -126,7 +126,7 @@ describe('Export', () => {
       .send({});
     expect(initRes.status).toBe(202);
     expect(initRes.headers['content-location']).toBeDefined();
-    await waitForJob(app, initRes.headers['content-location'], accessToken);
+    await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
   });
 
   test('exportResourceType iterating through paginated search results', async () => {

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { createTestProject, initTestAuth, waitFor, waitForAsyncJob } from '../../test.setup';
+import { createTestProject, initTestAuth, waitForAsyncJob } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { exportResourceType } from './export';
 import { BulkExporter } from './utils/bulkexporter';
@@ -68,15 +68,13 @@ describe('Export', () => {
 
     // Check the export status
     const contentLocation = new URL(initRes.headers['content-location']);
+    await waitForAsyncJob(initRes.headers['content-location'], app, accessToken);
 
-    let resBody: any;
-    await waitFor(async () => {
-      const statusRes = await request(app)
-        .get(contentLocation.pathname)
-        .set('Authorization', 'Bearer ' + accessToken);
-      expect(statusRes.status).toBe(200);
-      resBody = statusRes.body;
-    });
+    const statusRes = await request(app)
+      .get(contentLocation.pathname)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(statusRes.status).toBe(200);
+    const resBody = statusRes.body;
 
     const output = resBody?.output as BulkDataExportOutput[];
     expect(

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -9,6 +9,8 @@ import { systemRepo } from '../repo';
 import { exportResourceType } from './export';
 import { BulkExporter } from './utils/bulkexporter';
 
+jest.mock('../../logger');
+
 const app = express();
 
 describe('Export', () => {
@@ -97,6 +99,34 @@ describe('Export', () => {
     const resourceJSON = dataRes.text.trim().split('\n');
     expect(resourceJSON).toHaveLength(1);
     expect(JSON.parse(resourceJSON[0])?.subject?.reference).toEqual(`Patient/${res1.body.id}`);
+  });
+
+  test('System Export Accepted with GET', async () => {
+    const accessToken = await initTestAuth();
+
+    // Start the export
+    const initRes = await request(app)
+      .get('/fhir/R4/$export')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .set('X-Medplum', 'extended')
+      .send({});
+    expect(initRes.status).toBe(202);
+    expect(initRes.headers['content-location']).toBeDefined();
+  });
+
+  test('Patient Export Accepted with GET', async () => {
+    const accessToken = await initTestAuth();
+
+    // Start the export
+    const initRes = await request(app)
+      .get('/fhir/R4/Patient/$export')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .set('X-Medplum', 'extended')
+      .send({});
+    expect(initRes.status).toBe(202);
+    expect(initRes.headers['content-location']).toBeDefined();
   });
 
   test('exportResourceType iterating through paginated search results', async () => {

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -99,34 +99,6 @@ describe('Export', () => {
     expect(JSON.parse(resourceJSON[0])?.subject?.reference).toEqual(`Patient/${res1.body.id}`);
   });
 
-  test('System Export Accepted with GET', async () => {
-    const accessToken = await initTestAuth();
-
-    // Start the export
-    const initRes = await request(app)
-      .get('/fhir/R4/$export')
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/fhir+json')
-      .set('X-Medplum', 'extended')
-      .send({});
-    expect(initRes.status).toBe(202);
-    expect(initRes.headers['content-location']).toBeDefined();
-  });
-
-  test('Patient Export Accepted with GET', async () => {
-    const accessToken = await initTestAuth();
-
-    // Start the export
-    const initRes = await request(app)
-      .get('/fhir/R4/Patient/$export')
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/fhir+json')
-      .set('X-Medplum', 'extended')
-      .send({});
-    expect(initRes.status).toBe(202);
-    expect(initRes.headers['content-location']).toBeDefined();
-  });
-
   test('exportResourceType iterating through paginated search results', async () => {
     const { project } = await createTestProject();
     expect(project).toBeDefined();

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { createTestProject, initTestAuth, waitFor, waitForAsyncJob } from '../../test.setup';
+import { createTestProject, initTestAuth, waitForAsyncJob } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { groupExportResources } from './groupexport';
 import { BulkExporter } from './utils/bulkexporter';
@@ -104,14 +104,12 @@ describe('Group Export', () => {
 
     // Check the export status
     const contentLocation = new URL(res6.headers['content-location']);
+    await waitForAsyncJob(res6.headers['content-location'], app, accessToken);
 
-    let contentLocationRes: any;
-    await waitFor(async () => {
-      contentLocationRes = await request(app)
-        .get(contentLocation.pathname)
-        .set('Authorization', 'Bearer ' + accessToken);
-      expect(contentLocationRes.status).toBe(200);
-    });
+    const contentLocationRes = await request(app)
+      .get(contentLocation.pathname)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(contentLocationRes.status).toBe(200);
 
     const output = contentLocationRes.body.output as BulkDataExportOutput[];
     expect(output).toHaveLength(4);
@@ -201,14 +199,12 @@ describe('Group Export', () => {
 
     // Check the export status
     const contentLocation = new URL(res5.headers['content-location']);
+    await waitForAsyncJob(res5.headers['content-location'], app, accessToken);
 
-    let contentLocationRes: any;
-    await waitFor(async () => {
-      contentLocationRes = await request(app)
-        .get(contentLocation.pathname)
-        .set('Authorization', 'Bearer ' + accessToken);
-      expect(contentLocationRes.status).toBe(200);
-    });
+    const contentLocationRes = await request(app)
+      .get(contentLocation.pathname)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(contentLocationRes.status).toBe(200);
 
     const output = contentLocationRes.body.output as BulkDataExportOutput[];
     expect(output).toHaveLength(3);
@@ -282,14 +278,12 @@ describe('Group Export', () => {
 
     // Check the export status
     const contentLocation = new URL(res4.headers['content-location']);
+    await waitForAsyncJob(res4.headers['content-location'], app, accessToken);
 
-    let contentLocationRes: any;
-    await waitFor(async () => {
-      contentLocationRes = await request(app)
-        .get(contentLocation.pathname)
-        .set('Authorization', 'Bearer ' + accessToken);
-      expect(contentLocationRes.status).toBe(200);
-    });
+    const contentLocationRes = await request(app)
+      .get(contentLocation.pathname)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(contentLocationRes.status).toBe(200);
 
     const output = contentLocationRes.body.output as BulkDataExportOutput[];
     expect(output.some((o) => o.type === 'Patient')).toBeTruthy();

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -3,12 +3,10 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { createTestProject, initTestAuth, waitFor } from '../../test.setup';
+import { createTestProject, initTestAuth, waitFor, waitForJob } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { groupExportResources } from './groupexport';
 import { BulkExporter } from './utils/bulkexporter';
-
-jest.mock('../../logger');
 
 const app = express();
 let accessToken: string;
@@ -316,6 +314,7 @@ describe('Group Export', () => {
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res4.status).toBe(202);
     expect(res4.headers['content-location']).toBeDefined();
+    await waitForJob(app, res4.headers['content-location'], accessToken);
   });
 
   test('groupExportResources without members', async () => {

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { createTestProject, initTestAuth, waitFor, waitForJob } from '../../test.setup';
+import { createTestProject, initTestAuth, waitFor, waitForAsyncJob } from '../../test.setup';
 import { systemRepo } from '../repo';
 import { groupExportResources } from './groupexport';
 import { BulkExporter } from './utils/bulkexporter';
@@ -314,7 +314,7 @@ describe('Group Export', () => {
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res4.status).toBe(202);
     expect(res4.headers['content-location']).toBeDefined();
-    await waitForJob(app, res4.headers['content-location'], accessToken);
+    await waitForAsyncJob(res4.headers['content-location'], app, accessToken);
   });
 
   test('groupExportResources without members', async () => {

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -296,26 +296,6 @@ describe('Group Export', () => {
     expect(output.some((o) => o.type === 'Observation')).not.toBeTruthy();
   });
 
-  test('status accepted with error', async () => {
-    // Create group
-    const groupRes = await request(app)
-      .post(`/fhir/R4/Group`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', 'application/fhir+json')
-      .send({
-        resourceType: 'Group',
-        type: 'person',
-        actual: true,
-        member: [{ entity: { reference: `Patient/1234` } }],
-      });
-    expect(groupRes.status).toBe(201);
-    const res4 = await request(app)
-      .get(`/fhir/R4/Group/${groupRes.body.id}/$export`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res4.status).toBe(202);
-    expect(res4.headers['content-location']).toBeDefined();
-  });
-
   test('groupExportResources without members', async () => {
     const { project } = await createTestProject();
     expect(project).toBeDefined();

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -186,7 +186,7 @@ export function waitFor(fn: () => Promise<void>): Promise<void> {
   });
 }
 
-export async function waitForJob(app: Express, contentLocation: string, accessToken: string): Promise<void> {
+export async function waitForAsyncJob(contentLocation: string, app: Express, accessToken: string): Promise<void> {
   for (let i = 0; i < 10; i++) {
     const res = await request(app)
       .get(new URL(contentLocation).pathname)
@@ -196,7 +196,7 @@ export async function waitForJob(app: Express, contentLocation: string, accessTo
     }
     await sleep(1000);
   }
-  throw new Error('Job did not complete');
+  throw new Error('Async Job did not complete');
 }
 
 const sleep = (ms: number): Promise<void> =>

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -10,6 +10,8 @@ import {
   User,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
+import { Express } from 'express';
+import request from 'supertest';
 import { inviteUser } from './admin/invite';
 import { systemRepo } from './fhir/repo';
 import { generateAccessToken } from './oauth/keys';
@@ -183,3 +185,21 @@ export function waitFor(fn: () => Promise<void>): Promise<void> {
     }, 100);
   });
 }
+
+export async function waitForJob(app: Express, contentLocation: string, accessToken: string): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    const res = await request(app)
+      .get(new URL(contentLocation).pathname)
+      .set('Authorization', 'Bearer ' + accessToken);
+    if (res.status !== 202) {
+      return;
+    }
+    await sleep(1000);
+  }
+  throw new Error('Job did not complete');
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });


### PR DESCRIPTION
Using `waitForAsyncJob` to wait for an async job like Bulk export to complete before the test cases ends.


Related PRs
#2022 
#2080 
#1959 


https://github.com/medplum/medplum/actions/runs/5404805700/jobs/9819491438?pr=2322#step:6:1405
<img width="897" alt="image" src="https://github.com/medplum/medplum/assets/2465773/fb26b790-5efb-4383-a990-9077a3bef03f">

