### PR TITLE
Fix app env vars in publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          KEEP_ENV_VARS: 'true'
+          MEDPLUM_BASE_URL: '__MEDPLUM_BASE_URL__'
+          MEDPLUM_CLIENT_ID: '__MEDPLUM_CLIENT_ID__'
+          MEDPLUM_REGISTER_ENABLED: '__MEDPLUM_REGISTER_ENABLED__'
+          GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
+          RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
       - name: Publish
         run: ./scripts/publish.sh
         env:

--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -3,7 +3,7 @@ import { Document, Logo, RegisterForm, useMedplum } from '@medplum/react';
 import { IconAlertCircle } from '@tabler/icons-react';
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getConfig } from './config';
+import { getConfig, isRegisterEnabled } from './config';
 
 export function RegisterPage(): JSX.Element | null {
   const medplum = useMedplum();
@@ -16,7 +16,7 @@ export function RegisterPage(): JSX.Element | null {
     }
   }, [medplum, navigate]);
 
-  if (!config.registerEnabled) {
+  if (!isRegisterEnabled()) {
     return (
       <Document width={450}>
         <Alert icon={<IconAlertCircle size={16} />} title="New projects disabled" color="red">

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -2,7 +2,7 @@ import { Title } from '@mantine/core';
 import { Logo, SignInForm } from '@medplum/react';
 import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { getConfig } from './config';
+import { getConfig, isRegisterEnabled } from './config';
 
 export function SignInPage(): JSX.Element {
   const navigate = useNavigate();
@@ -13,7 +13,7 @@ export function SignInPage(): JSX.Element {
     <SignInForm
       onSuccess={() => navigate(searchParams.get('next') || '/')}
       onForgotPassword={() => navigate('/resetpassword')}
-      onRegister={config.registerEnabled ? () => navigate('/register') : undefined}
+      onRegister={isRegisterEnabled() ? () => navigate('/register') : undefined}
       googleClientId={config.googleClientId}
       login={searchParams.get('login') || undefined}
       projectId={searchParams.get('project') || undefined}

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -1,19 +1,24 @@
 export interface MedplumAppConfig {
-  baseUrl: string;
+  baseUrl?: string;
   clientId?: string;
   googleClientId?: string;
   recaptchaSiteKey?: string;
-  registerEnabled?: boolean;
+  registerEnabled?: boolean | string;
 }
 
 const config: MedplumAppConfig = {
-  baseUrl: import.meta.env?.MEDPLUM_BASE_URL as string,
-  clientId: import.meta.env?.MEDPLUM_CLIENT_ID || undefined,
-  googleClientId: import.meta.env?.GOOGLE_CLIENT_ID || undefined,
-  recaptchaSiteKey: import.meta.env?.RECAPTCHA_SITE_KEY || undefined,
-  registerEnabled: import.meta.env?.MEDPLUM_REGISTER_ENABLED !== 'false', // default true
+  baseUrl: import.meta.env?.MEDPLUM_BASE_URL,
+  clientId: import.meta.env?.MEDPLUM_CLIENT_ID,
+  googleClientId: import.meta.env?.GOOGLE_CLIENT_ID,
+  recaptchaSiteKey: import.meta.env?.RECAPTCHA_SITE_KEY,
+  registerEnabled: import.meta.env?.MEDPLUM_REGISTER_ENABLED,
 };
 
 export function getConfig(): MedplumAppConfig {
   return config;
+}
+
+export function isRegisterEnabled(): boolean {
+  // Default to true
+  return config.registerEnabled !== false && config.registerEnabled !== 'false';
 }

--- a/packages/cli/src/aws/update-app.ts
+++ b/packages/cli/src/aws/update-app.ts
@@ -1,7 +1,7 @@
 import { CreateInvalidationCommand } from '@aws-sdk/client-cloudfront';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import fastGlob from 'fast-glob';
-import { createReadStream, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { createReadStream, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import fetch from 'node-fetch';
 import { tmpdir } from 'os';
 import { join, sep } from 'path';
@@ -110,7 +110,7 @@ function replaceVariables(folderName: string, replacements: Record<string, strin
 function replaceVariablesInFile(fileName: string, replacements: Record<string, string>): void {
   let contents = readFileSync(fileName, 'utf-8');
   for (const [placeholder, replacement] of Object.entries(replacements)) {
-    contents = contents.replaceAll(`process.env.${placeholder}`, `'${replacement}'`);
+    contents = contents.replaceAll(`__${placeholder}__`, replacement);
   }
   writeFileSync(fileName, contents);
 }


### PR DESCRIPTION
Before, when using Webpack for building, you could specify `KEEP_ENV_VARS=true`, and it would keep the environment variables in the code as-is.

We need those placeholder values to enable using Medplum CLI to deploy the app, without building the app from source.

When we migrated to ESBuild and Vite, that broke.

This PR changes this around.  The `KEEP_ENV_VARS` model doesn't really work with Vite, so instead we leave in string placeholders.

To be clear, this has 3 parts that currently need to work in harmony together:
1. The `app` config settings and build process
2. The `publish.yml` Github Action
3. The Medplum CLI `deploy-app` / `update-app` commands which unpack these variables.