### PR TITLE
Run packages and examples tests separately

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,7 +22,9 @@ npm --version
 npx turbo run build
 
 # Test
-npx turbo run test -- --coverage
+# Run them separately because code coverage is resource intensive
+npx turbo run test --filter='./packages/*' -- --coverage
+npx turbo run test --filter='./examples/*'
 
 # Combine test coverage
 rm -rf coverage

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,8 +23,23 @@ npx turbo run build
 
 # Test
 # Run them separately because code coverage is resource intensive
-npx turbo run test --filter='./packages/*' -- --coverage
-npx turbo run test --filter='./examples/*'
+
+for dir in `ls packages`; do
+  if test -f "packages/$dir/package.json"; then
+    pushd "packages/$dir"
+    npm run test -- --coverage
+    popd
+  fi
+done
+
+for dir in `ls examples`; do
+  if test -f "examples/$dir/package.json"; then
+    pushd "examples/$dir"
+    npm run test
+    popd
+  fi
+done
+
 
 # Combine test coverage
 rm -rf coverage

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,7 +25,7 @@ npx turbo run build
 # Run them separately because code coverage is resource intensive
 
 for dir in `ls packages`; do
-  if test -f "packages/$dir/package.json"; then
+  if test -f "packages/$dir/package.json" && grep -q "\"test\":" "packages/$dir/package.json"; then
     pushd "packages/$dir"
     npm run test -- --coverage
     popd
@@ -33,7 +33,7 @@ for dir in `ls packages`; do
 done
 
 for dir in `ls examples`; do
-  if test -f "examples/$dir/package.json"; then
+  if test -f "examples/$dir/package.json" && grep -q "\"test\":" "examples/$dir/package.json"; then
     pushd "examples/$dir"
     npm run test
     popd


### PR DESCRIPTION
Currently hitting frequent failures with `Error: Process completed with exit code 143.`

That exit code suggests we're hitting resource limits of the runner: https://github.com/actions/runner-images/issues/6680#issuecomment-1334848113

The right solution is probably to move to "large runners": https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners

As a short term fix, I'm separating out the `test` step between `packages/*` and `examples/*`.

My hunch is that the recent addition of `medplum-nextjs-example` tipped us over the edge.  Calculating code coverage is expensive.  This should buy us some breathing room until we move to large runners.