### PR TITLE
Add `~` to SearchControl count to indicate estimated counts

### DIFF
--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -173,13 +173,13 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         search.resourceType as ResourceType,
         formatSearchQuery({ ...search, total: totalType, fields: undefined })
       )
-      .then((response: Bundle) => {
+      .then((response) => {
         setState({ ...stateRef.current, searchResponse: response });
         if (onLoad) {
           onLoad(new SearchLoadEvent(response));
         }
       })
-      .catch((reason: any) => {
+      .catch((reason) => {
         setState({ ...stateRef.current, searchResponse: undefined });
         setOutcome(reason);
       });

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -163,24 +163,27 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   const stateRef = useRef<SearchControlState>(state);
   stateRef.current = state;
 
+  const totalType = search.total ?? 'estimate';
+
   useEffect(() => {
     setOutcome(undefined);
+
     medplum
       .search(
         search.resourceType as ResourceType,
-        formatSearchQuery({ ...search, total: search.total ?? 'estimate', fields: undefined })
+        formatSearchQuery({ ...search, total: totalType, fields: undefined })
       )
-      .then((response) => {
+      .then((response: Bundle) => {
         setState({ ...stateRef.current, searchResponse: response });
         if (onLoad) {
           onLoad(new SearchLoadEvent(response));
         }
       })
-      .catch((reason) => {
+      .catch((reason: any) => {
         setState({ ...stateRef.current, searchResponse: undefined });
         setOutcome(reason);
       });
-  }, [medplum, search, onLoad]);
+  }, [medplum, search, totalType, onLoad]);
 
   function handleSingleCheckboxClick(e: React.ChangeEvent, id: string): void {
     e.stopPropagation();
@@ -369,7 +372,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
           {lastResult && (
             <Text size="xs" color="dimmed">
               {getStart(search, lastResult.total as number)}-{getEnd(search, lastResult.total as number)} of{' '}
-              {lastResult.total?.toLocaleString()}
+              {`${totalType === 'estimate' ? '~' : ''}${lastResult.total?.toLocaleString()}`}
             </Text>
           )}
         </Group>


### PR DESCRIPTION
Fixes #2371

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 52154cb</samp>

### Summary
🔎📊🔄

<!--
1.  🔎 for improving the search control component
2.  📊 for adding support for exact and estimated counts
3.  🔄 for re-triggering the search when the count mode changes
-->
Enhance `SearchControl` component with count modes and UI updates. Allow users to switch between exact and estimated counts, and show a tilde for estimates.

> _Sing, O Muse, of the search control's mighty deeds_
> _That `search-control`, the swift and skillful finder_
> _Who by his code could show the exact or vague results_
> _Of queries, like Apollo's arrows or the sands of the shore_

### Walkthrough
*  Trigger search when `totalType` changes and add type annotations for callbacks ([link](https://github.com/medplum/medplum/pull/2380/files?diff=unified&w=0#diff-89fd9380909bac02d207431ecc0adfe8a511ca3d8ad8403625ec1bd7c591b164L166-R176), [link](https://github.com/medplum/medplum/pull/2380/files?diff=unified&w=0#diff-89fd9380909bac02d207431ecc0adfe8a511ca3d8ad8403625ec1bd7c591b164L179-R186))
*  Prefix total count with tilde if `totalType` is `estimate` in `SearchControl.tsx` ([link](https://github.com/medplum/medplum/pull/2380/files?diff=unified&w=0#diff-89fd9380909bac02d207431ecc0adfe8a511ca3d8ad8403625ec1bd7c591b164L372-R375))


