### PR TITLE
Updated HL7 utils

### DIFF
--- a/packages/core/src/hl7.test.ts
+++ b/packages/core/src/hl7.test.ts
@@ -16,6 +16,13 @@ describe('HL7', () => {
     expect(msg).toBeDefined();
     expect(msg.segments.length).toBe(1);
     expect(msg.toString()).toBe(text);
+    expect(msg.header).toBeDefined();
+    expect(msg.header.name).toBe('MSH');
+
+    const msh = msg.header as Hl7Segment;
+    expect(msh.getField(0)?.toString()).toBe('MSH');
+    expect(msh.getField(1)?.toString()).toBe('|');
+    expect(msh.getField(2)?.toString()).toBe('^~\\&');
 
     const ack = msg.buildAck();
     expect(ack).toBeDefined();
@@ -35,6 +42,212 @@ describe('HL7', () => {
     expect(msg.toString()).toBe(text);
   });
 
+  test('Build ACK', () => {
+    // 1 message type components
+    const text1 =
+      'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT|MSG00001|P|2.1\r' +
+      'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-||C|1200 N ELM STREET^^GREENSBORO^NC^27401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10|123456789|987654^NC\r' +
+      'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
+      'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-';
+    const msg1 = Hl7Message.parse(text1);
+    expect(msg1).toBeDefined();
+    expect(msg1.buildAck().getSegment('MSH')?.getField(9)?.toString()).toBe('ACK');
+
+    // 2 message type components
+    const text2 =
+      'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
+      'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-||C|1200 N ELM STREET^^GREENSBORO^NC^27401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10|123456789|987654^NC\r' +
+      'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
+      'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-';
+    const msg2 = Hl7Message.parse(text2);
+    expect(msg2).toBeDefined();
+    expect(msg2.buildAck().getSegment('MSH')?.getField(9)?.toString()).toBe('ACK^A01');
+
+    // 2 message type components
+    const text3 =
+      'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01^ADT_A01|MSG00001|P|2.5.1\r' +
+      'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-||C|1200 N ELM STREET^^GREENSBORO^NC^27401-1020|GL|(919)379-1212|(919)271-3434||S||PATID12345001^2^M10|123456789|987654^NC\r' +
+      'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
+      'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-';
+    const msg3 = Hl7Message.parse(text3);
+    expect(msg3).toBeDefined();
+    expect(msg3.buildAck().getSegment('MSH')?.getField(9)?.toString()).toBe('ACK^A01^ACK');
+  });
+
+  test('ADT', () => {
+    const text = `MSH|^~\\&|EPIC|EPICADT|SMS|SMSADT|199912271408|CHARRIS|ADT^A04|1817457|D|2.5|
+PID||0493575^^^2^ID 1|454721||DOE^JOHN^^^^|DOE^JOHN^^^^|19480203|M||B|254 MYSTREET AVE^^MYTOWN^OH^44123^USA||(216)123-4567|||M|NON|400003403~1129086|
+NK1||ROE^MARIE^^^^|SPO||(216)123-4567||EC|||||||||||||||||||||||||||
+PV1||O|168 ~219~C~PMA^^^^^^^^^||||277^ALLEN MYLASTNAME^BONNIE^^^^|||||||||| ||2688684|||||||||||||||||||||||||199912271408||||||002376853`;
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(4);
+    expect(msg.segments[0].name).toBe('MSH');
+    expect(msg.segments[1].name).toBe('PID');
+    expect(msg.segments[2].name).toBe('NK1');
+    expect(msg.segments[3].name).toBe('PV1');
+
+    const msh = msg.getSegment('MSH') as Hl7Segment;
+    expect(msh).toBeDefined();
+    expect(msh.getField(3).toString()).toBe('EPIC');
+    expect(msh.getField(4).toString()).toBe('EPICADT');
+
+    const pid = msg.getSegment('PID') as Hl7Segment;
+    expect(pid).toBeDefined();
+    expect(pid.getField(2).getComponent(1)).toBe('0493575');
+    expect(pid.getField(2).toString()).toBe('0493575^^^2^ID 1');
+    expect(pid.getComponent(2, 1)).toBe('0493575');
+
+    const nk1 = msg.getSegment('NK1') as Hl7Segment;
+    expect(nk1).toBeDefined();
+    expect(nk1.getField(2).getComponent(1)).toBe('ROE');
+    expect(nk1.getField(2).getComponent(2)).toBe('MARIE');
+    expect(nk1.getField(2).toString()).toBe('ROE^MARIE^^^^');
+
+    const pv1 = msg.getSegment('PV1') as Hl7Segment;
+    expect(pv1).toBeDefined();
+    expect(pv1.getField(2).getComponent(1)).toBe('O');
+    expect(pv1.getField(2).toString()).toBe('O');
+  });
+
+  test('QBP_Q11', () => {
+    const text = `MSH|^~\\&|cobas® pro||host||20160724080600+0200||QBP^Q11^QBP_Q11|1233|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-27R^ROCHE
+QPD|INISEQ^^99ROC|query1233|123|50001|1|||||SERPLAS^^99ROC|SC^^99ROC|R
+RCP|I|1|R^^HL70394`;
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(3);
+    expect(msg.segments[0].name).toBe('MSH');
+    expect(msg.segments[1].name).toBe('QPD');
+    expect(msg.segments[2].name).toBe('RCP');
+
+    const msh = msg.getSegment('MSH') as Hl7Segment;
+    expect(msh).toBeDefined();
+    expect(msh.getField(3).toString()).toBe('cobas® pro');
+    expect(msh.getField(5).toString()).toBe('host');
+  });
+
+  test('OUL_R22', () => {
+    const text = `MSH|^~\\&|cobas pro||host||20180222150842+0100||OUL^R22^OUL_R22|97|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-29^IHE
+PID|||||^^^^^^U|||U
+SPM|1|022&BARCODE||SERPLAS^^99ROC|||||||P^^HL70369|||~~~~||||||||||PSCO^^99ROC|||SC^^99ROC
+SAC|||022^BARCODE|||||||50120|2||||||||||||||||||^1^:^1
+OBR|1|""||20490^^99ROC|||||||
+ORC|SC||||CM
+TQ1|||||||||R^^HL70485
+OBX|1|NM|20490^20490^99ROC^^^IHELAW|1|32.2|mg/L^^99ROC||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|2|CE|20490^20490^99ROC^^^IHELAW|1|^^99ROC|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+TCD|20490^^99ROC|^1^:^1
+INV|2049001|OK^^HL70383~CURRENT^^99ROC|R1|514|1|8||||||20181030||||256616
+INV|2049001|OK^^HL70383~CURRENT^^99ROC|R3|514|1|8||||||20181030||||256616
+OBX|3|DTM|PT^Pipetting_Time^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|20180222145824|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|4|EI|CalibrationID^CalibrationID^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|23|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|5|EI|QCTID^QC·Test·ID^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|62~67|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|6|CE|QCSTATE^QC·Status^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|2^^99ROC|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|7|ST|TR_TECHNICALLIMIT^TR_TECHNICALLIMIT^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|0.300·-·350|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|8|ST|TR_REPEATLIMIT^TR_REPEATLIMIT^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|-99999·-·999999|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT
+OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other·Supplemental^IHELAW|1|-99999·-·999999|||N^^HL70078|||F|||||Admin~REALTIME||c503^ROCHE~^ROCHE~1^ROCHE|20180222150842||||||||||RSLT`;
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(19);
+    expect(msg.segments[0].name).toBe('MSH');
+    expect(msg.segments[1].name).toBe('PID');
+    expect(msg.segments[2].name).toBe('SPM');
+
+    const pid = msg.getSegment('PID') as Hl7Segment;
+    expect(pid).toBeDefined();
+    expect(pid.toString()).toBe('PID|||||^^^^^^U|||U');
+
+    const msh = msg.getSegment('MSH') as Hl7Segment;
+    expect(msh).toBeDefined();
+    expect(msh.getField(3).toString()).toBe('cobas pro');
+    expect(msh.getField(5).toString()).toBe('host');
+
+    const obxs = msg.getAllSegments('OBX');
+    expect(obxs).toBeDefined();
+    expect(obxs.length).toBe(9);
+
+    let i = 1;
+    for (const obx of obxs) {
+      expect(obx.name).toBe('OBX');
+      expect(obx.getField(1).toString()).toBe(i.toString());
+      i++;
+    }
+  });
+
+  test('Non-standard encoding', () => {
+    const text =
+      'MSH_^~\\&_Main_XYZ_iFW_ABC_20160915003015__ACK_9B38584D_P_2.6.1_\r' +
+      'MSA_AA_9B38584D_Everything was okay dokay!_';
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(2);
+    expect(msg.toString()).toBe(text);
+
+    const msa = msg.getSegment('MSA') as Hl7Segment;
+    expect(msa).toBeDefined();
+    expect(msa.getField(1).toString()).toBe('AA');
+    expect(msa.getField(2).toString()).toBe('9B38584D');
+    expect(msa.getField(3).toString()).toBe('Everything was okay dokay!');
+  });
+
+  test('Sub-field values', () => {
+    const text =
+      'MSH|^~\\&|cobas pro||Host||20220812155051+0900||OUL^R22^OUL_R22|2019|P|2.5.1|||NE|AL||UNICODE UTF-8|||LAB-29^IHE\r' +
+      'PID|||||^^^^^^U|||U\r' +
+      'SPM|1|140799&BARCODE||SERPLAS^^99ROC|||||||P^^HL70369|||~~~~|||||||||||||SC^^99ROC\r' +
+      'SAC|||140799^BARCODE|||||||50036|1||||||||||||||||||^1^:^1\r' +
+      'OBR|1|""||10020^^99ROC|||||||\r' +
+      'ORC|SC||||CM\r' +
+      'TQ1|||||||||R^^HL70485\r' +
+      'OBX|1|NM|10020^10020^99ROC^^^IHELAW|1|112|ng/dL^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|2|CE|10020^10020^99ROC^^^IHELAW|1|^^99ROC|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'TCD|10020^^99ROC|^1^:^1\r' +
+      'INV|1310020|OK^^HL70383~CURRENT^^99ROC|ASY|24308|1|19||||||20230831||||620931\r' +
+      'INV|1018448|OK^^HL70383~CURRENT^^99ROC|PRC|12854|1|1||||||20231130||||620127\r' +
+      'OBX|3|DTM|PT^Pipetting_Time^99ROC^S_OTHER^Other Supplemental^IHELAW|1|20220812151841|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|4|EI|CalibrationID^CalibrationID^99ROC^S_OTHER^Other Supplemental^IHELAW|1|1081|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|5|EI|QCTID^QC Test ID^99ROC^S_OTHER^Other Supplemental^IHELAW|1|19132~19112~19092|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|6|CE|QCSTATE^QC Status^99ROC^S_OTHER^Other Supplemental^IHELAW|1|1^^99ROC|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|7|ST|TR_TECHNICALLIMIT^TR_TECHNICALLIMIT^99ROC^S_OTHER^Other Supplemental^IHELAW|1|2.50 - 1500|||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|8|ST|TR_REPEATLIMIT^TR_REPEATLIMIT^99ROC^S_OTHER^Other Supplemental^IHELAW|1|-9999900 - |||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other Supplemental^IHELAW|1|-9999900 - |||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|10|NM|10020_EFS^10020_EFS^99ROC^S_RAW^Raw Supplemental^IHELAW|1|42399.210|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|11|NM|10020_EFV^10020_EFV^99ROC^S_RAW^Raw Supplemental^IHELAW|1|-116.3324|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|12|NM|10020_EFC^10020_EFC^99ROC^S_RAW^Raw Supplemental^IHELAW|1|254.4396|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT\r' +
+      'OBX|13|NM|10020_PMT^10020_PMT^99ROC^S_RAW^Raw Supplemental^IHELAW|1|13773|COUNT^^99ROC||N^^HL70078|||F|||||ADMIN~BATCH||e801^ROCHE~2037-06^ROCHE~1^ROCHE|20220812153714||||||||||RSLT';
+
+    const msg = Hl7Message.parse(text);
+    expect(msg).toBeDefined();
+    expect(msg.segments.length).toBe(23);
+    expect(msg.toString()).toBe(text);
+
+    // Test sub-components with the "&" separator
+    const spm = msg.getSegment('SPM') as Hl7Segment;
+    expect(spm.getField(2).getComponent(1)).toEqual('140799&BARCODE');
+    expect(spm.getField(2).getComponent(1, 0)).toEqual('140799');
+    expect(spm.getField(2).getComponent(1, 1)).toEqual('BARCODE');
+
+    // Test repetition with the "~" separator
+    const obx = msg.getSegment('OBX') as Hl7Segment;
+    expect(obx.getField(18).toString()).toEqual('e801^ROCHE~2037-06^ROCHE~1^ROCHE');
+    expect(obx.getField(18).getComponent(1)).toEqual('e801');
+    expect(obx.getField(18).getComponent(1, 0, 0)).toEqual('e801');
+    expect(obx.getField(18).getComponent(2, 0, 0)).toEqual('ROCHE');
+    expect(obx.getField(18).getComponent(1, 0, 1)).toEqual('2037-06');
+    expect(obx.getField(18).getComponent(2, 0, 1)).toEqual('ROCHE');
+    expect(obx.getComponent(18, 1, 0, 0)).toEqual('e801');
+    expect(obx.getComponent(18, 1, 0, 1)).toEqual('2037-06');
+    expect(obx.getComponent(18, 2, 0, 0)).toEqual('ROCHE');
+    expect(obx.getComponent(18, 2, 0, 1)).toEqual('ROCHE');
+  });
+});
+
+describe('Legacy HL7 getters', () => {
   test('ADT', () => {
     const text = `MSH|^~\\&|EPIC|EPICADT|SMS|SMSADT|199912271408|CHARRIS|ADT^A04|1817457|D|2.5|
 PID||0493575^^^2^ID 1|454721||DOE^JOHN^^^^|DOE^JOHN^^^^|19480203|M||B|254 MYSTREET AVE^^MYTOWN^OH^44123^USA||(216)123-4567|||M|NON|400003403~1129086|
@@ -202,7 +415,9 @@ OBX|9|ST|TR_EXPECTEDVALUES^TR_EXPECTEDVALUES^99ROC^S_OTHER^Other·Supplemental^I
     expect(obx.get(18).get(0, 0, 1)).toEqual('2037-06');
     expect(obx.get(18).get(1, 0, 1)).toEqual('ROCHE');
   });
+});
 
+describe('Date time parsing', () => {
   test('Undefined for empty input', () => {
     expect(parseHl7Date(undefined)).toBeUndefined();
   });


### PR DESCRIPTION
Extracted the changes to our HL7 utils out of this PR: https://github.com/medplum/medplum/pull/2500

Before:
* All of the HL7 helper classes have `get` methods
* `Hl7Message.get(index)` returns an `Hl7Segment`
* `Hl7Segment.get(index)` returns an `Hl7Field`
* `Hl7Field.get(index)` returns a `string` component or subcomponent

What was wrong:
* `Hl7Segment` had off-by-one errors when working with an "MSH" segment
    * MSH is weird, especially MSH.1 and MSH.2
    * MSH.1 ***is*** the field separator, so it requires special handling
    * We were correctly parsing and using the field separator
    * But we blew away MSH.1 in the process, so all of the fields after MSH.1 were off-by-one
* `Hl7Field` was zero-indexed rather than one-indexed
    * That's just confusing when reading the docs
    * For example, to read PID.3.5, you would use `pid.get(3).get(4)` - an ugly mix of zero-based and one-based

In this PR:
* Adding new `get*` methods that use the correct indexing behavior
    * `Hl7Message.getSegment()` basically does the same thing
    * `Hl7Segment.getField()` correctly handles the MSH mess described above
    * `Hl7Field.getComponent()` is now one-based to align with `Hl7Segment.getField()`
    * So now, to read PID.3.5, you would use `pid.getField(3).getComponent(5)`
    * Or the new shortcut `pid.getComponent(3, 5)`
* Marking the existing `.get()` methods as deprecated.  Keeping the existing behavior, but marking them as deprecated.
    * While I'm ok-ish with breaking changes, I'm not ok with breaking changes that are not obvious
    * If we continued to use `.get()` but changed the index behavior, existing code would have compiled just fine but broke at runtime in surprising ways
    * So I'm opting to keep the existing as-is