### PR TITLE
Add request IDs to error responses

### DIFF
--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -3,6 +3,7 @@ import { OperationOutcome } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Response } from 'express';
 import { Result, ValidationError } from 'express-validator';
+import { getRequestContext } from '../context';
 
 export function invalidRequest(errors: Result<ValidationError>): OperationOutcome {
   return {
@@ -26,8 +27,20 @@ function getValidationErrorExpression(error: ValidationError): string[] | undefi
 }
 
 export function sendOutcome(res: Response, outcome: OperationOutcome): Response {
+  const ctx = getRequestContext();
   if (isAccepted(outcome) && outcome.issue?.[0].diagnostics) {
     res.set('Content-Location', outcome.issue[0].diagnostics);
   }
-  return res.status(getStatus(outcome)).json(outcome);
+  return res.status(getStatus(outcome)).json({
+    ...outcome,
+    extension: [
+      {
+        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
+        extension: [
+          { url: 'requestId', valueUuid: ctx.requestId },
+          { url: 'traceId', valueUuid: ctx.traceId },
+        ],
+      },
+    ],
+  } as OperationOutcome);
 }


### PR DESCRIPTION
Attaching the request and trace IDs to all `OperationOutcome` error responses is intended to aid in troubleshooting by allowing easy correlation of a given error response to all server logs associated with the corresponding request.  For example, an error response from the server might look like:
```json
{
    "extension": [
        {
            "extension": [
                {
                    "url": "requestId",
                    "valueUuid": "6bf2cf1d-9b75-4547-b0a9-61cc2c7aa99f"
                },
                {
                    "url": "traceId",
                    "valueUuid": "44130e70-8ca3-4400-b270-c05ea7085787"
                }
            ],
            "url": "https://medplum.com/fhir/StructureDefinition/tracing"
        }
    ],
    "id": "not-found",
    "issue": [
        {
            "code": "not-found",
            "details": {
                "text": "Not found"
            },
            "severity": "error"
        }
    ],
    "resourceType": "OperationOutcome"
}
```

In [AWS CloudWatch Logs Insights][aws-log-insights], you can easily query for all associated logs in chronological order:
```
fields timestamp, level, msg
| filter requestId = '6bf2cf1d-9b75-4547-b0a9-61cc2c7aa99f'
| sort timestamp asc
```

[aws-log-insights]: https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:logs-insights