### PR TITLE
feat(server/bullmq): remove all finalized jobs by default

### DIFF
--- a/packages/server/medplum.config.json
+++ b/packages/server/medplum.config.json
@@ -37,7 +37,7 @@
     "password": "medplum"
   },
   "bullmq": {
-    "removeOnFail": { "count": 0 },
-    "removeOnComplete": { "count": 0 }
+    "removeOnFail": { "count": 1 },
+    "removeOnComplete": { "count": 1 }
   }
 }

--- a/packages/server/medplum.config.json
+++ b/packages/server/medplum.config.json
@@ -35,5 +35,9 @@
     "host": "localhost",
     "port": 6379,
     "password": "medplum"
+  },
+  "bullmq": {
+    "removeOnFail": { "count": 0 },
+    "removeOnComplete": { "count": 0 }
   }
 }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -183,7 +183,7 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
     await seedDatabase();
     await initKeys(config);
     initBinaryStorage(config.binaryStorage);
-    initWorkers(config.redis);
+    initWorkers(config.redis, config.bullmq);
   });
 }
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -183,7 +183,7 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
     await seedDatabase();
     await initKeys(config);
     initBinaryStorage(config.binaryStorage);
-    initWorkers(config.redis, config.bullmq);
+    initWorkers(config);
   });
 }
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,5 +1,6 @@
 import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { KeepJobs } from 'bullmq';
 import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
@@ -25,6 +26,7 @@ export interface MedplumServerConfig {
   database: MedplumDatabaseConfig;
   redis: MedplumRedisConfig;
   smtp?: MedplumSmtpConfig;
+  bullmq?: MedplumBullmqConfig;
   googleClientId?: string;
   googleClientSecret?: string;
   recaptchaSiteKey?: string;
@@ -69,6 +71,11 @@ export interface MedplumSmtpConfig {
   port: number;
   username: string;
   password: string;
+}
+
+export interface MedplumBullmqConfig {
+  removeOnComplete: KeepJobs;
+  removeOnFail: KeepJobs;
 }
 
 let cachedConfig: MedplumServerConfig | undefined = undefined;
@@ -255,6 +262,7 @@ function addDefaults(config: MedplumServerConfig): MedplumServerConfig {
   config.awsRegion = config.awsRegion || DEFAULT_AWS_REGION;
   config.botLambdaLayerName = config.botLambdaLayerName || 'medplum-bot-layer';
   config.bcryptHashSalt = config.bcryptHashSalt || 10;
+  config.bullmq = { removeOnComplete: { count: 0 }, removeOnFail: { count: 0 }, ...config.bullmq };
   return config;
 }
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -262,7 +262,7 @@ function addDefaults(config: MedplumServerConfig): MedplumServerConfig {
   config.awsRegion = config.awsRegion || DEFAULT_AWS_REGION;
   config.botLambdaLayerName = config.botLambdaLayerName || 'medplum-bot-layer';
   config.bcryptHashSalt = config.bcryptHashSalt || 10;
-  config.bullmq = { removeOnComplete: { count: 0 }, removeOnFail: { count: 0 }, ...config.bullmq };
+  config.bullmq = { removeOnComplete: { count: 1 }, removeOnFail: { count: 1 }, ...config.bullmq };
   return config;
 }
 

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -2,12 +2,12 @@ import { ContentType, createReference } from '@medplum/core';
 import { Bot, Project, Resource, Timing } from '@medplum/fhirtypes';
 import { Job, Queue, QueueBaseOptions, Worker } from 'bullmq';
 import { isValidCron } from 'cron-validator';
-import { MedplumRedisConfig } from '../config';
+import { MedplumBullmqConfig, MedplumRedisConfig } from '../config';
+import { getRequestContext } from '../context';
 import { executeBot } from '../fhir/operations/execute';
 import { systemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { findProjectMembership } from './utils';
-import { getRequestContext } from '../context';
 
 const daysOfWeekConversion = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
 
@@ -41,11 +41,12 @@ let worker: Worker<CronJobData> | undefined = undefined;
  * Initializes the Cron worker.
  * Sets up the BullMQ job queue.
  * Sets up the BullMQ worker.
- * @param config The Redis config.
+ * @param redisConfig The Redis config.
+ * @param bullmqConfig The BullMQ config.
  */
-export function initCronWorker(config: MedplumRedisConfig): void {
+export function initCronWorker(redisConfig: MedplumRedisConfig, bullmqConfig?: MedplumBullmqConfig): void {
   const defaultOptions: QueueBaseOptions = {
-    connection: config,
+    connection: redisConfig,
   };
 
   queue = new Queue<CronJobData>(queueName, {
@@ -58,7 +59,11 @@ export function initCronWorker(config: MedplumRedisConfig): void {
       },
     },
   });
-  worker = new Worker<CronJobData>(queueName, execBot, defaultOptions);
+
+  worker = new Worker<CronJobData>(queueName, execBot, {
+    ...defaultOptions,
+    ...bullmqConfig,
+  });
   worker.on('completed', (job) => globalLogger.info(`Completed job ${job.id} successfully`));
   worker.on('failed', (job, err) => globalLogger.info(`Failed job ${job?.id} with ${err}`));
 }
@@ -66,7 +71,7 @@ export function initCronWorker(config: MedplumRedisConfig): void {
 /**
  * Shuts down the Cron worker.
  * Closes the BullMQ job queue.
- * Clsoes the BullMQ worker.
+ * Closes the BullMQ worker.
  */
 export async function closeCronWorker(): Promise<void> {
   if (queue) {
@@ -81,7 +86,7 @@ export async function closeCronWorker(): Promise<void> {
 }
 
 /**
- * Returns theCron queue instance.
+ * Returns the Cron queue instance.
  * This is used by the unit tests.
  * @returns The Cron queue (if available).
  */

--- a/packages/server/src/workers/index.test.ts
+++ b/packages/server/src/workers/index.test.ts
@@ -17,7 +17,7 @@ describe('Workers', () => {
     await initDatabase(config.database);
     await seedDatabase();
     initBinaryStorage('file:binary');
-    initWorkers(config.redis);
+    initWorkers(config);
     await closeWorkers();
     await closeDatabase();
     closeRedis();

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '@medplum/fhirtypes';
-import { MedplumBullmqConfig, MedplumRedisConfig } from '../config';
+import { MedplumServerConfig } from '../config';
 import { globalLogger } from '../logger';
 import { BackgroundJobContext } from './context';
 import { addCronJobs, closeCronWorker, initCronWorker } from './cron';
@@ -8,14 +8,13 @@ import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } 
 
 /**
  * Initializes all background workers.
- * @param redisConfig The Redis config.
- * @param bullmqConfig The BullMQ config.
+ * @param config The config to initialize the workers with. Should contain `redis` and optionally `bullmq` fields.
  */
-export function initWorkers(redisConfig: MedplumRedisConfig, bullmqConfig?: MedplumBullmqConfig): void {
+export function initWorkers(config: MedplumServerConfig): void {
   globalLogger.debug('Initializing workers...');
-  initSubscriptionWorker(redisConfig, bullmqConfig);
-  initDownloadWorker(redisConfig, bullmqConfig);
-  initCronWorker(redisConfig, bullmqConfig);
+  initSubscriptionWorker(config);
+  initDownloadWorker(config);
+  initCronWorker(config);
   globalLogger.debug('Workers initialized');
 }
 

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -1,20 +1,21 @@
 import { Resource } from '@medplum/fhirtypes';
-import { MedplumRedisConfig } from '../config';
+import { MedplumBullmqConfig, MedplumRedisConfig } from '../config';
 import { globalLogger } from '../logger';
 import { BackgroundJobContext } from './context';
-import { addDownloadJobs, closeDownloadWorker, initDownloadWorker } from './download';
 import { addCronJobs, closeCronWorker, initCronWorker } from './cron';
+import { addDownloadJobs, closeDownloadWorker, initDownloadWorker } from './download';
 import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } from './subscription';
 
 /**
  * Initializes all background workers.
- * @param config The Redis config.
+ * @param redisConfig The Redis config.
+ * @param bullmqConfig The BullMQ config.
  */
-export function initWorkers(config: MedplumRedisConfig): void {
+export function initWorkers(redisConfig: MedplumRedisConfig, bullmqConfig?: MedplumBullmqConfig): void {
   globalLogger.debug('Initializing workers...');
-  initSubscriptionWorker(config);
-  initDownloadWorker(config);
-  initCronWorker(config);
+  initSubscriptionWorker(redisConfig, bullmqConfig);
+  initDownloadWorker(redisConfig, bullmqConfig);
+  initCronWorker(redisConfig, bullmqConfig);
   globalLogger.debug('Workers initialized');
 }
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -15,7 +15,7 @@ import { Job, Queue, QueueBaseOptions, Worker } from 'bullmq';
 import { createHmac } from 'crypto';
 import fetch, { HeadersInit } from 'node-fetch';
 import { URL } from 'url';
-import { MedplumBullmqConfig, MedplumRedisConfig } from '../config';
+import { MedplumServerConfig } from '../config';
 import { getRequestContext } from '../context';
 import { executeBot } from '../fhir/operations/execute';
 import { systemRepo } from '../fhir/repo';
@@ -56,12 +56,11 @@ let worker: Worker<SubscriptionJobData> | undefined = undefined;
  * Initializes the subscription worker.
  * Sets up the BullMQ job queue.
  * Sets up the BullMQ worker.
- * @param redisConfig The Redis config.
- * @param bullmqConfig The BullMQ config.
+ * @param config The Medplum server config to use.
  */
-export function initSubscriptionWorker(redisConfig: MedplumRedisConfig, bullmqConfig?: MedplumBullmqConfig): void {
+export function initSubscriptionWorker(config: MedplumServerConfig): void {
   const defaultOptions: QueueBaseOptions = {
-    connection: redisConfig,
+    connection: config.redis,
   };
 
   queue = new Queue<SubscriptionJobData>(queueName, {
@@ -77,7 +76,7 @@ export function initSubscriptionWorker(redisConfig: MedplumRedisConfig, bullmqCo
 
   worker = new Worker<SubscriptionJobData>(queueName, execSubscriptionJob, {
     ...defaultOptions,
-    ...bullmqConfig,
+    ...config.bullmq,
   });
   worker.on('completed', (job) => globalLogger.info(`Completed job ${job.id} successfully`));
   worker.on('failed', (job, err) => globalLogger.info(`Failed job ${job?.id} with ${err}`));


### PR DESCRIPTION
## What this PR does
* Adds removal of all finalized jobs (completed and failed) from Redis cache by default.
* Adds `bullmq` to config, so that users can configure `removeOnComplete` and `removeOnFail`
* Closes #2996