### PR TITLE
Update lib-storage.ts manual mock to use aws-sdk-client-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -540,6 +540,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+      "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/chunked-blob-reader": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
@@ -1288,6 +1300,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+      "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
     "node_modules/@aws-sdk/hash-blob-browser": {
       "version": "3.357.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.357.0.tgz",
@@ -1527,6 +1551,46 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
+      "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.357.0",
+        "@aws-sdk/protocol-http": "3.357.0",
+        "@aws-sdk/querystring-builder": "3.357.0",
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+      "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.357.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+      "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.363.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.363.0.tgz",
@@ -1588,6 +1652,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-buffer-from": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
@@ -1612,10 +1688,50 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.310.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
       "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream": {
+      "version": "3.360.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
+      "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.357.0",
+        "@aws-sdk/node-http-handler": "3.360.0",
+        "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -23547,6 +23663,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -24023,7 +24140,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -28134,6 +28252,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -35541,6 +35660,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -38682,6 +38802,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -40445,6 +40566,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -40895,6 +41017,7 @@
         "@aws-sdk/cloudfront-signer": "3.363.0",
         "@aws-sdk/lib-storage": "3.363.0",
         "@aws-sdk/types": "3.357.0",
+        "@aws-sdk/util-stream": "^3.360.0",
         "@medplum/core": "*",
         "@medplum/definitions": "*",
         "@medplum/fhir-router": "*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
     "@aws-sdk/cloudfront-signer": "3.363.0",
     "@aws-sdk/lib-storage": "3.363.0",
     "@aws-sdk/types": "3.357.0",
+    "@aws-sdk/util-stream": "^3.360.0",
     "@medplum/core": "*",
     "@medplum/definitions": "*",
     "@medplum/fhir-router": "*",

--- a/packages/server/src/__mocks__/@aws-sdk/client-s3.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-s3.ts
@@ -1,7 +1,0 @@
-export const GetObjectCommand = jest.fn(() => ({}));
-
-export const S3Client = jest.fn(() => ({
-  send: jest.fn(() => ({
-    Body: jest.fn(),
-  })),
-}));

--- a/packages/server/src/__mocks__/@aws-sdk/lib-storage.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/lib-storage.ts
@@ -1,3 +1,0 @@
-export const Upload = jest.fn(() => ({
-  done: jest.fn(),
-}));

--- a/packages/server/src/fhir/storage.test.ts
+++ b/packages/server/src/fhir/storage.test.ts
@@ -1,5 +1,5 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
+import { sdkStreamMixin } from '@aws-sdk/util-stream';
 import { Binary } from '@medplum/fhirtypes';
 import { Request } from 'express';
 import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';

--- a/packages/server/src/fhir/storage.test.ts
+++ b/packages/server/src/fhir/storage.test.ts
@@ -1,23 +1,28 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { Upload } from '@aws-sdk/lib-storage';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import { Binary } from '@medplum/fhirtypes';
 import { Request } from 'express';
+import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';
 import internal, { Readable } from 'stream';
+import 'aws-sdk-client-mock-jest';
+import fs from 'fs';
+
 import { loadTestConfig } from '../config';
 import { getBinaryStorage, initBinaryStorage } from './storage';
 
-jest.mock('@aws-sdk/client-s3');
-jest.mock('@aws-sdk/lib-storage');
-
 describe('Storage', () => {
+  let mockS3Client: AwsClientStub<S3Client>;
+
   beforeAll(async () => {
     await loadTestConfig();
   });
 
   beforeEach(() => {
-    (S3Client as unknown as jest.Mock).mockClear();
-    (Upload as unknown as jest.Mock).mockClear();
-    (GetObjectCommand as unknown as jest.Mock).mockClear();
+    mockS3Client = mockClient(S3Client);
+  });
+
+  afterEach(() => {
+    mockS3Client.restore();
   });
 
   test('Undefined binary storage', () => {
@@ -56,21 +61,13 @@ describe('Storage', () => {
     expect(content).toEqual('foo');
 
     // Make sure we didn't touch S3 at all
-    expect(S3Client).toHaveBeenCalledTimes(0);
-    expect(Upload).toHaveBeenCalledTimes(0);
-    expect(GetObjectCommand).toHaveBeenCalledTimes(0);
+    expect(mockS3Client.send.callCount).toBe(0);
+    expect(mockS3Client).not.toHaveReceivedCommand(PutObjectCommand);
+    expect(mockS3Client).not.toHaveReceivedCommand(GetObjectCommand);
   });
 
   test('S3 storage', async () => {
     initBinaryStorage('s3:foo');
-    expect(S3Client).toHaveBeenCalled();
-
-    const client = (S3Client as unknown as jest.Mock).mock.instances[0];
-    client.send = async () => ({
-      Body: {
-        pipe: jest.fn(),
-      },
-    });
 
     const storage = getBinaryStorage();
     expect(storage).toBeDefined();
@@ -87,33 +84,27 @@ describe('Storage', () => {
     req.push('foo');
     req.push(null);
     (req as any).headers = {};
+
+    const sdkStream = sdkStreamMixin(req);
+    mockS3Client.on(GetObjectCommand).resolves({ Body: sdkStream });
+
     await storage.writeBinary(binary, 'test.txt', 'text/plain', req as Request);
-    expect(Upload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        params: expect.objectContaining({
-          Bucket: 'foo',
-          Key: 'binary/123/456',
-          ContentType: 'text/plain',
-        }),
-      })
-    );
+
+    expect(mockS3Client.send.callCount).toBe(1);
+    expect(mockS3Client).toReceiveCommandWith(PutObjectCommand, {
+      Bucket: 'foo',
+      Key: 'binary/123/456',
+      ContentType: 'text/plain',
+    });
 
     // Read a file
     const stream = await storage.readBinary(binary);
     expect(stream).toBeDefined();
-    expect(GetObjectCommand).toHaveBeenCalled();
+    expect(mockS3Client).toHaveReceivedCommand(GetObjectCommand);
   });
 
   test('Missing metadata', async () => {
     initBinaryStorage('s3:foo');
-    expect(S3Client).toHaveBeenCalled();
-
-    const client = (S3Client as unknown as jest.Mock).mock.instances[0];
-    client.send = async () => ({
-      Body: {
-        pipe: jest.fn(),
-      },
-    });
 
     const storage = getBinaryStorage();
     expect(storage).toBeDefined();
@@ -130,26 +121,26 @@ describe('Storage', () => {
     req.push('foo');
     req.push(null);
     (req as any).headers = {};
+
+    const sdkStream = sdkStreamMixin(req);
+    mockS3Client.on(GetObjectCommand).resolves({ Body: sdkStream });
+
     await storage.writeBinary(binary, '', '', req as Request);
-    expect(Upload).toHaveBeenCalledWith(
-      expect.objectContaining({
-        params: expect.objectContaining({
-          Bucket: 'foo',
-          Key: 'binary/123/456',
-          ContentType: 'application/octet-stream',
-        }),
-      })
-    );
+    expect(mockS3Client.send.callCount).toBe(1);
+    expect(mockS3Client).toReceiveCommandWith(PutObjectCommand, {
+      Bucket: 'foo',
+      Key: 'binary/123/456',
+      ContentType: 'application/octet-stream',
+    });
 
     // Read a file
     const stream = await storage.readBinary(binary);
     expect(stream).toBeDefined();
-    expect(GetObjectCommand).toHaveBeenCalled();
+    expect(mockS3Client).toHaveReceivedCommand(GetObjectCommand);
   });
 
   test('Invalid file extension', async () => {
     initBinaryStorage('s3:foo');
-    expect(S3Client).toHaveBeenCalled();
 
     const storage = getBinaryStorage();
     expect(storage).toBeDefined();
@@ -162,12 +153,11 @@ describe('Storage', () => {
     } catch (err) {
       expect((err as Error).message).toEqual('Invalid file extension');
     }
-    expect(Upload).not.toHaveBeenCalled();
+    expect(mockS3Client).not.toHaveReceivedCommand(PutObjectCommand);
   });
 
   test('Invalid content type', async () => {
     initBinaryStorage('s3:foo');
-    expect(S3Client).toHaveBeenCalled();
 
     const storage = getBinaryStorage();
     expect(storage).toBeDefined();
@@ -180,7 +170,32 @@ describe('Storage', () => {
     } catch (err) {
       expect((err as Error).message).toEqual('Invalid content type');
     }
-    expect(Upload).not.toHaveBeenCalled();
+    expect(mockS3Client).not.toHaveReceivedCommand(PutObjectCommand);
+  });
+
+  test('Should throw an error when file is not found in readBinary()', async () => {
+    initBinaryStorage('file:binary');
+
+    const storage = getBinaryStorage();
+    expect(storage).toBeDefined();
+
+    // Write a file
+    const binary: Binary = {
+      resourceType: 'Binary',
+      id: '123',
+      meta: {
+        versionId: '456',
+      },
+    };
+
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    try {
+      const stream = await storage.readBinary(binary);
+      expect(stream).not.toBeDefined();
+    } catch (err) {
+      expect((err as Error).message).toEqual('File not found');
+    }
   });
 });
 


### PR DESCRIPTION
This pull request includes the following commits:

Delete client-s3.ts: This commit removes the client-S3.ts file from the repository. It is no longer needed and can be safely deleted.

Delete lib-storage.ts: This commit removes the lib-storage.ts file from the repository. It is no longer needed and can be safely deleted.

Update storage.test.ts to use aws-sdk-client-mock: This commit modifies the storage.test.ts file to utilize the aws-sdk-client-mock library for mocking AWS SDK calls.

[#1423]