### PR TITLE
Fix SearchControl values with SearchParameter without ElementDefinition

### DIFF
--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -526,7 +526,7 @@ export function renderValue(resource: Resource, field: SearchControlField): stri
 
   // Priority 2: SearchParameter by exact match
   if (field.searchParams && field.searchParams.length === 1 && field.name === field.searchParams[0].code) {
-    return renderSearchParameterValue(resource, field.searchParams[0], field.elementDefinition);
+    return renderSearchParameterValue(resource, field.searchParams[0]);
   }
 
   // We don't know how to render this field definition
@@ -562,29 +562,12 @@ function renderPropertyValue(resource: Resource, elementDefinition: ElementDefin
  * Returns a fragment to be displayed in the search table for a search parameter.
  * @param resource The parent resource.
  * @param searchParam The search parameter.
- * @param elementDefinition Optional element definition.
  * @returns A React element or null.
  */
-function renderSearchParameterValue(
-  resource: Resource,
-  searchParam: SearchParameter,
-  elementDefinition: ElementDefinition | undefined
-): JSX.Element | null {
+function renderSearchParameterValue(resource: Resource, searchParam: SearchParameter): JSX.Element | null {
   const value = evalFhirPathTyped(searchParam.expression as string, [{ type: resource.resourceType, value: resource }]);
   if (!value || value.length === 0) {
     return null;
-  }
-
-  if (elementDefinition) {
-    return (
-      <ResourcePropertyDisplay
-        propertyType={value[0].type as PropertyType}
-        value={value[0].value}
-        maxWidth={200}
-        ignoreMissingValues={true}
-        link={false}
-      />
-    );
   }
 
   return (

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -590,9 +590,14 @@ function renderSearchParameterValue(
   return (
     <>
       {value.map((v, index) => (
-        <span key={`${index}-${value.length}`}>
-          {typeof v === 'object' ? JSON.stringify(v) : (v as string | number)}
-        </span>
+        <ResourcePropertyDisplay
+          key={`${index}-${value.length}`}
+          propertyType={v.type as PropertyType}
+          value={v.value}
+          maxWidth={200}
+          ignoreMissingValues={true}
+          link={false}
+        />
       ))}
     </>
   );


### PR DESCRIPTION
When using the `<SearchControl>` react component, we try our darndest to render the value that you would expect given the search.

The main two cases are:

1. Field is a property name - get the property value, and render the value
2. Field is a search parameter code - get the search parameter, evaluate the expression, render the value

In the 2nd case, we try to map the value back to an `ElementDefinition` to take advantage of all of our rendering machinery.

There are cases where the search param to element definition matching is difficult or impossible.  In those cases, we just splatted JSON.

It appears that our rendering machinery now no longer requires `ElementDefinition`, so we can just always use it.

Concrete example, search for "ProjectMembership" and add "Profile Type":

Before:

<img width="757" alt="image" src="https://github.com/medplum/medplum/assets/749094/e7986aab-3f92-4bf5-a684-541306ce259b">

After:

<img width="759" alt="image" src="https://github.com/medplum/medplum/assets/749094/5b1fa966-a56d-4eec-b22e-ef405f48de48">
