### PR TITLE
Fixes full truth table for FHIRPath 'or' atom

### DIFF
--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -1,9 +1,9 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle, Observation } from '@medplum/fhirtypes';
+import { AtomContext } from '../fhirlexer';
 import { indexStructureDefinitionBundle, PropertyType } from '../types';
 import { LiteralAtom, SymbolAtom } from './atoms';
 import { evalFhirPath, parseFhirPath } from './parse';
-import { AtomContext } from '../fhirlexer';
 
 let context: AtomContext;
 
@@ -50,6 +50,20 @@ describe('Atoms', () => {
   test('UnionAtom', () => {
     expect(evalFhirPath('{} | {}', [])).toEqual([]);
     expect(evalFhirPath('x | y', [])).toEqual([]);
+  });
+
+  test.each([
+    ['true or true', [true]],
+    ['true or false', [true]],
+    ['true or {}', [true]],
+    ['false or true', [true]],
+    ['false or false', [false]],
+    ['false or {}', []],
+    ['{} or true', [true]],
+    ['{} or false', []],
+    ['{} or {}', []],
+  ])('OrAtom: %s to equal %s', (input: any, expected: any) => {
+    expect(evalFhirPath(input, [])).toEqual(expected);
   });
 
   test.each([

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -1,5 +1,5 @@
 import { Atom, AtomContext, InfixOperatorAtom, PrefixOperatorAtom } from '../fhirlexer';
-import { PropertyType, TypedValue, isResource } from '../types';
+import { isResource, PropertyType, TypedValue } from '../types';
 import { functions } from './functions';
 import {
   booleanToTypedValue,
@@ -10,7 +10,6 @@ import {
   getTypedPropertyValue,
   isQuantity,
   removeDuplicates,
-  toJsBoolean,
   toTypedValue,
 } from './utils';
 
@@ -308,6 +307,12 @@ export class AndAtom extends BooleanInfixOperatorAtom {
   }
 }
 
+/**
+ * 6.5.2. or
+ * Returns false if both operands evaluate to false,
+ * true if either operand evaluates to true,
+ * and empty ({ }) otherwise:
+ */
 export class OrAtom extends BooleanInfixOperatorAtom {
   constructor(left: Atom, right: Atom) {
     super('or', left, right);
@@ -315,15 +320,13 @@ export class OrAtom extends BooleanInfixOperatorAtom {
 
   eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
     const leftValue = this.left.eval(context, input);
-    if (toJsBoolean(leftValue)) {
-      return leftValue;
-    }
-
     const rightValue = this.right.eval(context, input);
-    if (toJsBoolean(rightValue)) {
-      return rightValue;
+    if (leftValue[0]?.value === false && rightValue[0]?.value === false) {
+      return booleanToTypedValue(false);
     }
-
+    if (leftValue[0]?.value === true || rightValue[0]?.value === true) {
+      return booleanToTypedValue(true);
+    }
     return [];
   }
 }

--- a/packages/core/src/fhirpath/parse.test.ts
+++ b/packages/core/src/fhirpath/parse.test.ts
@@ -595,4 +595,17 @@ describe('FHIRPath parser', () => {
       },
     ]);
   });
+
+  test('ValueSet vsd-2', () => {
+    const expr = '(concept.exists() or filter.exists()) implies system.exists()';
+    const system = 'http://example.com';
+    const concept = [{ code: 'foo' }];
+    const filter = [{ property: 'bar', op: 'eq', value: 'baz' }];
+    expect(evalFhirPath(expr, {})).toEqual([true]);
+    expect(evalFhirPath(expr, { concept })).toEqual([false]);
+    expect(evalFhirPath(expr, { concept, filter })).toEqual([false]);
+    expect(evalFhirPath(expr, { filter })).toEqual([false]);
+    expect(evalFhirPath(expr, { concept, system })).toEqual([true]);
+    expect(evalFhirPath(expr, { concept, filter, system })).toEqual([true]);
+  });
 });


### PR DESCRIPTION
The `ValueSet` constraint `vsd-2` is failing.

The expression is:  `(concept.exists() or filter.exists()) implies system.exists()`

The problem is that there was a bug in our FHIRPath `or` atom, where `concept.exists() or filter.exists()` resulted in `{}` (empty) rather than `false`, which then failed the `implies` operator.

This PR fixes the `or` atom, and adds tests for `ValueSet vsd-2`

cc @mattwiller 