### PR TITLE
fix(admin/client): use `:projectId` param to create client as superadmin

### DIFF
--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
-import { getReferenceString, parseReference } from '@medplum/core';
+import { getReferenceString, resolveId } from '@medplum/core';
 
 import type { ClientApplication, BundleEntry, ProjectMembership } from '@medplum/fhirtypes';
 
@@ -97,7 +97,7 @@ describe('Client admin', () => {
     expect(clientMembership.resourceType).toBe('ProjectMembership');
 
     // Get the id of the project attached to this membership
-    const [, projectId] = parseReference(clientMembership.project) ?? [];
+    const projectId = resolveId(clientMembership.project);
 
     expect(projectId).toBe(project.id);
   });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -1,9 +1,14 @@
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
+import { getReferenceString, parseReference } from '@medplum/core';
+
+import type { ClientApplication, BundleEntry, ProjectMembership } from '@medplum/fhirtypes';
+
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
+import { createTestProject, initTestAuth } from '../test.setup';
 
 const app = express();
 
@@ -57,5 +62,43 @@ describe('Client admin', () => {
       .type('json')
       .send({ foo: 'bar' });
     expect(res4.status).toBe(400);
+  });
+
+  test('Create client as superadmin - verify projectID', async () => {
+    const { project } = await createTestProject();
+
+    // As a superadmin, create a new client
+    const superAdminAccessToken = await initTestAuth({ superAdmin: true });
+    const res = await request(app)
+      .post('/admin/projects/' + project.id + '/client')
+      .set('Authorization', 'Bearer ' + superAdminAccessToken)
+      .send({
+        name: 'Another one',
+        description: 'another one',
+      });
+
+    expect(res.status).toBe(201);
+    expect((res.body as ClientApplication).resourceType).toBe('ClientApplication');
+    expect((res.body as ClientApplication).id).toBeDefined();
+
+    // Get the client membership
+    const res2 = await request(app)
+      .get('/fhir/R4/ProjectMembership?profile=' + getReferenceString(res.body as ClientApplication))
+      .set('Authorization', 'Bearer ' + superAdminAccessToken);
+    expect(res2.status).toBe(200);
+    expect(res2.body.resourceType).toBe('Bundle');
+
+    // Find the membership
+    const clientMembership = res2.body.entry.find(
+      (e: BundleEntry<ProjectMembership>) =>
+        e.resource?.profile?.reference === getReferenceString(res.body as ClientApplication)
+    )?.resource;
+    expect(clientMembership.resourceType).toBe('ProjectMembership');
+
+    // Get the id of the project attached to this membership
+    const [, projectId] = parseReference(clientMembership.project) ?? [];
+
+    expect(clientMembership).toBeDefined();
+    expect(projectId).toBe(project.id);
   });
 });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -93,12 +93,12 @@ describe('Client admin', () => {
       (e: BundleEntry<ProjectMembership>) =>
         e.resource?.profile?.reference === getReferenceString(res.body as ClientApplication)
     )?.resource;
+    expect(clientMembership).toBeDefined();
     expect(clientMembership.resourceType).toBe('ProjectMembership');
 
     // Get the id of the project attached to this membership
     const [, projectId] = parseReference(clientMembership.project) ?? [];
 
-    expect(clientMembership).toBeDefined();
     expect(projectId).toBe(project.id);
   });
 });

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -73,8 +73,8 @@ describe('Client admin', () => {
       .post('/admin/projects/' + project.id + '/client')
       .set('Authorization', 'Bearer ' + superAdminAccessToken)
       .send({
-        name: 'Another one',
-        description: 'another one',
+        name: "Super Admin's test client",
+        description: 'A client for testing creating a client with superadmin privileges.',
       });
 
     expect(res.status).toBe(201);

--- a/packages/server/src/admin/client.test.ts
+++ b/packages/server/src/admin/client.test.ts
@@ -1,10 +1,8 @@
+import { getReferenceString, resolveId } from '@medplum/core';
+import type { BundleEntry, ClientApplication, ProjectMembership } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
-import { getReferenceString, resolveId } from '@medplum/core';
-
-import type { ClientApplication, BundleEntry, ProjectMembership } from '@medplum/fhirtypes';
-
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';

--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -27,7 +27,7 @@ export async function createClientHandler(req: Request, res: Response): Promise<
   if (localsProject.superAdmin) {
     project = { resourceType: 'Project', id: req.params.projectId };
   } else {
-    project = res.locals.project;
+    project = localsProject;
   }
 
   const client = await createClient(repo, {

--- a/packages/server/src/admin/client.ts
+++ b/packages/server/src/admin/client.ts
@@ -22,9 +22,17 @@ export async function createClientHandler(req: Request, res: Response): Promise<
     return;
   }
 
-  const client = await createClient(res.locals.repo as Repository, {
+  let project: Project;
+  const { project: localsProject, repo } = res.locals as { project: Project; repo: Repository };
+  if (localsProject.superAdmin) {
+    project = { resourceType: 'Project', id: req.params.projectId };
+  } else {
+    project = res.locals.project;
+  }
+
+  const client = await createClient(repo, {
     ...req.body,
-    project: res.locals.project,
+    project,
   });
 
   res.status(201).json(client);


### PR DESCRIPTION
Fixes #2717

Originally wanted to use `meta` fields on `ClientApplication` to check for the project ID, but may have found a bug around the meta field being clobbered by addition of versioning info on initial creation of a resource, or at least the `ClientApplication`. (Will probably open an issue about this tomorrow once I have more info)