### PR TITLE
Fix URLs in Super Admin page

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -33,11 +33,11 @@ export function SuperAdminPage(): JSX.Element {
   }
 
   function reindexResourceType(formData: Record<string, string>): void {
-    startAsyncJob(medplum, 'Reindexing Resources', 'admin/super/valuesets', formData);
+    startAsyncJob(medplum, 'Reindexing Resources', 'admin/super/reindex', formData);
   }
 
   function rebuildCompartments(formData: Record<string, string>): void {
-    startAsyncJob(medplum, 'Rebuilding Compartments', 'admin/super/valuesets', formData);
+    startAsyncJob(medplum, 'Rebuilding Compartments', 'admin/super/compartments', formData);
   }
 
   function removeBotIdJobsFromQueue(formData: Record<string, string>): void {


### PR DESCRIPTION
This PR fixes #2638: the URLs for `reindexResourceType` and `rebuildCompartments` are wrong.

New URLs are:
- `/admin/super/reindex`
- `/admin/super/compartments`

They align with:
https://github.com/medplum/medplum/blob/28c55783f32dffa58c351908f8dde5d44d518b6a/packages/server/src/admin/super.ts#L71
https://github.com/medplum/medplum/blob/28c55783f32dffa58c351908f8dde5d44d518b6a/packages/server/src/admin/super.ts#L89