### PR TITLE
feat(QuestionnaireForm): add support for `exists`, `!=`, etc. operators

### DIFF
--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -16,6 +16,12 @@ const TYPED_TRUE = { type: PropertyType.boolean, value: true };
 const TYPED_FALSE = { type: PropertyType.boolean, value: false };
 const TYPED_1 = { type: PropertyType.integer, value: 1 };
 const TYPED_2 = { type: PropertyType.integer, value: 2 };
+const TYPED_CODING_MEDPLUM123 = { type: PropertyType.Coding, value: { code: 'MEDPLUM123' } };
+const TYPED_CODING_MEDPLUM123_W_SYSTEM = {
+  type: PropertyType.Coding,
+  value: { code: 'MEDPLUM123', system: 'medplum-v123.456.789' },
+};
+const TYPED_CODING_NOT_MEDPLUM123 = { type: PropertyType.Coding, value: { code: 'NOT_MEDPLUM123' } };
 
 describe('FHIRPath utils', () => {
   beforeAll(() => {
@@ -86,6 +92,14 @@ describe('FHIRPath utils', () => {
     expect(fhirPathEquivalent(TYPED_1, TYPED_1)).toEqual([TYPED_TRUE]);
     expect(fhirPathEquivalent(TYPED_1, TYPED_2)).toEqual([TYPED_FALSE]);
     expect(fhirPathEquivalent(TYPED_2, TYPED_1)).toEqual([TYPED_FALSE]);
+
+    // Test `Coding` equivalence
+    expect(fhirPathEquivalent(TYPED_CODING_MEDPLUM123, TYPED_CODING_MEDPLUM123)).toEqual([TYPED_TRUE]);
+    expect(fhirPathEquivalent(TYPED_CODING_MEDPLUM123, TYPED_CODING_MEDPLUM123_W_SYSTEM)).toEqual([TYPED_FALSE]);
+    expect(fhirPathEquivalent(TYPED_CODING_MEDPLUM123, TYPED_CODING_NOT_MEDPLUM123)).toEqual([TYPED_FALSE]);
+    expect(fhirPathEquivalent(TYPED_CODING_MEDPLUM123_W_SYSTEM, TYPED_CODING_MEDPLUM123_W_SYSTEM)).toEqual([
+      TYPED_TRUE,
+    ]);
   });
 
   test('fhirPathArrayEquivalent', () => {

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -1,4 +1,4 @@
-import { ElementDefinition, Period, Quantity } from '@medplum/fhirtypes';
+import { ElementDefinition, Period, Quantity, Coding } from '@medplum/fhirtypes';
 import { buildTypeName, getElementDefinition, isResource, PropertyType, TypedValue } from '../types';
 import { capitalize, isEmpty } from '../utils';
 
@@ -285,8 +285,11 @@ export function fhirPathArrayEquivalent(x: TypedValue[], y: TypedValue[]): Typed
  * @returns True if equivalent.
  */
 export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
-  const xValue = x.value?.valueOf();
-  const yValue = y.value?.valueOf();
+  const { type: xType, value: xValueRaw } = x;
+  const { type: yType, value: yValueRaw } = y;
+  const xValue = xValueRaw?.valueOf();
+  const yValue = yValueRaw?.valueOf();
+
   if (typeof xValue === 'number' && typeof yValue === 'number') {
     // Use more generous threshold than equality
     // Decimal: values must be equal, comparison is done on values rounded to the precision of the least precise operand.
@@ -296,8 +299,25 @@ export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
   if (isQuantity(xValue) && isQuantity(yValue)) {
     return booleanToTypedValue(isQuantityEquivalent(xValue, yValue));
   }
+
+  if (xType === 'Coding' && yType === 'Coding') {
+    if (typeof xValue !== 'object' || typeof yValue !== 'object') {
+      return booleanToTypedValue(false);
+    }
+    // "In addition, for Coding values, equivalence is defined based on the code and system elements only.
+    // The version, display, and userSelected elements are ignored for the purposes of determining Coding equivalence."
+    // Source: https://hl7.org/fhir/fhirpath.html#changes
+
+    // Basically checking if one of the `Coding` resources has a system defined. If so, then the two's system values must be compared
+    const systemsAreEquivalent =
+      (xValue as Coding).system || (yValue as Coding).system
+        ? (xValue as Coding).system === (yValue as Coding).system
+        : true;
+    return booleanToTypedValue((xValue as Coding).code === (yValue as Coding).code && systemsAreEquivalent);
+  }
+
   if (typeof xValue === 'object' && typeof yValue === 'object') {
-    return booleanToTypedValue(deepEquals(xValue, yValue));
+    return booleanToTypedValue(deepEquals({ ...xValue, id: undefined }, { ...yValue, id: undefined }));
   }
   if (typeof xValue === 'string' && typeof yValue === 'string') {
     // String: the strings must be the same, ignoring case and locale, and normalizing whitespace

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -1,5 +1,5 @@
-import { ElementDefinition, Period, Quantity, Coding } from '@medplum/fhirtypes';
-import { buildTypeName, getElementDefinition, isResource, PropertyType, TypedValue } from '../types';
+import { Coding, ElementDefinition, Period, Quantity } from '@medplum/fhirtypes';
+import { PropertyType, TypedValue, buildTypeName, getElementDefinition, isResource } from '../types';
 import { capitalize, isEmpty } from '../utils';
 
 /**
@@ -308,12 +308,12 @@ export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
     // The version, display, and userSelected elements are ignored for the purposes of determining Coding equivalence."
     // Source: https://hl7.org/fhir/fhirpath.html#changes
 
-    // Basically checking if one of the `Coding` resources has a system defined. If so, then the two's system values must be compared
-    const systemsAreEquivalent =
-      (xValue as Coding).system || (yValue as Coding).system
-        ? (xValue as Coding).system === (yValue as Coding).system
-        : true;
-    return booleanToTypedValue((xValue as Coding).code === (yValue as Coding).code && systemsAreEquivalent);
+    // We need to check if both `code` and `system` are equivalent.
+    // If both have undefined `system` fields, If so, then the two's `system` values must be compared.
+    // Essentially they must both be `undefined` or both the same.
+    return booleanToTypedValue(
+      (xValue as Coding).code === (yValue as Coding).code && (xValue as Coding).system === (yValue as Coding).system
+    );
   }
 
   if (typeof xValue === 'object' && typeof yValue === 'object') {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -331,11 +331,11 @@ export const EnableWhen = (): JSX.Element => (
       questionnaire={{
         resourceType: 'Questionnaire',
         id: 'enable-when',
-        title: 'Enable When Example',
+        title: 'Enable When',
         item: [
           {
             linkId: 'q1',
-            text: 'Question 1',
+            text: 'Enabled when the answer is "Yes"',
             type: 'choice',
             answerOption: [
               {
@@ -349,12 +349,112 @@ export const EnableWhen = (): JSX.Element => (
           {
             linkId: 'q2',
             type: 'display',
-            text: 'Displayed!',
+            text: 'Displayed because the answer is "Yes"!',
             enableWhen: [
               {
                 question: 'q1',
                 operator: '=',
                 answerString: 'Yes',
+              },
+            ],
+          },
+          {
+            linkId: 'q3',
+            text: 'Enabled when there is an answer',
+            type: 'choice',
+            answerOption: [
+              {
+                valueString: 'Yes',
+              },
+              {
+                valueString: 'No',
+              },
+            ],
+          },
+          {
+            linkId: 'q4',
+            type: 'display',
+            text: 'Displayed because there is an answer!',
+            enableWhen: [
+              {
+                question: 'q3',
+                operator: 'exists', // `exists` signals if a given answer has a value
+                answerBoolean: true,
+              },
+            ],
+          },
+          {
+            linkId: 'q5',
+            text: "Enabled when there isn't an answer",
+            type: 'choice',
+            answerOption: [
+              {
+                valueString: 'Yes',
+              },
+              {
+                valueString: 'No',
+              },
+            ],
+          },
+          {
+            linkId: 'q6',
+            type: 'display',
+            text: "Displayed because there isn't an answer!",
+            enableWhen: [
+              {
+                question: 'q5',
+                operator: 'exists',
+                answerBoolean: false,
+              },
+            ],
+          },
+          {
+            linkId: 'q7',
+            text: 'Enabled when greater than 2',
+            type: 'choice',
+            answerOption: [
+              {
+                valueInteger: 2,
+              },
+              {
+                valueInteger: 5,
+              },
+            ],
+          },
+          {
+            linkId: 'q8',
+            type: 'display',
+            text: 'Displayed because answer is greater than 2!',
+            enableWhen: [
+              {
+                question: 'q7',
+                operator: '>',
+                answerInteger: 2,
+              },
+            ],
+          },
+          {
+            linkId: 'q9',
+            text: 'Enabled when greater than or equal to 2',
+            type: 'choice',
+            answerOption: [
+              {
+                valueInteger: 2,
+              },
+              {
+                valueInteger: 5,
+              },
+            ],
+          },
+          {
+            linkId: 'q10',
+            type: 'display',
+            text: 'Displayed because answer is greater than or equal to 2!',
+            enableWhen: [
+              {
+                question: 'q9',
+                operator: '>=',
+                answerInteger: 2,
               },
             ],
           },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1359,5 +1359,94 @@ describe('QuestionnaireForm', () => {
         )
       ).toBe(false);
     });
+
+    test('enableBehavior=any, enableWhen `=` operator for `valueCoding`', () => {
+      const enableWhen = [
+        { question: 'q1', operator: '=', answerCoding: { code: 'MEDPLUM123' } },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'MEDPLUM123' } },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `!=` operator for `valueCoding`', () => {
+      const enableWhen = [
+        { question: 'q1', operator: '!=', answerCoding: { code: 'MEDPLUM123' } },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'NOT_MEDPLUM123' } },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } },
+          }
+        )
+      ).toBe(false);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueCoding: { code: 'MEDPLUM123' } },
+          }
+        )
+      ).toBe(false);
+    });
   });
 });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1,5 +1,5 @@
 import { getQuestionnaireAnswers } from '@medplum/core';
-import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
+import { Questionnaire, QuestionnaireItemEnableWhen, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { randomUUID } from 'crypto';
@@ -968,97 +968,396 @@ describe('QuestionnaireForm', () => {
     expect(screen.queryByText('Hidden Text')).toBeInTheDocument();
   });
 
-  test('isQuestionEnabled', () => {
-    // enableBehavior=any, match
-    expect(
-      isQuestionEnabled(
-        {
-          enableBehavior: 'any',
-          enableWhen: [
-            {
-              question: 'q1',
-              answerString: 'Yes',
-            },
-            {
-              question: 'q2',
-              answerString: 'Yes',
-            },
-          ],
-        },
-        {
-          q1: { valueString: 'No' },
-          q2: { valueString: 'Yes' },
-        }
-      )
-    ).toBe(true);
+  describe('isQuestionEnabled', () => {
+    test('enableBehavior=any, match', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableBehavior: 'any',
+            enableWhen: [
+              {
+                question: 'q1',
+                answerString: 'Yes',
+                operator: '=',
+              },
+              {
+                question: 'q2',
+                answerString: 'Yes',
+                operator: '=',
+              },
+            ],
+          },
+          {
+            q1: { valueString: 'No' },
+            q2: { valueString: 'Yes' },
+          }
+        )
+      ).toBe(true);
+    });
 
-    // enableBehavior=any, no match
-    expect(
-      isQuestionEnabled(
-        {
-          enableBehavior: 'any',
-          enableWhen: [
-            {
-              question: 'q1',
-              answerString: 'Yes',
-            },
-            {
-              question: 'q2',
-              answerString: 'Yes',
-            },
-          ],
-        },
-        {
-          q1: { valueString: 'No' },
-          q2: { valueString: 'No' },
-        }
-      )
-    ).toBe(false);
+    test('enableBehavior=any, no match', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableBehavior: 'any',
+            enableWhen: [
+              {
+                question: 'q1',
+                answerString: 'Yes',
+                operator: '=',
+              },
+              {
+                question: 'q2',
+                answerString: 'Yes',
+                operator: '=',
+              },
+            ],
+          },
+          {
+            q1: { valueString: 'No' },
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(false);
+    });
 
-    // enableBehavior=all, match
-    expect(
-      isQuestionEnabled(
-        {
-          enableBehavior: 'all',
-          enableWhen: [
-            {
-              question: 'q1',
-              answerString: 'Yes',
-            },
-            {
-              question: 'q2',
-              answerString: 'Yes',
-            },
-          ],
-        },
-        {
-          q1: { valueString: 'Yes' },
-          q2: { valueString: 'Yes' },
-        }
-      )
-    ).toBe(true);
+    test('enableBehavior=all, match', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableBehavior: 'all',
+            enableWhen: [
+              {
+                question: 'q1',
+                answerString: 'Yes',
+                operator: '=',
+              },
+              {
+                question: 'q2',
+                answerString: 'Yes',
+                operator: '=',
+              },
+            ],
+          },
+          {
+            q1: { valueString: 'Yes' },
+            q2: { valueString: 'Yes' },
+          }
+        )
+      ).toBe(true);
+    });
 
-    // enableBehavior=all, no match
-    expect(
-      isQuestionEnabled(
+    test('enableBehavior=all, no match', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableBehavior: 'all',
+            enableWhen: [
+              {
+                question: 'q1',
+                answerString: 'Yes',
+                operator: '=',
+              },
+              {
+                question: 'q2',
+                answerString: 'Yes',
+                operator: '=',
+              },
+            ],
+          },
+          {
+            q1: { valueString: 'Yes' },
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `exists` operator, `answerBoolean` = true, answer present', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: 'exists',
+                answerBoolean: true,
+              },
+            ],
+          },
+          {
+            q1: { valueString: 'Yes' },
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(true);
+    });
+
+    test('enableBehavior=any, enableWhen `exists` operator, `answerBoolean` = false, answer present', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: 'exists',
+                answerBoolean: false,
+              },
+            ],
+          },
+          {
+            q1: { valueString: 'Yes' },
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `exists` operator, `answerBoolean` = true, answer missing', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: 'exists',
+                answerBoolean: true,
+              },
+            ],
+          },
+          {
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `exists` operator, `answerBoolean` = false, answer missing', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: 'exists',
+                answerBoolean: false,
+              },
+            ],
+          },
+          {
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(true);
+    });
+
+    test('enableBehavior=any, enableWhen `exists` operator, `answerBoolean` = false, answer missing', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: 'exists',
+                answerBoolean: false,
+              },
+            ],
+          },
+          {
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(true);
+    });
+
+    test('enableBehavior=any, enableWhen `exists` operator, `answerBoolean` = false, answer missing', () => {
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen: [
+              {
+                question: 'q1',
+                operator: 'exists',
+                answerBoolean: false,
+              },
+            ],
+          },
+          {
+            q2: { valueString: 'No' },
+          }
+        )
+      ).toBe(true);
+    });
+
+    test('enableBehavior=any, enableWhen `!=` operator', () => {
+      const enableWhen = [
         {
-          enableBehavior: 'all',
-          enableWhen: [
-            {
-              question: 'q1',
-              answerString: 'Yes',
-            },
-            {
-              question: 'q2',
-              answerString: 'Yes',
-            },
-          ],
+          question: 'q1',
+          operator: '!=',
+          answerString: 'Yes',
         },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueString: 'No' },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueString: 'Yes' },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `>` operator', () => {
+      const enableWhen = [
         {
-          q1: { valueString: 'Yes' },
-          q2: { valueString: 'No' },
-        }
-      )
-    ).toBe(false);
+          question: 'q1',
+          operator: '>',
+          answerInteger: 3,
+        },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 4 },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 2 },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `>=` operator', () => {
+      const enableWhen = [
+        {
+          question: 'q1',
+          operator: '>=',
+          answerInteger: 3,
+        },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 4 },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 3 },
+          }
+        )
+      ).toBe(true);
+    });
+
+    test('enableBehavior=any, enableWhen `<` operator', () => {
+      const enableWhen = [
+        {
+          question: 'q1',
+          operator: '<',
+          answerInteger: 3,
+        },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 2 },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 3 },
+          }
+        )
+      ).toBe(false);
+    });
+
+    test('enableBehavior=any, enableWhen `<=` operator', () => {
+      const enableWhen = [
+        {
+          question: 'q1',
+          operator: '<=',
+          answerInteger: 3,
+        },
+      ] satisfies QuestionnaireItemEnableWhen[];
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 2 },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 3 },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        isQuestionEnabled(
+          {
+            enableWhen,
+          },
+          {
+            q1: { valueInteger: 4 },
+          }
+        )
+      ).toBe(false);
+    });
   });
 });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -636,10 +636,14 @@ export function isQuestionEnabled(
     } else if (actualAnswer === undefined) {
       match = false;
     } else {
-      const [{ value }] = evalFhirPathTyped(`%actualAnswer ${operator} %expectedAnswer`, [actualAnswer], {
-        actualAnswer,
-        expectedAnswer,
-      });
+      const [{ value }] = evalFhirPathTyped(
+        `%actualAnswer ${operator?.replace('=', '~')} %expectedAnswer`,
+        [actualAnswer],
+        {
+          actualAnswer,
+          expectedAnswer,
+        }
+      );
       match = value;
     }
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -34,6 +34,7 @@ import {
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
   Reference,
+  Coding,
 } from '@medplum/fhirtypes';
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import { AttachmentInput } from '../AttachmentInput/AttachmentInput';
@@ -599,7 +600,7 @@ function isDropDownChoice(item: QuestionnaireItem): boolean {
 }
 
 /**
- * This method is not called `areSameType` because it only checks if the two value's types are not explicitly different and allows one value to be `undefined`.
+ * This function is not called `areSameType` because it only checks if the two value's types are not explicitly different and allows one value to be `undefined`.
  * @param value1 A value or `undefined`.
  * @param value2 Another value to compare `value1`'s type to.
  * @returns If the two values are NOT different types. It returns `true` if both are the same type or if `value1` is `undefined`.
@@ -650,12 +651,19 @@ export function isQuestionEnabled(
     } else {
       switch (enableWhen.operator) {
         case '=':
-          // if actualAnswer is === to `expectedTruthyAnswer`
-          match = deepEquals(actualAnswer, expectedAnswer);
+          if (expectedAnswer.type === 'Coding') {
+            match = !!actualAnswer && (actualAnswer.value as Coding).code === (expectedAnswer.value as Coding).code;
+          } else {
+            match = deepEquals(actualAnswer, expectedAnswer);
+          }
           break;
         case '!=':
           // if actualAnswer is !== to `expectedTruthyAnswer`
-          match = !deepEquals(actualAnswer, expectedAnswer);
+          if (expectedAnswer.type === 'Coding') {
+            match = !!actualAnswer && (actualAnswer.value as Coding).code !== (expectedAnswer.value as Coding).code;
+          } else {
+            match = !deepEquals(actualAnswer, expectedAnswer);
+          }
           break;
         case '>':
           match = !!actualAnswer && actualAnswer.value > expectedAnswer.value;

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -628,6 +628,7 @@ export function isQuestionEnabled(
     let match: boolean;
 
     const { operator } = enableWhen;
+
     // We handle exists separately since its so different in terms of comparisons than the other mathematical operators
     if (operator === 'exists') {
       // if actualAnswer is not undefined, then exists: true passes
@@ -636,14 +637,13 @@ export function isQuestionEnabled(
     } else if (actualAnswer === undefined) {
       match = false;
     } else {
-      const [{ value }] = evalFhirPathTyped(
-        `%actualAnswer ${operator?.replace('=', '~')} %expectedAnswer`,
-        [actualAnswer],
-        {
-          actualAnswer,
-          expectedAnswer,
-        }
-      );
+      // `=` and `!=` should be treated as the FHIRPath `~` and `!~`
+      // All other operators should be unmodified
+      const fhirOperator = operator === '=' || operator === '!=' ? operator?.replace('=', '~') : operator;
+      const [{ value }] = evalFhirPathTyped(`%actualAnswer ${fhirOperator} %expectedAnswer`, [actualAnswer], {
+        actualAnswer,
+        expectedAnswer,
+      });
       match = value;
     }
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -639,8 +639,8 @@ export function isQuestionEnabled(
     } else {
       // `=` and `!=` should be treated as the FHIRPath `~` and `!~`
       // All other operators should be unmodified
-      const fhirOperator = operator === '=' || operator === '!=' ? operator?.replace('=', '~') : operator;
-      const [{ value }] = evalFhirPathTyped(`%actualAnswer ${fhirOperator} %expectedAnswer`, [actualAnswer], {
+      const fhirPathOperator = operator === '=' || operator === '!=' ? operator?.replace('=', '~') : operator;
+      const [{ value }] = evalFhirPathTyped(`%actualAnswer ${fhirPathOperator} %expectedAnswer`, [actualAnswer], {
         actualAnswer,
         expectedAnswer,
       });


### PR DESCRIPTION
This PR adds support for the `!=`, `>`, `>=`, `<`, `<=`, and `exists` operators for `QuestionnaireItem`. See: http://hl7.org/fhir/R4/valueset-questionnaire-enable-operator.html

The FHIR spec is a little unclear about what to do when comparison between types that are "potentially comparable" are made, such as `Time` and `DateTime`.

Currently the behavior is to ignore comparisons between types that are "potentially" comparable.

If the two types compared are not exactly equal and if the current answer is not `undefined`, then a match is not made. If the values are exactly the same type or the answer is `undefined` then the comparison is performed and the match is made based on the comparison.

This may be something that should be discussed in the future.

Please let me know if I missed anything obvious in this PR.

This closes #2683.
