### PR TITLE
Added jwt bearer token auth to MedplumClient

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -572,6 +572,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result1 = await client.startJwtBearerLogin('test-client-id', 'test-client-secret', 'openid profile');
     expect(result1).toBeDefined();
+    expect(result1).toMatchObject({ resourceType: 'ClientApplication' });
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -14,7 +14,7 @@ import { TextEncoder } from 'util';
 import { encodeBase64 } from './base64';
 import { FetchLike, InviteBody, MedplumClient, NewPatientRequest, NewProjectRequest, NewUserRequest } from './client';
 import { getStatus, isOperationOutcome, notFound, OperationOutcomeError, unauthorized } from './outcomes';
-import { createReference, ProfileResource, stringify } from './utils';
+import { createReference, ProfileResource } from './utils';
 
 const patientStructureDefinition: StructureDefinition = {
   resourceType: 'StructureDefinition',
@@ -140,7 +140,7 @@ describe('Client', () => {
     window.localStorage.setItem(
       'activeLogin',
       JSON.stringify({
-        accessToken: '123',
+        accessToken: createFakeJwt({ client_id: '123', login_id: '123' }),
         refreshToken: '456',
         project: {
           reference: 'Project/123',
@@ -154,8 +154,8 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
+          access_token: createFakeJwt({ client_id: '123', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: '123' }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -197,7 +197,7 @@ describe('Client', () => {
     window.localStorage.setItem(
       'activeLogin',
       JSON.stringify({
-        accessToken: '123',
+        accessToken: createFakeJwt({ client_id: '123', login_id: '123' }),
         refreshToken: '456',
         project: {
           reference: 'Project/123',
@@ -211,8 +211,8 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
+          access_token: createFakeJwt({ client_id: '123', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: '123' }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -278,8 +278,8 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
+          access_token: createFakeJwt({ client_id: '123', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: '123' }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -352,8 +352,8 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(stringify({ client_id: clientId })) + '.signature',
-          refresh_token: 'header.' + window.btoa(stringify({ client_id: clientId })) + '.signature',
+          access_token: createFakeJwt({ client_id: clientId, login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: clientId }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -378,8 +378,8 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(stringify({ client_id: clientId2 })) + '.signature',
-          refresh_token: 'header.' + window.btoa(stringify({ client_id: clientId2 })) + '.signature',
+          access_token: createFakeJwt({ client_id: clientId2, login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: clientId2 }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -434,8 +434,8 @@ describe('Client', () => {
       }
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
+          access_token: createFakeJwt({ client_id: '123', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: '123' }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -480,8 +480,8 @@ describe('Client', () => {
       }
       if (url.includes('/oauth2/token')) {
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
+          access_token: createFakeJwt({ client_id: '123', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: '123' }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -530,8 +530,8 @@ describe('Client', () => {
       if (url.includes('oauth2/token')) {
         tokenExpired = false;
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: 'test-client-id' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: 'test-client-id' })) + '.signature',
+          access_token: createFakeJwt({ client_id: 'test-client-id', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: 'test-client-id' }),
           profile: { reference: 'ClientApplication/123' },
         };
       }
@@ -612,7 +612,7 @@ describe('Client', () => {
     const patientId = randomUUID();
     const clientId = 'test-client-id';
     const clientSecret = 'test-client-secret';
-    const accessToken = 'header.' + Buffer.from(JSON.stringify({ cid: clientId })).toString('base64') + '.signature';
+    const accessToken = createFakeJwt({ cid: clientId });
     const fetch = mockFetch(200, (url) => {
       if (url.includes(`Patient/${patientId}`)) {
         return { resourceType: 'Patient', id: patientId };
@@ -660,7 +660,7 @@ describe('Client', () => {
     const patientId = randomUUID();
     const clientId = 'test-client-id';
     const clientSecret = 'test-client-secret';
-    const accessToken = 'header.' + Buffer.from(JSON.stringify({ cid: clientId })).toString('base64') + '.signature';
+    const accessToken = createFakeJwt({ cid: clientId });
     const fetch = mockFetch(200, (url) => {
       if (url.includes(`Patient/${patientId}`)) {
         return { resourceType: 'Patient', id: patientId };
@@ -735,8 +735,7 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('oauth2/token')) {
         return {
-          access_token:
-            'header.' + Buffer.from(JSON.stringify({ cid: 'different-client-id' })).toString('base64') + '.signature',
+          access_token: createFakeJwt({ cid: 'different-client-id' }),
         };
       }
       return {};
@@ -773,8 +772,7 @@ describe('Client', () => {
     const fetch = mockFetch(200, (url) => {
       if (url.includes('oauth2/token')) {
         return {
-          access_token:
-            'header.' + Buffer.from(JSON.stringify({ exp: oneMinuteAgo })).toString('base64') + '.signature',
+          access_token: createFakeJwt({ exp: oneMinuteAgo }),
         };
       }
       return {};
@@ -829,8 +827,8 @@ describe('Client', () => {
       if (url.includes('oauth2/token')) {
         tokenExpired = false;
         return {
-          access_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
-          refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: '123' })) + '.signature',
+          access_token: createFakeJwt({ client_id: '123', login_id: '123' }),
+          refresh_token: createFakeJwt({ client_id: '123' }),
           profile: { reference: 'Patient/123' },
         };
       }
@@ -2277,6 +2275,10 @@ function createPdf(
     pdfDoc.on('error', reject);
     pdfDoc.end();
   });
+}
+
+function createFakeJwt(claims: Record<string, string | number>): string {
+  return 'header.' + window.btoa(JSON.stringify(claims)) + '.signature';
 }
 
 function fail(message: string): never {

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -26,3 +26,18 @@ export function parseJWTPayload(token: string): Record<string, number | string> 
   const [_header, payload, _signature] = token.split('.');
   return decodePayload(payload);
 }
+
+/**
+ * Returns true if the access token was issued by a Medplum server.
+ * @param accessToken An access token of unknown origin.
+ * @returns True if the access token was issued by a Medplum server.
+ */
+export function isMedplumAccessToken(accessToken: string): boolean {
+  try {
+    const payload = parseJWTPayload(accessToken);
+    const loginId = payload.login_id;
+    return typeof loginId === 'string';
+  } catch (err) {
+    return false;
+  }
+}

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -70,7 +70,8 @@ function mockFetch(url: string, options: any): Promise<any> {
   } else if (options.method === 'POST' && url.endsWith('/oauth2/token')) {
     status = 200;
     result = {
-      access_token: 'header.' + window.btoa(JSON.stringify({ client_id: 'my-client-id' })) + '.signature',
+      access_token:
+        'header.' + window.btoa(JSON.stringify({ client_id: 'my-client-id', login_id: '123' })) + '.signature',
       refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: 'my-client-id' })) + '.signature',
       expires_in: 1,
       token_type: 'Bearer',

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -118,7 +118,8 @@ function mockFetch(url: string, options: any): Promise<any> {
   } else if (options.method === 'POST' && url.endsWith('/oauth2/token')) {
     status = 200;
     result = {
-      access_token: 'header.' + window.btoa(JSON.stringify({ client_id: 'my-client-id' })) + '.signature',
+      access_token:
+        'header.' + window.btoa(JSON.stringify({ client_id: 'my-client-id', login_id: '123' })) + '.signature',
       refresh_token: 'header.' + window.btoa(JSON.stringify({ client_id: 'my-client-id' })) + '.signature',
       expires_in: 1,
       token_type: 'Bearer',


### PR DESCRIPTION
1. Added support for `urn:ietf:params:oauth:grant-type:jwt-bearer`
2. Added a `isMedplumAccessToken` helper to determine if using `MedplumClient` with a Medplum server vs generic FHIR server
3. Only do special Medplum stuff (lookup profile, access policies, etc) if using a Medplum server

This is in service of accessing the Health Gorilla FHIR API using `MedplumClient`, although it would apply to any FHIR server that requires "client assertion" JWT bearer tokens.