### PR TITLE
Change SearchControl to default to accurate

### DIFF
--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -163,7 +163,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   const stateRef = useRef<SearchControlState>(state);
   stateRef.current = state;
 
-  const totalType = search.total ?? 'estimate';
+  const totalType = search.total ?? 'accurate';
 
   useEffect(() => {
     setOutcome(undefined);


### PR DESCRIPTION
We tried defaulting to `estimate`, but our estimates were not accurate enough, which led to bad behavior in SearchControl pagination.

This PR also includes some common sense improvements to `estimate`, such as "the estimated count should always be at least as many rows as we've found".

We should revisit this in the future once after https://github.com/medplum/medplum/issues/2092