### PR TITLE
Fixes #2609 - Upgrade Sonar github action version

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Unzip code coverage'
         run: unzip medplum-code-coverage.zip -d coverage
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v1.8
+        uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Fixes https://github.com/medplum/medplum/issues/2609

Using recommended config from here: https://github.com/SonarSource/sonarcloud-github-action

We pinned the version due to previously failed upgrade: https://github.com/medplum/medplum/pull/1893

We'll see if this works.