### PR TITLE
Update client-sesv2 manual mock to use aws-sdk-client-mock

### DIFF
--- a/packages/server/src/__mocks__/@aws-sdk/client-sesv2.ts
+++ b/packages/server/src/__mocks__/@aws-sdk/client-sesv2.ts
@@ -1,4 +1,0 @@
-export const SendEmailCommand = jest.fn(() => ({}));
-export const SESv2Client = jest.fn(() => ({
-  send: jest.fn(),
-}));

--- a/packages/server/src/auth/profile.test.ts
+++ b/packages/server/src/auth/profile.test.ts
@@ -9,6 +9,8 @@ import { loadTestConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
 import { registerNew } from './register';
 
+jest.mock('@aws-sdk/client-sesv2');
+
 const app = express();
 const email = `multi${randomUUID()}@example.com`;
 const password = randomUUID();

--- a/packages/server/src/auth/revoke.test.ts
+++ b/packages/server/src/auth/revoke.test.ts
@@ -8,6 +8,8 @@ import { tryLogin } from '../oauth/utils';
 import { registerNew } from './register';
 import { setPassword } from './setpassword';
 
+jest.mock('@aws-sdk/client-sesv2');
+
 const app = express();
 
 describe('Revoke', () => {

--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -13,6 +13,8 @@ import { systemRepo } from '../fhir/repo';
 import { createTestProject } from '../test.setup';
 import { revokeLogin } from './utils';
 
+jest.mock('@aws-sdk/client-sesv2');
+
 const app = express();
 const email = randomUUID() + '@example.com';
 const password = randomUUID();

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -15,6 +15,7 @@ import { createTestProject } from '../test.setup';
 import { generateSecret } from './keys';
 import { hashCode } from './token';
 
+jest.mock('@aws-sdk/client-sesv2');
 jest.mock('jose', () => {
   const core = jest.requireActual('@medplum/core');
   const original = jest.requireActual('jose');


### PR DESCRIPTION
This pull request includes the following update:

Delete client-sesv2.ts: This commit removes the client-sesv2.ts file from the repository. It is no longer needed and can be safely deleted.

Update email.test.ts and invite.test.ts to use aws-sdk-client-mock

Mock client-sesv2 in other files using invite.test.ts or email.test.ts indirectly

[#1423]