### PR TITLE
Fixes #2374 - updated jest babel config

### DIFF
--- a/packages/app/babel.config.json
+++ b/packages/app/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript", "babel-preset-vite"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-react", "@babel/preset-typescript", "babel-preset-vite"]
 }

--- a/packages/cdk/babel.config.json
+++ b/packages/cdk/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/cli/babel.config.json
+++ b/packages/cli/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/core/babel.config.json
+++ b/packages/core/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/definitions/babel.config.json
+++ b/packages/definitions/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/fhir-router/babel.config.json
+++ b/packages/fhir-router/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/generator/babel.config.json
+++ b/packages/generator/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/mock/babel.config.json
+++ b/packages/mock/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/react/babel.config.json
+++ b/packages/react/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-react", "@babel/preset-typescript"]
 }

--- a/packages/server/babel.config.json
+++ b/packages/server/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [["@babel/preset-env", { "targets": { "node": "current" } }], "@babel/preset-typescript"]
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -48,6 +48,7 @@ import { randomUUID } from 'crypto';
 import { Pool, PoolClient } from 'pg';
 import { applyPatch, Operation } from 'rfc6902';
 import validator from 'validator';
+import { getConfig } from '../config';
 import { getClient } from '../database';
 import { logger } from '../logger';
 import { getRedis } from '../redis';


### PR DESCRIPTION
Updating our babel config to Jest recommendation:

https://jestjs.io/docs/getting-started#using-typescript

> Then add @babel/preset-typescript to the list of presets in your babel.config.js.
> 
> ```babel.config.js
> module.exports = {
>   presets: [
>     ['@babel/preset-env', {targets: {node: 'current'}}],
>     '@babel/preset-typescript',
>   ],
> };
> ```

We only use Babel for Jest, this does not affect production runtime at all.

What this will do is give better stack traces on test errors.