### PR TITLE
feat(cdk): add initial support for external secrets

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -34,6 +34,12 @@
         "useLiteralKeys": "warn",
         "useFlatMap": "warn",
         "noUselessFragments": "warn",
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": {
+            "maxAllowedComplexity": 15
+          }
+        },
 
         "noForEach": "warn",
         "useSimplifiedLogicExpression": "warn"
@@ -54,14 +60,6 @@
         "noPositiveTabindex": "warn",
         "useMediaCaption": "warn",
         "useAltText": "warn"
-      },
-      "nursery": {
-        "noExcessiveComplexity": {
-          "level": "warn",
-          "options": {
-            "maxAllowedComplexity": 15
-          }
-        }
       }
     }
   },

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -1,6 +1,7 @@
 import { MedplumInfraConfig } from '@medplum/core';
 import {
   Duration,
+  RemovalPolicy,
   aws_ec2 as ec2,
   aws_ecs as ecs,
   aws_elasticache as elasticache,
@@ -8,7 +9,6 @@ import {
   aws_iam as iam,
   aws_logs as logs,
   aws_rds as rds,
-  RemovalPolicy,
   aws_route53 as route53,
   aws_s3 as s3,
   aws_secretsmanager as secretsmanager,

--- a/packages/cdk/src/config.test.ts
+++ b/packages/cdk/src/config.test.ts
@@ -123,6 +123,13 @@ describe('Config', () => {
       mockSSMClient.restore();
     });
 
+    test('Missing `region` in config', async () => {
+      // @ts-expect-error Region must be defined
+      await expect(normalizeInfraConfig({ ...baseConfig, region: undefined })).rejects.toBeInstanceOf(
+        OperationOutcomeError
+      );
+    });
+
     test('Valid infra source config w/ external secrets', async () => {
       const result = await normalizeInfraConfig(baseConfig);
       expect(result).toEqual<MedplumInfraConfig>({

--- a/packages/cdk/src/config.test.ts
+++ b/packages/cdk/src/config.test.ts
@@ -1,4 +1,5 @@
 import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { MedplumInfraConfig } from '@medplum/core';
 import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { normalizeInfraConfig } from './config';
@@ -36,54 +37,175 @@ const baseConfig = {
   skipDns: true,
 } as const;
 
-// const additionalContainers = [
-//   {
-//     name: 'BIG IMAGE',
-//     image: 'arn:big_image',
-//     environment: {
-//       FOO: 'BAR',
-//       OTHER_FOO: { system: 'aws_ssm_parameter_store', key: '/:OTHER_FOO', type: 'string' },
-//     },
-//   },
-// ] as const;
+const additionalContainers = [
+  {
+    name: 'BIG IMAGE',
+    image: 'arn:big_image',
+    environment: {
+      FOO: 'BAR',
+      MED: { system: 'aws_ssm_parameter_store', key: '/:MED', type: 'string' },
+    },
+  },
+] as const;
 
-// const cloudTrailAlarms = {
-//   logGroupName: { system: 'aws_ssm_parameter_store', key: '/:logGroupName', type: 'string' },
-//   logGroupCreate: { system: 'aws_ssm_parameter_store', key: '/:logGroupCreate', type: 'boolean' },
-// } as const;
+const cloudTrailAlarms = {
+  logGroupName: { system: 'aws_ssm_parameter_store', key: '/:logGroupName', type: 'string' },
+  logGroupCreate: { system: 'aws_ssm_parameter_store', key: '/:logGroupCreate', type: 'boolean' },
+} as const;
 
 describe('Config', () => {
-  let mockSSMClient: AwsClientStub<SSMClient>;
+  describe('normalizeInfraConfig', () => {
+    let mockSSMClient: AwsClientStub<SSMClient>;
 
-  beforeEach(() => {
-    mockSSMClient = mockClient(SSMClient);
+    beforeEach(() => {
+      mockSSMClient = mockClient(SSMClient);
 
-    mockSSMClient.on(GetParametersByPathCommand).resolves({
-      Parameters: [
-        { Name: 'stackName', Value: 'MyFoomedicalStack' },
-        { Name: 'apiPort', Value: '1337' },
-        { Name: 'apiDomainName', Value: 'api.foomedical.com' },
-        { Name: 'apiSslCertArn', Value: 'arn:foomedical_api_ssl_cert' },
-        { Name: 'appApiProxy', Value: 'true' },
-        { Name: 'signingKeyId', Value: 'key-abc123' },
-        { Name: 'storageBucketName', Value: 'foomedical_storage_bucket' },
-        { Name: 'storagePublicKey', Value: 'VERY_LONG_KEY' },
-        { Name: 'maxAzs', Value: '6' },
-        { Name: 'rdsInstances', Value: '10' },
-        { Name: 'desiredServerCount', Value: '0' },
-        { Name: 'serverMemory', Value: '16384' },
-        { Name: 'serverCpu', Value: '4096' },
-      ],
+      mockSSMClient.on(GetParametersByPathCommand).resolves({
+        Parameters: [
+          { Name: 'stackName', Value: 'MyFoomedicalStack' },
+          { Name: 'apiPort', Value: '1337' },
+          { Name: 'apiDomainName', Value: 'api.foomedical.com' },
+          { Name: 'apiSslCertArn', Value: 'arn:foomedical_api_ssl_cert' },
+          { Name: 'appApiProxy', Value: 'true' },
+          { Name: 'signingKeyId', Value: 'key-abc123' },
+          { Name: 'storageBucketName', Value: 'foomedical_storage_bucket' },
+          { Name: 'storagePublicKey', Value: 'VERY_LONG_KEY' },
+          { Name: 'maxAzs', Value: '6' },
+          { Name: 'rdsInstances', Value: '10' },
+          { Name: 'desiredServerCount', Value: '0' },
+          { Name: 'serverMemory', Value: '16384' },
+          { Name: 'serverCpu', Value: '4096' },
+          { Name: 'MED', Value: 'PLUM' },
+          { Name: 'logGroupName', Value: 'FOOMEDICAL_PROD' },
+          { Name: 'logGroupCreate', Value: 'false' },
+        ],
+      });
     });
-  });
 
-  afterEach(() => {
-    mockSSMClient.restore();
-  });
+    afterEach(() => {
+      mockSSMClient.restore();
+    });
 
-  test('It should function', async () => {
-    const result = await normalizeInfraConfig(baseConfig);
-    expect(result).toBeDefined();
-    console.log(result);
+    test('Valid infra source config w/ external secrets', async () => {
+      const result = await normalizeInfraConfig(baseConfig);
+      expect(result).toEqual<MedplumInfraConfig>({
+        name: 'MyMedplumApp',
+        stackName: 'MyFoomedicalStack',
+        accountNumber: 'medplum123',
+        region: 'us-east-1',
+        domainName: 'foomedical.com',
+        vpcId: 'abc-321123',
+        apiPort: 1337,
+        apiDomainName: 'api.foomedical.com',
+        apiSslCertArn: 'arn:foomedical_api_ssl_cert',
+        apiInternetFacing: true,
+        appDomainName: 'app.foomedical.com',
+        appSslCertArn: 'arn:abc-123',
+        appApiProxy: true,
+        storageBucketName: 'foomedical_storage_bucket',
+        storageDomainName: 'storage.foomedical.com',
+        storageSslCertArn: 'arn:def-123',
+        signingKeyId: 'key-abc123',
+        storagePublicKey: 'VERY_LONG_KEY',
+        baseUrl: 'foomedical.com',
+        maxAzs: 6,
+        rdsInstances: 10,
+        rdsInstanceType: 'big',
+        desiredServerCount: 0,
+        serverImage: 'arn:our-image',
+        serverMemory: 16384,
+        serverCpu: 4096,
+        clamscanEnabled: false,
+        clamscanLoggingBucket: 'no_logging',
+        clamscanLoggingPrefix: 'foo_',
+        skipDns: true,
+      });
+    });
+
+    test('Valid source config w/ additional containers', async () => {
+      const result = await normalizeInfraConfig({ ...baseConfig, additionalContainers: [...additionalContainers] });
+      expect(result).toEqual<MedplumInfraConfig>({
+        name: 'MyMedplumApp',
+        stackName: 'MyFoomedicalStack',
+        accountNumber: 'medplum123',
+        region: 'us-east-1',
+        domainName: 'foomedical.com',
+        vpcId: 'abc-321123',
+        apiPort: 1337,
+        apiDomainName: 'api.foomedical.com',
+        apiSslCertArn: 'arn:foomedical_api_ssl_cert',
+        apiInternetFacing: true,
+        appDomainName: 'app.foomedical.com',
+        appSslCertArn: 'arn:abc-123',
+        appApiProxy: true,
+        storageBucketName: 'foomedical_storage_bucket',
+        storageDomainName: 'storage.foomedical.com',
+        storageSslCertArn: 'arn:def-123',
+        signingKeyId: 'key-abc123',
+        storagePublicKey: 'VERY_LONG_KEY',
+        baseUrl: 'foomedical.com',
+        maxAzs: 6,
+        rdsInstances: 10,
+        rdsInstanceType: 'big',
+        desiredServerCount: 0,
+        serverImage: 'arn:our-image',
+        serverMemory: 16384,
+        serverCpu: 4096,
+        clamscanEnabled: false,
+        clamscanLoggingBucket: 'no_logging',
+        clamscanLoggingPrefix: 'foo_',
+        skipDns: true,
+        additionalContainers: [
+          {
+            name: 'BIG IMAGE',
+            image: 'arn:big_image',
+            environment: {
+              FOO: 'BAR',
+              MED: 'PLUM',
+            },
+          },
+        ],
+      });
+    });
+
+    test('Valid source config w/ `cloudTrailAlarms`', async () => {
+      const result = await normalizeInfraConfig({ ...baseConfig, cloudTrailAlarms: { ...cloudTrailAlarms } });
+      expect(result).toEqual<MedplumInfraConfig>({
+        name: 'MyMedplumApp',
+        stackName: 'MyFoomedicalStack',
+        accountNumber: 'medplum123',
+        region: 'us-east-1',
+        domainName: 'foomedical.com',
+        vpcId: 'abc-321123',
+        apiPort: 1337,
+        apiDomainName: 'api.foomedical.com',
+        apiSslCertArn: 'arn:foomedical_api_ssl_cert',
+        apiInternetFacing: true,
+        appDomainName: 'app.foomedical.com',
+        appSslCertArn: 'arn:abc-123',
+        appApiProxy: true,
+        storageBucketName: 'foomedical_storage_bucket',
+        storageDomainName: 'storage.foomedical.com',
+        storageSslCertArn: 'arn:def-123',
+        signingKeyId: 'key-abc123',
+        storagePublicKey: 'VERY_LONG_KEY',
+        baseUrl: 'foomedical.com',
+        maxAzs: 6,
+        rdsInstances: 10,
+        rdsInstanceType: 'big',
+        desiredServerCount: 0,
+        serverImage: 'arn:our-image',
+        serverMemory: 16384,
+        serverCpu: 4096,
+        clamscanEnabled: false,
+        clamscanLoggingBucket: 'no_logging',
+        clamscanLoggingPrefix: 'foo_',
+        skipDns: true,
+        cloudTrailAlarms: {
+          logGroupName: 'FOOMEDICAL_PROD',
+          logGroupCreate: false,
+        },
+      });
+    });
   });
 });

--- a/packages/cdk/src/config.test.ts
+++ b/packages/cdk/src/config.test.ts
@@ -1,5 +1,5 @@
 import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { ExternalSecret, MedplumInfraConfig, OperationOutcomeError } from '@medplum/core';
+import { ExternalSecret, MedplumInfraConfig, MedplumSourceInfraConfig, OperationOutcomeError } from '@medplum/core';
 import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import {
@@ -42,7 +42,7 @@ const baseConfig = {
   clamscanLoggingBucket: 'no_logging',
   clamscanLoggingPrefix: 'foo_',
   skipDns: true,
-} as const;
+} as const satisfies MedplumSourceInfraConfig;
 
 const additionalContainers = [
   {

--- a/packages/cdk/src/config.test.ts
+++ b/packages/cdk/src/config.test.ts
@@ -1,0 +1,38 @@
+import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
+import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-jest';
+import { normalizeInfraConfig } from './config';
+
+describe('Config', () => {
+  let mockSSMClient: AwsClientStub<SSMClient>;
+
+  beforeEach(() => {
+    mockSSMClient = mockClient(SSMClient);
+
+    mockSSMClient.on(GetParametersByPathCommand).resolves({
+      Parameters: [
+        { Name: 'stackName', Value: 'MyMedplumStack' },
+        { Name: 'apiInternetFacing', Value: 'false' },
+        { Name: 'appApiProxy', Value: 'true' },
+        { Name: 'rdsInstances', Value: '10' },
+        { Name: 'desiredServerCount', Value: '0' },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    mockSSMClient.restore();
+  });
+
+  test('It should function', async () => {
+    const result = await normalizeInfraConfig({
+      stackName: { system: 'aws_ssm_parameter_store', key: '/:stackName', type: 'string' },
+      apiInternetFacing: { system: 'aws_ssm_parameter_store', key: '/:apiInternetFacing', type: 'boolean' },
+      appApiProxy: { system: 'aws_ssm_parameter_store', key: '/:appApiProxy', type: 'boolean' },
+      rdsInstances: { system: 'aws_ssm_parameter_store', key: '/:rdsInstances', type: 'number' },
+      desiredServerCount: { system: 'aws_ssm_parameter_store', key: '/:desiredServerCount', type: 'number' },
+    });
+    expect(result).toBeDefined();
+    console.log(result);
+  });
+});

--- a/packages/cdk/src/config.test.ts
+++ b/packages/cdk/src/config.test.ts
@@ -3,6 +3,55 @@ import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { normalizeInfraConfig } from './config';
 
+const baseConfig = {
+  name: 'MyMedplumApp',
+  stackName: { system: 'aws_ssm_parameter_store', key: '/:stackName', type: 'string' },
+  accountNumber: 'medplum123',
+  region: 'us-east-1',
+  domainName: 'foomedical.com',
+  vpcId: 'abc-321123',
+  apiPort: { system: 'aws_ssm_parameter_store', key: '/:apiPort', type: 'number' },
+  apiDomainName: { system: 'aws_ssm_parameter_store', key: '/:apiDomainName', type: 'string' },
+  apiSslCertArn: { system: 'aws_ssm_parameter_store', key: '/:apiSslCertArn', type: 'string' },
+  apiInternetFacing: true,
+  appDomainName: 'app.foomedical.com',
+  appSslCertArn: 'arn:abc-123',
+  appApiProxy: { system: 'aws_ssm_parameter_store', key: '/:appApiProxy', type: 'boolean' },
+  storageBucketName: { system: 'aws_ssm_parameter_store', key: '/:storageBucketName', type: 'string' },
+  storageDomainName: 'storage.foomedical.com',
+  storageSslCertArn: 'arn:def-123',
+  signingKeyId: { system: 'aws_ssm_parameter_store', key: '/:signingKeyId', type: 'string' },
+  storagePublicKey: { system: 'aws_ssm_parameter_store', key: '/:storagePublicKey', type: 'string' },
+  baseUrl: 'foomedical.com',
+  maxAzs: { system: 'aws_ssm_parameter_store', key: '/:maxAzs', type: 'number' },
+  rdsInstances: { system: 'aws_ssm_parameter_store', key: '/:rdsInstances', type: 'number' },
+  rdsInstanceType: 'big',
+  desiredServerCount: { system: 'aws_ssm_parameter_store', key: '/:desiredServerCount', type: 'number' },
+  serverImage: 'arn:our-image',
+  serverMemory: { system: 'aws_ssm_parameter_store', key: '/:serverMemory', type: 'number' },
+  serverCpu: { system: 'aws_ssm_parameter_store', key: '/:serverCpu', type: 'number' },
+  clamscanEnabled: false,
+  clamscanLoggingBucket: 'no_logging',
+  clamscanLoggingPrefix: 'foo_',
+  skipDns: true,
+} as const;
+
+// const additionalContainers = [
+//   {
+//     name: 'BIG IMAGE',
+//     image: 'arn:big_image',
+//     environment: {
+//       FOO: 'BAR',
+//       OTHER_FOO: { system: 'aws_ssm_parameter_store', key: '/:OTHER_FOO', type: 'string' },
+//     },
+//   },
+// ] as const;
+
+// const cloudTrailAlarms = {
+//   logGroupName: { system: 'aws_ssm_parameter_store', key: '/:logGroupName', type: 'string' },
+//   logGroupCreate: { system: 'aws_ssm_parameter_store', key: '/:logGroupCreate', type: 'boolean' },
+// } as const;
+
 describe('Config', () => {
   let mockSSMClient: AwsClientStub<SSMClient>;
 
@@ -11,11 +60,19 @@ describe('Config', () => {
 
     mockSSMClient.on(GetParametersByPathCommand).resolves({
       Parameters: [
-        { Name: 'stackName', Value: 'MyMedplumStack' },
-        { Name: 'apiInternetFacing', Value: 'false' },
+        { Name: 'stackName', Value: 'MyFoomedicalStack' },
+        { Name: 'apiPort', Value: '1337' },
+        { Name: 'apiDomainName', Value: 'api.foomedical.com' },
+        { Name: 'apiSslCertArn', Value: 'arn:foomedical_api_ssl_cert' },
         { Name: 'appApiProxy', Value: 'true' },
+        { Name: 'signingKeyId', Value: 'key-abc123' },
+        { Name: 'storageBucketName', Value: 'foomedical_storage_bucket' },
+        { Name: 'storagePublicKey', Value: 'VERY_LONG_KEY' },
+        { Name: 'maxAzs', Value: '6' },
         { Name: 'rdsInstances', Value: '10' },
         { Name: 'desiredServerCount', Value: '0' },
+        { Name: 'serverMemory', Value: '16384' },
+        { Name: 'serverCpu', Value: '4096' },
       ],
     });
   });
@@ -25,13 +82,7 @@ describe('Config', () => {
   });
 
   test('It should function', async () => {
-    const result = await normalizeInfraConfig({
-      stackName: { system: 'aws_ssm_parameter_store', key: '/:stackName', type: 'string' },
-      apiInternetFacing: { system: 'aws_ssm_parameter_store', key: '/:apiInternetFacing', type: 'boolean' },
-      appApiProxy: { system: 'aws_ssm_parameter_store', key: '/:appApiProxy', type: 'boolean' },
-      rdsInstances: { system: 'aws_ssm_parameter_store', key: '/:rdsInstances', type: 'number' },
-      desiredServerCount: { system: 'aws_ssm_parameter_store', key: '/:desiredServerCount', type: 'number' },
-    });
+    const result = await normalizeInfraConfig(baseConfig);
     expect(result).toBeDefined();
     console.log(result);
   });

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -57,7 +57,7 @@ export function normalizeFetchedValue(
   if (!VALID_PRIMITIVE_TYPES.includes(typeOfVal)) {
     throw new OperationOutcomeError(
       validationError(
-        `Invalid value found for type, expected 'string' or 'boolean' or 'number', received: '${typeOfVal}'`
+        `Invalid value found for type; expected either ${VALID_PRIMITIVE_TYPES.join(', or')} but got ${typeOfVal}`
       )
     );
   }
@@ -67,7 +67,7 @@ export function normalizeFetchedValue(
     const normalized = (rawValue as string).toLowerCase() as 'true' | 'false';
     if (normalized !== 'true' && normalized !== 'false') {
       throw new OperationOutcomeError(
-        validationError(`Invalid value found for key '${key}', expected boolean value but got '${rawValue}'`)
+        validationError(`Invalid value found for key '${key}'; expected boolean value but got '${rawValue}'`)
       );
     }
     return normalized === 'true';
@@ -75,13 +75,13 @@ export function normalizeFetchedValue(
     const parsed = parseInt(rawValue as string, 10);
     if (Number.isNaN(parsed)) {
       throw new OperationOutcomeError(
-        validationError(`Invalid value found for key '${key}', expected integer value but got '${rawValue}'`)
+        validationError(`Invalid value found for key '${key}'; expected integer value but got '${rawValue}'`)
       );
     }
     return parsed;
   } else {
     throw new OperationOutcomeError(
-      validationError(`Invalid value found for type, expected '${expectedType}', received: '${typeOfVal}'`)
+      validationError(`Invalid value found for type; expected ${expectedType} value but got value of type ${typeOfVal}`)
     );
   }
 }
@@ -163,10 +163,8 @@ async function normalizeValueForKey(obj: Record<string, any>, key: string): Prom
 export async function normalizeObjectInInfraConfig(obj: Record<string, any>): Promise<Record<string, any>> {
   const normalizedObj = { ...obj };
   // walk config object
-  for (const key in normalizedObj) {
-    if (Object.hasOwn(normalizedObj, key)) {
-      await normalizeValueForKey(normalizedObj, key);
-    }
+  for (const key of Object.keys(normalizedObj)) {
+    await normalizeValueForKey(normalizedObj, key);
   }
   return normalizedObj;
 }

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -182,24 +182,6 @@ export function isExternalSecretLike(obj: Record<string, any>): obj is ExternalS
   );
 }
 
-export function assertValidExternalSecret(obj: Record<string, any>): asserts obj is ExternalSecret {
-  if (
-    typeof obj !== 'object' ||
-    typeof obj.system !== 'string' ||
-    typeof obj.key !== 'string' ||
-    typeof obj.type !== 'string'
-  ) {
-    throw new OperationOutcomeError(
-      validationError('obj is not a valid `ExternalSecret`, must contain a valid `system`, `key`, and `type` prop.')
-    );
-  }
-  if (!VALID_PRIMITIVE_TYPES.includes(obj.type)) {
-    throw new OperationOutcomeError(
-      validationError(`'${obj.type}' is not a valid primitive type. Must be one of ${VALID_PRIMITIVE_TYPES.join(',')}`)
-    );
-  }
-}
-
 export function isExternalSecret(obj: Record<string, any>): obj is ExternalSecret {
   return (
     typeof obj === 'object' &&
@@ -207,6 +189,14 @@ export function isExternalSecret(obj: Record<string, any>): obj is ExternalSecre
     typeof obj.key === 'string' &&
     VALID_PRIMITIVE_TYPES.includes(obj.type)
   );
+}
+
+export function assertValidExternalSecret(obj: Record<string, any>): asserts obj is ExternalSecret {
+  if (!isExternalSecret(obj)) {
+    throw new OperationOutcomeError(
+      validationError('obj is not a valid `ExternalSecret`, must contain a valid `system`, `key`, and `type` prop.')
+    );
+  }
 }
 
 export async function normalizeInfraConfig(config: MedplumSourceInfraConfig): Promise<MedplumInfraConfig> {

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -61,11 +61,9 @@ export function normalizeFetchedValue(
       )
     );
   }
-  if (expectedType === 'string' && typeOfVal === 'string') {
+  if (typeOfVal === expectedType) {
     return rawValue;
-  } else if (expectedType !== 'string' && typeOfVal === expectedType) {
-    return rawValue;
-  } else if (expectedType === 'boolean' && typeOfVal === 'string') {
+  } else if (typeOfVal === 'string' && expectedType === 'boolean') {
     const normalized = (rawValue as string).toLowerCase() as 'true' | 'false';
     if (normalized !== 'true' && normalized !== 'false') {
       throw new OperationOutcomeError(
@@ -73,7 +71,7 @@ export function normalizeFetchedValue(
       );
     }
     return normalized === 'true';
-  } else if (expectedType === 'number' && typeOfVal === 'string') {
+  } else if (typeOfVal === 'string' && expectedType === 'number') {
     const parsed = parseInt(rawValue as string, 10);
     if (Number.isNaN(parsed)) {
       throw new OperationOutcomeError(

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -1,6 +1,8 @@
 import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
 import {
   ExternalSecret,
+  ExternalSecretPrimitive,
+  ExternalSecretPrimitiveType,
   MedplumInfraConfig,
   MedplumSourceInfraConfig,
   OperationOutcomeError,
@@ -46,9 +48,9 @@ export async function fetchParameterStoreSecret(path: string, key: string): Prom
 
 function normalizeFetchedValue(
   key: string,
-  rawValue: string | boolean | number,
-  expectedType: 'string' | 'boolean' | 'number'
-): string | boolean | number {
+  rawValue: ExternalSecretPrimitive,
+  expectedType: ExternalSecretPrimitiveType
+): ExternalSecretPrimitive {
   const typeOfVal = typeof rawValue;
   // Return raw type if type is string and value is of type string, or if type isn't string and typeof val isn't string
   if (!['string', 'boolean', 'number'].includes(typeOfVal)) {
@@ -85,11 +87,9 @@ function normalizeFetchedValue(
   }
 }
 
-export async function fetchExternalSecret(
-  externalSecret: ExternalSecret<'string' | 'boolean' | 'number'>
-): Promise<string | number | boolean> {
+export async function fetchExternalSecret(externalSecret: ExternalSecret): Promise<ExternalSecretPrimitive> {
   const { system, key, type } = externalSecret;
-  let rawValue: string | boolean | number;
+  let rawValue: ExternalSecretPrimitive;
   switch (system) {
     case 'aws_ssm_parameter_store': {
       const [paramPath, paramKey] = key.split(':');
@@ -137,7 +137,7 @@ export async function normalizeObjectInInfraConfig(obj: Record<string, any>): Pr
               | string
               | boolean
               | number
-              | ExternalSecret<'string' | 'boolean' | 'number'>;
+              | ExternalSecret<ExternalSecretPrimitiveType>;
             if (typeof currIdxVal !== 'object') {
               newArray[i] = currIdxVal;
               continue;

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -177,9 +177,6 @@ export function isExternalSecret(obj: Record<string, any>): obj is ExternalSecre
   );
 }
 
-// TODO: Don't use partials???
-export async function normalizeInfraConfig(
-  config: Partial<MedplumSourceInfraConfig>
-): Promise<Partial<MedplumInfraConfig>> {
-  return normalizeObjectInInfraConfig(config) as Promise<Partial<MedplumInfraConfig>>;
+export async function normalizeInfraConfig(config: MedplumSourceInfraConfig): Promise<MedplumInfraConfig> {
+  return normalizeObjectInInfraConfig(config) as Promise<MedplumInfraConfig>;
 }

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -18,6 +18,9 @@ export class InfraConfigNormalizer {
   private clients: { ssm: SSMClient };
   constructor(config: MedplumSourceInfraConfig) {
     const { region } = config;
+    if (!region) {
+      throw new OperationOutcomeError(validationError("'region' must be defined as a string literal in config."));
+    }
     if (!ssmClients[region]) {
       ssmClients[region] = new SSMClient({ region });
     }

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -104,7 +104,9 @@ export async function fetchExternalSecret(externalSecret: ExternalSecret): Promi
       break;
     }
     default:
-      throw new Error(`Unknown system '${system}' for ExternalSecret. Unable to fetch the secret for key '${key}'.`);
+      throw new OperationOutcomeError(
+        validationError(`Unknown system '${system}' for ExternalSecret. Unable to fetch the secret for key '${key}'.`)
+      );
   }
   return normalizeFetchedValue(key, rawValue, type);
 }

--- a/packages/cdk/src/config.ts
+++ b/packages/cdk/src/config.ts
@@ -1,0 +1,185 @@
+import { GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
+import {
+  ExternalSecret,
+  MedplumInfraConfig,
+  MedplumSourceInfraConfig,
+  OperationOutcomeError,
+  badRequest,
+  validationError,
+} from '@medplum/core';
+
+const DEFAULT_AWS_REGION = 'us-east-1';
+
+export async function fetchParameterStoreSecret(path: string, key: string): Promise<string> {
+  const region = DEFAULT_AWS_REGION;
+  const client = new SSMClient({ region });
+
+  let nextToken: string | undefined;
+  do {
+    const response = await client.send(
+      new GetParametersByPathCommand({
+        Path: path,
+        NextToken: nextToken,
+        WithDecryption: true,
+      })
+    );
+    if (response.Parameters) {
+      for (const param of response.Parameters) {
+        const paramKey = (param.Name as string).replace(path, '');
+        if (paramKey === key) {
+          if (!param.Value) {
+            throw new OperationOutcomeError(badRequest(`Key ${key} found in path ${path} but missing a value.`));
+          }
+          return param.Value;
+        }
+      }
+    }
+    nextToken = response.NextToken;
+  } while (nextToken);
+
+  throw new OperationOutcomeError(
+    badRequest(
+      `Key ${key} not found at path ${path}. Make sure your path and key are correct and are defined in your Parameter Store.`
+    )
+  );
+}
+
+function normalizeFetchedValue(
+  key: string,
+  rawValue: string | boolean | number,
+  expectedType: 'string' | 'boolean' | 'number'
+): string | boolean | number {
+  const typeOfVal = typeof rawValue;
+  // Return raw type if type is string and value is of type string, or if type isn't string and typeof val isn't string
+  if (!['string', 'boolean', 'number'].includes(typeOfVal)) {
+    throw new OperationOutcomeError(
+      validationError(
+        `Invalid value found for type, expected 'string' or 'boolean' or 'number', received: '${typeOfVal}'`
+      )
+    );
+  }
+  if (expectedType === 'string' && typeOfVal === 'string') {
+    return rawValue;
+  } else if (expectedType !== 'string' && typeOfVal !== 'string') {
+    return rawValue;
+  } else if (expectedType === 'boolean' && typeOfVal === 'string') {
+    const normalized = (rawValue as string).toLowerCase() as 'true' | 'false';
+    if (normalized !== 'true' && normalized !== 'false') {
+      throw new OperationOutcomeError(
+        validationError(`Invalid value found for key '${key}', expected boolean value but got '${rawValue}'`)
+      );
+    }
+    return normalized === 'true';
+  } else if (expectedType === 'number' && typeOfVal === 'string') {
+    const parsed = parseInt(rawValue as string, 10);
+    if (Number.isNaN(parsed)) {
+      throw new OperationOutcomeError(
+        validationError(`Invalid value found for key '${key}', expected integer value but got '${rawValue}'`)
+      );
+    }
+    return parsed;
+  } else {
+    throw new OperationOutcomeError(
+      validationError(`Invalid value found for type, expected '${expectedType}', received: '${typeOfVal}'`)
+    );
+  }
+}
+
+export async function fetchExternalSecret(
+  externalSecret: ExternalSecret<'string' | 'boolean' | 'number'>
+): Promise<string | number | boolean> {
+  const { system, key, type } = externalSecret;
+  let rawValue: string | boolean | number;
+  switch (system) {
+    case 'aws_ssm_parameter_store': {
+      const [paramPath, paramKey] = key.split(':');
+      if (!(paramPath && paramKey)) {
+        throw new OperationOutcomeError(
+          validationError(
+            'Keys for AWS Param Store secrets must be a path followed by a ":" and a key. (/path/to/param:my_key)'
+          )
+        );
+      }
+      rawValue = await fetchParameterStoreSecret(paramPath, paramKey);
+      break;
+    }
+    default:
+      throw new Error(`Unknown system '${system}' for ExternalSecret. Unable to fetch the secret for key '${key}'.`);
+  }
+  return normalizeFetchedValue(key, rawValue, type);
+}
+
+export async function normalizeObjectInInfraConfig(obj: Record<string, any>): Promise<Record<string, any>> {
+  const normalizedObj = {};
+  // walk config object
+  for (const key in obj) {
+    if (Object.hasOwn(obj, key)) {
+      const currentVal = obj[key];
+      // cases:
+      // --- case 1: primitive
+      if (typeof currentVal !== 'object') {
+        // @ts-expect-error Unable to match type info for keys generically at runtime
+        normalizedObj[key] = currentVal;
+      }
+      // --- case 2: object conforming to `ExternalSecret` schema
+      else if (isExternalSecret(currentVal)) {
+        // @ts-expect-error Unable to match type info for keys generically at runtime
+        normalizedObj[key] = await fetchExternalSecret(currentVal);
+      }
+      // --- case 3: an array of:
+      else if (Array.isArray(currentVal) && currentVal.length) {
+        // ------ case 3a: primitives or `ExternalSecret`
+        const firstEle = currentVal[0];
+        if ((typeof firstEle !== 'object' && firstEle !== null) || isExternalSecret(firstEle)) {
+          const newArray = new Array(currentVal.length) as (string | number | boolean)[];
+          for (let i = 0; i < currentVal.length; i++) {
+            const currIdxVal = currentVal[i] as unknown as
+              | string
+              | boolean
+              | number
+              | ExternalSecret<'string' | 'boolean' | 'number'>;
+            if (typeof currIdxVal !== 'object') {
+              newArray[i] = currIdxVal;
+              continue;
+            }
+            const fetchedVal = await fetchExternalSecret(currIdxVal);
+            newArray[i] = fetchedVal;
+          }
+          // @ts-expect-error Unable to match type info for keys generically at runtime
+          normalizedObj[key] = newArray;
+        }
+        // ------ case 3b: other objects (recurse)
+        else {
+          const newArray = new Array(currentVal.length) as Record<string, any>[];
+          for (let i = 0; i < currentVal.length; i++) {
+            newArray[i] = await normalizeObjectInInfraConfig(currentVal[i]);
+          }
+          // @ts-expect-error Unable to match type info for keys generically at runtime
+          normalizedObj[key] = newArray;
+        }
+      }
+      // --- case 4: other object (recurse)
+      else if (typeof currentVal === 'object') {
+        // @ts-expect-error Unable to match type info for keys generically at runtime
+        normalizedObj[key] = await normalizeObjectInInfraConfig(currentVal);
+      }
+    }
+  }
+  return normalizedObj;
+}
+
+export function isExternalSecret(obj: Record<string, any>): obj is ExternalSecret<'boolean' | 'number' | 'string'> {
+  return (
+    typeof obj === 'object' &&
+    typeof obj.system === 'string' &&
+    typeof obj.key === 'string' &&
+    (obj.type === 'string' || obj.type === 'boolean' || obj.type === 'number')
+  );
+}
+
+// TODO: Don't use partials???
+export async function normalizeInfraConfig(
+  config: Partial<MedplumSourceInfraConfig>
+): Promise<Partial<MedplumInfraConfig>> {
+  return normalizeObjectInInfraConfig(config) as Promise<Partial<MedplumInfraConfig>>;
+}

--- a/packages/cdk/src/index.ts
+++ b/packages/cdk/src/index.ts
@@ -1,7 +1,8 @@
-import { MedplumInfraConfig } from '@medplum/core';
+import { MedplumSourceInfraConfig } from '@medplum/core';
 import { App } from 'aws-cdk-lib';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { normalizeInfraConfig } from './config';
 import { MedplumStack } from './stack';
 
 export * from './backend';
@@ -21,12 +22,19 @@ export function main(context?: Record<string, string>): void {
     return;
   }
 
-  const config = JSON.parse(readFileSync(resolve(configFileName), 'utf-8')) as MedplumInfraConfig;
+  const config = JSON.parse(readFileSync(resolve(configFileName), 'utf-8')) as MedplumSourceInfraConfig;
 
-  const stack = new MedplumStack(app, config);
-  console.log('Stack', stack.primaryStack.stackId);
+  normalizeInfraConfig(config)
+    .then((normalizedConfig) => {
+      const stack = new MedplumStack(app, normalizedConfig);
+      console.log('Stack', stack.primaryStack.stackId);
 
-  app.synth();
+      app.synth();
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 }
 
 if (require.main === module) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,8 +3,10 @@ export const ExternalSecretSystems = {
 } as const;
 
 export type ExternalSecretSystem = keyof typeof ExternalSecretSystems;
+export type ExternalSecretPrimitive = string | boolean | number;
+export type ExternalSecretPrimitiveType = 'string' | 'boolean' | 'number';
 
-export type ExternalSecret<T extends 'string' | 'number' | 'boolean'> = {
+export type ExternalSecret<T extends ExternalSecretPrimitiveType = ExternalSecretPrimitiveType> = {
   system: ExternalSecretSystem;
   key: string;
   type: T;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,3 +1,5 @@
+import { TypeName } from './types';
+
 export const ExternalSecretSystems = {
   aws_ssm_parameter_store: 'aws_ssm_parameter_store',
 } as const;
@@ -5,68 +7,68 @@ export const ExternalSecretSystems = {
 export type ExternalSecretSystem = keyof typeof ExternalSecretSystems;
 export type ExternalSecretPrimitive = string | boolean | number;
 export type ExternalSecretPrimitiveType = 'string' | 'boolean' | 'number';
-
-export type ExternalSecret<T extends ExternalSecretPrimitiveType = ExternalSecretPrimitiveType> = {
+export type ExternalSecret<T extends ExternalSecretPrimitive = ExternalSecretPrimitive> = {
   system: ExternalSecretSystem;
   key: string;
-  type: T;
+  type: TypeName<T>;
 };
+export type ValueOrExternalSecret<T extends ExternalSecretPrimitive> = T | ExternalSecret<T>;
 
 export interface MedplumSourceInfraConfig {
-  name: string | ExternalSecret<'string'>;
-  stackName: string | ExternalSecret<'string'>;
-  accountNumber: string | ExternalSecret<'string'>;
-  region: string | ExternalSecret<'string'>;
-  domainName: string | ExternalSecret<'string'>;
-  vpcId: string | ExternalSecret<'string'>;
-  apiPort: number | ExternalSecret<'number'>;
-  apiDomainName: string | ExternalSecret<'string'>;
-  apiSslCertArn: string | ExternalSecret<'string'>;
-  apiInternetFacing?: boolean | ExternalSecret<'boolean'>;
-  appDomainName: string | ExternalSecret<'string'>;
-  appSslCertArn: string | ExternalSecret<'string'>;
-  appApiProxy?: boolean | ExternalSecret<'boolean'>;
-  appLoggingBucket?: string | ExternalSecret<'string'>;
-  appLoggingPrefix?: string | ExternalSecret<'string'>;
-  storageBucketName: string | ExternalSecret<'string'>;
-  storageDomainName: string | ExternalSecret<'string'>;
-  storageSslCertArn: string | ExternalSecret<'string'>;
-  signingKeyId: string | ExternalSecret<'string'>;
-  storagePublicKey: string | ExternalSecret<'string'>;
-  storageLoggingBucket?: string | ExternalSecret<'string'>;
-  storageLoggingPrefix?: string | ExternalSecret<'string'>;
-  baseUrl: string | ExternalSecret<'string'>;
-  maxAzs: number | ExternalSecret<'number'>;
-  rdsInstances: number | ExternalSecret<'number'>;
-  rdsInstanceType: string | ExternalSecret<'string'>;
-  rdsSecretsArn?: string | ExternalSecret<'string'>;
-  cacheNodeType?: string | ExternalSecret<'string'>;
-  desiredServerCount: number | ExternalSecret<'number'>;
-  serverImage: string | ExternalSecret<'string'>;
-  serverMemory: number | ExternalSecret<'number'>;
-  serverCpu: number | ExternalSecret<'number'>;
-  loadBalancerLoggingBucket?: string | ExternalSecret<'string'>;
-  loadBalancerLoggingPrefix?: string | ExternalSecret<'string'>;
-  clamscanEnabled: boolean | ExternalSecret<'boolean'>;
-  clamscanLoggingBucket: string | ExternalSecret<'string'>;
-  clamscanLoggingPrefix: string | ExternalSecret<'string'>;
-  skipDns?: boolean | ExternalSecret<'boolean'>;
+  name: ValueOrExternalSecret<string>;
+  stackName: ValueOrExternalSecret<string>;
+  accountNumber: ValueOrExternalSecret<string>;
+  region: ValueOrExternalSecret<string>;
+  domainName: ValueOrExternalSecret<string>;
+  vpcId: ValueOrExternalSecret<string>;
+  apiPort: ValueOrExternalSecret<number>;
+  apiDomainName: ValueOrExternalSecret<string>;
+  apiSslCertArn: ValueOrExternalSecret<string>;
+  apiInternetFacing?: ValueOrExternalSecret<boolean>;
+  appDomainName: ValueOrExternalSecret<string>;
+  appSslCertArn: ValueOrExternalSecret<string>;
+  appApiProxy?: ValueOrExternalSecret<boolean>;
+  appLoggingBucket?: ValueOrExternalSecret<string>;
+  appLoggingPrefix?: ValueOrExternalSecret<string>;
+  storageBucketName: ValueOrExternalSecret<string>;
+  storageDomainName: ValueOrExternalSecret<string>;
+  storageSslCertArn: ValueOrExternalSecret<string>;
+  signingKeyId: ValueOrExternalSecret<string>;
+  storagePublicKey: ValueOrExternalSecret<string>;
+  storageLoggingBucket?: ValueOrExternalSecret<string>;
+  storageLoggingPrefix?: ValueOrExternalSecret<string>;
+  baseUrl: ValueOrExternalSecret<string>;
+  maxAzs: ValueOrExternalSecret<number>;
+  rdsInstances: ValueOrExternalSecret<number>;
+  rdsInstanceType: ValueOrExternalSecret<string>;
+  rdsSecretsArn?: ValueOrExternalSecret<string>;
+  cacheNodeType?: ValueOrExternalSecret<string>;
+  desiredServerCount: ValueOrExternalSecret<number>;
+  serverImage: ValueOrExternalSecret<string>;
+  serverMemory: ValueOrExternalSecret<number>;
+  serverCpu: ValueOrExternalSecret<number>;
+  loadBalancerLoggingBucket?: ValueOrExternalSecret<string>;
+  loadBalancerLoggingPrefix?: ValueOrExternalSecret<string>;
+  clamscanEnabled: ValueOrExternalSecret<boolean>;
+  clamscanLoggingBucket: ValueOrExternalSecret<string>;
+  clamscanLoggingPrefix: ValueOrExternalSecret<string>;
+  skipDns?: ValueOrExternalSecret<boolean>;
   additionalContainers?: {
-    name: string | ExternalSecret<'string'>;
-    image: string | ExternalSecret<'string'>;
-    cpu?: number | ExternalSecret<'number'>;
-    memory?: number | ExternalSecret<'number'>;
-    essential?: boolean | ExternalSecret<'boolean'>;
-    command?: (string | ExternalSecret<'string'>)[];
+    name: ValueOrExternalSecret<string>;
+    image: ValueOrExternalSecret<string>;
+    cpu?: ValueOrExternalSecret<number>;
+    memory?: ValueOrExternalSecret<number>;
+    essential?: ValueOrExternalSecret<boolean>;
+    command?: ValueOrExternalSecret<string>[];
     environment?: {
-      [key: string]: string | ExternalSecret<'string'>;
+      [key: string]: ValueOrExternalSecret<string>;
     };
   }[];
   cloudTrailAlarms?: {
-    logGroupName: string | ExternalSecret<'string'>;
-    logGroupCreate?: boolean | ExternalSecret<'boolean'>;
-    snsTopicArn?: string | ExternalSecret<'string'>;
-    snsTopicName?: string | ExternalSecret<'string'>;
+    logGroupName: ValueOrExternalSecret<string>;
+    logGroupCreate?: ValueOrExternalSecret<boolean>;
+    snsTopicArn?: ValueOrExternalSecret<string>;
+    snsTopicName?: ValueOrExternalSecret<string>;
   };
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,66 +4,67 @@ export const ExternalSecretSystems = {
 
 export type ExternalSecretSystem = keyof typeof ExternalSecretSystems;
 
-export type ExternalSecret = {
+export type ExternalSecret<T extends 'string' | 'number' | 'boolean'> = {
   system: ExternalSecretSystem;
   key: string;
+  type: T;
 };
 
 export interface MedplumSourceInfraConfig {
-  name: string | ExternalSecret;
-  stackName: string | ExternalSecret;
-  accountNumber: string | ExternalSecret;
-  region: string | ExternalSecret;
-  domainName: string | ExternalSecret;
-  vpcId: string | ExternalSecret;
-  apiPort: number | ExternalSecret;
-  apiDomainName: string | ExternalSecret;
-  apiSslCertArn: string | ExternalSecret;
-  apiInternetFacing?: boolean | ExternalSecret;
-  appDomainName: string | ExternalSecret;
-  appSslCertArn: string | ExternalSecret;
-  appApiProxy?: boolean | ExternalSecret;
-  appLoggingBucket?: string | ExternalSecret;
-  appLoggingPrefix?: string | ExternalSecret;
-  storageBucketName: string | ExternalSecret;
-  storageDomainName: string | ExternalSecret;
-  storageSslCertArn: string | ExternalSecret;
-  signingKeyId: string | ExternalSecret;
-  storagePublicKey: string | ExternalSecret;
-  storageLoggingBucket?: string | ExternalSecret;
-  storageLoggingPrefix?: string | ExternalSecret;
-  baseUrl: string | ExternalSecret;
-  maxAzs: number | ExternalSecret;
-  rdsInstances: number | ExternalSecret;
-  rdsInstanceType: string | ExternalSecret;
-  rdsSecretsArn?: string | ExternalSecret;
-  cacheNodeType?: string | ExternalSecret;
-  desiredServerCount: number | ExternalSecret;
-  serverImage: string | ExternalSecret;
-  serverMemory: number | ExternalSecret;
-  serverCpu: number | ExternalSecret;
-  loadBalancerLoggingBucket?: string | ExternalSecret;
-  loadBalancerLoggingPrefix?: string | ExternalSecret;
-  clamscanEnabled: boolean | ExternalSecret;
-  clamscanLoggingBucket: string | ExternalSecret;
-  clamscanLoggingPrefix: string | ExternalSecret;
-  skipDns?: boolean | ExternalSecret;
+  name: string | ExternalSecret<'string'>;
+  stackName: string | ExternalSecret<'string'>;
+  accountNumber: string | ExternalSecret<'string'>;
+  region: string | ExternalSecret<'string'>;
+  domainName: string | ExternalSecret<'string'>;
+  vpcId: string | ExternalSecret<'string'>;
+  apiPort: number | ExternalSecret<'number'>;
+  apiDomainName: string | ExternalSecret<'string'>;
+  apiSslCertArn: string | ExternalSecret<'string'>;
+  apiInternetFacing?: boolean | ExternalSecret<'boolean'>;
+  appDomainName: string | ExternalSecret<'string'>;
+  appSslCertArn: string | ExternalSecret<'string'>;
+  appApiProxy?: boolean | ExternalSecret<'boolean'>;
+  appLoggingBucket?: string | ExternalSecret<'string'>;
+  appLoggingPrefix?: string | ExternalSecret<'string'>;
+  storageBucketName: string | ExternalSecret<'string'>;
+  storageDomainName: string | ExternalSecret<'string'>;
+  storageSslCertArn: string | ExternalSecret<'string'>;
+  signingKeyId: string | ExternalSecret<'string'>;
+  storagePublicKey: string | ExternalSecret<'string'>;
+  storageLoggingBucket?: string | ExternalSecret<'string'>;
+  storageLoggingPrefix?: string | ExternalSecret<'string'>;
+  baseUrl: string | ExternalSecret<'string'>;
+  maxAzs: number | ExternalSecret<'number'>;
+  rdsInstances: number | ExternalSecret<'number'>;
+  rdsInstanceType: string | ExternalSecret<'string'>;
+  rdsSecretsArn?: string | ExternalSecret<'string'>;
+  cacheNodeType?: string | ExternalSecret<'string'>;
+  desiredServerCount: number | ExternalSecret<'number'>;
+  serverImage: string | ExternalSecret<'string'>;
+  serverMemory: number | ExternalSecret<'number'>;
+  serverCpu: number | ExternalSecret<'number'>;
+  loadBalancerLoggingBucket?: string | ExternalSecret<'string'>;
+  loadBalancerLoggingPrefix?: string | ExternalSecret<'string'>;
+  clamscanEnabled: boolean | ExternalSecret<'boolean'>;
+  clamscanLoggingBucket: string | ExternalSecret<'string'>;
+  clamscanLoggingPrefix: string | ExternalSecret<'string'>;
+  skipDns?: boolean | ExternalSecret<'boolean'>;
   additionalContainers?: {
-    name: string | ExternalSecret;
-    image: string | ExternalSecret;
-    cpu?: number | ExternalSecret;
-    memory?: number | ExternalSecret;
-    essential?: boolean | ExternalSecret;
-    command?: (string | ExternalSecret)[];
+    name: string | ExternalSecret<'string'>;
+    image: string | ExternalSecret<'string'>;
+    cpu?: number | ExternalSecret<'number'>;
+    memory?: number | ExternalSecret<'number'>;
+    essential?: boolean | ExternalSecret<'boolean'>;
+    command?: (string | ExternalSecret<'string'>)[];
     environment?: {
-      [key: string]: string | ExternalSecret;
+      [key: string]: string | ExternalSecret<'string'>;
     };
   }[];
   cloudTrailAlarms?: {
-    logGroupName: string | ExternalSecret;
-    logGroupCreate?: boolean | ExternalSecret;
-    snsTopicArn?: string | ExternalSecret;
-    snsTopicName?: string | ExternalSecret;
+    logGroupName: string | ExternalSecret<'string'>;
+    logGroupCreate?: boolean | ExternalSecret<'boolean'>;
+    snsTopicArn?: string | ExternalSecret<'string'>;
+    snsTopicName?: string | ExternalSecret<'string'>;
   };
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,3 +1,72 @@
+export const ExternalSecretSystems = {
+  aws_ssm_parameter_store: 'aws_ssm_parameter_store',
+} as const;
+
+export type ExternalSecretSystem = keyof typeof ExternalSecretSystems;
+
+export type ExternalSecret = {
+  system: ExternalSecretSystem;
+  key: string;
+};
+
+export interface MedplumSourceInfraConfig {
+  name: string | ExternalSecret;
+  stackName: string | ExternalSecret;
+  accountNumber: string | ExternalSecret;
+  region: string | ExternalSecret;
+  domainName: string | ExternalSecret;
+  vpcId: string | ExternalSecret;
+  apiPort: number | ExternalSecret;
+  apiDomainName: string | ExternalSecret;
+  apiSslCertArn: string | ExternalSecret;
+  apiInternetFacing?: boolean | ExternalSecret;
+  appDomainName: string | ExternalSecret;
+  appSslCertArn: string | ExternalSecret;
+  appApiProxy?: boolean | ExternalSecret;
+  appLoggingBucket?: string | ExternalSecret;
+  appLoggingPrefix?: string | ExternalSecret;
+  storageBucketName: string | ExternalSecret;
+  storageDomainName: string | ExternalSecret;
+  storageSslCertArn: string | ExternalSecret;
+  signingKeyId: string | ExternalSecret;
+  storagePublicKey: string | ExternalSecret;
+  storageLoggingBucket?: string | ExternalSecret;
+  storageLoggingPrefix?: string | ExternalSecret;
+  baseUrl: string | ExternalSecret;
+  maxAzs: number | ExternalSecret;
+  rdsInstances: number | ExternalSecret;
+  rdsInstanceType: string | ExternalSecret;
+  rdsSecretsArn?: string | ExternalSecret;
+  cacheNodeType?: string | ExternalSecret;
+  desiredServerCount: number | ExternalSecret;
+  serverImage: string | ExternalSecret;
+  serverMemory: number | ExternalSecret;
+  serverCpu: number | ExternalSecret;
+  loadBalancerLoggingBucket?: string | ExternalSecret;
+  loadBalancerLoggingPrefix?: string | ExternalSecret;
+  clamscanEnabled: boolean | ExternalSecret;
+  clamscanLoggingBucket: string | ExternalSecret;
+  clamscanLoggingPrefix: string | ExternalSecret;
+  skipDns?: boolean | ExternalSecret;
+  additionalContainers?: {
+    name: string | ExternalSecret;
+    image: string | ExternalSecret;
+    cpu?: number | ExternalSecret;
+    memory?: number | ExternalSecret;
+    essential?: boolean | ExternalSecret;
+    command?: (string | ExternalSecret)[];
+    environment?: {
+      [key: string]: string | ExternalSecret;
+    };
+  }[];
+  cloudTrailAlarms?: {
+    logGroupName: string | ExternalSecret;
+    logGroupCreate?: boolean | ExternalSecret;
+    snsTopicArn?: string | ExternalSecret;
+    snsTopicName?: string | ExternalSecret;
+  };
+}
+
 export interface MedplumInfraConfig {
   name: string;
   stackName: string;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,7 +18,7 @@ export interface MedplumSourceInfraConfig {
   name: ValueOrExternalSecret<string>;
   stackName: ValueOrExternalSecret<string>;
   accountNumber: ValueOrExternalSecret<string>;
-  region: ValueOrExternalSecret<string>;
+  region: string;
   domainName: ValueOrExternalSecret<string>;
   vpcId: ValueOrExternalSecret<string>;
   apiPort: ValueOrExternalSecret<number>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,8 +11,18 @@ import {
 } from '@medplum/fhirtypes';
 import { formatHumanName } from './format';
 import { SearchParameterDetails } from './search/details';
-import { getAllDataTypes, InternalSchemaElement, InternalTypeSchema, tryGetDataType } from './typeschema/types';
+import { InternalSchemaElement, InternalTypeSchema, getAllDataTypes, tryGetDataType } from './typeschema/types';
 import { capitalize, createReference } from './utils';
+
+export type TypeName<T> = T extends string
+  ? 'string'
+  : T extends number
+  ? 'number'
+  : T extends boolean
+  ? 'boolean'
+  : T extends undefined
+  ? 'undefined'
+  : 'object';
 
 export interface TypedValue {
   readonly type: string;


### PR DESCRIPTION
## What this PR does
* Adds support for external secrets in `MedplumInfraConfig` during CDK deployments
* Closes #2788

## TODO:
- [x] Add tests
- [x] Refactor logic to make it less hard to read
- [x] Consider implications of serially fetching secrets vs. parallelization
- [ ] Update docs for CDK config?
