### PR TITLE
Automatically restart redis docker container on local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - '5432:5432'
   redis:
     image: redis:6
+    restart: always
     command: redis-server --requirepass medplum
     ports:
       - '6379:6379'


### PR DESCRIPTION
This is a minor convenience improvement to automatically restart the Redis docker container.

For example, if you reboot your dev machine, the Redis container will automatically restart.

We already did this for Postgres, probably due to lucky copy pasting at the time ([2021!](https://github.com/medplum/medplum/commit/a9d38a028f7491a27b4041efdfbeb93786b149ee))