### PR TITLE
Fixed landing page for storybook

### DIFF
--- a/examples/medplum-hello-world/README.md
+++ b/examples/medplum-hello-world/README.md
@@ -13,7 +13,7 @@ This example app demonstrates the following:
 - Adding basic URL routing
 - Using the [Medplum client](https://www.medplum.com/docs/sdk/classes/MedplumClient) to search for FHIR resources
 - Using [Medplum GraphQL](https://graphiql.medplum.com/) queries to fetch linked resources
-- Using [Medplum React Components](https://storybook.medplum.com/?path=/docs/medplum-introduction--page) to display FHIR data
+- Using [Medplum React Components](https://storybook.medplum.com/?path=/docs/medplum-introduction--docs) to display FHIR data
 
 ### Getting Started
 

--- a/packages/docs/docs/tutorials/medplum-hello-world.md
+++ b/packages/docs/docs/tutorials/medplum-hello-world.md
@@ -7,7 +7,7 @@ sidebar_label: Medplum Hello World
 
 Digital health companies often build custom UIs on top of the Medplum platform to design streamlined patient and physician experiences. This tutorial will cover to run the **Medplum "Hello World"** example, a simple [React](https://reactjs.org/) app that visualizes patient information.
 
-Hello World is built with Medplum's [React Component](https://storybook.medplum.com/?path=/docs/medplum-introduction--page) library, which is a great resource for rapid prototyping and building internal tools.
+Hello World is built with Medplum's [React Component](https://storybook.medplum.com/?path=/docs/medplum-introduction--docs) library, which is a great resource for rapid prototyping and building internal tools.
 
 ## Clone and Run the App
 

--- a/packages/docs/docs/ui-components/index.md
+++ b/packages/docs/docs/ui-components/index.md
@@ -2,6 +2,6 @@
 
 Medplum maintains a library of React components which we use in the [Medplum app](../app/index.md) and are open source. We support use of our React component library in third party apps as well.
 
-- [Storybook](https://storybook.medplum.com/?path=/docs/medplum-introduction--page)
+- [Storybook](https://storybook.medplum.com/?path=/docs/medplum-introduction--docs)
 - [Source Code](https://github.com/medplum/medplum/tree/main/packages/react) on Github
 - [Features and Fixes](https://github.com/medplum/medplum/pulls?q=is%3Apr+label%3Areact+) on Github for React component library


### PR DESCRIPTION
The correct URL for the storybook landing page is `https://storybook.medplum.com/?path=/docs/medplum-introduction--docs`. Changed the docs to reflect that.

<img width="1720" alt="Screen Shot 2023-06-27 at 9 09 20 PM" src="https://github.com/medplum/medplum/assets/10239468/39d27049-0166-41ff-ac28-51870c7efec4">
