### PR TITLE
feat(ResourceTimeline): add support for `note`s on `ResourceTimeline`

### DIFF
--- a/packages/react/src/ResourceTimeline/ResourceTimeline.stories.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.stories.tsx
@@ -1,6 +1,6 @@
 import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Bundle, Encounter, ResourceType } from '@medplum/fhirtypes';
-import { HomerEncounter } from '@medplum/mock';
+import { HomerEncounter, HomerSimpsonSpecimen } from '@medplum/mock';
 import { Meta } from '@storybook/react';
 import React from 'react';
 import { Document } from '../Document/Document';
@@ -60,6 +60,25 @@ export const WithComments = (): JSX.Element => (
         operator: createReference(operator),
         content,
       })}
+    />
+  </Document>
+);
+
+export const WithNotes = (): JSX.Element => (
+  <Document>
+    <ResourceTimeline
+      value={HomerSimpsonSpecimen}
+      loadTimelineResources={(
+        medplum: MedplumClient,
+        resourceType: ResourceType,
+        id: string
+      ): Promise<PromiseSettledResult<Bundle>[]> => {
+        return Promise.allSettled([
+          medplum.readHistory(resourceType, id),
+          medplum.search('Communication', 'encounter=' + resourceType + '/' + id),
+          medplum.search('Media', 'encounter=' + resourceType + '/' + id),
+        ]);
+      }}
     />
   </Document>
 );

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
@@ -1,6 +1,6 @@
 import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Bundle, Encounter, Resource, ResourceType } from '@medplum/fhirtypes';
-import { HomerEncounter, MockClient } from '@medplum/mock';
+import { HomerEncounter, HomerSimpsonSpecimen, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -56,6 +56,19 @@ describe('ResourceTimeline', () => {
 
     const items = screen.getAllByTestId('timeline-item');
     expect(items).toBeDefined();
+  });
+
+  test('Renders notes (`Annotation`s) on resources with `note` property', async () => {
+    await setup({
+      value: HomerSimpsonSpecimen,
+      loadTimelineResources,
+    });
+
+    await waitFor(() => screen.getAllByTestId('timeline-item'));
+
+    const items = screen.getAllByTestId('timeline-item');
+    expect(items).toBeDefined();
+    expect(items.length).toEqual(3);
   });
 
   test('Create comment', async () => {

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -497,11 +497,13 @@ function CommunicationTimelineItem(props: BaseTimelineItemProps<Communication>):
 function NoteTimelineItem({ note }: { note: ProcessedNote }): JSX.Element {
   const {
     meta: { parentResource },
+    authorReference,
+    text,
     time,
   } = note;
   return (
-    <TimelineItem resource={parentResource} profile={note.authorReference} dateTime={time} padding={true}>
-      <p>{note.text}</p>
+    <TimelineItem resource={parentResource} profile={authorReference} dateTime={time} padding={true}>
+      <p>{text}</p>
     </TimelineItem>
   );
   // @TODO(ThatOneBro 30 Aug 2023): Note should support Markdown per spec

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -502,10 +502,9 @@ function NoteTimelineItem({ note }: { note: ProcessedNote }): JSX.Element {
   return (
     <TimelineItem
       resource={parentResource}
-      // profile={note.a}
+      profile={note.authorReference}
       dateTime={time}
       padding={true}
-      // popupMenuItems={<TimelineItemPopupMenu {...props} />}
     >
       <p>{note.text}</p>
     </TimelineItem>

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -500,12 +500,7 @@ function NoteTimelineItem({ note }: { note: ProcessedNote }): JSX.Element {
     time,
   } = note;
   return (
-    <TimelineItem
-      resource={parentResource}
-      profile={note.authorReference}
-      dateTime={time}
-      padding={true}
-    >
+    <TimelineItem resource={parentResource} profile={note.authorReference} dateTime={time} padding={true}>
       <p>{note.text}</p>
     </TimelineItem>
   );

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -66,7 +66,11 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
   const loadTimelineResources = props.loadTimelineResources;
 
   const itemsRef = useRef<Resource[]>(items);
-  itemsRef.current = items;
+
+  // Without this effect, itemsRef will not stay in sync if the items object is changed
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
 
   /**
    * Sorts and sets the items.
@@ -84,10 +88,10 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
    * See "sortByDateAndPriority()" for more details.
    */
   const sortAndSetItems = useCallback(
-    (newItmes: Resource[]): void => {
-      sortByDateAndPriority(newItmes, resource);
-      newItmes.reverse();
-      setItems(newItmes);
+    (newItems: Resource[]): void => {
+      sortByDateAndPriority(newItems, resource);
+      newItems.reverse();
+      setItems(newItems);
     },
     [resource]
   );
@@ -160,7 +164,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
     }
     medplum
       .createResource(props.createCommunication(resource, sender, contentString))
-      .then((result) => addResource(result))
+      .then((result: Resource) => addResource(result))
       .catch(console.log);
   }
 
@@ -175,7 +179,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
     }
     medplum
       .createResource(props.createMedia(resource, sender, attachment))
-      .then((result) => addResource(result))
+      .then((result: Resource) => addResource(result))
       .then(() =>
         updateNotification({
           id: 'upload-notification',
@@ -186,7 +190,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
           autoClose: 2000,
         })
       )
-      .catch((reason) =>
+      .catch((reason: Error) =>
         updateNotification({
           id: 'upload-notification',
           color: 'red',

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -27,7 +27,7 @@ export interface TimelineItemProps extends PanelProps {
 }
 
 export function TimelineItem(props: TimelineItemProps): JSX.Element {
-  const { resource, profile, padding, popupMenuItems, ...others } = props;
+  const { resource, profile, padding, popupMenuItems, children, ...others } = props;
   const author = profile ?? resource.meta?.author;
   const dateTime = props.dateTime ?? resource.meta?.lastUpdated;
 
@@ -40,21 +40,21 @@ export function TimelineItem(props: TimelineItemProps): JSX.Element {
             <ResourceName color="dark" weight={500} value={author} link={true} />
           </Text>
           <Text size="xs">
-            <MedplumLink color="dimmed" to={props.resource}>
+            <MedplumLink color="dimmed" to={resource}>
               {formatDateTime(dateTime)}
             </MedplumLink>
             <Text component="span" color="dimmed" mx={8}>
               &middot;
             </Text>
-            <MedplumLink color="dimmed" to={props.resource}>
-              {props.resource.resourceType}
+            <MedplumLink color="dimmed" to={resource}>
+              {resource.resourceType}
             </MedplumLink>
           </Text>
         </div>
         {popupMenuItems && (
           <Menu position="bottom-end" shadow="md" width={200}>
             <Menu.Target>
-              <ActionIcon radius="xl" aria-label={`Actions for ${getReferenceString(props.resource)}`}>
+              <ActionIcon radius="xl" aria-label={`Actions for ${getReferenceString(resource)}`}>
                 <IconDots />
               </ActionIcon>
             </Menu.Target>
@@ -63,8 +63,7 @@ export function TimelineItem(props: TimelineItemProps): JSX.Element {
         )}
       </Group>
       <ErrorBoundary>
-        {padding && <div style={{ padding: '0 16px 16px 16px' }}>{props.children}</div>}
-        {!padding && <>{props.children}</>}
+        {padding ? <div style={{ padding: '0 16px 16px 16px' }}>{children}</div> : <>{children}</>}
       </ErrorBoundary>
     </Panel>
   );

--- a/packages/react/src/utils/date.test.ts
+++ b/packages/react/src/utils/date.test.ts
@@ -1,71 +1,150 @@
 import { Communication, Resource } from '@medplum/fhirtypes';
-import { sortByDateAndPriority } from './date';
+import { TimeSortable, sortByDateAndPriority, sortByDateAndPriorityGeneric } from './date';
 
 describe('Date utils', () => {
-  test('Sort by date', () => {
-    const input: Resource[] = [
-      { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
-      { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
-      { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
-      { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
-      { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
-      { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
-      { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
-      { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
-    ];
-    const expected: Resource[] = [
-      { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
-      { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
-      { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
-      { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
-      { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
-      { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
-      { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
-      { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
-    ];
-    sortByDateAndPriority(input);
-    expect(input).toMatchObject(expected);
+  describe('sortByDateAndPriority()', () => {
+    test('Sort by date', () => {
+      const input: Resource[] = [
+        { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
+        { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
+        { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
+        { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
+        { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
+      ];
+      const expected: Resource[] = [
+        { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
+        { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
+        { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
+        { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
+        { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
+      ];
+      sortByDateAndPriority(input);
+      expect(input).toMatchObject(expected);
+    });
+
+    test('Sort by date and priority', () => {
+      const input: Communication[] = [
+        { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
+        { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
+      ];
+      const expected: Communication[] = [
+        { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
+        { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
+      ];
+      sortByDateAndPriority(input);
+      expect(input).toMatchObject(expected);
+    });
+
+    test('Ignore sorting special cases on timeline', () => {
+      // When looking at a particular resource's timeline view,
+      // history events for that resource should not use the sorting special cases
+      const resourceType = 'Communication';
+      const id = '1234';
+      const input: Communication[] = [
+        { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
+      ];
+      const expected: Communication[] = [
+        { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
+      ];
+      sortByDateAndPriority(input, input[0]);
+      expect(input).toMatchObject(expected);
+    });
   });
 
-  test('Sort by date and priority', () => {
-    const input: Communication[] = [
-      { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
-      { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
-      { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
-      { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
-      { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
-    ];
-    const expected: Communication[] = [
-      { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
-      { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
-      { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
-      { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
-      { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
-    ];
-    sortByDateAndPriority(input);
-    expect(input).toMatchObject(expected);
-  });
+  describe('sortByDateAndPriorityGeneric()', () => {
+    test('Sort by date with generic `TimeSortable` and `Resource` items', () => {
+      const input = [
+        { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
+        { time: '2010-04-04T00:00:00.000Z' },
+        { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
+        { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
+        { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
+        { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
+        { time: '2005-04-04T00:00:00.000Z' },
+      ] satisfies TimeSortable[];
+      const expected = [
+        { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'Patient', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
+        { time: '2005-04-04T00:00:00.000Z' },
+        { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
+        { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
+        { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
+        { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
+        { time: '2010-04-04T00:00:00.000Z' },
+      ] satisfies TimeSortable[];
+      sortByDateAndPriorityGeneric(input);
+      expect(input).toMatchObject(expected);
+    });
 
-  test('Ignore sorting special cases on timeline', () => {
-    // When looking at a particular resource's timeline view,
-    // history events for that resource should not use the sorting special cases
-    const resourceType = 'Communication';
-    const id = '1234';
-    const input: Communication[] = [
-      { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
-      { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
-      { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
-      { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
-      { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
-    ];
-    const expected: Communication[] = [
-      { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
-      { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
-      { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
-      { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
-      { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
-    ];
-    sortByDateAndPriority(input, input[0]);
-    expect(input).toMatchObject(expected);
+    test('Sort by date and priority with generic and `Resource` items', () => {
+      const input = [
+        { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
+        { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
+        { time: '2010-04-04T00:00:00.000Z' },
+      ] satisfies TimeSortable[];
+      const expected = [
+        { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
+        { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
+        { time: '2010-04-04T00:00:00.000Z' },
+        { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
+      ] satisfies TimeSortable[];
+      sortByDateAndPriorityGeneric(input);
+      expect(input).toMatchObject(expected);
+    });
+
+    test('Ignore sorting special cases on timeline with generics', () => {
+      // When looking at a particular resource's timeline view,
+      // history events for that resource should not use the sorting special cases
+      const resourceType = 'Communication';
+      const id = '1234';
+      const input = [
+        { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
+        { time: '2002-01-05T00:00:00.000Z' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
+      ] satisfies TimeSortable[];
+      const expected = [
+        { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
+        { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
+        { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
+        { time: '2002-01-05T00:00:00.000Z' },
+      ] satisfies TimeSortable[];
+      sortByDateAndPriorityGeneric(input, input[0] as Communication);
+      expect(input).toMatchObject(expected);
+    });
   });
 });

--- a/packages/react/src/utils/date.ts
+++ b/packages/react/src/utils/date.ts
@@ -1,5 +1,7 @@
 import { Resource } from '@medplum/fhirtypes';
 
+const PRIORITY_RANKINGS = { stat: 4, asap: 3, urgent: 2 } as const;
+
 /**
  * Sorts an array of resources in place by meta.lastUpdated ascending.
  * @param resources Array of resources.
@@ -25,7 +27,7 @@ function getPriorityScore(resource: Resource, timelineResource: Resource | undef
 
     const priority = (resource as any).priority;
     if (typeof priority === 'string') {
-      return { stat: 4, asap: 3, urgent: 2 }[priority] ?? 0;
+      return PRIORITY_RANKINGS[priority as keyof typeof PRIORITY_RANKINGS] ?? 0;
     }
   }
   return 0;

--- a/packages/react/src/utils/date.ts
+++ b/packages/react/src/utils/date.ts
@@ -3,16 +3,16 @@ import { Resource } from '@medplum/fhirtypes';
 
 const PRIORITY_RANKINGS = { stat: 4, asap: 3, urgent: 2 } as const;
 
+interface Timestamped {
+  time: string;
+}
+
 /**
  * This is a type that you can use to check if something is sortable by `sortByDateAndPriorityGeneric` from this module.
  *
  * This could eventually be a mixin interface which establishes some methods to give information about how to sort a particular data type.
  */
-export type TimeSortable =
-  | {
-      time: string;
-    }
-  | Resource;
+export type TimeSortable = Timestamped | Resource;
 
 /**
  * Sorts an array of resources in place by meta.lastUpdated ascending.


### PR DESCRIPTION
## Background
There are a few `Resource` types which have a `note` property. Currently the notes from this `note` property only show up in the parent `resource` in the timeline view.

As described in #2715, we want to be able to add the notes on these resources such as `Specimen` or `Observation` to the `ResourceTimeline` as a separate entry, sorted into the timeline based on when the `note` was recorded.

## What this PR does
* Adds notes to the `ResourceTimeline` and derivative timeline components when a `note` property is found on a `Resource`.
* Closes #2715
<img width="973" alt="Screen Shot 2023-08-30 at 5 47 31 PM" src="https://github.com/medplum/medplum/assets/1592008/529b1df0-2558-4998-a428-18105deb40aa">

## Notes about changes
There were are few things about this issue that made it a little more difficult than originally thought at first glance:
1. `ResourceTimeline` expected items to be `Resource`s
2. Sorting items in the timeline relied on a sorting function `sortByDateAndPriority()` which deals with sorting `Resource`s based on different fields and whether a resource is marked with a special `priority`. This makes it a bit tricky to sort `note`s which wouldn't have some of these fields necessarily and aren't shaped like `Resource`s.

The solution was to make `ResourceTimeline` generic on items which implement an interface `TimeSortable` which guarantees a datatype is a `Resource` or has a `time` property with a date string. We then created a `sortByDateAndPriorityGeneric()` which can sort these objects alongside resources. In the future, if needed, more logic can be added to extract different fields from `Resource`s and put them and sort them in the timeline as well.
