### PR TITLE
Only use github secrets in deploy step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,6 @@ jobs:
       - name: Build Project
         run: ./scripts/build.sh
         env:
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          MEDPLUM_BASE_URL: ${{ secrets.MEDPLUM_BASE_URL }}
-          MEDPLUM_CLIENT_ID: ${{ secrets.MEDPLUM_CLIENT_ID }}
-          MEDPLUM_INTROSPECTION_URL: ${{ secrets.MEDPLUM_INTROSPECTION_URL }}
-          RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
           POSTGRES_HOST: localhost
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
       - name: Coveralls GitHub Action
@@ -94,4 +89,7 @@ jobs:
           DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}
           ECS_CLUSTER: ${{ secrets.ECS_CLUSTER }}
           ECS_SERVICE: ${{ secrets.ECS_SERVICE }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          MEDPLUM_BASE_URL: ${{ secrets.MEDPLUM_BASE_URL }}
           MEDPLUM_INTROSPECTION_URL: ${{ secrets.MEDPLUM_INTROSPECTION_URL }}
+          RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -87,15 +87,18 @@ fi
 
 if [[ "$DEPLOY_APP" = true ]]; then
   echo "Deploy app"
+  npm run build -- --force --filter=@medplum/app
   source ./scripts/deploy-app.sh
 fi
 
 if [[ "$DEPLOY_GRAPHIQL" = true ]]; then
   echo "Deploy GraphiQL"
+  npm run build -- --force --filter=@medplum/graphiql
   source ./scripts/deploy-graphiql.sh
 fi
 
 if [[ "$DEPLOY_SERVER" = true ]]; then
   echo "Deploy server"
+  npm run build -- --force --filter=@medplum/server
   source ./scripts/deploy-server.sh
 fi


### PR DESCRIPTION
This fixes PR's from forked repositories.

See an example of a broken PR: https://github.com/medplum/medplum/actions/runs/5547932829/jobs/10131846794?pr=2458

What happened?
1. One of our amazing contributors opened a PR from a forked repository
2. Github Actions started a build process
3. Our build script set some environment variables with values from Github Secrets
4. HOWEVER, when building a branch from a forked repository, Github Secrets are blanked out, so the env var is empty string
5. We recently changed many instances of `||` to `??`
6. One such case is here: https://github.com/medplum/medplum/blob/main/packages/cli/src/util/client.ts#L5
    a. Before the empty value would fail `||` and fall back to the default value
    b. But when using `??` the empty string is used as the value
7. This caused a test failure, only for PRs from forked repositories

The fix is to not use any Github Secrets in the build step.  We can rebuild when deploying.