### PR TITLE
Adding tests to confirm hidden fields behavior

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -5,7 +5,6 @@ import {
   canWriteResourceType,
   deepEquals,
   evalFhirPath,
-  validate,
   forbidden,
   formatSearchQuery,
   getSearchParameterDetails,
@@ -28,6 +27,7 @@ import {
   SearchRequest,
   stringify,
   tooManyRequests,
+  validate,
   validateResourceType,
 } from '@medplum/core';
 import { BaseRepository, FhirRepository } from '@medplum/fhir-router';
@@ -1587,6 +1587,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    */
   private removeField<T extends Resource>(input: T, path: string): T {
     const patch: Operation[] = [{ op: 'remove', path: `/${path.replaceAll('.', '/')}` }];
+    // applyPatch returns errors if the value is missing
+    // but we don't care if the value is missing in this case
     applyPatch(input, patch);
     return input;
   }


### PR DESCRIPTION
Thankfully this test passed without code modification.  However... it's a pretty critical case, so I wanted to add an explicit test.

JSONPatch `remove` requires that the removed field actually be there.  If it's not there, then it is an error.

`applyPatch` does return an error.  We just were not checking it.

Now adding comments and an explicit test in case we ever change JSONPatch implementations (which we have done before).