### PR TITLE
Add medplum version to <meta> tag in app.

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -9,6 +9,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="theme-color" content="#5b2876" />
+    <meta name="medplum-version" content="%MEDPLUM_VERSION%" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/img/medplum-logo-512x512.png" />
   </head>

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2,10 +2,15 @@
 import react from '@vitejs/plugin-react';
 import { copyFileSync, existsSync } from 'fs';
 import { defineConfig } from 'vite';
+import packageJson from './package.json' assert { type: 'json' };
+import { execSync } from 'child_process';
 
 if (!existsSync('.env')) {
   copyFileSync('.env.defaults', '.env');
 }
+
+const gitHash = execSync('git rev-parse --short HEAD').toString().trim();
+process.env.MEDPLUM_VERSION = packageJson.version + '-' + gitHash;
 
 export default defineConfig({
   envPrefix: ['MEDPLUM_', 'GOOGLE_', 'RECAPTCHA_'],


### PR DESCRIPTION
Implements #2566 

Hey there :wave:

I am getting a feel for this platform and figured a good way to test the waters was to grab an issue and contribute. I hope you all don't mind. :slightly_smiling_face: 

I essentially implemented exactly as @codyebberson described.

Here is the version appearing in a metatag locally:

![medplum-version-tag](https://github.com/medplum/medplum/assets/20322135/44b5f223-fe9a-409e-b0e2-ca24d87b9e39)

