### PR TITLE
Github action to add issue to projects

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,21 @@
+name: Add issue to projects
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/medplum/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/medplum/projects/3
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: customer


### PR DESCRIPTION
Uses https://github.com/actions/add-to-project

Always adds new issues to main project: https://github.com/orgs/medplum/projects/1/views/1

Conditionally adds issues to customer project if labeled "customer"