### PR TITLE
config(prettier): only run `prettier` on JS/TS-like files from CLI

### DIFF
--- a/examples/medplum-react-native-example/babel.config.js
+++ b/examples/medplum-react-native-example/babel.config.js
@@ -1,4 +1,4 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "eslint .",
-    "prettier": "prettier --write .",
+    "prettier": "prettier --write \"**/*.{ts,tsx,cts,mts,js,jsx,cjs,mjs}\"",
     "cyclonedx": "cyclonedx-npm --omit dev --omit optional --omit peer"
   },
   "workspaces": [


### PR DESCRIPTION
## Background
I noticed `.mdx` and `.md` files do not format stably with `prettier` for some reason. Every time `prettier` runs on them it creates conflicts, usually due to whitespacing (adding or removing a space that it itself added before). 

So I figured since `prettier` is already going to run on `.mdx` files when edited in VSCode, we don't really need to have it on the CI or CLI `prettier` runs. 

This will create less noise and only error on JS-like files in CI (already configured this way) and only create changes to JS-like files when run from CLI.

## What this PR does
* Changes the `prettier` script to only write changes to JS/TS-like files.