### PR TITLE
Agent installer performs silent upgrades

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,5 +96,5 @@ jobs:
               repo: context.repo.repo,
               release_id: release.data.id,
               name: "medplum-agent-win-x64.exe",
-              data: await fs.readFileSync("packages/agent/dist/medplum-agent-win-x64.exe")
+              data: await fs.readFileSync("packages/agent/medplum-agent-installer.exe")
             });


### PR DESCRIPTION
If the agent is already installed, the installer goes into a "upgrade" flow.  When upgrading, it just updates the .exe file and restarts the Windows service.

This supports NSIS "silent mode", which I'm experimenting with for our auto-updater strategy.  The idea is that the installer .exe can also be used as the auto-updater .exe for an existing agent.

Also fixed the path on the .exe added to the Releases page 🤦‍♂️