### PR TITLE
Fix several typos in User Management Guide

### DIFF
--- a/packages/docs/docs/auth/user-management-guide.md
+++ b/packages/docs/docs/auth/user-management-guide.md
@@ -38,7 +38,7 @@ Users in Medplum can be members of multiple projects, so cannot be edited direct
 
 ### Creating Memberships
 
-Only administrators can invite users, and can do so on the [Invite](https://app.medplum.com/admin/invite) page. You can specify a role and [AccessPolity](/docs/auth/access-control) at time of invite. The invite flow will do the following:
+Only administrators can invite users, and can do so on the [Invite](https://app.medplum.com/admin/invite) page. You can specify a role and [AccessPolicy](/docs/auth/access-control) at time of invite. The invite flow will do the following:
 
 1. Create a `User` if one does not already exist
 2. Create a FHIR resource (Patient, Practitioner or RelatedPerson)
@@ -55,7 +55,7 @@ Do not delete Patient, Practitioner or RelatedPerson resources that belong to Pr
 
 Tor remove users from the existing project navigate to your [Project settings](https://app.medplum.com/admin/project) and to the Users and Patient tabs respectively. Click on a specific users or patients and click **Remove User**.
 
-We highly recommend leaving the associated FHIR resource (Patient, Practitioner, etc.) in place for audibility, record keeping and in case the membership needs to be reonstructed for some reason.
+We highly recommend leaving the associated FHIR resource (Patient, Practitioner, etc.) in place for audibility, record keeping and in case the membership needs to be reconstructed for some reason.
 
 ## Invite via API
 
@@ -82,7 +82,7 @@ curl 'https://api.medplum.com/admin/projects/${projectId}/invite' \
   --data-raw '{"resourceType":"Patient","firstName":"Homer","lastName":"Simpson","email":"homer@example.com", "sendEmail":"false"}'
 ```
 
-The `/invite` endpoint creates a [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership). The `ProjectMembership` resource includes additional properties to customize the user experience. The `/invite` endpoint accepts a partial `ProjectMebership` in the `membership` property where you can provide membership details.
+The `/invite` endpoint creates a [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership). The `ProjectMembership` resource includes additional properties to customize the user experience. The `/invite` endpoint accepts a partial `ProjectMembership` in the `membership` property where you can provide membership details.
 
 For example, use `admin: true` to make the new user a project administrator:
 


### PR DESCRIPTION
Hey team, noticed a few typos in the [this guide](https://www.medplum.com/docs/auth/user-management-guide). In this PR the following have been corrected:

- `AccessPolity` to `AccessPolicy`
- `reonstructed` to `reconstructed`
- `ProjectMebership` to `ProjectMembership`