### PR TITLE
Fix 'sign-in' vs 'sign in' in invite email

### DIFF
--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -14,12 +14,12 @@ import Mail from 'nodemailer/lib/mailer';
 import { resetPassword } from '../auth/resetpassword';
 import { bcryptHashPassword, createProfile, createProjectMembership } from '../auth/utils';
 import { getConfig } from '../config';
+import { getAuthenticatedContext } from '../context';
 import { sendEmail } from '../email/email';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { systemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { getUserByEmailInProject, getUserByEmailWithoutProject } from '../oauth/utils';
-import { getAuthenticatedContext } from '../context';
 
 export const inviteValidators = [
   body('resourceType').isIn(['Patient', 'Practitioner', 'RelatedPerson']).withMessage('Resource type is required'),
@@ -211,7 +211,7 @@ async function sendInviteEmail(
     options.text = [
       `You were invited to ${request.project.name}`,
       '',
-      `The next time you sign-in, you will see ${request.project.name} as an option.`,
+      `The next time you sign in, you will see ${request.project.name} as an option.`,
       '',
       `You can sign in here: ${getConfig().appBaseUrl}signin`,
       '',


### PR DESCRIPTION
This bothered me:

![image](https://github.com/medplum/medplum/assets/749094/e01d277e-e401-4a2a-a77d-fdd503f55030)

https://english.stackexchange.com/questions/49850/sign-in-signin-or-sign-in

> The verb is sign in.
> 
> The noun is sign-in.
> 
> The noun is better with the hyphen, because signin could be confused with an abbreviated signing that's lost its apostrophe.
> 
> Alternatively you could use the more common log in for the verb, and login for the noun.