### PR TITLE
Update Health Gorilla demo to order multiple tests

### DIFF
--- a/examples/medplum-demo-bots/src/health-gorilla/receive-from-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/receive-from-health-gorilla.ts
@@ -139,10 +139,15 @@ function touchUpBundle(bundle: Bundle<HealthGorillaResource>): void {
     }
 
     if (resource.resourceType === 'ServiceRequest') {
+      // The ServiceRequest identifier is the requisition and the code
       const requisition = resource.requisition?.value;
-      if (requisition) {
-        request.ifNoneExist = 'requisition=' + requisition;
+      const code = resource.code?.coding?.[0]?.code;
+      const identifier = requisition + '-' + code;
+      if (!resource.identifier) {
+        resource.identifier = [];
       }
+      resource.identifier.push({ system: HEALTH_GORILLA_SYSTEM, value: identifier });
+      request.ifNoneExist = 'identifier=' + identifier;
     }
   }
 }


### PR DESCRIPTION
Step-by-step example walkthrough:

## Step 1: Patient

First, I'm going to manually create a new patient.

* Patients must have a Health Gorilla MRN in the `identifier` array with the MRN CodeSystem
* Patients must have an address, and the address must include `country`
* Patients must have phone number and email address in `telecom`

```json
{
  "resourceType": "Patient",
  "identifier": [
    {
      "type": {
        "coding": [
          {
            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
            "code": "MR",
            "display": "Medical record number"
          }
        ],
        "text": "Medical record number"
      },
      "value": "55555591"
    }
  ],
  "name": [
    {
      "given": [
        "Lisa"
      ],
      "family": "Simpson"
    }
  ],
  "gender": "female",
  "birthDate": "1992-01-01",
  "address": [
    {
      "line": [
        "2477 Sutter St"
      ],
      "city": "San Francisco",
      "state": "CA",
      "postalCode": "94115",
      "country": "US"
    }
  ],
  "telecom": [
    {
      "system": "email",
      "use": "home",
      "value": "lisa@example.com"
    },
    {
      "system": "phone",
      "use": "home",
      "value": "5555555555"
    }
  ]
}
```

## Step 2: Order form

Next I'm going to go to the Health Gorilla Order Form questionnaire

(TODO: figure out how we're going to share this with customers)

![image](https://github.com/medplum/medplum/assets/749094/3cafff3a-2f6e-4937-a538-54b7cbf17036)

This is all highly customizable to match customer requirements.

* In this example, "Patient" is a question on the questionnaire.  It may make more sense for "Patient" to be in the "subject", so that you could launch the questionnaire from the "Apps" tab.
* In this example, "Ordering Provider" is a question.  It could make more sense to use "current user".  That depends on customer needs.
* Performing Lab must be an `Organization` resource with a Health Gorilla identifier.  The Health Gorilla identifier values will be provided by Health Gorilla account manager.
* Tests here are somewhat hardcoded using the Health Gorilla compendium codes.
    * We could load in full compendium and using a `<CodeableConceptInput>` for auto complete
    * My intuition is that customers will prefer to have commonly used tests available as checkboxes like this
    * Each test has corresponding "priority" and "notes", which only appear if test is selected using Questionnaire `enableWhen`
    * Some Health Gorilla tests have additional parameters (specimen details, etc) - I think we should work with initial design partners to establish best practices for how to represent that here
* Current implementation assumes "bill to patient" - that could be a separate questionnaire input

## Step 3: order bot

Submitting the order form creates a `QuestionnaireResponse`

That triggers a FHIR `Subscription` and executes "Health Gorilla Order Bot", which is `send-to-health-gorilla.ts` in this PR.

The order bot creates a `RequestGroup` in Health Gorilla as an "async" operation.  In this context, "async" means "start the create operation without getting an immediate response with the result".  So we throw it over the fence and wait for Health Gorilla to say whether or not it worked.

You can look at the events to see that the bot executed successfully:

![image](https://github.com/medplum/medplum/assets/749094/f645d62a-5c67-4121-901c-9c8cb379a446)

## Step 4: Receive RequestGroup and ServiceRequest from Health Gorilla

The 2nd bot is "Health Gorilla Callback Bot", which is "receive-from-health-gorilla.ts` in this PR.

This bot is triggered by webhooks from Health Gorilla.  We receive updates for all changes to `RequestGroup`, `ServiceRequest`, and `DiagnosticReport` resources.

Shortly after creating the order -- usually within 10 seconds -- we will get the first webhooks for `RequestGroup` and `ServiceRequest`.

The "Health Gorilla Callback Bot" attempts to unpack those resources and map them to FHIR resources in Medplum.

Here is the `ServiceRequest`:

![image](https://github.com/medplum/medplum/assets/749094/1f5eb5ca-9b92-40fb-8ab1-efb29e1b6214)

## Step 5: Receive DiagnosticReport from Health Gorilla

A while later -- usually within 30 seconds -- we will receive webhooks for the `DiagnosticReport`.

Similar to `RequestGroup` and `ServiceRequest`, we unpack those resources and map them to FHIR resources in Medplum.

![image](https://github.com/medplum/medplum/assets/749094/6e469488-ee6e-4e88-9d1a-026c2aee496d)
