### PR TITLE
Fixes #3077 - correct valueCoding in QuestionnaireForm

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -585,52 +585,6 @@ export const LabOrdering = (): JSX.Element => {
   );
 };
 
-export const Choices = (): JSX.Element => (
-  <Document>
-    <QuestionnaireForm
-      questionnaire={{
-        resourceType: 'Questionnaire',
-        id: 'pages-example',
-        title: 'Pages Example',
-        item: [
-          {
-            linkId: 'group1',
-            type: 'group',
-            text: 'group1',
-            repeats: true,
-            item: [
-              {
-                linkId: 'group2',
-                type: 'group',
-                text: 'group2',
-                repeats: true,
-                item: [
-                  {
-                    linkId: 'q1',
-                    type: 'choice',
-                    text: 'Question 1',
-                    answerOption: [
-                      {
-                        valueString: 'Yes',
-                      },
-                      {
-                        valueString: 'No',
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }}
-      onSubmit={(formData: any) => {
-        console.log('submit', formData);
-      }}
-    />
-  </Document>
-);
-
 export const PageSequence = (): JSX.Element => (
   <Document>
     <QuestionnaireForm

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -295,7 +295,12 @@ function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps):
 function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.Element {
   const { name, item, initial, onChangeAnswer, allResponses } = props;
   if (item.answerValueSet) {
-    return <ValueSetAutocomplete binding={item.answerValueSet} onChange={onChangeAnswer} />;
+    return (
+      <ValueSetAutocomplete
+        binding={item.answerValueSet}
+        onChange={(answer) => onChangeAnswer({ valueCoding: answer?.[0] })}
+      />
+    );
   }
   return (
     <QuestionnaireChoiceRadioInput

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -28,6 +28,7 @@ import {
   QuestionnaireItemType,
 } from '../../utils/questionnaire';
 import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
+import { CodingInput } from '../../CodingInput/CodingInput';
 
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;
@@ -296,9 +297,10 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
   const { name, item, initial, onChangeAnswer, allResponses } = props;
   if (item.answerValueSet) {
     return (
-      <ValueSetAutocomplete
+      <CodingInput
+        name={name}
         binding={item.answerValueSet}
-        onChange={(answer) => (answer?.length ? onChangeAnswer({ valueCoding: answer[0] }) : undefined)}
+        onChange={(code) => (code ? onChangeAnswer({ valueCoding: code }) : undefined)}
       />
     );
   }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -298,7 +298,7 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
     return (
       <ValueSetAutocomplete
         binding={item.answerValueSet}
-        onChange={(answer) => onChangeAnswer({ valueCoding: answer?.[0] })}
+        onChange={(answer) => (answer?.length ? onChangeAnswer({ valueCoding: answer[0] }) : undefined)}
       />
     );
   }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -299,7 +299,7 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
       <CodingInput
         name={name}
         binding={item.answerValueSet}
-        onChange={(code) => (code ? onChangeAnswer({ valueCoding: code }) : undefined)}
+        onChange={(code) => onChangeAnswer({ valueCoding: code })}
       />
     );
   }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -1,12 +1,12 @@
 import { Checkbox, Group, MultiSelect, NativeSelect, Radio, Textarea, TextInput } from '@mantine/core';
 import {
-  TypedValue,
   capitalize,
   deepEquals,
   formatCoding,
   getElementDefinition,
   getTypedPropertyValue,
   stringify,
+  TypedValue,
 } from '@medplum/core';
 import {
   QuestionnaireItem,
@@ -18,6 +18,7 @@ import {
 import React, { ChangeEvent } from 'react';
 import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
 import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
+import { CodingInput } from '../../CodingInput/CodingInput';
 import { DateTimeInput } from '../../DateTimeInput/DateTimeInput';
 import { QuantityInput } from '../../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
@@ -27,8 +28,6 @@ import {
   getQuestionnaireItemReferenceTargetTypes,
   QuestionnaireItemType,
 } from '../../utils/questionnaire';
-import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
-import { CodingInput } from '../../CodingInput/CodingInput';
 
 export interface QuestionnaireFormItemProps {
   item: QuestionnaireItem;


### PR DESCRIPTION
https://github.com/medplum/medplum/issues/3077

Currently the valueset answer is this 

`{code: "", system: "", display:""}`

it should be `{valueCoding:  {code: "", system: "", display:""}}`

Tested in localhost

https://github.com/medplum/medplum/assets/6913745/2a8a1760-7bf6-4d93-bf8a-f982a30269cf

Returned 
```
      "id": "id-4",
      "linkId": "q1",
      "text": "Question",
      "answer": [
        {
          "valueCoding": {
            "system": "http://terminology.hl7.org/CodeSystem/v3-ActStatus",
            "code": "cancelled",
            "display": "cancelled"
          }
        }
      ]
    }
```