### PR TITLE
Perf improvement to getTypedPropertyValue

### DIFF
--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -64,10 +64,7 @@ export function getTypedPropertyValue(input: TypedValue, path: string): TypedVal
 
   const elementDefinition = getElementDefinition(input.type, path);
   if (elementDefinition) {
-    const typedResult = getTypedPropertyValueWithSchema(input, path, elementDefinition);
-    if (typedResult) {
-      return typedResult;
-    }
+    return getTypedPropertyValueWithSchema(input, path, elementDefinition);
   }
 
   return getTypedPropertyValueWithoutSchema(input, path);


### PR DESCRIPTION
Context:
* `getTypedPropertyValue` is an internal helper for getting property values, and handling all of the FHIR complexity of "choice of type" (e.g., `value[x]` properties)
* There are actually 2 implementations of `getTypedPropertyValue`
* `getTypedPropertyValueWithSchema` when we have a schema loaded
* `getTypedPropertyValueWithoutSchema` when we don't have a schema loaded

Before:
* We would call `getTypedPropertyValueWithSchema`
* But, if it returned `undefined`, we would also call `getTypedPropertyValueWithoutSchema`
* That was done for this PR: https://github.com/medplum/medplum/pull/708

After:
* We only call `getTypedPropertyValueWithSchema` or `getTypedPropertyValueWithoutSchema`
* The tests from that PR still pass
* This is a significant speedup for the happy path `getTypedPropertyValueWithSchema`
* That's because `getTypedPropertyValueWithoutSchema` is significantly slower, because it has to do a more exhaustive search in the case of "choice of type" (e.g., `value[x]` properties)