### PR TITLE
Use getElementDefinitionTypeName

### DIFF
--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -1,5 +1,5 @@
 import { Coding, ElementDefinition, Period, Quantity } from '@medplum/fhirtypes';
-import { PropertyType, TypedValue, buildTypeName, getElementDefinition, isResource } from '../types';
+import { getElementDefinition, getElementDefinitionTypeName, isResource, PropertyType, TypedValue } from '../types';
 import { capitalize, isEmpty } from '../utils';
 
 /**
@@ -127,7 +127,7 @@ function getTypedPropertyValueWithSchema(
   }
 
   if (resultType === 'Element' || resultType === 'BackboneElement') {
-    resultType = buildTypeName(property.path?.split('.') as string[]);
+    resultType = getElementDefinitionTypeName(property);
   }
 
   if (Array.isArray(resultValue)) {

--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -10,7 +10,7 @@ import {
   parseFhirPath,
   UnionAtom,
 } from '../fhirpath';
-import { buildTypeName, getElementDefinition, globalSchema, PropertyType } from '../types';
+import { getElementDefinition, getElementDefinitionTypeName, globalSchema, PropertyType } from '../types';
 import { capitalize } from '../utils';
 
 export enum SearchParameterType {
@@ -150,7 +150,7 @@ function crawlSearchParameterDetails(
   for (const elementDefinitionType of elementDefinition.type as ElementDefinitionType[]) {
     let propertyType = elementDefinitionType.code as string;
     if (isBackboneElement(propertyType)) {
-      propertyType = buildTypeName(elementDefinition.path?.split('.') as string[]);
+      propertyType = getElementDefinitionTypeName(elementDefinition);
     }
     crawlSearchParameterDetails(details, atoms, propertyType, nextIndex);
   }

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -113,6 +113,18 @@ describe('Type Utils', () => {
     expect(getElementDefinitionTypeName({ path: 'Timing.repeat', type: [{ code: 'Element' }] })).toEqual(
       'TimingRepeat'
     );
+
+    // There is an important special case for ElementDefinition with contentReference
+    // In the original StructureDefinition, contentReference is used to point to another ElementDefinition
+    // In StructureDefinitionParser.peek(), we merge the referenced ElementDefinition into the current one
+    // In that case, ElementDefinition.path will be the original, but ElementDefinition.base.path will be the referenced.
+    expect(
+      getElementDefinitionTypeName({
+        path: 'Questionnaire.item.item',
+        base: { path: 'Questionnaire.item' },
+        type: [{ code: 'Element' }],
+      })
+    ).toEqual('QuestionnaireItem');
   });
 
   test('isResourceTypeSchema', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -321,7 +321,7 @@ export function indexSearchParameter(searchParam: SearchParameter): void {
 export function getElementDefinitionTypeName(elementDefinition: ElementDefinition): string {
   const code = elementDefinition.type?.[0]?.code as string;
   return code === 'BackboneElement' || code === 'Element'
-    ? buildTypeName(elementDefinition.path?.split('.') as string[])
+    ? buildTypeName((elementDefinition.base?.path ?? elementDefinition.path)?.split('.') as string[])
     : code;
 }
 

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -1,7 +1,7 @@
-import { Bundle, ElementDefinition, ResourceType, StructureDefinition, Resource, Coding } from '@medplum/fhirtypes';
+import { Bundle, Coding, ElementDefinition, Resource, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
 import { getTypedPropertyValue } from '../fhirpath';
 import { OperationOutcomeError, serverError } from '../outcomes';
-import { TypedValue } from '../types';
+import { getElementDefinitionTypeName, TypedValue } from '../types';
 import { capitalize, isEmpty } from '../utils';
 
 /**
@@ -197,7 +197,7 @@ class StructureDefinitionParser {
       }
       this.backboneContext = {
         type: {
-          name: buildTypeName(element.path?.split('.') ?? []) as ResourceType,
+          name: getElementDefinitionTypeName(element),
           fields: {},
           constraints: this.parseFieldDefinition(element).constraints,
           innerTypes: [],
@@ -325,7 +325,7 @@ class StructureDefinitionParser {
       })),
       type: (ed.type ?? []).map((t) => ({
         code: ['BackboneElement', 'Element'].includes(t.code as string)
-          ? buildTypeName(ed.base?.path?.split('.') ?? [])
+          ? getElementDefinitionTypeName(ed)
           : t.code ?? '',
         targetProfile: t.targetProfile ?? [],
       })),
@@ -407,13 +407,6 @@ function pathsCompatible(parent: string | undefined, child: string | undefined):
     return false;
   }
   return child.startsWith(parent + '.') || child === parent;
-}
-
-function buildTypeName(components: string[]): string {
-  if (components.length === 1) {
-    return components[0];
-  }
-  return components.map(capitalize).join('');
 }
 
 function firstValue(obj: TypedValue | TypedValue[] | undefined): TypedValue | undefined {

--- a/packages/fhir-router/src/graphql/input-types.ts
+++ b/packages/fhir-router/src/graphql/input-types.ts
@@ -1,4 +1,10 @@
-import { buildTypeName, capitalize, getElementDefinition, getResourceTypeSchema, isResourceType } from '@medplum/core';
+import {
+  capitalize,
+  getElementDefinition,
+  getElementDefinitionTypeName,
+  getResourceTypeSchema,
+  isResourceType,
+} from '@medplum/core';
 import { ElementDefinition, ElementDefinitionType, ResourceType } from '@medplum/fhirtypes';
 import {
   GraphQLInputFieldConfig,
@@ -70,7 +76,7 @@ function buildInputPropertyField(
 ): void {
   let typeName = elementDefinitionType.code as string;
   if (typeName === 'Element' || typeName === 'BackboneElement') {
-    typeName = buildTypeName(elementDefinition.path?.split('.') as string[]);
+    typeName = getElementDefinitionTypeName(elementDefinition);
   }
 
   const fieldConfig: GraphQLInputFieldConfig = {

--- a/packages/fhir-router/src/graphql/output-types.ts
+++ b/packages/fhir-router/src/graphql/output-types.ts
@@ -1,8 +1,8 @@
 import {
-  buildTypeName,
   capitalize,
   evalFhirPathTyped,
   getElementDefinition,
+  getElementDefinitionTypeName,
   getResourceTypes,
   getResourceTypeSchema,
   getSearchParameters,
@@ -107,7 +107,7 @@ function buildOutputPropertyField(
 ): void {
   let typeName = elementDefinitionType.code as string;
   if (typeName === 'Element' || typeName === 'BackboneElement') {
-    typeName = buildTypeName(elementDefinition.path?.split('.') as string[]);
+    typeName = getElementDefinitionTypeName(elementDefinition);
   }
 
   const fieldConfig: GraphQLFieldConfig<any, any> = {


### PR DESCRIPTION
Found while working on https://github.com/medplum/medplum/pull/2859

1. We were not consistently using `ElementDefinition.base.path` when building a type name from an `ElementDefinition`
2. We had duplicated the logic in 7 different places

This fixes the issue with `ElementDefinition.base.path` and uses the already existing helper `getElementDefinitionTypeName` when possible rather than duplicating logic.
