### PR TITLE
Fixes #3071 - useSearch hooks

### DIFF
--- a/packages/app/src/BulkAppPage.tsx
+++ b/packages/app/src/BulkAppPage.tsx
@@ -10,7 +10,7 @@ export function BulkAppPage(): JSX.Element {
   };
   const queryParams = Object.fromEntries(new URLSearchParams(location.search).entries()) as Record<string, string>;
   const ids = (queryParams.ids || '').split(',').filter((e) => !!e);
-  const questionnaires = useSearchResources('Questionnaire', `subject-type=${resourceType}`);
+  const [questionnaires] = useSearchResources('Questionnaire', `subject-type=${resourceType}`);
 
   if (!questionnaires) {
     return <Loading />;

--- a/packages/app/src/BulkAppPage.tsx
+++ b/packages/app/src/BulkAppPage.tsx
@@ -1,7 +1,6 @@
 import { Title } from '@mantine/core';
-import { Questionnaire } from '@medplum/fhirtypes';
-import { Document, Loading, MedplumLink, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { Document, Loading, MedplumLink, useSearchResources } from '@medplum/react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function BulkAppPage(): JSX.Element {
@@ -11,12 +10,7 @@ export function BulkAppPage(): JSX.Element {
   };
   const queryParams = Object.fromEntries(new URLSearchParams(location.search).entries()) as Record<string, string>;
   const ids = (queryParams.ids || '').split(',').filter((e) => !!e);
-  const medplum = useMedplum();
-  const [questionnaires, setQuestionnaires] = useState<Questionnaire[]>();
-
-  useEffect(() => {
-    medplum.searchResources('Questionnaire', `subject-type=${resourceType}`).then(setQuestionnaires).catch(console.log);
-  }, [medplum, resourceType]);
+  const questionnaires = useSearchResources('Questionnaire', `subject-type=${resourceType}`);
 
   if (!questionnaires) {
     return <Loading />;

--- a/packages/app/src/lab/AssaysPage.tsx
+++ b/packages/app/src/lab/AssaysPage.tsx
@@ -1,12 +1,15 @@
 import { Table } from '@mantine/core';
 import { capitalize, formatRange } from '@medplum/core';
 import { ObservationDefinition, ObservationDefinitionQualifiedInterval } from '@medplum/fhirtypes';
-import { CodeableConceptDisplay, RangeDisplay, useMedplum } from '@medplum/react';
+import { CodeableConceptDisplay, Loading, RangeDisplay, useSearchResources } from '@medplum/react';
 import React, { Fragment } from 'react';
 
 export function AssaysPage(): JSX.Element {
-  const medplum = useMedplum();
-  const assays = medplum.searchResources('ObservationDefinition', '_count=100').read();
+  const assays = useSearchResources('ObservationDefinition', '_count=100');
+
+  if (!assays) {
+    return <Loading />;
+  }
 
   return (
     <Table withBorder withColumnBorders>

--- a/packages/app/src/lab/AssaysPage.tsx
+++ b/packages/app/src/lab/AssaysPage.tsx
@@ -5,7 +5,7 @@ import { CodeableConceptDisplay, Loading, RangeDisplay, useSearchResources } fro
 import React, { Fragment } from 'react';
 
 export function AssaysPage(): JSX.Element {
-  const assays = useSearchResources('ObservationDefinition', '_count=100');
+  const [assays] = useSearchResources('ObservationDefinition', '_count=100');
 
   if (!assays) {
     return <Loading />;

--- a/packages/app/src/lab/PanelsPage.tsx
+++ b/packages/app/src/lab/PanelsPage.tsx
@@ -4,8 +4,8 @@ import { CodeableConceptDisplay, Loading, useSearchResources } from '@medplum/re
 import React from 'react';
 
 export function PanelsPage(): JSX.Element {
-  const panels = useSearchResources('ActivityDefinition', '_count=100');
-  const assays = useSearchResources('ObservationDefinition', '_count=100');
+  const [panels] = useSearchResources('ActivityDefinition', '_count=100');
+  const [assays] = useSearchResources('ObservationDefinition', '_count=100');
 
   if (!panels || !assays) {
     return <Loading />;

--- a/packages/app/src/lab/PanelsPage.tsx
+++ b/packages/app/src/lab/PanelsPage.tsx
@@ -1,12 +1,15 @@
 import { Table } from '@mantine/core';
 import { ObservationDefinition } from '@medplum/fhirtypes';
-import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
+import { CodeableConceptDisplay, Loading, useSearchResources } from '@medplum/react';
 import React from 'react';
 
 export function PanelsPage(): JSX.Element {
-  const medplum = useMedplum();
-  const panels = medplum.searchResources('ActivityDefinition', '_count=100').read();
-  const assays = medplum.searchResources('ObservationDefinition', '_count=100').read();
+  const panels = useSearchResources('ActivityDefinition', '_count=100');
+  const assays = useSearchResources('ObservationDefinition', '_count=100');
+
+  if (!panels || !assays) {
+    return <Loading />;
+  }
 
   return (
     <Table withBorder withColumnBorders>

--- a/packages/app/src/resource/AppsPage.tsx
+++ b/packages/app/src/resource/AppsPage.tsx
@@ -10,8 +10,8 @@ export function AppsPage(): JSX.Element | null {
   const medplum = useMedplum();
   const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
   const resource = useResource({ reference: resourceType + '/' + id });
-  const questionnaires = useSearchResources('Questionnaire', 'subject-type=' + resourceType);
-  const clientApplications = useSearchResources('ClientApplication', { _count: 1000 })?.filter(
+  const [questionnaires] = useSearchResources('Questionnaire', 'subject-type=' + resourceType);
+  const clientApplications = useSearchResources('ClientApplication', { _count: 1000 })?.[0]?.filter(
     (c) => isSmartLaunchType(resourceType) && !!c.launchUri
   );
 

--- a/packages/react/src/Scheduler/Scheduler.tsx
+++ b/packages/react/src/Scheduler/Scheduler.tsx
@@ -43,7 +43,7 @@ export function Scheduler(props: SchedulerProps): JSX.Element | null {
   const [slot, setSlot] = useState<Slot>();
   const [response, setResponse] = useState<QuestionnaireResponse>();
 
-  const slots = useSearchResources(
+  const [slots] = useSearchResources(
     'Slot',
     new URLSearchParams([
       ['_count', (30 * 24).toString()],

--- a/packages/react/src/Scheduler/Scheduler.tsx
+++ b/packages/react/src/Scheduler/Scheduler.tsx
@@ -1,14 +1,14 @@
 import { Button, createStyles, Stack, Text } from '@mantine/core';
-import { getReferenceString } from '@medplum/core';
+import { getReferenceString, isReference } from '@medplum/core';
 import { Questionnaire, QuestionnaireResponse, Reference, Schedule, Slot } from '@medplum/fhirtypes';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { CalendarInput } from '../CalendarInput/CalendarInput';
 import { getStartMonth } from '../CalendarInput/CalendarInput.utils';
-import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 import { QuestionnaireForm } from '../QuestionnaireForm/QuestionnaireForm';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceName } from '../ResourceName/ResourceName';
 import { useResource } from '../useResource/useResource';
+import { useSearchResources } from '../useSearch/useSearch';
 
 const useStyles = createStyles((theme) => ({
   container: {
@@ -35,38 +35,28 @@ export interface SchedulerProps {
 
 export function Scheduler(props: SchedulerProps): JSX.Element | null {
   const { classes } = useStyles();
-  const medplum = useMedplum();
   const schedule = useResource(props.schedule);
   const questionnaire = useResource(props.questionnaire);
-
-  const [slots, setSlots] = useState<Slot[]>();
-  const slotsRef = useRef<Slot[]>();
-  slotsRef.current = slots;
 
   const [month, setMonth] = useState<Date>(getStartMonth());
   const [date, setDate] = useState<Date>();
   const [slot, setSlot] = useState<Slot>();
   const [response, setResponse] = useState<QuestionnaireResponse>();
 
-  useEffect(() => {
-    if (schedule) {
-      setSlots([]);
-      medplum
-        .searchResources(
-          'Slot',
-          new URLSearchParams([
-            ['_count', (30 * 24).toString()],
-            ['schedule', getReferenceString(schedule)],
-            ['start', 'gt' + getStart(month)],
-            ['start', 'lt' + getEnd(month)],
-          ])
-        )
-        .then(setSlots)
-        .catch(console.log);
-    } else {
-      setSlots(undefined);
-    }
-  }, [medplum, schedule, month]);
+  const slots = useSearchResources(
+    'Slot',
+    new URLSearchParams([
+      ['_count', (30 * 24).toString()],
+      [
+        'schedule',
+        isReference(props.schedule)
+          ? (props.schedule.reference as string)
+          : getReferenceString(props.schedule as Schedule),
+      ],
+      ['start', 'gt' + getStart(month)],
+      ['start', 'lt' + getEnd(month)],
+    ])
+  );
 
   if (!schedule || !slots || !questionnaire) {
     return null;
@@ -137,7 +127,9 @@ function getEnd(month: Date): string {
 }
 
 function formatSlotInstant(time: number): string {
-  return new Date(Math.max(Date.now(), time)).toISOString();
+  const date = new Date(Math.max(Date.now(), time));
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString();
 }
 
 function formatTime(date: Date): string {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -87,6 +87,7 @@ export * from './StatusBadge/StatusBadge';
 export * from './Timeline/Timeline';
 export * from './TimingInput/TimingInput';
 export * from './useResource/useResource';
+export * from './useSearch/useSearch';
 export * from './utils/date';
 export * from './utils/outcomes';
 export * from './utils/questionnaire';

--- a/packages/react/src/useSearch/useSearch.test.tsx
+++ b/packages/react/src/useSearch/useSearch.test.tsx
@@ -1,0 +1,47 @@
+import { operationOutcomeToString } from '@medplum/core';
+import { MockClient } from '@medplum/mock';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { useSearch } from './useSearch';
+
+function TestComponent(): JSX.Element {
+  const [bundle, loading, outcome] = useSearch('Patient', { name: 'homer' });
+  return (
+    <div>
+      <div data-testid="bundle">{JSON.stringify(bundle)}</div>
+      <div data-testid="loading">{loading}</div>
+      <div data-testid="outcome">{outcome && operationOutcomeToString(outcome)}</div>
+    </div>
+  );
+}
+
+describe('useSearch hooks', () => {
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+
+  async function setup(children: React.ReactNode): Promise<void> {
+    const medplum = new MockClient();
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+        </MemoryRouter>
+      );
+    });
+  }
+
+  test('Happy path', async () => {
+    await setup(<TestComponent />);
+    await waitFor(() => screen.getByText('All OK'));
+
+    const el = screen.getByTestId('bundle');
+    expect(el).toBeInTheDocument();
+
+    const bundle = JSON.parse(el.innerHTML);
+    expect(bundle.resourceType).toBe('Bundle');
+    expect(bundle.entry).toHaveLength(1);
+  });
+});

--- a/packages/react/src/useSearch/useSearch.ts
+++ b/packages/react/src/useSearch/useSearch.ts
@@ -1,0 +1,70 @@
+import { QueryTypes, ResourceArray } from '@medplum/core';
+import { Bundle, ExtractResource, ResourceType } from '@medplum/fhirtypes';
+import { useEffect, useState } from 'react';
+import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
+
+export function useSearch<K extends ResourceType>(
+  resourceType: K,
+  query?: QueryTypes
+): Bundle<ExtractResource<K>> | undefined {
+  const medplum = useMedplum();
+  const [searchKey, setSearchKey] = useState<string>();
+  const [bundle, setBundle] = useState<Bundle<ExtractResource<K>>>();
+
+  useEffect(() => {
+    const key = medplum.fhirSearchUrl(resourceType, query).toString();
+    if (key !== searchKey) {
+      setSearchKey(key);
+      medplum
+        .search(resourceType, query)
+        .then(setBundle)
+        .catch(() => setBundle(undefined));
+    }
+  }, [medplum, resourceType, query, searchKey, setBundle]);
+
+  return bundle;
+}
+
+export function useSearchOne<K extends ResourceType>(
+  resourceType: K,
+  query?: QueryTypes
+): ExtractResource<K> | undefined {
+  const medplum = useMedplum();
+  const [searchKey, setSearchKey] = useState<string>();
+  const [resource, setResource] = useState<ExtractResource<K>>();
+
+  useEffect(() => {
+    const key = medplum.fhirSearchUrl(resourceType, query).toString();
+    if (key !== searchKey) {
+      setSearchKey(key);
+      medplum
+        .searchOne(resourceType, query)
+        .then(setResource)
+        .catch(() => setResource(undefined));
+    }
+  }, [medplum, resourceType, query, searchKey, setResource]);
+
+  return resource;
+}
+
+export function useSearchResources<K extends ResourceType>(
+  resourceType: K,
+  query?: QueryTypes
+): ResourceArray<ExtractResource<K>> | undefined {
+  const medplum = useMedplum();
+  const [searchKey, setSearchKey] = useState<string>();
+  const [resources, setResources] = useState<ResourceArray<ExtractResource<K>>>();
+
+  useEffect(() => {
+    const key = medplum.fhirSearchUrl(resourceType, query).toString();
+    if (key !== searchKey) {
+      setSearchKey(key);
+      medplum
+        .searchResources(resourceType, query)
+        .then(setResources)
+        .catch(() => setResources(undefined));
+    }
+  }, [medplum, resourceType, query, searchKey, setResources]);
+
+  return resources;
+}

--- a/packages/react/src/useSearch/useSearchOne.test.tsx
+++ b/packages/react/src/useSearch/useSearchOne.test.tsx
@@ -1,0 +1,46 @@
+import { operationOutcomeToString } from '@medplum/core';
+import { MockClient } from '@medplum/mock';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { useSearchOne } from './useSearch';
+
+function TestComponent(): JSX.Element {
+  const [patient, loading, outcome] = useSearchOne('Patient', { name: 'homer' });
+  return (
+    <div>
+      <div data-testid="patient">{JSON.stringify(patient)}</div>
+      <div data-testid="loading">{loading}</div>
+      <div data-testid="outcome">{outcome && operationOutcomeToString(outcome)}</div>
+    </div>
+  );
+}
+
+describe('useSearch hooks', () => {
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+
+  async function setup(children: React.ReactNode): Promise<void> {
+    const medplum = new MockClient();
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+        </MemoryRouter>
+      );
+    });
+  }
+
+  test('Happy path', async () => {
+    await setup(<TestComponent />);
+    await waitFor(() => screen.getByText('All OK'));
+
+    const el = screen.getByTestId('patient');
+    expect(el).toBeInTheDocument();
+
+    const patient = JSON.parse(el.innerHTML);
+    expect(patient?.resourceType).toBe('Patient');
+  });
+});

--- a/packages/react/src/useSearch/useSearchResources.test.tsx
+++ b/packages/react/src/useSearch/useSearchResources.test.tsx
@@ -1,0 +1,48 @@
+import { operationOutcomeToString } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
+import { useSearchResources } from './useSearch';
+
+function TestComponent(): JSX.Element {
+  const [resources, loading, outcome] = useSearchResources('Patient', { name: 'homer' });
+  return (
+    <div>
+      <div data-testid="resources">{JSON.stringify(resources)}</div>
+      <div data-testid="loading">{loading}</div>
+      <div data-testid="outcome">{outcome && operationOutcomeToString(outcome)}</div>
+    </div>
+  );
+}
+
+describe('useSearch hooks', () => {
+  beforeAll(() => {
+    console.error = jest.fn();
+  });
+
+  async function setup(children: React.ReactNode): Promise<void> {
+    const medplum = new MockClient();
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+        </MemoryRouter>
+      );
+    });
+  }
+
+  test('Happy path', async () => {
+    await setup(<TestComponent />);
+    await waitFor(() => screen.getByText('All OK'));
+
+    const el = screen.getByTestId('resources');
+    expect(el).toBeInTheDocument();
+
+    const resources = JSON.parse(el.innerHTML);
+    expect(Array.isArray(resources)).toBe(true);
+    expect(resources as Patient[]).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
This PR introduces 3 new React hooks:

1. `useSearch` - a hook to wrap and manage `medplum.search()`
2. `useSearchResources` - a hook to wrap and manage `medplum.searchResources()`
3. `useSearchOne`

The return values are 3-element tuples with `[return value, loading boolean, operation outcome]`

This is most important for `useSearchOne`, where "loading" and/or "operation outcome" are necessary to differentiate between "still loading" and "search complete with no results".

Examples:

```tsx
const [bundle, loading, outcome] = useSearch('Patient');
const [tasks] = useSearchResources('Task', { active: true });
const [smokingStatus, loading] = useSearchOne('Observation', { patient, code });
```
