### PR TITLE
HL7 fixes for SimHospital

### DIFF
--- a/examples/medplum-demo-bots/src/examples/lab-integration/read-oru-message.test.ts
+++ b/examples/medplum-demo-bots/src/examples/lab-integration/read-oru-message.test.ts
@@ -241,7 +241,7 @@ describe('Read from Partner Lab', () => {
 
     // Check that Specimen collection dates have been set
     const checkSpecimen1 = await medplum.readReference(serviceRequest.specimen?.[0] as Reference<Specimen>);
-    expect(checkSpecimen1.receivedTime).toBe('2023-02-09T11:43:00.000-05:00');
+    expect(checkSpecimen1.receivedTime).toBe('2023-02-09T16:43:00.000Z');
 
     // Check that a PDF has been uploaded
     expect(createBinarySpy).toHaveBeenCalled();

--- a/packages/agent/esbuild.mjs
+++ b/packages/agent/esbuild.mjs
@@ -1,0 +1,28 @@
+/* global console */
+/* eslint no-console: "off" */
+
+import esbuild from 'esbuild';
+import { writeFileSync } from 'fs';
+
+const options = {
+  entryPoints: ['./src/main.ts'],
+  bundle: true,
+  platform: 'node',
+  loader: { '.js': 'js', '.ts': 'ts' },
+  resolveExtensions: ['.js', '.ts'],
+  target: 'es2021',
+  tsconfig: 'tsconfig.json',
+  external: ['iconv-lite', 'pdfmake'],
+};
+
+// The single executable application feature only supports running a single embedded CommonJS file.
+// https://nodejs.org/dist/latest-v18.x/docs/api/single-executable-applications.html
+
+esbuild
+  .build({
+    ...options,
+    format: 'cjs',
+    outfile: './dist/cjs/index.cjs',
+  })
+  .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
+  .catch(console.error);

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -15,8 +15,9 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && tsc",
-    "test": "jest"
+    "build": "npm run clean && tsc && node esbuild.mjs",
+    "test": "jest",
+    "package": "pkg ./dist/cjs/index.cjs --targets node18-win-x64 --output dist/medplum-agent-win-x64.exe"
   },
   "dependencies": {
     "@medplum/core": "*",

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -39,7 +39,7 @@ export class App {
   private async handler(event: Hl7MessageEvent): Promise<void> {
     try {
       console.log('Received:');
-      console.log(event.message.toString());
+      console.log(event.message.toString().replaceAll('\r', '\n'));
 
       await this.medplum.post(
         this.medplum.fhirUrl('Bot', this.bot.id as string, '$execute'),
@@ -49,7 +49,7 @@ export class App {
 
       const ack = event.message.buildAck();
       console.log('Response:');
-      console.log(ack.toString());
+      console.log(ack.toString().replaceAll('\r', '\n'));
       event.send(ack);
     } catch (err) {
       console.log('HL7 error', err);


### PR DESCRIPTION
Setting up [SimHospital](https://github.com/google/simhospital) for testing our on-prem agent

Bunch of HL7 bug fixes:
- MSH.1 was duplicated in ACK
- MSH.7 was malformed date/time in ACK
- Date/time parsing did not handle all optional date/time components
- Added `formatHl7DateTime()` helper method

While work on this, I updated `read-oru-message.ts` to use all of the new HL7 utilities such as `.getField()` and `.getComponent()`.

Also added the initial `npm run package` command which uses [Vercel pkg](https://github.com/vercel/pkg) to create a standalone binary .exe file.

See basic docs on SimHospital: https://github.com/google/simhospital/blob/master/docs/get-started.md

Example command to produce HL7 messages and send via MLLP every 5 seconds:

```
docker run --rm -it -p 8000:8000 eu.gcr.io/simhospital-images/simhospital:latest health/simulator \
    -output mllp \
    -mllp_destination 192.168.50.10:56000 \
    -pathways_per_hour 720
```