### PR TITLE
Fixes ElementDefinition.contentReference in deep nested backbone element

### DIFF
--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -1,16 +1,17 @@
+import { readJson } from '@medplum/definitions';
+import { Observation, StructureDefinition } from '@medplum/fhirtypes';
 import { readFileSync } from 'fs';
-import {
-  ElementValidator,
-  InternalTypeSchema,
-  SlicingRules,
-  loadDataTypes,
-  parseStructureDefinition,
-  subsetResource,
-} from './types';
 import { resolve } from 'path';
 import { TypedValue } from '../types';
-import { Observation, StructureDefinition } from '@medplum/fhirtypes';
-import { readJson } from '@medplum/definitions';
+import {
+  ElementValidator,
+  getDataType,
+  InternalTypeSchema,
+  loadDataTypes,
+  parseStructureDefinition,
+  SlicingRules,
+  subsetResource,
+} from './types';
 
 describe('FHIR resource and data type representations', () => {
   test('Base resource parsing', () => {
@@ -318,5 +319,12 @@ describe('FHIR resource and data type representations', () => {
         reference: 'Patient/example',
       },
     });
+  });
+
+  test('Deeply nested content reference', () => {
+    // Make sure we can handle contentReference more than 2 layers down
+    const structureMapGroupRuleType = getDataType('StructureMapGroupRule');
+    expect(structureMapGroupRuleType).toBeDefined();
+    expect(structureMapGroupRuleType.fields['rule']).toBeDefined();
   });
 });

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -168,6 +168,9 @@ class StructureDefinitionParser {
         }
 
         if (!parentContext) {
+          // Within R4 StructureDefinitions, there are 2 cases where StructureDefinition.name !== ElementDefinition.path.
+          // For SimpleQuantity and MoneyQuantity, the names are the names, but the root ElementDefinition.path is Quantity.
+          // We need to use StructureDefinition.name for the type name, and ElementDefinition.path for the path.
           const path = elementPath(element, this.root.path);
           if (element.isSummary) {
             this.resourceSchema.summaryProperties?.add(path.replace('[x]', ''));

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -107,6 +107,7 @@ interface BackboneContext {
  * @experimental
  */
 class StructureDefinitionParser {
+  private readonly root: ElementDefinition;
   private readonly elements: ElementDefinition[];
   private readonly elementIndex: Record<string, ElementDefinition>;
   private index: number;
@@ -123,15 +124,15 @@ class StructureDefinitionParser {
     if (!sd.snapshot?.element || sd.snapshot.element.length === 0) {
       throw new Error(`No snapshot defined for StructureDefinition '${sd.name}'`);
     }
-    const root = sd.snapshot.element[0];
 
+    this.root = sd.snapshot.element[0];
     this.elements = sd.snapshot.element.slice(1);
     this.elementIndex = Object.create(null);
     this.index = 0;
     this.resourceSchema = {
       name: sd.type as ResourceType,
       fields: {},
-      constraints: this.parseFieldDefinition(root).constraints,
+      constraints: this.parseFieldDefinition(this.root).constraints,
       innerTypes: [],
       summaryProperties: new Set(),
       mandatoryProperties: new Set(),
@@ -157,12 +158,17 @@ class StructureDefinitionParser {
         this.checkFieldEnter(element, field);
 
         // Record field in schema
-        if (this.backboneContext && element.path?.startsWith(this.backboneContext.path + '.')) {
-          this.backboneContext.type.fields[elementPath(element, this.backboneContext.path)] = field;
-        } else if (this.backboneContext?.parent && element.path?.startsWith(this.backboneContext.parent.path + '.')) {
-          this.backboneContext.parent.type.fields[elementPath(element, this.backboneContext.parent.path)] = field;
-        } else {
-          const path = elementPath(element, this.resourceSchema.name);
+        let parentContext: BackboneContext | undefined = this.backboneContext;
+        while (parentContext) {
+          if (element.path?.startsWith(parentContext.path + '.')) {
+            parentContext.type.fields[elementPath(element, parentContext.path)] = field;
+            break;
+          }
+          parentContext = parentContext.parent;
+        }
+
+        if (!parentContext) {
+          const path = elementPath(element, this.root.path);
           if (element.isSummary) {
             this.resourceSchema.summaryProperties?.add(path.replace('[x]', ''));
           }


### PR DESCRIPTION
Discovered while working on https://github.com/medplum/medplum/pull/2859

`StructureMap.group.rule.rule` was incorrectly added as a field of `StructureMap` rather than `StructureMapGroupRule` because it was 3 contexts deep, and we only supported 2.

This fix supports any level of context nesting.