### PR TITLE
Health Gorilla demo bots part 2

### DIFF
--- a/examples/medplum-demo-bots/src/health-gorilla/README.md
+++ b/examples/medplum-demo-bots/src/health-gorilla/README.md
@@ -25,9 +25,33 @@ The demo bots expect a number of configuration settings in your Medplum Project 
 | HEALTH_GORILLA_SUBTENANT_ACCOUNT_NUMBER | The subtenant account number             |                                     |
 | HEALTH_GORILLA_SCOPES                   | OAuth scopes                             | `user/_._`                          |
 
+You will also need a FHIR `Organization` resource representing the performing lab. For example:
+
+```js
+{
+  "resourceType": "Organization",
+  "name": "Testing Lab Facility",
+  "identifier": [
+    {
+      "system": "https://www.healthgorilla.com",
+      "value": "f-123412341234" // This value will be provided by Health Gorilla
+    }
+  ]
+}
+```
+
 ## Sending Orders
 
-The `send-to-health-gorilla.ts` demonstrates how to convert a `QuestionnaireResponse` into a Health Gorilla order. It does the following:
+The `send-to-health-gorilla.ts` demonstrates how to convert a `QuestionnaireResponse` into a Health Gorilla order.
+
+The expected answers in the `QuestionnaireResponse` include:
+
+1. `patient` - reference to the `Patient` resource
+2. `practitioner` - reference to the `Practitioner` resource representing the ordering physician
+3. `performer` - referenc to the `Organization` resource representing the performing lab facility
+4. TODO: test details
+
+The bot then does the following:
 
 1. Gathers `Patient`, `Practitioner`, and order details
 2. Validates the input data

--- a/examples/medplum-demo-bots/src/health-gorilla/receive-from-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/receive-from-health-gorilla.ts
@@ -1,0 +1,161 @@
+import { allOk, BotEvent, getIdentifier, getReferenceString, MedplumClient, normalizeErrorString } from '@medplum/core';
+import {
+  Account,
+  DiagnosticReport,
+  Observation,
+  OperationOutcome,
+  Patient,
+  Practitioner,
+  PractitionerRole,
+  RequestGroup,
+  ServiceRequest,
+} from '@medplum/fhirtypes';
+
+type HealthGorillaResource =
+  | Account
+  | DiagnosticReport
+  | Observation
+  | Patient
+  | Practitioner
+  | PractitionerRole
+  | RequestGroup
+  | ServiceRequest;
+
+type HealthGorillaResourceType = HealthGorillaResource['resourceType'];
+
+const HEALTH_GORILLA_SYSTEM = 'https://www.healthgorilla.com';
+
+const referenceMap = new Map<string, string>();
+
+export async function handler(
+  medplum: MedplumClient,
+  event: BotEvent<HealthGorillaResource>
+): Promise<OperationOutcome> {
+  try {
+    const resource = event.input;
+
+    if (resource.contained) {
+      for (const containedResource of resource.contained) {
+        await syncResource(medplum, containedResource as HealthGorillaResource, true);
+      }
+
+      // Remove contained resources before syncing the parent resource
+      resource.contained = undefined;
+    }
+
+    await syncResource(medplum, resource);
+  } catch (err) {
+    console.log(normalizeErrorString(err));
+  }
+
+  return allOk;
+}
+
+export async function syncResource<T extends HealthGorillaResource>(
+  medplum: MedplumClient,
+  healthGorillaResource: T,
+  contained = false
+): Promise<void> {
+  if (healthGorillaResource.resourceType === 'Account' && !healthGorillaResource.status) {
+    // Health Gorilla drops Account.status which is a required field
+    healthGorillaResource.status = 'active';
+  }
+
+  // Rewrite references to other resources
+  // For example, convert references to Patient and Organization resources
+  // from Health Gorilla references to Medplum references
+  await rewriteReferences(medplum, healthGorillaResource);
+
+  let existingResource: HealthGorillaResource | undefined = undefined;
+  let healthGorillaId: string | undefined = undefined;
+
+  const mergeResourceTypes: HealthGorillaResourceType[] = ['Account'];
+  if (mergeResourceTypes.includes(healthGorillaResource.resourceType)) {
+    // For some resource types, we attempt a "merge" operation with existing resources.
+    // For other resource types, we always create a new resource.
+    healthGorillaId = getHealthGorillaId(healthGorillaResource, contained) as string;
+    existingResource = await searchByHealthGorillaId(medplum, healthGorillaResource.resourceType, healthGorillaId);
+  }
+
+  if (existingResource) {
+    // Update the existing resource
+    const updatedResource = await medplum.updateResource({
+      ...healthGorillaResource,
+      id: existingResource.id,
+      identifier: existingResource.identifier,
+    });
+    console.log('Updated', updatedResource.resourceType, updatedResource.id);
+    if (healthGorillaResource.id) {
+      referenceMap.set('#' + healthGorillaResource.id, getReferenceString(updatedResource));
+    }
+  } else {
+    // Create a new resource
+    const createdResource = await medplum.createResource({
+      ...healthGorillaResource,
+      id: undefined,
+      identifier: [{ system: HEALTH_GORILLA_SYSTEM, value: healthGorillaId }],
+    });
+    console.log('Created', createdResource.resourceType, createdResource.id);
+    if (healthGorillaResource.id) {
+      referenceMap.set('#' + healthGorillaResource.id, getReferenceString(createdResource));
+    }
+  }
+}
+
+async function rewriteReferences(medplum: MedplumClient, value: unknown): Promise<void> {
+  if (!value) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    await rewriteReferencesInArray(medplum, value);
+  } else if (typeof value === 'object') {
+    await rewriteReferencesInObject(medplum, value as Record<string, unknown>);
+  }
+}
+
+async function rewriteReferencesInArray(medplum: MedplumClient, array: unknown[]): Promise<void> {
+  for (const entry of array) {
+    await rewriteReferences(medplum, entry);
+  }
+}
+
+async function rewriteReferencesInObject(medplum: MedplumClient, obj: Record<string, unknown>): Promise<void> {
+  if ('reference' in obj && typeof obj.reference === 'string') {
+    // Rewrite the reference
+    const reference = obj.reference;
+    if (referenceMap.has(reference)) {
+      obj.reference = referenceMap.get(reference);
+      console.log('Rewrite', reference, '->', obj.reference);
+    } else if (reference.includes('/')) {
+      const [resourceType, id] = reference.split('/');
+      const resource = await searchByHealthGorillaId(medplum, resourceType as HealthGorillaResourceType, id);
+      if (resource) {
+        referenceMap.set(reference, getReferenceString(resource));
+        obj.reference = getReferenceString(resource);
+        console.log('Rewrite', getReferenceString(resource), '->', obj.reference);
+      } else {
+        console.log('WARNING: Could not find reference', reference);
+      }
+    }
+    return;
+  }
+  // Recursively rewrite the object
+  for (const child of Object.values(obj)) {
+    await rewriteReferences(medplum, child);
+  }
+}
+
+function getHealthGorillaId(resource: HealthGorillaResource, contained: boolean): string | undefined {
+  if (!contained && resource.id) {
+    return resource.id;
+  }
+  return getIdentifier(resource, HEALTH_GORILLA_SYSTEM);
+}
+
+async function searchByHealthGorillaId(
+  medplum: MedplumClient,
+  resourceType: HealthGorillaResourceType,
+  id: string
+): Promise<HealthGorillaResource | undefined> {
+  return medplum.searchOne(resourceType, { identifier: id });
+}


### PR DESCRIPTION
New features:

* Updated "send" bot
  * Ensures active FHIR subscriptions to key resource types
  * Creates order resources both in Medplum and in Health Gorilla
  * Removes more hardcoded values in favor of FHIR resources and `QuestionnaireResponse` values
* Callback bot which parses webhooks and creates FHIR resources in Medplum
  * Creates `DiagnosticReport` and `Observation` resources
  * Rewrites references to `Account`, `Patient`, and `Organization` resources

Todo (maybe future PR):

* Some open "todos" for bot config settings (callback bot ID, callback client ID/secret)
* `Observation` resources use "observation grouping", and are not represented in order, so need to use a DAG or some other method to properly sequence the writes
* `ServiceRequest` mapping does not work because HG drops the `identifier` properties