### PR TITLE
fix: make `config.binaryStorage` optional

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -15,7 +15,7 @@ export interface MedplumServerConfig {
   userInfoUrl: string;
   appBaseUrl: string;
   logLevel?: string;
-  binaryStorage: string;
+  binaryStorage?: string;
   storageBaseUrl: string;
   signingKey: string;
   signingKeyId: string;

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -8,10 +8,10 @@ import { getConfig } from '../config';
 
 let binaryStorage: BinaryStorage | undefined = undefined;
 
-export function initBinaryStorage(type: string): void {
-  if (type.startsWith('s3:')) {
+export function initBinaryStorage(type?: string): void {
+  if (type?.startsWith('s3:')) {
     binaryStorage = new S3Storage(type.replace('s3:', ''));
-  } else if (type.startsWith('file:')) {
+  } else if (type?.startsWith('file:')) {
     binaryStorage = new FileSystemStorage(type.replace('file:', ''));
   } else {
     binaryStorage = undefined;


### PR DESCRIPTION
👋🏽 hello! Really enjoying working with Medplum so far.

One small thing noticed while playing around & getting set up is that binaryStorage can be optionally undefined, but is required to be configured. 