### PR TITLE
feat(core/utils): add `parseReference()` util

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -24,6 +24,7 @@ import {
   isLowerCase,
   isProfileResource,
   isUUID,
+  parseReference,
   preciseEquals,
   preciseGreaterThan,
   preciseGreaterThanOrEquals,
@@ -76,6 +77,16 @@ describe('Core Utils', () => {
     expect(resolveId({ id: '123' })).toBeUndefined();
     expect(resolveId({ reference: 'Patient' })).toBeUndefined();
     expect(resolveId({ reference: 'Patient/123' })).toBe('123');
+  });
+
+  test('parseReference', () => {
+    expect(parseReference(undefined)).toBeUndefined();
+    expect(parseReference({})).toBeUndefined();
+    expect(parseReference({ id: '123' })).toBeUndefined();
+    expect(parseReference({ reference: 'Patient' })).toBeUndefined();
+    expect(parseReference({ reference: '/' })).toBeUndefined();
+    expect(parseReference({ reference: 'Patient/' })).toBeUndefined();
+    expect(parseReference({ reference: 'Patient/123' })).toEqual(['Patient', '123']);
   });
 
   test('isProfileResource', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -14,6 +14,7 @@ import {
   Reference,
   RelatedPerson,
   Resource,
+  ResourceType,
 } from '@medplum/fhirtypes';
 import { formatHumanName } from './format';
 
@@ -57,6 +58,24 @@ export function getReferenceString(resource: Resource): string {
  */
 export function resolveId(reference: Reference | undefined): string | undefined {
   return reference?.reference?.split('/')[1];
+}
+
+/**
+ * Parses a reference and returns a tuple of [ResourceType, ID].
+ * @param reference A reference to a FHIR resource.
+ * @returns A tuple containing the `ResourceType` and the ID of the resource or `undefined` when `undefined` or an invalid reference is passed.
+ */
+export function parseReference(reference: Reference): [ResourceType, string] | undefined;
+export function parseReference(reference: undefined): undefined;
+export function parseReference(reference: Reference | undefined): [ResourceType, string] | undefined {
+  if (reference === undefined || reference?.reference === undefined) {
+    return undefined;
+  }
+  const [type, id] = reference.reference.split('/');
+  if (type === '' || id === '' || id === undefined) {
+    return undefined;
+  }
+  return [type as ResourceType, id];
 }
 
 /**


### PR DESCRIPTION
This PR adds the `parseReference()` util in `core/utils` as mentioned in #1257.