### PR TITLE
Ignore unrecognized references in convertToTransactionBundle

### DIFF
--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -184,6 +184,34 @@ describe('Bundle tests', () => {
       const specimen = transaction.entry?.find((e) => e.resource?.resourceType === 'Specimen')?.resource as Specimen;
       expect(isUUID(specimen?.subject?.reference?.split(':')[2] ?? '')).toBeTruthy();
     });
+
+    test('Ignore unrecognized references', () => {
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        entry: [
+          {
+            fullUrl: 'https://example.com/Specimen/xyz',
+            resource: {
+              resourceType: 'Specimen',
+              subject: { reference: 'Patient/xyz' },
+            },
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+      expect(result).toMatchObject({
+        resourceType: 'Bundle',
+        entry: [
+          {
+            resource: {
+              resourceType: 'Specimen',
+              subject: { reference: 'Patient/xyz' },
+            },
+          },
+        ],
+      });
+    });
   });
 
   describe('convertContainedResourcesToBundle', () => {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -54,7 +54,10 @@ function referenceReplacer(key: string, value: string, idToUuid: Record<string, 
       id = value.slice(1);
     }
     if (id) {
-      return 'urn:uuid:' + idToUuid[id];
+      const replacement = idToUuid[id];
+      if (replacement) {
+        return 'urn:uuid:' + replacement;
+      }
     }
   }
   return value;


### PR DESCRIPTION
`convertToTransactionBundle` is a helper utility in `@medplum/core` which will convert a non-transaction `Bundle` into a transaction `Bundle` by reordering resources and rewriting references.

I ran into an issue where valid references in the `Bundle` were being replaced with `urn:uuid:undefined`.

This PR fixes that, so that unrecognized references are ignored and left alone, because they could be perfectly valid.  It is up to the server to resolve and enforce them.