### PR TITLE
Improvements to search input dialog

### DIFF
--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -8,6 +8,7 @@ export interface DateTimeInputProps {
   name?: string;
   placeholder?: string;
   defaultValue?: string;
+  autoFocus?: boolean;
   required?: boolean;
   outcome?: OperationOutcome;
   onChange?: (value: string) => void;
@@ -26,11 +27,13 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
     <TextInput
       id={props.name}
       name={props.name}
+      data-autofocus={props.autoFocus}
       data-testid={props.name}
       placeholder={props.placeholder}
       required={props.required}
       type={getInputType()}
       defaultValue={convertIsoToLocal(props.defaultValue)}
+      autoFocus={props.autoFocus}
       error={getErrorsForInput(props.outcome, props.name)}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         if (props.onChange) {

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -5,6 +5,7 @@ import React, { useState, WheelEvent } from 'react';
 export interface QuantityInputProps {
   name: string;
   defaultValue?: Quantity;
+  autoFocus?: boolean;
   onChange?: (value: Quantity) => void;
   disableWheel?: boolean;
 }
@@ -36,10 +37,12 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
       <TextInput
         id={props.name}
         name={props.name}
+        data-autofocus={props.autoFocus}
         data-testid={props.name + '-value'}
         type="number"
         placeholder="Value"
         defaultValue={value?.value}
+        autoFocus={props.autoFocus}
         step="any"
         onWheel={(e: WheelEvent<HTMLInputElement>) => {
           if (props.disableWheel) {

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -9,6 +9,7 @@ export interface ReferenceInputProps {
   placeholder?: string;
   defaultValue?: Reference;
   targetTypes?: string[];
+  autoFocus?: boolean;
   onChange?: (value: Reference | undefined) => void;
 }
 
@@ -35,15 +36,19 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
     <Group spacing="xs" grow noWrap>
       {targetTypes ? (
         <NativeSelect
+          data-autofocus={props.autoFocus}
           data-testid="reference-input-resource-type-select"
           defaultValue={resourceType}
+          autoFocus={props.autoFocus}
           onChange={(e) => setResourceType(e.currentTarget.value)}
           data={targetTypes}
         />
       ) : (
         <TextInput
+          data-autofocus={props.autoFocus}
           data-testid="reference-input-resource-type-input"
           defaultValue={resourceType}
+          autoFocus={props.autoFocus}
           onChange={(e) => setResourceType(e.currentTarget.value)}
         />
       )}

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -555,11 +555,11 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
       <SearchFilterValueDialog
         key={state.filterDialogSearchParam?.code}
         visible={stateRef.current.filterDialogVisible}
-        title={'Input'}
+        title={state.filterDialogSearchParam?.code ? buildFieldNameString(state.filterDialogSearchParam.code) : ''}
         resourceType={resourceType}
         searchParam={state.filterDialogSearchParam}
         filter={state.filterDialogFilter}
-        defaultValue={''}
+        defaultValue=""
         onOk={(filter) => {
           emitSearchChange(addFilter(props.search, filter.code, filter.operator, filter.value));
           setState({

--- a/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
+++ b/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from '@mantine/core';
+import { Button, Grid, Modal } from '@mantine/core';
 import { Filter } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
@@ -29,18 +29,24 @@ export function SearchFilterValueDialog(props: SearchFilterValueDialogProps): JS
 
   return (
     <Modal title={props.title} size="xl" opened={props.visible} onClose={props.onCancel}>
-      <div style={{ width: 500 }}>
-        <Form onSubmit={onOk}>
-          <SearchFilterValueInput
-            resourceType={props.resourceType}
-            searchParam={props.searchParam}
-            defaultValue={value}
-            autoFocus={true}
-            onChange={setValue}
-          />
-        </Form>
-      </div>
-      <Button onClick={onOk}>OK</Button>
+      <Form onSubmit={onOk}>
+        <Grid>
+          <Grid.Col span={10}>
+            <SearchFilterValueInput
+              resourceType={props.resourceType}
+              searchParam={props.searchParam}
+              defaultValue={value}
+              autoFocus={true}
+              onChange={setValue}
+            />
+          </Grid.Col>
+          <Grid.Col span={2}>
+            <Button onClick={onOk} fullWidth>
+              OK
+            </Button>
+          </Grid.Col>
+        </Grid>
+      </Form>
     </Modal>
   );
 }

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
@@ -25,6 +25,7 @@ export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.
           name={name}
           defaultValue={{ reference: props.defaultValue }}
           targetTypes={props.searchParam.target}
+          autoFocus={props.autoFocus}
           onChange={(newReference: Reference | undefined) => {
             if (newReference) {
               props.onChange(newReference.reference as string);
@@ -39,8 +40,10 @@ export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.
       return (
         <Checkbox
           name={name}
+          data-autofocus={props.autoFocus}
           data-testid={name}
           defaultChecked={props.defaultValue === 'true'}
+          autoFocus={props.autoFocus}
           onChange={(e) => props.onChange(e.currentTarget.checked.toString())}
         />
       );
@@ -50,22 +53,33 @@ export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.
         <TextInput
           type="date"
           name={name}
+          data-autofocus={props.autoFocus}
           data-testid={name}
           defaultValue={props.defaultValue}
+          autoFocus={props.autoFocus}
           onChange={(e) => props.onChange(e.currentTarget.value)}
         />
       );
 
     case SearchParameterType.DATETIME:
-      return <DateTimeInput name={name} defaultValue={props.defaultValue} onChange={props.onChange} />;
+      return (
+        <DateTimeInput
+          name={name}
+          defaultValue={props.defaultValue}
+          autoFocus={props.autoFocus}
+          onChange={props.onChange}
+        />
+      );
 
     case SearchParameterType.NUMBER:
       return (
         <TextInput
           type="number"
           name={name}
+          data-autofocus={props.autoFocus}
           data-testid={name}
           defaultValue={props.defaultValue}
+          autoFocus={props.autoFocus}
           onChange={(e) => props.onChange(e.currentTarget.value)}
         />
       );
@@ -75,6 +89,7 @@ export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.
         <QuantityInput
           name={name}
           defaultValue={tryParseQuantity(props.defaultValue)}
+          autoFocus={props.autoFocus}
           onChange={(newQuantity: Quantity | undefined) => {
             if (newQuantity) {
               props.onChange(`${newQuantity.value}`);
@@ -89,6 +104,7 @@ export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.
       return (
         <TextInput
           name={name}
+          data-autofocus={props.autoFocus}
           data-testid={name}
           defaultValue={props.defaultValue}
           autoFocus={props.autoFocus}


### PR DESCRIPTION
Before:

![image](https://github.com/medplum/medplum/assets/749094/a37f5db8-1530-49ea-af9f-6c8466e65796)

After:

<img width="607" alt="image" src="https://github.com/medplum/medplum/assets/749094/b716b6ad-480d-4977-9cb6-e2607f42f551">

Changes:

- Use search code rather than fixed string "Input"
- Move "OK" button to inline
- Fixed auto focus (this was a surprisingly awkward change, which depends on using Mantine's `data-autofocus` magic prop)