### PR TITLE
Fix #2481 - _include and _revinclude in search query

### DIFF
--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -250,4 +250,27 @@ describe('Search Utils', () => {
       })
     ).toEqual('?code:not=x');
   });
+
+  test('Format token not', () => {
+    expect(
+      formatSearchQuery({
+        resourceType: 'Condition',
+        filters: [{ code: 'code', operator: Operator.NOT, value: 'x' }],
+      })
+    ).toEqual('?code:not=x');
+  });
+
+  test('Format _include', () => {
+    expect(
+      formatSearchQuery({
+        resourceType: 'Patient',
+        include: [
+          {
+            resourceType: 'Patient',
+            searchParam: 'organization',
+          },
+        ],
+      })
+    ).toEqual('?_include=Patient:organization');
+  });
 });

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -450,6 +450,14 @@ export function formatSearchQuery(definition: SearchRequest): string {
     params.push('_total=' + definition.total);
   }
 
+  if (definition.include) {
+    definition.include.forEach((target) => params.push(formatIncludeTarget('_include', target)));
+  }
+
+  if (definition.revInclude) {
+    definition.revInclude.forEach((target) => params.push(formatIncludeTarget('_revinclude', target)));
+  }
+
   if (params.length === 0) {
     return '';
   }
@@ -466,4 +474,10 @@ function formatFilter(filter: Filter): string {
 
 function formatSortRules(sortRules: SortRule[]): string {
   return '_sort=' + sortRules.map((sr) => (sr.descending ? '-' + sr.code : sr.code)).join(',');
+}
+
+function formatIncludeTarget(kind: '_include' | '_revinclude', target: IncludeTarget): string {
+  return (
+    kind + '=' + target.resourceType + ':' + target.searchParam + (target.targetType ? ':' + target.targetType : '')
+  );
 }


### PR DESCRIPTION
This PR fixes #2481.

The bug seemed to originate from the `@medplum/core` `formatSearchQuery` method that is used to build
the `link` search url on the server.

This PR simply adds support for `_include` and `_revinclude` parameters to build the search query.