### PR TITLE
Bot structure update

### DIFF
--- a/packages/app/src/resource/BotEditor.test.tsx
+++ b/packages/app/src/resource/BotEditor.test.tsx
@@ -1,6 +1,7 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { allOk, badRequest } from '@medplum/core';
+import { Bot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -12,7 +13,9 @@ let medplum: MockClient;
 
 describe('BotEditor', () => {
   async function setup(url: string): Promise<void> {
-    medplum = new MockClient();
+    if (!medplum) {
+      medplum = new MockClient();
+    }
 
     // Mock bot operations
     medplum.router.router.add('POST', 'Bot/:id/$deploy', async () => [allOk]);
@@ -196,5 +199,39 @@ describe('BotEditor', () => {
     });
 
     expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  test('Legacy bot', async () => {
+    // Bots now use "sourceCode" and "executableCode" instead of "code"
+    // While "code" is deprecated, it is still supported for legacy bots
+
+    // Create a Bot with "code" instead of "sourceCode" and "executableCode"
+    medplum = new MockClient();
+    const legacyBot = await medplum.createResource<Bot>({
+      resourceType: 'Bot',
+      code: 'console.log("foo");',
+    });
+
+    await setup(`/Bot/${legacyBot.id}/editor`);
+    await waitFor(() => screen.getByText('Save'));
+
+    // Mock the code frame
+    (screen.getByTestId<HTMLIFrameElement>('code-frame').contentWindow as Window).postMessage = (
+      _message: any,
+      _targetOrigin: any,
+      transfer?: Transferable[]
+    ) => {
+      (transfer?.[0] as MessagePort).postMessage({ result: 'console.log("foo");' });
+    };
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+
+    const check = await medplum.readResource('Bot', legacyBot.id as string);
+    expect(check.sourceCode).toBeDefined();
+    expect(check.sourceCode?.url).toBeDefined();
   });
 });

--- a/packages/app/src/resource/BotEditor.test.tsx
+++ b/packages/app/src/resource/BotEditor.test.tsx
@@ -15,6 +15,7 @@ describe('BotEditor', () => {
   async function setup(url: string): Promise<void> {
     if (!medplum) {
       medplum = new MockClient();
+      jest.spyOn(medplum, 'download').mockImplementation(async () => ({ text: async () => 'test' }));
     }
 
     // Mock bot operations
@@ -52,6 +53,7 @@ describe('BotEditor', () => {
   test('Bot editor', async () => {
     await setup('/Bot/123/editor');
     await waitFor(() => screen.getByText('Editor'));
+    await waitFor(() => screen.getByTestId('code-frame'));
     expect(screen.getByText('Editor')).toBeInTheDocument();
 
     await act(async () => {

--- a/packages/app/src/resource/BotEditor.test.tsx
+++ b/packages/app/src/resource/BotEditor.test.tsx
@@ -15,7 +15,7 @@ describe('BotEditor', () => {
   async function setup(url: string): Promise<void> {
     if (!medplum) {
       medplum = new MockClient();
-      jest.spyOn(medplum, 'download').mockImplementation(async () => ({ text: async () => 'test' }));
+      jest.spyOn(medplum, 'download').mockImplementation(async () => ({ text: async () => 'test' } as unknown as Blob));
     }
 
     // Mock bot operations

--- a/packages/app/src/resource/BotEditor.tsx
+++ b/packages/app/src/resource/BotEditor.tsx
@@ -50,7 +50,7 @@ export function BotEditor(): JSX.Element | null {
       setLoading(true);
       try {
         const code = await getCode();
-        const sourceCode = await medplum.createAttachment(code, 'index.ts', 'application/typescript');
+        const sourceCode = await medplum.createAttachment(code, 'index.ts', 'text/typescript');
         const operations: PatchOperation[] = [];
         if (bot?.sourceCode) {
           operations.push({

--- a/packages/app/src/resource/BotEditor.tsx
+++ b/packages/app/src/resource/BotEditor.tsx
@@ -65,12 +65,6 @@ export function BotEditor(): JSX.Element | null {
             value: sourceCode,
           });
         }
-        if (bot?.code) {
-          operations.push({
-            op: 'remove',
-            path: '/code',
-          });
-        }
         await medplum.patchResource('Bot', id, operations);
         showNotification({ color: 'green', message: 'Saved' });
       } catch (err) {

--- a/packages/app/src/resource/BotEditor.tsx
+++ b/packages/app/src/resource/BotEditor.tsx
@@ -116,7 +116,7 @@ export function BotEditor(): JSX.Element | null {
     [medplum, id, getSampleInput]
   );
 
-  if (!bot) {
+  if (!bot || defaultCode === undefined) {
     return null;
   }
 
@@ -175,7 +175,7 @@ export function BotEditor(): JSX.Element | null {
   );
 }
 
-async function getBotCode(medplum: MedplumClient, bot: Bot): Promise<string | undefined> {
+async function getBotCode(medplum: MedplumClient, bot: Bot): Promise<string> {
   if (bot.sourceCode?.url) {
     // Medplum storage service does not allow CORS requests for security reasons.
     // So instead, we have to use the FHIR Binary API to fetch the source code.
@@ -183,8 +183,8 @@ async function getBotCode(medplum: MedplumClient, bot: Bot): Promise<string | un
     // The Binary ID is the first UUID in the URL.
     const binaryId = bot.sourceCode.url?.split('/')?.find(isUUID) as string;
     const blob = await medplum.download(medplum.fhirUrl('Binary', binaryId));
-    await blob.text();
+    return blob.text();
   }
 
-  return bot.code;
+  return bot.code ?? '';
 }

--- a/packages/app/src/resource/CodeEditor.tsx
+++ b/packages/app/src/resource/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useState } from 'react';
+import React, { RefObject } from 'react';
 import { sendCommand } from '../utils';
 
 export interface CodeEditorProps {
@@ -12,17 +12,6 @@ export interface CodeEditorProps {
 
 export function CodeEditor(props: CodeEditorProps): JSX.Element {
   const code = props.defaultValue;
-  const iframeRef = props.iframeRef;
-  const [loaded, setLoaded] = useState(false);
-  const [lastDefaultCode, setLastDefaultCode] = useState<string | undefined>(code);
-
-  useEffect(() => {
-    if (loaded && iframeRef.current && code !== lastDefaultCode) {
-      sendCommand(iframeRef.current, { command: 'setValue', value: code }).catch(console.error);
-      setLastDefaultCode(code);
-    }
-  }, [iframeRef, loaded, code, lastDefaultCode]);
-
   const url = new URL(`https://codeeditor.medplum.com/${props.language}-editor.html`);
   if (props.module) {
     url.searchParams.set('module', props.module);
@@ -37,7 +26,6 @@ export function CodeEditor(props: CodeEditorProps): JSX.Element {
       data-testid={props.testId}
       onLoad={(e) => {
         sendCommand(e.currentTarget as HTMLIFrameElement, { command: 'setValue', value: code }).catch(console.error);
-        setLoaded(true);
       }}
     />
   );

--- a/packages/app/src/resource/CodeEditor.tsx
+++ b/packages/app/src/resource/CodeEditor.tsx
@@ -4,7 +4,7 @@ import { sendCommand } from '../utils';
 export interface CodeEditorProps {
   language: 'typescript' | 'json';
   module?: 'commonjs' | 'esnext';
-  defaultValue: string;
+  defaultValue?: string;
   iframeRef?: React.RefObject<HTMLIFrameElement>;
   testId?: string;
   minHeight?: string;
@@ -23,7 +23,11 @@ export function CodeEditor(props: CodeEditorProps): JSX.Element {
       style={{ width: '100%', height: '100%', minHeight: props.minHeight }}
       ref={props.iframeRef}
       data-testid={props.testId}
-      onLoad={(e) => sendCommand(e.currentTarget as HTMLIFrameElement, { command: 'setValue', value: code })}
+      onLoad={(e) => {
+        if (code) {
+          sendCommand(e.currentTarget as HTMLIFrameElement, { command: 'setValue', value: code }).catch(console.error);
+        }
+      }}
     />
   );
 }

--- a/packages/app/src/resource/CodeEditor.tsx
+++ b/packages/app/src/resource/CodeEditor.tsx
@@ -1,21 +1,33 @@
-import React from 'react';
+import React, { RefObject, useEffect, useState } from 'react';
 import { sendCommand } from '../utils';
 
 export interface CodeEditorProps {
   language: 'typescript' | 'json';
   module?: 'commonjs' | 'esnext';
   defaultValue?: string;
-  iframeRef?: React.RefObject<HTMLIFrameElement>;
+  iframeRef: RefObject<HTMLIFrameElement>;
   testId?: string;
   minHeight?: string;
 }
 
 export function CodeEditor(props: CodeEditorProps): JSX.Element {
   const code = props.defaultValue;
+  const iframeRef = props.iframeRef;
+  const [loaded, setLoaded] = useState(false);
+  const [lastDefaultCode, setLastDefaultCode] = useState<string | undefined>(code);
+
+  useEffect(() => {
+    if (loaded && iframeRef.current && code !== lastDefaultCode) {
+      sendCommand(iframeRef.current, { command: 'setValue', value: code }).catch(console.error);
+      setLastDefaultCode(code);
+    }
+  }, [iframeRef, loaded, code, lastDefaultCode]);
+
   const url = new URL(`https://codeeditor.medplum.com/${props.language}-editor.html`);
   if (props.module) {
     url.searchParams.set('module', props.module);
   }
+
   return (
     <iframe
       frameBorder="0"
@@ -24,9 +36,8 @@ export function CodeEditor(props: CodeEditorProps): JSX.Element {
       ref={props.iframeRef}
       data-testid={props.testId}
       onLoad={(e) => {
-        if (code) {
-          sendCommand(e.currentTarget as HTMLIFrameElement, { command: 'setValue', value: code }).catch(console.error);
-        }
+        sendCommand(e.currentTarget as HTMLIFrameElement, { command: 'setValue', value: code }).catch(console.error);
+        setLoaded(true);
       }}
     />
   );

--- a/packages/cli/src/aws/update-app.ts
+++ b/packages/cli/src/aws/update-app.ts
@@ -133,17 +133,17 @@ async function uploadAppToS3(tmpDir: string, bucketName: string): Promise<void> 
     ['css/**/*.css.map', 'application/json', true],
     ['img/**/*.png', 'image/png', true],
     ['img/**/*.svg', 'image/svg+xml', true],
-    ['js/**/*.js', 'application/javascript', true],
+    ['js/**/*.js', 'text/javascript', true],
     ['js/**/*.js.map', 'application/json', true],
     ['js/**/*.txt', 'text/plain', true],
     ['favicon.ico', 'image/vnd.microsoft.icon', true],
     ['robots.txt', 'text/plain', true],
-    ['workbox-*.js', 'application/javascript', true],
+    ['workbox-*.js', 'text/javascript', true],
     ['workbox-*.js.map', 'application/json', true],
 
     // Not cached
     ['manifest.webmanifest', 'application/manifest+json', false],
-    ['service-worker.js', 'application/javascript', false],
+    ['service-worker.js', 'text/javascript', false],
     ['service-worker.js.map', 'application/json', false],
     ['index.html', 'text/html', false],
   ];

--- a/packages/cli/src/bot.test.ts
+++ b/packages/cli/src/bot.test.ts
@@ -141,6 +141,32 @@ describe('CLI Bots', () => {
     expect(check.sourceCode).toBeDefined();
   });
 
+  test('Deploy bot without dist success', async () => {
+    // Create the bot
+    const bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
+    expect(bot.code).toBeUndefined();
+
+    // Setup bot config
+    (fs.existsSync as unknown as jest.Mock).mockReturnValue(true);
+    (fs.readFileSync as unknown as jest.Mock).mockReturnValue(
+      JSON.stringify({
+        bots: [
+          {
+            name: 'hello-world',
+            id: bot.id,
+            source: 'src/hello-world.ts',
+          },
+        ],
+      })
+    );
+
+    await main(['node', 'index.js', 'bot', 'deploy', 'hello-world']);
+    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    const check = await medplum.readResource('Bot', bot.id as string);
+    expect(check.code).toBeUndefined();
+    expect(check.sourceCode).toBeDefined();
+  });
+
   test('Deploy bot for multiple bot with wildcards ', async () => {
     // Create the bot
     const bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });

--- a/packages/cli/src/bot.test.ts
+++ b/packages/cli/src/bot.test.ts
@@ -110,8 +110,8 @@ describe('CLI Bots', () => {
     await main(['node', 'index.js', 'bot', 'save', 'hello-world']);
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
-    expect(check.code).toBeDefined();
-    expect(check.code).not.toEqual('');
+    expect(check.code).toBeUndefined();
+    expect(check.sourceCode).toBeDefined();
   });
 
   test('Deploy bot success', async () => {
@@ -137,8 +137,8 @@ describe('CLI Bots', () => {
     await main(['node', 'index.js', 'bot', 'deploy', 'hello-world']);
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
-    expect(check.code).toBeDefined();
-    expect(check.code).not.toEqual('');
+    expect(check.code).toBeUndefined();
+    expect(check.sourceCode).toBeDefined();
   });
 
   test('Deploy bot for multiple bot with wildcards ', async () => {
@@ -294,8 +294,8 @@ describe('CLI Bots', () => {
     await main(['node', 'index.js', 'save-bot', 'hello-world']);
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
-    expect(check.code).toBeDefined();
-    expect(check.code).not.toEqual('');
+    expect(check.code).toBeUndefined();
+    expect(check.sourceCode).toBeDefined();
   });
 
   test('Deprecate Deploy bot success', async () => {
@@ -321,8 +321,8 @@ describe('CLI Bots', () => {
     await main(['node', 'index.js', 'deploy-bot', 'hello-world']);
     expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
-    expect(check.code).toBeDefined();
-    expect(check.code).not.toEqual('');
+    expect(check.code).toBeUndefined();
+    expect(check.sourceCode).toBeDefined();
   });
 
   test('Deprecate Deploy bot for multiple bot with wildcards ', async () => {

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { Writable } from 'stream';
 import tar from 'tar';
-import { safeTarExtractor } from './utils';
+import { getCodeContentType, safeTarExtractor } from './utils';
 
 jest.mock('tar', () => ({
   x: jest.fn(),
@@ -51,5 +51,18 @@ describe('CLI utils', () => {
     } catch (err) {
       expect((err as Error).message).toEqual('Tar extractor reached max size');
     }
+  });
+
+  test('getCodeContentType', () => {
+    expect(getCodeContentType('foo.cjs')).toEqual('text/javascript');
+    expect(getCodeContentType('foo.js')).toEqual('text/javascript');
+    expect(getCodeContentType('foo.mjs')).toEqual('text/javascript');
+
+    expect(getCodeContentType('foo.cts')).toEqual('text/typescript');
+    expect(getCodeContentType('foo.mts')).toEqual('text/typescript');
+    expect(getCodeContentType('foo.ts')).toEqual('text/typescript');
+
+    expect(getCodeContentType('foo.txt')).toEqual('text/plain');
+    expect(getCodeContentType('foo')).toEqual('text/plain');
   });
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,7 +1,7 @@
 import { MedplumClient } from '@medplum/core';
 import { Bot, Extension, OperationOutcome } from '@medplum/fhirtypes';
 import { existsSync, readFileSync, writeFile } from 'fs';
-import { basename, resolve } from 'path';
+import { basename, extname, resolve } from 'path';
 import internal from 'stream';
 import tar from 'tar';
 
@@ -182,12 +182,13 @@ export function getUnsupportedExtension(): Extension {
   };
 }
 
-function getCodeContentType(filename: string): string {
-  if (filename.endsWith('.ts')) {
-    return 'text/typescript';
-  }
-  if (filename.endsWith('.js')) {
+export function getCodeContentType(filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  if (['.cjs', '.mjs', '.js'].includes(ext)) {
     return 'text/javascript';
+  }
+  if (['.cts', '.mts', '.ts'].includes(ext)) {
+    return 'text/typescript';
   }
   return 'text/plain';
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -184,10 +184,10 @@ export function getUnsupportedExtension(): Extension {
 
 function getCodeContentType(filename: string): string {
   if (filename.endsWith('.ts')) {
-    return 'application/typescript';
+    return 'text/typescript';
   }
   if (filename.endsWith('.js')) {
-    return 'application/javascript';
+    return 'text/javascript';
   }
   return 'text/plain';
 }

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1154,6 +1154,24 @@ describe('Client', () => {
     }
   });
 
+  test('Create attachment', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const result = await client.createAttachment('Hello world', undefined, 'text/plain');
+    expect(result).toBeDefined();
+    expect(fetch).toBeCalledWith(
+      'https://api.medplum.com/fhir/R4/Binary',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Accept: 'application/fhir+json',
+          'Content-Type': 'text/plain',
+          'X-Medplum': 'extended',
+        },
+      })
+    );
+  });
+
   test('Create binary', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3,6 +3,7 @@
 
 import {
   AccessPolicy,
+  Attachment,
   Binary,
   BulkDataExport,
   Bundle,
@@ -1600,6 +1601,44 @@ export class MedplumClient extends EventTarget {
   async createResourceIfNoneExist<T extends Resource>(resource: T, query: string, options?: RequestInit): Promise<T> {
     return ((await this.searchOne(resource.resourceType, query, options)) ??
       this.createResource(resource, options)) as Promise<T>;
+  }
+
+  /**
+   * Creates a FHIR `Attachment` with the provided data content.
+   *
+   * This is a convenience method for creating a `Binary` resource and then creating an `Attachment` element.
+   *
+   * The `data` parameter can be a string or a `File` object.
+   *
+   * A `File` object often comes from a `<input type="file">` element.
+   *
+   * Example:
+   *
+   * ```typescript
+   * const result = await medplum.createAttachment(myFile, 'test.jpg', 'image/jpeg');
+   * console.log(result);
+   * ```
+   *
+   * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
+   * @category Create
+   * @param data The binary data to upload.
+   * @param filename Optional filename for the binary.
+   * @param contentType Content type for the binary.
+   * @param onProgress Optional callback for progress events.
+   * @returns The result of the create operation.
+   */
+  async createAttachment(
+    data: string | File | Blob | Uint8Array,
+    filename: string | undefined,
+    contentType: string,
+    onProgress?: (e: ProgressEvent) => void
+  ): Promise<Attachment> {
+    const binary = await this.createBinary(data, filename, contentType, onProgress);
+    return {
+      contentType,
+      url: binary.url,
+      title: filename,
+    };
   }
 
   /**

--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -61777,10 +61777,6 @@
           "description": "A schedule for the bot to be executed.",
           "$ref": "#/definitions/string"
         },
-        "code": {
-          "description": "Bot logic script.",
-          "$ref": "#/definitions/string"
-        },
         "category": {
           "description": "A code that classifies the service for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
           "items": {
@@ -61791,6 +61787,37 @@
         "runAsUser": {
           "description": "Optional flag to indicate that the bot should be run as the user.",
           "$ref": "#/definitions/boolean"
+        },
+        "auditEventTrigger": {
+          "description": "Criteria for creating an AuditEvent as a result of the bot invocation. Possible values are \u0027always\u0027, \u0027never\u0027, \u0027on-error\u0027, or \u0027on-output\u0027. Default value is \u0027always\u0027.",
+          "enum": [
+            "always",
+            "never",
+            "on-error",
+            "on-output"
+          ]
+        },
+        "auditEventDestination": {
+          "description": "The destination system in which the AuditEvent is to be sent. Possible values are \u0027log\u0027 or \u0027resource\u0027. Default value is \u0027resource\u0027.",
+          "items": {
+            "enum": [
+              "log",
+              "resource"
+            ]
+          },
+          "type": "array"
+        },
+        "sourceCode": {
+          "description": "Bot logic in original source code form written by developers.",
+          "$ref": "#/definitions/Attachment"
+        },
+        "executableCode": {
+          "description": "Bot logic in executable form as a result of compiling and bundling source code.",
+          "$ref": "#/definitions/Attachment"
+        },
+        "code": {
+          "description": "DEPRECATED Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
+          "$ref": "#/definitions/string"
         }
       },
       "additionalProperties": false,

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -1338,21 +1338,6 @@
             }
           },
           {
-            "id" : "Bot.code",
-            "path" : "Bot.code",
-            "definition" : "Bot logic script.",
-            "min" : 0,
-            "max" : "1",
-            "type" : [{
-              "code" : "string"
-            }],
-            "base" : {
-              "path" : "Bot.code",
-              "min" : 0,
-              "max" : "1"
-            }
-          },
-          {
             "id" : "Bot.category",
             "path" : "Bot.category",
             "short" : "Classification of service",
@@ -1380,6 +1365,89 @@
             }],
             "base" : {
               "path" : "Bot.runAsUser",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id" : "Bot.auditEventTrigger",
+            "path" : "Bot.auditEventTrigger",
+            "definition" : "Criteria for creating an AuditEvent as a result of the bot invocation. Possible values are 'always', 'never', 'on-error', or 'on-output'. Default value is 'always'.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "Bot.auditEventTrigger",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "code"
+            }],
+            "binding" : {
+              "strength" : "required",
+              "valueSet" : "https://medplum.com/fhir/ValueSet/bot-audit-event-trigger|4.0.1"
+            }
+          },
+          {
+            "id" : "Bot.auditEventDestination",
+            "path" : "Bot.auditEventDestination",
+            "definition" : "The destination system in which the AuditEvent is to be sent. Possible values are 'log' or 'resource'. Default value is 'resource'.",
+            "min" : 0,
+            "max" : "*",
+            "base" : {
+              "path" : "Bot.auditEventDestination",
+              "min" : 0,
+              "max" : "*"
+            },
+            "type" : [{
+              "code" : "code"
+            }],
+            "binding" : {
+              "strength" : "required",
+              "valueSet" : "https://medplum.com/fhir/ValueSet/bot-audit-event-destination|4.0.1"
+            }
+          },
+          {
+            "id" : "Bot.sourceCode",
+            "path" : "Bot.sourceCode",
+            "definition" : "Bot logic in original source code form written by developers.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "Bot.sourceCode",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "Attachment"
+            }]
+          },
+          {
+            "id" : "Bot.executableCode",
+            "path" : "Bot.executableCode",
+            "definition" : "Bot logic in executable form as a result of compiling and bundling source code.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "Bot.executableCode",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "Attachment"
+            }]
+          },
+          {
+            "id" : "Bot.code",
+            "path" : "Bot.code",
+            "definition" : "DEPRECATED Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "string"
+            }],
+            "base" : {
+              "path" : "Bot.code",
               "min" : 0,
               "max" : "1"
             }

--- a/packages/fhirtypes/dist/Bot.d.ts
+++ b/packages/fhirtypes/dist/Bot.d.ts
@@ -82,11 +82,6 @@ export interface Bot {
   cronString?: string;
 
   /**
-   * Bot logic script.
-   */
-  code?: string;
-
-  /**
    * A code that classifies the service for searching, sorting and display
    * purposes (e.g. &quot;Surgical Procedure&quot;).
    */
@@ -96,4 +91,34 @@ export interface Bot {
    * Optional flag to indicate that the bot should be run as the user.
    */
   runAsUser?: boolean;
+
+  /**
+   * Criteria for creating an AuditEvent as a result of the bot invocation.
+   * Possible values are 'always', 'never', 'on-error', or 'on-output'.
+   * Default value is 'always'.
+   */
+  auditEventTrigger?: 'always' | 'never' | 'on-error' | 'on-output';
+
+  /**
+   * The destination system in which the AuditEvent is to be sent. Possible
+   * values are 'log' or 'resource'. Default value is 'resource'.
+   */
+  auditEventDestination?: ('log' | 'resource')[];
+
+  /**
+   * Bot logic in original source code form written by developers.
+   */
+  sourceCode?: Attachment;
+
+  /**
+   * Bot logic in executable form as a result of compiling and bundling
+   * source code.
+   */
+  executableCode?: Attachment;
+
+  /**
+   * DEPRECATED Bot logic script. Use Bot.sourceCode or Bot.executableCode
+   * instead.
+   */
+  code?: string;
 }

--- a/packages/mock/src/mocks/bot.ts
+++ b/packages/mock/src/mocks/bot.ts
@@ -1,10 +1,20 @@
-import { Bot, ClientApplication } from '@medplum/fhirtypes';
+import { Binary, Bot, ClientApplication } from '@medplum/fhirtypes';
+
+export const ExampleBotSourceCode: Binary = {
+  resourceType: 'Binary',
+  id: 'bot-source-code',
+  contentType: 'application/javascript',
+};
 
 export const ExampleBot: Bot = {
   resourceType: 'Bot',
   id: '123',
   name: 'Test Bot',
-  code: 'console.log("hello world");',
+  sourceCode: {
+    contentType: 'application/javascript',
+    title: 'index.js',
+    url: 'Binary/bot-source-code',
+  },
 };
 
 export const ExampleClient: ClientApplication = {

--- a/packages/server/src/admin/bot.test.ts
+++ b/packages/server/src/admin/bot.test.ts
@@ -39,7 +39,8 @@ describe('Bot admin', () => {
     expect(res2.status).toBe(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
-    expect(res2.body.code).toBeDefined();
+    expect(res2.body.code).toBeUndefined();
+    expect(res2.body.sourceCode).toBeDefined();
 
     // Read the bot
     const res3 = await request(app)

--- a/packages/server/src/admin/bot.ts
+++ b/packages/server/src/admin/bot.ts
@@ -1,9 +1,11 @@
-import { createReference } from '@medplum/core';
-import { AccessPolicy, Bot, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
+import { createReference, getReferenceString } from '@medplum/core';
+import { AccessPolicy, Binary, Bot, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
+import { Readable } from 'stream';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { Repository, systemRepo } from '../fhir/repo';
+import { getBinaryStorage } from '../fhir/storage';
 
 export const createBotValidators = [body('name').notEmpty().withMessage('Bot name is required')];
 
@@ -37,6 +39,14 @@ export interface CreateBotRequest {
 }
 
 export async function createBot(repo: Repository, request: CreateBotRequest): Promise<Bot> {
+  const filename = 'index.ts';
+  const contentType = 'text/typescript';
+  const binary = await repo.createResource<Binary>({
+    resourceType: 'Binary',
+    contentType,
+  });
+  await getBinaryStorage().writeBinary(binary, filename, contentType, Readable.from(defaultBotCode));
+
   const bot = await repo.createResource<Bot>({
     meta: {
       project: request.project.id,
@@ -45,7 +55,11 @@ export async function createBot(repo: Repository, request: CreateBotRequest): Pr
     name: request.name,
     description: request.description,
     runtimeVersion: 'awslambda',
-    code: defaultBotCode,
+    sourceCode: {
+      contentType,
+      title: filename,
+      url: getReferenceString(binary),
+    },
   });
 
   await systemRepo.createResource<ProjectMembership>({

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -41,6 +41,7 @@ export interface MedplumServerConfig {
   bcryptHashSalt: number;
   introspectionEnabled?: boolean;
   keepAliveTimeout?: number;
+  vmContextBotsEnabled?: boolean;
 }
 
 /**

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -37,7 +37,7 @@ function isOriginAllowed(origin: string | undefined): boolean {
   return false;
 }
 
-const prefixes = ['/.well-known/', '/admin/', '/auth/', '/email/', '/fhir/', '/oauth2/'];
+const prefixes = ['/.well-known/', '/admin/', '/auth/', '/email/', '/fhir/', '/oauth2/', '/storage/'];
 
 function isPathAllowed(path: string): boolean {
   return prefixes.some((prefix) => path.startsWith(prefix));

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -37,7 +37,7 @@ function isOriginAllowed(origin: string | undefined): boolean {
   return false;
 }
 
-const prefixes = ['/.well-known/', '/admin/', '/auth/', '/email/', '/fhir/', '/oauth2/', '/storage/'];
+const prefixes = ['/.well-known/', '/admin/', '/auth/', '/email/', '/fhir/', '/oauth2/'];
 
 function isPathAllowed(path: string): boolean {
   return prefixes.some((prefix) => path.startsWith(prefix));

--- a/packages/server/src/fhir/operations/deploy.test.ts
+++ b/packages/server/src/fhir/operations/deploy.test.ts
@@ -193,7 +193,7 @@ describe('Deploy', () => {
     expect(res2.status).toBe(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
-    expect(res2.body.code).toBeDefined();
+    expect(res2.body.sourceCode).toBeDefined();
 
     // Try to deploy the bot
     // This should fail because bots are not enabled

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -138,8 +138,9 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
 
     // Deploy the bot
     if (updatedBot.runtimeVersion === 'awslambda') {
-      await deployLambda(updatedBot, code as string);
+      await deployLambda(updatedBot, code);
     }
+
     sendOutcome(res, allOk);
   } catch (err) {
     sendOutcome(res, badRequest((err as Error).message));

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -9,14 +9,16 @@ import {
   UpdateFunctionConfigurationCommand,
 } from '@aws-sdk/client-lambda';
 import { allOk, badRequest } from '@medplum/core';
-import { Bot } from '@medplum/fhirtypes';
+import { Binary, Bot } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import JSZip from 'jszip';
+import { Readable } from 'stream';
 import { asyncWrap } from '../../async';
 import { getConfig } from '../../config';
 import { logger } from '../../logger';
 import { sendOutcome } from '../outcomes';
 import { Repository, systemRepo } from '../repo';
+import { getBinaryStorage } from '../storage';
 import { isBotEnabled } from './execute';
 
 const LAMBDA_RUNTIME = 'nodejs18.x';
@@ -95,6 +97,13 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
   const { id } = req.params;
   const repo = res.locals.repo as Repository;
 
+  // Validate that the request body has a code property
+  const code = req.body.code as string | undefined;
+  if (!code) {
+    sendOutcome(res, badRequest('Missing code'));
+    return;
+  }
+
   // First read the bot as the user to verify access
   await repo.readResource<Bot>('Bot', id);
 
@@ -106,26 +115,40 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
     return;
   }
 
-  const client = new LambdaClient({ region: getConfig().awsRegion });
-  const name = `medplum-bot-lambda-${bot.id}`;
-
-  // By default, use the code on the bot
-  // Allow the client to override the code
-  // This is useful for sending compiled output when the bot code is TypeScript
-  let code = bot.code;
-  if (req.body.code) {
-    code = req.body.code;
-  }
-
   try {
-    await deployLambda(client, name, code as string);
+    const filename = 'index.js';
+    const contentType = 'text/javascript';
+
+    // Create a Binary for the executable code
+    const binary = await repo.createResource<Binary>({
+      resourceType: 'Binary',
+      contentType,
+    });
+    await getBinaryStorage().writeBinary(binary, filename, contentType, Readable.from(code));
+
+    // Update the bot
+    const updatedBot = await repo.updateResource<Bot>({
+      ...bot,
+      executableCode: {
+        contentType,
+        url: binary.url,
+        title: filename,
+      },
+    });
+
+    // Deploy the bot
+    if (updatedBot.runtimeVersion === 'awslambda') {
+      await deployLambda(updatedBot, code as string);
+    }
     sendOutcome(res, allOk);
   } catch (err) {
     sendOutcome(res, badRequest((err as Error).message));
   }
 });
 
-export async function deployLambda(client: LambdaClient, name: string, code: string): Promise<void> {
+async function deployLambda(bot: Bot, code: string): Promise<void> {
+  const client = new LambdaClient({ region: getConfig().awsRegion });
+  const name = `medplum-bot-lambda-${bot.id}`;
   logger.info('Deploying lambda function for bot', { name });
   const zipFile = await createZipFile(code);
   logger.debug('Lambda function zip size', { bytes: zipFile.byteLength });

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -8,7 +8,7 @@ import {
   UpdateFunctionCodeCommand,
   UpdateFunctionConfigurationCommand,
 } from '@aws-sdk/client-lambda';
-import { allOk, badRequest } from '@medplum/core';
+import { allOk, badRequest, getReferenceString } from '@medplum/core';
 import { Binary, Bot } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import JSZip from 'jszip';
@@ -131,7 +131,7 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
       ...bot,
       executableCode: {
         contentType,
-        url: binary.url,
+        url: getReferenceString(binary),
         title: filename,
       },
     });

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -207,7 +207,7 @@ describe('Execute', () => {
     expect(res2.status).toBe(201);
     expect(res2.body.resourceType).toBe('Bot');
     expect(res2.body.id).toBeDefined();
-    expect(res2.body.code).toBeDefined();
+    expect(res2.body.sourceCode).toBeDefined();
 
     // Try to execute the bot
     // This should fail because bots are not enabled

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -157,12 +157,6 @@ describe('Execute', () => {
         resourceType: 'Bot',
         name: 'Test Bot',
         runtimeVersion: 'unsupported',
-        code: `
-        export async function handler() {
-          console.log('input', input);
-          return input;
-        }
-        `,
       });
     expect(res1.status).toBe(201);
     const bot = res1.body as Bot;
@@ -172,7 +166,14 @@ describe('Execute', () => {
       .post(`/fhir/R4/Bot/${bot.id}/$deploy`)
       .set('Content-Type', 'application/fhir+json')
       .set('Authorization', 'Bearer ' + accessToken)
-      .send({});
+      .send({
+        code: `
+        export async function handler() {
+          console.log('input', input);
+          return input;
+        }
+        `,
+      });
     expect(res2.status).toBe(200);
 
     // Step 3: Execute the bot

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -117,10 +117,6 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
     return { success: false, logResult: 'Bots not enabled' };
   }
 
-  if (!bot.code) {
-    return { success: false, logResult: 'Ignore bots with no code' };
-  }
-
   if (bot.runtimeVersion === 'awslambda') {
     return runInLambda(request);
   } else {

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -198,7 +198,6 @@ const BLOCKED_FILE_EXTENSIONS = [
   '.isp',
   '.iso',
   '.jar',
-  '.js',
   '.jse',
   '.lib',
   '.lnk',
@@ -241,7 +240,6 @@ const BLOCKED_CONTENT_TYPES = [
   'application/vnd.microsoft.portable-executable',
   'application/vnd.rar',
   'application/zip',
-  'text/javascript',
 ];
 
 /**

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -22,7 +22,7 @@ aws s3 cp dist/ "s3://${APP_BUCKET}/" \
 
 aws s3 cp dist/ "s3://${APP_BUCKET}/" \
   --recursive \
-  --content-type "application/javascript" \
+  --content-type "text/javascript" \
   --cache-control "public, max-age=31536000" \
   --exclude "*" \
   --include "*.js"

--- a/scripts/deploy-graphiql.sh
+++ b/scripts/deploy-graphiql.sh
@@ -25,7 +25,7 @@ aws s3 cp dist/ s3://graphiql.medplum.com/ \
 aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --region us-east-1 \
   --recursive \
-  --content-type "application/javascript" \
+  --content-type "text/javascript" \
   --cache-control "public, max-age=31536000" \
   --exclude "*" \
   --include "*.js"


### PR DESCRIPTION
Bot structure update:

- Moving `code: string` to `sourceCode: Attachment`
- Deprecating `code`
- Adding `executableCode: Attachment`
- Adding `auditEventTrigger` and `auditEventDestination`
- Bringing back VM Context bots

How this looks in practice

No more ugly diffs in the Bot timeline view:

<img width="946" alt="image" src="https://github.com/medplum/medplum/assets/749094/d8a2e861-d1d8-43dc-95e2-3f6e5765e51f">

You can click on those to open up the raw source in a new file.  Someday we could add a code viewer inline.

![image](https://github.com/medplum/medplum/assets/749094/2c534888-d236-442e-8f62-a049dce50b9b)


----

Fixes:

- Move Bot code to attachment #2138
- Use VMContext Bots for localhost testing #2516
- Configurable Bot audit mode #2518
