### PR TITLE
Fixes #1790 - Merge /invite and project membership

### DIFF
--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, Group, List, NativeSelect, Stack, Text, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { InviteBody, isOperationOutcome, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
+import { InviteRequest, isOperationOutcome, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { AccessPolicy, OperationOutcome, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Form, FormSection, MedplumLink, ResourceInput, getErrorsForInput, useMedplum } from '@medplum/react';
 import React, { useCallback, useState } from 'react';
@@ -26,7 +26,7 @@ export function InvitePage(): JSX.Element {
         admin: formData.isAdmin === 'on',
       };
       medplum
-        .invite(project?.id as string, body as InviteBody)
+        .invite(project?.id as string, body as InviteRequest)
         .then((response: ProjectMembership | OperationOutcome) => {
           medplum.invalidateSearches('Patient');
           medplum.invalidateSearches('Practitioner');

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -1,4 +1,4 @@
-import { InviteBody, LoginState, MedplumClient } from '@medplum/core';
+import { InviteRequest, LoginState, MedplumClient } from '@medplum/core';
 import { Command, Option } from 'commander';
 import { createMedplumClient } from './util/client';
 import { createMedplumCommand } from './util/command';
@@ -67,7 +67,7 @@ projectInviteCommand
     }
 
     const projectId = login.project.reference.split('/')[1];
-    const inviteBody: InviteBody = {
+    const inviteBody: InviteRequest = {
       resourceType: options.role,
       firstName,
       lastName,
@@ -89,7 +89,7 @@ async function switchProject(medplum: MedplumClient, projectId: string): Promise
   }
 }
 
-async function inviteUser(projectId: string, inviteBody: InviteBody, medplum: MedplumClient): Promise<void> {
+async function inviteUser(projectId: string, inviteBody: InviteRequest, medplum: MedplumClient): Promise<void> {
   try {
     await medplum.invite(projectId, inviteBody);
     if (inviteBody.sendEmail) {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -12,7 +12,14 @@ import PdfPrinter from 'pdfmake';
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
 import { TextEncoder } from 'util';
 import { encodeBase64 } from './base64';
-import { FetchLike, InviteBody, MedplumClient, NewPatientRequest, NewProjectRequest, NewUserRequest } from './client';
+import {
+  FetchLike,
+  InviteRequest,
+  MedplumClient,
+  NewPatientRequest,
+  NewProjectRequest,
+  NewUserRequest,
+} from './client';
 import { getStatus, isOperationOutcome, notFound, OperationOutcomeError, unauthorized } from './outcomes';
 import { createReference, ProfileResource } from './utils';
 
@@ -813,7 +820,7 @@ describe('Client', () => {
   test('Invite user', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
-    const body: InviteBody = {
+    const body: InviteRequest = {
       resourceType: 'Patient',
       firstName: 'Sally',
       lastName: 'Foo',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -18,6 +18,7 @@ import {
   Patient,
   Project,
   ProjectMembership,
+  ProjectMembershipAccess,
   ProjectSecret,
   Reference,
   Resource,
@@ -354,13 +355,20 @@ export interface BotEvent<T = Resource | Hl7Message | string | Record<string, an
   readonly secrets: Record<string, ProjectSecret>;
 }
 
-export interface InviteBody {
+export interface InviteRequest {
   resourceType: 'Patient' | 'Practitioner' | 'RelatedPerson';
   firstName: string;
   lastName: string;
   email?: string;
+  externalId?: string;
+  password?: string;
   sendEmail?: boolean;
+  membership?: Partial<ProjectMembership>;
+  /** @deprecated Use membership.accessPolicy instead. */
   accessPolicy?: Reference<AccessPolicy>;
+  /** @deprecated Use membership.access instead. */
+  access?: ProjectMembershipAccess[];
+  /** @deprecated Use membership.admin instead. */
   admin?: boolean;
 }
 
@@ -2790,10 +2798,10 @@ export class MedplumClient extends EventTarget {
   /**
    * Invite a user to a project.
    * @param projectId The project ID.
-   * @param body The InviteBody.
+   * @param body The InviteRequest.
    * @returns Promise that returns a project membership or an operation outcome.
    */
-  async invite(projectId: string, body: InviteBody): Promise<ProjectMembership | OperationOutcome> {
+  async invite(projectId: string, body: InviteRequest): Promise<ProjectMembership | OperationOutcome> {
     return this.post('admin/projects/' + projectId + '/invite', body);
   }
 

--- a/packages/docs/docs/auth/user-management-guide.md
+++ b/packages/docs/docs/auth/user-management-guide.md
@@ -68,7 +68,6 @@ Prepare JSON payload:
   "resourceType": "Patient",
   "firstName": "Homer",
   "lastName": "Simpson",
-  "resourceType": "Patient",
   "email": "homer@example.com",
   "sendEmail": false
 }
@@ -82,6 +81,57 @@ curl 'https://api.medplum.com/admin/projects/${projectId}/invite' \
   -H 'Content-Type: application/json' \
   --data-raw '{"resourceType":"Patient","firstName":"Homer","lastName":"Simpson","email":"homer@example.com", "sendEmail":"false"}'
 ```
+
+The `/invite` endpoint creates a [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership). The `ProjectMembership` resource includes additional properties to customize the user experience. The `/invite` endpoint accepts a partial `ProjectMebership` in the `membership` property where you can provide membership details.
+
+For example, use `admin: true` to make the new user a project administrator:
+
+```json
+{
+  "resourceType": "Practitioner",
+  "firstName": "Homer",
+  "lastName": "Simpson",
+  "email": "homer@example.com",
+  "membership": {
+    "admin": true
+  }
+}
+```
+
+Or use the `access` property to specify a user's `AccessPolicy` with optional parameters.
+
+```json
+{
+  "resourceType": "Patient",
+  "firstName": "Homer",
+  "lastName": "Simpson",
+  "email": "homer@example.com",
+  "membership": {
+    "access": [
+      {
+        "policy": { "reference": "AccessPolicy/123" },
+        "parameter": [
+          {
+            "name": "provider_organization",
+            "valueReference": { "reference": "Organization/abc" }
+          }
+        ]
+      },
+      {
+        "policy": { "reference": "AccessPolicy/123" },
+        "parameter": [
+          {
+            "name": "provider_organization",
+            "valueReference": { "reference": "Organization/def" }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+See [Access Control](/docs/auth/access-control) for more details.
 
 :::caution
 

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -63,14 +63,16 @@ export async function createScimUser(
 
   const { user, membership } = await inviteUser({
     project,
-    invitedBy,
     resourceType,
     firstName: scimUser.name?.givenName as string,
     lastName: scimUser.name?.familyName as string,
     email: scimUser.emails?.[0]?.value,
     externalId: scimUser.externalId,
     sendEmail: false,
-    accessPolicy,
+    membership: {
+      accessPolicy,
+      invitedBy,
+    },
   });
 
   return convertToScimUser(user, membership);

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -112,8 +112,10 @@ export async function addTestUser(
     resourceType: 'Practitioner',
     firstName: 'Bob',
     lastName: 'Jones',
-    accessPolicy: accessPolicy && createReference(accessPolicy),
     sendEmail: false,
+    membership: {
+      accessPolicy: accessPolicy && createReference(accessPolicy),
+    },
   });
 
   const login = await tryLogin({


### PR DESCRIPTION
All existing behavior still supported, although marked as `@deprecated`.

There is a new optional `membership` property available in the invite request.  If present, it acts as a template for the new `ProjectMembership` resource.

Properties that should use `membership`:
* `accessPolicy` - use `membership.accessPolicy`
* `access` - use `membership.access`
* `admin` - use `membership.admin`
