### PR TITLE
Increase Fargate health check grace period

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -309,6 +309,7 @@ export class BackEnd extends Construct {
       },
       desiredCount: config.desiredServerCount,
       securityGroups: [fargateSecurityGroup],
+      healthCheckGracePeriod: Duration.minutes(5),
     });
 
     // Add dependencies - make sure Fargate service is created after RDS and Redis


### PR DESCRIPTION
As discussed in yesterday's infra bug bash, this PR increases the Fargate health check grace period.  This provides more time for slow moving database setup and migrations.

See: https://aws.amazon.com/about-aws/whats-new/2017/12/amazon-ecs-adds-elb-health-check-grace-period/

Longer term, we will provide a more direct "initial database setup" script, so clusters do not need to sequentially go through all historical migrations.  This PR buys us some time for that.

Already deployed to Medplum staging and prod.