### PR TITLE
Fixes #2971 - update Questionnaire reference inputs

### DIFF
--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -2,9 +2,9 @@ import { Button, createStyles, Navbar as MantineNavbar, ScrollArea, Space, Text 
 import { IconPlus } from '@tabler/icons-react';
 import React, { useState } from 'react';
 import { BookmarkDialog } from '../BookmarkDialog/BookmarkDialog';
-import { CodeInput } from '../CodeInput/CodeInput';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { useMedplumNavigate } from '../MedplumProvider/MedplumProvider';
+import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
 
 const useStyles = createStyles((theme) => {
   return {
@@ -103,20 +103,11 @@ export function Navbar(props: NavbarProps): JSX.Element {
       <MantineNavbar width={{ sm: 250 }} p="xs">
         <ScrollArea>
           <MantineNavbar.Section mb="sm">
-            <CodeInput
+            <ResourceTypeInput
               key={window.location.pathname}
               name="resourceType"
               placeholder="Resource Type"
-              property={{
-                binding: {
-                  valueSet: 'https://medplum.com/fhir/ValueSet/resource-types',
-                },
-              }}
               onChange={(newValue) => navigateResourceType(newValue)}
-              creatable={false}
-              maxSelectedValues={0}
-              clearSearchOnChange={true}
-              clearable={false}
             />
           </MantineNavbar.Section>
           <MantineNavbar.Section grow>

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
@@ -460,18 +460,18 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Reference 1'));
     });
     await act(async () => {
-      fireEvent.click(screen.getByText('Add Resource'));
+      fireEvent.click(screen.getByText('Add Resource Type'));
     });
     await act(async () => {
-      fireEvent.change(screen.getByDisplayValue(''), {
+      fireEvent.change(screen.getByPlaceholderText('Resource Type'), {
         target: { value: 'Patient' },
       });
     });
     await act(async () => {
-      fireEvent.click(screen.getByText('Add Resource'));
+      fireEvent.click(screen.getByText('Add Resource Type'));
     });
     await act(async () => {
-      fireEvent.change(screen.getByDisplayValue(''), {
+      fireEvent.change(screen.getAllByPlaceholderText('Resource Type')[1], {
         target: { value: 'Organization' },
       });
     });

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -592,9 +592,9 @@ function ReferenceProfiles(props: ReferenceTypeProps): JSX.Element {
   const targetTypes = getQuestionnaireItemReferenceTargetTypes(props.item) ?? [];
   return (
     <>
-      {targetTypes.map((targetType: ResourceType) => {
+      {targetTypes.map((targetType: ResourceType, index: number) => {
         return (
-          <Group key={targetType}>
+          <Group key={`${targetType}-${index}`}>
             <ResourceTypeInput
               name="resourceType"
               placeholder="Resource Type"

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -1,12 +1,23 @@
-import { Anchor, Box, Button, createStyles, NativeSelect, Space, Textarea, TextInput, Title } from '@mantine/core';
+import {
+  Anchor,
+  Box,
+  Button,
+  createStyles,
+  Group,
+  NativeSelect,
+  Space,
+  Textarea,
+  TextInput,
+  Title,
+} from '@mantine/core';
 import { globalSchema, IndexedStructureDefinition, isResource as isResourceType } from '@medplum/core';
 import {
-  Coding,
   Extension,
   Questionnaire,
   QuestionnaireItem,
   QuestionnaireItemAnswerOption,
   Reference,
+  ResourceType,
 } from '@medplum/fhirtypes';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
 import React, { useEffect, useRef, useState } from 'react';
@@ -15,9 +26,15 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider';
 import { QuestionnaireFormItem } from '../QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { ResourcePropertyInput } from '../ResourcePropertyInput/ResourcePropertyInput';
+import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
 import { useResource } from '../useResource/useResource';
 import { killEvent } from '../utils/dom';
-import { isChoiceQuestion, QuestionnaireItemType } from '../utils/questionnaire';
+import {
+  getQuestionnaireItemReferenceTargetTypes,
+  isChoiceQuestion,
+  QuestionnaireItemType,
+  setQuestionnaireItemReferenceTargetTypes,
+} from '../utils/questionnaire';
 
 const useStyles = createStyles((theme) => ({
   section: {
@@ -264,9 +281,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
                 onChange={(e) => changeProperty('text', e.currentTarget.value)}
               />
             )}
-            {item.type === 'reference' && (
-              <ReferenceProfiles item={item} onChange={(newOptions) => changeProperty('extension', newOptions)} />
-            )}
+            {item.type === 'reference' && <ReferenceProfiles item={item} onChange={updateItem} />}
             {isChoiceQuestion(item) && <AnswerBuilder item={item} onChange={(item) => updateItem(item)} />}
           </>
         ) : (
@@ -570,82 +585,54 @@ function AnswerOptionsInput(props: AnswerOptionsInputProps): JSX.Element {
 
 interface ReferenceTypeProps {
   item: QuestionnaireItem;
-  onChange: (newOptions: QuestionnaireItemAnswerOption[]) => void;
+  onChange: (updatedItem: QuestionnaireItem) => void;
 }
 
 function ReferenceProfiles(props: ReferenceTypeProps): JSX.Element {
-  const references = props.item.extension ?? [];
-  const referenceProfiles =
-    references.filter((e) => e.url === 'http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource') ?? [];
+  const targetTypes = getQuestionnaireItemReferenceTargetTypes(props.item) ?? [];
   return (
     <>
-      {referenceProfiles.map((reference: Extension) => {
+      {targetTypes.map((targetType: ResourceType) => {
         return (
-          <div key={reference.id}>
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                width: '80%',
+          <Group key={targetType}>
+            <ResourceTypeInput
+              name="resourceType"
+              placeholder="Resource Type"
+              defaultValue={targetType}
+              onChange={(newValue: ResourceType | undefined) => {
+                props.onChange(
+                  setQuestionnaireItemReferenceTargetTypes(
+                    props.item,
+                    targetTypes.map((t) => (t === targetType ? (newValue as ResourceType) : t))
+                  )
+                );
+              }}
+            />
+            <Anchor
+              href="#"
+              onClick={(e: React.SyntheticEvent) => {
+                killEvent(e);
+                props.onChange(
+                  setQuestionnaireItemReferenceTargetTypes(
+                    props.item,
+                    targetTypes.filter((t) => t !== targetType)
+                  )
+                );
               }}
             >
-              <div>
-                <TextInput
-                  key={reference.id}
-                  name="value[x]"
-                  value={reference.valueCodeableConcept?.coding?.[0].code ?? ''}
-                  onChange={(e: any) => {
-                    e.preventDefault();
-                    const newReferences = [...references];
-                    const index = newReferences.findIndex((o) => o.id === reference.id);
-                    const coding = newReferences[index].valueCodeableConcept?.coding?.[0] ?? ([] as Coding);
-                    coding.display = e.target.value;
-                    coding.code = e.target.value;
-
-                    props.onChange(newReferences);
-                  }}
-                />
-              </div>
-            </div>
-            <div>
-              <Anchor
-                href="#"
-                onClick={(e: React.SyntheticEvent) => {
-                  killEvent(e);
-                  props.onChange(references.filter((r) => r.id !== reference.id));
-                }}
-              >
-                Remove
-              </Anchor>
-            </div>
-          </div>
+              Remove
+            </Anchor>
+          </Group>
         );
       })}
       <Anchor
         href="#"
         onClick={(e: React.SyntheticEvent) => {
           killEvent(e);
-          props.onChange([
-            ...references,
-            {
-              id: generateId(),
-              url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource',
-              valueCodeableConcept: {
-                coding: [
-                  {
-                    system: 'http://hl7.org/fhir/fhir-types',
-                    display: '',
-                    code: '',
-                  },
-                ],
-              },
-            },
-          ]);
+          props.onChange(setQuestionnaireItemReferenceTargetTypes(props.item, [...targetTypes, '' as ResourceType]));
         }}
       >
-        Add Resource
+        Add Resource Type
       </Anchor>
     </>
   );

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -548,7 +548,7 @@ describe('QuestionnaireForm', () => {
       onSubmit,
     });
 
-    const input = screen.getByTestId('reference-input-resource-type-input');
+    const input = screen.getByPlaceholderText('Resource Type');
     expect(input).toBeInTheDocument();
 
     await act(async () => {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -641,7 +641,7 @@ describe('QuestionnaireForm', () => {
     expect(answers3['q1']).toMatchObject({});
   });
 
-  test('Reference Extensions', async () => {
+  test('referenceResource extension with valueCodeableConcept', async () => {
     const onSubmit = jest.fn();
 
     await setup({
@@ -661,13 +661,6 @@ describe('QuestionnaireForm', () => {
                       display: 'Patient',
                       code: 'Patient',
                     },
-                  ],
-                },
-              },
-              {
-                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource',
-                valueCodeableConcept: {
-                  coding: [
                     {
                       system: 'http://hl7.org/fhir/fhir-types',
                       display: 'Organization',
@@ -688,6 +681,31 @@ describe('QuestionnaireForm', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Patient'));
     });
+  });
+
+  test('referenceResource extension with valueCode', async () => {
+    const onSubmit = jest.fn();
+
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        item: [
+          {
+            linkId: 'q1',
+            type: QuestionnaireItemType.reference,
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource',
+                valueCode: 'Patient',
+              },
+            ],
+          },
+        ],
+      },
+      onSubmit,
+    });
+
+    expect(screen.queryByText('Patient')).not.toBeInTheDocument();
   });
 
   test('Drop down choice input default value', async () => {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -24,7 +24,11 @@ import { QuantityInput } from '../../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
 import { ResourcePropertyDisplay } from '../../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
-import { QuestionnaireItemType, getNewMultiSelectValues } from '../../utils/questionnaire';
+import {
+  QuestionnaireItemType,
+  getNewMultiSelectValues,
+  getQuestionnaireItemReferenceTargetTypes,
+} from '../../utils/questionnaire';
 
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
@@ -170,7 +174,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <ReferenceInput
           name={name}
-          targetTypes={addTargetTypes(item)}
+          targetTypes={getQuestionnaireItemReferenceTargetTypes(item)}
           defaultValue={defaultValue?.value}
           onChange={(newValue) => onChangeAnswer({ valueReference: newValue }, index)}
         />
@@ -382,20 +386,6 @@ function updateAnswerArray(
     answers.push(newResponseAnswer);
     return answers;
   }
-}
-
-function addTargetTypes(item: QuestionnaireItem): string[] {
-  if (item.type !== QuestionnaireItemType.reference) {
-    return [];
-  }
-  const extensions = item.extension?.filter(
-    (e) => e.url === 'http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource'
-  );
-  if (!extensions || extensions.length === 0) {
-    return [];
-  }
-  const targets = extensions.map((e) => e.valueCodeableConcept?.coding?.[0]?.code) as string[];
-  return targets;
 }
 
 function isDropDownChoice(item: QuestionnaireItem): boolean {

--- a/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
@@ -30,7 +30,7 @@ describe('ReferenceInput', () => {
     setup({
       name: 'foo',
     });
-    expect(screen.getByTestId('reference-input-resource-type-input')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Resource Type')).toBeInTheDocument();
   });
 
   test('Renders default value resource type', async () => {
@@ -42,8 +42,8 @@ describe('ReferenceInput', () => {
         },
       });
     });
-    expect(screen.getByTestId('reference-input-resource-type-input')).toBeInTheDocument();
-    expect((screen.getByTestId('reference-input-resource-type-input') as HTMLInputElement).value).toBe('Patient');
+    expect(screen.getByText('Patient')).toBeInTheDocument();
+    expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Change resource type without target types', async () => {
@@ -52,12 +52,12 @@ describe('ReferenceInput', () => {
     });
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('reference-input-resource-type-input'), {
+      fireEvent.change(screen.getByPlaceholderText('Resource Type'), {
         target: { value: 'Practitioner' },
       });
     });
 
-    expect(screen.getByTestId('reference-input-resource-type-input')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Practitioner')).toBeInTheDocument();
   });
 
   test('Renders property with target types', () => {
@@ -166,7 +166,7 @@ describe('ReferenceInput', () => {
       name: 'foo',
       targetTypes: [],
     });
-    expect(screen.getByTestId('reference-input-resource-type-input')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Resource Type')).toBeInTheDocument();
     expect(screen.queryByTestId('reference-input-resource-type-select')).not.toBeInTheDocument();
   });
 
@@ -176,7 +176,7 @@ describe('ReferenceInput', () => {
       targetTypes: ['Resource'],
     });
     // "Resource" is a FHIR special case that means "any resource type"
-    expect(screen.getByTestId('reference-input-resource-type-input')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Resource Type')).toBeInTheDocument();
     expect(screen.queryByTestId('reference-input-resource-type-select')).not.toBeInTheDocument();
   });
 });

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -1,8 +1,9 @@
-import { Group, NativeSelect, TextInput } from '@mantine/core';
+import { Group, NativeSelect } from '@mantine/core';
 import { createReference } from '@medplum/core';
 import { Reference, Resource, ResourceType } from '@medplum/fhirtypes';
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { ResourceInput } from '../ResourceInput/ResourceInput';
+import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
 
 export interface ReferenceInputProps {
   name: string;
@@ -17,13 +18,7 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
   const targetTypes = getTargetTypes(props.targetTypes);
   const initialResourceType = getInitialResourceType(props.defaultValue, targetTypes);
   const [value, setValue] = useState<Reference | undefined>(props.defaultValue);
-  const [resourceType, setResourceType] = useState<string | undefined>(initialResourceType);
-
-  const valueRef = useRef<Reference>();
-  valueRef.current = value;
-
-  const resourceTypeRef = useRef<string>();
-  resourceTypeRef.current = resourceType;
+  const [resourceType, setResourceType] = useState<ResourceType | undefined>(initialResourceType);
 
   function setValueHelper(newValue: Reference | undefined): void {
     setValue(newValue);
@@ -34,22 +29,24 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
 
   return (
     <Group spacing="xs" grow noWrap>
-      {targetTypes ? (
+      {targetTypes && targetTypes.length > 1 && (
         <NativeSelect
           data-autofocus={props.autoFocus}
           data-testid="reference-input-resource-type-select"
           defaultValue={resourceType}
           autoFocus={props.autoFocus}
-          onChange={(e) => setResourceType(e.currentTarget.value)}
+          onChange={(e) => setResourceType(e.currentTarget.value as ResourceType)}
           data={targetTypes}
         />
-      ) : (
-        <TextInput
+      )}
+      {!targetTypes && (
+        <ResourceTypeInput
           data-autofocus={props.autoFocus}
           data-testid="reference-input-resource-type-input"
           defaultValue={resourceType}
-          autoFocus={props.autoFocus}
-          onChange={(e) => setResourceType(e.currentTarget.value)}
+          onChange={setResourceType}
+          name={props.name + '-resourceType'}
+          placeholder="Resource Type"
         />
       )}
       <ResourceInput
@@ -75,14 +72,14 @@ function getTargetTypes(targetTypes: string[] | undefined): string[] | undefined
 function getInitialResourceType(
   defaultValue: Reference | undefined,
   targetTypes: string[] | undefined
-): string | undefined {
+): ResourceType | undefined {
   const defaultValueResourceType = defaultValue?.reference?.split('/')[0];
   if (defaultValueResourceType) {
-    return defaultValueResourceType;
+    return defaultValueResourceType as ResourceType;
   }
 
   if (targetTypes && targetTypes.length > 0) {
-    return targetTypes[0];
+    return targetTypes[0] as ResourceType;
   }
 
   return undefined;

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -41,8 +41,8 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
       )}
       {!targetTypes && (
         <ResourceTypeInput
-          data-autofocus={props.autoFocus}
-          data-testid="reference-input-resource-type-input"
+          autoFocus={props.autoFocus}
+          testId="reference-input-resource-type-input"
           defaultValue={resourceType}
           onChange={setResourceType}
           name={props.name + '-resourceType'}

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.test.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.test.tsx
@@ -569,7 +569,7 @@ describe('ResourcePropertyInput', () => {
     });
   });
 
-  test('Reference property', async () => {
+  test('Reference property single target type', async () => {
     const property: ElementDefinition = {
       type: [
         {
@@ -581,6 +581,26 @@ describe('ResourcePropertyInput', () => {
 
     await setup({
       name: 'managingOrganization',
+      property,
+    });
+
+    const comboboxes = screen.getAllByRole('combobox');
+    expect(comboboxes).toHaveLength(1);
+    expect(comboboxes[0]).toBeInstanceOf(HTMLDivElement);
+  });
+
+  test('Reference property multiple target types', async () => {
+    const property: ElementDefinition = {
+      type: [
+        {
+          code: 'Reference',
+          targetProfile: ['Patient', 'Practitioner'],
+        },
+      ],
+    };
+
+    await setup({
+      name: 'subject',
       property,
     });
 

--- a/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
+++ b/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
@@ -1,0 +1,48 @@
+import { ResourceType } from '@medplum/fhirtypes';
+import React, { useCallback, useState } from 'react';
+import { CodeInput } from '../CodeInput/CodeInput';
+
+export interface ResourceTypeInputProps {
+  name: string;
+  placeholder?: string;
+  defaultValue?: ResourceType;
+  targetTypes?: string[];
+  autoFocus?: boolean;
+  testId?: string;
+  onChange?: (value: ResourceType | undefined) => void;
+}
+
+export function ResourceTypeInput(props: ResourceTypeInputProps): JSX.Element {
+  const [resourceType, setResourceType] = useState<string | undefined>(props.defaultValue);
+  const onChange = props.onChange;
+
+  const setResourceTypeWrapper = useCallback(
+    (newResourceType: string | undefined) => {
+      setResourceType(newResourceType);
+      if (onChange) {
+        onChange(newResourceType as ResourceType);
+      }
+    },
+    [onChange]
+  );
+
+  return (
+    <CodeInput
+      data-autofocus={props.autoFocus}
+      data-testid={props.testId}
+      defaultValue={resourceType}
+      onChange={setResourceTypeWrapper}
+      name={props.name}
+      placeholder={props.placeholder}
+      property={{
+        binding: {
+          valueSet: 'https://medplum.com/fhir/ValueSet/resource-types',
+        },
+      }}
+      creatable={false}
+      maxSelectedValues={0}
+      clearSearchOnChange={true}
+      clearable={false}
+    />
+  );
+}


### PR DESCRIPTION
1. Support both `valueCode` and `valueCodeableConcept` in "http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource" extensions
    a. Use `valueCode` for single resource type (technically, this is the only one in the spec)
    b. Use `valueCodeableConcept` for multiple resource types
2. Added special case in `<ReferenceInput>` when only one resource `targetType` - don't show resource type selector
3. Added `<ResourceTypeInput>` component specifically for capturing resource types
4. Use `<ResourceTypeInput>` in QuestionnaireBuilder