### PR TITLE
Fix bug on page sequence input changes 

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -751,6 +751,11 @@ describe('QuestionnaireForm', () => {
                 text: visibleQuestion,
                 type: 'string',
               },
+              {
+                linkId: 'question2-string',
+                text: 'visible question 2',
+                type: 'string',
+              },
             ],
             extension: [
               {
@@ -795,24 +800,38 @@ describe('QuestionnaireForm', () => {
       },
       onSubmit: jest.fn(),
     });
-    // The form should render
-    expect(screen.getByText(visibleQuestion)).toBeInTheDocument();
 
-    // The hidden text should be hidden
-    expect(screen.queryByText(hiddenQuestion)).not.toBeInTheDocument();
+    const visibleQuestionInput = screen.getByLabelText(visibleQuestion);
+    fireEvent.change(visibleQuestionInput, { target: { value: 'Test Value' } });
+
+    expect((visibleQuestionInput as HTMLInputElement).value).toBe('Test Value');
+
+    const question2StringInput = screen.getByLabelText('visible question 2');
+    fireEvent.change(question2StringInput, { target: { value: 'Test Value for Question2-String' } });
+
+    expect((question2StringInput as HTMLInputElement).value).toBe('Test Value for Question2-String');
 
     await act(async () => {
       fireEvent.click(screen.getByText('Next'));
     });
 
+    // Check that the texts for visibleQuestion and question2-string are no longer in the document.
     expect(screen.queryByText(visibleQuestion)).not.toBeInTheDocument();
+    expect(screen.queryByText('visible question 1')).not.toBeInTheDocument();
 
-    // The hidden text should now be visible
+    // Check that the hidden text is now visible.
     expect(screen.getByText(hiddenQuestion)).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Back'));
     });
+
+    // Check that the values in the visibleQuestion and question2-string inputs are still the same.
+    const updatedVisibleQuestionInput = screen.getByLabelText(visibleQuestion) as HTMLInputElement;
+    expect(updatedVisibleQuestionInput.value).toBe('Test Value');
+
+    const updatedQuestion2StringInput = screen.getByLabelText('visible question 1') as HTMLInputElement;
+    expect(updatedQuestion2StringInput.value).toBe('Test Value for Question2-String');
   });
 
   test('Page Sequence with non page items in root', async () => {
@@ -1083,6 +1102,13 @@ describe('QuestionnaireForm', () => {
             text: 'Group',
             type: 'group',
             repeats: true,
+            item: [
+              {
+                linkId: 'question2',
+                text: 'Question 2',
+                type: 'string',
+              },
+            ],
           },
         ],
       },
@@ -1096,5 +1122,9 @@ describe('QuestionnaireForm', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Add Group'));
     });
+
+    expect(screen.getAllByText('Group').length).toBe(2);
+
+    expect(screen.getAllByText('Question 2').length).toBe(2);
   });
 });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -817,7 +817,7 @@ describe('QuestionnaireForm', () => {
 
     // Check that the texts for visibleQuestion and question2-string are no longer in the document.
     expect(screen.queryByText(visibleQuestion)).not.toBeInTheDocument();
-    expect(screen.queryByText('visible question 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('visible question 2')).not.toBeInTheDocument();
 
     // Check that the hidden text is now visible.
     expect(screen.getByText(hiddenQuestion)).toBeInTheDocument();
@@ -830,7 +830,7 @@ describe('QuestionnaireForm', () => {
     const updatedVisibleQuestionInput = screen.getByLabelText(visibleQuestion) as HTMLInputElement;
     expect(updatedVisibleQuestionInput.value).toBe('Test Value');
 
-    const updatedQuestion2StringInput = screen.getByLabelText('visible question 1') as HTMLInputElement;
+    const updatedQuestion2StringInput = screen.getByLabelText('visible question 2') as HTMLInputElement;
     expect(updatedQuestion2StringInput.value).toBe('Test Value for Question2-String');
   });
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -428,9 +428,6 @@ function mergeItemsWithSameLinkId(
     } else if (newItems[i]) {
       // If only a new item exists for the current index, add it to the result.
       result.push(newItems[i]);
-    } else if (prevItems[i]) {
-      // If only an old item exists for the current index, add it to the result.
-      result.push(prevItems[i]);
     }
   }
   return result;

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -1,10 +1,10 @@
 import { Anchor, Button, Group, Stack, Stepper, Title } from '@mantine/core';
 import {
+  IndexedStructureDefinition,
+  ProfileResource,
   createReference,
   getExtension,
   getReferenceString,
-  IndexedStructureDefinition,
-  ProfileResource,
 } from '@medplum/core';
 import {
   Questionnaire,
@@ -55,9 +55,12 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
   }, [questionnaire]);
 
   function setItems(newResponseItems: QuestionnaireResponseItem[]): void {
+    const currentItems = response?.item ?? [];
+    const mergedItems = mergeItems(currentItems, newResponseItems);
+
     const newResponse: QuestionnaireResponse = {
       resourceType: 'QuestionnaireResponse',
-      item: newResponseItems,
+      item: mergedItems,
     };
 
     setResponse(newResponse);
@@ -393,4 +396,61 @@ function getNumberOfGroups(item: QuestionnaireItem, responses: QuestionnaireResp
   // This is to maintain the group number for the stepper
   const responseLength = responses.filter((r) => r.linkId === item.linkId).length;
   return responseLength > 0 ? responseLength : 1;
+}
+
+function mergeIndividualItems(
+  prevItem: QuestionnaireResponseItem,
+  newItem: QuestionnaireResponseItem
+): QuestionnaireResponseItem {
+  // Recursively merge the nested items.
+  const mergedNestedItems = mergeItems(prevItem.item ?? [], newItem.item ?? []);
+
+  return {
+    ...newItem,
+    item: mergedNestedItems,
+    // Prioritize answers from the new item, but fall back to the old item's answers if the new item doesn't provide any.
+    answer: newItem.answer && newItem.answer.length > 0 ? newItem.answer : prevItem.answer,
+  };
+}
+
+function mergeItemsWithSameLinkId(
+  prevItems: QuestionnaireResponseItem[],
+  newItems: QuestionnaireResponseItem[]
+): QuestionnaireResponseItem[] {
+  const result: QuestionnaireResponseItem[] = [];
+  const maxLength = Math.max(prevItems.length, newItems.length);
+
+  // Loop over items to handle cases where there are varying counts of items with the same linkId between old and new items.
+  for (let i = 0; i < maxLength; i++) {
+    if (prevItems[i] && newItems[i]) {
+      // If both old and new items exist for the current index, merge them.
+      result.push(mergeIndividualItems(prevItems[i], newItems[i]));
+    } else if (newItems[i]) {
+      // If only a new item exists for the current index, add it to the result.
+      result.push(newItems[i]);
+    } else if (prevItems[i]) {
+      // If only an old item exists for the current index, add it to the result.
+      result.push(prevItems[i]);
+    }
+  }
+  return result;
+}
+
+function mergeItems(
+  prevItems: QuestionnaireResponseItem[],
+  newItems: QuestionnaireResponseItem[]
+): QuestionnaireResponseItem[] {
+  let result: QuestionnaireResponseItem[] = [];
+
+  // Iterate over unique linkIds from newItems.
+  for (const linkId of new Set(newItems.map((item) => item.linkId))) {
+    // Gather all items from the old and new list that share the current linkId.
+    const prevMatchedItems = prevItems.filter((oldItem) => oldItem.linkId === linkId);
+    const newMatchedItems = newItems.filter((newItem) => newItem.linkId === linkId);
+
+    // Merge the gathered items and append to the result.
+    result = result.concat(mergeItemsWithSameLinkId(prevMatchedItems, newMatchedItems));
+  }
+
+  return result;
 }


### PR DESCRIPTION
Currently with the Page Sequence tool, when we go back the input persists, however when we change one of the inputs, the others clear out automatically. Now we change the setItems method so that it merges the previous responses to the newer responses and keeps all of the inputs. 


https://github.com/medplum/medplum/assets/6913745/13f8aa01-04fc-450d-b681-e85fadf8147b

