### PR TITLE
Added setIdentifier helper

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -35,6 +35,7 @@ import {
   resolveId,
   ResourceWithCode,
   setCodeBySystem,
+  setIdentifier,
   stringify,
 } from './utils';
 
@@ -347,6 +348,26 @@ describe('Core Utils', () => {
     expect(
       getIdentifier({ resourceType: 'SpecimenDefinition', identifier: { system: 'y', value: 'y' } }, 'x')
     ).toBeUndefined();
+  });
+
+  test('Set identifier', () => {
+    const r1: Patient = { resourceType: 'Patient' };
+    setIdentifier(r1, 'x', 'y');
+    expect(r1).toEqual({ resourceType: 'Patient', identifier: [{ system: 'x', value: 'y' }] });
+
+    const r2: Patient = { resourceType: 'Patient', identifier: [] };
+    setIdentifier(r2, 'x', 'y');
+    expect(r2).toEqual({ resourceType: 'Patient', identifier: [{ system: 'x', value: 'y' }] });
+
+    const r3: Patient = { resourceType: 'Patient', identifier: [{ system: 'a', value: 'b' }] };
+    setIdentifier(r3, 'x', 'y');
+    expect(r3).toEqual({
+      resourceType: 'Patient',
+      identifier: [
+        { system: 'a', value: 'b' },
+        { system: 'x', value: 'y' },
+      ],
+    });
   });
 
   test('Get extension value', () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -368,6 +368,13 @@ describe('Core Utils', () => {
         { system: 'x', value: 'y' },
       ],
     });
+
+    const r4: Patient = { resourceType: 'Patient', identifier: [{ system: 'x', value: 'b' }] };
+    setIdentifier(r4, 'x', 'y');
+    expect(r4).toEqual({
+      resourceType: 'Patient',
+      identifier: [{ system: 'x', value: 'y' }],
+    });
   });
 
   test('Get extension value', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -3,6 +3,7 @@ import {
   CodeableConcept,
   Device,
   Extension,
+  Identifier,
   ObservationDefinition,
   ObservationDefinitionQualifiedInterval,
   Patient,
@@ -344,6 +345,36 @@ export function getIdentifier(resource: Resource, system: string): string | unde
     }
   }
   return undefined;
+}
+
+/**
+ * Sets a resource identifier for the given system.
+ *
+ * Note that this method is only available on resources that have an "identifier" property,
+ * and that property must be an array of Identifier objects,
+ * which is not true for all FHIR resources.
+ *
+ * If the identifier already exists, then the value is updated.
+ *
+ * Otherwise a new identifier is added.
+ *
+ * @param resource The resource to add the identifier to.
+ * @param system The identifier system.
+ * @param value The identifier value.
+ */
+export function setIdentifier(resource: Resource & { identifier?: Identifier[] }, system: string, value: string): void {
+  const identifiers = resource.identifier;
+  if (!identifiers) {
+    resource.identifier = [{ system, value }];
+    return;
+  }
+  for (const identifier of identifiers) {
+    if (identifier.system === system) {
+      identifier.value = value;
+      return;
+    }
+  }
+  identifiers.push({ system, value });
 }
 
 /**


### PR DESCRIPTION
Adding the complement to `getIdentifier`

This will be useful in the Health Gorilla demo bots.  I'm intentionally not using it in those bots yet, because we need this to go out in a release first before we update the bot lambda layer.