### PR TITLE
Keep super admin notifications open until user closes

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -188,7 +188,8 @@ function startAsyncJob(medplum: MedplumClient, title: string, url: string, body?
         title,
         message: 'Done',
         icon: <IconCheck size="1rem" />,
-        autoClose: 2000,
+        autoClose: false,
+        withCloseButton: true,
       });
     })
     .catch((err) => {
@@ -198,7 +199,8 @@ function startAsyncJob(medplum: MedplumClient, title: string, url: string, body?
         title,
         message: normalizeErrorString(err),
         icon: <IconX size="1rem" />,
-        autoClose: 2000,
+        autoClose: false,
+        withCloseButton: true,
       });
     });
 }


### PR DESCRIPTION
For long running super admin jobs ("Rebuild Structure Definitions", "Rebuild Search Parameters", etc), it's annoying that the notification automatically goes away by itself.  These operations usually take 1-2 minutes, so users will often look away while the operation is running.

This PR changes the "autoClose" from 2 seconds to never.  The user now has to click on the "X" close icon.