### PR TITLE
fix(docs): fix typo in `family-relationships.mdx`

### DIFF
--- a/packages/docs/docs/fhir-datastore/family-relationships/family-relationships.mdx
+++ b/packages/docs/docs/fhir-datastore/family-relationships/family-relationships.mdx
@@ -89,7 +89,7 @@ import Approach1Diagram from './approach-1.png';
 <BrowserOnlyTabs>
 <TabItem value="diagram" label="Diagram" default>
 
-<img src={Approach1Diagram} alt="Approach #1" style={{ maxHeight: '400px', width: 'auto' }} />;
+<img src={Approach1Diagram} alt="Approach #1" style={{ maxHeight: '400px', width: 'auto' }} />
 
 </TabItem>
 


### PR DESCRIPTION
<img width="601" alt="Screen Shot 2023-08-07 at 10 51 10 PM" src="https://github.com/medplum/medplum/assets/1592008/3da3d6fc-6a22-488e-8e9e-39bb97f10f61">

Fixes this