### PR TITLE
Update sweep.yaml

### DIFF
--- a/sweep.yaml
+++ b/sweep.yaml
@@ -2,3 +2,13 @@
 branch: 'main'
 gha_enabled: True
 description: 'In the packages directory, a file will usually have tests located in the same folder. Please make sure we update the tests in this case. For example if you modify packages/fhir-router/src/urlrouter.ts, you should check packages/fhir-router/src/urlrouter.tests.ts in case we need to test the new code. We care about test coverage, so if you add a separate execution path, add a new test rather than replacing the logic.'
+
+sandbox:
+  install:
+    - npm i
+  check:
+    - npx prettier --write {file_path}
+    - 'npx eslint --rule "@typescript-eslint/no-redundant-type-constituents: off" {file_path}'
+  
+rules:
+  - Every time a new component gets created, write a unit test for it. For example, if FileName.tsx is created, write a unit test titled FileName.test.tsx.


### PR DESCRIPTION
Updated `sweep.yaml` to run `prettier` and `eslint`. I tried also setting up building and testing but it doesn't seem like it's succeeding, I'm getting the error logs below.

Wrote a Sweep rule to always write unit tests so that if a PR is merged without a corresponding unit test a corresponding unit test will be written.

```
@medplum/core:build: > @medplum/core@2.1.1 clean
@medplum/core:build: > rimraf dist
@medplum/core:build: 
@medplum/core:build: node:internal/errors:464
@medplum/core:build:     ErrorCaptureStackTrace(err);
@medplum/core:build:     ^
@medplum/core:build: 
@medplum/core:build: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".json" for /home/kevin/medplum/packages/core/package.json
@medplum/core:build:     at new NodeError (node:internal/errors:371:5)
@medplum/core:build:     at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:87:11)
@medplum/core:build:     at defaultGetFormat (node:internal/modules/esm/get_format:102:38)
@medplum/core:build:     at defaultLoad (node:internal/modules/esm/load:21:14)
@medplum/core:build:     at ESMLoader.load (node:internal/modules/esm/loader:359:26)
@medplum/core:build:     at ESMLoader.moduleProvider (node:internal/modules/esm/loader:280:58)
@medplum/core:build:     at new ModuleJob (node:internal/modules/esm/module_job:66:26)
@medplum/core:build:     at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:297:17)
@medplum/core:build:     at ESMLoader.getModuleJob (node:internal/modules/esm/loader:261:34)
@medplum/core:build:     at async ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:81:21) {
@medplum/core:build:   code: 'ERR_UNKNOWN_FILE_EXTENSION'
@medplum/core:build: }
@medplum/core:build: npm ERR! Lifecycle script `build` failed with error: 
@medplum/core:build: npm ERR! Error: command failed 
@medplum/core:build: npm ERR!   in workspace: @medplum/core@2.1.1 
@medplum/core:build: npm ERR!   at location: /home/kevin/medplum/packages/core 
@medplum/core:build: ERROR: command finished with error: command (/home/kevin/medplum/packages/core) npm run build exited (1)
@medplum/core#build: command (/home/kevin/medplum/packages/core) npm run build exited (1)
```