### PR TITLE
Clean up temp binary storage for unit tests

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -6,6 +6,7 @@ import { Express, json, NextFunction, Request, Response, Router, text, urlencode
 import { rmSync } from 'fs';
 import http from 'http';
 import { tmpdir } from 'os';
+import { join } from 'path';
 import { adminRouter } from './admin';
 import { asyncWrap } from './async';
 import { authRouter } from './auth';
@@ -191,7 +192,7 @@ export async function shutdownApp(): Promise<void> {
 
   // If binary storage is a temporary directory, delete it
   const binaryStorage = getConfig().binaryStorage;
-  if (binaryStorage?.startsWith('file:' + tmpdir())) {
+  if (binaryStorage?.startsWith('file:' + join(tmpdir(), 'medplum-temp-storage'))) {
     rmSync(binaryStorage.replace('file:', ''), { recursive: true, force: true });
   }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,7 +3,9 @@ import { OperationOutcome } from '@medplum/fhirtypes';
 import compression from 'compression';
 import cors from 'cors';
 import { Express, json, NextFunction, Request, Response, Router, text, urlencoded } from 'express';
+import { rmSync } from 'fs';
 import http from 'http';
+import { tmpdir } from 'os';
 import { adminRouter } from './admin';
 import { asyncWrap } from './async';
 import { authRouter } from './auth';
@@ -185,5 +187,11 @@ export async function shutdownApp(): Promise<void> {
   if (server) {
     server.close();
     server = undefined;
+  }
+
+  // If binary storage is a temporary directory, delete it
+  const binaryStorage = getConfig().binaryStorage;
+  if (binaryStorage?.startsWith('file:' + tmpdir())) {
+    rmSync(binaryStorage.replace('file:', ''), { recursive: true, force: true });
   }
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -117,7 +117,7 @@ export async function loadConfig(configName: string): Promise<MedplumServerConfi
  */
 export async function loadTestConfig(): Promise<MedplumServerConfig> {
   const config = await loadConfig('file:medplum.config.json');
-  config.binaryStorage = 'file:' + mkdtempSync(join(tmpdir(), 'medplum-binary-storage'));
+  config.binaryStorage = 'file:' + mkdtempSync(join(tmpdir(), 'medplum-temp-storage'));
   config.allowedOrigins = undefined;
   config.database.host = process.env['POSTGRES_HOST'] ?? 'localhost';
   config.database.port = process.env['POSTGRES_PORT'] ? parseInt(process.env['POSTGRES_PORT'], 10) : 5432;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,7 +1,8 @@
 import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { mkdtempSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 
 const DEFAULT_AWS_REGION = 'us-east-1';
 
@@ -116,6 +117,7 @@ export async function loadConfig(configName: string): Promise<MedplumServerConfi
  */
 export async function loadTestConfig(): Promise<MedplumServerConfig> {
   const config = await loadConfig('file:medplum.config.json');
+  config.binaryStorage = 'file:' + mkdtempSync(join(tmpdir(), 'medplum-binary-storage'));
   config.allowedOrigins = undefined;
   config.database.host = process.env['POSTGRES_HOST'] ?? 'localhost';
   config.database.port = process.env['POSTGRES_PORT'] ? parseInt(process.env['POSTGRES_PORT'], 10) : 5432;

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -4,11 +4,9 @@ import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { randomUUID } from 'crypto';
 import { Request } from 'express';
-import { mkdtempSync, rmSync } from 'fs';
 import { simpleParser } from 'mailparser';
 import nodemailer, { Transporter } from 'nodemailer';
 import Mail from 'nodemailer/lib/mailer';
-import { sep } from 'path';
 import { Readable } from 'stream';
 import { initAppServices, shutdownApp } from '../app';
 import { getConfig, loadTestConfig } from '../config';
@@ -16,21 +14,17 @@ import { systemRepo } from '../fhir/repo';
 import { getBinaryStorage } from '../fhir/storage';
 import { sendEmail } from './email';
 
-const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
-
 describe('Email', () => {
   let mockSESv2Client: AwsClientStub<SESv2Client>;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
-    config.binaryStorage = 'file:' + binaryDir;
     config.storageBaseUrl = 'https://storage.example.com/';
     await initAppServices(config);
   });
 
   afterAll(async () => {
     await shutdownApp();
-    rmSync(binaryDir, { recursive: true, force: true });
   });
 
   beforeEach(() => {

--- a/packages/server/src/fhir/binary.test.ts
+++ b/packages/server/src/fhir/binary.test.ts
@@ -1,7 +1,5 @@
 import { ContentType } from '@medplum/core';
 import express from 'express';
-import { mkdtempSync, rmSync } from 'fs';
-import { sep } from 'path';
 import { Duplex, Readable } from 'stream';
 import request from 'supertest';
 import zlib from 'zlib';
@@ -10,7 +8,6 @@ import { loadTestConfig } from '../config';
 import { initTestAuth } from '../test.setup';
 
 const app = express();
-const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
 let accessToken: string;
 
 describe('Binary', () => {
@@ -22,7 +19,6 @@ describe('Binary', () => {
 
   afterAll(async () => {
     await shutdownApp();
-    rmSync(binaryDir, { recursive: true, force: true });
   });
 
   test('Create and read binary', async () => {

--- a/packages/server/src/fhir/operations/deploy.test.ts
+++ b/packages/server/src/fhir/operations/deploy.test.ts
@@ -13,8 +13,6 @@ import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { randomUUID } from 'crypto';
 import express from 'express';
-import { mkdtempSync, rmSync } from 'fs';
-import { sep } from 'path';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { registerNew } from '../../auth/register';
@@ -22,7 +20,6 @@ import { loadTestConfig } from '../../config';
 import { initTestAuth } from '../../test.setup';
 
 const app = express();
-const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
 let accessToken: string;
 let mockLambdaClient: AwsClientStub<LambdaClient>;
 
@@ -35,7 +32,6 @@ describe('Deploy', () => {
 
   afterAll(async () => {
     await shutdownApp();
-    rmSync(binaryDir, { recursive: true, force: true });
   });
 
   beforeEach(() => {

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -2,8 +2,6 @@ import { ContentType, createReference, getReferenceString } from '@medplum/core'
 import { Binary, Encounter, Patient, Practitioner, ServiceRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
-import { mkdtempSync, rmSync } from 'fs';
-import { sep } from 'path';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { registerNew } from '../../auth/register';
@@ -12,7 +10,6 @@ import { addTestUser } from '../../test.setup';
 import { Repository } from '../repo';
 
 const app = express();
-const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
 let practitioner: Practitioner;
 let accessToken: string;
 let binary: Binary;
@@ -124,7 +121,6 @@ describe('GraphQL', () => {
 
   afterAll(async () => {
     await shutdownApp();
-    rmSync(binaryDir, { recursive: true, force: true });
   });
 
   test.skip('IntrospectionQuery', async () => {

--- a/packages/server/src/storage.test.ts
+++ b/packages/server/src/storage.test.ts
@@ -2,8 +2,8 @@ import { ContentType } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express, { Request } from 'express';
-import { mkdtempSync, rmSync, unlinkSync } from 'fs';
-import { resolve, sep } from 'path';
+import { unlinkSync } from 'fs';
+import { resolve } from 'path';
 import { Readable } from 'stream';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
@@ -12,13 +12,11 @@ import { systemRepo } from './fhir/repo';
 import { getBinaryStorage } from './fhir/storage';
 
 const app = express();
-const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
 let binary: Binary;
 
 describe('Storage Routes', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
-    config.binaryStorage = 'file:' + binaryDir;
     await initApp(app, config);
 
     binary = await systemRepo.createResource<Binary>({
@@ -35,7 +33,6 @@ describe('Storage Routes', () => {
 
   afterAll(async () => {
     await shutdownApp();
-    rmSync(binaryDir, { recursive: true, force: true });
   });
 
   test('Missing signature', async () => {

--- a/packages/server/src/workers/download.test.ts
+++ b/packages/server/src/workers/download.test.ts
@@ -2,9 +2,7 @@ import { ContentType } from '@medplum/core';
 import { Media } from '@medplum/fhirtypes';
 import { Job } from 'bullmq';
 import { randomUUID } from 'crypto';
-import { mkdtempSync, rmSync } from 'fs';
 import fetch from 'node-fetch';
-import { sep } from 'path';
 import { Readable } from 'stream';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
@@ -13,7 +11,6 @@ import { closeDownloadWorker, execDownloadJob, getDownloadQueue } from './downlo
 
 jest.mock('node-fetch');
 
-const binaryDir = mkdtempSync(__dirname + sep + 'binary-');
 let repo: Repository;
 
 describe('Download Worker', () => {
@@ -32,7 +29,6 @@ describe('Download Worker', () => {
   afterAll(async () => {
     await shutdownApp();
     await closeDownloadWorker(); // Double close to ensure quite ignore
-    rmSync(binaryDir, { recursive: true, force: true });
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
**A long time ago**: server unit tests were more verbose.  In `beforeAll`, each test file would setup subsystems one-by-one, including the "binary storage" system.

**Then a while later**: we refactored those tests to use `initApp`.  However, I didn't correctly update all of the cases of temp binary storage, which means that a lot of unnecessary temp files persisted after running unit tests.

**In this PR**: Cleaning that up more conclusively, by setting `config.binaryStorage` inside `loadTestConfig`.  

**Important**: in `shutdownApp`, if `config.binaryStorage` is a temp directory, as defined by (1) using local file system, and (2) path starts with `os.tmpdir()` + `medplum-temp-storage`, then we'll delete all of the temp files in the directory.