### PR TITLE
Added convertContainedResourcesToBundle helper

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -244,8 +244,6 @@ export function convertContainedResourcesToBundle(resource: Resource & { contain
 
   // Convert to a transaction bundle
   // This adds fullUrl and request properties to each entry
-  const transactionBundle = convertToTransactionBundle(simpleBundle);
-
-  // Reorder the bundle to ensure that contained resources are created before they are referenced
-  return reorderBundle(transactionBundle);
+  // and reorders the bundle to ensure that contained resources are created before they are referenced.
+  return convertToTransactionBundle(simpleBundle);
 }

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -1,4 +1,4 @@
-import { Bundle, BundleEntry } from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, Resource } from '@medplum/fhirtypes';
 import { generateId } from './crypto';
 import { isReference } from './types';
 import { deepClone } from './utils';
@@ -50,6 +50,8 @@ function referenceReplacer(key: string, value: string, idToUuid: Record<string, 
       id = value.split('/')[1];
     } else if (value.startsWith('urn:uuid:')) {
       id = value.slice(9);
+    } else if (value.startsWith('#')) {
+      id = value.slice(1);
     }
     if (id) {
       return 'urn:uuid:' + idToUuid[id];
@@ -204,4 +206,46 @@ function buildAdjacencyList(bundle: Bundle): AdjacencyList {
   }
 
   return adjacencyList;
+}
+
+/**
+ * Converts a resource with contained resources to a transaction bundle.
+ * This function is useful when creating a resource that contains other resources.
+ * Handles local references and topological sorting.
+ * @param resource The input resource which may or may not include contained resources.
+ * @returns A bundle with the input resource and all contained resources.
+ */
+export function convertContainedResourcesToBundle(resource: Resource & { contained?: Resource[] }): Bundle {
+  // Create a clone so we don't modify the original resource
+  resource = deepClone(resource);
+
+  // Create the simple naive bundle
+  const simpleBundle = {
+    resourceType: 'Bundle',
+    type: 'transaction',
+    entry: [{ resource }] as BundleEntry[],
+  } satisfies Bundle;
+
+  // Move all contained resources to the bundle
+  if (resource.contained) {
+    for (const contained of resource.contained) {
+      simpleBundle.entry.push({ resource: contained });
+    }
+    resource.contained = undefined;
+  }
+
+  // Make sure that all resources have an ID
+  // This is required for convertToTransactionBundle
+  for (const entry of simpleBundle.entry) {
+    if (entry.resource && !entry.resource.id) {
+      entry.resource.id = generateId();
+    }
+  }
+
+  // Convert to a transaction bundle
+  // This adds fullUrl and request properties to each entry
+  const transactionBundle = convertToTransactionBundle(simpleBundle);
+
+  // Reorder the bundle to ensure that contained resources are created before they are referenced
+  return reorderBundle(transactionBundle);
 }


### PR DESCRIPTION
When we receive a `DiagnosticReport` from Health Gorilla, the referenced `Observation` resources are included inside `DiagnosticReport.contained` and referenced by `DiagnosticReport.result` using `#` hash references.

We want to pull those observations out and represent them as first class resources (for searching, sorting, filtering, etc).  However, that can be messy when the `Observation` resources refer to each other using `Observation.hasMember` and observation grouping.

The included helper is mostly a wrapper around 2 existing helpers: 
1. `convertToTransactionBundle` - convert an array of resources into a `transaction` `Bundle`
2. `reorderBundle` - topologically sort the bundle to handle out-of-order references

The following test tells the story:

```ts
    test('Contained observations', () => {
      const input: DiagnosticReport = {
        resourceType: 'DiagnosticReport',
        contained: [
          {
            resourceType: 'Observation',
            id: '123',
            hasMember: [{ reference: '#456' }],
          },
          {
            resourceType: 'Observation',
            id: '456',
          },
        ],
        result: [{ reference: '#123' }],
      };

      const result = convertContainedResourcesToBundle(input);
      expect(result).toMatchObject({
        resourceType: 'Bundle',
        type: 'transaction',
        entry: [
          {
            fullUrl: expect.stringMatching(/^urn:uuid:[a-f0-9-]{36}$/),
            request: { method: 'POST', url: 'Observation' },
            resource: {
              resourceType: 'Observation',
            },
          },
          {
            fullUrl: expect.stringMatching(/^urn:uuid:[a-f0-9-]{36}$/),
            request: { method: 'POST', url: 'Observation' },
            resource: {
              resourceType: 'Observation',
              hasMember: [
                {
                  reference: expect.stringMatching(/^urn:uuid:[a-f0-9-]{36}$/),
                },
              ],
            },
          },
          {
            fullUrl: expect.stringMatching(/^urn:uuid:[a-f0-9-]{36}$/),
            request: { method: 'POST', url: 'DiagnosticReport' },
            resource: {
              resourceType: 'DiagnosticReport',
              result: [
                {
                  reference: expect.stringMatching(/^urn:uuid:[a-f0-9-]{36}$/),
                },
              ],
            },
          },
        ],
      });
    });
```