### PR TITLE
Persistent state for components in previous pages

### DIFF
--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -238,7 +238,9 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
           <>
             {resource.title && <Title>{resource.title}</Title>}
             {item.text && <div>{item.text}</div>}
-            {!isContainer && <QuestionnaireFormItem item={item} index={0} allResponses={[]} onChange={() => undefined} />}
+            {!isContainer && (
+              <QuestionnaireFormItem item={item} index={0} allResponses={[]} onChange={() => undefined} />
+            )}
           </>
         )}
       </div>

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -238,7 +238,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
           <>
             {resource.title && <Title>{resource.title}</Title>}
             {item.text && <div>{item.text}</div>}
-            {!isContainer && <QuestionnaireFormItem item={item} index={0} responses={[]} onChange={() => undefined} />}
+            {!isContainer && <QuestionnaireFormItem item={item} index={0} allResponses={[]} onChange={() => undefined} />}
           </>
         )}
       </div>

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -238,7 +238,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
           <>
             {resource.title && <Title>{resource.title}</Title>}
             {item.text && <div>{item.text}</div>}
-            {!isContainer && <QuestionnaireFormItem item={item} index={0} answers={{}} onChange={() => undefined} />}
+            {!isContainer && <QuestionnaireFormItem item={item} index={0} responses={[]} onChange={() => undefined} />}
           </>
         )}
       </div>

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -597,6 +597,7 @@ export const PageSequence = (): JSX.Element => (
             linkId: 'group1',
             text: 'Page Sequence 1',
             type: 'group',
+            repeats: true,
             item: [
               {
                 linkId: 'question1',

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -622,7 +622,7 @@ export const PageSequence = (): JSX.Element => (
                 ],
               },
               {
-                linkId: 'question4',
+                linkId: 'question1-4',
                 text: 'Multi Select Question',
                 type: 'choice',
                 repeats: true,

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -597,7 +597,6 @@ export const PageSequence = (): JSX.Element => (
             linkId: 'group1',
             text: 'Page Sequence 1',
             type: 'group',
-            repeats: true,
             item: [
               {
                 linkId: 'question1',
@@ -619,6 +618,35 @@ export const PageSequence = (): JSX.Element => (
                   },
                   {
                     valueString: 'No',
+                  },
+                ],
+              },
+              {
+                linkId: 'question4',
+                text: 'Multi Select Question',
+                type: 'choice',
+                repeats: true,
+                answerOption: [
+                  {
+                    valueString: 'value1',
+                  },
+                  {
+                    valueString: 'value2',
+                  },
+                ],
+                extension: [
+                  {
+                    url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                    valueCodeableConcept: {
+                      coding: [
+                        {
+                          system: 'http://hl7.org/fhir/questionnaire-item-control',
+                          code: 'drop-down',
+                          display: 'Drop down',
+                        },
+                      ],
+                      text: 'Drop down',
+                    },
                   },
                 ],
               },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -1,7 +1,6 @@
 import { Anchor, Button, Group, Stack, Stepper, Title } from '@mantine/core';
 import {
   createReference,
-  getAllQuestionnaireAnswers,
   getExtension,
   getReferenceString,
   IndexedStructureDefinition,
@@ -61,12 +60,8 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
       resourceType: 'QuestionnaireResponse',
       item: newResponseItems,
     };
+
     setResponse(newResponse);
-    // const newAnswers = getAllQuestionnaireAnswers(newResponse);
-    // setAnswers((prevAnswers) => ({
-    //   ...prevAnswers,
-    //   ...newAnswers,
-    // }));
   }
 
   if (!schema || !questionnaire) {
@@ -118,6 +113,7 @@ interface QuestionnaireFormItemArrayProps {
   items: QuestionnaireItem[];
   // answers: Record<string, QuestionnaireResponseItemAnswer[]>;
   responses: QuestionnaireResponseItem[];
+  groupNumber?: number;
   renderPages?: boolean;
   activePage?: number;
   onChange: (newResponseItems: QuestionnaireResponseItem[]) => void;
@@ -148,6 +144,7 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
             key={`${item.linkId}-${index}`}
             item={item}
             index={index}
+            groupNumber={props.groupNumber}
             responses={props.responses}
             responseItems={responseItems}
             setResponseItem={setResponseItem}
@@ -160,6 +157,7 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
         key={`${item.linkId}-${index}`}
         item={item}
         index={index}
+        groupNumber={props.groupNumber}
         responses={props.responses}
         responseItems={responseItems}
         setResponseItem={setResponseItem}
@@ -182,6 +180,7 @@ interface QuestionnaireFormArrayContentProps {
   index: number;
   // answers: Record<string, QuestionnaireResponseItemAnswer[]>;
   responses: QuestionnaireResponseItem[];
+  groupNumber?: number;
   responseItems: QuestionnaireResponseItem[];
   setResponseItem: (responseId: string, newResponseItem: QuestionnaireResponseItem) => void;
 }
@@ -199,6 +198,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
         key={props.item.linkId}
         item={props.item}
         responses={props.responses}
+        groupNumber={props.groupNumber}
         responseItems={props.responseItems}
         onChange={(newResponseItem) => props.setResponseItem(newResponseItem.id as string, newResponseItem)}
       />
@@ -209,6 +209,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
       <QuestionnaireRepeatWrapper
         item={props.item}
         responses={props.responses}
+        groupNumber={props.groupNumber}
         responseItems={props.responseItems}
         onChange={(newResponseItem) => props.setResponseItem(newResponseItem.id as string, newResponseItem)}
       />
@@ -219,6 +220,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
 export interface QuestionnaireRepeatWrapperProps {
   item: QuestionnaireItem;
   responses: QuestionnaireResponseItem[];
+  groupNumber?: number;
   responseItems: QuestionnaireResponseItem[];
   onChange: (newResponseItem: QuestionnaireResponseItem, index?: number) => void;
 }
@@ -341,7 +343,7 @@ interface RepeatableGroupProps {
 }
 
 function RepeatableGroup(props: RepeatableGroupProps): JSX.Element | null {
-  const [number, setNumber] = useState(1);
+  const [number, setNumber] = useState(getNumberOfGroups(props.item, props.responses));
 
   const item = props.item;
   return (
@@ -353,6 +355,7 @@ function RepeatableGroup(props: RepeatableGroupProps): JSX.Element | null {
             <QuestionnaireFormItemArray
               items={item.item ?? []}
               responses={props.responses}
+              groupNumber={i}
               onChange={(response) => props.onChange(response, i)}
             />
           </div>
@@ -389,4 +392,9 @@ function getResponseId(responses: QuestionnaireResponseItem[], index: number): s
     return generateId();
   }
   return responses[index].id as string;
+}
+
+function getNumberOfGroups(item: QuestionnaireItem, responses: QuestionnaireResponseItem[]): number {
+  // This is to maintain the number of groups for the stepper when typing backwards
+  return responses.filter((r) => r.linkId === item.linkId).length ?? 0;
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -88,7 +88,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
       {questionnaire.item && (
         <QuestionnaireFormItemArray
           items={questionnaire.item ?? []}
-          responses={response?.item ?? []}
+          allResponses={response?.item ?? []}
           onChange={setItems}
           renderPages={numberOfPages > 1}
           activePage={activePage}
@@ -109,7 +109,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
 
 interface QuestionnaireFormItemArrayProps {
   items: QuestionnaireItem[];
-  responses: QuestionnaireResponseItem[];
+  allResponses: QuestionnaireResponseItem[];
   renderPages?: boolean;
   activePage?: number;
   groupSequence?: number;
@@ -141,7 +141,7 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
             key={`${item.linkId}-${index}`}
             item={item}
             index={index}
-            responses={props.responses}
+            allResponses={props.allResponses}
             currentResponseItems={currentResponseItems}
             groupSequence={props.groupSequence}
             setResponseItem={setResponseItem}
@@ -155,7 +155,7 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
         item={item}
         index={index}
         groupSequence={props.groupSequence}
-        responses={props.responses}
+        allResponses={props.allResponses}
         currentResponseItems={currentResponseItems}
         setResponseItem={setResponseItem}
       />
@@ -175,14 +175,14 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
 interface QuestionnaireFormArrayContentProps {
   item: QuestionnaireItem;
   index: number;
-  responses: QuestionnaireResponseItem[];
+  allResponses: QuestionnaireResponseItem[];
   currentResponseItems: QuestionnaireResponseItem[];
   groupSequence?: number;
   setResponseItem: (responseId: string, newResponseItem: QuestionnaireResponseItem) => void;
 }
 
 function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps): JSX.Element | null {
-  if (!isQuestionEnabled(props.item, props.responses)) {
+  if (!isQuestionEnabled(props.item, props.allResponses)) {
     return null;
   }
   if (props.item.type === QuestionnaireItemType.display) {
@@ -193,7 +193,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
       <QuestionnaireRepeatWrapper
         key={props.item.linkId}
         item={props.item}
-        responses={props.responses}
+        allResponses={props.allResponses}
         currentResponseItems={props.currentResponseItems}
         groupSequence={props.groupSequence}
         onChange={(newResponseItem) => props.setResponseItem(newResponseItem.id as string, newResponseItem)}
@@ -204,7 +204,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
     <FormSection key={props.item.linkId} htmlFor={props.item.linkId} title={props.item.text ?? ''}>
       <QuestionnaireRepeatWrapper
         item={props.item}
-        responses={props.responses}
+        allResponses={props.allResponses}
         currentResponseItems={props.currentResponseItems}
         groupSequence={props.groupSequence}
         onChange={(newResponseItem) => props.setResponseItem(newResponseItem.id as string, newResponseItem)}
@@ -215,7 +215,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
 
 export interface QuestionnaireRepeatWrapperProps {
   item: QuestionnaireItem;
-  responses: QuestionnaireResponseItem[];
+  allResponses: QuestionnaireResponseItem[];
   currentResponseItems: QuestionnaireResponseItem[];
   groupSequence?: number;
   onChange: (newResponseItem: QuestionnaireResponseItem, index?: number) => void;
@@ -239,7 +239,7 @@ export function QuestionnaireRepeatWrapper(props: QuestionnaireRepeatWrapperProp
         key={props.item.linkId}
         text={item.text ?? ''}
         item={item ?? []}
-        responses={props.responses}
+        allResponses={props.allResponses}
         onChange={onChangeItem}
       />
     );
@@ -333,12 +333,12 @@ function getNumberOfPages(items: QuestionnaireItem[]): number {
 interface RepeatableGroupProps {
   item: QuestionnaireItem;
   text: string;
-  responses: QuestionnaireResponseItem[];
+  allResponses: QuestionnaireResponseItem[];
   onChange: (newResponseItem: QuestionnaireResponseItem[], index?: number) => void;
 }
 
 function RepeatableGroup(props: RepeatableGroupProps): JSX.Element | null {
-  const [number, setNumber] = useState(getNumberOfGroups(props.item, props.responses));
+  const [number, setNumber] = useState(getNumberOfGroups(props.item, props.allResponses));
 
   const item = props.item;
   return (
@@ -349,7 +349,7 @@ function RepeatableGroup(props: RepeatableGroupProps): JSX.Element | null {
             <h3>{props.text}</h3>
             <QuestionnaireFormItemArray
               items={item.item ?? []}
-              responses={props.responses}
+              allResponses={props.allResponses}
               groupSequence={i}
               onChange={(response) => props.onChange(response, i)}
             />

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -37,7 +37,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
   const [schema, setSchema] = useState<IndexedStructureDefinition | undefined>();
   const questionnaire = useResource(props.questionnaire);
   const [response, setResponse] = useState<QuestionnaireResponse | undefined>();
-  const [answers, setAnswers] = useState<Record<string, QuestionnaireResponseItemAnswer[]>>({});
+  // const [answers, setAnswers] = useState<Record<string, QuestionnaireResponseItemAnswer[]>>({});
   const [activePage, setActivePage] = useState(0);
 
   const numberOfPages = getNumberOfPages(questionnaire?.item ?? []);
@@ -62,11 +62,11 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
       item: newResponseItems,
     };
     setResponse(newResponse);
-    const newAnswers = getAllQuestionnaireAnswers(newResponse);
-    setAnswers((prevAnswers) => ({
-      ...prevAnswers,
-      ...newAnswers,
-    }));
+    // const newAnswers = getAllQuestionnaireAnswers(newResponse);
+    // setAnswers((prevAnswers) => ({
+    //   ...prevAnswers,
+    //   ...newAnswers,
+    // }));
   }
 
   if (!schema || !questionnaire) {
@@ -94,7 +94,8 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
       {questionnaire.item && (
         <QuestionnaireFormItemArray
           items={questionnaire.item ?? []}
-          answers={answers}
+          // answers={answers}
+          responses={response?.item ?? []}
           onChange={setItems}
           renderPages={numberOfPages > 1}
           activePage={activePage}
@@ -115,7 +116,8 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
 
 interface QuestionnaireFormItemArrayProps {
   items: QuestionnaireItem[];
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  // answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  responses: QuestionnaireResponseItem[];
   renderPages?: boolean;
   activePage?: number;
   onChange: (newResponseItems: QuestionnaireResponseItem[]) => void;
@@ -146,7 +148,7 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
             key={`${item.linkId}-${index}`}
             item={item}
             index={index}
-            answers={props.answers}
+            responses={props.responses}
             responseItems={responseItems}
             setResponseItem={setResponseItem}
           />
@@ -158,7 +160,7 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
         key={`${item.linkId}-${index}`}
         item={item}
         index={index}
-        answers={props.answers}
+        responses={props.responses}
         responseItems={responseItems}
         setResponseItem={setResponseItem}
       />
@@ -178,13 +180,14 @@ function QuestionnaireFormItemArray(props: QuestionnaireFormItemArrayProps): JSX
 interface QuestionnaireFormArrayContentProps {
   item: QuestionnaireItem;
   index: number;
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  // answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  responses: QuestionnaireResponseItem[];
   responseItems: QuestionnaireResponseItem[];
   setResponseItem: (responseId: string, newResponseItem: QuestionnaireResponseItem) => void;
 }
 
 function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps): JSX.Element | null {
-  if (!isQuestionEnabled(props.item, props.answers)) {
+  if (!isQuestionEnabled(props.item, props.responses)) {
     return null;
   }
   if (props.item.type === QuestionnaireItemType.display) {
@@ -195,7 +198,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
       <QuestionnaireRepeatWrapper
         key={props.item.linkId}
         item={props.item}
-        answers={props.answers}
+        responses={props.responses}
         responseItems={props.responseItems}
         onChange={(newResponseItem) => props.setResponseItem(newResponseItem.id as string, newResponseItem)}
       />
@@ -205,7 +208,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
     <FormSection key={props.item.linkId} htmlFor={props.item.linkId} title={props.item.text ?? ''}>
       <QuestionnaireRepeatWrapper
         item={props.item}
-        answers={props.answers}
+        responses={props.responses}
         responseItems={props.responseItems}
         onChange={(newResponseItem) => props.setResponseItem(newResponseItem.id as string, newResponseItem)}
       />
@@ -215,7 +218,7 @@ function QuestionnaireFormArrayContent(props: QuestionnaireFormArrayContentProps
 
 export interface QuestionnaireRepeatWrapperProps {
   item: QuestionnaireItem;
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  responses: QuestionnaireResponseItem[];
   responseItems: QuestionnaireResponseItem[];
   onChange: (newResponseItem: QuestionnaireResponseItem, index?: number) => void;
 }
@@ -238,7 +241,7 @@ export function QuestionnaireRepeatWrapper(props: QuestionnaireRepeatWrapperProp
         key={props.item.linkId}
         text={item.text ?? ''}
         item={item ?? []}
-        answers={props.answers}
+        responses={props.responses}
         onChange={onChangeItem}
       />
     );
@@ -332,7 +335,8 @@ function getNumberOfPages(items: QuestionnaireItem[]): number {
 interface RepeatableGroupProps {
   item: QuestionnaireItem;
   text: string;
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  // answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  responses: QuestionnaireResponseItem[];
   onChange: (newResponseItem: QuestionnaireResponseItem[], index?: number) => void;
 }
 
@@ -348,7 +352,7 @@ function RepeatableGroup(props: RepeatableGroupProps): JSX.Element | null {
             <h3>{props.text}</h3>
             <QuestionnaireFormItemArray
               items={item.item ?? []}
-              answers={props.answers}
+              responses={props.responses}
               onChange={(response) => props.onChange(response, i)}
             />
           </div>

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -62,7 +62,11 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
       item: newResponseItems,
     };
     setResponse(newResponse);
-    setAnswers(getAllQuestionnaireAnswers(newResponse));
+    const newAnswers = getAllQuestionnaireAnswers(newResponse);
+    setAnswers((prevAnswers) => ({
+      ...prevAnswers,
+      ...newAnswers,
+    }));
   }
 
   if (!schema || !questionnaire) {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -396,5 +396,6 @@ function getResponseId(responses: QuestionnaireResponseItem[], index: number): s
 
 function getNumberOfGroups(item: QuestionnaireItem, responses: QuestionnaireResponseItem[]): number {
   // This is to maintain the number of groups for the stepper when typing backwards
-  return responses.filter((r) => r.linkId === item.linkId).length ?? 0;
+  const responseLength = responses.filter((r) => r.linkId === item.linkId).length;
+  return responseLength > 0 ? responseLength : 1;
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -1,5 +1,13 @@
 import { Checkbox, MultiSelect, NativeSelect, Radio, TextInput, Textarea } from '@mantine/core';
-import { PropertyType, TypedValue, capitalize, getTypedPropertyValue, globalSchema, stringify } from '@medplum/core';
+import {
+  PropertyType,
+  TypedValue,
+  capitalize,
+  formatCoding,
+  getTypedPropertyValue,
+  globalSchema,
+  stringify,
+} from '@medplum/core';
 import {
   QuestionnaireItem,
   QuestionnaireItemAnswerOption,
@@ -8,19 +16,19 @@ import {
   QuestionnaireResponseItemAnswer,
 } from '@medplum/fhirtypes';
 import React, { ChangeEvent } from 'react';
-import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
-import { QuestionnaireItemType } from '../../utils/questionnaire';
-import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
 import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
-import { QuantityInput } from '../../QuantityInput/QuantityInput';
-import { ResourcePropertyDisplay } from '../../ResourcePropertyDisplay/ResourcePropertyDisplay';
+import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
 import { DateTimeInput } from '../../DateTimeInput/DateTimeInput';
+import { QuantityInput } from '../../QuantityInput/QuantityInput';
+import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
+import { ResourcePropertyDisplay } from '../../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
+import { QuestionnaireItemType } from '../../utils/questionnaire';
 
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
   index: number;
-  responses: QuestionnaireResponseItem[];
+  allResponses: QuestionnaireResponseItem[];
   currentResponseItems?: QuestionnaireResponseItem[];
   groupSequence?: number;
   onChange: (newResponseItem: QuestionnaireResponseItem) => void;
@@ -72,7 +80,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             id={props.item.linkId}
             name={props.item.linkId}
             defaultChecked={
-              initial?.valueBoolean ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)
+              getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueBoolean
             }
             onChange={(e) => onChangeAnswer({ valueBoolean: e.currentTarget.checked }, index)}
           />
@@ -85,7 +93,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step="any"
           id={name}
           name={name}
-          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueDecimal}
           onChange={(e) => onChangeAnswer({ valueDecimal: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -96,7 +104,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step={1}
           id={name}
           name={name}
-          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueInteger}
           onChange={(e) => onChangeAnswer({ valueInteger: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -106,7 +114,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="date"
           id={name}
           name={name}
-          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueDate}
           onChange={(e) => onChangeAnswer({ valueDate: e.currentTarget.value }, index)}
         />
       );
@@ -114,7 +122,9 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <DateTimeInput
           name={name}
-          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={
+            getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueDateTime
+          }
           onChange={(newValue: string) => onChangeAnswer({ valueDateTime: newValue }, index)}
         />
       );
@@ -124,7 +134,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="time"
           id={name}
           name={name}
-          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueTime}
           onChange={(e) => onChangeAnswer({ valueTime: e.currentTarget.value }, index)}
         />
       );
@@ -134,7 +144,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <TextInput
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueString}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -143,7 +153,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <Textarea
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueString}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -151,7 +161,9 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <AttachmentInput
           name={name}
-          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={
+            getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueAttachment
+          }
           onChange={(newValue) => onChangeAnswer({ valueAttachment: newValue }, index)}
         />
       );
@@ -160,7 +172,9 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <ReferenceInput
           name={name}
           targetTypes={addTargetTypes(item)}
-          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={
+            getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueReference
+          }
           onChange={(newValue) => onChangeAnswer({ valueReference: newValue }, index)}
         />
       );
@@ -168,7 +182,9 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <QuantityInput
           name={name}
-          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
+          defaultValue={
+            getDefaultAnswer(props.allResponses, item, index, props.groupSequence) ?? initial?.valueQuantity
+          }
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue }, index)}
           disableWheel
         />
@@ -181,7 +197,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             name={name}
             item={item}
             initial={initial}
-            responses={props.responses}
+            allResponses={props.allResponses}
             index={index}
             groupSequence={props.groupSequence}
             onChangeAnswer={(e) => onChangeAnswer(e, index)}
@@ -193,7 +209,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             name={name}
             item={item}
             initial={initial}
-            responses={props.responses}
+            allResponses={props.allResponses}
             onChangeAnswer={(e) => onChangeAnswer(e, index)}
           />
         );
@@ -207,7 +223,7 @@ interface QuestionnaireChoiceInputProps {
   name: string;
   item: QuestionnaireItem;
   initial: QuestionnaireItemInitial | undefined;
-  responses: QuestionnaireResponseItem[];
+  allResponses: QuestionnaireResponseItem[];
   index?: number;
   groupSequence?: number;
   onChangeAnswer: (newResponseAnswer: QuestionnaireResponseItemAnswer | QuestionnaireResponseItemAnswer[]) => void;
@@ -231,9 +247,9 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
   }
   if (item.repeats) {
     const { propertyName, data } = formatSelectData(props.item);
-    const defaultAnswer = typedValueToString(initialValue)
-      ? [typedValueToString(initialValue)]
-      : getDefaultAnswer(props.responses, item, props.index, props.groupSequence, true);
+    const defaultAnswer = getDefaultAnswer(props.allResponses, item, props.index, props.groupSequence, true)
+      ? getDefaultAnswer(props.allResponses, item, props.index, props.groupSequence, true)
+      : [typedValueToString(initialValue)];
 
     return (
       <MultiSelect
@@ -277,7 +293,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         props.onChangeAnswer({ [propertyName]: optionValue.value });
       }}
       defaultValue={
-        typedValueToString(initialValue) ?? getDefaultAnswer(props.responses, item, props.index, props.groupSequence)
+        getDefaultAnswer(props.allResponses, item, props.index, props.groupSequence) ?? typedValueToString(initialValue)
       }
       data={data}
     />
@@ -285,7 +301,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
 }
 
 function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.Element {
-  const { name, item, initial, onChangeAnswer, responses } = props;
+  const { name, item, initial, onChangeAnswer, allResponses } = props;
   if (item.answerValueSet) {
     return (
       <ValueSetAutocomplete
@@ -299,7 +315,7 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
       name={name}
       item={item}
       initial={initial}
-      responses={responses}
+      allResponses={allResponses}
       onChangeAnswer={onChangeAnswer}
     />
   );
@@ -442,10 +458,10 @@ function typedValueToString(typedValue: TypedValue | undefined): string | undefi
   return typedValue.value.toString();
 }
 
-function getItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: string): QuestionnaireResponseItem[] {
+function getItemsByLinkId(allResponses: QuestionnaireResponseItem[], linkId: string): QuestionnaireResponseItem[] {
   let result: QuestionnaireResponseItem[] = [];
 
-  for (const item of responses) {
+  for (const item of allResponses) {
     // If the linkId matches, add it to the result array
     if (item.linkId === linkId) {
       result.push(item);
@@ -464,21 +480,18 @@ function getItemValue(answer: QuestionnaireResponseItemAnswer): any {
     { type: 'QuestionnaireItemAnswerOption', value: answer },
     'value'
   ) as TypedValue;
-  if (itemValue?.type === 'Coding') {
-    return itemValue?.value?.display;
-  } else {
-    return itemValue?.value;
-  }
+  // formatCoding returns '' if nothing is there so we need to use ||
+  return formatCoding(itemValue?.value) || itemValue?.value;
 }
 
 function getDefaultAnswer(
-  responses: QuestionnaireResponseItem[],
+  allResponses: QuestionnaireResponseItem[],
   item: QuestionnaireItem,
   index: number = 0,
   groupSequence: number = 0,
   multiple: boolean = false
 ): any {
-  const results = getItemsByLinkId(responses, item.linkId ?? '');
+  const results = getItemsByLinkId(allResponses, item.linkId ?? '');
   const selectedItem = results[groupSequence]?.answer;
   if (multiple) {
     return selectedItem?.map((a) => getItemValue(a));

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -61,6 +61,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
   if (!name) {
     return null;
   }
+  console.log('Default Value for', item.linkId, getDefaultAnswer(props.answers, item));
 
   const initial = item.initial && item.initial.length > 0 ? item.initial[0] : undefined;
 
@@ -428,4 +429,24 @@ function typedValueToString(typedValue: TypedValue | undefined): string | undefi
     return typedValue.value.display;
   }
   return typedValue.value.toString();
+}
+
+function getDefaultAnswer(
+  answers: Record<string, QuestionnaireResponseItemAnswer[]>,
+  item: QuestionnaireItem,
+  multiple?: boolean
+): any {
+  const results = [];
+  for (const answer in answers) {
+    if (answer === item.linkId) {
+      for (const answerValue of answers[answer]) {
+        const itemValue = getTypedPropertyValue(
+          { type: 'QuestionnaireItemAnswerOption', value: answerValue },
+          'value'
+        ) as TypedValue;
+        results.push(itemValue?.value);
+      }
+    }
+  }
+  return multiple ? results : results[0];
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -20,7 +20,7 @@ import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocom
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
   index: number;
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  responses: QuestionnaireResponseItem[];
   responseItems?: QuestionnaireResponseItem[];
   onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }
@@ -71,7 +71,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           <Checkbox
             id={props.item.linkId}
             name={props.item.linkId}
-            defaultChecked={initial?.valueBoolean ?? getDefaultAnswer(props.answers, item, responses, index)}
+            defaultChecked={initial?.valueBoolean ?? getDefaultAnswer(props.responses, item, index)}
             onChange={(e) => onChangeAnswer({ valueBoolean: e.currentTarget.checked }, index)}
           />
         </CheckboxFormSection>
@@ -83,7 +83,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step="any"
           id={name}
           name={name}
-          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(e) => onChangeAnswer({ valueDecimal: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -94,7 +94,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step={1}
           id={name}
           name={name}
-          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(e) => onChangeAnswer({ valueInteger: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -104,7 +104,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="date"
           id={name}
           name={name}
-          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(e) => onChangeAnswer({ valueDate: e.currentTarget.value }, index)}
         />
       );
@@ -112,7 +112,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <DateTimeInput
           name={name}
-          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(newValue: string) => onChangeAnswer({ valueDateTime: newValue }, index)}
         />
       );
@@ -122,7 +122,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="time"
           id={name}
           name={name}
-          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(e) => onChangeAnswer({ valueTime: e.currentTarget.value }, index)}
         />
       );
@@ -132,7 +132,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <TextInput
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -141,7 +141,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <Textarea
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -149,7 +149,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <AttachmentInput
           name={name}
-          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(newValue) => onChangeAnswer({ valueAttachment: newValue }, index)}
         />
       );
@@ -158,7 +158,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <ReferenceInput
           name={name}
           targetTypes={addTargetTypes(item)}
-          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(newValue) => onChangeAnswer({ valueReference: newValue }, index)}
         />
       );
@@ -166,7 +166,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <QuantityInput
           name={name}
-          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.answers, item, responses, index)}
+          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.responses, item, index)}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue }, index)}
           disableWheel
         />
@@ -203,7 +203,7 @@ interface QuestionnaireChoiceInputProps {
   name: string;
   item: QuestionnaireItem;
   initial: QuestionnaireItemInitial | undefined;
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>;
+  responses: QuestionnaireResponseItem[];
   onChangeAnswer: (newResponseAnswer: QuestionnaireResponseItemAnswer | QuestionnaireResponseItemAnswer[]) => void;
 }
 
@@ -266,7 +266,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         const propertyName = 'value' + capitalize(optionValue.type);
         props.onChangeAnswer({ [propertyName]: optionValue.value });
       }}
-      defaultValue={typedValueToString(initialValue) ?? getDefaultAnswer(props.answers, item, [])}
+      defaultValue={typedValueToString(initialValue) ?? getDefaultAnswer(props.responses, item, [])}
       data={data}
     />
   );
@@ -431,18 +431,19 @@ function typedValueToString(typedValue: TypedValue | undefined): string | undefi
 }
 
 function getAnswerResponse(
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>,
+  responses: QuestionnaireResponseItem[],
   item: QuestionnaireItem,
   index: number = 0
 ): QuestionnaireResponseItemAnswer[] {
-  const answerResponses: QuestionnaireResponseItemAnswer[][] = [];
-  for (const answer in answers) {
-    if (answer === item.linkId) {
-      answerResponses.push(answers[answer]);
-    }
-  }
-  // console.log(answerResponses)
-  return answerResponses[index] ?? [];
+  // const answerResponses: QuestionnaireResponseItemAnswer[][] = [];
+  // for (const answer in answers) {
+  //   if (answer === item.linkId) {
+  //     answerResponses.push(answers[answer]);
+  //   }
+  // }
+  // // console.log(answerResponses)
+  // return answerResponses[index] ?? [];
+  return [];
 }
 
 // function getAnswerResponse(
@@ -473,17 +474,17 @@ function findItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: strin
 
 
 function getDefaultAnswer(
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>,
-  item: QuestionnaireItem,
   responses: QuestionnaireResponseItem[],
+  item: QuestionnaireItem,
   index: number = 0,
   multiple?: boolean
 ): any {
   const results = [];
-  // const result = findItemsByLinkId(responses, item.linkId ?? '', index);
+  const result = findItemsByLinkId(responses, item.linkId ?? '', index);
   // console.log('items', result)
   // return result?.answer?.[0]?.valueString ?? '';
-  const answerResponse = getAnswerResponse(answers, item, index);
+  const answerResponse = getAnswerResponse(responses, item, index);
+
   for (const answerValue of answerResponse) {
     const itemValue = getTypedPropertyValue(
       { type: 'QuestionnaireItemAnswerOption', value: answerValue },

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -284,8 +284,8 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
   );
 }
 
-function QuestionnaireChoiceSetInput(props: any): JSX.Element {
-  const { name, item, initial, onChangeAnswer, answers } = props;
+function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.Element {
+  const { name, item, initial, onChangeAnswer, responses } = props;
   if (item.answerValueSet) {
     return (
       <ValueSetAutocomplete
@@ -299,7 +299,7 @@ function QuestionnaireChoiceSetInput(props: any): JSX.Element {
       name={name}
       item={item}
       initial={initial}
-      answers={answers}
+      responses={responses}
       onChangeAnswer={onChangeAnswer}
     />
   );

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -21,8 +21,8 @@ export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
   index: number;
   responses: QuestionnaireResponseItem[];
-  groupNumber?: number;
-  responseItems?: QuestionnaireResponseItem[];
+  currentResponseItems?: QuestionnaireResponseItem[];
+  groupSequence?: number;
   onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }
 
@@ -35,7 +35,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
     repeatedIndex?: number
   ): void {
     const number = repeatedIndex ?? 0;
-    const responses = props.responseItems?.filter((r) => r.linkId === item.linkId) ?? [];
+    const responses = props.currentResponseItems?.filter((r) => r.linkId === item.linkId) ?? [];
 
     let updatedAnswers: QuestionnaireResponseItemAnswer[];
     if (Array.isArray(newResponseAnswer)) {
@@ -64,7 +64,6 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
   }
 
   const initial = item.initial && item.initial.length > 0 ? item.initial[0] : undefined;
-  // const responses = props.responseItems ?? [];
   switch (type) {
     case QuestionnaireItemType.boolean:
       return (
@@ -72,7 +71,9 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           <Checkbox
             id={props.item.linkId}
             name={props.item.linkId}
-            defaultChecked={initial?.valueBoolean ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+            defaultChecked={
+              initial?.valueBoolean ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)
+            }
             onChange={(e) => onChangeAnswer({ valueBoolean: e.currentTarget.checked }, index)}
           />
         </CheckboxFormSection>
@@ -84,7 +85,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step="any"
           id={name}
           name={name}
-          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(e) => onChangeAnswer({ valueDecimal: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -95,7 +96,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step={1}
           id={name}
           name={name}
-          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(e) => onChangeAnswer({ valueInteger: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -105,7 +106,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="date"
           id={name}
           name={name}
-          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(e) => onChangeAnswer({ valueDate: e.currentTarget.value }, index)}
         />
       );
@@ -113,7 +114,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <DateTimeInput
           name={name}
-          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(newValue: string) => onChangeAnswer({ valueDateTime: newValue }, index)}
         />
       );
@@ -123,7 +124,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="time"
           id={name}
           name={name}
-          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(e) => onChangeAnswer({ valueTime: e.currentTarget.value }, index)}
         />
       );
@@ -133,7 +134,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <TextInput
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -142,7 +143,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <Textarea
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -150,7 +151,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <AttachmentInput
           name={name}
-          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(newValue) => onChangeAnswer({ valueAttachment: newValue }, index)}
         />
       );
@@ -159,7 +160,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <ReferenceInput
           name={name}
           targetTypes={addTargetTypes(item)}
-          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(newValue) => onChangeAnswer({ valueReference: newValue }, index)}
         />
       );
@@ -167,7 +168,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <QuantityInput
           name={name}
-          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
+          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.responses, item, index, props.groupSequence)}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue }, index)}
           disableWheel
         />
@@ -181,6 +182,8 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             item={item}
             initial={initial}
             responses={props.responses}
+            index={index}
+            groupSequence={props.groupSequence}
             onChangeAnswer={(e) => onChangeAnswer(e, index)}
           />
         );
@@ -205,6 +208,8 @@ interface QuestionnaireChoiceInputProps {
   item: QuestionnaireItem;
   initial: QuestionnaireItemInitial | undefined;
   responses: QuestionnaireResponseItem[];
+  index?: number;
+  groupSequence?: number;
   onChangeAnswer: (newResponseAnswer: QuestionnaireResponseItemAnswer | QuestionnaireResponseItemAnswer[]) => void;
 }
 
@@ -226,12 +231,16 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
   }
   if (item.repeats) {
     const { propertyName, data } = formatSelectData(props.item);
+    const defaultAnswer = typedValueToString(initialValue)
+      ? [typedValueToString(initialValue)]
+      : getDefaultAnswer(props.responses, item, props.index, props.groupSequence, true);
+
     return (
       <MultiSelect
         data={data}
         placeholder="Select items"
         searchable
-        defaultValue={[typedValueToString(initialValue) ?? '']}
+        defaultValue={defaultAnswer}
         onChange={(selected) => {
           const values = selected.map((o) => {
             const option = item.answerOption?.find(
@@ -267,7 +276,9 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         const propertyName = 'value' + capitalize(optionValue.type);
         props.onChangeAnswer({ [propertyName]: optionValue.value });
       }}
-      defaultValue={typedValueToString(initialValue) ?? getDefaultAnswer(props.responses, item, 0)}
+      defaultValue={
+        typedValueToString(initialValue) ?? getDefaultAnswer(props.responses, item, props.index, props.groupSequence)
+      }
       data={data}
     />
   );
@@ -431,31 +442,7 @@ function typedValueToString(typedValue: TypedValue | undefined): string | undefi
   return typedValue.value.toString();
 }
 
-// function getAnswerResponse(
-//   responses: QuestionnaireResponseItem[],
-//   item: QuestionnaireItem,
-//   index: number = 0
-// ): QuestionnaireResponseItemAnswer[] {
-//   // const answerResponses: QuestionnaireResponseItemAnswer[][] = [];
-//   // for (const answer in answers) {
-//   //   if (answer === item.linkId) {
-//   //     answerResponses.push(answers[answer]);
-//   //   }
-//   // }
-//   // // console.log(answerResponses)
-//   // return answerResponses[index] ?? [];
-//   return [];
-// }
-
-// function getAnswerResponse(
-//   responses: QuestionnaireResponseItem[],
-//   item: QuestionnaireItem,
-//   index: number = 0
-// ): any[] {
-
-// }
-
-function findItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: string): QuestionnaireResponseItem[] {
+function getItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: string): QuestionnaireResponseItem[] {
   let result: QuestionnaireResponseItem[] = [];
 
   for (let item of responses) {
@@ -466,25 +453,15 @@ function findItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: strin
 
     // If the current item has nested items, search them too
     if (item.item) {
-      result = result.concat(findItemsByLinkId(item.item, linkId));
+      result = result.concat(getItemsByLinkId(item.item, linkId));
     }
   }
   return result;
 }
 
-function getDefaultAnswer(
-  responses: QuestionnaireResponseItem[],
-  item: QuestionnaireItem,
-  index: number = 0,
-  groupNumber: number = 0,
-  multiple?: boolean
-): any {
-  const results = findItemsByLinkId(responses, item.linkId ?? '');
-  // console.log(responses);
-  // console.log('results', results[groupNumber]?.answer?.[index]?.valueString ?? '');
-  const selectedItem = results[groupNumber]?.answer?.[index];
+function getItemValue(answer: QuestionnaireResponseItemAnswer): any {
   const itemValue = getTypedPropertyValue(
-    { type: 'QuestionnaireItemAnswerOption', value: selectedItem },
+    { type: 'QuestionnaireItemAnswerOption', value: answer },
     'value'
   ) as TypedValue;
   if (itemValue?.type === 'Coding') {
@@ -492,23 +469,20 @@ function getDefaultAnswer(
   } else {
     return itemValue?.value;
   }
+}
 
-  // console.log('items', result)
-  // return result?.answer?.[0]?.valueString ?? '';
-
-  // const answerResponse = getAnswerResponse(responses, item, index);
-
-  // for (const answerValue of answerResponse) {
-  //   const itemValue = getTypedPropertyValue(
-  //     { type: 'QuestionnaireItemAnswerOption', value: answerValue },
-  //     'value'
-  //   ) as TypedValue;
-  //   if (itemValue?.type === 'Coding') {
-  //     results.push(itemValue?.value?.display);
-  //   } else {
-  //     results.push(itemValue?.value);
-  //   }
-  // }
-
-  // return multiple ? results : results[0];
+function getDefaultAnswer(
+  responses: QuestionnaireResponseItem[],
+  item: QuestionnaireItem,
+  index: number = 0,
+  groupSequence: number = 0,
+  multiple?: boolean
+): any {
+  const results = getItemsByLinkId(responses, item.linkId ?? '');
+  const selectedItem = results[groupSequence]?.answer;
+  if (multiple) {
+    return selectedItem?.map((a) => getItemValue(a));
+  } else {
+    return getItemValue(selectedItem?.[index] ?? {});
+  }
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -445,7 +445,7 @@ function typedValueToString(typedValue: TypedValue | undefined): string | undefi
 function getItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: string): QuestionnaireResponseItem[] {
   let result: QuestionnaireResponseItem[] = [];
 
-  for (let item of responses) {
+  for (const item of responses) {
     // If the linkId matches, add it to the result array
     if (item.linkId === linkId) {
       result.push(item);
@@ -476,7 +476,7 @@ function getDefaultAnswer(
   item: QuestionnaireItem,
   index: number = 0,
   groupSequence: number = 0,
-  multiple?: boolean
+  multiple: boolean = false
 ): any {
   const results = getItemsByLinkId(responses, item.linkId ?? '');
   const selectedItem = results[groupSequence]?.answer;

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -21,6 +21,7 @@ export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
   index: number;
   responses: QuestionnaireResponseItem[];
+  groupNumber?: number;
   responseItems?: QuestionnaireResponseItem[];
   onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }
@@ -63,7 +64,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
   }
 
   const initial = item.initial && item.initial.length > 0 ? item.initial[0] : undefined;
-  const responses = props.responseItems ?? []
+  // const responses = props.responseItems ?? [];
   switch (type) {
     case QuestionnaireItemType.boolean:
       return (
@@ -71,7 +72,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           <Checkbox
             id={props.item.linkId}
             name={props.item.linkId}
-            defaultChecked={initial?.valueBoolean ?? getDefaultAnswer(props.responses, item, index)}
+            defaultChecked={initial?.valueBoolean ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
             onChange={(e) => onChangeAnswer({ valueBoolean: e.currentTarget.checked }, index)}
           />
         </CheckboxFormSection>
@@ -83,7 +84,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step="any"
           id={name}
           name={name}
-          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueDecimal ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(e) => onChangeAnswer({ valueDecimal: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -94,7 +95,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step={1}
           id={name}
           name={name}
-          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueInteger ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(e) => onChangeAnswer({ valueInteger: e.currentTarget.valueAsNumber }, index)}
         />
       );
@@ -104,7 +105,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="date"
           id={name}
           name={name}
-          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueDate ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(e) => onChangeAnswer({ valueDate: e.currentTarget.value }, index)}
         />
       );
@@ -112,7 +113,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <DateTimeInput
           name={name}
-          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueDateTime ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(newValue: string) => onChangeAnswer({ valueDateTime: newValue }, index)}
         />
       );
@@ -122,7 +123,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="time"
           id={name}
           name={name}
-          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueTime ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(e) => onChangeAnswer({ valueTime: e.currentTarget.value }, index)}
         />
       );
@@ -132,7 +133,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <TextInput
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -141,7 +142,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <Textarea
           id={name}
           name={name}
-          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueString ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value }, index)}
         />
       );
@@ -149,7 +150,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <AttachmentInput
           name={name}
-          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueAttachment ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(newValue) => onChangeAnswer({ valueAttachment: newValue }, index)}
         />
       );
@@ -158,7 +159,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <ReferenceInput
           name={name}
           targetTypes={addTargetTypes(item)}
-          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueReference ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(newValue) => onChangeAnswer({ valueReference: newValue }, index)}
         />
       );
@@ -166,7 +167,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <QuantityInput
           name={name}
-          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.responses, item, index)}
+          defaultValue={initial?.valueQuantity ?? getDefaultAnswer(props.responses, item, index, props.groupNumber)}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue }, index)}
           disableWheel
         />
@@ -179,7 +180,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             name={name}
             item={item}
             initial={initial}
-            answers={props.answers}
+            responses={props.responses}
             onChangeAnswer={(e) => onChangeAnswer(e, index)}
           />
         );
@@ -189,8 +190,8 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             name={name}
             item={item}
             initial={initial}
-            answers={props.answers}
-            onChangeAnswer={(e: any) => onChangeAnswer(e, index)}
+            responses={props.responses}
+            onChangeAnswer={(e) => onChangeAnswer(e, index)}
           />
         );
       }
@@ -266,7 +267,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         const propertyName = 'value' + capitalize(optionValue.type);
         props.onChangeAnswer({ [propertyName]: optionValue.value });
       }}
-      defaultValue={typedValueToString(initialValue) ?? getDefaultAnswer(props.responses, item, [])}
+      defaultValue={typedValueToString(initialValue) ?? getDefaultAnswer(props.responses, item, 0)}
       data={data}
     />
   );
@@ -430,72 +431,84 @@ function typedValueToString(typedValue: TypedValue | undefined): string | undefi
   return typedValue.value.toString();
 }
 
-function getAnswerResponse(
-  responses: QuestionnaireResponseItem[],
-  item: QuestionnaireItem,
-  index: number = 0
-): QuestionnaireResponseItemAnswer[] {
-  // const answerResponses: QuestionnaireResponseItemAnswer[][] = [];
-  // for (const answer in answers) {
-  //   if (answer === item.linkId) {
-  //     answerResponses.push(answers[answer]);
-  //   }
-  // }
-  // // console.log(answerResponses)
-  // return answerResponses[index] ?? [];
-  return [];
-}
+// function getAnswerResponse(
+//   responses: QuestionnaireResponseItem[],
+//   item: QuestionnaireItem,
+//   index: number = 0
+// ): QuestionnaireResponseItemAnswer[] {
+//   // const answerResponses: QuestionnaireResponseItemAnswer[][] = [];
+//   // for (const answer in answers) {
+//   //   if (answer === item.linkId) {
+//   //     answerResponses.push(answers[answer]);
+//   //   }
+//   // }
+//   // // console.log(answerResponses)
+//   // return answerResponses[index] ?? [];
+//   return [];
+// }
 
 // function getAnswerResponse(
-//   responses: QuestionnaireResponseItem[], 
+//   responses: QuestionnaireResponseItem[],
 //   item: QuestionnaireItem,
 //   index: number = 0
 // ): any[] {
-  
+
 // }
 
-function findItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: string, index: number): QuestionnaireResponseItem {
+function findItemsByLinkId(responses: QuestionnaireResponseItem[], linkId: string): QuestionnaireResponseItem[] {
   let result: QuestionnaireResponseItem[] = [];
-  console.log(responses)
+
   for (let item of responses) {
-      // If the linkId matches, add it to the result array
-      if (item.linkId === linkId) {
-          result.push(item);
-      }
+    // If the linkId matches, add it to the result array
+    if (item.linkId === linkId) {
+      result.push(item);
+    }
 
-      // If the current item has nested items, search them too
-      if (item.item) {
-          result = result.concat(findItemsByLinkId(item.item, linkId, index));
-      }
+    // If the current item has nested items, search them too
+    if (item.item) {
+      result = result.concat(findItemsByLinkId(item.item, linkId));
+    }
   }
-
-  return result[index] ?? [];
+  return result;
 }
-
 
 function getDefaultAnswer(
   responses: QuestionnaireResponseItem[],
   item: QuestionnaireItem,
   index: number = 0,
+  groupNumber: number = 0,
   multiple?: boolean
 ): any {
-  const results = [];
-  const result = findItemsByLinkId(responses, item.linkId ?? '', index);
-  // console.log('items', result)
-  // return result?.answer?.[0]?.valueString ?? '';
-  const answerResponse = getAnswerResponse(responses, item, index);
-
-  for (const answerValue of answerResponse) {
-    const itemValue = getTypedPropertyValue(
-      { type: 'QuestionnaireItemAnswerOption', value: answerValue },
-      'value'
-    ) as TypedValue;
-    if (itemValue?.type === 'Coding') {
-      results.push(itemValue?.value?.display);
-    } else {
-      results.push(itemValue?.value);
-    }
+  const results = findItemsByLinkId(responses, item.linkId ?? '');
+  // console.log(responses);
+  // console.log('results', results[groupNumber]?.answer?.[index]?.valueString ?? '');
+  const selectedItem = results[groupNumber]?.answer?.[index];
+  const itemValue = getTypedPropertyValue(
+    { type: 'QuestionnaireItemAnswerOption', value: selectedItem },
+    'value'
+  ) as TypedValue;
+  if (itemValue?.type === 'Coding') {
+    return itemValue?.value?.display;
+  } else {
+    return itemValue?.value;
   }
 
-  return multiple ? results : results[0];
+  // console.log('items', result)
+  // return result?.answer?.[0]?.valueString ?? '';
+
+  // const answerResponse = getAnswerResponse(responses, item, index);
+
+  // for (const answerValue of answerResponse) {
+  //   const itemValue = getTypedPropertyValue(
+  //     { type: 'QuestionnaireItemAnswerOption', value: answerValue },
+  //     'value'
+  //   ) as TypedValue;
+  //   if (itemValue?.type === 'Coding') {
+  //     results.push(itemValue?.value?.display);
+  //   } else {
+  //     results.push(itemValue?.value);
+  //   }
+  // }
+
+  // return multiple ? results : results[0];
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -346,10 +346,13 @@ function QuestionnaireChoiceRadioInput(props: QuestionnaireChoiceInputProps): JS
     }
   }
 
+  const defaultAnswer = getDefaultAnswer(props.allResponses, item, props.index, props.groupSequence);
+  const answerLinkId = options.find((option) => option[1].value === defaultAnswer)?.[0];
+
   return (
     <Radio.Group
       name={name}
-      defaultValue={defaultValue}
+      value={answerLinkId ?? defaultValue}
       onChange={(newValue) => {
         const option = options.find((option) => option[0] === newValue);
         if (option) {

--- a/packages/react/src/utils/questionnaire.test.ts
+++ b/packages/react/src/utils/questionnaire.test.ts
@@ -26,10 +26,20 @@ test('isQuestionEnabled', () => {
           },
         ],
       },
-      {
-        q1: [{ valueString: 'No' }],
-        q2: [{ valueString: 'Yes' }],
-      }
+      [
+        {
+          linkId: 'q1',
+          answer: [{ valueString: 'No' }],
+        },
+        {
+          linkId: 'q2',
+          answer: [{ valueString: 'Yes' }],
+        },
+      ]
+      // {
+      //   q1: [{ valueString: 'No' }],
+      //   q2: [{ valueString: 'Yes' }],
+      // }
     )
   ).toBe(true);
 });
@@ -53,10 +63,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'No' }],
-          q2: [{ valueString: 'Yes' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'Yes' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'No' }],
+        //   q2: [{ valueString: 'Yes' }],
+        // }
       )
     ).toBe(true);
   });
@@ -79,10 +99,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'No' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'No' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(false);
   });
@@ -105,10 +135,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }],
-          q2: [{ valueString: 'Yes' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'Yes' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }],
+        //   q2: [{ valueString: 'Yes' }],
+        // }
       )
     ).toBe(true);
   });
@@ -131,10 +171,21 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'Yes' }],
+          },
+        ]
+        // },
+        // {
+        //   q1: [{ valueString: 'Yes' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(false);
   });
@@ -157,10 +208,21 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-          q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        }
+
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }, {valueString: 'Maybe'}],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }, {valueString: 'Maybe'}],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+        // }
       )
     ).toBe(false);
   });
@@ -183,10 +245,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-          q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+        // }
       )
     ).toBe(false);
   });
@@ -209,10 +281,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'No' }, { valueString: 'Yes' }],
-          q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }, { valueString: 'Yes' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'No' }, { valueString: 'Yes' }],
+        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+        // }
       )
     ).toBe(true);
   });
@@ -235,10 +317,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
-          q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
+        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
+        // }
       )
     ).toBe(false);
   });
@@ -261,10 +353,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
-          q2: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
+        //   q2: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
+        // }
       )
     ).toBe(true);
   });
@@ -281,10 +383,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
   });
@@ -301,10 +413,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(false);
   });
@@ -321,9 +443,15 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(false);
   });
@@ -340,9 +468,15 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
   });
@@ -359,9 +493,15 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
   });
@@ -378,9 +518,15 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
   });
@@ -397,10 +543,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }, { valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
   });
@@ -417,10 +573,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }, { valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(false);
   });
@@ -437,10 +603,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }, { valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(false);
   });
@@ -457,10 +633,20 @@ describe('isQuestionEnabled', () => {
             },
           ],
         },
-        {
-          q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-          q2: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }, { valueString: 'No' }],
+          },
+          {
+            linkId: 'q2',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
+        //   q2: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
   });
@@ -479,9 +665,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueString: 'No' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'No' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'No' }],
+        // }
       )
     ).toBe(true);
 
@@ -490,9 +682,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueString: 'Yes' }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueString: 'Yes' }],
+          },
+        ]
+        // {
+        //   q1: [{ valueString: 'Yes' }],
+        // }
       )
     ).toBe(false);
   });
@@ -511,9 +709,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 4 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 4 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 4 }],
+        // }
       )
     ).toBe(true);
 
@@ -522,9 +726,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 2 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 2 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 2 }],
+        // }
       )
     ).toBe(false);
   });
@@ -543,9 +753,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 4 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 4 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 4 }],
+        // }
       )
     ).toBe(true);
 
@@ -554,9 +770,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 3 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 3 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 3 }],
+        // }
       )
     ).toBe(true);
   });
@@ -575,9 +797,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 2 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 2 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 2 }],
+        // }
       )
     ).toBe(true);
 
@@ -586,9 +814,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 3 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 3 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 3 }],
+        // }
       )
     ).toBe(false);
   });
@@ -607,9 +841,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 2 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 2 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 2 }],
+        // }
       )
     ).toBe(true);
 
@@ -618,9 +858,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 3 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 3 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 3 }],
+        // }
       )
     ).toBe(true);
 
@@ -629,9 +875,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueInteger: 4 }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueInteger: 4 }],
+          },
+        ]
+        // {
+        //   q1: [{ valueInteger: 4 }],
+        // }
       )
     ).toBe(false);
   });
@@ -646,9 +898,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'MEDPLUM123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'MEDPLUM123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'MEDPLUM123' } }],
+        // }
       )
     ).toBe(true);
 
@@ -657,9 +915,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
+        // }
       )
     ).toBe(true);
 
@@ -668,9 +932,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
+        // }
       )
     ).toBe(false);
   });
@@ -685,9 +955,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'NOT_MEDPLUM123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'NOT_MEDPLUM123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'NOT_MEDPLUM123' } }],
+        // }
       )
     ).toBe(true);
 
@@ -696,9 +972,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
+        // }
       )
     ).toBe(true);
 
@@ -707,9 +989,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
+        // }
       )
     ).toBe(false);
 
@@ -718,9 +1006,15 @@ describe('isQuestionEnabled', () => {
         {
           enableWhen,
         },
-        {
-          q1: [{ valueCoding: { code: 'MEDPLUM123' } }],
-        }
+        [
+          {
+            linkId: 'q1',
+            answer: [{ valueCoding: { code: 'MEDPLUM123' } }],
+          },
+        ]
+        // {
+        //   q1: [{ valueCoding: { code: 'MEDPLUM123' } }],
+        // }
       )
     ).toBe(false);
   });

--- a/packages/react/src/utils/questionnaire.test.ts
+++ b/packages/react/src/utils/questionnaire.test.ts
@@ -10,7 +10,6 @@ describe('QuestionnaireUtils', () => {
 });
 
 test('isQuestionEnabled', () => {
-  // enableBehavior=any, match
   expect(
     isQuestionEnabled(
       {
@@ -36,10 +35,6 @@ test('isQuestionEnabled', () => {
           answer: [{ valueString: 'Yes' }],
         },
       ]
-      // {
-      //   q1: [{ valueString: 'No' }],
-      //   q2: [{ valueString: 'Yes' }],
-      // }
     )
   ).toBe(true);
 });
@@ -73,10 +68,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'Yes' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'No' }],
-        //   q2: [{ valueString: 'Yes' }],
-        // }
       )
     ).toBe(true);
   });
@@ -109,10 +100,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'No' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(false);
   });
@@ -145,10 +132,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'Yes' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }],
-        //   q2: [{ valueString: 'Yes' }],
-        // }
       )
     ).toBe(true);
   });
@@ -181,11 +164,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'Yes' }],
           },
         ]
-        // },
-        // {
-        //   q1: [{ valueString: 'Yes' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(false);
   });
@@ -212,17 +190,13 @@ describe('isQuestionEnabled', () => {
         [
           {
             linkId: 'q1',
-            answer: [{ valueString: 'No' }, {valueString: 'Maybe'}],
+            answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
           },
           {
             linkId: 'q2',
-            answer: [{ valueString: 'No' }, {valueString: 'Maybe'}],
+            answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        // }
       )
     ).toBe(false);
   });
@@ -255,10 +229,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        // }
       )
     ).toBe(false);
   });
@@ -291,10 +261,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'No' }, { valueString: 'Yes' }],
-        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        // }
       )
     ).toBe(true);
   });
@@ -327,10 +293,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }, { valueString: 'Maybe' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
-        //   q2: [{ valueString: 'No' }, { valueString: 'Maybe' }],
-        // }
       )
     ).toBe(false);
   });
@@ -363,10 +325,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
-        //   q2: [{ valueString: 'Yes' }, { valueString: 'Yes' }],
-        // }
       )
     ).toBe(true);
   });
@@ -393,10 +351,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
   });
@@ -423,10 +377,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(false);
   });
@@ -449,9 +399,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(false);
   });
@@ -474,9 +421,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
   });
@@ -499,9 +443,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
   });
@@ -524,9 +465,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
   });
@@ -553,10 +491,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
   });
@@ -583,10 +517,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(false);
   });
@@ -613,10 +543,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(false);
   });
@@ -643,10 +569,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }, { valueString: 'No' }],
-        //   q2: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
   });
@@ -671,9 +593,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'No' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'No' }],
-        // }
       )
     ).toBe(true);
 
@@ -688,9 +607,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueString: 'Yes' }],
           },
         ]
-        // {
-        //   q1: [{ valueString: 'Yes' }],
-        // }
       )
     ).toBe(false);
   });
@@ -715,9 +631,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 4 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 4 }],
-        // }
       )
     ).toBe(true);
 
@@ -732,9 +645,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 2 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 2 }],
-        // }
       )
     ).toBe(false);
   });
@@ -759,9 +669,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 4 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 4 }],
-        // }
       )
     ).toBe(true);
 
@@ -776,9 +683,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 3 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 3 }],
-        // }
       )
     ).toBe(true);
   });
@@ -803,9 +707,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 2 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 2 }],
-        // }
       )
     ).toBe(true);
 
@@ -820,9 +721,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 3 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 3 }],
-        // }
       )
     ).toBe(false);
   });
@@ -847,9 +745,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 2 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 2 }],
-        // }
       )
     ).toBe(true);
 
@@ -864,9 +759,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 3 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 3 }],
-        // }
       )
     ).toBe(true);
 
@@ -881,9 +773,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueInteger: 4 }],
           },
         ]
-        // {
-        //   q1: [{ valueInteger: 4 }],
-        // }
       )
     ).toBe(false);
   });
@@ -904,9 +793,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'MEDPLUM123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'MEDPLUM123' } }],
-        // }
       )
     ).toBe(true);
 
@@ -938,9 +824,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
-        // }
       )
     ).toBe(false);
   });
@@ -961,9 +844,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'NOT_MEDPLUM123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'NOT_MEDPLUM123' } }],
-        // }
       )
     ).toBe(true);
 
@@ -978,9 +858,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'NOT_MEDPLUM123', display: 'Medplum123' } }],
-        // }
       )
     ).toBe(true);
 
@@ -995,9 +872,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
-        // }
       )
     ).toBe(false);
 
@@ -1012,9 +886,6 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'MEDPLUM123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'MEDPLUM123' } }],
-        // }
       )
     ).toBe(false);
   });

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -30,10 +30,7 @@ export function isChoiceQuestion(item: QuestionnaireItem): boolean {
   return item.type === 'choice' || item.type === 'open-choice';
 }
 
-export function isQuestionEnabled(
-  item: QuestionnaireItem,
-  responseItems: QuestionnaireResponseItem[]
-): boolean {
+export function isQuestionEnabled(item: QuestionnaireItem, responseItems: QuestionnaireResponseItem[]): boolean {
   if (!item.enableWhen) {
     return true;
   }

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -1,5 +1,10 @@
 import { TypedValue, evalFhirPathTyped, getTypedPropertyValue } from '@medplum/core';
-import { QuestionnaireItem, QuestionnaireItemEnableWhen, QuestionnaireResponseItemAnswer } from '@medplum/fhirtypes';
+import {
+  QuestionnaireItem,
+  QuestionnaireItemEnableWhen,
+  QuestionnaireResponseItem,
+  QuestionnaireResponseItemAnswer,
+} from '@medplum/fhirtypes';
 
 export enum QuestionnaireItemType {
   group = 'group',
@@ -27,7 +32,7 @@ export function isChoiceQuestion(item: QuestionnaireItem): boolean {
 
 export function isQuestionEnabled(
   item: QuestionnaireItem,
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>
+  responseItems: QuestionnaireResponseItem[]
 ): boolean {
   if (!item.enableWhen) {
     return true;
@@ -36,18 +41,16 @@ export function isQuestionEnabled(
   const enableBehavior = item.enableBehavior ?? 'any';
 
   for (const enableWhen of item.enableWhen) {
-    if (
-      enableWhen.operator === 'exists' &&
-      !enableWhen.answerBoolean &&
-      !answers[enableWhen.question as string]?.length
-    ) {
+    const actualAnswers = getByLinkId(responseItems, enableWhen.question as string);
+
+    if (enableWhen.operator === 'exists' && !enableWhen.answerBoolean && !actualAnswers?.length) {
       if (enableBehavior === 'any') {
         return true;
       } else {
         continue;
       }
     }
-    const { anyMatch, allMatch } = checkAnswers(enableWhen, answers, enableBehavior);
+    const { anyMatch, allMatch } = checkAnswers(enableWhen, actualAnswers, enableBehavior);
 
     if (enableBehavior === 'any' && anyMatch) {
       return true;
@@ -58,6 +61,33 @@ export function isQuestionEnabled(
   }
 
   return enableBehavior !== 'any';
+}
+
+function getByLinkId(
+  responseItems: QuestionnaireResponseItem[] | undefined,
+  linkId: string
+): QuestionnaireResponseItemAnswer[] | undefined {
+  if (!Array.isArray(responseItems)) {
+    return undefined;
+  }
+
+  const response = responseItems.find((response) => response.linkId === linkId);
+
+  if (response) {
+    return response.answer;
+  }
+
+  // If not found at the current level, search in nested items
+  for (const nestedResponse of responseItems) {
+    if (nestedResponse.item) {
+      const nestedAnswer = getByLinkId(nestedResponse.item, linkId);
+      if (nestedAnswer) {
+        return nestedAnswer;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 function evaluateMatch(actualAnswer: TypedValue | undefined, expectedAnswer: TypedValue, operator?: string): boolean {
@@ -82,10 +112,10 @@ function evaluateMatch(actualAnswer: TypedValue | undefined, expectedAnswer: Typ
 
 function checkAnswers(
   enableWhen: QuestionnaireItemEnableWhen,
-  answers: Record<string, QuestionnaireResponseItemAnswer[]>,
+  answers: QuestionnaireResponseItemAnswer[] | undefined,
   enableBehavior: 'any' | 'all'
 ): { anyMatch: boolean; allMatch: boolean } {
-  const actualAnswers = answers[enableWhen.question as string] || [];
+  const actualAnswers = answers || [];
   const expectedAnswer = getTypedPropertyValue(
     {
       type: 'QuestionnaireItemEnableWhen',


### PR DESCRIPTION
In order to persist state in the components when using the Stepper, we have to pass down the responses object, which stores all data and isn't flattened out. 

The `answers` state was primarily used for the isQuestionEnabled method, removing this state from the component meant having to use the response object. 

Added state - `groupSequence` 
   - Since the Groups are identical - we need to differentiate them when adding the value, otherwise all of the groups are going to show the same data

I'm open to discussing the use of `response` as a context instead of prop drilling it. However I'm curious to hear the thoughts of the trade offs when adding an extra layer abstraction and complexity. 

**Thoughts** - if the questionnaire is starting to get hefty, perhaps we look at a library that could help with the Questionnaire, even a lightweight one could help. 

https://github.com/medplum/medplum/assets/6913745/a8061bb8-c783-4184-8e02-3b50bb22c72c


And the enablement stories 



https://github.com/medplum/medplum/assets/6913745/edd11961-2ffd-44c8-8c6b-2c2680cbea6c

