### PR TITLE
Deploy sourcemaps

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -29,6 +29,13 @@ aws s3 cp dist/ "s3://${APP_BUCKET}/" \
 
 aws s3 cp dist/ "s3://${APP_BUCKET}/" \
   --recursive \
+  --content-type "application/json" \
+  --cache-control "public, max-age=31536000" \
+  --exclude "*" \
+  --include "*.map"
+
+aws s3 cp dist/ "s3://${APP_BUCKET}/" \
+  --recursive \
   --content-type "text/plain" \
   --cache-control "public, max-age=31536000" \
   --exclude "*" \

--- a/scripts/deploy-graphiql.sh
+++ b/scripts/deploy-graphiql.sh
@@ -31,6 +31,13 @@ aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --include "*.js"
 
 aws s3 cp dist/ s3://graphiql.medplum.com/ \
+  --recursive \
+  --content-type "application/json" \
+  --cache-control "public, max-age=31536000" \
+  --exclude "*" \
+  --include "*.map"
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --region us-east-1 \
   --recursive \
   --content-type "text/plain" \


### PR DESCRIPTION
Start deploying sourcemaps again.

When we converted to ESBuild/Vite, we stopped building sourcemaps: https://github.com/medplum/medplum/pull/2298

Then we brought them back, but didn't deploy them: https://github.com/medplum/medplum/pull/2309

This isn't a big deal, but it (1) makes prod stack traces easier to debug and (2) fixes some benign console warnings.  It makes the deploy slightly slower (because sourcemaps can be big to upload).  But the tradeoff seems worth it.