### PR TITLE
Add bundle to resource array in MedplumClient

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1496,6 +1496,8 @@ describe('Client', () => {
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
     expect(result[0].resourceType).toBe('Patient');
+    expect(result.bundle).toBeDefined();
+    expect(result.bundle.resourceType).toBe('Bundle');
   });
 
   test('Search resources with record of params', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -246,6 +246,13 @@ export interface FetchLike {
  */
 export type QueryTypes = URLSearchParams | string[][] | Record<string, any> | string | undefined;
 
+/**
+ * ResourceArray is an array of resources with a bundle property.
+ * The bundle property is a FHIR Bundle containing the search results.
+ * This is useful for retrieving bundle metadata such as total, offset, and next link.
+ */
+export type ResourceArray<T extends Resource = Resource> = T[] & { bundle: Bundle<T> };
+
 export interface CreatePdfFunction {
   (
     docDefinition: TDocumentDefinitions,
@@ -1196,18 +1203,14 @@ export class MedplumClient extends EventTarget {
     resourceType: K,
     query?: QueryTypes,
     options?: RequestInit
-  ): ReadablePromise<ExtractResource<K>[]> {
+  ): ReadablePromise<ResourceArray<ExtractResource<K>>> {
     const url = this.fhirSearchUrl(resourceType, query);
     const cacheKey = url.toString() + '-searchResources';
     const cached = this.getCacheEntry(cacheKey, options);
     if (cached) {
       return cached.value;
     }
-    const promise = new ReadablePromise(
-      this.search<K>(resourceType, query, options).then(
-        (b) => b.entry?.map((e) => e.resource as ExtractResource<K>) ?? []
-      )
-    );
+    const promise = new ReadablePromise(this.search<K>(resourceType, query, options).then(bundleToResourceArray));
     this.setCacheEntry(cacheKey, promise);
     return promise;
   }
@@ -1236,7 +1239,7 @@ export class MedplumClient extends EventTarget {
     resourceType: K,
     query?: QueryTypes,
     options?: RequestInit
-  ): AsyncGenerator<ExtractResource<K>[]> {
+  ): AsyncGenerator<ResourceArray<ExtractResource<K>>> {
     let url: URL | undefined = this.fhirSearchUrl(resourceType, query);
 
     while (url) {
@@ -1247,7 +1250,7 @@ export class MedplumClient extends EventTarget {
         break;
       }
 
-      yield bundle.entry?.map((e) => e.resource as ExtractResource<K>) ?? [];
+      yield bundleToResourceArray(bundle);
       url = nextLink?.url ? new URL(nextLink.url) : undefined;
     }
   }
@@ -2965,4 +2968,15 @@ async function tryGetContentLocation(response: Response): Promise<string | undef
 
   // If all else fails, return undefined.
   return undefined;
+}
+
+/**
+ * Converts a FHIR resource bundle to a resource array.
+ * The bundle is attached to the array as a property named "bundle".
+ * @param bundle A FHIR resource bundle.
+ * @returns The resource array with the bundle attached.
+ */
+function bundleToResourceArray<T extends Resource>(bundle: Bundle<T>): ResourceArray<T> {
+  const array = bundle.entry?.map((e) => e.resource as T) ?? [];
+  return Object.assign(array, { bundle });
 }

--- a/packages/docs/docs/search/basic-search.mdx
+++ b/packages/docs/docs/search/basic-search.mdx
@@ -76,6 +76,8 @@ Because iterating over the `Bundle.entry` array is such a common pattern, the Me
   {ExampleCode}
 </MedplumCodeBlock>
 
+The array returned by `searchResources` also includes a `bundle` property that contains the original `Bundle` resource. You can use this to access bundle metadata such as `Bundle.total` and `Bundle.link`.
+
 ## Searching Multiple Criteria
 
 You can perform and AND search by specifying multiple query parameters

--- a/packages/docs/docs/search/paginated-search.mdx
+++ b/packages/docs/docs/search/paginated-search.mdx
@@ -127,6 +127,8 @@ The [`searchResourcePages()`](/docs/sdk/classes/MedplumClient#searchresourcepage
   {ExampleCode}
 </MedplumCodeBlock>
 
+The array returned by `searchResourcePages` also includes a `bundle` property that contains the original `Bundle` resource. You can use this to access bundle metadata such as `Bundle.total` and `Bundle.link`.
+
 ## Conclusion
 
 In this guide, we've discussed how to perform paginated search queries using the `_count` and `_offset` search parameters, as well as the the `Bundle.link` element.


### PR DESCRIPTION
Context: https://medplum.slack.com/archives/C04A55B3VU5/p1689171579275589

This adds a `.bundle` property to search arrays.  Example usage:

```ts
const array = await medplum.searchResources('Patient', { name: 'alice' });

// You can now use .bundle.total to get total results
console.log('total', array.bundle.total);

// You can continue to use the array as normal
for (const patient of array) {
    console.log(patient);
}
```