### PR TITLE
Bind async callbacks to context local storage

### DIFF
--- a/packages/server/src/async.ts
+++ b/packages/server/src/async.ts
@@ -11,7 +11,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
  * @returns Async wrapped handler.
  */
 export function asyncWrap(callback: (req: Request, res: Response, next: NextFunction) => Promise<any>): RequestHandler {
-  AsyncLocalStorage.bind(callback);
+  callback = AsyncLocalStorage.bind(callback);
   return function (req: Request, res: Response, next: NextFunction): void {
     callback(req, res, next).catch(next);
   };

--- a/packages/server/src/async.ts
+++ b/packages/server/src/async.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from 'async_hooks';
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 
 /**
@@ -11,7 +10,6 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
  * @returns Async wrapped handler.
  */
 export function asyncWrap(callback: (req: Request, res: Response, next: NextFunction) => Promise<any>): RequestHandler {
-  callback = AsyncLocalStorage.bind(callback);
   return function (req: Request, res: Response, next: NextFunction): void {
     callback(req, res, next).catch(next);
   };

--- a/packages/server/src/async.ts
+++ b/packages/server/src/async.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 
 /**
@@ -10,6 +11,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
  * @returns Async wrapped handler.
  */
 export function asyncWrap(callback: (req: Request, res: Response, next: NextFunction) => Promise<any>): RequestHandler {
+  AsyncLocalStorage.bind(callback);
   return function (req: Request, res: Response, next: NextFunction): void {
     callback(req, res, next).catch(next);
   };

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -35,7 +35,7 @@ export class AsyncJobExecutor {
   }
 
   async run(callback: () => Promise<any>): Promise<void> {
-    AsyncLocalStorage.bind(callback);
+    callback = AsyncLocalStorage.bind(callback);
     if (!this.resource) {
       throw new Error('AsyncJob missing');
     }

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -1,6 +1,7 @@
 import { AsyncJob } from '@medplum/fhirtypes';
 import { Repository, systemRepo } from '../../repo';
 import { getRequestContext } from '../../../context';
+import { AsyncLocalStorage } from 'async_hooks';
 
 export class AsyncJobExecutor {
   readonly repo: Repository;
@@ -34,6 +35,7 @@ export class AsyncJobExecutor {
   }
 
   async run(callback: () => Promise<any>): Promise<void> {
+    AsyncLocalStorage.bind(callback);
     if (!this.resource) {
       throw new Error('AsyncJob missing');
     }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -718,20 +718,17 @@ export class Repository extends BaseRepository implements FhirRepository {
     const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.addDeletedFilter(builder);
 
-    await builder.executeCursor(
-      client,
-      AsyncLocalStorage.bind(async (row: any) => {
-        try {
-          const resource = JSON.parse(row.content) as Resource;
-          (resource.meta as Meta).compartment = this.getCompartments(resource);
-          await this.updateResourceImpl(JSON.parse(row.content) as Resource, false);
-        } catch (err) {
-          getRequestContext().logger.error('Failed to rebuild compartments for resource', {
-            error: normalizeErrorString(err),
-          });
-        }
-      })
-    );
+    await builder.executeCursor(client, async (row: any) => {
+      try {
+        const resource = JSON.parse(row.content) as Resource;
+        (resource.meta as Meta).compartment = this.getCompartments(resource);
+        await this.updateResourceImpl(JSON.parse(row.content) as Resource, false);
+      } catch (err) {
+        getRequestContext().logger.error('Failed to rebuild compartments for resource', {
+          error: normalizeErrorString(err),
+        });
+      }
+    });
   }
 
   /**
@@ -749,16 +746,13 @@ export class Repository extends BaseRepository implements FhirRepository {
     const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.addDeletedFilter(builder);
 
-    await builder.executeCursor(
-      client,
-      AsyncLocalStorage.bind(async (row: any) => {
-        try {
-          await this.reindexResourceImpl(JSON.parse(row.content) as Resource);
-        } catch (err) {
-          getRequestContext().logger.error('Failed to reindex resource', { error: normalizeErrorString(err) });
-        }
-      })
-    );
+    await builder.executeCursor(client, async (row: any) => {
+      try {
+        await this.reindexResourceImpl(JSON.parse(row.content) as Resource);
+      } catch (err) {
+        getRequestContext().logger.error('Failed to reindex resource', { error: normalizeErrorString(err) });
+      }
+    });
   }
 
   /**

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -82,7 +82,6 @@ import { rewriteAttachments, RewriteMode } from './rewrite';
 import { buildSearchExpression, getFullUrl, searchImpl } from './search';
 import { Condition, DeleteQuery, Disjunction, Expression, InsertQuery, Operator, SelectQuery } from './sql';
 import { getSearchParameters } from './structure';
-import { AsyncLocalStorage } from 'async_hooks';
 
 /**
  * The RepositoryContext interface defines standard metadata for repository actions.

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import { Client, Pool, PoolClient } from 'pg';
 import Cursor from 'pg-cursor';
 
@@ -400,6 +401,7 @@ export class SelectQuery extends BaseQuery {
   }
 
   async executeCursor(pool: Pool, callback: (row: any) => Promise<void>): Promise<void> {
+    AsyncLocalStorage.bind(callback);
     const BATCH_SIZE = 100;
 
     const sql = new SqlBuilder();

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -401,7 +401,7 @@ export class SelectQuery extends BaseQuery {
   }
 
   async executeCursor(pool: Pool, callback: (row: any) => Promise<void>): Promise<void> {
-    AsyncLocalStorage.bind(callback);
+    callback = AsyncLocalStorage.bind(callback);
     const BATCH_SIZE = 100;
 
     const sql = new SqlBuilder();


### PR DESCRIPTION
Followup fix to handle binding context to async callbacks inside the function accepting the callback, rather than at every call site