### PR TITLE
CLI tools to send and receive HL7 messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51467,6 +51467,7 @@
         "@aws-sdk/client-sts": "3.414.0",
         "@aws-sdk/types": "3.413.0",
         "@medplum/core": "*",
+        "@medplum/hl7": "*",
         "aws-sdk-client-mock": "3.0.0",
         "commander": "11.0.0",
         "dotenv": "16.3.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/client-sts": "3.414.0",
     "@aws-sdk/types": "3.413.0",
     "@medplum/core": "*",
+    "@medplum/hl7": "*",
     "aws-sdk-client-mock": "3.0.0",
     "commander": "11.0.0",
     "dotenv": "16.3.1",

--- a/packages/cli/src/hl7.test.ts
+++ b/packages/cli/src/hl7.test.ts
@@ -32,7 +32,7 @@ describe('HL7 commands', () => {
     (console.log as unknown as jest.Mock).mockClear();
 
     // Send a generated message
-    await main(['node', 'index.js', 'hl7', 'send', 'localhost', '56999', '--generate']);
+    await main(['node', 'index.js', 'hl7', 'send', 'localhost', '56999', '--generate-example']);
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('MSH|^~\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|'));
     (console.log as unknown as jest.Mock).mockClear();
 

--- a/packages/cli/src/hl7.test.ts
+++ b/packages/cli/src/hl7.test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import net from 'net';
+import { generateSampleHl7Message } from './hl7';
+import { main } from './index';
+
+describe('HL7 commands', () => {
+  test('Client and server', async () => {
+    console.error = jest.fn();
+    console.log = jest.fn();
+
+    const originalCreateServer = net.createServer;
+    let capturedReturnValue: net.Server | undefined = undefined;
+
+    const createServerSpy = jest.spyOn(net, 'createServer').mockImplementation((...args) => {
+      capturedReturnValue = originalCreateServer(...args);
+      return capturedReturnValue;
+    });
+
+    // Start a server
+    await main(['node', 'index.js', 'hl7', 'listen', '56999']);
+    expect(console.log).toHaveBeenCalledWith('Listening on port 56999');
+    (console.log as unknown as jest.Mock).mockClear();
+
+    // Send a message with missing body
+    await main(['node', 'index.js', 'hl7', 'send', 'localhost', '56999', '']);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Missing HL7 message body'));
+
+    // Send a message from file
+    jest.spyOn(fs, 'readFileSync').mockImplementation(() => generateSampleHl7Message());
+    await main(['node', 'index.js', 'hl7', 'send', 'localhost', '56999', '--file', 'sample.hl7']);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('MSH|^~\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|'));
+    (console.log as unknown as jest.Mock).mockClear();
+
+    // Send a generated message
+    await main(['node', 'index.js', 'hl7', 'send', 'localhost', '56999', '--generate']);
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('MSH|^~\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|'));
+    (console.log as unknown as jest.Mock).mockClear();
+
+    expect(createServerSpy).toHaveBeenCalled();
+    (capturedReturnValue as unknown as net.Server).close();
+    createServerSpy.mockRestore();
+  });
+});

--- a/packages/cli/src/hl7.ts
+++ b/packages/cli/src/hl7.ts
@@ -1,0 +1,58 @@
+import { formatHl7DateTime, Hl7Message } from '@medplum/core';
+import { Hl7Client, Hl7Server } from '@medplum/hl7';
+import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { createMedplumCommand } from './util/command';
+
+const HL7_NOW = formatHl7DateTime(new Date());
+const HL7_CONTROL_ID = Date.now().toString();
+const SAMPLE_HL7_MESSAGE = `MSH|^~\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|${HL7_NOW}||ADT^A01|${HL7_CONTROL_ID}|P|2.5|
+EVN|A01|${HL7_NOW}||
+PID|1|12345|12345^^^HOSP^MR|123456|DOE^JOHN^MIDDLE^SUFFIX|19800101|M|||123 STREET^APT 4B^CITY^ST^12345-6789||555-555-5555||S|
+PV1|1|I|2000^2012^01||||12345^DOCTOR^DOC||||||||||1234567^DOCTOR^DOC||AMB|||||||||||||||||||||||||202309280900|`;
+
+const send = createMedplumCommand('send')
+  .description('Send an HL7 v2 message via MLLP')
+  .argument('<host>', 'The destination host name or IP address')
+  .argument('<port>', 'The destination port number')
+  .argument('[body]', 'Optional HL7 message body')
+  .option('--generate', 'Generate a sample HL7 message')
+  .option('--file', 'Read the HL7 message from a file')
+  .action(async (host, port, body, options) => {
+    if (options.generate) {
+      body = SAMPLE_HL7_MESSAGE;
+    } else if (options.file) {
+      body = readFileSync(resolve(process.cwd(), body), 'utf8');
+    }
+
+    if (!body) {
+      throw new Error('Missing HL7 message body');
+    }
+
+    const client = new Hl7Client({
+      host,
+      port: parseInt(port, 10),
+    });
+
+    const response = await client.sendAndWait(Hl7Message.parse(body));
+    console.log(response.toString().replaceAll('\r', '\n'));
+    client.close();
+  });
+
+const listen = createMedplumCommand('listen')
+  .description('Starts an HL7 v2 MLLP server')
+  .argument('<port>')
+  .action(async (port) => {
+    const server = new Hl7Server((connection) => {
+      connection.addEventListener('message', ({ message }) => {
+        console.log(message.toString().replaceAll('\r', '\n'));
+        connection.send(message.buildAck());
+      });
+    });
+
+    server.start(parseInt(port, 10));
+    console.log('Listening on port ' + port);
+  });
+
+export const hl7 = new Command('hl7').addCommand(send).addCommand(listen);

--- a/packages/cli/src/hl7.ts
+++ b/packages/cli/src/hl7.ts
@@ -2,15 +2,7 @@ import { formatHl7DateTime, Hl7Message } from '@medplum/core';
 import { Hl7Client, Hl7Server } from '@medplum/hl7';
 import { Command } from 'commander';
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
 import { createMedplumCommand } from './util/command';
-
-const HL7_NOW = formatHl7DateTime(new Date());
-const HL7_CONTROL_ID = Date.now().toString();
-const SAMPLE_HL7_MESSAGE = `MSH|^~\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|${HL7_NOW}||ADT^A01|${HL7_CONTROL_ID}|P|2.5|
-EVN|A01|${HL7_NOW}||
-PID|1|12345|12345^^^HOSP^MR|123456|DOE^JOHN^MIDDLE^SUFFIX|19800101|M|||123 STREET^APT 4B^CITY^ST^12345-6789||555-555-5555||S|
-PV1|1|I|2000^2012^01||||12345^DOCTOR^DOC||||||||||1234567^DOCTOR^DOC||AMB|||||||||||||||||||||||||202309280900|`;
 
 const send = createMedplumCommand('send')
   .description('Send an HL7 v2 message via MLLP')
@@ -18,12 +10,12 @@ const send = createMedplumCommand('send')
   .argument('<port>', 'The destination port number')
   .argument('[body]', 'Optional HL7 message body')
   .option('--generate', 'Generate a sample HL7 message')
-  .option('--file', 'Read the HL7 message from a file')
+  .option('--file <file>', 'Read the HL7 message from a file')
   .action(async (host, port, body, options) => {
     if (options.generate) {
-      body = SAMPLE_HL7_MESSAGE;
+      body = generateSampleHl7Message();
     } else if (options.file) {
-      body = readFileSync(resolve(process.cwd(), body), 'utf8');
+      body = readFileSync(options.file, 'utf8');
     }
 
     if (!body) {
@@ -56,3 +48,12 @@ const listen = createMedplumCommand('listen')
   });
 
 export const hl7 = new Command('hl7').addCommand(send).addCommand(listen);
+
+export function generateSampleHl7Message(): string {
+  const now = formatHl7DateTime(new Date());
+  const controlId = Date.now().toString();
+  return `MSH|^~\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|${now}||ADT^A01|${controlId}|P|2.5|
+EVN|A01|${now}||
+PID|1|12345|12345^^^HOSP^MR|123456|DOE^JOHN^MIDDLE^SUFFIX|19800101|M|||123 STREET^APT 4B^CITY^ST^12345-6789||555-555-5555||S|
+PV1|1|I|2000^2012^01||||12345^DOCTOR^DOC||||||||||1234567^DOCTOR^DOC||AMB|||||||||||||||||||||||||202309280900|`;
+}

--- a/packages/cli/src/hl7.ts
+++ b/packages/cli/src/hl7.ts
@@ -9,7 +9,7 @@ const send = createMedplumCommand('send')
   .argument('<host>', 'The destination host name or IP address')
   .argument('<port>', 'The destination port number')
   .argument('[body]', 'Optional HL7 message body')
-  .option('--generate', 'Generate a sample HL7 message')
+  .option('--generate-example', 'Generate a sample HL7 message')
   .option('--file <file>', 'Read the HL7 message from a file')
   .action(async (host, port, body, options) => {
     if (options.generate) {
@@ -27,9 +27,12 @@ const send = createMedplumCommand('send')
       port: parseInt(port, 10),
     });
 
-    const response = await client.sendAndWait(Hl7Message.parse(body));
-    console.log(response.toString().replaceAll('\r', '\n'));
-    client.close();
+    try {
+      const response = await client.sendAndWait(Hl7Message.parse(body));
+      console.log(response.toString().replaceAll('\r', '\n'));
+    } finally {
+      client.close();
+    }
   });
 
 const listen = createMedplumCommand('listen')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,9 +5,10 @@ import { login, whoami } from './auth';
 import { aws } from './aws/index';
 import { bot, createBotDeprecate, deployBotDeprecate, saveBotDeprecate } from './bots';
 import { bulk } from './bulk';
+import { hl7 } from './hl7';
+import { profile } from './profiles';
 import { project } from './project';
 import { deleteObject, get, patch, post, put } from './rest';
-import { profile } from './profiles';
 
 export async function main(argv: string[]): Promise<void> {
   try {
@@ -44,6 +45,9 @@ export async function main(argv: string[]): Promise<void> {
 
     // AWS commands
     index.addCommand(aws);
+
+    // HL7 commands
+    index.addCommand(hl7);
 
     await index.parseAsync(argv);
   } catch (err) {


### PR DESCRIPTION
Start an HL7 server on port 56001:

```bash
medplum hl7 listen 56001
```

Send an HL7 message to that server:

```bash
medplum hl7 send localhost 56001 'MSH|...'
```

Don't want to type in an HL7 message?  No problem.

Send an automatically generated message to the server:

```bash
medplum hl7 send localhost 56001 --generate
```

Send a message stored in a file:

```bash
medplum hl7 send localhost 56001 --file my-sample-hl7.txt
```

I briefly looked into supporting piped input, but it looks like we need to handle that at a lower level, so saving that for another day: https://github.com/tj/commander.js/issues/137