### PR TITLE
Fixes #2823 Fixes #2826 Fixes #2848 Fixes #2850 - cli auth cleanup

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -1,11 +1,11 @@
-import { ContentType, MedplumClient, getDisplayString, normalizeErrorString } from '@medplum/core';
+import { ContentType, getDisplayString, MedplumClient, normalizeErrorString } from '@medplum/core';
 import { exec } from 'child_process';
 import { createServer } from 'http';
 import { platform } from 'os';
 import { FileSystemStorage } from './storage';
 import { createMedplumClient } from './util/client';
 import { createMedplumCommand } from './util/command';
-import { Profile, jwtAssertionLogin, jwtBearerLogin, loadProfile, profileExists, saveProfile } from './utils';
+import { jwtAssertionLogin, jwtBearerLogin, loadProfile, Profile, profileExists, saveProfile } from './utils';
 
 const clientId = 'medplum-cli';
 const redirectUri = 'http://localhost:9615';
@@ -44,15 +44,9 @@ async function startLogin(medplum: MedplumClient, profile: Profile): Promise<voi
       throw new Error('Missing values, make sure to add --client-id, and --client-secret for JWT Bearer login');
     }
     console.log('Starting JWT login...');
-    const accessToken = await jwtBearerLogin(medplum, profile);
-    const storage = new FileSystemStorage(profile.name as string);
-    storage.setObject('activeLogin', { accessToken });
+    await jwtBearerLogin(medplum, profile);
   } else if (profile.authType === 'jwt-assertion') {
-    const accessToken = await jwtAssertionLogin(medplum, profile);
-    const storage = new FileSystemStorage(profile.name as string);
-    storage.setObject('activeLogin', {
-      accessToken,
-    });
+    await jwtAssertionLogin(medplum, profile);
   }
   console.log('Login successful');
 }

--- a/packages/cli/src/profile-auth.test.ts
+++ b/packages/cli/src/profile-auth.test.ts
@@ -45,27 +45,12 @@ describe('Profiles Auth', () => {
 
   test('JWT Bearer', async () => {
     const profileName = 'jwtProfile';
-    const jwtObj = {
-      authType: 'jwt-bearer',
-      baseUrl: 'https://valid.gov',
-      fhirUrlPath: 'api/v2',
-      tokenUrl: '/oauth2/token',
-      clientId: 'validClientId',
-      clientSecret: 'validClientSecret',
-      scope: 'validScope',
-      audience: '/oauth2/token',
-      authorizeUrl: 'https://valid.gov/authorize',
-      subject: 'john_doe',
-      issuer: 'https://valid.gov',
-    };
-
-    const accessTokenFromClientId = createFakeJwt({ client_id: 'test-client-id', login_id: '123' });
+    const clientId = 'test-client-id';
+    const accessTokenFromClientId = createFakeJwt({ client_id: clientId, login_id: '123' });
 
     const fetch = mockFetch(200, (url) => {
       if (url.includes('oauth2/token')) {
-        return JSON.stringify({
-          access_token: accessTokenFromClientId,
-        });
+        return { access_token: accessTokenFromClientId };
       }
       return {};
     });
@@ -81,23 +66,23 @@ describe('Profiles Auth', () => {
       '-p',
       profileName,
       '--auth-type',
-      jwtObj.authType,
+      'jwt-bearer',
       '--client-id',
-      jwtObj.clientId,
-      '--scope',
-      jwtObj.scope,
-      '--authorize-url',
-      jwtObj.authorizeUrl,
-      '--subject',
-      jwtObj.subject,
-      '--audience',
-      jwtObj.audience,
+      clientId,
       '--client-secret',
-      jwtObj.clientSecret,
+      'validClientSecret',
+      '--scope',
+      'validScope',
+      '--authorize-url',
+      'https://valid.gov/authorize',
+      '--subject',
+      'john_doe',
+      '--audience',
+      '/oauth2/token',
       '--issuer',
-      jwtObj.issuer,
+      'https://valid.gov',
       '--token-url',
-      jwtObj.tokenUrl,
+      '/oauth2/token',
     ]);
 
     expect(profile.getObject('activeLogin')).toEqual({

--- a/packages/cli/src/util/client.ts
+++ b/packages/cli/src/util/client.ts
@@ -2,7 +2,9 @@ import { MedplumClient, MedplumClientOptions } from '@medplum/core';
 import { FileSystemStorage } from '../storage';
 import { Profile } from '../utils';
 
-export async function createMedplumClient(options: MedplumClientOptions): Promise<MedplumClient> {
+export async function createMedplumClient(
+  options: MedplumClientOptions & { profile?: string }
+): Promise<MedplumClient> {
   const profileName = options.profile ?? 'default';
 
   const storage = new FileSystemStorage(profileName);
@@ -23,7 +25,8 @@ export async function createMedplumClient(options: MedplumClientOptions): Promis
     fhirUrlPath,
     authorizeUrl,
     storage,
-    onUnauthenticated: onUnauthenticated,
+    onUnauthenticated,
+    verbose: options.verbose,
   });
 
   if (accessToken) {

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -17,6 +17,7 @@ export function createMedplumCommand(name: string): Command {
     .option('--private-key-path <privateKeyPath>', 'Private key path for JWT assertion')
     .option('--audience <audience>', 'Audience for JWT assertion')
     .option('-p, --profile <profile>', 'Profile name')
+    .option('-v --verbose', 'Verbose output')
     .addOption(
       new Option('--auth-type <authType>', 'Type of authentication').choices([
         'basic',

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -237,7 +237,7 @@ export function profileExists(storage: FileSystemStorage, profile: string): bool
   return true;
 }
 
-export async function jwtBearerLogin(medplum: MedplumClient, profile: Profile): Promise<string> {
+export async function jwtBearerLogin(medplum: MedplumClient, profile: Profile): Promise<void> {
   const header = {
     typ: 'JWT',
     alg: 'HS256',
@@ -259,22 +259,10 @@ export async function jwtBearerLogin(medplum: MedplumClient, profile: Profile): 
     .update(token)
     .digest('base64url');
   const signedToken = `${token}.${signature}`;
-
-  const formBody = new URLSearchParams();
-  formBody.set('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
-  formBody.set('client_id', profile.clientId as string);
-  formBody.set('assertion', signedToken);
-  formBody.set('scope', profile.scope ?? '');
-
-  const res = await medplum.post(profile.tokenUrl as string, formBody.toString(), 'application/x-www-form-urlencoded', {
-    credentials: 'include',
-  });
-
-  const obj = await JSON.parse(res);
-  return obj.access_token;
+  await medplum.startJwtBearerLogin(profile.clientId as string, signedToken, profile.scope ?? '');
 }
 
-export async function jwtAssertionLogin(externalClient: MedplumClient, profile: Profile): Promise<string> {
+export async function jwtAssertionLogin(medplum: MedplumClient, profile: Profile): Promise<void> {
   const privateKey = createPrivateKey(readFileSync(resolve(profile.privateKeyPath as string)));
   const jwt = await new SignJWT({})
     .setProtectedHeader({ alg: 'RS384', typ: 'JWT' })
@@ -285,21 +273,5 @@ export async function jwtAssertionLogin(externalClient: MedplumClient, profile: 
     .setIssuedAt()
     .setExpirationTime('5m')
     .sign(privateKey);
-
-  const formBody = new URLSearchParams();
-  formBody.append('grant_type', 'client_credentials');
-  formBody.append('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
-  formBody.append('client_assertion', jwt);
-
-  const res = await externalClient.post(
-    profile.tokenUrl as string,
-    formBody.toString(),
-    'application/x-www-form-urlencoded',
-    { credentials: 'include' }
-  );
-
-  if (!res.access_token) {
-    throw new Error(`Failed to login: ${res}`);
-  }
-  return res.access_token;
+  await medplum.startJwtAssertionLogin(jwt);
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -815,9 +815,7 @@ export class MedplumClient extends EventTarget {
    */
   post(url: URL | string, body: any, contentType?: string, options: RequestInit = {}): Promise<any> {
     url = url.toString();
-    if (body) {
-      this.setRequestBody(options, body);
-    }
+    this.setRequestBody(options, body);
     if (contentType) {
       this.setRequestContentType(options, contentType);
     }
@@ -840,9 +838,7 @@ export class MedplumClient extends EventTarget {
    */
   put(url: URL | string, body: any, contentType?: string, options: RequestInit = {}): Promise<any> {
     url = url.toString();
-    if (body) {
-      this.setRequestBody(options, body);
-    }
+    this.setRequestBody(options, body);
     if (contentType) {
       this.setRequestContentType(options, contentType);
     }
@@ -2615,9 +2611,7 @@ export class MedplumClient extends EventTarget {
   private logResponse(response: Response): void {
     console.log(`< ${response.status} ${response.statusText}`);
     if (response.headers) {
-      response.headers.forEach((value, key) => {
-        console.log(`< ${key}: ${value}`);
-      });
+      response.headers.forEach((value, key) => console.log(`< ${key}: ${value}`));
     }
   }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -182,15 +182,6 @@ export interface MedplumClientOptions {
   fetch?: FetchLike;
 
   /**
-   * The profile name.
-   *
-   * This is for handling multiple profiles to access different FHIR Servers
-   *
-   * If undefined, the default profile is "default".
-   */
-  profile?: string;
-
-  /**
    * Storage implementation.
    *
    * Default is window.localStorage (if available), this is the common implementation for use in the browser, or an in-memory storage implementation.  If using Medplum on a server it may be useful to provide a custom storage implementation, for example using redis, a database or a file based storage.  Medplum CLI is an an example of `FileSystemStorage`, for reference.
@@ -246,6 +237,20 @@ export interface MedplumClientOptions {
    * For client side applications, consider redirecting to a sign in page.
    */
   onUnauthenticated?: () => void;
+
+  /**
+   * The default redirect behavior.
+   *
+   * The default behavior is to not follow redirects.
+   *
+   * Use "follow" to automatically follow redirects.
+   */
+  redirect?: RequestRedirect;
+
+  /**
+   * When the verbose flag is set, the client will log all requests and responses to the console.
+   */
+  verbose?: boolean;
 }
 
 export interface FetchLike {
@@ -511,6 +516,15 @@ export enum OAuthTokenType {
   Saml2Token = 'urn:ietf:params:oauth:token-type:saml2',
 }
 
+/**
+ * OAuth 2.0 Client Authentication Methods
+ * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
+ */
+export enum OAuthClientAssertionType {
+  /** Using JWTs for Client Authentication */
+  JwtBearer = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+}
+
 interface SessionDetails {
   project: Project;
   membership: ProjectMembership;
@@ -571,6 +585,7 @@ interface SessionDetails {
  *  </head>
  */
 export class MedplumClient extends EventTarget {
+  private readonly options: MedplumClientOptions;
   private readonly fetch: FetchLike;
   private readonly createPdfImpl?: CreatePdfFunction;
   private readonly storage: ClientStorage;
@@ -604,6 +619,7 @@ export class MedplumClient extends EventTarget {
       }
     }
 
+    this.options = options ?? {};
     this.fetch = options?.fetch ?? getDefaultFetch();
     this.storage = options?.storage ?? new ClientStorage();
     this.createPdfImpl = options?.createPdf;
@@ -2343,7 +2359,7 @@ export class MedplumClient extends EventTarget {
       url = this.fhirUrl(urlString);
     }
     this.addFetchOptionsDefaults(options);
-    const response = await this.fetch(url.toString(), options);
+    const response = await this.fetchWithRetry(url.toString(), options);
     return response.blob();
   }
 
@@ -2532,7 +2548,8 @@ export class MedplumClient extends EventTarget {
     }
 
     const contentLocation = response.headers.get('content-location');
-    if (response.status === 201 && contentLocation && options.redirect === 'follow') {
+    const redirectMode = options.redirect ?? this.options.redirect;
+    if (response.status === 201 && contentLocation && redirectMode === 'follow') {
       // Follow redirect
       return this.request('GET', contentLocation, { ...options, body: undefined });
     }
@@ -2566,7 +2583,13 @@ export class MedplumClient extends EventTarget {
     let response: Response | undefined = undefined;
     for (let retry = 0; retry < maxRetries; retry++) {
       try {
+        if (this.options.verbose) {
+          this.logRequest(url, options);
+        }
         response = (await this.fetch(url, options)) as Response;
+        if (this.options.verbose) {
+          this.logResponse(response);
+        }
         if (response.status < 500) {
           return response;
         }
@@ -2576,6 +2599,26 @@ export class MedplumClient extends EventTarget {
       await sleep(retryDelay);
     }
     return response as Response;
+  }
+
+  private logRequest(url: string, options: RequestInit): void {
+    console.log(`> ${options.method} ${url}`);
+    if (options.headers) {
+      const headers = options.headers as Record<string, string>;
+      const entries = Object.entries(headers).sort((a, b) => a[0].localeCompare(b[0]));
+      for (const [key, value] of entries) {
+        console.log(`> ${key}: ${value}`);
+      }
+    }
+  }
+
+  private logResponse(response: Response): void {
+    console.log(`< ${response.status} ${response.statusText}`);
+    if (response.headers) {
+      response.headers.forEach((value, key) => {
+        console.log(`< ${key}: ${value}`);
+      });
+    }
   }
 
   private async pollStatus<T>(statusUrl: string): Promise<T> {
@@ -2841,6 +2884,7 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+   *
    * @category Authentication
    * @param clientId The client ID.
    * @param clientSecret The client secret.
@@ -2867,6 +2911,8 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.1
+   *
+   * @category Authentication
    * @param clientId The client ID.
    * @param assertion The JWT assertion.
    * @param scope The OAuth scope.
@@ -2880,6 +2926,23 @@ export class MedplumClient extends EventTarget {
     formBody.set('client_id', clientId);
     formBody.set('assertion', assertion);
     formBody.set('scope', scope);
+    return this.fetchTokens(formBody);
+  }
+
+  /**
+   * Starts a new OAuth2 JWT assertion flow.
+   *
+   * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
+   *
+   * @category Authentication
+   * @param jwt The JWT assertion.
+   * @returns Promise that resolves to the client profile.
+   */
+  async startJwtAssertionLogin(jwt: string): Promise<ProfileResource> {
+    const formBody = new URLSearchParams();
+    formBody.append('grant_type', OAuthGrantType.ClientCredentials);
+    formBody.append('client_assertion_type', OAuthClientAssertionType.JwtBearer);
+    formBody.append('client_assertion', jwt);
     return this.fetchTokens(formBody);
   }
 
@@ -2918,7 +2981,7 @@ export class MedplumClient extends EventTarget {
    * @returns The user profile resource.
    */
   private async fetchTokens(formBody: URLSearchParams): Promise<ProfileResource> {
-    const options = {
+    const options: RequestInit = {
       method: 'POST',
       headers: { 'Content-Type': ContentType.FORM_URL_ENCODED },
       body: formBody.toString(),
@@ -2930,7 +2993,7 @@ export class MedplumClient extends EventTarget {
       headers['Authorization'] = `Basic ${this.basicAuth}`;
     }
 
-    const response = await this.fetch(this.tokenUrl, options);
+    const response = await this.fetchWithRetry(this.tokenUrl, options);
     if (!response.ok) {
       this.clearActiveLogin();
       try {

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1,6 +1,7 @@
 import {
   ContentType,
   createReference,
+  OAuthClientAssertionType,
   OAuthGrantType,
   OAuthTokenType,
   parseJWTPayload,
@@ -1161,7 +1162,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(200);
@@ -1187,7 +1188,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);
@@ -1213,7 +1214,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);
@@ -1247,7 +1248,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);
@@ -1281,7 +1282,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);
@@ -1315,7 +1316,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);
@@ -1349,7 +1350,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(200);
@@ -1380,7 +1381,7 @@ describe('OAuth2 Token', () => {
     // Then use the JWT for a client credentials grant
     const res = await request(app).post('/oauth2/token').type('form').send({
       grant_type: 'client_credentials',
-      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion_type: OAuthClientAssertionType.JwtBearer,
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -4,6 +4,7 @@ import {
   getStatus,
   normalizeErrorString,
   normalizeOperationOutcome,
+  OAuthClientAssertionType,
   OAuthGrantType,
   OAuthTokenType,
   Operator,
@@ -431,12 +432,12 @@ async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
  * 2. https://www.hl7.org/fhir/smart-app-launch/example-backend-services.html#step-2-discovery
  * 3. https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/csimg/obtaining-access-token-using-self-signed-client-assertion.html
  * 4. https://darutk.medium.com/oauth-2-0-client-authentication-4b5f929305d4
- * @param clientAssertiontype The client assertion type.
+ * @param clientAssertionType The client assertion type.
  * @param clientAssertion The client assertion JWT.
  * @returns The parsed client ID and secret on success, or an error message on failure.
  */
-async function parseClientAssertion(clientAssertiontype: string, clientAssertion: string): Promise<ClientIdAndSecret> {
-  if (clientAssertiontype !== 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer') {
+async function parseClientAssertion(clientAssertionType: string, clientAssertion: string): Promise<ClientIdAndSecret> {
+  if (clientAssertionType !== OAuthClientAssertionType.JwtBearer) {
     return { error: 'Unsupported client assertion type' };
   }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -436,7 +436,10 @@ async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
  * @param clientAssertion The client assertion JWT.
  * @returns The parsed client ID and secret on success, or an error message on failure.
  */
-async function parseClientAssertion(clientAssertionType: string, clientAssertion: string): Promise<ClientIdAndSecret> {
+async function parseClientAssertion(
+  clientAssertionType: OAuthClientAssertionType,
+  clientAssertion: string
+): Promise<ClientIdAndSecret> {
   if (clientAssertionType !== OAuthClientAssertionType.JwtBearer) {
     return { error: 'Unsupported client assertion type' };
   }


### PR DESCRIPTION
Fixes #2823 - added `verbose` option to `MedplumClient` and all CLI commands

Fixes #2826 - added `redirect` option to `MedplumClient` to always follow redirects

Fixes #2848
- I believe the "logging in multiple times" bug is fixed, or at least I haven't been able to repro it
- Persisting `fhirUrlPath`
- Use `fetchTokens` rather than raw `fetch`

Fixes #2840 - Added `startJwtAssertionLogin` to `MedplumClient`, which unifies code paths in CLI and the Epic demo bot

--------

All said and done, I believe this fixes the most pressing Epic rough edges.

Example of connecting to Epic:

```bash
medplum login \
  --profile epic \
  --auth-type jwt-assertion \
  --base-url "https://fhir.epic.com/interconnect-fhir-oauth/" \
  --token-url "oauth2/token" \
  --fhir-url "api/FHIR/R4" \
  --client-id MY_CLIENT_ID \
  --private-key-path ./epic.private.key
```

Then, after connected, example of using the FHIR API:

```bash
medplum get Patient/erXuFYUfucBZaryVksYEcMg3 --profile epic
```