### PR TITLE
Enable profile validation logic

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -531,14 +531,7 @@ export class Repository extends BaseRepository implements FhirRepository {
       const profileUrls = resource.meta?.profile;
       validate(resource);
       if (profileUrls) {
-        try {
-          await this.validateProfiles(resource, profileUrls);
-        } catch (err) {
-          logger.error('Profile validation error', {
-            resource: `${resource.resourceType}/${resource.id}`,
-            error: normalizeErrorString(err),
-          });
-        }
+        await this.validateProfiles(resource, profileUrls);
       }
 
       const elapsedTime = Number(process.hrtime.bigint() - start);


### PR DESCRIPTION
Turns on profile validation, which will block if the resource does not satisfy recognized profiles to which it claims to conform.  Note that this only applies to profiles included in the base FHIR spec currently, since no other profile `StructureDefinition` resources are present in the DB as of yet.  If a written resource claims to conform to a profile whose URL is not recognized, no error or warning will be produced in the API response.

Resolves #2061 