### PR TITLE
Fixes #2354 - always use normalizeOperationOutcome

### DIFF
--- a/packages/app/src/admin/SitesPage.tsx
+++ b/packages/app/src/admin/SitesPage.tsx
@@ -1,7 +1,7 @@
 import { Button, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { deepClone, IndexedStructureDefinition } from '@medplum/core';
-import { OperationOutcome, ProjectSite } from '@medplum/fhirtypes';
+import { deepClone, IndexedStructureDefinition, normalizeOperationOutcome } from '@medplum/core';
+import { ProjectSite } from '@medplum/fhirtypes';
 import { ResourcePropertyInput, useMedplum } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
 import { getProjectId } from '../utils';
@@ -38,7 +38,7 @@ export function SitesPage(): JSX.Element {
           .then(() => medplum.get(`admin/projects/${projectId}`, { cache: 'reload' }))
           .then(() => showNotification({ color: 'green', message: 'Saved' }))
           .catch((err) => {
-            const operationOutcome = err as OperationOutcome;
+            const operationOutcome = normalizeOperationOutcome(err);
             // Only show the first error
             showNotification({
               color: 'red',

--- a/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
+++ b/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
@@ -10,7 +10,7 @@ export interface OperationOutcomeAlertProps {
 
 export function OperationOutcomeAlert(props: OperationOutcomeAlertProps): JSX.Element | null {
   const issues = props.outcome?.issue || props.issues;
-  if (!issues) {
+  if (!issues || issues.length === 0) {
     return null;
   }
   return (

--- a/packages/react/src/auth/NewProjectForm.tsx
+++ b/packages/react/src/auth/NewProjectForm.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Button, Center, Group, Stack, Text, TextInput, Title } from '@mantine/core';
-import { LoginAuthenticationResponse } from '@medplum/core';
+import { LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { Form } from '../Form/Form';
@@ -27,7 +27,7 @@ export function NewProjectForm(props: NewProjectFormProps): JSX.Element {
             })
           );
         } catch (err) {
-          setOutcome(err as OperationOutcome);
+          setOutcome(normalizeOperationOutcome(err));
         }
       }}
     >

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -1,5 +1,5 @@
 import { Anchor, Button, Center, Checkbox, Divider, Group, PasswordInput, Stack, Text, TextInput } from '@mantine/core';
-import { GoogleCredentialResponse, LoginAuthenticationResponse } from '@medplum/core';
+import { GoogleCredentialResponse, LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
 import { Form } from '../Form/Form';
@@ -52,7 +52,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
             })
           );
         } catch (err) {
-          setOutcome(err as OperationOutcome);
+          setOutcome(normalizeOperationOutcome(err));
         }
       }}
     >
@@ -73,7 +73,7 @@ export function NewUserForm(props: NewUserFormProps): JSX.Element {
                     })
                   );
                 } catch (err) {
-                  setOutcome(err as OperationOutcome);
+                  setOutcome(normalizeOperationOutcome(err));
                 }
               }}
             />

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import { LoginAuthenticationResponse } from '@medplum/core';
+import { isOperationOutcome, LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';
@@ -27,7 +27,7 @@ export function RegisterForm(props: RegisterFormProps): JSX.Element {
         .startNewPatient({ login, projectId: projectId as string })
         .then((response) => medplum.processCode(response.code as string))
         .then(() => onSuccess())
-        .catch((err) => setOutcome(err as OperationOutcome));
+        .catch((err) => setOutcome(normalizeOperationOutcome(err)));
     }
   }, [medplum, type, projectId, login, onSuccess]);
 

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import { isOperationOutcome, LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
+import { LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -1,5 +1,5 @@
-import { badRequest, NewUserRequest, Operator } from '@medplum/core';
-import { OperationOutcome, Project, User } from '@medplum/fhirtypes';
+import { badRequest, NewUserRequest, normalizeOperationOutcome, Operator } from '@medplum/core';
+import { Project, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
@@ -104,8 +104,8 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
       userAgent: req.get('User-Agent'),
     });
     res.status(200).json({ login: login.id });
-  } catch (outcome) {
-    sendOutcome(res, outcome as OperationOutcome);
+  } catch (err) {
+    sendOutcome(res, normalizeOperationOutcome(err));
   }
 }
 


### PR DESCRIPTION
The immediate issue is fixing inline errors in the "New User" registration flow.

The deeper issue is that a bunch of React components were casting `err: unknown` to `OperationOutcome` without checking if the `err` is actually an `OperationOutcome`.

That probably worked a long time ago when the components were initially written, because there was a time when we would simply `throw myOperationOutcome`.

Overtime, we adopted the rule that "you can only throw errors", and we introduced `OperationOutcomeError` which is an `Error` that wraps an `OperationOutcome`.

We addressed this at the time with the helper function `normalizeOperationOutcome(error: unknown)`, which is designed to take anything you can throw at it, and make sure that it always returns an `OperationOutcome`.

So, to fix the deeper issue, I went through every case of casting `as OperationOutcome` and replaced with `normalizeOperationOutcome(x)`.  If the original input was an `OperationOutcome`, that is a no-op.  If the input is an `OperationOutcomeError`, it unwraps it.  If it's something else, it converts it to a general purpose "bad" `OperationOutcome`.