### PR TITLE
Persisting currentValues for special cases 

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1095,6 +1095,45 @@ describe('QuestionnaireForm', () => {
     expect(screen.queryByText('Hidden Text')).toBeInTheDocument();
   });
 
+  test('Multi Select shows with no data', async () => {
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        item: [
+          {
+            linkId: 'q1',
+            type: QuestionnaireItemType.choice,
+            repeats: true,
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                  text: 'Drop down',
+                },
+              },
+            ],
+            text: 'q1',
+            answerOption: [],
+          },
+        ],
+      },
+      onSubmit: jest.fn(),
+    });
+
+    expect(screen.getByText('q1')).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText('Select items');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toBeInstanceOf(HTMLInputElement);
+  });
+
   test('repeatableQuestion', async () => {
     await setup({
       questionnaire: {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1187,7 +1187,7 @@ describe('QuestionnaireForm', () => {
     });
 
     const searchInput1 = screen.getByPlaceholderText('Select items');
-    expect(searchInput1).toBeInTheDocument()
+    expect(searchInput1).toBeInTheDocument();
   });
 
   test('Multi Select shows with no data', async () => {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1,7 +1,7 @@
 import { getQuestionnaireAnswers } from '@medplum/core';
 import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { randomUUID } from 'crypto';
 import each from 'jest-each';
 import React from 'react';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -628,6 +628,17 @@ describe('QuestionnaireForm', () => {
     const response2 = onSubmit.mock.calls[1][0];
     const answers2 = getQuestionnaireAnswers(response2);
     expect(answers2['q1']).toMatchObject({ valueString: 'a2' });
+
+    await act(async () => {
+      fireEvent.change(dropDown, { target: { value: '' } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('OK'));
+    });
+
+    const response3 = onSubmit.mock.calls[2][0];
+    const answers3 = getQuestionnaireAnswers(response3);
+    expect(answers3['q1']).toMatchObject({});
   });
 
   test('Reference Extensions', async () => {
@@ -1082,65 +1093,6 @@ describe('QuestionnaireForm', () => {
 
     // Now the hidden text should be visible
     expect(screen.queryByText('Hidden Text')).toBeInTheDocument();
-  });
-
-  test('Multi Select', async () => {
-    const onSubmit = jest.fn();
-
-    await setup({
-      questionnaire: {
-        resourceType: 'Questionnaire',
-        item: [
-          {
-            linkId: 'q1',
-            type: QuestionnaireItemType.choice,
-            repeats: true,
-            extension: [
-              {
-                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-                valueCodeableConcept: {
-                  coding: [
-                    {
-                      system: 'http://hl7.org/fhir/questionnaire-item-control',
-                      code: 'drop-down',
-                      display: 'Drop down',
-                    },
-                  ],
-                  text: 'Drop down',
-                },
-              },
-            ],
-            text: 'q1',
-            answerOption: [
-              {
-                valueString: 'value1',
-              },
-              {
-                valueString: 'value2',
-              },
-            ],
-          },
-        ],
-      },
-      onSubmit,
-    });
-    expect(screen.getByText('q1')).toBeInTheDocument();
-
-    const dropDown = screen.getByPlaceholderText('Select items');
-    expect(dropDown).toBeInTheDocument();
-    expect(dropDown).toBeInstanceOf(HTMLInputElement);
-
-    await act(async () => {
-      fireEvent.click(screen.getByPlaceholderText('Select items'));
-    });
-
-    await act(async () => {
-      fireEvent.change(dropDown, { target: 'value1' });
-    });
-
-    await act(async () => {
-      fireEvent.change(dropDown, { target: ['value1', 'value2'] });
-    });
   });
 
   test('repeatableQuestion', async () => {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1,4 +1,4 @@
-import { getQuestionnaireAnswers, getAllQuestionnaireAnswers } from '@medplum/core';
+import { getQuestionnaireAnswers } from '@medplum/core';
 import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -24,7 +24,7 @@ import { QuantityInput } from '../../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
 import { ResourcePropertyDisplay } from '../../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
-import { QuestionnaireItemType, onChangeMultiSelectValues } from '../../utils/questionnaire';
+import { QuestionnaireItemType, getNewMultiSelectValues } from '../../utils/questionnaire';
 
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
@@ -256,7 +256,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         searchable
         defaultValue={currentAnswer || [typedValueToString(initialValue)]}
         onChange={(selected) => {
-          const values = onChangeMultiSelectValues(selected, propertyName, item);
+          const values = getNewMultiSelectValues(selected, propertyName, item);
           props.onChangeAnswer(values as QuestionnaireResponseItemAnswer[]);
         }}
       />

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -347,7 +347,9 @@ function QuestionnaireChoiceRadioInput(props: QuestionnaireChoiceInputProps): JS
   }
 
   const defaultAnswer = getDefaultAnswer(props.allResponses, item, props.index, props.groupSequence);
-  const answerLinkId = options.find((option) => option[1].value === defaultAnswer)?.[0];
+  const answerLinkId = options.find(
+    (option) => (formatCoding(option[1].value) || option[1].value) === defaultAnswer
+  )?.[0];
 
   return (
     <Radio.Group

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -10,7 +10,6 @@ import {
   stringify,
 } from '@medplum/core';
 import {
-  Coding,
   QuestionnaireItem,
   QuestionnaireItemAnswerOption,
   QuestionnaireItemInitial,

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -481,10 +481,7 @@ function getItemsByLinkId(allResponses: QuestionnaireResponseItem[], linkId: str
 }
 
 function getItemValue(answer: QuestionnaireResponseItemAnswer): any {
-  const itemValue = getTypedPropertyValue(
-    { type: 'QuestionnaireItemAnswerOption', value: answer },
-    'value'
-  ) as TypedValue;
+  const itemValue = getTypedPropertyValue({ type: 'QuestionnaireItemAnswer', value: answer }, 'value') as TypedValue;
   // formatCoding returns '' if nothing is there so we need to use ||
   return formatCoding(itemValue?.value) || itemValue?.value;
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -256,18 +256,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         searchable
         defaultValue={currentAnswer || [typedValueToString(initialValue)]}
         onChange={(selected) => {
-          const values = selected.map((o) => {
-            const option = item.answerOption?.find(
-              (option) =>
-                formatCoding(option.valueCoding) === o ||
-                option[propertyName as keyof QuestionnaireItemAnswerOption] === o
-            );
-            const optionValue = getTypedPropertyValue(
-              { type: 'QuestionnaireItemAnswerOption', value: option },
-              'value'
-            ) as TypedValue;
-            return { [propertyName]: optionValue.value };
-          });
+          const values = multiSelectOnChange(selected, propertyName, item);
           props.onChangeAnswer(values as QuestionnaireResponseItemAnswer[]);
         }}
       />
@@ -507,6 +496,24 @@ function getCurrentMultiSelectAnswer(
   }
   const typedValues = selectedItem.map((a) => getItemValue(a));
   return typedValues.map((type) => formatCoding(type?.value) || type?.value);
+}
+
+function multiSelectOnChange(
+  selected: string[],
+  propertyName: string,
+  item: QuestionnaireItem
+): QuestionnaireResponseItemAnswer[] {
+  return selected.map((o) => {
+    const option = item.answerOption?.find(
+      (option) =>
+        formatCoding(option.valueCoding) === o || option[propertyName as keyof QuestionnaireItemAnswerOption] === o
+    );
+    const optionValue = getTypedPropertyValue(
+      { type: 'QuestionnaireItemAnswerOption', value: option },
+      'value'
+    ) as TypedValue;
+    return { [propertyName]: optionValue.value };
+  });
 }
 
 function getCurrentRadioAnswer(options: [string, TypedValue][], defaultAnswer: TypedValue): string | undefined {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -3,6 +3,7 @@ import {
   PropertyType,
   TypedValue,
   capitalize,
+  deepEquals,
   formatCoding,
   getTypedPropertyValue,
   globalSchema,
@@ -507,8 +508,5 @@ function getRetainedMultiSelectAnswer(
 }
 
 function getRetainedRadioAnswer(options: [string, TypedValue][], defaultAnswer: TypedValue): string | undefined {
-  return options.find(
-    (option) =>
-      option[1].value === defaultAnswer?.value || formatCoding(option[1].value) === formatCoding(defaultAnswer?.value)
-  )?.[0];
+  return options.find((option) => deepEquals(option[1].value, defaultAnswer?.value))?.[0];
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -257,7 +257,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         defaultValue={currentAnswer || [typedValueToString(initialValue)]}
         onChange={(selected) => {
           const values = getNewMultiSelectValues(selected, propertyName, item);
-          props.onChangeAnswer(values as QuestionnaireResponseItemAnswer[]);
+          props.onChangeAnswer(values);
         }}
       />
     );

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -24,7 +24,7 @@ import { QuantityInput } from '../../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
 import { ResourcePropertyDisplay } from '../../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
-import { QuestionnaireItemType } from '../../utils/questionnaire';
+import { QuestionnaireItemType, onChangeMultiSelectValues } from '../../utils/questionnaire';
 
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
@@ -256,7 +256,7 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
         searchable
         defaultValue={currentAnswer || [typedValueToString(initialValue)]}
         onChange={(selected) => {
-          const values = multiSelectOnChange(selected, propertyName, item);
+          const values = onChangeMultiSelectValues(selected, propertyName, item);
           props.onChangeAnswer(values as QuestionnaireResponseItemAnswer[]);
         }}
       />
@@ -496,24 +496,6 @@ function getCurrentMultiSelectAnswer(
   }
   const typedValues = selectedItem.map((a) => getItemValue(a));
   return typedValues.map((type) => formatCoding(type?.value) || type?.value);
-}
-
-function multiSelectOnChange(
-  selected: string[],
-  propertyName: string,
-  item: QuestionnaireItem
-): QuestionnaireResponseItemAnswer[] {
-  return selected.map((o) => {
-    const option = item.answerOption?.find(
-      (option) =>
-        formatCoding(option.valueCoding) === o || option[propertyName as keyof QuestionnaireItemAnswerOption] === o
-    );
-    const optionValue = getTypedPropertyValue(
-      { type: 'QuestionnaireItemAnswerOption', value: option },
-      'value'
-    ) as TypedValue;
-    return { [propertyName]: optionValue.value };
-  });
 }
 
 function getCurrentRadioAnswer(options: [string, TypedValue][], defaultAnswer: TypedValue): string | undefined {

--- a/packages/react/src/utils/questionnaire.test.ts
+++ b/packages/react/src/utils/questionnaire.test.ts
@@ -1,5 +1,5 @@
 import { QuestionnaireItemEnableWhen } from '@medplum/fhirtypes';
-import { isChoiceQuestion, isQuestionEnabled } from './questionnaire';
+import { isChoiceQuestion, isQuestionEnabled, onChangeMultiSelectValues } from './questionnaire';
 
 describe('QuestionnaireUtils', () => {
   test('isChoiceQuestion', () => {
@@ -888,5 +888,85 @@ describe('isQuestionEnabled', () => {
         ]
       )
     ).toBe(false);
+  });
+
+  test('multi-select map selected values', () => {
+    const selected = ['value1', 'value2'];
+    const propertyName = 'valueString';
+    const item = {
+      answerOption: [
+        {
+          valueString: 'value1',
+        },
+        {
+          valueString: 'value2',
+        },
+      ],
+    };
+
+    const result = onChangeMultiSelectValues(selected, propertyName, item);
+
+    expect(result).toEqual([{ valueString: 'value1' }, { valueString: 'value2' }]);
+  });
+
+  test('multi-select non selected values', () => {
+    const selected = ['nonMatchingValue'];
+    const propertyName = 'valueString';
+    const item = {
+      answerOption: [
+        {
+          valueString: 'value1',
+        },
+        {
+          valueString: 'value2',
+        },
+      ],
+    };
+
+    const result = onChangeMultiSelectValues(selected, propertyName, item);
+
+    expect(result).toEqual([{ valueString: undefined }]);
+  });
+
+  test('multi-select empty array', () => {
+    const selected: string[] = [];
+    const propertyName = 'valueString';
+    const item = {
+      answerOption: [{ valueString: 'value1' }, { valueString: 'value2' }],
+    };
+
+    const result = onChangeMultiSelectValues(selected, propertyName, item);
+
+    expect(result).toEqual([]);
+  });
+
+  test('multi-select with value coding', () => {
+    const selected = ['code1'];
+    const propertyName = 'valueCoding';
+    const item = {
+      answerOption: [
+        {
+          valueCoding: { code: 'code1' },
+        },
+        {
+          valueCoding: { code: 'code2' },
+        },
+      ],
+    };
+
+    const result = onChangeMultiSelectValues(selected, propertyName, item);
+    expect(result).toEqual([{ valueCoding: { code: 'code1' } }]);
+  });
+
+  test('multi-select with non existing values', () => {
+    const selected = ['value1'];
+    const propertyName = 'nonExistingProperty';
+    const item = {
+      answerOption: [{ valueString: 'value1' }],
+    };
+
+    const result = onChangeMultiSelectValues(selected, propertyName, item);
+
+    expect(result).toEqual([{ nonExistingProperty: undefined }]);
   });
 });

--- a/packages/react/src/utils/questionnaire.test.ts
+++ b/packages/react/src/utils/questionnaire.test.ts
@@ -1,5 +1,5 @@
 import { QuestionnaireItemEnableWhen } from '@medplum/fhirtypes';
-import { isChoiceQuestion, isQuestionEnabled, onChangeMultiSelectValues } from './questionnaire';
+import { isChoiceQuestion, isQuestionEnabled, getNewMultiSelectValues } from './questionnaire';
 
 describe('QuestionnaireUtils', () => {
   test('isChoiceQuestion', () => {
@@ -904,7 +904,7 @@ describe('isQuestionEnabled', () => {
       ],
     };
 
-    const result = onChangeMultiSelectValues(selected, propertyName, item);
+    const result = getNewMultiSelectValues(selected, propertyName, item);
 
     expect(result).toEqual([{ valueString: 'value1' }, { valueString: 'value2' }]);
   });
@@ -923,7 +923,7 @@ describe('isQuestionEnabled', () => {
       ],
     };
 
-    const result = onChangeMultiSelectValues(selected, propertyName, item);
+    const result = getNewMultiSelectValues(selected, propertyName, item);
 
     expect(result).toEqual([{ valueString: undefined }]);
   });
@@ -935,7 +935,7 @@ describe('isQuestionEnabled', () => {
       answerOption: [{ valueString: 'value1' }, { valueString: 'value2' }],
     };
 
-    const result = onChangeMultiSelectValues(selected, propertyName, item);
+    const result = getNewMultiSelectValues(selected, propertyName, item);
 
     expect(result).toEqual([]);
   });
@@ -954,7 +954,7 @@ describe('isQuestionEnabled', () => {
       ],
     };
 
-    const result = onChangeMultiSelectValues(selected, propertyName, item);
+    const result = getNewMultiSelectValues(selected, propertyName, item);
     expect(result).toEqual([{ valueCoding: { code: 'code1' } }]);
   });
 
@@ -965,7 +965,7 @@ describe('isQuestionEnabled', () => {
       answerOption: [{ valueString: 'value1' }],
     };
 
-    const result = onChangeMultiSelectValues(selected, propertyName, item);
+    const result = getNewMultiSelectValues(selected, propertyName, item);
 
     expect(result).toEqual([{ nonExistingProperty: undefined }]);
   });

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -1,6 +1,7 @@
-import { TypedValue, evalFhirPathTyped, getTypedPropertyValue } from '@medplum/core';
+import { TypedValue, evalFhirPathTyped, formatCoding, getTypedPropertyValue } from '@medplum/core';
 import {
   QuestionnaireItem,
+  QuestionnaireItemAnswerOption,
   QuestionnaireItemEnableWhen,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
@@ -58,6 +59,24 @@ export function isQuestionEnabled(item: QuestionnaireItem, responseItems: Questi
   }
 
   return enableBehavior !== 'any';
+}
+
+export function onChangeMultiSelectValues(
+  selected: string[],
+  propertyName: string,
+  item: QuestionnaireItem
+): QuestionnaireResponseItemAnswer[] {
+  return selected.map((o) => {
+    const option = item.answerOption?.find(
+      (option) =>
+        formatCoding(option.valueCoding) === o || option[propertyName as keyof QuestionnaireItemAnswerOption] === o
+    );
+    const optionValue = getTypedPropertyValue(
+      { type: 'QuestionnaireItemAnswerOption', value: option },
+      'value'
+    ) as TypedValue;
+    return { [propertyName]: optionValue?.value };
+  });
 }
 
 function getByLinkId(

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -61,7 +61,7 @@ export function isQuestionEnabled(item: QuestionnaireItem, responseItems: Questi
   return enableBehavior !== 'any';
 }
 
-export function onChangeMultiSelectValues(
+export function getNewMultiSelectValues(
   selected: string[],
   propertyName: string,
   item: QuestionnaireItem


### PR DESCRIPTION
In the QuestionnaireItem values, we used QuestionnaireItemAnswerOption which didn't have boolean as a backbone element. QuestionnaireItemAnswer fixes the retained values of the checkbox

In the Multi-stepper, we are changing the data format to strings. In the onChange, we retrieve the values based on the option matched and getting the whole value in the response

<img width="922" alt="Screenshot 2023-10-02 at 3 15 45 PM" src="https://github.com/medplum/medplum/assets/6913745/8c23f8d2-3bfd-4252-baa9-d7e9d25f2d2a">



https://github.com/medplum/medplum/assets/6913745/4bf6f0a5-36de-433a-9d2c-91d4e2a6a8c5



https://github.com/medplum/medplum/assets/6913745/b5b3226b-7139-41b2-823d-4f0fdf47ca3a



