### PR TITLE
Fixed CLI update-app command, added --dryrun

### DIFF
--- a/packages/cli/src/aws/index.ts
+++ b/packages/cli/src/aws/index.ts
@@ -29,4 +29,8 @@ aws
   .alias('deploy-app')
   .description('Update the app site')
   .argument('<tag>')
+  .option(
+    '--dryrun',
+    'Displays the operations that would be performed using the specified command without actually running them.'
+  )
   .action(updateAppCommand);

--- a/packages/cli/src/aws/update-app.test.ts
+++ b/packages/cli/src/aws/update-app.test.ts
@@ -1,12 +1,19 @@
 import {
   CloudFormationClient,
+  CloudFormationClientResolvedConfig,
   DescribeStackResourcesCommand,
   DescribeStacksCommand,
   ListStacksCommand,
+  ServiceInputTypes,
+  ServiceOutputTypes,
 } from '@aws-sdk/client-cloudformation';
-import { CloudFrontClient, CreateInvalidationCommand } from '@aws-sdk/client-cloudfront';
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  CloudFrontClient,
+  CloudFrontClientResolvedConfig,
+  CreateInvalidationCommand,
+} from '@aws-sdk/client-cloudfront';
+import { PutObjectCommand, S3Client, S3ClientResolvedConfig } from '@aws-sdk/client-s3';
+import { AwsStub, mockClient } from 'aws-sdk-client-mock';
 import fastGlob from 'fast-glob';
 import fs from 'fs';
 import fetch from 'node-fetch';
@@ -42,9 +49,13 @@ jest.mock('tar', () => ({
 
 const { Response: NodeFetchResponse } = jest.requireActual('node-fetch');
 
+let cfMock: AwsStub<ServiceInputTypes, ServiceOutputTypes, CloudFormationClientResolvedConfig>;
+let s3Mock: AwsStub<ServiceInputTypes, ServiceOutputTypes, S3ClientResolvedConfig>;
+let cloudFrontMock: AwsStub<ServiceInputTypes, ServiceOutputTypes, CloudFrontClientResolvedConfig>;
+
 describe('update-app command', () => {
-  beforeAll(() => {
-    const cfMock = mockClient(CloudFormationClient);
+  beforeEach(() => {
+    cfMock = mockClient(CloudFormationClient);
 
     cfMock.on(ListStacksCommand).resolves({
       StackSummaries: [
@@ -120,10 +131,14 @@ describe('update-app command', () => {
       StackResources: [],
     });
 
-    const s3Mock = mockClient(S3Client);
+    s3Mock = mockClient(S3Client);
     s3Mock.on(PutObjectCommand).resolves({});
 
-    const cloudFrontMock = mockClient(CloudFrontClient);
+    cloudFrontMock = mockClient(CloudFrontClient) as AwsStub<
+      ServiceInputTypes,
+      ServiceOutputTypes,
+      CloudFrontClientResolvedConfig
+    >;
     cloudFrontMock.on(CreateInvalidationCommand).resolves({});
   });
 
@@ -195,6 +210,76 @@ describe('update-app command', () => {
     expect(fetch).toHaveBeenNthCalledWith(1, 'https://registry.npmjs.org/@medplum/app/latest');
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://example.com/tarball.tar.gz');
     expect(console.log).toBeCalledWith('Done');
+    expect(s3Mock.calls()).toHaveLength(1);
+    expect(cloudFrontMock.calls()).toHaveLength(1);
+  });
+
+  test('Update app dryrun', async () => {
+    console.log = jest.fn();
+
+    // Mock the config file
+    (fs.existsSync as jest.Mock).mockReturnValueOnce(true);
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce(
+      JSON.stringify({
+        baseUrl: 'https://api.staging.medplum.com/',
+        clientId: '',
+        googleClientId: '659647315343-c0p9rkl3pq38q18r13bkrchs4iqjogv1.apps.googleusercontent.com',
+        recaptchaSiteKey: '6LfXscQdAAAAAKlNFAoXqjliz0xbR8hvQw_pZfb2',
+        registerEnabled: true,
+      })
+    );
+
+    // Mock the 2 fetch requests
+    (fetch as jest.MockedFunction<typeof fetch>)
+      // First request is for the package metadata
+      .mockResolvedValueOnce(
+        new NodeFetchResponse('{"dist":{"tarball":"https://example.com/tarball.tar.gz"}}', { status: 200 })
+      )
+      // Second request is for the tarball
+      .mockResolvedValueOnce(
+        new NodeFetchResponse(
+          new Readable({
+            read() {
+              this.push(null); // Signal the end of the stream
+            },
+          }),
+          { status: 200 }
+        )
+      );
+
+    // Mock the tar extract
+    (tar.x as jest.Mock).mockReturnValueOnce(
+      new Writable({
+        write(_chunk, _encoding, callback) {
+          callback();
+        },
+      })
+    );
+
+    // Mock the readdirSync to list files to replace variables
+    (fs.readdirSync as jest.Mock).mockImplementation((folderName) => {
+      if (folderName.endsWith('dist')) {
+        return [{ name: 'js', isDirectory: () => true, isFile: () => false }];
+      }
+      return [
+        { name: 'main.js', isDirectory: () => false, isFile: () => true },
+        { name: 'nonejsfile', isDirectory: () => false, isFile: () => true },
+      ];
+    });
+
+    // Mock the readFileSync to read the file to replace variables
+    (fs.readFileSync as jest.Mock).mockReturnValueOnce('console.log("Hello, world!");');
+
+    // Mock the glob search for files to upload
+    (fastGlob.sync as jest.Mock).mockReturnValueOnce(['index.html']);
+
+    await main(['node', 'index.js', 'aws', 'update-app', 'dev', '--dryrun']);
+
+    expect(fetch).toHaveBeenNthCalledWith(1, 'https://registry.npmjs.org/@medplum/app/latest');
+    expect(fetch).toHaveBeenNthCalledWith(2, 'https://example.com/tarball.tar.gz');
+    expect(console.log).toBeCalledWith('Done');
+    expect(s3Mock.calls()).toHaveLength(0);
+    expect(cloudFrontMock.calls()).toHaveLength(0);
   });
 
   test('Update app command without optional configs', async () => {

--- a/packages/cli/src/aws/update-app.ts
+++ b/packages/cli/src/aws/update-app.ts
@@ -10,11 +10,16 @@ import { pipeline } from 'stream/promises';
 import { readConfig, safeTarExtractor } from '../utils';
 import { cloudFrontClient, getStackByTag, s3Client } from './utils';
 
+export interface UpdateAppOptions {
+  dryrun?: boolean;
+}
+
 /**
  * The AWS "update-app" command updates the Medplum app in a Medplum CloudFormation stack to the latest version.
  * @param tag The Medplum stack tag.
+ * @param options The update options.
  */
-export async function updateAppCommand(tag: string): Promise<void> {
+export async function updateAppCommand(tag: string, options: UpdateAppOptions): Promise<void> {
   const config = readConfig(tag);
   if (!config) {
     console.log('Config not found');
@@ -43,10 +48,10 @@ export async function updateAppCommand(tag: string): Promise<void> {
   });
 
   // Upload the app to S3 with correct content-type and cache-control
-  await uploadAppToS3(tmpDir, appBucket.PhysicalResourceId as string);
+  await uploadAppToS3(tmpDir, appBucket.PhysicalResourceId as string, options);
 
   // Create a CloudFront invalidation to clear any cached resources
-  if (details.appDistribution?.PhysicalResourceId) {
+  if (details.appDistribution?.PhysicalResourceId && !options.dryrun) {
     await createInvalidation(details.appDistribution.PhysicalResourceId);
   }
 
@@ -121,8 +126,9 @@ function replaceVariablesInFile(fileName: string, replacements: Record<string, s
  * Ensures correct content-type and cache-control for each file.
  * @param tmpDir The temporary directory where the app is located.
  * @param bucketName The destination S3 bucket name.
+ * @param options The update options.
  */
-async function uploadAppToS3(tmpDir: string, bucketName: string): Promise<void> {
+async function uploadAppToS3(tmpDir: string, bucketName: string, options: UpdateAppOptions): Promise<void> {
   // Manually iterate and upload files
   // Automatic content-type detection is not reliable on Microsoft Windows
   // So we explicitly set content-type
@@ -130,23 +136,18 @@ async function uploadAppToS3(tmpDir: string, bucketName: string): Promise<void> 
     // Cached
     // These files generally have a hash, so they can be cached forever
     // It is important to upload them first to avoid broken references from index.html
-    ['css/**/*.css', ContentType.CSS, true],
-    ['css/**/*.css.map', ContentType.JSON, true],
+    ['assets/**/*.css', ContentType.CSS, true],
+    ['assets/**/*.css.map', ContentType.JSON, true],
+    ['assets/**/*.js', ContentType.JAVASCRIPT, true],
+    ['assets/**/*.js.map', ContentType.JSON, true],
+    ['assets/**/*.txt', ContentType.TEXT, true],
+    ['assets/**/*.ico', ContentType.FAVICON, true],
     ['img/**/*.png', ContentType.PNG, true],
-    ['img/**/*.svg', 'image/svg+xml', true],
-    ['js/**/*.js', ContentType.JAVASCRIPT, true],
-    ['js/**/*.js.map', ContentType.JSON, true],
-    ['js/**/*.txt', ContentType.TEXT, true],
-    ['favicon.ico', ContentType.FAVICON, true],
+    ['img/**/*.svg', ContentType.SVG, true],
     ['robots.txt', ContentType.TEXT, true],
-    ['workbox-*.js', ContentType.JAVASCRIPT, true],
-    ['workbox-*.js.map', ContentType.JSON, true],
 
     // Not cached
-    ['manifest.webmanifest', 'application/manifest+json', false],
-    ['service-worker.js', ContentType.JAVASCRIPT, false],
-    ['service-worker.js.map', ContentType.JSON, false],
-    ['index.html', 'text/html', false],
+    ['index.html', ContentType.HTML, false],
   ];
   for (const uploadPattern of uploadPatterns) {
     await uploadFolderToS3({
@@ -155,6 +156,7 @@ async function uploadAppToS3(tmpDir: string, bucketName: string): Promise<void> 
       fileNamePattern: uploadPattern[0],
       contentType: uploadPattern[1],
       cached: uploadPattern[2],
+      dryrun: options.dryrun,
     });
   }
 }
@@ -167,6 +169,7 @@ async function uploadAppToS3(tmpDir: string, bucketName: string): Promise<void> 
  * @param options.fileNamePattern The glob file pattern to upload.
  * @param options.contentType The content type MIME type.
  * @param options.cached True to mark as public and cached forever.
+ * @param options.dryrun True to skip the upload.
  */
 async function uploadFolderToS3(options: {
   rootDir: string;
@@ -174,6 +177,7 @@ async function uploadFolderToS3(options: {
   fileNamePattern: string;
   contentType: string;
   cached: boolean;
+  dryrun?: boolean;
 }): Promise<void> {
   const items = fastGlob.sync(options.fileNamePattern, { cwd: options.rootDir });
   for (const item of items) {
@@ -189,6 +193,7 @@ async function uploadFolderToS3(options: {
  * @param options.bucketName The destination bucket name.
  * @param options.contentType The content type MIME type.
  * @param options.cached True to mark as public and cached forever.
+ * @param options.dryrun True to skip the upload.
  */
 async function uploadFileToS3(
   filePath: string,
@@ -197,6 +202,7 @@ async function uploadFileToS3(
     bucketName: string;
     contentType: string;
     cached: boolean;
+    dryrun?: boolean;
   }
 ): Promise<void> {
   const fileStream = createReadStream(filePath);
@@ -214,7 +220,9 @@ async function uploadFileToS3(
   };
 
   console.log(`Uploading ${s3Key} to ${options.bucketName}...`);
-  await s3Client.send(new PutObjectCommand(putObjectParams));
+  if (!options.dryrun) {
+    await s3Client.send(new PutObjectCommand(putObjectParams));
+  }
 }
 
 /**

--- a/packages/core/src/contenttype.ts
+++ b/packages/core/src/contenttype.ts
@@ -7,6 +7,7 @@ export const ContentType = {
   FHIR_JSON: 'application/fhir+json',
   FORM_URL_ENCODED: 'application/x-www-form-urlencoded',
   HL7_V2: 'x-application/hl7-v2+er7',
+  HTML: 'text/html',
   JAVASCRIPT: 'text/javascript',
   JSON: 'application/json',
   JSON_PATCH: 'application/json-patch+json',


### PR DESCRIPTION
Deployed to staging with the CLI: https://app.staging.medplum.com/

For Medplum engineers with appropriate AWS permissions, here is how to deploy to staging using the Medplum CLI:

First, you need a staging config file:

`medplum.staging.config.json`

```json
{
  "region": "us-east-1",
  "name": "staging",
  "stackName": "MedplumStaging",
  "appBucket": "app.staging.medplum.com",
  "baseUrl": "https://api.staging.medplum.com/",
  "googleClientId": "659647315343-c0p9rkl3pq38q18r13bkrchs4iqjogv1.apps.googleusercontent.com",
  "recaptchaSiteKey": "6LfXscQdAAAAAKlNFAoXqjliz0xbR8hvQw_pZfb2"
}
```

Then you can use the CLI to deploy.  When running from within the repo, you can use `npm run medplum`:

```bash
cd packages/cli
npm run medplum -- aws update-app staging
```

You can use the new `--dryrun` option to show which files would be deployed:

```bash
cd packages/cli
npm run medplum -- aws update-app staging --dryrun
```
