### PR TITLE
Add merge group CI triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 jobs:
   build:
     name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,6 +21,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '30 14 * * 4'
 


### PR DESCRIPTION
Adding the necessary configuration to run our GitHub Action CI checks as part of a merge queue.  After this PR is merged, we should be able to enable the merge queue in the `main` branch protection rules