### PR TITLE
Clarify error message when modifying read-only resources

### DIFF
--- a/packages/docs/docs/auth/access-control.md
+++ b/packages/docs/docs/auth/access-control.md
@@ -80,6 +80,8 @@ The following access policy grants read-only access to the "Patient" resource ty
 }
 ```
 
+Attempting to modify a read-only resource will result in an HTTP result of [`403: Forbidden`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403).
+
 ### Hidden fields
 
 The following access policy grants read-only access to the "Patient" resource type, but hides "name" and "address":


### PR DESCRIPTION
User driven: https://discord.com/channels/905144809105260605/1131288083078328471

User was trying to submit a PUT and PATCH request to a resource with a "read-only" access policy and received a `403: Forbidden` error. Our docs didn't not explicitly define what the expected result would be. 