### PR TITLE
Batch upload tool to handle multiple files and display the results

### DIFF
--- a/packages/app/src/BatchPage.tsx
+++ b/packages/app/src/BatchPage.tsx
@@ -32,8 +32,6 @@ export function BatchPage(): JSX.Element {
   const medplum = useMedplum();
   const [output, setOutput] = useState<Record<string, Bundle>>({});
 
-  console.log(output);
-
   const submitBatch = useCallback(
     async (str: string, fileName: string) => {
       try {
@@ -58,7 +56,6 @@ export function BatchPage(): JSX.Element {
   const handleFiles = useCallback(
     async (files: FileWithPath[]) => {
       for (const file of files) {
-        console.log(file.name);
         const reader = new FileReader();
         reader.onload = (e) => submitBatch(e.target?.result as string, file.name as string);
         reader.readAsText(file);


### PR DESCRIPTION
[#2570](https://github.com/medplum/medplum/issues/2570)

I first created a for loop iterate over the submitted files in the handleFiles function and call submitBatch on each file. To display separate tabs for each file, I modified the function submitBatch to take an additional fileName variable as well as made the output state to be an object with the key being the file name and the value being the bundle. I then mapped over the object keys to create the tabs for each file and panels for the corresponding data.

This is what the final result looks like.
![image](https://github.com/medplum/medplum/assets/59585815/2781c52e-ddb8-4a7d-9b20-500e6cf6da74)
