### PR TITLE
Add support for _elements and _summary search parameters

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2424,7 +2424,7 @@ export class MedplumClient extends EventTarget {
    * @param resource The resource to cache.
    */
   private cacheResource(resource: Resource | undefined): void {
-    if (resource?.id) {
+    if (resource?.id && !resource.meta?.tag?.some((t) => t.code === 'SUBSETTED')) {
       this.setCacheEntry(
         this.fhirUrl(resource.resourceType, resource.id).toString(),
         new ReadablePromise(Promise.resolve(resource))

--- a/packages/core/src/search/parse.test.ts
+++ b/packages/core/src/search/parse.test.ts
@@ -97,11 +97,18 @@ describe('Search parser', () => {
     });
   });
 
-  test('Parse summary', () => {
-    expect(parseSearchRequest('Patient', { _summary: 'true' })).toMatchObject<SearchRequest>({
-      resourceType: 'Patient',
-      total: 'accurate',
-      count: 0,
+  test.each<[string, Partial<SearchRequest>]>([
+    ['count', { total: 'accurate', count: 0 }],
+    ['true', { summary: 'true' }],
+    ['data', { summary: 'data' }],
+    ['text', { summary: 'text' }],
+    ['false', {}],
+    ['notarealvalue', {}],
+  ])('Parse _summary=%s', (value, expected) => {
+    const resourceType = 'Patient';
+    expect(parseSearchRequest(resourceType, { _summary: value })).toMatchObject<SearchRequest>({
+      resourceType,
+      ...expected,
     });
   });
 

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -15,6 +15,7 @@ export interface SearchRequest<T extends Resource = Resource> {
   total?: 'none' | 'estimate' | 'accurate';
   include?: IncludeTarget[];
   revInclude?: IncludeTarget[];
+  summary?: 'true' | 'text' | 'data';
 }
 
 export interface Filter {
@@ -216,8 +217,12 @@ function parseKeyValue(searchRequest: SearchRequest, key: string, value: string)
       break;
 
     case '_summary':
-      searchRequest.total = 'accurate';
-      searchRequest.count = 0;
+      if (value === 'count') {
+        searchRequest.total = 'accurate';
+        searchRequest.count = 0;
+      } else if (value === 'true' || value === 'data' || value === 'text') {
+        searchRequest.summary = value;
+      }
       break;
 
     case '_include': {
@@ -247,6 +252,7 @@ function parseKeyValue(searchRequest: SearchRequest, key: string, value: string)
     }
 
     case '_fields':
+    case '_elements':
       searchRequest.fields = value.split(',');
       break;
 

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -140,6 +140,26 @@ describe('FHIR resource and data type representations', () => {
         'value[x]': expect.objectContaining({}),
       },
     });
+    expect(profile.summaryProperties.sort()).toEqual([
+      'basedOn',
+      'code',
+      'component',
+      'derivedFrom',
+      'effective',
+      'encounter',
+      'focus',
+      'hasMember',
+      'id',
+      'identifier',
+      'implicitRules',
+      'issued',
+      'meta',
+      'partOf',
+      'performer',
+      'status',
+      'subject',
+      'value',
+    ]);
   });
 
   test('Nested BackboneElement parsing', () => {

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -218,7 +218,7 @@ describe('FHIR resource and data type representations', () => {
   });
 
   test('subsetResource', () => {
-    loadDataTypes(readJson('fhir/R4/profiles-resources.json'));
+    loadDataTypes(readJson('fhir/r4/profiles-resources.json'));
     const observation: Observation = {
       resourceType: 'Observation',
       id: 'example',

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -1,8 +1,16 @@
 import { readFileSync } from 'fs';
-import { ElementValidator, InternalTypeSchema, SlicingRules, parseStructureDefinition, subsetResource } from './types';
+import {
+  ElementValidator,
+  InternalTypeSchema,
+  SlicingRules,
+  loadDataTypes,
+  parseStructureDefinition,
+  subsetResource,
+} from './types';
 import { resolve } from 'path';
 import { TypedValue } from '../types';
 import { Observation } from '@medplum/fhirtypes';
+import { readJson } from '@medplum/definitions';
 
 describe('FHIR resource and data type representations', () => {
   test('Base resource parsing', () => {
@@ -210,6 +218,7 @@ describe('FHIR resource and data type representations', () => {
   });
 
   test('subsetResource', () => {
+    loadDataTypes(readJson('fhir/R4/profiles-resources.json'));
     const observation: Observation = {
       resourceType: 'Observation',
       id: 'example',

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -141,7 +141,7 @@ describe('FHIR resource and data type representations', () => {
         'value[x]': expect.objectContaining({}),
       },
     });
-    expect(profile.summaryProperties.sort()).toEqual([
+    expect([...(profile.summaryProperties as Set<string>)].sort()).toEqual([
       'basedOn',
       'code',
       'component',

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -159,12 +159,11 @@ class StructureDefinitionParser {
         } else if (this.backboneContext?.parent && element.path?.startsWith(this.backboneContext.parent.path + '.')) {
           this.backboneContext.parent.type.fields[elementPath(element, this.backboneContext.parent.path)] = field;
         } else {
+          const path = elementPath(element, this.resourceSchema.name);
           if (element.isSummary) {
-            this.resourceSchema.summaryProperties.push(
-              elementPath(element, this.resourceSchema.name).replace('[x]', '')
-            );
+            this.resourceSchema.summaryProperties.push(path.replace('[x]', ''));
           }
-          this.resourceSchema.fields[elementPath(element, this.resourceSchema.name)] = field;
+          this.resourceSchema.fields[path] = field;
         }
 
         // Clean up contextual book-keeping

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -342,6 +342,12 @@ export function subsetResource<T extends Resource>(resource: T | undefined, prop
   if (!resource) {
     return undefined;
   }
+  for (const property of properties) {
+    const choiceTypeField = DATA_TYPES[resource.resourceType].fields[property + '[x]'];
+    if (choiceTypeField) {
+      properties.push(...choiceTypeField.type.map((t) => property + capitalize(t.code)));
+    }
+  }
   const subset = { ...resource };
   for (const property of Object.getOwnPropertyNames(resource)) {
     if (!properties.includes(property) && !mandatorySubsetProperties.includes(property)) {

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -342,15 +342,21 @@ export function subsetResource<T extends Resource>(resource: T | undefined, prop
   if (!resource) {
     return undefined;
   }
+  const extraProperties = [];
   for (const property of properties) {
     const choiceTypeField = DATA_TYPES[resource.resourceType].fields[property + '[x]'];
+    extraProperties.push('_' + property);
     if (choiceTypeField) {
-      properties.push(...choiceTypeField.type.map((t) => property + capitalize(t.code)));
+      extraProperties.push(...choiceTypeField.type.map((t) => property + capitalize(t.code)));
     }
   }
   const subset = { ...resource };
   for (const property of Object.getOwnPropertyNames(resource)) {
-    if (!properties.includes(property) && !mandatorySubsetProperties.includes(property)) {
+    if (
+      !properties.includes(property) &&
+      !extraProperties.includes(property) &&
+      !mandatorySubsetProperties.includes(property)
+    ) {
       Object.defineProperty(subset, property, {
         enumerable: false,
         writable: false,

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -12,6 +12,7 @@ export interface InternalTypeSchema {
   fields: Record<string, ElementValidator>;
   constraints: Constraint[];
   innerTypes: InternalTypeSchema[];
+  summaryProperties: string[];
 }
 
 export interface ElementValidator {
@@ -130,6 +131,7 @@ class StructureDefinitionParser {
       fields: {},
       constraints: this.parseFieldDefinition(root).constraints,
       innerTypes: [],
+      summaryProperties: [],
     };
     this.innerTypes = [];
   }
@@ -157,6 +159,11 @@ class StructureDefinitionParser {
         } else if (this.backboneContext?.parent && element.path?.startsWith(this.backboneContext.parent.path + '.')) {
           this.backboneContext.parent.type.fields[elementPath(element, this.backboneContext.parent.path)] = field;
         } else {
+          if (element.isSummary) {
+            this.resourceSchema.summaryProperties.push(
+              elementPath(element, this.resourceSchema.name).replace('[x]', '')
+            );
+          }
           this.resourceSchema.fields[elementPath(element, this.resourceSchema.name)] = field;
         }
 
@@ -189,6 +196,7 @@ class StructureDefinitionParser {
           fields: {},
           constraints: this.parseFieldDefinition(element).constraints,
           innerTypes: [],
+          summaryProperties: [],
         },
         path: element.path ?? '',
         parent: pathsCompatible(this.backboneContext?.path, element.path)

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -258,14 +258,7 @@ describe('FHIR Search', () => {
         tag: [subsetTag],
       }),
       birthDate: resource.birthDate,
-      _birthDate: {
-        extension: [
-          {
-            url: 'http://hl7.org/fhir/StructureDefinition/patient-birthTime',
-            valueDateTime: '2000-01-01T00:00:00.001Z',
-          },
-        ],
-      },
+      _birthDate: (resource as any)._birthDate,
       deceasedBoolean: resource.deceasedBoolean,
     } as unknown as Patient);
   });

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -231,9 +231,17 @@ describe('FHIR Search', () => {
     const patient: Patient = {
       resourceType: 'Patient',
       birthDate: '2000-01-01',
+      _birthDate: {
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/patient-birthTime',
+            valueDateTime: '2000-01-01T00:00:00.001Z',
+          },
+        ],
+      },
       multipleBirthInteger: 2,
       deceasedBoolean: false,
-    };
+    } as unknown as Patient;
     const resource = await systemRepo.createResource(patient);
 
     const results = await systemRepo.search({
@@ -250,8 +258,16 @@ describe('FHIR Search', () => {
         tag: [subsetTag],
       }),
       birthDate: resource.birthDate,
+      _birthDate: {
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/patient-birthTime',
+            valueDateTime: '2000-01-01T00:00:00.001Z',
+          },
+        ],
+      },
       deceasedBoolean: resource.deceasedBoolean,
-    });
+    } as unknown as Patient);
   });
 
   test('Search next link', async () => {

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -226,6 +226,34 @@ describe('FHIR Search', () => {
     expect(summaryResult).toEqual<Partial<Patient>>(summaryResource);
   });
 
+  test('Search _elements', async () => {
+    const subsetTag: Coding = { system: 'http://hl7.org/fhir/v3/ObservationValue', code: 'SUBSETTED' };
+    const patient: Patient = {
+      resourceType: 'Patient',
+      birthDate: '2000-01-01',
+      multipleBirthInteger: 2,
+      deceasedBoolean: false,
+    };
+    const resource = await systemRepo.createResource(patient);
+
+    const results = await systemRepo.search({
+      resourceType: 'Patient',
+      filters: [{ code: '_id', operator: Operator.EQUALS, value: resource.id ?? '' }],
+      fields: ['birthDate', 'deceased'],
+    });
+    expect(results.entry).toHaveLength(1);
+    const result = results.entry?.[0]?.resource as Resource;
+    expect(result).toEqual<Partial<Patient>>({
+      resourceType: 'Patient',
+      id: resource.id,
+      meta: expect.objectContaining({
+        tag: [subsetTag],
+      }),
+      birthDate: resource.birthDate,
+      deceasedBoolean: resource.deceasedBoolean,
+    });
+  });
+
   test('Search next link', async () => {
     const family = randomUUID();
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -135,22 +135,29 @@ async function getSearchEntries<T extends Resource>(
   }
 
   for (const entry of entries) {
-    repo.removeHiddenFields(entry.resource as Resource);
+    if (!entry.resource) {
+      continue;
+    }
+    repo.removeHiddenFields(entry.resource);
     if (searchRequest.fields) {
-      entry.resource = subsetResource(entry.resource, searchRequest.fields);
+      const schema = getDataType(entry.resource.resourceType);
+      entry.resource = subsetResource(
+        entry.resource,
+        schema.mandatoryProperties ? [...schema.mandatoryProperties, ...searchRequest.fields] : searchRequest.fields
+      );
     } else if (searchRequest.summary) {
-      if (searchRequest.summary === 'data' && entry.resource) {
+      if (searchRequest.summary === 'data') {
         entry.resource = subsetResource(
           entry.resource,
           Object.keys(entry.resource).filter((k) => k !== 'text')
         );
-      } else if (searchRequest.summary === 'text' && entry.resource) {
+      } else if (searchRequest.summary === 'text') {
         const schema = getDataType(entry.resource?.resourceType);
         entry.resource = subsetResource(
           entry.resource,
           schema.mandatoryProperties ? ['text', ...schema.mandatoryProperties] : ['text']
         );
-      } else if (searchRequest.summary === 'true' && entry.resource) {
+      } else if (searchRequest.summary === 'true') {
         const schema = getDataType(entry.resource?.resourceType);
         entry.resource = subsetResource(entry.resource, schema.summaryProperties ? [...schema.summaryProperties] : []);
       }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -138,30 +138,7 @@ async function getSearchEntries<T extends Resource>(
     if (!entry.resource) {
       continue;
     }
-    repo.removeHiddenFields(entry.resource);
-    if (searchRequest.fields) {
-      const schema = getDataType(entry.resource.resourceType);
-      entry.resource = subsetResource(
-        entry.resource,
-        schema.mandatoryProperties ? [...schema.mandatoryProperties, ...searchRequest.fields] : searchRequest.fields
-      );
-    } else if (searchRequest.summary) {
-      if (searchRequest.summary === 'data') {
-        entry.resource = subsetResource(
-          entry.resource,
-          Object.keys(entry.resource).filter((k) => k !== 'text')
-        );
-      } else if (searchRequest.summary === 'text') {
-        const schema = getDataType(entry.resource?.resourceType);
-        entry.resource = subsetResource(
-          entry.resource,
-          schema.mandatoryProperties ? ['text', ...schema.mandatoryProperties] : ['text']
-        );
-      } else if (searchRequest.summary === 'true') {
-        const schema = getDataType(entry.resource?.resourceType);
-        entry.resource = subsetResource(entry.resource, schema.summaryProperties ? [...schema.summaryProperties] : []);
-      }
-    }
+    removeResourceFields(entry.resource, repo, searchRequest);
   }
 
   return {
@@ -169,6 +146,29 @@ async function getSearchEntries<T extends Resource>(
     rowCount,
     hasMore: rows.length > count,
   };
+}
+
+function removeResourceFields(resource: Resource, repo: Repository, searchRequest: SearchRequest): void {
+  repo.removeHiddenFields(resource);
+  if (searchRequest.fields) {
+    const schema = getDataType(resource.resourceType);
+    subsetResource(
+      resource,
+      schema.mandatoryProperties ? [...schema.mandatoryProperties, ...searchRequest.fields] : searchRequest.fields
+    );
+  } else if (searchRequest.summary) {
+    const schema = getDataType(resource.resourceType);
+    if (searchRequest.summary === 'data') {
+      subsetResource(
+        resource,
+        Object.keys(resource).filter((k) => k !== 'text')
+      );
+    } else if (searchRequest.summary === 'text') {
+      subsetResource(resource, schema.mandatoryProperties ? ['text', ...schema.mandatoryProperties] : ['text']);
+    } else if (searchRequest.summary === 'true') {
+      subsetResource(resource, schema.summaryProperties ? [...schema.summaryProperties] : []);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Added a general-purpose `subsetResource()` utility function for generating a version of a resource with selected properties removed, which correctly handles known edge cases and marks the result as a subset of the whole resource.  This utility forms the basis of the implementation of both `_elements` and `_summary` search parameters: the former allowing direct selection of subset properties, and the latter providing several predefined subsets.

Resolves #2332 