### PR TITLE
Fix project ID in super admin rebuild tools

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -9,9 +9,9 @@ import { loadTestConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
 import { logger } from '../logger';
 import { generateAccessToken } from '../oauth/keys';
-import { createSearchParameters } from '../seeds/searchparameters';
+import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
-import { createValueSets } from '../seeds/valuesets';
+import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { createTestProject, waitForAsyncJob } from '../test.setup';
 
 jest.mock('../seeds/valuesets');
@@ -125,7 +125,7 @@ describe('Super Admin routes', () => {
   });
 
   test('Rebuild ValueSetElements as super admin with respond-async', async () => {
-    (createValueSets as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
+    (rebuildR4ValueSets as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
       return Promise.resolve(true);
     });
 
@@ -143,7 +143,7 @@ describe('Super Admin routes', () => {
 
   test('Rebuild ValueSetElements as super admin with respond-async error', async () => {
     const err = new Error('createvalueSet test error');
-    (createValueSets as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
+    (rebuildR4ValueSets as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
       return Promise.reject(err);
     });
     const loggerErrorSpy = jest.spyOn(logger, 'error').mockReturnValueOnce();
@@ -237,7 +237,7 @@ describe('Super Admin routes', () => {
   });
 
   test('Rebuild searchparameters as super admin with respond-async', async () => {
-    (createSearchParameters as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
+    (rebuildR4SearchParameters as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
       return Promise.resolve(true);
     });
 
@@ -255,7 +255,7 @@ describe('Super Admin routes', () => {
 
   test('Rebuild searchparameters as super admin with respond-async error', async () => {
     const err = new Error('rebuild searchparameters test error');
-    (createSearchParameters as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
+    (rebuildR4SearchParameters as unknown as jest.Mock).mockImplementationOnce((): Promise<any> => {
       return Promise.reject(err);
     });
     const loggerErrorSpy = jest.spyOn(logger, 'error').mockReturnValueOnce();

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -16,14 +16,14 @@ import { getClient } from '../database';
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { Repository, systemRepo } from '../fhir/repo';
+import { logger } from '../logger';
 import * as dataMigrations from '../migrations/data';
 import { authenticateToken } from '../oauth/middleware';
 import { getUserByEmail } from '../oauth/utils';
-import { createSearchParameters } from '../seeds/searchparameters';
+import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
-import { createValueSets } from '../seeds/valuesets';
+import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { removeBullMQJobByKey } from '../workers/cron';
-import { logger } from '../logger';
 
 export const superAdminRouter = Router();
 superAdminRouter.use(authenticateToken);
@@ -37,7 +37,7 @@ superAdminRouter.post(
     requireSuperAdmin(res);
     requireAsync(req);
 
-    await sendAsyncResponse(req, res, () => createValueSets(res.locals.project));
+    await sendAsyncResponse(req, res, () => rebuildR4ValueSets());
   })
 );
 
@@ -50,7 +50,7 @@ superAdminRouter.post(
     requireSuperAdmin(res);
     requireAsync(req);
 
-    await sendAsyncResponse(req, res, () => rebuildR4StructureDefinitions(res.locals.project));
+    await sendAsyncResponse(req, res, () => rebuildR4StructureDefinitions());
   })
 );
 
@@ -63,7 +63,7 @@ superAdminRouter.post(
     requireSuperAdmin(res);
     requireAsync(req);
 
-    await sendAsyncResponse(req, res, () => createSearchParameters(res.locals.project));
+    await sendAsyncResponse(req, res, () => rebuildR4SearchParameters());
   })
 );
 

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -1,12 +1,12 @@
 import { createReference } from '@medplum/core';
 import { Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
+import { NIL as nullUuid, v5 } from 'uuid';
 import { bcryptHashPassword } from './auth/utils';
 import { systemRepo } from './fhir/repo';
 import { logger } from './logger';
-import { createSearchParameters } from './seeds/searchparameters';
+import { rebuildR4SearchParameters } from './seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from './seeds/structuredefinitions';
-import { createValueSets } from './seeds/valuesets';
-import { v5, NIL as nullUuid } from 'uuid';
+import { rebuildR4ValueSets } from './seeds/valuesets';
 
 export const r4ProjectId = v5('R4', nullUuid);
 
@@ -33,7 +33,7 @@ export async function seedDatabase(): Promise<void> {
     superAdmin: true,
   });
 
-  const r4Project = await systemRepo.updateResource<Project>({
+  await systemRepo.updateResource<Project>({
     resourceType: 'Project',
     id: r4ProjectId,
     name: 'FHIR R4',
@@ -67,9 +67,9 @@ export async function seedDatabase(): Promise<void> {
     admin: true,
   });
 
-  await rebuildR4StructureDefinitions(r4Project);
-  await createValueSets(r4Project);
-  await createSearchParameters(r4Project);
+  await rebuildR4StructureDefinitions();
+  await rebuildR4ValueSets();
+  await rebuildR4SearchParameters();
 }
 
 /**

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,31 +1,30 @@
 import { readJson } from '@medplum/definitions';
-import { BundleEntry, Project, SearchParameter } from '@medplum/fhirtypes';
+import { BundleEntry, SearchParameter } from '@medplum/fhirtypes';
 import { getClient } from '../database';
 import { systemRepo } from '../fhir/repo';
 import { logger } from '../logger';
+import { r4ProjectId } from '../seed';
 
 /**
  * Creates all SearchParameter resources.
- *
- * @param project The project in which to create the SearchParameter resources
  */
-export async function createSearchParameters(project: Project): Promise<void> {
+export async function rebuildR4SearchParameters(): Promise<void> {
   const client = getClient();
-  await client.query('DELETE FROM "SearchParameter" WHERE "projectId" = $1', [project.id]);
+  await client.query('DELETE FROM "SearchParameter" WHERE "projectId" = $1', [r4ProjectId]);
 
   for (const entry of readJson('fhir/r4/search-parameters.json').entry as BundleEntry[]) {
-    await createParameter(entry.resource as SearchParameter, project);
+    await createParameter(entry.resource as SearchParameter);
   }
   for (const entry of readJson('fhir/r4/search-parameters-medplum.json').entry as BundleEntry[]) {
-    await createParameter(entry.resource as SearchParameter, project);
+    await createParameter(entry.resource as SearchParameter);
   }
 }
 
-async function createParameter(param: SearchParameter, project: Project): Promise<void> {
+async function createParameter(param: SearchParameter): Promise<void> {
   logger.debug('SearchParameter: ' + param.name);
   await systemRepo.createResource<SearchParameter>({
     ...param,
-    meta: { ...param.meta, project: project.id },
+    meta: { ...param.meta, project: r4ProjectId },
     text: undefined,
   });
 }

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,23 +1,22 @@
 import { readJson } from '@medplum/definitions';
-import { Bundle, BundleEntry, Project, Resource, StructureDefinition } from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
 import { getClient } from '../database';
 import { systemRepo } from '../fhir/repo';
 import { logger } from '../logger';
+import { r4ProjectId } from '../seed';
 
 /**
  * Creates all StructureDefinition resources.
- *
- * @param project The project in which to create the StructureDefinition resources
  */
-export async function rebuildR4StructureDefinitions(project: Project): Promise<void> {
+export async function rebuildR4StructureDefinitions(): Promise<void> {
   const client = getClient();
-  await client.query(`DELETE FROM "StructureDefinition" WHERE "projectId" = $1`, [project.id]);
-  await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-resources.json') as Bundle, project);
-  await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle, project);
-  await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-others.json') as Bundle, project);
+  await client.query(`DELETE FROM "StructureDefinition" WHERE "projectId" = $1`, [r4ProjectId]);
+  await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+  await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-others.json') as Bundle);
 }
 
-async function createStructureDefinitionsForBundle(structureDefinitions: Bundle, project: Project): Promise<void> {
+async function createStructureDefinitionsForBundle(structureDefinitions: Bundle): Promise<void> {
   for (const entry of structureDefinitions.entry as BundleEntry[]) {
     const resource = entry.resource as Resource;
 
@@ -25,7 +24,7 @@ async function createStructureDefinitionsForBundle(structureDefinitions: Bundle,
       logger.debug('StructureDefinition: ' + resource.name);
       const result = await systemRepo.createResource<StructureDefinition>({
         ...resource,
-        meta: { ...resource.meta, project: project.id },
+        meta: { ...resource.meta, project: r4ProjectId },
         text: undefined,
         differential: undefined,
       });

--- a/packages/server/src/seeds/valuesets.ts
+++ b/packages/server/src/seeds/valuesets.ts
@@ -1,14 +1,13 @@
 import { Operator } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
-import { Bundle, BundleEntry, CodeSystem, Project, ValueSet } from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, CodeSystem, ValueSet } from '@medplum/fhirtypes';
 import { systemRepo } from '../fhir/repo';
+import { r4ProjectId } from '../seed';
 
 /**
  * Imports all built-in ValueSets and CodeSystems into the database.
- *
- * @param project The project in which to create the ValueSet and CodeSystem resources
  */
-export async function createValueSets(project: Project): Promise<void> {
+export async function rebuildR4ValueSets(): Promise<void> {
   const files = ['valuesets.json', 'v3-codesystems.json', 'valuesets-medplum.json'];
   for (const file of files) {
     const bundle = readJson('fhir/r4/' + file) as Bundle<CodeSystem | ValueSet>;
@@ -17,7 +16,7 @@ export async function createValueSets(project: Project): Promise<void> {
       await deleteExisting(resource);
       await systemRepo.createResource({
         ...resource,
-        meta: { ...resource.meta, project: project.id },
+        meta: { ...resource.meta, project: r4ProjectId },
       });
     }
   }


### PR DESCRIPTION
Before: Super admin tools were using the Super Admin project ID for R4 resources.

After: Use the R4 project ID for the R4 resources.