### PR TITLE
Use repo.searchOne where possible

### DIFF
--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -131,7 +131,7 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
   await sendLoginResult(res, login);
 }
 
-async function getProjectByGoogleClientId(
+function getProjectByGoogleClientId(
   googleClientId: string,
   projectId: string | undefined
 ): Promise<Project | undefined> {
@@ -151,10 +151,5 @@ async function getProjectByGoogleClientId(
     });
   }
 
-  const bundle = await systemRepo.search<Project>({
-    resourceType: 'Project',
-    count: 1,
-    filters,
-  });
-  return bundle.entry && bundle.entry.length > 0 ? bundle.entry[0].resource : undefined;
+  return systemRepo.searchOne<Project>({ resourceType: 'Project', filters });
 }

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -149,7 +149,7 @@ export async function createUser(request: NewUserRequest): Promise<User> {
   return result;
 }
 
-async function getProjectByRecaptchaSiteKey(
+function getProjectByRecaptchaSiteKey(
   recaptchaSiteKey: string,
   projectId: string | undefined
 ): Promise<Project | undefined> {
@@ -169,10 +169,5 @@ async function getProjectByRecaptchaSiteKey(
     });
   }
 
-  const bundle = await systemRepo.search<Project>({
-    resourceType: 'Project',
-    count: 1,
-    filters,
-  });
-  return bundle.entry && bundle.entry.length > 0 ? bundle.entry[0].resource : undefined;
+  return systemRepo.searchOne<Project>({ resourceType: 'Project', filters });
 }

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -101,13 +101,11 @@ export const expandOperator = asyncWrap(async (req: Request, res: Response) => {
   } as ValueSet);
 });
 
-async function getValueSetByUrl(url: string): Promise<ValueSet | undefined> {
-  const result = await systemRepo.search<ValueSet>({
+function getValueSetByUrl(url: string): Promise<ValueSet | undefined> {
+  return systemRepo.searchOne<ValueSet>({
     resourceType: 'ValueSet',
-    count: 1,
     filters: [{ code: 'url', operator: SearchOperator.EQUALS, value: url }],
   });
-  return result.entry?.[0]?.resource;
 }
 
 function buildValueSetSystems(valueSet: ValueSet): Expression[] {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -334,12 +334,9 @@ export async function getMembershipsForLogin(login: Login): Promise<ProjectMembe
  * @param client The client application.
  * @returns The project membership for the client application if found; otherwise undefined.
  */
-export async function getClientApplicationMembership(
-  client: ClientApplication
-): Promise<ProjectMembership | undefined> {
-  const bundle = await systemRepo.search<ProjectMembership>({
+export function getClientApplicationMembership(client: ClientApplication): Promise<ProjectMembership | undefined> {
+  return systemRepo.searchOne<ProjectMembership>({
     resourceType: 'ProjectMembership',
-    count: 1,
     filters: [
       {
         code: 'user',
@@ -348,8 +345,6 @@ export async function getClientApplicationMembership(
       },
     ],
   });
-
-  return bundle.entry && bundle.entry.length > 0 ? (bundle.entry[0].resource as ProjectMembership) : undefined;
 }
 
 /**

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -72,10 +72,6 @@ export async function seedDatabase(): Promise<void> {
  * Returns true if the database is already seeded.
  * @returns True if already seeded.
  */
-async function isSeeded(): Promise<boolean> {
-  const bundle = await systemRepo.search({
-    resourceType: 'User',
-    count: 1,
-  });
-  return !!bundle.entry && bundle.entry.length > 0;
+function isSeeded(): Promise<User | undefined> {
+  return systemRepo.searchOne({ resourceType: 'User' });
 }

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -1,3 +1,4 @@
+import { createReference, evalFhirPathTyped, getExtension, Operator, toTypedValue } from '@medplum/core';
 import {
   AuditEvent,
   Bot,
@@ -8,17 +9,12 @@ import {
   Subscription,
 } from '@medplum/fhirtypes';
 import { systemRepo } from '../fhir/repo';
-import { createReference, evalFhirPathTyped, getExtension, Operator, toTypedValue } from '@medplum/core';
-import { AuditEventOutcome } from '../util/auditevent';
 import { logger } from '../logger';
+import { AuditEventOutcome } from '../util/auditevent';
 
-export async function findProjectMembership(
-  project: string,
-  profile: Reference
-): Promise<ProjectMembership | undefined> {
-  const bundle = await systemRepo.search<ProjectMembership>({
+export function findProjectMembership(project: string, profile: Reference): Promise<ProjectMembership | undefined> {
+  return systemRepo.searchOne<ProjectMembership>({
     resourceType: 'ProjectMembership',
-    count: 1,
     filters: [
       {
         code: 'project',
@@ -32,7 +28,6 @@ export async function findProjectMembership(
       },
     ],
   });
-  return bundle.entry?.[0]?.resource;
 }
 
 /**


### PR DESCRIPTION
There were a handful of cases where we were using `repo.search({ count: 1 })` rather than `repo.searchOne()`

This should be 100% logically equivalent, just a code cleanup.