### PR TITLE
Release Version 2.0.25

### DIFF
--- a/examples/foomedical/package.json
+++ b/examples/foomedical/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foomedical",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -18,10 +18,10 @@
     "@mantine/core": "6.0.13",
     "@mantine/hooks": "6.0.13",
     "@mantine/notifications": "6.0.13",
-    "@medplum/core": "2.0.24",
-    "@medplum/fhirtypes": "2.0.24",
-    "@medplum/mock": "2.0.24",
-    "@medplum/react": "2.0.24",
+    "@medplum/core": "2.0.25",
+    "@medplum/fhirtypes": "2.0.25",
+    "@medplum/mock": "2.0.25",
+    "@medplum/react": "2.0.25",
     "@tabler/icons-react": "2.22.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",

--- a/examples/medplum-hello-world/package.json
+++ b/examples/medplum-hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "medplum-hello-world",
   "private": true,
-  "version": "2.0.24",
+  "version": "2.0.25",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -12,9 +12,9 @@
     "@mantine/core": "6.0.13",
     "@mantine/hooks": "6.0.13",
     "@mantine/notifications": "6.0.13",
-    "@medplum/core": "2.0.24",
-    "@medplum/fhirtypes": "2.0.24",
-    "@medplum/react": "2.0.24",
+    "@medplum/core": "2.0.25",
+    "@medplum/fhirtypes": "2.0.25",
+    "@medplum/react": "2.0.25",
     "@tabler/icons-react": "2.22.0",
     "@types/node": "20.3.1",
     "@types/react": "18.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "workspaces": [
         "packages/*",
         "examples/*"
@@ -49,7 +49,7 @@
       }
     },
     "examples/foomedical": {
-      "version": "2.0.24",
+      "version": "2.0.25",
       "devDependencies": {
         "@babel/core": "7.22.5",
         "@babel/preset-env": "7.22.5",
@@ -59,10 +59,10 @@
         "@mantine/core": "6.0.13",
         "@mantine/hooks": "6.0.13",
         "@mantine/notifications": "6.0.13",
-        "@medplum/core": "2.0.24",
-        "@medplum/fhirtypes": "2.0.24",
-        "@medplum/mock": "2.0.24",
-        "@medplum/react": "2.0.24",
+        "@medplum/core": "2.0.25",
+        "@medplum/fhirtypes": "2.0.25",
+        "@medplum/mock": "2.0.25",
+        "@medplum/react": "2.0.25",
         "@tabler/icons-react": "2.22.0",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "14.0.0",
@@ -153,15 +153,15 @@
       }
     },
     "examples/medplum-hello-world": {
-      "version": "2.0.24",
+      "version": "2.0.25",
       "devDependencies": {
         "@emotion/react": "11.11.1",
         "@mantine/core": "6.0.13",
         "@mantine/hooks": "6.0.13",
         "@mantine/notifications": "6.0.13",
-        "@medplum/core": "2.0.24",
-        "@medplum/fhirtypes": "2.0.24",
-        "@medplum/react": "2.0.24",
+        "@medplum/core": "2.0.25",
+        "@medplum/fhirtypes": "2.0.25",
+        "@medplum/react": "2.0.25",
         "@tabler/icons-react": "2.22.0",
         "@types/node": "20.3.1",
         "@types/react": "18.2.13",
@@ -38600,7 +38600,7 @@
     },
     "packages/app": {
       "name": "@medplum/app",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@emotion/react": "11.11.1",
@@ -38628,7 +38628,7 @@
     },
     "packages/bot-layer": {
       "name": "@medplum/bot-layer",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@medplum/core": "*",
@@ -38665,7 +38665,7 @@
     },
     "packages/cdk": {
       "name": "@medplum/cdk",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.347.0",
@@ -38682,7 +38682,7 @@
     },
     "packages/cli": {
       "name": "@medplum/cli",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-acm": "3.354.0",
@@ -38721,7 +38721,7 @@
     },
     "packages/core": {
       "name": "@medplum/core",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@medplum/definitions": "*",
@@ -38738,12 +38738,12 @@
     },
     "packages/definitions": {
       "name": "@medplum/definitions",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0"
     },
     "packages/docs": {
       "name": "@medplum/docs",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@docusaurus/core": "2.4.1",
@@ -38780,7 +38780,7 @@
     },
     "packages/eslint-config": {
       "name": "@medplum/eslint-config",
-      "version": "0.1.0",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/parser": "5.59.9",
@@ -38955,7 +38955,7 @@
     },
     "packages/examples": {
       "name": "@medplum/examples",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@jest/globals": "29.5.0",
@@ -38967,7 +38967,7 @@
     },
     "packages/fhir-router": {
       "name": "@medplum/fhir-router",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@medplum/core": "*",
@@ -38980,12 +38980,12 @@
     },
     "packages/fhirtypes": {
       "name": "@medplum/fhirtypes",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0"
     },
     "packages/generator": {
       "name": "@medplum/generator",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@medplum/core": "*",
@@ -38998,7 +38998,7 @@
     },
     "packages/graphiql": {
       "name": "@medplum/graphiql",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@graphiql/react": "0.17.6",
@@ -39020,7 +39020,7 @@
     },
     "packages/mock": {
       "name": "@medplum/mock",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@medplum/core": "*",
@@ -39036,7 +39036,7 @@
     },
     "packages/react": {
       "name": "@medplum/react",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@emotion/react": "11.11.1",
@@ -39095,7 +39095,7 @@
     },
     "packages/server": {
       "name": "@medplum/server",
-      "version": "2.0.24",
+      "version": "2.0.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.354.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "engines": {
     "npm": ">=8.0.0",
     "node": ">=18.0.0"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@medplum/app",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum App",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/bot-layer/package.json
+++ b/packages/bot-layer/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@medplum/bot-layer",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Bot Lambda Layer",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/cdk",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum CDK Infra as Code",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/cli",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Command Line Interface",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/core",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum TS/JS Library",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/definitions",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Data Definitions",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/docs",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Docs",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/eslint-config",
-  "version": "0.1.0",
+  "version": "2.0.25",
   "description": "Shared ESLint configuration for Medplum projects",
   "main": "index.cjs",
   "repository": {
@@ -14,7 +14,10 @@
     "url": "https://github.com/medplum/medplum/issues"
   },
   "homepage": "https://github.com/medplum/medplum#readme",
-  "keywords": ["eslint", "eslintconfig"],
+  "keywords": [
+    "eslint",
+    "eslintconfig"
+  ],
   "peerDependencies": {
     "eslint": ">= 8",
     "@typescript-eslint/eslint-plugin": ">= 5"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/examples",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Code Examples",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/fhir-router",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum FHIR Router",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/fhirtypes/package.json
+++ b/packages/fhirtypes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/fhirtypes",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum FHIR Type Definitions",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/generator",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Code Generator",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/graphiql",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum GraphiQL",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/mock",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Mock Client",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/react",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum React Component Library",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medplum/server",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "Medplum Server",
   "author": "Medplum <hello@medplum.com>",
   "license": "Apache-2.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.organization=medplum
 sonar.projectKey=medplum_medplum
 sonar.projectName=Medplum
-sonar.projectVersion=2.0.24
+sonar.projectVersion=2.0.25
 sonar.sources=packages
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=**/node_modules/**,\


### PR DESCRIPTION
Update client-cloudwatch-logs manual mock to use aws-sdk-client-mock (#2342)
Log resource for validator latency warning (#2338)
Minor tweaks to aws init tool and docs (#2340)
Allow contentReference elements to override cardinality rules (#2339)
Fixes #2315 - allow bot success without return value (#2336)
Fix app env vars in publish job (#2335)
Fixes #2310 - CLI rest with --fhir-url-path (#2313)
Unify all of the sleep helper functions (#2331)
Increase Fargate health check grace period (#2330)
Remove PWA and service worker (#2329)
Updating subscription documentation to reflect behavior when resources are deleted (#2328)
Add app to publish.sh (#2326)
Fixes #2306 - remove console.log from export tests due to race conditions (#2322)
Fixed landing page for storybook (#2323)
Bring back sourcemaps (#2309)
Split custom Medplum search parameter definitions into separate file (#2178)
Poll status follow Location header (#2307)
Copy .env.defaults to .env if not exists (#2308)
Allow extra URL path content with Bot execute (#2305)
Fixes #2182- All Patient Export (#2293)
Strict validation of property cardinality (#2300)
Request from ACN (#2299)
Fixed CLI shebang (#2301)
ESBuild (#2298)
Add logs and parity tests for new validator (#2291)
Fixes #2277 - Updated access policies docs (#2292)
Add non-null requirements to values in GraphQL array types (#2290)
Validating Fixed and Pattern Values (#2288)
Fixes #2195 - updated cdk init docs (#2289)