### PR TITLE
fix(client): read `clientSecret` from medplum client constructor options

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -602,6 +602,7 @@ export class MedplumClient extends EventTarget {
     this.baseUrl = ensureTrailingSlash(options?.baseUrl) ?? DEFAULT_BASE_URL;
     this.fhirBaseUrl = this.baseUrl + (ensureTrailingSlash(options?.fhirUrlPath) ?? 'fhir/R4/');
     this.clientId = options?.clientId ?? '';
+    this.clientSecret = options?.clientSecret ?? '';
     this.authorizeUrl = options?.authorizeUrl ?? this.baseUrl + 'oauth2/authorize';
     this.tokenUrl = options?.tokenUrl ?? this.baseUrl + 'oauth2/token';
     this.logoutUrl = options?.logoutUrl ?? this.baseUrl + 'oauth2/logout';


### PR DESCRIPTION
Hey team, thanks so much for all the help recently debugging.

I just noticed this line is missing from the medplum client constructor and I'm just opening this PR to ask what I might be missing with this.

I am doing a `medplumClient.createResource(bundle)` call, with my medplum client set up with my `clientId` and `clientSecret` via the constructor options, but I think this line being missing is causing `handleUnauthenticated` to not be able to get a `refreshPromise` from the `refresh` method.

Am I completely off base here? Sorry for the noise if so.