### PR TITLE
Require hyphen after @param jsdoc

### DIFF
--- a/examples/medplum-demo-bots/src/candid-health/send-to-candid.ts
+++ b/examples/medplum-demo-bots/src/candid-health/send-to-candid.ts
@@ -115,9 +115,9 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Encounter>
 /**
  * Authenticates into the Candid Health API using API key and API secret, and posts the CodedEncounter object to
  * Candid's /v1/coded_encounters endpoint
- * @param candidCodedEncounter A JS representation of the CodedEncounter object
- * @param apiKey  Candid Health API Key
- * @param apiSecret Candid Health API Secret
+ * @param candidCodedEncounter - A JS representation of the CodedEncounter object
+ * @param apiKey - Candid Health API Key
+ * @param apiSecret - Candid Health API Secret
  * @returns The Candid Health API response
  */
 async function submitCandidEncounter(candidCodedEncounter: any, apiKey: string, apiSecret: string): Promise<any> {
@@ -146,7 +146,7 @@ async function submitCandidEncounter(candidCodedEncounter: any, apiKey: string, 
 
 /**
  * Converts a FHIR patient to a Candid Health patient
- * @param patient The FHIR patient.
+ * @param patient - The FHIR patient.
  * @returns The Candid Health patient.
  */
 function convertPatient(patient: Patient | undefined): any {

--- a/examples/medplum-demo-bots/src/candid-health/sync-candid-tasks.ts
+++ b/examples/medplum-demo-bots/src/candid-health/sync-candid-tasks.ts
@@ -86,9 +86,9 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
 /**
  * Authenticates into the Candid Health API using API key and API secret, and gets the Task object from
  * Candid's /v1/tasks endpoint
- * @param candidCodedEncounter The CodedEncounter object to send to Candid Health
- * @param apiKey  Candid Health API Key
- * @param apiSecret Candid Health API Secret
+ * @param candidCodedEncounter - The CodedEncounter object to send to Candid Health
+ * @param apiKey - Candid Health API Key
+ * @param apiSecret - Candid Health API Secret
  * @returns The response from the Candid Health API
  */
 async function getCandidTasks(candidCodedEncounter: any, apiKey: string, apiSecret: string): Promise<any> {

--- a/examples/medplum-demo-bots/src/deduplication/merge-matching-patients.ts
+++ b/examples/medplum-demo-bots/src/deduplication/merge-matching-patients.ts
@@ -203,12 +203,12 @@ export function mergePatientRecords(src: Patient, target: Patient, fields?: Part
 /**
  * Rewrites all references to source patient to the target patient, for the given resource type.
  *
- * @param medplum The MedplumClient
- * @param sourcePatient Source `Patient` resource. After this operation, no resources of the specified type will refer
+ * @param medplum - The MedplumClient
+ * @param sourcePatient - Source `Patient` resource. After this operation, no resources of the specified type will refer
  * to this `Patient`
- * @param targetPatient Target `Patient` resource. After this operation, no resources of the specified type will refer
+ * @param targetPatient - Target `Patient` resource. After this operation, no resources of the specified type will refer
  * to this `Patient`
- * @param resourceType Resource type to rewrite (e.g. `Encounter`)
+ * @param resourceType - Resource type to rewrite (e.g. `Encounter`)
  */
 export async function updateResourceReferences<T extends ResourceType>(
   medplum: MedplumClient,
@@ -231,9 +231,9 @@ export async function updateResourceReferences<T extends ResourceType>(
 
 /**
  * Recursive function to search for all references to the source resource, and translate them to the target resource
- * @param obj A FHIR resource or element
- * @param srcReference The reference string referring to the source resource
- * @param targetReference The reference string referring to the target resource
+ * @param obj - A FHIR resource or element
+ * @param srcReference - The reference string referring to the source resource
+ * @param targetReference - The reference string referring to the target resource
  */
 function replaceReferences(obj: any, srcReference: string, targetReference: string): void {
   for (const key in obj) {

--- a/examples/medplum-demo-bots/src/health-gorilla/connection-test.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/connection-test.ts
@@ -40,7 +40,7 @@ export async function handler(
 /**
  * Returns the Health Gorilla config settings from the Medplum project secrets.
  * If any required config values are missing, this method will throw and the bot will terminate.
- * @param event The bot input event.
+ * @param event - The bot input event.
  * @returns The Health Gorilla config settings.
  */
 function getHealthGorillaConfig(event: BotEvent): HealthGorillaConfig {
@@ -64,7 +64,7 @@ function getHealthGorillaConfig(event: BotEvent): HealthGorillaConfig {
 
 /**
  * Connects to the Health Gorilla API and returns a FHIR client.
- * @param config The Health Gorilla config settings.
+ * @param config - The Health Gorilla config settings.
  * @returns The FHIR client.
  */
 async function connectToHealthGorilla(config: HealthGorillaConfig): Promise<MedplumClient> {

--- a/examples/medplum-demo-bots/src/health-gorilla/receive-from-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/receive-from-health-gorilla.ts
@@ -70,8 +70,8 @@ const referenceMap = new Map<string, string>();
  *
  * The majority of this bot is dedicated to rewriting references from Health Gorilla.
  *
- * @param medplum The Medplum client.
- * @param event The Bot execution event with a Health Gorilla resource.
+ * @param medplum - The Medplum client.
+ * @param event - The Bot execution event with a Health Gorilla resource.
  * @returns Returns OK OperationOutcome on success, or an error OperationOutcome on failure.
  */
 export async function handler(
@@ -129,7 +129,7 @@ export async function handler(
 /**
  * Returns the Health Gorilla config settings from the Medplum project secrets.
  * If any required config values are missing, this method will throw and the bot will terminate.
- * @param event The bot input event.
+ * @param event - The bot input event.
  * @returns The Health Gorilla config settings.
  */
 function getHealthGorillaConfig(event: BotEvent): HealthGorillaConfig {
@@ -161,7 +161,7 @@ function requireStringSecret(secrets: Record<string, ProjectSecret>, name: strin
 
 /**
  * Connects to the Health Gorilla API and returns a FHIR client.
- * @param config The Health Gorilla config settings.
+ * @param config - The Health Gorilla config settings.
  * @returns The FHIR client.
  */
 async function connectToHealthGorilla(config: HealthGorillaConfig): Promise<MedplumClient> {
@@ -204,7 +204,7 @@ async function connectToHealthGorilla(config: HealthGorillaConfig): Promise<Medp
  *
  * We also take advantage of the "ifNoneExist" feature of FHIR to avoid creating duplicate resources.
  *
- * @param bundle The Health Gorilla bundle.
+ * @param bundle - The Health Gorilla bundle.
  */
 function touchUpBundle(bundle: Bundle<HealthGorillaResource>): void {
   for (const entry of bundle.entry ?? []) {
@@ -257,8 +257,8 @@ function touchUpBundle(bundle: Bundle<HealthGorillaResource>): void {
 /**
  * Rewrites Health Gorilla references to Medplum references.
  *
- * @param medplum The Medplum client.
- * @param value An unknown value.
+ * @param medplum - The Medplum client.
+ * @param value - An unknown value.
  */
 async function rewriteReferences(medplum: MedplumClient, value: unknown): Promise<void> {
   if (!value) {
@@ -310,9 +310,9 @@ async function rewriteReferencesInObject(medplum: MedplumClient, obj: Record<str
  *
  * There are some special cases where "identifier" is not available.
  *
- * @param medplum The Medplum client.
- * @param resourceType The FHIR resource type.
- * @param id The Health Gorilla resource ID.
+ * @param medplum - The Medplum client.
+ * @param resourceType - The FHIR resource type.
+ * @param id - The Health Gorilla resource ID.
  * @returns The Medplum resource, or undefined if not found.
  */
 async function searchByHealthGorillaId(
@@ -333,8 +333,8 @@ async function searchByHealthGorillaId(
 
 /**
  * Downloads the PDF from Health Gorilla and attaches it to the Medplum resource as a Media resource.
- * @param medplum The Medplum client.
- * @param event The Bot execution event with a Health Gorilla resource.
+ * @param medplum - The Medplum client.
+ * @param event - The Bot execution event with a Health Gorilla resource.
  */
 async function attachPdf<T extends HealthGorillaResource>(medplum: MedplumClient, event: BotEvent<T>): Promise<void> {
   const resource = event.input;

--- a/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
@@ -228,7 +228,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
 /**
  * Returns the Health Gorilla config settings from the Medplum project secrets.
  * If any required config values are missing, this method will throw and the bot will terminate.
- * @param event The bot input event.
+ * @param event - The bot input event.
  * @returns The Health Gorilla config settings.
  */
 function getHealthGorillaConfig(event: BotEvent): HealthGorillaConfig {
@@ -252,7 +252,7 @@ function getHealthGorillaConfig(event: BotEvent): HealthGorillaConfig {
 
 /**
  * Connects to the Health Gorilla API and returns a FHIR client.
- * @param config The Health Gorilla config settings.
+ * @param config - The Health Gorilla config settings.
  * @returns The FHIR client.
  */
 async function connectToHealthGorilla(config: HealthGorillaConfig): Promise<MedplumClient> {
@@ -294,8 +294,8 @@ async function connectToHealthGorilla(config: HealthGorillaConfig): Promise<Medp
  * If the subscriptions are in "error" status, this method will delete them and create new ones.
  * If the subscriptions are in "active" status, this method will do nothing.
  *
- * @param config The Health Gorilla config settings.
- * @param healthGorilla The Health Gorilla FHIR client.
+ * @param config - The Health Gorilla config settings.
+ * @param healthGorilla - The Health Gorilla FHIR client.
  */
 export async function ensureSubscriptions(config: HealthGorillaConfig, healthGorilla: MedplumClient): Promise<void> {
   // Get all subscriptions
@@ -308,10 +308,10 @@ export async function ensureSubscriptions(config: HealthGorillaConfig, healthGor
 /**
  * Ensures that there is an active subscription for the given criteria.
  *
- * @param config The Health Gorilla config settings.
- * @param healthGorilla The Health Gorilla FHIR client.
- * @param existingSubscriptions The existing subscriptions.
- * @param criteria The subscription criteria.
+ * @param config - The Health Gorilla config settings.
+ * @param healthGorilla - The Health Gorilla FHIR client.
+ * @param existingSubscriptions - The existing subscriptions.
+ * @param criteria - The subscription criteria.
  */
 export async function ensureSubscription(
   config: HealthGorillaConfig,
@@ -354,9 +354,9 @@ export async function ensureSubscription(
  *
  * Returns the Health Gorilla patient resource.
  *
- * @param medplum The Medplum FHIR client.
- * @param healthGorilla The Health Gorilla FHIR client.
- * @param patient The Medplum patient resource.
+ * @param medplum - The Medplum FHIR client.
+ * @param healthGorilla - The Health Gorilla FHIR client.
+ * @param patient - The Medplum patient resource.
  * @returns The Health Gorilla patient resource.
  */
 export async function syncPatient(
@@ -432,10 +432,10 @@ export async function syncPatient(
  *
  * Returns the Health Gorilla patient resource.
  *
- * @param medplum The Medplum FHIR client.
- * @param medplumPatient The Medplum patient resource.
- * @param healthGorillaPatient The Health Gorilla patient resource.
- * @param billingType The Health Gorilla billing type.
+ * @param medplum - The Medplum FHIR client.
+ * @param medplumPatient - The Medplum patient resource.
+ * @param healthGorillaPatient - The Health Gorilla patient resource.
+ * @param billingType - The Health Gorilla billing type.
  * @returns The Health Gorilla account resource.
  */
 export async function syncAccount(
@@ -489,8 +489,8 @@ export async function syncAccount(
  * If the Medplum Practitioner resource does not have a Health Gorilla ID in `identifier`,
  * this method will throw and the bot will terminate.
  *
- * @param healthGorilla The Health Gorilla FHIR client.
- * @param practitioner The Medplum practitioner resource.
+ * @param healthGorilla - The Health Gorilla FHIR client.
+ * @param practitioner - The Medplum practitioner resource.
  * @returns The Health Gorilla practitioner resource.
  */
 export async function getPractitioner(healthGorilla: MedplumClient, practitioner: Practitioner): Promise<Practitioner> {
@@ -544,14 +544,14 @@ export async function createServiceRequest(
  *
  * The FHIR RequestGroup is a combination of the following resources:
  *
- * @param healthGorilla The Health Gorilla FHIR client.
- * @param healthGorillaTenantOrganization The authorizing organization resource.
- * @param healthGorillaSubtenantOrganization The authorizing organization resource.
- * @param healthGorillaPerformingOrganization The performing organization resource.
- * @param healthGorillaAccount The account resource.
- * @param healthGorillaPatient The patient resource.
- * @param healthGorillaPractitioner The practitioner resource.
- * @param healthGorillaServiceRequests The service request resources.
+ * @param healthGorilla - The Health Gorilla FHIR client.
+ * @param healthGorillaTenantOrganization - The authorizing organization resource.
+ * @param healthGorillaSubtenantOrganization - The authorizing organization resource.
+ * @param healthGorillaPerformingOrganization - The performing organization resource.
+ * @param healthGorillaAccount - The account resource.
+ * @param healthGorillaPatient - The patient resource.
+ * @param healthGorillaPractitioner - The practitioner resource.
+ * @param healthGorillaServiceRequests - The service request resources.
  */
 export async function createRequestGroup(
   healthGorilla: MedplumClient,

--- a/examples/medplum-demo-bots/src/lab-integration/read-oru-message.ts
+++ b/examples/medplum-demo-bots/src/lab-integration/read-oru-message.ts
@@ -198,10 +198,10 @@ export async function processOruMessage(
  * Check if the order was cancelled and set the appropriate status fields if so
  * @param medplum - MedplumClient object
  * @param message - parsed HL7 message
- * @param serviceRequest `ServiceRequest` representing this order
+ * @param serviceRequest - `ServiceRequest` representing this order
  * @param observations - parsed `Observation` resources
- * @param report `DiagnosticReport` for these results
- * @param specimens `Specimen` associated with the results
+ * @param report - `DiagnosticReport` for these results
+ * @param specimens - `Specimen` associated with the results
  */
 async function handleOrderCancellation(
   medplum: MedplumClient,

--- a/examples/medplum-demo-bots/src/lab-integration/read-oru-message.ts
+++ b/examples/medplum-demo-bots/src/lab-integration/read-oru-message.ts
@@ -36,8 +36,8 @@ const PARTNER_TIMEZONE = '-05:00';
  * resources. Incoming data is the the form of HL7v2 ORU messages
  *
  * See: https://v2plus.hl7.org/2021Jan/message-structure/ORU_R01.html
- * @param medplum The Medplum client
- * @param event The Bot event
+ * @param medplum - The Medplum client
+ * @param event - The Bot event
  * @returns The Bot result
  */
 export async function handler(medplum: MedplumClient, event: BotEvent): Promise<any> {
@@ -95,9 +95,9 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
  *
  * Note: While ORU is an HL7 standard, every LIS/EHR system implements the standard in a slightly different way
  *
- * @param medplum The Medplum Client object
- * @param message Parsed ORU message.
- * @param performer The `Organization` resource corresponding to the lab that performed the test.
+ * @param medplum - The Medplum Client object
+ * @param message - Parsed ORU message.
+ * @param performer - The `Organization` resource corresponding to the lab that performed the test.
  */
 export async function processOruMessage(
   medplum: MedplumClient,
@@ -196,10 +196,10 @@ export async function processOruMessage(
 
 /**
  * Check if the order was cancelled and set the appropriate status fields if so
- * @param medplum MedplumClient object
- * @param message  parsed HL7 message
+ * @param medplum - MedplumClient object
+ * @param message - parsed HL7 message
  * @param serviceRequest `ServiceRequest` representing this order
- * @param observations  parsed `Observation` resources
+ * @param observations - parsed `Observation` resources
  * @param report `DiagnosticReport` for these results
  * @param specimens `Specimen` associated with the results
  */
@@ -234,9 +234,9 @@ async function handleOrderCancellation(
 /**
  * Check to see if the order was cancelled. If so, return the cancellation reason
  *
- * @param medplum The MedplumClient object.
- * @param message The parsed HL7 message.
- * @param serviceRequest The ServiceRequest resource.
+ * @param medplum - The MedplumClient object.
+ * @param message - The parsed HL7 message.
+ * @param serviceRequest - The ServiceRequest resource.
  * @returns The cancellation reason, if any.
  */
 async function getCancellationReason(
@@ -316,9 +316,9 @@ async function readSFTPDirectory(sftp: SftpClient, dir: string, batchSize = 25):
  * Some observations have notes that are stored in subsequent lines, so we need to keep a pointer to the last
  * processed observation
  *
- * @param message Parsed HL7 Message
- * @param serviceRequest Current `ServiceRequest` representing the lab order
- * @param performer A reference to the performing lab
+ * @param message - Parsed HL7 Message
+ * @param serviceRequest - Current `ServiceRequest` representing the lab order
+ * @param performer - A reference to the performing lab
  * @returns An array of `Observation` resources.
  */
 function processObxSegments(
@@ -368,9 +368,9 @@ function processObxSegments(
  *
  * Note that some systems send numerical values with comparators (e.g. <, >) as structured text fields
  *
- * @param segment The OBX segment to convert.
- * @param serviceRequest The current `ServiceRequest` representing the lab order.
- * @param performer The performing lab.
+ * @param segment - The OBX segment to convert.
+ * @param serviceRequest - The current `ServiceRequest` representing the lab order.
+ * @param performer - The performing lab.
  * @returns The converted `Observation` resource.
  */
 function processObservation(
@@ -437,9 +437,9 @@ function processObservation(
 
 /**
  * Check if there is an existing `Observation` resource with the same LOINC code, and update if necessary
- * @param medplum The Medplum Client
- * @param updatedObservation The latest `Observation`
- * @param existingObservations The existing `Observation` on the server
+ * @param medplum - The Medplum Client
+ * @param updatedObservation - The latest `Observation`
+ * @param existingObservations - The existing `Observation` on the server
  * @returns The updated `Observation` resource.
  */
 function createOrUpdateObservation(
@@ -464,10 +464,10 @@ function createOrUpdateObservation(
 /**
  * Upload any embedded rendered PDF reports in the HL7 message as a FHIR `Media` resource
  * and attach it to the diagnostic report in the `DiagnosticReport.presentedForm` property
- * @param medplum The Medplum Client.
- * @param report The current `DiagnosticReport` resource.
- * @param fileName The name of the PDF file.
- * @param message The HL7 message.
+ * @param medplum - The Medplum Client.
+ * @param report - The current `DiagnosticReport` resource.
+ * @param fileName - The name of the PDF file.
+ * @param message - The HL7 message.
  * @returns The uploaded `Media` resources.
  */
 async function uploadEmbeddedPdfs(

--- a/examples/medplum-demo-bots/src/lab-integration/send-orm-message.ts
+++ b/examples/medplum-demo-bots/src/lab-integration/send-orm-message.ts
@@ -19,8 +19,8 @@ const FACILITY_CODE = '52054';
  *
  * See: https://hl7-definition.caristix.com/v2/HL7v2.3/TriggerEvents/ORM_O01
  *
- * @param medplum The Medplum Client object
- * @param event The BotEvent object
+ * @param medplum - The Medplum Client object
+ * @param event - The BotEvent object
  * @returns The data returned by the `list` command
  */
 export async function handler(medplum: MedplumClient, event: BotEvent<QuestionnaireResponse>): Promise<any> {

--- a/examples/medplum-demo-bots/src/sample-account-setup.ts
+++ b/examples/medplum-demo-bots/src/sample-account-setup.ts
@@ -78,7 +78,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
 /**
  * Returns a practitioner resource.
  * Creates the practitioner if one does not already exist.
- * @param medplum The medplum client.
+ * @param medplum - The medplum client.
  * @returns The practitioner resource.
  */
 async function ensureQuestionnaire(medplum: MedplumClient): Promise<void> {
@@ -142,7 +142,7 @@ async function ensureQuestionnaire(medplum: MedplumClient): Promise<void> {
 /**
  * Returns a practitioner resource.
  * Creates the practitioner if one does not already exist.
- * @param medplum The medplum client.
+ * @param medplum - The medplum client.
  * @returns The practitioner resource.
  */
 async function getPractitioner(medplum: MedplumClient): Promise<Practitioner> {
@@ -179,8 +179,8 @@ async function getPractitioner(medplum: MedplumClient): Promise<Practitioner> {
 
 /**
  * Ensures that the practitioner has a schedule, and that the schedule has slots.
- * @param medplum The medplum client.
- * @param practitioner The practitioner.
+ * @param medplum - The medplum client.
+ * @param practitioner - The practitioner.
  */
 async function ensureSchedule(medplum: MedplumClient, practitioner: Practitioner): Promise<void> {
   // Try to get the schedule
@@ -204,9 +204,9 @@ async function ensureSchedule(medplum: MedplumClient, practitioner: Practitioner
 
 /**
  * Ensures that the schedule has slots for the given date.
- * @param medplum The medplum client.
- * @param schedule The practitioner's schedule.
- * @param slotDate The day of slots.
+ * @param medplum - The medplum client.
+ * @param schedule - The practitioner's schedule.
+ * @param slotDate - The day of slots.
  */
 async function ensureSlots(medplum: MedplumClient, schedule: Schedule, slotDate: Date): Promise<void> {
   const existingSlots = await medplum.search(
@@ -235,8 +235,8 @@ async function ensureSlots(medplum: MedplumClient, schedule: Schedule, slotDate:
 
 /**
  * Creates a CarePlan that was completed in the past.
- * @param medplum The medplum client
- * @param patient The patient.
+ * @param medplum - The medplum client
+ * @param patient - The patient.
  */
 async function createCompletedCarePlan(medplum: MedplumClient, patient: Patient): Promise<void> {
   const tasks: Task[] = [
@@ -275,8 +275,8 @@ async function createCompletedCarePlan(medplum: MedplumClient, patient: Patient)
 
 /**
  * Creates an active CarePlan that starts today.
- * @param medplum The medplum client
- * @param patient The patient.
+ * @param medplum - The medplum client
+ * @param patient - The patient.
  */
 async function createActiveCarePlan(medplum: MedplumClient, patient: Patient): Promise<void> {
   const tasks: Task[] = [
@@ -301,9 +301,9 @@ async function createActiveCarePlan(medplum: MedplumClient, patient: Patient): P
 
 /**
  * Creates a Care Plan based on the tasks for the given patient
- * @param medplum The medplum client
- * @param patient The patient
- * @param tasks The set of tasks to complete for the care plan
+ * @param medplum - The medplum client
+ * @param patient - The patient
+ * @param tasks - The set of tasks to complete for the care plan
  * @returns The created care plan
  */
 async function createCarePlan(medplum: MedplumClient, patient: Patient, tasks: Task[]): Promise<CarePlan> {
@@ -367,8 +367,8 @@ function createA1CObservation(patient: Patient): Observation {
 
 /**
  * Creates a DiagnosticReport with an A1C observation.
- * @param patient The patient.
- * @param a1c The A1C observation.
+ * @param patient - The patient.
+ * @param a1c - The A1C observation.
  * @returns The DiagnosticReport.
  */
 function createDiagnosticReport(patient: Patient, a1c: Observation): DiagnosticReport {

--- a/examples/medplum-task-demo/src/utils.ts
+++ b/examples/medplum-task-demo/src/utils.ts
@@ -4,7 +4,7 @@ import { Task } from '@medplum/fhirtypes';
 /**
  * Calculates a score for a task.
  * Higher scores are more important.
- * @param task The task.
+ * @param task - The task.
  * @returns The score.
  */
 export function scoreTask(task: Task): number {

--- a/packages/app/src/CreateResourcePage.tsx
+++ b/packages/app/src/CreateResourcePage.tsx
@@ -13,7 +13,7 @@ export function CreateResourcePage(): JSX.Element {
 
   /**
    * Handles a tab change event.
-   * @param newTabName The new tab name.
+   * @param newTabName - The new tab name.
    */
   function onTabChange(newTabName: string): void {
     setCurrentTab(newTabName);

--- a/packages/app/src/admin/ProjectPage.tsx
+++ b/packages/app/src/admin/ProjectPage.tsx
@@ -17,7 +17,7 @@ export function ProjectPage(): JSX.Element {
 
   /**
    * Handles a tab change event.
-   * @param newTabName The new tab name.
+   * @param newTabName - The new tab name.
    */
   function onTabChange(newTabName: string): void {
     navigate(`/admin/${newTabName}`);

--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -95,7 +95,7 @@ export function ResourcePage(): JSX.Element | null {
 
   /**
    * Handles a tab change event.
-   * @param newTabName The new tab name.
+   * @param newTabName - The new tab name.
    */
   function onTabChange(newTabName: string): void {
     setCurrentTab(newTabName);

--- a/packages/app/src/resource/useCreateResource.ts
+++ b/packages/app/src/resource/useCreateResource.ts
@@ -5,8 +5,8 @@ import { useNavigate } from 'react-router-dom';
 
 /**
  * React Hook providing helpers to create a FHIR resource.
- * @param resourceType The FHIR resource type.
- * @param setOutcome Optional callback to set the OperationOutcome.
+ * @param resourceType - The FHIR resource type.
+ * @param setOutcome - Optional callback to set the OperationOutcome.
  * @returns An object with `defaultValue` to seed a creation view and `handleSubmit`
  * to create the new resource on submission.
  */

--- a/packages/app/src/resource/utils.ts
+++ b/packages/app/src/resource/utils.ts
@@ -5,7 +5,7 @@ import { Resource } from '@medplum/fhirtypes';
  * For most users, this will not matter, because meta values are set by the server.
  * However, some administrative users are allowed to specify some meta values.
  * The admin use case is special though, and unwanted here on the resource page.
- * @param resource The input resource.
+ * @param resource - The input resource.
  * @returns The cleaned output resource.
  */
 export function cleanResource(resource: Resource): Resource {

--- a/packages/app/src/utils.ts
+++ b/packages/app/src/utils.ts
@@ -3,7 +3,7 @@ import { Patient, Reference, Resource, Specimen } from '@medplum/fhirtypes';
 
 /**
  * Tries to return the patient for the given the resource.
- * @param resource Any FHIR resource.
+ * @param resource - Any FHIR resource.
  * @returns The patient associated with the resource, if available.
  */
 export function getPatient(resource: Resource): Patient | Reference<Patient> | undefined {
@@ -23,7 +23,7 @@ export function getPatient(resource: Resource): Patient | Reference<Patient> | u
 
 /**
  * Tries to return the specimen for the given the resource.
- * @param resource Any FHIR resource.
+ * @param resource - Any FHIR resource.
  * @returns The specimen associated with the resource, if available.
  */
 export function getSpecimen(resource: Resource): Specimen | Reference<Specimen> | undefined {
@@ -44,8 +44,8 @@ export function getSpecimen(resource: Resource): Specimen | Reference<Specimen> 
  *
  * Normally postMessage implies global event listeners. This method uses
  * MessageChannel to create a message channel between the iframe and the parent.
- * @param frame The receiving IFrame.
- * @param command The command to send.
+ * @param frame - The receiving IFrame.
+ * @param command - The command to send.
  * @returns Promise to the response from the IFrame.
  * @see https://advancedweb.hu/how-to-use-async-await-with-postmessage/
  */
@@ -68,7 +68,7 @@ export function sendCommand(frame: HTMLIFrameElement, command: any): Promise<any
 
 /**
  * Returns the current project ID for the given client.
- * @param medplum The Medplum client.
+ * @param medplum - The Medplum client.
  * @returns The current project ID.
  */
 export function getProjectId(medplum: MedplumClient): string {
@@ -77,8 +77,8 @@ export function getProjectId(medplum: MedplumClient): string {
 
 /**
  * Creates a Blob object from the JSON object given and downloads the object.
- * @param jsonString The JSON string.
- * @param fileName Optional file name. Default is based on current timestamp.
+ * @param jsonString - The JSON string.
+ * @param fileName - Optional file name. Default is based on current timestamp.
  */
 export function exportJsonFile(jsonString: string, fileName?: string): void {
   const blobForExport = new Blob([jsonString], { type: ContentType.JSON });

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -462,8 +462,8 @@ export class BackEnd extends Construct {
    * Returns a container image for the given image name.
    * If the image name is an ECR image, then the image will be pulled from ECR.
    * Otherwise, the image name is assumed to be a Docker Hub image.
-   * @param config The config settings (account number and region).
-   * @param imageName The image name.
+   * @param config - The config settings (account number and region).
+   * @param imageName - The image name.
    * @returns The container image.
    */
   private getContainerImage(config: MedplumInfraConfig, imageName: string): ecs.ContainerImage {

--- a/packages/cdk/src/oai.ts
+++ b/packages/cdk/src/oai.ts
@@ -12,8 +12,8 @@ import { aws_cloudfront as cloudfront, aws_iam as iam, aws_s3 as s3 } from 'aws-
  *
  * See: https://stackoverflow.com/a/60917015
  *
- * @param bucket The S3 bucket.
- * @param identity The CloudFront Origin Access Identity.
+ * @param bucket - The S3 bucket.
+ * @param identity - The CloudFront Origin Access Identity.
  * @returns The policy statement.
  */
 export function grantBucketAccessToOriginAccessIdentity(

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -76,7 +76,7 @@ async function startWebServer(medplum: MedplumClient): Promise<void> {
 /**
  * Opens a web browser to the specified URL.
  * See: https://hasinthaindrajee.medium.com/browser-sso-for-cli-applications-b0be743fa656
- * @param url The URL to open.
+ * @param url - The URL to open.
  */
 async function openBrowser(url: string): Promise<void> {
   const os = platform();
@@ -100,7 +100,7 @@ async function openBrowser(url: string): Promise<void> {
 
 /**
  * Prints the current user and project.
- * @param medplum The Medplum client.
+ * @param medplum - The Medplum client.
  */
 function printMe(medplum: MedplumClient): void {
   const loginState = medplum.getActiveLogin();

--- a/packages/cli/src/aws/describe.ts
+++ b/packages/cli/src/aws/describe.ts
@@ -2,7 +2,7 @@ import { getStackByTag, printStackDetails } from './utils';
 
 /**
  * The AWS "describe" command prints details about a Medplum CloudFormation stack.
- * @param tag The Medplum stack tag.
+ * @param tag - The Medplum stack tag.
  */
 export async function describeStacksCommand(tag: string): Promise<void> {
   const details = await getStackByTag(tag);

--- a/packages/cli/src/aws/init.ts
+++ b/packages/cli/src/aws/init.ts
@@ -276,7 +276,7 @@ export async function initStackCommand(): Promise<void> {
 
 /**
  * Prints to stdout.
- * @param text The text to print.
+ * @param text - The text to print.
  */
 function print(text: string): void {
   terminal.write(text + '\n');
@@ -284,7 +284,7 @@ function print(text: string): void {
 
 /**
  * Prints a header with extra line spacing.
- * @param text The text to print.
+ * @param text - The text to print.
  */
 function header(text: string): void {
   print('\n' + text + '\n');
@@ -292,8 +292,8 @@ function header(text: string): void {
 
 /**
  * Prints a question and waits for user input.
- * @param text The question text to print.
- * @param defaultValue Optional default value.
+ * @param text - The question text to print.
+ * @param defaultValue - Optional default value.
  * @returns The selected value, or default value on empty selection.
  */
 function ask(text: string, defaultValue: string | number = ''): Promise<string> {
@@ -306,9 +306,9 @@ function ask(text: string, defaultValue: string | number = ''): Promise<string> 
 
 /**
  * Prints a question and waits for user to choose one of the provided options.
- * @param text The prompt text to print.
- * @param options The list of options that the user can select.
- * @param defaultValue Optional default value.
+ * @param text - The prompt text to print.
+ * @param options - The list of options that the user can select.
+ * @param defaultValue - Optional default value.
  * @returns The selected value, or default value on empty selection.
  */
 async function choose(text: string, options: (string | number)[], defaultValue = ''): Promise<string> {
@@ -325,9 +325,9 @@ async function choose(text: string, options: (string | number)[], defaultValue =
 
 /**
  * Prints a question and waits for the user to choose a valid integer option.
- * @param text The prompt text to print.
- * @param options The list of options that the user can select.
- * @param defaultValue Default value.
+ * @param text - The prompt text to print.
+ * @param options - The list of options that the user can select.
+ * @param defaultValue - Default value.
  * @returns The selected value, or default value on empty selection.
  */
 async function chooseInt(text: string, options: number[], defaultValue: number): Promise<number> {
@@ -343,7 +343,7 @@ async function chooseInt(text: string, options: number[], defaultValue: number):
 
 /**
  * Prints a question and waits for the user to choose yes or no.
- * @param text The question to print.
+ * @param text - The question to print.
  * @returns true on accept or false on reject.
  */
 async function yesOrNo(text: string): Promise<boolean> {
@@ -352,7 +352,7 @@ async function yesOrNo(text: string): Promise<boolean> {
 
 /**
  * Prints a question and waits for the user to confirm yes. Throws error on no, and exits the program.
- * @param text The prompt text to print.
+ * @param text - The prompt text to print.
  */
 async function checkOk(text: string): Promise<void> {
   if (!(await yesOrNo(text))) {
@@ -363,8 +363,8 @@ async function checkOk(text: string): Promise<void> {
 
 /**
  * Writes a config file to disk.
- * @param configFileName The config file name.
- * @param config The config file contents.
+ * @param configFileName - The config file name.
+ * @param config - The config file contents.
  */
 function writeConfig(configFileName: string, config: MedplumInfraConfig): void {
   writeFileSync(resolve(configFileName), JSON.stringify(config, undefined, 2), 'utf-8');
@@ -373,7 +373,7 @@ function writeConfig(configFileName: string, config: MedplumInfraConfig): void {
 /**
  * Returns the current AWS account ID.
  * This is used as the default value for the "accountNumber" config setting.
- * @param region The AWS region.
+ * @param region - The AWS region.
  * @returns The AWS account ID.
  */
 async function getAccountId(region: string): Promise<string | undefined> {
@@ -392,7 +392,7 @@ async function getAccountId(region: string): Promise<string | undefined> {
  * Returns a list of all AWS certificates.
  * This is used to find existing certificates for the subdomains.
  * If the primary region is not us-east-1, then certificates in us-east-1 will also be returned.
- * @param region The AWS region.
+ * @param region - The AWS region.
  * @returns The list of AWS Certificates.
  */
 async function listAllCertificates(region: string): Promise<CertificateSummary[]> {
@@ -407,7 +407,7 @@ async function listAllCertificates(region: string): Promise<CertificateSummary[]
 /**
  * Returns a list of AWS Certificates.
  * This is used to find existing certificates for the subdomains.
- * @param region The AWS region.
+ * @param region - The AWS region.
  * @returns The list of AWS Certificates.
  */
 async function listCertificates(region: string): Promise<CertificateSummary[]> {
@@ -428,10 +428,10 @@ async function listCertificates(region: string): Promise<CertificateSummary[]> {
  * 1. If the certificate already exists, return the ARN.
  * 2. If the certificate does not exist, and the user wants to create a new certificate, create it and return the ARN.
  * 3. If the certificate does not exist, and the user does not want to create a new certificate, return a placeholder.
- * @param config In-progress config settings.
- * @param allCerts List of all existing certificates.
- * @param region The AWS region where the certificate is needed.
- * @param certName The name of the certificate (api, app, or storage).
+ * @param config - In-progress config settings.
+ * @param allCerts - List of all existing certificates.
+ * @param region - The AWS region where the certificate is needed.
+ * @param certName - The name of the certificate (api, app, or storage).
  * @returns The ARN of the certificate or placeholder if a new certificate is needed.
  */
 async function processCert(
@@ -460,8 +460,8 @@ async function processCert(
 
 /**
  * Requests an AWS Certificate.
- * @param region The AWS region.
- * @param domain The domain name.
+ * @param region - The AWS region.
+ * @param domain - The domain name.
  * @returns The AWS Certificate ARN on success, or undefined on failure.
  */
 async function requestCert(region: string, domain: string): Promise<string> {
@@ -494,7 +494,7 @@ async function requestCert(region: string, domain: string): Promise<string> {
  *   3. It must be a 2048-bit key pair.
  *
  * See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-trusted-signers.html#private-content-creating-cloudfront-key-pairs
- * @param keyName The key name.
+ * @param keyName - The key name.
  * @returns A new signing key.
  */
 async function generateSigningKey(keyName: string): Promise<{
@@ -538,8 +538,8 @@ async function generateSigningKey(keyName: string): Promise<{
 
 /**
  * Reads a parameter from AWS Parameter Store.
- * @param client The AWS SSM client.
- * @param name The parameter name.
+ * @param client - The AWS SSM client.
+ * @param name - The parameter name.
  * @returns The parameter value, or undefined if not found.
  */
 async function readParameter(client: SSMClient, name: string): Promise<string | undefined> {
@@ -560,9 +560,9 @@ async function readParameter(client: SSMClient, name: string): Promise<string | 
 
 /**
  * Writes a parameter to AWS Parameter Store.
- * @param client The AWS SSM client.
- * @param name The parameter name.
- * @param value The parameter value.
+ * @param client - The AWS SSM client.
+ * @param name - The parameter name.
+ * @param value - The parameter value.
  */
 async function writeParameter(client: SSMClient, name: string, value: string): Promise<void> {
   const command = new PutParameterCommand({
@@ -576,9 +576,9 @@ async function writeParameter(client: SSMClient, name: string, value: string): P
 
 /**
  * Writes a collection of parameters to AWS Parameter Store.
- * @param region The AWS region.
- * @param prefix The AWS Parameter Store prefix.
- * @param params The parameters to write.
+ * @param region - The AWS region.
+ * @param prefix - The AWS Parameter Store prefix.
+ * @param params - The parameters to write.
  */
 async function writeParameters(region: string, prefix: string, params: Record<string, string | number>): Promise<void> {
   const client = new SSMClient({ region });

--- a/packages/cli/src/aws/update-app.ts
+++ b/packages/cli/src/aws/update-app.ts
@@ -15,8 +15,8 @@ export interface UpdateAppOptions {
 
 /**
  * The AWS "update-app" command updates the Medplum app in a Medplum CloudFormation stack to the latest version.
- * @param tag The Medplum stack tag.
- * @param options The update options.
+ * @param tag - The Medplum stack tag.
+ * @param options - The update options.
  */
 export async function updateAppCommand(tag: string, options: UpdateAppOptions): Promise<void> {
   const config = readConfig(tag);
@@ -60,8 +60,8 @@ export async function updateAppCommand(tag: string, options: UpdateAppOptions): 
 /**
  * Returns NPM package metadata for a given package name.
  * See: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#getpackageversion
- * @param packageName The npm package name.
- * @param version The npm package version string.
+ * @param packageName - The npm package name.
+ * @param version - The npm package version string.
  * @returns The package.json metadata content.
  */
 async function getNpmPackageMetadata(packageName: string, version: string): Promise<any> {
@@ -72,8 +72,8 @@ async function getNpmPackageMetadata(packageName: string, version: string): Prom
 
 /**
  * Downloads and extracts an NPM package.
- * @param packageName The NPM package name.
- * @param version The NPM package version or "latest".
+ * @param packageName - The NPM package name.
+ * @param version - The NPM package version or "latest".
  * @returns Path to temporary directory where the package was downloaded and extracted.
  */
 async function downloadNpmPackage(packageName: string, version: string): Promise<string> {
@@ -93,8 +93,8 @@ async function downloadNpmPackage(packageName: string, version: string): Promise
 
 /**
  * Replaces variables in all JS files in the given folder.
- * @param folderName The folder name of the files.
- * @param replacements The collection of variable placeholders and replacements.
+ * @param folderName - The folder name of the files.
+ * @param replacements - The collection of variable placeholders and replacements.
  */
 function replaceVariables(folderName: string, replacements: Record<string, string>): void {
   for (const item of readdirSync(folderName, { withFileTypes: true })) {
@@ -109,8 +109,8 @@ function replaceVariables(folderName: string, replacements: Record<string, strin
 
 /**
  * Replaces variables in the JS file.
- * @param fileName The file name.
- * @param replacements The collection of variable placeholders and replacements.
+ * @param fileName - The file name.
+ * @param replacements - The collection of variable placeholders and replacements.
  */
 function replaceVariablesInFile(fileName: string, replacements: Record<string, string>): void {
   let contents = readFileSync(fileName, 'utf-8');
@@ -123,9 +123,9 @@ function replaceVariablesInFile(fileName: string, replacements: Record<string, s
 /**
  * Uploads the app to S3.
  * Ensures correct content-type and cache-control for each file.
- * @param tmpDir The temporary directory where the app is located.
- * @param bucketName The destination S3 bucket name.
- * @param options The update options.
+ * @param tmpDir - The temporary directory where the app is located.
+ * @param bucketName - The destination S3 bucket name.
+ * @param options - The update options.
  */
 async function uploadAppToS3(tmpDir: string, bucketName: string, options: UpdateAppOptions): Promise<void> {
   // Manually iterate and upload files
@@ -162,7 +162,7 @@ async function uploadAppToS3(tmpDir: string, bucketName: string, options: Update
 
 /**
  * Uploads a directory of files to S3.
- * @param options The upload options such as bucket name, content type, and cache control.
+ * @param options - The upload options such as bucket name, content type, and cache control.
  * @param options.rootDir The root directory of the upload.
  * @param options.bucketName The destination bucket name.
  * @param options.fileNamePattern The glob file pattern to upload.
@@ -186,8 +186,8 @@ async function uploadFolderToS3(options: {
 
 /**
  * Uploads a file to S3.
- * @param filePath The file path.
- * @param options The upload options such as bucket name, content type, and cache control.
+ * @param filePath - The file path.
+ * @param options - The upload options such as bucket name, content type, and cache control.
  * @param options.rootDir The root directory of the upload.
  * @param options.bucketName The destination bucket name.
  * @param options.contentType The content type MIME type.

--- a/packages/cli/src/aws/update-app.ts
+++ b/packages/cli/src/aws/update-app.ts
@@ -163,12 +163,12 @@ async function uploadAppToS3(tmpDir: string, bucketName: string, options: Update
 /**
  * Uploads a directory of files to S3.
  * @param options - The upload options such as bucket name, content type, and cache control.
- * @param options.rootDir The root directory of the upload.
- * @param options.bucketName The destination bucket name.
- * @param options.fileNamePattern The glob file pattern to upload.
- * @param options.contentType The content type MIME type.
- * @param options.cached True to mark as public and cached forever.
- * @param options.dryrun True to skip the upload.
+ * @param options.rootDir - The root directory of the upload.
+ * @param options.bucketName - The destination bucket name.
+ * @param options.fileNamePattern - The glob file pattern to upload.
+ * @param options.contentType - The content type MIME type.
+ * @param options.cached - True to mark as public and cached forever.
+ * @param options.dryrun - True to skip the upload.
  */
 async function uploadFolderToS3(options: {
   rootDir: string;
@@ -188,11 +188,11 @@ async function uploadFolderToS3(options: {
  * Uploads a file to S3.
  * @param filePath - The file path.
  * @param options - The upload options such as bucket name, content type, and cache control.
- * @param options.rootDir The root directory of the upload.
- * @param options.bucketName The destination bucket name.
- * @param options.contentType The content type MIME type.
- * @param options.cached True to mark as public and cached forever.
- * @param options.dryrun True to skip the upload.
+ * @param options.rootDir - The root directory of the upload.
+ * @param options.bucketName - The destination bucket name.
+ * @param options.contentType - The content type MIME type.
+ * @param options.cached - True to mark as public and cached forever.
+ * @param options.dryrun - True to skip the upload.
  */
 async function uploadFileToS3(
   filePath: string,

--- a/packages/cli/src/aws/update-bucket-policies.ts
+++ b/packages/cli/src/aws/update-bucket-policies.ts
@@ -24,8 +24,8 @@ interface PolicyStatement {
  *
  * This is necessary for Medplum deployments outside of the us-east-1 region.
  *
- * @param tag The Medplum stack tag.
- * @param options The update options.
+ * @param tag - The Medplum stack tag.
+ * @param options - The update options.
  */
 export async function updateBucketPoliciesCommand(tag: string, options: UpdateBucketPoliciesOptions): Promise<void> {
   const config = readConfig(tag);

--- a/packages/cli/src/aws/update-server.ts
+++ b/packages/cli/src/aws/update-server.ts
@@ -3,7 +3,7 @@ import { ecsClient, getEcsServiceName, getStackByTag } from './utils';
 
 /**
  * The AWS "update-server" command updates the Medplum server in a Medplum CloudFormation stack.
- * @param tag The Medplum stack tag.
+ * @param tag - The Medplum stack tag.
  */
 export async function updateServerCommand(tag: string): Promise<void> {
   const details = await getStackByTag(tag);

--- a/packages/cli/src/aws/utils.ts
+++ b/packages/cli/src/aws/utils.ts
@@ -45,7 +45,7 @@ export async function getAllStacks(): Promise<(StackSummary & { StackName: strin
 
 /**
  * Returns Medplum stack details for the given tag.
- * @param tag The Medplum stack tag.
+ * @param tag - The Medplum stack tag.
  * @returns The Medplum stack details.
  */
 export async function getStackByTag(tag: string): Promise<MedplumStackDetails | undefined> {
@@ -62,7 +62,7 @@ export async function getStackByTag(tag: string): Promise<MedplumStackDetails | 
 
 /**
  * Returns Medplum stack details for the given stack name.
- * @param stackName The CloudFormation stack name.
+ * @param stackName - The CloudFormation stack name.
  * @returns The Medplum stack details.
  */
 export async function getStackDetails(stackName: string): Promise<MedplumStackDetails | undefined> {
@@ -76,9 +76,9 @@ export async function getStackDetails(stackName: string): Promise<MedplumStackDe
 
 /**
  * Builds the Medplum stack details for the given stack name and region.
- * @param client The CloudFormation client.
- * @param stackName The CloudFormation stack name.
- * @param result The Medplum stack details builder.
+ * @param client - The CloudFormation client.
+ * @param stackName - The CloudFormation stack name.
+ * @param result - The Medplum stack details builder.
  */
 async function buildStackDetails(
   client: CloudFormationClient,
@@ -148,7 +148,7 @@ function assignStackDetails(resource: StackResource, result: Partial<MedplumStac
 
 /**
  * Prints the given Medplum stack details to stdout.
- * @param details The Medplum stack details.
+ * @param details - The Medplum stack details.
  */
 export function printStackDetails(details: MedplumStackDetails): void {
   console.log(`Medplum Tag:           ${details.tag}`);
@@ -167,7 +167,7 @@ export function printStackDetails(details: MedplumStackDetails): void {
 
 /**
  * Parses the ECS service name from the given AWS ECS service resource.
- * @param resource The AWS ECS service resource.
+ * @param resource - The AWS ECS service resource.
  * @returns The ECS service name.
  */
 export function getEcsServiceName(resource: StackResource | undefined): string | undefined {
@@ -180,7 +180,7 @@ export function getEcsServiceName(resource: StackResource | undefined): string |
  * In a perfect world, every deploy is clean, and hashed resources should be cached forever.
  * However, we do not recalculate hashes after variable replacements.
  * So if variables change, we need to invalidate the cache.
- * @param distributionId The CloudFront distribution ID.
+ * @param distributionId - The CloudFront distribution ID.
  */
 export async function createInvalidation(distributionId: string): Promise<void> {
   const response = await cloudFrontClient.send(

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -166,7 +166,7 @@ function escapeRegex(str: string): string {
  * Expanding archive files without controlling resource consumption is security-sensitive
  *
  * See: https://sonarcloud.io/organizations/medplum/rules?open=typescript%3AS5042&rule_key=typescript%3AS5042
- * @param destinationDir The destination directory where all files will be extracted.
+ * @param destinationDir - The destination directory where all files will be extracted.
  * @returns A tar file extractor.
  */
 export function safeTarExtractor(destinationDir: string): internal.Writable {

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -52,8 +52,8 @@ const resourceReadInteractions = [
 
 /**
  * Determines if the current user can read the specified resource type.
- * @param accessPolicy The access policy.
- * @param resourceType The resource type.
+ * @param accessPolicy - The access policy.
+ * @param resourceType - The resource type.
  * @returns True if the current user can read the specified resource type.
  */
 export function canReadResourceType(accessPolicy: AccessPolicy, resourceType: ResourceType): boolean {
@@ -71,8 +71,8 @@ export function canReadResourceType(accessPolicy: AccessPolicy, resourceType: Re
  * Determines if the current user can write the specified resource type.
  * This is a preliminary check before evaluating a write operation in depth.
  * If a user cannot write a resource type at all, then don't bother looking up previous versions.
- * @param accessPolicy The access policy.
- * @param resourceType The resource type.
+ * @param accessPolicy - The access policy.
+ * @param resourceType - The resource type.
  * @returns True if the current user can write the specified resource type.
  */
 export function canWriteResourceType(accessPolicy: AccessPolicy, resourceType: ResourceType): boolean {
@@ -92,8 +92,8 @@ export function canWriteResourceType(accessPolicy: AccessPolicy, resourceType: R
 /**
  * Determines if the current user can write the specified resource.
  * This is a more in-depth check after building the candidate result of a write operation.
- * @param accessPolicy The access policy.
- * @param resource The resource.
+ * @param accessPolicy - The access policy.
+ * @param resource - The resource.
  * @returns True if the current user can write the specified resource type.
  */
 export function canWriteResource(accessPolicy: AccessPolicy, resource: Resource): boolean {
@@ -106,9 +106,9 @@ export function canWriteResource(accessPolicy: AccessPolicy, resource: Resource)
 
 /**
  * Returns true if the resource satisfies the current access policy.
- * @param accessPolicy The access policy.
- * @param resource The resource.
- * @param readonlyMode True if the resource is being read.
+ * @param accessPolicy - The access policy.
+ * @param resource - The resource.
+ * @param readonlyMode - True if the resource is being read.
  * @returns True if the resource matches the access policy.
  * @deprecated Use satisfiedAccessPolicy() instead.
  */
@@ -131,9 +131,9 @@ export function matchesAccessPolicy(accessPolicy: AccessPolicy, resource: Resour
 
 /**
  * Checks that there is an access policy permitting the given resource interaction, returning the matching policy object.
- * @param resource The resource being acted upon.
- * @param interaction The interaction being performed on the resource.
- * @param accessPolicy The relevant access policy for the current user.
+ * @param resource - The resource being acted upon.
+ * @param interaction - The interaction being performed on the resource.
+ * @param accessPolicy - The relevant access policy for the current user.
  * @returns The satisfied access policy, or undefined if the access policy does not permit the given interaction.
  */
 export function satisfiedAccessPolicy(
@@ -156,9 +156,9 @@ export function satisfiedAccessPolicy(
 
 /**
  * Returns true if the resource satisfies the specified access policy resource policy.
- * @param resource The resource.
- * @param interaction The interaction being performed on the resource.
- * @param resourcePolicy One per-resource policy section from the access policy.
+ * @param resource - The resource.
+ * @param interaction - The interaction being performed on the resource.
+ * @param resourcePolicy - One per-resource policy section from the access policy.
  * @returns True if the resource matches the access policy.
  */
 function matchesAccessPolicyResourcePolicy(
@@ -191,8 +191,8 @@ function matchesAccessPolicyResourcePolicy(
 
 /**
  * Returns true if the resource type matches the access policy resource type.
- * @param accessPolicyResourceType The resource type from the access policy.
- * @param resourceType The candidate resource resource type.
+ * @param accessPolicyResourceType - The resource type from the access policy.
+ * @param resourceType - The candidate resource resource type.
  * @returns True if the resource type matches the access policy resource type.
  */
 function matchesAccessPolicyResourceType(

--- a/packages/core/src/base64.ts
+++ b/packages/core/src/base64.ts
@@ -1,7 +1,7 @@
 /**
  * Decodes a base64 string.
  * Handles both browser and Node environments.
- * @param data The base-64 encoded input string.
+ * @param data - The base-64 encoded input string.
  * @returns The decoded string.
  */
 export function decodeBase64(data: string): string {
@@ -17,7 +17,7 @@ export function decodeBase64(data: string): string {
 /**
  * Encodes a base64 string.
  * Handles both browser and Node environments.
- * @param data The unencoded input string.
+ * @param data - The unencoded input string.
  * @returns The base-64 encoded string.
  */
 export function encodeBase64(data: string): string {

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -10,7 +10,7 @@ import { deepClone } from './utils';
 
 /**
  * Takes a bundle and creates a Transaction Type bundle
- * @param bundle The Bundle object that we'll receive from the search query
+ * @param bundle - The Bundle object that we'll receive from the search query
  * @returns transaction type bundle
  */
 export function convertToTransactionBundle(bundle: Bundle): Bundle {
@@ -70,7 +70,7 @@ function referenceReplacer(key: string, value: string, idToUuid: Record<string, 
  * In the event of cycles, this function will first create a POST request for each resource in the cycle, and then will
  * append a PUT request to the bundle. This ensures that each resources in the cycle is visited twice, and all
  * references can be resolved
- * @param bundle Input bundle with type `batch` or `transaction`
+ * @param bundle - Input bundle with type `batch` or `transaction`
  * @returns Bundle of the same type, with Bundle.entry reordered
  */
 export function reorderBundle(bundle: Bundle): Bundle {
@@ -215,7 +215,7 @@ function buildAdjacencyList(bundle: Bundle): AdjacencyList {
  * Converts a resource with contained resources to a transaction bundle.
  * This function is useful when creating a resource that contains other resources.
  * Handles local references and topological sorting.
- * @param resource The input resource which may or may not include contained resources.
+ * @param resource - The input resource which may or may not include contained resources.
  * @returns A bundle with the input resource and all contained resources.
  */
 export function convertContainedResourcesToBundle(resource: Resource & { contained?: Resource[] }): Bundle {

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -20,7 +20,7 @@ export class LRUCache<T> {
 
   /**
    * Returns the value for the given key.
-   * @param key The key to retrieve.
+   * @param key - The key to retrieve.
    * @returns The value if found; undefined otherwise.
    */
   get(key: string): T | undefined {
@@ -34,8 +34,8 @@ export class LRUCache<T> {
 
   /**
    * Sets the value for the given key.
-   * @param key The key to set.
-   * @param val The value to set.
+   * @param key - The key to set.
+   * @param val - The value to set.
    */
   set(key: string, val: T): void {
     if (this.cache.has(key)) {
@@ -48,7 +48,7 @@ export class LRUCache<T> {
 
   /**
    * Deletes the value for the given key.
-   * @param key The key to delete.
+   * @param key - The key to delete.
    */
   delete(key: string): void {
     this.cache.delete(key);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -753,7 +753,7 @@ export class MedplumClient extends EventTarget {
   /**
    * Invalidates any cached values or cached requests for the given URL.
    * @category Caching
-   * @param url The URL to invalidate.
+   * @param url - The URL to invalidate.
    */
   invalidateUrl(url: URL | string): void {
     url = url.toString();
@@ -771,7 +771,7 @@ export class MedplumClient extends EventTarget {
   /**
    * Invalidates all cached search results or cached requests for the given resourceType.
    * @category Caching
-   * @param resourceType The resource type to invalidate.
+   * @param resourceType - The resource type to invalidate.
    */
   invalidateSearches<K extends ResourceType>(resourceType: K): void {
     const url = this.fhirBaseUrl + resourceType;
@@ -791,8 +791,8 @@ export class MedplumClient extends EventTarget {
    * For common operations, we recommend using higher level methods
    * such as `readResource()`, `search()`, etc.
    * @category HTTP
-   * @param url The target URL.
-   * @param options Optional fetch options.
+   * @param url - The target URL.
+   * @param options - Optional fetch options.
    * @returns Promise to the response content.
    */
   get<T = any>(url: URL | string, options: RequestInit = {}): ReadablePromise<T> {
@@ -833,10 +833,10 @@ export class MedplumClient extends EventTarget {
    * For common operations, we recommend using higher level methods
    * such as `createResource()`.
    * @category HTTP
-   * @param url The target URL.
-   * @param body The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
-   * @param contentType The content type to be included in the "Content-Type" header.
-   * @param options Optional fetch options.
+   * @param url - The target URL.
+   * @param body - The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
+   * @param contentType - The content type to be included in the "Content-Type" header.
+   * @param options - Optional fetch options.
    * @returns Promise to the response content.
    */
   post(url: URL | string, body: any, contentType?: string, options: RequestInit = {}): Promise<any> {
@@ -856,10 +856,10 @@ export class MedplumClient extends EventTarget {
    * For common operations, we recommend using higher level methods
    * such as `updateResource()`.
    * @category HTTP
-   * @param url The target URL.
-   * @param body The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
-   * @param contentType The content type to be included in the "Content-Type" header.
-   * @param options Optional fetch options.
+   * @param url - The target URL.
+   * @param body - The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
+   * @param contentType - The content type to be included in the "Content-Type" header.
+   * @param options - Optional fetch options.
    * @returns Promise to the response content.
    */
   put(url: URL | string, body: any, contentType?: string, options: RequestInit = {}): Promise<any> {
@@ -879,9 +879,9 @@ export class MedplumClient extends EventTarget {
    * For common operations, we recommend using higher level methods
    * such as `patchResource()`.
    * @category HTTP
-   * @param url The target URL.
-   * @param operations Array of JSONPatch operations.
-   * @param options Optional fetch options.
+   * @param url - The target URL.
+   * @param operations - Array of JSONPatch operations.
+   * @param options - Optional fetch options.
    * @returns Promise to the response content.
    */
   patch(url: URL | string, operations: PatchOperation[], options: RequestInit = {}): Promise<any> {
@@ -900,8 +900,8 @@ export class MedplumClient extends EventTarget {
    * For common operations, we recommend using higher level methods
    * such as `deleteResource()`.
    * @category HTTP
-   * @param url The target URL.
-   * @param options Optional fetch options.
+   * @param url - The target URL.
+   * @param options - Optional fetch options.
    * @returns Promise to the response content.
    */
   delete(url: URL | string, options?: RequestInit): Promise<any> {
@@ -917,8 +917,8 @@ export class MedplumClient extends EventTarget {
    * 1) New Practitioner and new Project
    * 2) New Patient registration
    * @category Authentication
-   * @param newUserRequest Register request including email and password.
-   * @param options Optional fetch options.
+   * @param newUserRequest - Register request including email and password.
+   * @param options - Optional fetch options.
    * @returns Promise to the authentication response.
    */
   async startNewUser(newUserRequest: NewUserRequest, options?: RequestInit): Promise<LoginAuthenticationResponse> {
@@ -940,8 +940,8 @@ export class MedplumClient extends EventTarget {
    * Initiates a new project flow.
    *
    * This requires a partial login from `startNewUser` or `startNewGoogleUser`.
-   * @param newProjectRequest Register request including email and password.
-   * @param options Optional fetch options.
+   * @param newProjectRequest - Register request including email and password.
+   * @param options - Optional fetch options.
    * @returns Promise to the authentication response.
    */
   async startNewProject(
@@ -955,8 +955,8 @@ export class MedplumClient extends EventTarget {
    * Initiates a new patient flow.
    *
    * This requires a partial login from `startNewUser` or `startNewGoogleUser`.
-   * @param newPatientRequest Register request including email and password.
-   * @param options Optional fetch options.
+   * @param newPatientRequest - Register request including email and password.
+   * @param options - Optional fetch options.
    * @returns Promise to the authentication response.
    */
   async startNewPatient(
@@ -969,8 +969,8 @@ export class MedplumClient extends EventTarget {
   /**
    * Initiates a user login flow.
    * @category Authentication
-   * @param loginRequest Login request including email and password.
-   * @param options Optional fetch options.
+   * @param loginRequest - Login request including email and password.
+   * @param options - Optional fetch options.
    * @returns Promise to the authentication response.
    */
   async startLogin(
@@ -994,8 +994,8 @@ export class MedplumClient extends EventTarget {
    * The response parameter is the result of a Google authentication.
    * See: https://developers.google.com/identity/gsi/web/guides/handle-credential-responses-js-functions
    * @category Authentication
-   * @param loginRequest Login request including Google credential response.
-   * @param options Optional fetch options.
+   * @param loginRequest - Login request including Google credential response.
+   * @param options - Optional fetch options.
    * @returns Promise to the authentication response.
    */
   async startGoogleLogin(
@@ -1019,7 +1019,7 @@ export class MedplumClient extends EventTarget {
    * If the login request already includes a code challenge, it is returned.
    * Otherwise, a new PKCE code challenge is generated.
    * @category Authentication
-   * @param loginRequest The original login request.
+   * @param loginRequest - The original login request.
    * @returns The PKCE code challenge and method.
    */
   async ensureCodeChallenge<T extends BaseLoginRequest>(loginRequest: T): Promise<T> {
@@ -1044,7 +1044,7 @@ export class MedplumClient extends EventTarget {
    * Returns true if the user is signed in.
    * This may result in navigating away to the sign in page.
    * @category Authentication
-   * @param loginParams Optional login parameters.
+   * @param loginParams - Optional login parameters.
    * @returns The user profile resource if available.
    */
   async signInWithRedirect(loginParams?: Partial<BaseLoginRequest>): Promise<ProfileResource | undefined> {
@@ -1069,10 +1069,10 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Initiates sign in with an external identity provider.
-   * @param authorizeUrl The external authorization URL.
-   * @param clientId The external client ID.
-   * @param redirectUri The external identity provider redirect URI.
-   * @param baseLogin The Medplum login request.
+   * @param authorizeUrl - The external authorization URL.
+   * @param clientId - The external client ID.
+   * @param redirectUri - The external identity provider redirect URI.
+   * @param baseLogin - The Medplum login request.
    * @category Authentication
    */
   async signInWithExternalAuth(
@@ -1087,8 +1087,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Exchange an external access token for a Medplum access token.
-   * @param token The access token that was generated by the external identity provider.
-   * @param clientId The ID of the `ClientApplication` in your Medplum project that will be making the exchange request.
+   * @param token - The access token that was generated by the external identity provider.
+   * @param clientId - The ID of the `ClientApplication` in your Medplum project that will be making the exchange request.
    * @returns The user profile resource.
    * @category Authentication
    */
@@ -1108,10 +1108,10 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Builds the external identity provider redirect URI.
-   * @param authorizeUrl The external authorization URL.
-   * @param clientId The external client ID.
-   * @param redirectUri The external identity provider redirect URI.
-   * @param loginRequest  The Medplum login request.
+   * @param authorizeUrl - The external authorization URL.
+   * @param clientId - The external client ID.
+   * @param redirectUri - The external identity provider redirect URI.
+   * @param loginRequest - The Medplum login request.
    * @returns The external identity provider redirect URI.
    * @category Authentication
    */
@@ -1144,7 +1144,7 @@ export class MedplumClient extends EventTarget {
    * Builds a FHIR URL from a collection of URL path components.
    * For example, `buildUrl('/Patient', '123')` returns `fhir/R4/Patient/123`.
    * @category HTTP
-   * @param path The path component of the URL.
+   * @param path - The path component of the URL.
    * @returns The well-formed FHIR URL.
    */
   fhirUrl(...path: string[]): URL {
@@ -1155,8 +1155,8 @@ export class MedplumClient extends EventTarget {
    * Builds a FHIR search URL from a search query or structured query object.
    * @category HTTP
    * @category Search
-   * @param resourceType The FHIR resource type.
-   * @param query The FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
+   * @param resourceType - The FHIR resource type.
+   * @param query - The FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
    * @returns The well-formed FHIR URL.
    */
   fhirSearchUrl(resourceType: ResourceType, query: QueryTypes): URL {
@@ -1209,9 +1209,9 @@ export class MedplumClient extends EventTarget {
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
    * @category Search
-   * @param resourceType The FHIR resource type.
-   * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
+   * @param options - Optional fetch options.
    * @returns Promise to the search result bundle.
    */
   search<K extends ResourceType>(
@@ -1256,9 +1256,9 @@ export class MedplumClient extends EventTarget {
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
    * @category Search
-   * @param resourceType The FHIR resource type.
-   * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
+   * @param options - Optional fetch options.
    * @returns Promise to the first search result.
    */
   searchOne<K extends ResourceType>(
@@ -1297,9 +1297,9 @@ export class MedplumClient extends EventTarget {
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
    * @category Search
-   * @param resourceType The FHIR resource type.
-   * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
+   * @param options - Optional fetch options.
    * @returns Promise to the array of search results.
    */
   searchResources<K extends ResourceType>(
@@ -1333,9 +1333,9 @@ export class MedplumClient extends EventTarget {
    * }
    * ```
    * @category Search
-   * @param resourceType The FHIR resource type.
-   * @param query Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
+   * @param options - Optional fetch options.
    * @yields An async generator, where each result is an array of resources for each page.
    */
   async *searchResourcePages<K extends ResourceType>(
@@ -1362,9 +1362,9 @@ export class MedplumClient extends EventTarget {
    * Searches a ValueSet resource using the "expand" operation.
    * See: https://www.hl7.org/fhir/operation-valueset-expand.html
    * @category Search
-   * @param system The ValueSet system url.
-   * @param filter The search string.
-   * @param options Optional fetch options.
+   * @param system - The ValueSet system url.
+   * @param filter - The search string.
+   * @param options - Optional fetch options.
    * @returns Promise to expanded ValueSet.
    */
   searchValueSet(system: string, filter: string, options?: RequestInit): ReadablePromise<ValueSet> {
@@ -1377,8 +1377,8 @@ export class MedplumClient extends EventTarget {
   /**
    * Returns a cached resource if it is available.
    * @category Caching
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
    * @returns The resource if it is available in the cache; undefined otherwise.
    */
   getCached<K extends ResourceType>(resourceType: K, id: string): ExtractResource<K> | undefined {
@@ -1389,7 +1389,7 @@ export class MedplumClient extends EventTarget {
   /**
    * Returns a cached resource if it is available.
    * @category Caching
-   * @param reference The FHIR reference.
+   * @param reference - The FHIR reference.
    * @returns The resource if it is available in the cache; undefined otherwise.
    */
   getCachedReference<T extends Resource>(reference: Reference<T>): T | undefined {
@@ -1419,9 +1419,9 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "read" operation for full details: https://www.hl7.org/fhir/http.html#read
    * @category Read
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
+   * @param options - Optional fetch options.
    * @returns The resource if available; undefined otherwise.
    */
   readResource<K extends ResourceType>(
@@ -1447,8 +1447,8 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "read" operation for full details: https://www.hl7.org/fhir/http.html#read
    * @category Read
-   * @param reference The FHIR reference object.
-   * @param options Optional fetch options.
+   * @param reference - The FHIR reference object.
+   * @param options - Optional fetch options.
    * @returns The resource if available; undefined otherwise.
    */
   readReference<T extends Resource>(reference: Reference<T>, options?: RequestInit): ReadablePromise<T> {
@@ -1470,7 +1470,7 @@ export class MedplumClient extends EventTarget {
    * Requests the schema for a resource type.
    * If the schema is already cached, the promise is resolved immediately.
    * @category Schema
-   * @param resourceType The FHIR resource type.
+   * @param resourceType - The FHIR resource type.
    * @returns Promise to a schema with the requested resource type.
    */
   requestSchema(resourceType: string): Promise<void> {
@@ -1552,9 +1552,9 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "history" operation for full details: https://www.hl7.org/fhir/http.html#history
    * @category Read
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
+   * @param options - Optional fetch options.
    * @returns Promise to the resource history.
    */
   readHistory<K extends ResourceType>(
@@ -1577,10 +1577,10 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "vread" operation for full details: https://www.hl7.org/fhir/http.html#vread
    * @category Read
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
-   * @param vid The version ID.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
+   * @param vid - The version ID.
+   * @param options - Optional fetch options.
    * @returns The resource if available; undefined otherwise.
    */
   readVersion<K extends ResourceType>(
@@ -1604,8 +1604,8 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "patient-everything" operation for full details: https://hl7.org/fhir/operation-patient-everything.html
    * @category Read
-   * @param id The Patient Id
-   * @param options Optional fetch options.
+   * @param id - The Patient Id
+   * @param options - Optional fetch options.
    * @returns A Bundle of all Resources related to the Patient
    */
   readPatientEverything(id: string, options?: RequestInit): ReadablePromise<Bundle> {
@@ -1632,8 +1632,8 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
    * @category Create
-   * @param resource The FHIR resource to create.
-   * @param options Optional fetch options.
+   * @param resource - The FHIR resource to create.
+   * @param options - Optional fetch options.
    * @returns The result of the create operation.
    */
   createResource<T extends Resource>(resource: T, options?: RequestInit): Promise<T> {
@@ -1679,9 +1679,9 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "conditional create" operation for full details: https://www.hl7.org/fhir/http.html#ccreate
    * @category Create
-   * @param resource The FHIR resource to create.
-   * @param query The search query for an equivalent resource (should not include resource type or "?").
-   * @param options Optional fetch options.
+   * @param resource - The FHIR resource to create.
+   * @param query - The search query for an equivalent resource (should not include resource type or "?").
+   * @param options - Optional fetch options.
    * @returns The result of the create operation.
    */
   async createResourceIfNoneExist<T extends Resource>(resource: T, query: string, options?: RequestInit): Promise<T> {
@@ -1707,10 +1707,10 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
    * @category Create
-   * @param data The binary data to upload.
-   * @param filename Optional filename for the binary.
-   * @param contentType Content type for the binary.
-   * @param onProgress Optional callback for progress events.
+   * @param data - The binary data to upload.
+   * @param filename - Optional filename for the binary.
+   * @param contentType - Content type for the binary.
+   * @param onProgress - Optional callback for progress events.
    * @returns The result of the create operation.
    */
   async createAttachment(
@@ -1745,10 +1745,10 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
    * @category Create
-   * @param data The binary data to upload.
-   * @param filename Optional filename for the binary.
-   * @param contentType Content type for the binary.
-   * @param onProgress Optional callback for progress events.
+   * @param data - The binary data to upload.
+   * @param filename - Optional filename for the binary.
+   * @param contentType - Content type for the binary.
+   * @param onProgress - Optional callback for progress events.
    * @returns The result of the create operation.
    */
   createBinary(
@@ -1822,10 +1822,10 @@ export class MedplumClient extends EventTarget {
    *
    * See the pdfmake document definition for full details: https://pdfmake.github.io/docs/0.1/document-definition-object/
    * @category Media
-   * @param docDefinition The PDF document definition.
-   * @param filename Optional filename for the PDF binary resource.
-   * @param tableLayouts Optional pdfmake custom table layout.
-   * @param fonts Optional pdfmake custom font dictionary.
+   * @param docDefinition - The PDF document definition.
+   * @param filename - Optional filename for the PDF binary resource.
+   * @param tableLayouts - Optional pdfmake custom table layout.
+   * @param fonts - Optional pdfmake custom font dictionary.
    * @returns The result of the create operation.
    */
   async createPdf(
@@ -1846,9 +1846,9 @@ export class MedplumClient extends EventTarget {
    *
    * This is a convenience method to handle commmon cases where a `Communication` resource is created with a `payload`.
    * @category Create
-   * @param resource The FHIR resource to comment on.
-   * @param text The text of the comment.
-   * @param options Optional fetch options.
+   * @param resource - The FHIR resource to comment on.
+   * @param text - The text of the comment.
+   * @param options - Optional fetch options.
    * @returns The result of the create operation.
    */
   createComment(resource: Resource, text: string, options?: RequestInit): Promise<Communication> {
@@ -1905,8 +1905,8 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "update" operation for full details: https://www.hl7.org/fhir/http.html#update
    * @category Write
-   * @param resource The FHIR resource to update.
-   * @param options Optional fetch options.
+   * @param resource - The FHIR resource to update.
+   * @param options - Optional fetch options.
    * @returns The result of the update operation.
    */
   async updateResource<T extends Resource>(resource: T, options?: RequestInit): Promise<T> {
@@ -1946,10 +1946,10 @@ export class MedplumClient extends EventTarget {
    *
    * See the JSONPatch specification for full details: https://tools.ietf.org/html/rfc6902
    * @category Write
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
-   * @param operations The JSONPatch operations.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
+   * @param operations - The JSONPatch operations.
+   * @param options - Optional fetch options.
    * @returns The result of the patch operations.
    */
   patchResource<K extends ResourceType>(
@@ -1973,9 +1973,9 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR "delete" operation for full details: https://www.hl7.org/fhir/http.html#delete
    * @category Delete
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
-   * @param options Optional fetch options.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
+   * @param options - Optional fetch options.
    * @returns The result of the delete operation.
    */
   deleteResource(resourceType: ResourceType, id: string, options?: RequestInit): Promise<any> {
@@ -1997,8 +1997,8 @@ export class MedplumClient extends EventTarget {
    * ```
    *
    * See the FHIR "$validate" operation for full details: https://www.hl7.org/fhir/resource-operation-validate.html
-   * @param resource The FHIR resource.
-   * @param options Optional fetch options.
+   * @param resource - The FHIR resource.
+   * @param options - Optional fetch options.
    * @returns The validate operation outcome.
    */
   validateResource<T extends Resource>(resource: T, options?: RequestInit): Promise<OperationOutcome> {
@@ -2007,10 +2007,10 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Executes a bot by ID or Identifier.
-   * @param idOrIdentifier The Bot ID or Identifier.
-   * @param body The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
-   * @param contentType The content type to be included in the "Content-Type" header.
-   * @param options Optional fetch options.
+   * @param idOrIdentifier - The Bot ID or Identifier.
+   * @param body - The content body. Strings and `File` objects are passed directly. Other objects are converted to JSON.
+   * @param contentType - The content type to be included in the "Content-Type" header.
+   * @param options - Optional fetch options.
    * @returns The Bot return value.
    */
   executeBot(
@@ -2074,8 +2074,8 @@ export class MedplumClient extends EventTarget {
    *
    * See The FHIR "batch/transaction" section for full details: https://hl7.org/fhir/http.html#transaction
    * @category Batch
-   * @param bundle The FHIR batch/transaction bundle.
-   * @param options Optional fetch options.
+   * @param bundle - The FHIR batch/transaction bundle.
+   * @param options - Optional fetch options.
    * @returns The FHIR batch/transaction response bundle.
    */
   executeBatch(bundle: Bundle, options?: RequestInit): Promise<Bundle> {
@@ -2116,8 +2116,8 @@ export class MedplumClient extends EventTarget {
    *
    * See options here: https://nodemailer.com/extras/mailcomposer/
    * @category Media
-   * @param email The MailComposer options.
-   * @param options Optional fetch options.
+   * @param email - The MailComposer options.
+   * @param options - Optional fetch options.
    * @returns Promise to the operation outcome.
    */
   sendEmail(email: MailOptions, options?: RequestInit): Promise<OperationOutcome> {
@@ -2165,10 +2165,10 @@ export class MedplumClient extends EventTarget {
    *
    * See the FHIR GraphQL documentation for FHIR specific details: https://www.hl7.org/fhir/graphql.html
    * @category Read
-   * @param query The GraphQL query.
-   * @param operationName Optional GraphQL operation name.
-   * @param variables Optional GraphQL variables.
-   * @param options Optional fetch options.
+   * @param query - The GraphQL query.
+   * @param operationName - Optional GraphQL operation name.
+   * @param variables - Optional GraphQL variables.
+   * @param options - Optional fetch options.
    * @returns The GraphQL result.
    */
   graphql(query: string, operationName?: string | null, variables?: any, options?: RequestInit): Promise<any> {
@@ -2179,10 +2179,10 @@ export class MedplumClient extends EventTarget {
    * Executes the $graph operation on this resource to fetch a Bundle of resources linked to the target resource
    * according to a graph definition
    * @category Read
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
    * @param graphName `name` parameter of the GraphDefinition
-   * @param options Optional fetch options.
+   * @param options - Optional fetch options.
    * @returns A Bundle
    */
   readResourceGraph<K extends ResourceType>(
@@ -2197,11 +2197,11 @@ export class MedplumClient extends EventTarget {
   /**
    * Pushes a message to an agent.
    *
-   * @param agent The agent to push to.
-   * @param destination The destination device.
-   * @param body The message body.
-   * @param contentType Optional message content type.
-   * @param options Optional fetch options.
+   * @param agent - The agent to push to.
+   * @param destination - The destination device.
+   * @param body - The message body.
+   * @param contentType - Optional message content type.
+   * @param options - Optional fetch options.
    * @returns Promise to the operation outcome.
    */
   pushToAgent(
@@ -2233,7 +2233,7 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Sets the active login.
-   * @param login The new active login state.
+   * @param login - The new active login state.
    * @category Authentication
    */
   async setActiveLogin(login: LoginState): Promise<void> {
@@ -2258,8 +2258,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Sets the current access token.
-   * @param accessToken The new access token.
-   * @param refreshToken Optional refresh token.
+   * @param accessToken - The new access token.
+   * @param refreshToken - Optional refresh token.
    * @category Authentication
    */
   setAccessToken(accessToken: string, refreshToken?: string): void {
@@ -2396,8 +2396,8 @@ export class MedplumClient extends EventTarget {
   /**
    * Downloads the URL as a blob. Can accept binary URLs in the form of `Binary/{id}` as well.
    * @category Read
-   * @param url The URL to request. Can be a standard URL or one in the form of `Binary/{id}`.
-   * @param options Optional fetch request init options.
+   * @param url - The URL to request. Can be a standard URL or one in the form of `Binary/{id}`.
+   * @param options - Optional fetch request init options.
    * @returns Promise to the response body as a blob.
    */
   async download(url: URL | string, options: RequestInit = {}): Promise<Blob> {
@@ -2415,11 +2415,11 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Upload media to the server and create a Media instance for the uploaded content.
-   * @param contents The contents of the media file, as a string, Uint8Array, File, or Blob.
-   * @param contentType The media type of the content.
-   * @param filename The name of the file to be uploaded, or undefined if not applicable.
-   * @param additionalFields Additional fields for Media.
-   * @param options Optional fetch options.
+   * @param contents - The contents of the media file, as a string, Uint8Array, File, or Blob.
+   * @param contentType - The media type of the content.
+   * @param filename - The name of the file to be uploaded, or undefined if not applicable.
+   * @param additionalFields - Additional fields for Media.
+   * @param options - Optional fetch options.
    * @returns Promise that resolves to the created Media
    */
   async uploadMedia(
@@ -2447,10 +2447,10 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Performs Bulk Data Export operation request flow. See The FHIR "Bulk Data Export" for full details: https://build.fhir.org/ig/HL7/bulk-data/export.html#bulk-data-export
-   * @param exportLevel Optional export level. Defaults to system level export. 'Group/:id' - Group of Patients, 'Patient' - All Patients.
-   * @param resourceTypes A string of comma-delimited FHIR resource types.
-   * @param since Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).
-   * @param options Optional fetch options.
+   * @param exportLevel - Optional export level. Defaults to system level export. 'Group/:id' - Group of Patients, 'Patient' - All Patients.
+   * @param resourceTypes - A string of comma-delimited FHIR resource types.
+   * @param since - Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).
+   * @param options - Optional fetch options.
    * @returns Bulk Data Response containing links to Bulk Data files. See "Response - Complete Status" for full details: https://build.fhir.org/ig/HL7/bulk-data/export.html#response---complete-status
    */
   async bulkExport(
@@ -2476,8 +2476,8 @@ export class MedplumClient extends EventTarget {
   /**
    * Starts an async request following the FHIR "Asynchronous Request Pattern".
    * See: https://hl7.org/fhir/r4/async.html
-   * @param url The URL to request.
-   * @param options Optional fetch options.
+   * @param url - The URL to request.
+   * @param options - Optional fetch options.
    * @returns The response body.
    */
   async startAsyncRequest<T>(url: string, options: RequestInit = {}): Promise<T> {
@@ -2504,8 +2504,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Returns the cache entry if available and not expired.
-   * @param key The cache key to retrieve.
-   * @param options Optional fetch options for cache settings.
+   * @param key - The cache key to retrieve.
+   * @param options - Optional fetch options for cache settings.
    * @returns The cached entry if found.
    */
   private getCacheEntry(key: string, options: RequestInit | undefined): RequestCacheEntry | undefined {
@@ -2521,8 +2521,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Adds a readable promise to the cache.
-   * @param key The cache key to store.
-   * @param value The readable promise to store.
+   * @param key - The cache key to store.
+   * @param value - The readable promise to store.
    */
   private setCacheEntry(key: string, value: ReadablePromise<any>): void {
     if (this.requestCache) {
@@ -2534,7 +2534,7 @@ export class MedplumClient extends EventTarget {
    * Adds a concrete value as the cache entry for the given resource.
    * This is used in cases where the resource is loaded indirectly.
    * For example, when a resource is loaded as part of a Bundle.
-   * @param resource The resource to cache.
+   * @param resource - The resource to cache.
    */
   private cacheResource(resource: Resource | undefined): void {
     if (resource?.id && !resource.meta?.tag?.some((t) => t.code === 'SUBSETTED')) {
@@ -2547,7 +2547,7 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Deletes a cache entry.
-   * @param key The cache key to delete.
+   * @param key - The cache key to delete.
    */
   private deleteCacheEntry(key: string): void {
     if (this.requestCache) {
@@ -2557,9 +2557,9 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Makes an HTTP request.
-   * @param method The HTTP method (GET, POST, etc).
-   * @param url The target URL.
-   * @param options Optional fetch request init options.
+   * @param method - The HTTP method (GET, POST, etc).
+   * @param url - The target URL.
+   * @param options - Optional fetch request init options.
    * @returns The JSON content body if available.
    */
   private async request<T>(method: string, url: string, options: RequestInit = {}): Promise<T> {
@@ -2752,7 +2752,7 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Adds default options to the fetch options.
-   * @param options The options to add defaults to.
+   * @param options - The options to add defaults to.
    */
   private addFetchOptionsDefaults(options: RequestInit): void {
     let headers = options.headers as Record<string, string> | undefined;
@@ -2787,8 +2787,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Sets the "Content-Type" header on fetch options.
-   * @param options The fetch options.
-   * @param contentType The new content type to set.
+   * @param options - The fetch options.
+   * @param contentType - The new content type to set.
    */
   private setRequestContentType(options: RequestInit, contentType: string): void {
     if (!options.headers) {
@@ -2800,8 +2800,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Sets the body on fetch options.
-   * @param options The fetch options.
-   * @param data The new content body.
+   * @param options - The fetch options.
+   * @param data - The new content body.
    */
   private setRequestBody(options: RequestInit, data: any): void {
     if (
@@ -2820,9 +2820,9 @@ export class MedplumClient extends EventTarget {
    * Handles an unauthenticated response from the server.
    * First, tries to refresh the access token and retry the request.
    * Otherwise, calls unauthenticated callbacks and rejects.
-   * @param method The HTTP method of the original request.
-   * @param url The URL of the original request.
-   * @param options Optional fetch request init options.
+   * @param method - The HTTP method of the original request.
+   * @param url - The URL of the original request.
+   * @param options - Optional fetch request init options.
    * @returns The result of the retry.
    */
   private handleUnauthenticated(method: string, url: string, options: RequestInit): Promise<any> {
@@ -2859,7 +2859,7 @@ export class MedplumClient extends EventTarget {
   /**
    * Redirects the user to the login screen for authorization.
    * Clears all auth state including local storage and session storage.
-   * @param loginParams The authorization login parameters.
+   * @param loginParams - The authorization login parameters.
    * @see https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
    */
   private async requestAuthorization(loginParams?: Partial<BaseLoginRequest>): Promise<void> {
@@ -2878,8 +2878,8 @@ export class MedplumClient extends EventTarget {
   /**
    * Processes an OAuth authorization code.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
-   * @param code The authorization code received by URL parameter.
-   * @param loginParams Optional login parameters.
+   * @param code - The authorization code received by URL parameter.
+   * @param loginParams - Optional login parameters.
    * @returns The user profile resource.
    * @category Authentication
    */
@@ -2939,8 +2939,8 @@ export class MedplumClient extends EventTarget {
    * See: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
    *
    * @category Authentication
-   * @param clientId The client ID.
-   * @param clientSecret The client secret.
+   * @param clientId - The client ID.
+   * @param clientSecret - The client secret.
    * @returns Promise that resolves to the client profile.
    */
   async startClientLogin(clientId: string, clientSecret: string): Promise<ProfileResource> {
@@ -2966,9 +2966,9 @@ export class MedplumClient extends EventTarget {
    * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.1
    *
    * @category Authentication
-   * @param clientId The client ID.
-   * @param assertion The JWT assertion.
-   * @param scope The OAuth scope.
+   * @param clientId - The client ID.
+   * @param assertion - The JWT assertion.
+   * @param scope - The OAuth scope.
    * @returns Promise that resolves to the client profile.
    */
   async startJwtBearerLogin(clientId: string, assertion: string, scope: string): Promise<ProfileResource> {
@@ -2988,7 +2988,7 @@ export class MedplumClient extends EventTarget {
    * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
    *
    * @category Authentication
-   * @param jwt The JWT assertion.
+   * @param jwt - The JWT assertion.
    * @returns Promise that resolves to the client profile.
    */
   async startJwtAssertionLogin(jwt: string): Promise<ProfileResource> {
@@ -3008,8 +3008,8 @@ export class MedplumClient extends EventTarget {
    * await medplum.searchResources('Patient')
    * ```
    * @category Authentication
-   * @param clientId The client ID.
-   * @param clientSecret The client secret.
+   * @param clientId - The client ID.
+   * @param clientSecret - The client secret.
    */
   setBasicAuth(clientId: string, clientSecret: string): void {
     this.clientId = clientId;
@@ -3023,8 +3023,8 @@ export class MedplumClient extends EventTarget {
    * Once you have the `SubscriptionRequest` returned from this method, you can call `fhircastConnect(subscriptionRequest)` to connect to the subscription stream.
    *
    * @category FHIRcast
-   * @param topic The topic to publish to. Usually a UUID.
-   * @param events An array of event names to listen for.
+   * @param topic - The topic to publish to. Usually a UUID.
+   * @param events - An array of event names to listen for.
    * @returns A `Promise` that resolves once the request completes, or rejects if it fails.
    */
   async fhircastSubscribe(topic: string, events: FhircastEventName[]): Promise<SubscriptionRequest> {
@@ -3066,7 +3066,7 @@ export class MedplumClient extends EventTarget {
    * Unsubscribes from the specified topic.
    *
    * @category FHIRcast
-   * @param subRequest A `SubscriptionRequest` representing a subscription to cancel. Mode will be set to `unsubscribe` automatically.
+   * @param subRequest - A `SubscriptionRequest` representing a subscription to cancel. Mode will be set to `unsubscribe` automatically.
    * @returns A `Promise` that resolves when request to unsubscribe is completed.
    */
   async fhircastUnsubscribe(subRequest: SubscriptionRequest): Promise<void> {
@@ -3091,7 +3091,7 @@ export class MedplumClient extends EventTarget {
    * Connects to a `FHIRcast` session.
    *
    * @category FHIRcast
-   * @param subRequest The `SubscriptionRequest` to use for connecting.
+   * @param subRequest - The `SubscriptionRequest` to use for connecting.
    * @returns A `FhircastConnection` which emits lifecycle events for the `FHIRcast` WebSocket connection.
    */
   fhircastConnect(subRequest: SubscriptionRequest): FhircastConnection {
@@ -3102,9 +3102,9 @@ export class MedplumClient extends EventTarget {
    * Publishes a new context to a given topic for a specified event type.
    *
    * @category FHIRcast
-   * @param topic The topic to publish to. Usually a UUID.
-   * @param event The name of the event to publish an updated context for, ie. `patient-open`.
-   * @param context The updated context containing resources relevant to this event.
+   * @param topic - The topic to publish to. Usually a UUID.
+   * @param event - The name of the event to publish an updated context for, ie. `patient-open`.
+   * @param context - The updated context containing resources relevant to this event.
    * @returns A `Promise` that resolves once the request completes, or rejects if it fails.
    */
   async fhircastPublish(
@@ -3117,8 +3117,8 @@ export class MedplumClient extends EventTarget {
 
   /**
    * Invite a user to a project.
-   * @param projectId The project ID.
-   * @param body The InviteRequest.
+   * @param projectId - The project ID.
+   * @param body - The InviteRequest.
    * @returns Promise that returns a project membership or an operation outcome.
    */
   async invite(projectId: string, body: InviteRequest): Promise<ProjectMembership | OperationOutcome> {
@@ -3128,7 +3128,7 @@ export class MedplumClient extends EventTarget {
   /**
    * Makes a POST request to the tokens endpoint.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
-   * @param formBody Token parameters in URL encoded format.
+   * @param formBody - Token parameters in URL encoded format.
    * @returns The user profile resource.
    */
   private async fetchTokens(formBody: URLSearchParams): Promise<ProfileResource> {
@@ -3163,7 +3163,7 @@ export class MedplumClient extends EventTarget {
    * Verifies the tokens received from the auth server.
    * Validates the JWT against the JWKS.
    * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
-   * @param tokens The token response.
+   * @param tokens - The token response.
    * @returns Promise to complete.
    */
   private async verifyTokens(tokens: TokenResponse): Promise<void> {
@@ -3255,7 +3255,7 @@ function getWindowOrigin(): string {
 
 /**
  * Ensures the given URL has a trailing slash.
- * @param url The URL to ensure has a trailing slash.
+ * @param url - The URL to ensure has a trailing slash.
  * @returns The URL with a trailing slash.
  */
 function ensureTrailingSlash(url: string): string {
@@ -3267,8 +3267,8 @@ function ensureTrailingSlash(url: string): string {
  *
  * If the URL is absolute, it is returned as-is.
  *
- * @param baseUrl The base URL.
- * @param url The URL to concat. Can be relative or absolute.
+ * @param baseUrl - The base URL.
+ * @param url - The URL to concat. Can be relative or absolute.
  * @returns The concatenated URL.
  */
 function concatUrls(baseUrl: string, url: string): string {
@@ -3287,7 +3287,7 @@ function concatUrls(baseUrl: string, url: string): string {
  * from the 'diagnostics' field of the first issue in an OperationOutcome object
  * present in the response body. If all attempts fail, the function returns 'undefined'.
  * @async
- * @param response The HTTP response object from which to extract the content location.
+ * @param response - The HTTP response object from which to extract the content location.
  * @returns A Promise that resolves to the content location string if it is found, or 'undefined' if the content location cannot be determined from the response.
  */
 async function tryGetContentLocation(response: Response): Promise<string | undefined> {
@@ -3318,7 +3318,7 @@ async function tryGetContentLocation(response: Response): Promise<string | undef
 /**
  * Converts a FHIR resource bundle to a resource array.
  * The bundle is attached to the array as a property named "bundle".
- * @param bundle A FHIR resource bundle.
+ * @param bundle - A FHIR resource bundle.
  * @returns The resource array with the bundle attached.
  */
 function bundleToResourceArray<T extends Resource>(bundle: Bundle<T>): ResourceArray<T> {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2181,7 +2181,7 @@ export class MedplumClient extends EventTarget {
    * @category Read
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
-   * @param graphName `name` parameter of the GraphDefinition
+   * @param graphName - `name` parameter of the GraphDefinition
    * @param options - Optional fetch options.
    * @returns A Bundle
    */

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -12,7 +12,7 @@ export function getRandomString(): string {
 
 /**
  * Encrypts a string with SHA256 encryption.
- * @param str The unencrypted input string.
+ * @param str - The unencrypted input string.
  * @returns The encrypted value in an ArrayBuffer.
  */
 export async function encryptSHA256(str: string): Promise<ArrayBuffer> {

--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -34,7 +34,7 @@ const FHIRCAST_EVENT_OPTIONAL_RESOURCES = {
 /**
  * Checks if a `ResourceType` can be used in a `FHIRcast` context.
  *
- * @param resourceType A `ResourceType` to test.
+ * @param resourceType - A `ResourceType` to test.
  * @returns `true` if this is a resource type associated with `FHIRcast` contexts, otherwise returns `false`.
  */
 export function isFhircastResourceType(resourceType: FhircastResourceType): boolean {
@@ -97,7 +97,7 @@ export function isCompletedSubscriptionRequest(
 /**
  * Creates a serialized url-encoded payload for a `FHIRcast` subscription from a `SubscriptionRequest` object that can be directly used in an HTTP request to the Hub.
  *
- * @param subscriptionRequest An object representing a subscription request.
+ * @param subscriptionRequest - An object representing a subscription request.
  * @returns A serialized subscription in url-encoded form.
  */
 export function serializeFhircastSubscriptionRequest(
@@ -127,7 +127,7 @@ export function serializeFhircastSubscriptionRequest(
 /**
  * Validates that a `SubscriptionRequest`.
  *
- * @param subscriptionRequest The `SubscriptionRequest` to validate.
+ * @param subscriptionRequest - The `SubscriptionRequest` to validate.
  * @returns A `boolean` indicating whether or not the `SubscriptionRequest` is valid.
  */
 export function validateFhircastSubscriptionRequest(
@@ -169,10 +169,10 @@ export function validateFhircastSubscriptionRequest(
 /**
  * Throws if the context is invalid. Intended as a helper for `validateFhircastContexts` only.
  *
- * @param event The `FHIRcast` event name associated with the provided contexts.
- * @param context The `FHIRcast` event contexts to validate.
- * @param i The index of the current context in the context list.
- * @param keysSeen Set of keys seen so far. Used to prevent duplicate keys.
+ * @param event - The `FHIRcast` event name associated with the provided contexts.
+ * @param context - The `FHIRcast` event contexts to validate.
+ * @param i - The index of the current context in the context list.
+ * @param keysSeen - Set of keys seen so far. Used to prevent duplicate keys.
  */
 function validateFhircastContext(
   event: FhircastEventName,
@@ -241,8 +241,8 @@ function validateFhircastContext(
 /**
  * Throws if any context in the given array of contexts is invalid.
  *
- * @param event The `FHIRcast` event name associated with the provided contexts.
- * @param contexts The `FHIRcast` event contexts to validate.
+ * @param event - The `FHIRcast` event name associated with the provided contexts.
+ * @param contexts - The `FHIRcast` event contexts to validate.
  */
 function validateFhircastContexts(event: FhircastEventName, contexts: FhircastEventContext[]): void {
   const keysSeen = new Set<FhircastEventContextKey>();
@@ -254,9 +254,9 @@ function validateFhircastContexts(event: FhircastEventName, contexts: FhircastEv
 /**
  * Creates a serializable JSON payload for the `FHIRcast` protocol
  *
- * @param topic The topic that this message will be published on. Usually a UUID.
- * @param event The event name, ie. "patient-open" or "patient-close".
- * @param context The updated context, containing new versions of resources related to this event.
+ * @param topic - The topic that this message will be published on. Usually a UUID.
+ * @param event - The event name, ie. "patient-open" or "patient-close".
+ * @param context - The updated context, containing new versions of resources related to this event.
  * @returns A serializable `FhircastMessagePayload`.
  */
 export function createFhircastMessagePayload(
@@ -318,7 +318,7 @@ export class FhircastConnection extends TypedEventTarget<FhircastSubscriptionEve
 
   /**
    * Creates a new `FhircastConnection`.
-   * @param subRequest The subscription request to initialize the connection from.
+   * @param subRequest - The subscription request to initialize the connection from.
    */
   constructor(subRequest: SubscriptionRequest) {
     super();

--- a/packages/core/src/fhirmapper/parse.ts
+++ b/packages/core/src/fhirmapper/parse.ts
@@ -364,7 +364,7 @@ const fhirPathParserBuilder = initFhirPathParserBuilder()
 
 /**
  * Parses a FHIR Mapping Language document into an AST.
- * @param input The FHIR Mapping Language document to parse.
+ * @param input - The FHIR Mapping Language document to parse.
  * @returns The AST representing the document.
  */
 export function parseMappingLanguage(input: string): StructureMap {

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -29,8 +29,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns true if the input collection is empty ({ }) and false otherwise.
    *
    * See: https://hl7.org/fhirpath/#empty-boolean
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the input collection is empty ({ }) and false otherwise.
    */
   empty: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -47,9 +47,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * for where(criteria).exists().
    *
    * See: https://hl7.org/fhirpath/#existscriteria-expression-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param criteria The evaluation criteria.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param criteria - The evaluation criteria.
    * @returns True if the collection has unknown elements, and false otherwise.
    */
   exists: (context: AtomContext, input: TypedValue[], criteria?: Atom): TypedValue[] => {
@@ -67,9 +67,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#allcriteria-expression-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param criteria The evaluation criteria.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param criteria - The evaluation criteria.
    * @returns True if for every element in the input collection, criteria evaluates to true.
    */
   all: (context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
@@ -82,8 +82,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#alltrue-boolean
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if all the items are true.
    */
   allTrue: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -100,8 +100,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If all the items are false, or if the input is empty ({ }), the result is false.
    *
    * See: https://hl7.org/fhirpath/#anytrue-boolean
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if unknown of the items are true.
    */
   anyTrue: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -119,8 +119,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input is empty ({ }), the result is true.
    *
    * See: https://hl7.org/fhirpath/#allfalse-boolean
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if all the items are false.
    */
   allFalse: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -137,8 +137,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If all the items are true, or if the input is empty ({ }), the result is false.
    *
    * See: https://hl7.org/fhirpath/#anyfalse-boolean
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if for every element in the input collection, criteria evaluates to true.
    */
   anyFalse: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -181,8 +181,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns 0 when the input collection is empty.
    *
    * See: https://hl7.org/fhirpath/#count-integer
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
   count: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -200,8 +200,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * preserved in the result.
    *
    * See: https://hl7.org/fhirpath/#distinct-collection
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
   distinct: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -220,8 +220,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * as defined below.
    *
    * See: https://hl7.org/fhirpath/#isdistinct-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns The integer count of the number of items in the input collection.
    */
   isDistinct: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -245,9 +245,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * consistent with singleton evaluation of collections behavior.
    *
    * See: https://hl7.org/fhirpath/#wherecriteria-expression-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param criteria The condition atom.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param criteria - The condition atom.
    * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
    */
   where: (context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
@@ -264,9 +264,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * the input collection is empty ({ }), the result is empty as well.
    *
    * See: http://hl7.org/fhirpath/#selectprojection-expression-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param criteria The condition atom.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param criteria - The condition atom.
    * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
    */
   select: (context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
@@ -289,9 +289,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * must resolve to the name of a type in a model
    *
    * See: http://hl7.org/fhirpath/#oftypetype-type-specifier-collection
-   * @param _context The evaluation context.
-   * @param input The input collection.
-   * @param criteria The condition atom.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
+   * @param criteria - The condition atom.
    * @returns A collection containing only those elements in the input collection that are of the given type or a subclass thereof.
    */
   ofType: (_context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
@@ -310,8 +310,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * about cardinality is violated at run-time.
    *
    * See: https://hl7.org/fhirpath/#single-collection
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The single item in the input if there is just one item.
    */
   single: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -326,8 +326,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * This function is equivalent to item[0], so it will return an empty collection if the input collection has no items.
    *
    * See: https://hl7.org/fhirpath/#first-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing only the first item in the input collection.
    */
   first: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -339,8 +339,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * Will return an empty collection if the input collection has no items.
    *
    * See: https://hl7.org/fhirpath/#last-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing only the last item in the input collection.
    */
   last: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -352,8 +352,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * Will return an empty collection if the input collection has no items, or only one item.
    *
    * See: https://hl7.org/fhirpath/#tail-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing all but the first item in the input collection.
    */
   tail: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -367,9 +367,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If num is less than or equal to zero, the input collection is simply returned.
    *
    * See: https://hl7.org/fhirpath/#skipnum-integer-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param num The atom representing the number of elements to skip.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param num - The atom representing the number of elements to skip.
    * @returns A collection containing all but the first item in the input collection.
    */
   skip: (context: AtomContext, input: TypedValue[], num: Atom): TypedValue[] => {
@@ -393,9 +393,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * take returns an empty collection.
    *
    * See: https://hl7.org/fhirpath/#takenum-integer-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param num The atom representing the number of elements to take.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param num - The atom representing the number of elements to take.
    * @returns A collection containing the first num items in the input collection.
    */
   take: (context: AtomContext, input: TypedValue[], num: Atom): TypedValue[] => {
@@ -418,9 +418,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * Order of items is not guaranteed to be preserved in the result of this function.
    *
    * See: http://hl7.org/fhirpath/#intersectother-collection-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param other The atom representing the collection of elements to intersect.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param other - The atom representing the collection of elements to intersect.
    * @returns A collection containing the elements that are in both collections.
    */
   intersect: (context: AtomContext, input: TypedValue[], other: Atom): TypedValue[] => {
@@ -444,9 +444,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * e.g. (1 | 2 | 3).exclude(2) returns (1 | 3).
    *
    * See: http://hl7.org/fhirpath/#excludeother-collection-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param other The atom representing the collection of elements to exclude.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param other - The atom representing the collection of elements to exclude.
    * @returns A collection containing the elements that are in the input collection but not the other collection.
    */
   exclude: (context: AtomContext, input: TypedValue[], other: Atom): TypedValue[] => {
@@ -477,9 +477,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * In other words, this function returns the distinct list of elements from both inputs.
    *
    * See: http://hl7.org/fhirpath/#unionother-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param other The atom representing the collection of elements to merge.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param other - The atom representing the collection of elements to merge.
    * @returns A collection containing the elements that represent the union of both collections.
    */
   union: (context: AtomContext, input: TypedValue[], other: Atom): TypedValue[] => {
@@ -498,9 +498,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * There is no expectation of order in the resulting collection.
    *
    * See: http://hl7.org/fhirpath/#combineother-collection-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param other The atom representing the collection of elements to merge.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param other - The atom representing the collection of elements to merge.
    * @returns A collection containing the elements that represent the combination of both collections including duplicates.
    */
   combine: (context: AtomContext, input: TypedValue[], other: Atom): TypedValue[] => {
@@ -515,9 +515,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns true if the input is a value HTML element.
    *
    * See: https://hl7.org/fhir/fhirpath.html#variables
-   * @param _context The evaluation context.
-   * @param _input The input collection.
-   * @param _other The atom representing the collection of elements to validate the html.
+   * @param _context - The evaluation context.
+   * @param _input - The input collection.
+   * @param _other - The atom representing the collection of elements to validate the html.
    * @returns A collection of boolean values
    */
   htmlChecks: (_context: AtomContext, _input: TypedValue[], _other: Atom): TypedValue[] => {
@@ -545,11 +545,11 @@ export const functions: Record<string, FhirPathFunction> = {
    * true-result should only be evaluated if the criterion evaluates to true,
    * and otherwise-result should only be evaluated otherwise. For implementations,
    * this means delaying evaluation of the arguments.
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param criterion The atom representing the conditional.
-   * @param trueResult The atom to be used if the conditional evaluates to true.
-   * @param otherwiseResult Optional atom to be used if the conditional evaluates to false.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param criterion - The atom representing the conditional.
+   * @param trueResult - The atom to be used if the conditional evaluates to true.
+   * @param otherwiseResult - Optional atom to be used if the conditional evaluates to false.
    * @returns The result of the iif function.
    */
   iif: (
@@ -587,8 +587,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one the above types, or the item is a String, Integer, or Decimal, but is not equal to one of the possible values convertible to a Boolean, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#toboolean-boolean
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The input converted to boolean value.
    */
   toBoolean: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -632,8 +632,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: http://hl7.org/fhirpath/#convertstoboolean-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the input can be converted to boolean.
    */
   convertsToBoolean: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -660,8 +660,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tointeger-integer
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The string representation of the input.
    */
   toInteger: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -695,8 +695,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstointeger-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the input can be converted to an integer.
    */
   convertsToInteger: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -721,8 +721,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#todate-date
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The value converted to a date if possible; otherwise empty array.
    */
   toDate: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -751,8 +751,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodate-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the item can be converted to a date.
    */
   convertsToDate: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -779,8 +779,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#todatetime-datetime
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The value converted to a datetime if possible; otherwise empty array.
    */
   toDateTime: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -807,8 +807,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodatetime-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the item can be converted to a dateTime.
    */
   convertsToDateTime: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -832,8 +832,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#decimal-conversion-functions
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The value converted to a decimal if possible; otherwise empty array.
    */
   toDecimal: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -866,8 +866,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstodecimal-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns The value converted to a decimal if possible; otherwise empty array.
    */
   convertsToDecimal: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -887,8 +887,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one of the above types, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#quantity-conversion-functions
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The value converted to a quantity if possible; otherwise empty array.
    */
   toQuantity: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -930,8 +930,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the unit argument is provided, it must be the string representation of a UCUM code (or a FHIRPath calendar duration keyword), and is used to determine whether the input quantity can be converted to the given unit, according to the unit conversion rules specified by UCUM. If the input quantity can be converted, the result is true, otherwise, the result is false.
    *
    * See: https://hl7.org/fhirpath/#convertstoquantityunit-string-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the item can be converted to a quantity.
    */
   convertsToQuantity: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -953,8 +953,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the item is not one of the above types, the result is false.
    *
    * See: https://hl7.org/fhirpath/#tostring-string
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The string representation of the input.
    */
   toString: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -987,8 +987,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tostring-string
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the item can be converted to a string
    */
   convertsToString: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1014,8 +1014,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#totime-time
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The value converted to a time if possible; otherwise empty array.
    */
   toTime: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1044,8 +1044,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection is empty, the result is empty.
    *
    * See: https://hl7.org/fhirpath/#convertstotime-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the item can be converted to a time.
    */
   convertsToTime: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1071,9 +1071,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#indexofsubstring-string-integer
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param substringAtom The substring to search for.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param substringAtom - The substring to search for.
    * @returns The index of the substring.
    */
   indexOf: (context: AtomContext, input: TypedValue[], substringAtom: Atom): TypedValue[] => {
@@ -1090,10 +1090,10 @@ export const functions: Record<string, FhirPathFunction> = {
    * If an empty length is provided, the behavior is the same as if length had not been provided.
    *
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param startAtom The start index atom.
-   * @param lengthAtom Optional length atom.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param startAtom - The start index atom.
+   * @param lengthAtom - Optional length atom.
    * @returns The substring.
    */
   substring: (context: AtomContext, input: TypedValue[], startAtom: Atom, lengthAtom?: Atom): TypedValue[] => {
@@ -1120,9 +1120,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#startswithprefix-string-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param prefixAtom The prefix substring to test.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param prefixAtom - The prefix substring to test.
    * @returns True if the input string starts with the given prefix string.
    */
   startsWith: (context: AtomContext, input: TypedValue[], prefixAtom: Atom): TypedValue[] => {
@@ -1139,9 +1139,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#endswithsuffix-string-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param suffixAtom The suffix substring to test.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param suffixAtom - The suffix substring to test.
    * @returns True if the input string ends with the given suffix string.
    */
   endsWith: (context: AtomContext, input: TypedValue[], suffixAtom: Atom): TypedValue[] => {
@@ -1158,9 +1158,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#containssubstring-string-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param substringAtom The substring to test.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param substringAtom - The substring to test.
    * @returns True if the input string contains the given substring.
    */
   contains: (context: AtomContext, input: TypedValue[], substringAtom: Atom): TypedValue[] => {
@@ -1174,8 +1174,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#upper-string
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns The string converted to upper case.
    */
   upper: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1190,8 +1190,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#lower-string
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns The string converted to lower case.
    */
   lower: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1208,10 +1208,10 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#replacepattern-string-substitution-string-string
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param patternAtom The pattern to search for.
-   * @param substitionAtom The substition to replace with.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param patternAtom - The pattern to search for.
+   * @param substitionAtom - The substition to replace with.
    * @returns The string with all instances of the search pattern replaced with the substitution string.
    */
   replace: (context: AtomContext, input: TypedValue[], patternAtom: Atom, substitionAtom: Atom): TypedValue[] => {
@@ -1232,9 +1232,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#matchesregex-string-boolean
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param regexAtom The regular expression atom.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param regexAtom - The regular expression atom.
    * @returns True if the input string matches the given regular expression.
    */
   matches: (context: AtomContext, input: TypedValue[], regexAtom: Atom): TypedValue[] => {
@@ -1249,10 +1249,10 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#replacematchesregex-string-substitution-string-string
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param regexAtom The regular expression atom.
-   * @param substitionAtom The substition to replace with.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param regexAtom - The regular expression atom.
+   * @param substitionAtom - The substition to replace with.
    * @returns The string with all instances of the search pattern replaced with the substitution string.
    */
   replaceMatches: (context: AtomContext, input: TypedValue[], regexAtom: Atom, substitionAtom: Atom): TypedValue[] => {
@@ -1266,8 +1266,8 @@ export const functions: Record<string, FhirPathFunction> = {
   },
 
   /**
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns The index of the substring.
    */
   length: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1278,8 +1278,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * Returns the list of characters in the input string. If the input collection is empty ({ }), the result is empty.
    *
    * See: https://hl7.org/fhirpath/#tochars-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns Array of characters.
    */
   toChars: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1298,8 +1298,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#abs-integer-decimal-quantity
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   abs: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1314,8 +1314,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#ceiling-integer
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   ceiling: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1332,8 +1332,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#exp-decimal
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   exp: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1348,8 +1348,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#floor-integer
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   floor: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1366,8 +1366,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#ln-decimal
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   ln: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1386,9 +1386,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#logbase-decimal-decimal
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param baseAtom The logarithm base.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param baseAtom - The logarithm base.
    * @returns A collection containing the result.
    */
   log: (context: AtomContext, input: TypedValue[], baseAtom: Atom): TypedValue[] => {
@@ -1405,9 +1405,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#powerexponent-integer-decimal-integer-decimal
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param expAtom The exponent power.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param expAtom - The exponent power.
    * @returns A collection containing the result.
    */
   power: (context: AtomContext, input: TypedValue[], expAtom: Atom): TypedValue[] => {
@@ -1426,8 +1426,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#roundprecision-integer-decimal
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   round: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1446,8 +1446,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * Note that this function is equivalent to raising a number of the power of 0.5 using the power() function.
    *
    * See: https://hl7.org/fhirpath/#sqrt-decimal
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   sqrt: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1462,8 +1462,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * If the input collection contains multiple items, the evaluation of the expression will end and signal an error to the calling environment.
    *
    * See: https://hl7.org/fhirpath/#truncate-integer
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns A collection containing the result.
    */
   truncate: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1493,9 +1493,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * function unchanged.
    *
    * See: https://hl7.org/fhirpath/#tracename-string-projection-expression-collection
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param nameAtom The log name.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param nameAtom - The log name.
    * @returns The input collection.
    */
   trace: (context: AtomContext, input: TypedValue[], nameAtom: Atom): TypedValue[] => {
@@ -1540,11 +1540,11 @@ export const functions: Record<string, FhirPathFunction> = {
    *
    * IBM FHIR issue: https://github.com/IBM/FHIR/issues/1014
    * IBM FHIR PR: https://github.com/IBM/FHIR/pull/1023
-   * @param context The evaluation context.
-   * @param input The input collection.
-   * @param startAtom The start date/time.
-   * @param endAtom The end date/time.
-   * @param unitsAtom Which units to return ("years", "months", or "days").
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param startAtom - The start date/time.
+   * @param endAtom - The end date/time.
+   * @param unitsAtom - Which units to return ("years", "months", or "days").
    * @returns The Quantity of time between the two dates.
    */
   between: (
@@ -1582,9 +1582,9 @@ export const functions: Record<string, FhirPathFunction> = {
    * For implementations with compile-time typing, this requires special-case
    * handling when processing the argument to treat it as a type specifier rather
    * than an identifier expression:
-   * @param _context The evaluation context.
-   * @param input The input collection.
-   * @param typeAtom The desired type.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
+   * @param typeAtom - The desired type.
    * @returns True if the input element is of the desired type.
    */
   is: (_context: AtomContext, input: TypedValue[], typeAtom: Atom): TypedValue[] => {
@@ -1608,8 +1608,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * 6.5.3. not() : Boolean
    *
    * Returns true if the input collection evaluates to false, and false if it evaluates to true. Otherwise, the result is empty ({ }):
-   * @param context The evaluation context.
-   * @param input The input collection.
+   * @param context - The evaluation context.
+   * @param input - The input collection.
    * @returns True if the input evaluates to false.
    */
   not: (context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1624,8 +1624,8 @@ export const functions: Record<string, FhirPathFunction> = {
   /**
    * For each item in the collection, if it is a string that is a uri (or canonical or url), locate the target of the reference, and add it to the resulting collection. If the item does not resolve to a resource, the item is ignored and nothing is added to the output collection.
    * The items in the collection may also represent a Reference, in which case the Reference.reference is resolved.
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The resolved resource.
    */
   resolve: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1661,8 +1661,8 @@ export const functions: Record<string, FhirPathFunction> = {
 
   /**
    * The as operator can be used to treat a value as a specific type.
-   * @param _context The evaluation context.
-   * @param input The input value.
+   * @param _context - The evaluation context.
+   * @param input - The input value.
    * @returns The value as the specific type.
    */
   as: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {
@@ -1683,8 +1683,8 @@ export const functions: Record<string, FhirPathFunction> = {
    * https://hl7.org/fhirpath/modelinfo.xsd
    *
    * See: https://hl7.org/fhirpath/#model-information
-   * @param _context The evaluation context.
-   * @param input The input collection.
+   * @param _context - The evaluation context.
+   * @param input - The input collection.
    * @returns The type of the input value.
    */
   type: (_context: AtomContext, input: TypedValue[]): TypedValue[] => {

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -220,7 +220,7 @@ const fhirPathParserBuilder = initFhirPathParserBuilder();
  * The result can be used to evaluate the expression against a resource or other object.
  * This method is useful if you know that you will evaluate the same expression many times
  * against different resources.
- * @param input The FHIRPath expression to parse.
+ * @param input - The FHIRPath expression to parse.
  * @returns The AST representing the expression.
  */
 export function parseFhirPath(input: string): FhirPathAtom {
@@ -229,8 +229,8 @@ export function parseFhirPath(input: string): FhirPathAtom {
 
 /**
  * Evaluates a FHIRPath expression against a resource or other object.
- * @param expression The FHIRPath expression to parse.
- * @param input The resource or object to evaluate the expression against.
+ * @param expression - The FHIRPath expression to parse.
+ * @param input - The resource or object to evaluate the expression against.
  * @returns The result of the FHIRPath expression against the resource or object.
  */
 export function evalFhirPath(expression: string, input: unknown): unknown[] {
@@ -248,9 +248,9 @@ export function evalFhirPath(expression: string, input: unknown): unknown[] {
 
 /**
  * Evaluates a FHIRPath expression against a resource or other object.
- * @param expression The FHIRPath expression to parse.
- * @param input The resource or object to evaluate the expression against.
- * @param variables A map of variables for eval input.
+ * @param expression - The FHIRPath expression to parse.
+ * @param input - The resource or object to evaluate the expression against.
+ * @param variables - A map of variables for eval input.
  * @returns The result of the FHIRPath expression against the resource or object.
  */
 export function evalFhirPathTyped(

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -5,7 +5,7 @@ import { capitalize, isEmpty } from '../utils';
 
 /**
  * Returns a single element array with a typed boolean value.
- * @param value The primitive boolean value.
+ * @param value - The primitive boolean value.
  * @returns Single element array with a typed boolean value.
  */
 export function booleanToTypedValue(value: boolean): [TypedValue] {
@@ -14,7 +14,7 @@ export function booleanToTypedValue(value: boolean): [TypedValue] {
 
 /**
  * Returns a "best guess" TypedValue for a given value.
- * @param value The unknown value to check.
+ * @param value - The unknown value to check.
  * @returns A "best guess" TypedValue for the given value.
  */
 export function toTypedValue(value: unknown): TypedValue {
@@ -41,7 +41,7 @@ export function toTypedValue(value: unknown): TypedValue {
  * Converts unknown object into a JavaScript boolean.
  * Note that this is different than the FHIRPath "toBoolean",
  * which has particular semantics around arrays, empty arrays, and type conversions.
- * @param obj Any value or array of values.
+ * @param obj - Any value or array of values.
  * @returns The converted boolean value according to FHIRPath rules.
  */
 export function toJsBoolean(obj: TypedValue[]): boolean {
@@ -64,8 +64,8 @@ export function singleton(collection: TypedValue[], type?: string): TypedValue |
  * For example, "Observation.value[x]" can be "valueString", "valueInteger", "valueQuantity", etc.
  * According to the spec, there can only be one property for a given element definition.
  * This function returns the value and the type.
- * @param input The base context (FHIR resource or backbone element).
- * @param path The property path.
+ * @param input - The base context (FHIR resource or backbone element).
+ * @param path - The property path.
  * @returns The value of the property and the property type.
  */
 export function getTypedPropertyValue(input: TypedValue, path: string): TypedValue[] | TypedValue | undefined {
@@ -83,9 +83,9 @@ export function getTypedPropertyValue(input: TypedValue, path: string): TypedVal
 
 /**
  * Returns the value of the property and the property type using a type schema.
- * @param input The base context (FHIR resource or backbone element).
- * @param path The property path.
- * @param element The property element definition.
+ * @param input - The base context (FHIR resource or backbone element).
+ * @param path - The property path.
+ * @param element - The property element definition.
  * @returns The value of the property and the property type.
  */
 function getTypedPropertyValueWithSchema(
@@ -149,8 +149,8 @@ function toTypedValueWithType(value: any, type: string): TypedValue {
  * Returns the value of the property and the property type using a type schema.
  * Note that because the type schema is not available, this function may be inaccurate.
  * In some cases, that is the desired behavior.
- * @param typedValue The base context (FHIR resource or backbone element).
- * @param path The property path.
+ * @param typedValue - The base context (FHIR resource or backbone element).
+ * @param path - The property path.
  * @returns The value of the property and the property type.
  */
 function getTypedPropertyValueWithoutSchema(
@@ -195,7 +195,7 @@ function getTypedPropertyValueWithoutSchema(
 
 /**
  * Removes duplicates in array using FHIRPath equality rules.
- * @param arr The input array.
+ * @param arr - The input array.
  * @returns The result array with duplicates removed.
  */
 export function removeDuplicates(arr: TypedValue[]): TypedValue[] {
@@ -217,7 +217,7 @@ export function removeDuplicates(arr: TypedValue[]): TypedValue[] {
 
 /**
  * Returns a negated FHIRPath boolean expression.
- * @param input The input array.
+ * @param input - The input array.
  * @returns The negated type value array.
  */
 export function fhirPathNot(input: TypedValue[]): TypedValue[] {
@@ -226,8 +226,8 @@ export function fhirPathNot(input: TypedValue[]): TypedValue[] {
 
 /**
  * Determines if two arrays are equal according to FHIRPath equality rules.
- * @param x The first array.
- * @param y The second array.
+ * @param x - The first array.
+ * @param y - The second array.
  * @returns FHIRPath true if the arrays are equal.
  */
 export function fhirPathArrayEquals(x: TypedValue[], y: TypedValue[]): TypedValue[] {
@@ -242,8 +242,8 @@ export function fhirPathArrayEquals(x: TypedValue[], y: TypedValue[]): TypedValu
 
 /**
  * Determines if two values are equal according to FHIRPath equality rules.
- * @param x The first value.
- * @param y The second value.
+ * @param x - The first value.
+ * @param y - The second value.
  * @returns True if equal.
  */
 export function fhirPathEquals(x: TypedValue, y: TypedValue): TypedValue[] {
@@ -263,8 +263,8 @@ export function fhirPathEquals(x: TypedValue, y: TypedValue): TypedValue[] {
 
 /**
  * Determines if two arrays are equivalent according to FHIRPath equality rules.
- * @param x The first array.
- * @param y The second array.
+ * @param x - The first array.
+ * @param y - The second array.
  * @returns FHIRPath true if the arrays are equivalent.
  */
 export function fhirPathArrayEquivalent(x: TypedValue[], y: TypedValue[]): TypedValue[] {
@@ -281,8 +281,8 @@ export function fhirPathArrayEquivalent(x: TypedValue[], y: TypedValue[]): Typed
 
 /**
  * Determines if two values are equivalent according to FHIRPath equality rules.
- * @param x The first value.
- * @param y The second value.
+ * @param x - The first value.
+ * @param y - The second value.
  * @returns True if equivalent.
  */
 export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
@@ -330,8 +330,8 @@ export function fhirPathEquivalent(x: TypedValue, y: TypedValue): TypedValue[] {
 
 /**
  * Returns the sort order of two values for FHIRPath array equivalence.
- * @param x The first value.
- * @param y The second value.
+ * @param x - The first value.
+ * @param y - The second value.
  * @returns The sort order of the values.
  */
 function fhirPathEquivalentCompare(x: TypedValue, y: TypedValue): number {
@@ -348,8 +348,8 @@ function fhirPathEquivalentCompare(x: TypedValue, y: TypedValue): number {
 
 /**
  * Determines if the typed value is the desired type.
- * @param typedValue The typed value to check.
- * @param desiredType The desired type name.
+ * @param typedValue - The typed value to check.
+ * @param desiredType - The desired type name.
  * @returns True if the typed value is of the desired type.
  */
 export function fhirPathIs(typedValue: TypedValue, desiredType: string): boolean {
@@ -382,7 +382,7 @@ export function fhirPathIs(typedValue: TypedValue, desiredType: string): boolean
 /**
  * Determines if the input is a Period object.
  * This is heuristic based, as we do not have strong typing at runtime.
- * @param input The input value.
+ * @param input - The input value.
  * @returns True if the input is a period.
  */
 export function isPeriod(input: unknown): input is Period {
@@ -392,7 +392,7 @@ export function isPeriod(input: unknown): input is Period {
 /**
  * Determines if the input is a Quantity object.
  * This is heuristic based, as we do not have strong typing at runtime.
- * @param input The input value.
+ * @param input - The input value.
  * @returns True if the input is a quantity.
  */
 export function isQuantity(input: unknown): input is Quantity {
@@ -409,8 +409,8 @@ export function isQuantityEquivalent(x: Quantity, y: Quantity): boolean {
 /**
  * Resource equality.
  * See: https://dmitripavlutin.com/how-to-compare-objects-in-javascript/#4-deep-equality
- * @param object1 The first object.
- * @param object2 The second object.
+ * @param object1 - The first object.
+ * @param object2 - The second object.
  * @returns True if the objects are equal.
  */
 function deepEquals<T1 extends object, T2 extends object>(object1: T1, object2: T2): boolean {

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -95,7 +95,7 @@ const fhirPathParserBuilder = initFhirPathParserBuilder();
 
 /**
  * Parses a FHIR _filter parameter expression into an AST.
- * @param input The FHIR _filter parameter expression.
+ * @param input - The FHIR _filter parameter expression.
  * @returns The AST representing the filters.
  */
 export function parseFilterParameter(input: string): FhirFilterExpression {

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -29,8 +29,8 @@ export interface HumanNameFormatOptions {
 
 /**
  * Formats a FHIR Address as a string.
- * @param address The address to format.
- * @param options Optional address format options.
+ * @param address - The address to format.
+ * @param options - Optional address format options.
  * @returns The formatted address string.
  */
 export function formatAddress(address: Address, options?: AddressFormatOptions): string {
@@ -63,8 +63,8 @@ export function formatAddress(address: Address, options?: AddressFormatOptions):
 
 /**
  * Formats a FHIR HumanName as a string.
- * @param name The name to format.
- * @param options Optional name format options.
+ * @param name - The name to format.
+ * @param options - Optional name format options.
  * @returns The formatted name string.
  */
 export function formatHumanName(name: HumanName, options?: HumanNameFormatOptions): string {
@@ -99,7 +99,7 @@ export function formatHumanName(name: HumanName, options?: HumanNameFormatOption
 
 /**
  * Formats the given name portion of a FHIR HumanName element.
- * @param name The name to format.
+ * @param name - The name to format.
  * @returns The formatted given name string.
  */
 export function formatGivenName(name: HumanName): string {
@@ -112,7 +112,7 @@ export function formatGivenName(name: HumanName): string {
 
 /**
  * Formats the family name portion of a FHIR HumanName element.
- * @param name The name to format.
+ * @param name - The name to format.
  * @returns The formatted family name string.
  */
 export function formatFamilyName(name: HumanName): string {
@@ -122,7 +122,7 @@ export function formatFamilyName(name: HumanName): string {
 /**
  * Returns true if the given date object is a valid date.
  * Dates can be invalid if created by parsing an invalid string.
- * @param date A date object.
+ * @param date - A date object.
  * @returns Returns true if the date is a valid date.
  */
 export function isValidDate(date: Date): boolean {
@@ -132,9 +132,9 @@ export function isValidDate(date: Date): boolean {
 /**
  * Formats a FHIR date string as a human readable string.
  * Handles missing values and invalid dates.
- * @param date The date to format.
- * @param locales Optional locales.
- * @param options Optional date format options.
+ * @param date - The date to format.
+ * @param locales - Optional locales.
+ * @param options - Optional date format options.
  * @returns The formatted date string.
  */
 export function formatDate(
@@ -156,9 +156,9 @@ export function formatDate(
 /**
  * Formats a FHIR time string as a human readable string.
  * Handles missing values and invalid dates.
- * @param time The date to format.
- * @param locales Optional locales.
- * @param options Optional time format options.
+ * @param time - The date to format.
+ * @param locales - Optional locales.
+ * @param options - Optional time format options.
  * @returns The formatted time string.
  */
 export function formatTime(
@@ -179,9 +179,9 @@ export function formatTime(
 /**
  * Formats a FHIR dateTime string as a human readable string.
  * Handles missing values and invalid dates.
- * @param dateTime The dateTime to format.
- * @param locales Optional locales.
- * @param options Optional dateTime format options.
+ * @param dateTime - The dateTime to format.
+ * @param locales - Optional locales.
+ * @param options - Optional dateTime format options.
  * @returns The formatted dateTime string.
  */
 export function formatDateTime(
@@ -201,9 +201,9 @@ export function formatDateTime(
 
 /**
  * Formats a FHIR Period as a human readable string.
- * @param period The period to format.
- * @param locales Optional locales.
- * @param options Optional period format options.
+ * @param period - The period to format.
+ * @param locales - Optional locales.
+ * @param options - Optional period format options.
  * @returns The formatted period string.
  */
 export function formatPeriod(
@@ -249,7 +249,7 @@ const pluralUnits: Record<string, string> = {
 
 /**
  * Formats a FHIR Timing as a human readable string.
- * @param timing The timing to format.
+ * @param timing - The timing to format.
  * @returns The formatted timing string.
  */
 export function formatTiming(timing: Timing | undefined): string {
@@ -269,8 +269,8 @@ export function formatTiming(timing: Timing | undefined): string {
 
 /**
  * Formats a FHIR Timing repeat element as a human readable string.
- * @param builder The output string builder.
- * @param repeat The timing repeat element.
+ * @param builder - The output string builder.
+ * @param repeat - The timing repeat element.
  */
 function formatTimingRepeat(builder: string[], repeat: TimingRepeat | undefined): void {
   if (!repeat?.periodUnit) {
@@ -309,9 +309,9 @@ function formatTimingRepeat(builder: string[], repeat: TimingRepeat | undefined)
 
 /**
  * Returns a human-readable string for a FHIR Range datatype, taking into account one-sided ranges
- * @param range A FHIR Range element
- * @param precision Number of decimal places to display in the rendered quantity values
- * @param exclusive If true, one-sided ranges will be rendered with the '>' or '<' bounds rather than '>=' or '<='
+ * @param range - A FHIR Range element
+ * @param precision - Number of decimal places to display in the rendered quantity values
+ * @param exclusive - If true, one-sided ranges will be rendered with the '>' or '<' bounds rather than '>=' or '<='
  * @returns A human-readable string representation of the Range
  */
 export function formatRange(range: Range | undefined, precision?: number, exclusive = false): string {
@@ -352,8 +352,8 @@ export function formatRange(range: Range | undefined, precision?: number, exclus
 
 /**
  * Returns a human-readable string for a FHIR Quantity datatype, taking into account units and comparators
- * @param quantity A FHIR Quantity element
- * @param precision Number of decimal places to display in the rendered quantity values
+ * @param quantity - A FHIR Quantity element
+ * @param precision - Number of decimal places to display in the rendered quantity values
  * @returns A human-readable string representation of the Quantity
  */
 export function formatQuantity(quantity: Quantity | undefined, precision?: number): string {
@@ -400,7 +400,7 @@ export function formatMoney(money: Money | undefined): string {
 
 /**
  * Formats a CodeableConcept element as a string.
- * @param codeableConcept A FHIR CodeableConcept element
+ * @param codeableConcept - A FHIR CodeableConcept element
  * @returns The codeable concept as a string.
  */
 export function formatCodeableConcept(codeableConcept: CodeableConcept | undefined): string {
@@ -418,7 +418,7 @@ export function formatCodeableConcept(codeableConcept: CodeableConcept | undefin
 
 /**
  * Formats a Coding element as a string.
- * @param coding A FHIR Coding element
+ * @param coding - A FHIR Coding element
  * @returns The coding as a string.
  */
 export function formatCoding(coding: Coding | undefined): string {
@@ -427,7 +427,7 @@ export function formatCoding(coding: Coding | undefined): string {
 
 /**
  * Formats a FHIR Observation resource value as a string.
- * @param obs A FHIR Observation resource.
+ * @param obs - A FHIR Observation resource.
  * @returns A human-readable string representation of the Observation.
  */
 export function formatObservationValue(obs: Observation | ObservationComponent | undefined): string {
@@ -456,8 +456,8 @@ export function formatObservationValue(obs: Observation | ObservationComponent |
 
 /**
  * Returns the input number increased by the `n` units of the specified precision
- * @param a The input number.
- * @param precision The precision in number of digits.
+ * @param a - The input number.
+ * @param precision - The precision in number of digits.
  * @param n (default 1) The number of units to add.
  * @returns The result of the increment.
  */
@@ -467,8 +467,8 @@ function preciseIncrement(a: number, precision: number, n = 1): number {
 
 /**
  * Returns the input number decreased by the `n` units of the specified precision
- * @param a The input number.
- * @param precision The precision in number of digits.
+ * @param a - The input number.
+ * @param precision - The precision in number of digits.
  * @param n (default 1) The number of units to subtract.
  * @returns The result of the decrement.
  */
@@ -479,8 +479,8 @@ function preciseDecrement(a: number, precision: number, n = 1): number {
 /**
  * Returns an integer representation of the number with the given precision.
  * For example, if precision is 2, then 1.2345 will be returned as 123.
- * @param a The number.
- * @param precision Optional precision in number of digits.
+ * @param a - The number.
+ * @param precision - Optional precision in number of digits.
  * @returns The integer with the given precision.
  */
 function toPreciseInteger(a: number, precision?: number): number {

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -458,7 +458,7 @@ export function formatObservationValue(obs: Observation | ObservationComponent |
  * Returns the input number increased by the `n` units of the specified precision
  * @param a - The input number.
  * @param precision - The precision in number of digits.
- * @param n (default 1) The number of units to add.
+ * @param n - (default 1) The number of units to add.
  * @returns The result of the increment.
  */
 function preciseIncrement(a: number, precision: number, n = 1): number {
@@ -469,7 +469,7 @@ function preciseIncrement(a: number, precision: number, n = 1): number {
  * Returns the input number decreased by the `n` units of the specified precision
  * @param a - The input number.
  * @param precision - The precision in number of digits.
- * @param n (default 1) The number of units to subtract.
+ * @param n - (default 1) The number of units to subtract.
  * @returns The result of the decrement.
  */
 function preciseDecrement(a: number, precision: number, n = 1): number {

--- a/packages/core/src/hl7.ts
+++ b/packages/core/src/hl7.ts
@@ -49,8 +49,8 @@ export class Hl7Message {
 
   /**
    * Creates a new HL7 message.
-   * @param segments The HL7 segments.
-   * @param context Optional HL7 parsing context.
+   * @param segments - The HL7 segments.
+   * @param context - Optional HL7 parsing context.
    */
   constructor(segments: Hl7Segment[], context = new Hl7Context()) {
     this.context = context;
@@ -67,7 +67,7 @@ export class Hl7Message {
 
   /**
    * Returns an HL7 segment by index or by name.
-   * @param index The HL7 segment index or name.
+   * @param index - The HL7 segment index or name.
    * @returns The HL7 segment if found; otherwise, undefined.
    * @deprecated Use getSegment() instead. This method will be removed in a future release.
    */
@@ -77,7 +77,7 @@ export class Hl7Message {
 
   /**
    * Returns all HL7 segments of a given name.
-   * @param name The HL7 segment name.
+   * @param name - The HL7 segment name.
    * @returns An array of HL7 segments with the specified name.
    * @deprecated Use getAllSegments() instead. This method will be removed in a future release.
    */
@@ -92,7 +92,7 @@ export class Hl7Message {
    *
    * When using a string index, this method returns the first segment with the specified name.
    *
-   * @param index The HL7 segment index or name.
+   * @param index - The HL7 segment index or name.
    * @returns The HL7 segment if found; otherwise, undefined.
    */
   getSegment(index: number | string): Hl7Segment | undefined {
@@ -104,7 +104,7 @@ export class Hl7Message {
 
   /**
    * Returns all HL7 segments of a given name.
-   * @param name The HL7 segment name.
+   * @param name - The HL7 segment name.
    * @returns An array of HL7 segments with the specified name.
    */
   getAllSegments(name: string): Hl7Segment[] {
@@ -176,7 +176,7 @@ export class Hl7Message {
 
   /**
    * Parses an HL7 message string into an Hl7Message object.
-   * @param text The HL7 message text.
+   * @param text - The HL7 message text.
    * @returns The parsed HL7 message.
    */
   static parse(text: string): Hl7Message {
@@ -212,8 +212,8 @@ export class Hl7Segment {
 
   /**
    * Creates a new HL7 segment.
-   * @param fields The HL7 fields. The first field is the segment name.
-   * @param context Optional HL7 parsing context.
+   * @param fields - The HL7 fields. The first field is the segment name.
+   * @param context - Optional HL7 parsing context.
    */
   constructor(fields: Hl7Field[] | string[], context = new Hl7Context()) {
     this.context = context;
@@ -227,7 +227,7 @@ export class Hl7Segment {
 
   /**
    * Returns an HL7 field by index.
-   * @param index The HL7 field index.
+   * @param index - The HL7 field index.
    * @returns The HL7 field.
    * @deprecated Use getSegment() instead. This method includes the segment name in the index, which leads to confusing behavior. This method will be removed in a future release.
    */
@@ -246,7 +246,7 @@ export class Hl7Segment {
    *
    * Field zero is the segment name.
    *
-   * @param index The HL7 field index.
+   * @param index - The HL7 field index.
    * @returns The HL7 field.
    */
   getField(index: number): Hl7Field {
@@ -279,10 +279,10 @@ export class Hl7Segment {
    *
    * This aligns with HL7 component names such as MSH.9.2.
    *
-   * @param fieldIndex The HL7 field index.
-   * @param component The component index.
-   * @param subcomponent Optional subcomponent index.
-   * @param repetition Optional repetition index.
+   * @param fieldIndex - The HL7 field index.
+   * @param component - The component index.
+   * @param subcomponent - Optional subcomponent index.
+   * @param repetition - Optional repetition index.
    * @returns The string value of the specified component.
    */
   getComponent(fieldIndex: number, component: number, subcomponent?: number, repetition = 0): string {
@@ -299,8 +299,8 @@ export class Hl7Segment {
 
   /**
    * Parses an HL7 segment string into an Hl7Segment object.
-   * @param text The HL7 segment text.
-   * @param context Optional HL7 parsing context.
+   * @param text - The HL7 segment text.
+   * @param context - Optional HL7 parsing context.
    * @returns The parsed HL7 segment.
    */
   static parse(text: string, context = new Hl7Context()): Hl7Segment {
@@ -321,8 +321,8 @@ export class Hl7Field {
 
   /**
    * Creates a new HL7 field.
-   * @param components The HL7 components.
-   * @param context Optional HL7 parsing context.
+   * @param components - The HL7 components.
+   * @param context - Optional HL7 parsing context.
    */
   constructor(components: string[][], context = new Hl7Context()) {
     this.context = context;
@@ -331,9 +331,9 @@ export class Hl7Field {
 
   /**
    * Returns an HL7 component by index.
-   * @param component The component index.
-   * @param subcomponent Optional subcomponent index.
-   * @param repetition Optional repetition index.
+   * @param component - The component index.
+   * @param subcomponent - Optional subcomponent index.
+   * @param repetition - Optional repetition index.
    * @returns The string value of the specified component.
    * @deprecated Use getComponent() instead. This method will be removed in a future release.
    */
@@ -350,9 +350,9 @@ export class Hl7Field {
    *
    * This aligns with HL7 component names such as MSH.9.2.
    *
-   * @param component The component index.
-   * @param subcomponent Optional subcomponent index.
-   * @param repetition Optional repetition index.
+   * @param component - The component index.
+   * @param subcomponent - Optional subcomponent index.
+   * @param repetition - Optional repetition index.
    * @returns The string value of the specified component.
    */
   getComponent(component: number, subcomponent?: number, repetition = 0): string {
@@ -375,8 +375,8 @@ export class Hl7Field {
 
   /**
    * Parses an HL7 field string into an Hl7Field object.
-   * @param text The HL7 field text.
-   * @param context Optional HL7 parsing context.
+   * @param text - The HL7 field text.
+   * @param context - Optional HL7 parsing context.
    * @returns The parsed HL7 field.
    */
   static parse(text: string, context = new Hl7Context()): Hl7Field {
@@ -403,8 +403,8 @@ export interface Hl7DateParseOptions {
  *
  * Format: YYYY[MM[DD[HH[MM[SS[. S[S[S[S]]]]]]]]][+/-ZZZZ].
  *
- * @param hl7DateTime Date/time string.
- * @param options Optional parsing options.
+ * @param hl7DateTime - Date/time string.
+ * @param options - Optional parsing options.
  * @returns The date in ISO-8601 format.
  */
 export function parseHl7DateTime(hl7DateTime: string | undefined, options?: Hl7DateParseOptions): string | undefined {
@@ -436,8 +436,8 @@ export function parseHl7DateTime(hl7DateTime: string | undefined, options?: Hl7D
 
 /**
  * Parses an integer value from a string.
- * @param str The string to parse.
- * @param defaultValue The default value to return if the string is not a number.
+ * @param str - The string to parse.
+ * @param defaultValue - The default value to return if the string is not a number.
  * @returns The parsed integer value, or the default value if the string is not a number.
  */
 function parseIntOrDefault(str: string, defaultValue: number): number {
@@ -447,8 +447,8 @@ function parseIntOrDefault(str: string, defaultValue: number): number {
 
 /**
  * Returns the timezone offset in milliseconds.
- * @param hl7DateTime The HL7 date/time string.
- * @param defaultOffset Optional default timezone offset.
+ * @param hl7DateTime - The HL7 date/time string.
+ * @param defaultOffset - Optional default timezone offset.
  * @returns The timezone offset in milliseconds.
  */
 function parseTimeZoneOffset(hl7DateTime: string, defaultOffset?: string): number {
@@ -480,7 +480,7 @@ function parseTimeZoneOffset(hl7DateTime: string, defaultOffset?: string): numbe
 
 /**
  * Formats an ISO date/time string into an HL7 date/time string.
- * @param isoDate The ISO date/time string.
+ * @param isoDate - The ISO date/time string.
  * @returns The HL7 date/time string.
  */
 export function formatHl7DateTime(isoDate: Date | string): string {

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -3,7 +3,7 @@ import { decodeBase64 } from './base64';
 /**
  * Decodes a section of a JWT.
  * See: https://tools.ietf.org/html/rfc7519
- * @param payload The JWT payload string.
+ * @param payload - The JWT payload string.
  * @returns Collection of key value claims in the JWT payload.
  */
 function decodePayload(payload: string): Record<string, number | string> {
@@ -19,7 +19,7 @@ function decodePayload(payload: string): Record<string, number | string> {
 
 /**
  * Returns true if the token is a JWT.
- * @param token The potential JWT token.
+ * @param token - The potential JWT token.
  * @returns True if the token is a JWT.
  */
 export function isJwt(token: string): boolean {
@@ -28,7 +28,7 @@ export function isJwt(token: string): boolean {
 
 /**
  * Parses the JWT payload.
- * @param token JWT token.
+ * @param token - JWT token.
  * @returns Collection of key value claims in the JWT payload.
  */
 export function parseJWTPayload(token: string): Record<string, number | string> {
@@ -38,7 +38,7 @@ export function parseJWTPayload(token: string): Record<string, number | string> 
 
 /**
  * Returns true if the access token was issued by a Medplum server.
- * @param accessToken An access token of unknown origin.
+ * @param accessToken - An access token of unknown origin.
  * @returns True if the access token was issued by a Medplum server.
  */
 export function isMedplumAccessToken(accessToken: string): boolean {

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -239,8 +239,8 @@ export function getStatus(outcome: OperationOutcome): number {
 
 /**
  * Asserts that the operation completed successfully and that the resource is defined.
- * @param outcome The operation outcome.
- * @param resource The resource that may or may not have been returned.
+ * @param outcome - The operation outcome.
+ * @param resource - The resource that may or may not have been returned.
  */
 export function assertOk<T>(outcome: OperationOutcome, resource: T | undefined): asserts resource is T {
   if (!isOk(outcome) || resource === undefined) {
@@ -260,7 +260,7 @@ export class OperationOutcomeError extends Error {
 
 /**
  * Normalizes an error object into an OperationOutcome.
- * @param error The error value which could be a string, Error, OperationOutcome, or other unknown type.
+ * @param error - The error value which could be a string, Error, OperationOutcome, or other unknown type.
  * @returns The normalized OperationOutcome.
  */
 export function normalizeOperationOutcome(error: unknown): OperationOutcome {
@@ -275,7 +275,7 @@ export function normalizeOperationOutcome(error: unknown): OperationOutcome {
 
 /**
  * Normalizes an error object into a displayable error string.
- * @param error The error value which could be a string, Error, OperationOutcome, or other unknown type.
+ * @param error - The error value which could be a string, Error, OperationOutcome, or other unknown type.
  * @returns A display string for the error.
  */
 export function normalizeErrorString(error: unknown): string {
@@ -299,7 +299,7 @@ export function normalizeErrorString(error: unknown): string {
 
 /**
  * Returns a string represenation of the operation outcome.
- * @param outcome The operation outcome.
+ * @param outcome - The operation outcome.
  * @returns The string representation of the operation outcome.
  */
 export function operationOutcomeToString(outcome: OperationOutcome): string {
@@ -309,7 +309,7 @@ export function operationOutcomeToString(outcome: OperationOutcome): string {
 
 /**
  * Returns a string represenation of the operation outcome issue.
- * @param issue The operation outcome issue.
+ * @param issue - The operation outcome issue.
  * @returns The string representation of the operation outcome issue.
  */
 export function operationOutcomeIssueToString(issue: OperationOutcomeIssue): string {

--- a/packages/core/src/readablepromise.ts
+++ b/packages/core/src/readablepromise.ts
@@ -61,8 +61,8 @@ export class ReadablePromise<T> implements Promise<T> {
 
   /**
    * Attaches callbacks for the resolution and/or rejection of the Promise.
-   * @param onfulfilled The callback to execute when the Promise is resolved.
-   * @param onrejected The callback to execute when the Promise is rejected.
+   * @param onfulfilled - The callback to execute when the Promise is resolved.
+   * @param onrejected - The callback to execute when the Promise is rejected.
    * @returns A Promise for the completion of which ever callback is executed.
    */
   then<TResult1 = T, TResult2 = never>(
@@ -74,7 +74,7 @@ export class ReadablePromise<T> implements Promise<T> {
 
   /**
    * Attaches a callback for only the rejection of the Promise.
-   * @param onrejected The callback to execute when the Promise is rejected.
+   * @param onrejected - The callback to execute when the Promise is rejected.
    * @returns A Promise for the completion of the callback.
    */
   catch<TResult = never>(
@@ -86,7 +86,7 @@ export class ReadablePromise<T> implements Promise<T> {
   /**
    * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
    * resolved value cannot be modified from the callback.
-   * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+   * @param onfinally - The callback to execute when the Promise is settled (fulfilled or rejected).
    * @returns A Promise for the completion of the callback.
    */
   finally(onfinally?: (() => void) | undefined | null): Promise<T> {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -32,7 +32,7 @@ import { isResourceType } from './typeschema/types';
  * const medplum = new MedplumClient();
  * await medplum.requestSchema('Patient');
  * ```
- * @param resourceType The candidate resource type string.
+ * @param resourceType - The candidate resource type string.
  */
 export function validateResourceType(resourceType: string): void {
   if (!resourceType) {
@@ -47,9 +47,9 @@ export function validateResourceType(resourceType: string): void {
  * Recursively checks for null values in an object.
  *
  * Note that "null" is a special value in JSON that is not allowed in FHIR.
- * @param value Input value of any type.
- * @param path Path string to the value for OperationOutcome.
- * @param issues Output list of issues.
+ * @param value - Input value of any type.
+ * @param path - Path string to the value for OperationOutcome.
+ * @param issues - Output list of issues.
  */
 export function checkForNull(value: unknown, path: string, issues: OperationOutcomeIssue[]): void {
   if (value === null) {

--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -49,8 +49,8 @@ interface SearchParameterDetailsBuilder {
  *   1) The "date" type includes "date", "datetime", and "period".
  *   2) The "token" type includes enums and booleans.
  *   3) Arrays/multiple values are not reflected at all.
- * @param resourceType The root resource type.
- * @param searchParam The search parameter.
+ * @param resourceType - The root resource type.
+ * @param searchParam - The search parameter.
  * @returns The search parameter type details.
  */
 export function getSearchParameterDetails(resourceType: string, searchParam: SearchParameter): SearchParameterDetails {
@@ -185,7 +185,7 @@ function isBackboneElement(propertyType: string): boolean {
 
 /**
  * Converts a hyphen-delimited code to camelCase string.
- * @param code The search parameter code.
+ * @param code - The search parameter code.
  * @returns The SQL column name.
  */
 function convertCodeToColumnName(code: string): string {

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -6,8 +6,8 @@ import { Filter, Operator, SearchRequest } from './search';
 
 /**
  * Determines if the resource matches the search request.
- * @param resource The resource that was created or updated.
- * @param searchRequest The subscription criteria as a search request.
+ * @param resource - The resource that was created or updated.
+ * @param searchRequest - The subscription criteria as a search request.
  * @returns True if the resource satisfies the search request.
  */
 export function matchesSearchRequest(resource: Resource, searchRequest: SearchRequest): boolean {
@@ -26,9 +26,9 @@ export function matchesSearchRequest(resource: Resource, searchRequest: SearchRe
 
 /**
  * Determines if the resource matches the search filter.
- * @param resource The resource that was created or updated.
- * @param searchRequest The search request.
- * @param filter One of the filters of a subscription criteria.
+ * @param resource - The resource that was created or updated.
+ * @param searchRequest - The search request.
+ * @param filter - One of the filters of a subscription criteria.
  * @returns True if the resource satisfies the search filter.
  */
 function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, filter: Filter): boolean {

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -120,8 +120,8 @@ const PREFIX_OPERATORS: Record<string, Operator> = {
 
 /**
  * Parses a search URL into a search request.
- * @param resourceType The FHIR resource type.
- * @param query The collection of query string parameters.
+ * @param resourceType - The FHIR resource type.
+ * @param query - The collection of query string parameters.
  * @returns A parsed SearchRequest.
  */
 export function parseSearchRequest<T extends Resource = Resource>(
@@ -143,7 +143,7 @@ export function parseSearchRequest<T extends Resource = Resource>(
 
 /**
  * Parses a search URL into a search request.
- * @param url The search URL.
+ * @param url - The search URL.
  * @returns A parsed SearchRequest.
  */
 export function parseSearchUrl<T extends Resource = Resource>(url: URL): SearchRequest<T> {
@@ -158,7 +158,7 @@ export function parseSearchUrl<T extends Resource = Resource>(url: URL): SearchR
 
 /**
  * Parses a URL string into a SearchRequest.
- * @param url The URL to parse.
+ * @param url - The URL to parse.
  * @returns Parsed search definition.
  */
 export function parseSearchDefinition<T extends Resource = Resource>(url: string): SearchRequest<T> {
@@ -168,7 +168,7 @@ export function parseSearchDefinition<T extends Resource = Resource>(url: string
 /**
  * Parses a FHIR criteria string into a SearchRequest.
  * FHIR criteria strings are found on resources such as Subscription.
- * @param criteria The FHIR criteria string.
+ * @param criteria - The FHIR criteria string.
  * @returns Parsed search definition.
  */
 export function parseCriteriaAsSearchRequest(criteria: string): SearchRequest {
@@ -418,8 +418,8 @@ const subexpressionPattern = /{{([^{}]+)}}/g;
  * any embedded FHIRPath subexpressions (e.g. `{{ %patient.id }}`) with the provided variables.
  *
  * @see https://hl7.org/fhir/fhir-xquery.html
- * @param query The X-Fhir-Query string to parse
- * @param variables Values to pass into embedded FHIRPath expressions
+ * @param query - The X-Fhir-Query string to parse
+ * @param variables - Values to pass into embedded FHIRPath expressions
  * @returns The parsed search request
  */
 export function parseXFhirQuery(query: string, variables: Record<string, TypedValue>): SearchRequest {
@@ -436,7 +436,7 @@ export function parseXFhirQuery(query: string, variables: Record<string, TypedVa
 /**
  * Formats a search definition object into a query string.
  * Note: The return value does not include the resource type.
- * @param definition The search definition.
+ * @param definition - The search definition.
  * @returns Formatted URL.
  */
 export function formatSearchQuery(definition: SearchRequest): string {

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -67,7 +67,7 @@ export class MemoryStorage implements Storage {
 
   /**
    * Returns the current value associated with the given key, or null if the given key does not exist.
-   * @param key The specified storage key.
+   * @param key - The specified storage key.
    * @returns The current value associated with the given key, or null if the given key does not exist.
    */
   getItem(key: string): string | null {
@@ -76,8 +76,8 @@ export class MemoryStorage implements Storage {
 
   /**
    * Sets the value of the pair identified by key to value, creating a new key/value pair if none existed for key previously.
-   * @param key The storage key.
-   * @param value The new value.
+   * @param key - The storage key.
+   * @param value - The new value.
    */
   setItem(key: string, value: string | null): void {
     if (value) {
@@ -89,7 +89,7 @@ export class MemoryStorage implements Storage {
 
   /**
    * Removes the key/value pair with the given key, if a key/value pair with the given key exists.
-   * @param key The storage key.
+   * @param key - The storage key.
    */
   removeItem(key: string): void {
     this.data.delete(key);
@@ -97,7 +97,7 @@ export class MemoryStorage implements Storage {
 
   /**
    * Returns the name of the nth key, or null if n is greater than or equal to the number of key/value pairs.
-   * @param index The numeric index.
+   * @param index - The numeric index.
    * @returns The nth key.
    */
   key(index: number): string | null {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,7 +140,7 @@ export interface TypeInfo {
 
 /**
  * Indexes a bundle of SearchParameter resources for faster lookup.
- * @param bundle A FHIR bundle SearchParameter resources.
+ * @param bundle - A FHIR bundle SearchParameter resources.
  * @see {@link IndexedStructureDefinition} for more details on indexed StructureDefinitions.
  */
 export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): void {
@@ -155,7 +155,7 @@ export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): voi
 /**
  * Indexes a SearchParameter resource for fast lookup.
  * Indexes by SearchParameter.code, which is the query string parameter name.
- * @param searchParam The SearchParameter resource.
+ * @param searchParam - The SearchParameter resource.
  * @see {@link IndexedStructureDefinition} for more details on indexed StructureDefinitions.
  */
 export function indexSearchParameter(searchParam: SearchParameter): void {
@@ -221,7 +221,7 @@ export function indexSearchParameter(searchParam: SearchParameter): void {
 
 /**
  * Returns the type name for an ElementDefinition.
- * @param elementDefinition The element definition.
+ * @param elementDefinition - The element definition.
  * @returns The Medplum type name.
  */
 export function getElementDefinitionTypeName(elementDefinition: ElementDefinition): string {
@@ -240,7 +240,7 @@ export function buildTypeName(components: string[]): string {
 
 /**
  * Returns true if the type schema is a non-abstract FHIR resource.
- * @param typeSchema The type schema to check.
+ * @param typeSchema - The type schema to check.
  * @returns True if the type schema is a non-abstract FHIR resource.
  */
 export function isResourceTypeSchema(typeSchema: InternalTypeSchema): boolean {
@@ -260,7 +260,7 @@ export function getResourceTypes(): ResourceType[] {
 
 /**
  * Returns the search parameters for the resource type indexed by search code.
- * @param resourceType The resource type.
+ * @param resourceType - The resource type.
  * @returns The search parameters for the resource type indexed by search code.
  */
 export function getSearchParameters(resourceType: string): Record<string, SearchParameter> | undefined {
@@ -269,8 +269,8 @@ export function getSearchParameters(resourceType: string): Record<string, Search
 
 /**
  * Returns a search parameter for a resource type by search code.
- * @param resourceType The FHIR resource type.
- * @param code The search parameter code.
+ * @param resourceType - The FHIR resource type.
+ * @param code - The search parameter code.
  * @returns The search parameter if found, otherwise undefined.
  */
 export function getSearchParameter(resourceType: string, code: string): SearchParameter | undefined {
@@ -279,7 +279,7 @@ export function getSearchParameter(resourceType: string, code: string): SearchPa
 
 /**
  * Returns a human friendly display name for a FHIR element definition path.
- * @param path The FHIR element definition path.
+ * @param path - The FHIR element definition path.
  * @returns The best guess of the display name.
  */
 export function getPropertyDisplayName(path: string): string {
@@ -315,8 +315,8 @@ function capitalizeDisplayWord(word: string): string {
 /**
  * Returns an element definition by type and property name.
  * Handles content references.
- * @param typeName The type name.
- * @param propertyName The property name.
+ * @param typeName - The type name.
+ * @param propertyName - The property name.
  * @returns The element definition if found.
  */
 export function getElementDefinition(typeName: string, propertyName: string): InternalSchemaElement | undefined {
@@ -329,7 +329,7 @@ export function getElementDefinition(typeName: string, propertyName: string): In
 
 /**
  * Typeguard to validate that an object is a FHIR resource
- * @param value The object to check
+ * @param value - The object to check
  * @returns True if the input is of type 'object' and contains property 'resourceType'
  */
 export function isResource(value: unknown): value is Resource {
@@ -338,7 +338,7 @@ export function isResource(value: unknown): value is Resource {
 
 /**
  * Typeguard to validate that an object is a FHIR resource
- * @param value The object to check
+ * @param value - The object to check
  * @returns True if the input is of type 'object' and contains property 'reference'
  */
 export function isReference(value: unknown): value is Reference & { reference: string } {
@@ -352,7 +352,7 @@ export const globalSchema: IndexedStructureDefinition = { types: {} };
 
 /**
  * Output the string representation of a value, suitable for use as part of a search query.
- * @param v The value to format as a string
+ * @param v - The value to format as a string
  * @returns The stringified value
  */
 export function stringifyTypedValue(v: TypedValue): string {

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -79,7 +79,7 @@ export interface SliceDiscriminator {
 /**
  * Parses a StructureDefinition resource into an internal schema better suited for
  * programmatic validation and usage in internal systems
- * @param sd The StructureDefinition resource to parse
+ * @param sd - The StructureDefinition resource to parse
  * @returns The parsed schema for the given resource type
  * @experimental
  */
@@ -139,7 +139,7 @@ export function getDataType(type: string): InternalTypeSchema {
  * isResourceType('XYZ'); // false
  * ```
  *
- * @param resourceType The candidate resource type string.
+ * @param resourceType - The candidate resource type string.
  * @returns True if the resource type is a valid FHIR resource type.
  */
 export function isResourceType(resourceType: string): boolean {
@@ -167,7 +167,7 @@ class StructureDefinitionParser {
   private backboneContext: BackboneContext | undefined;
 
   /**
-   * @param sd The StructureDefinition to parse
+   * @param sd - The StructureDefinition to parse
    * @throws Throws when the StructureDefinition does not have a populated `snapshot` field
    */
   constructor(sd: StructureDefinition) {
@@ -415,8 +415,8 @@ class StructureDefinitionParser {
  * Construct the subset of a resource containing a minimum set of fields.  The returned resource is not guaranteed
  * to contain only the provided properties, and may contain others (e.g. `resourceType` and `id`)
  *
- * @param resource The resource to subset
- * @param properties The minimum properties to include in the subset
+ * @param resource - The resource to subset
+ * @param properties - The minimum properties to include in the subset
  * @returns The modified resource, containing the listed properties and possibly other mandatory ones
  */
 export function subsetResource<T extends Resource>(resource: T | undefined, properties: string[]): T | undefined {
@@ -473,8 +473,8 @@ function trimPrefix(str: string | undefined, prefix: string): string {
 
 /**
  * Tests whether two element paths are compatible, i.e. whether the child path is nested under the parent.
- * @param parent The expected parent path, which should be a prefix of the child path.
- * @param child The child path to test for compatibility with the parent path.
+ * @param parent - The expected parent path, which should be a prefix of the child path.
+ * @param child - The child path to test for compatibility with the parent path.
  * @returns True if the given path is a child of the parent.
  */
 function pathsCompatible(parent: string | undefined, child: string | undefined): boolean {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -41,7 +41,7 @@ export type ResourceWithCode = Resource & Code;
 
 /**
  * Creates a reference resource.
- * @param resource The FHIR reesource.
+ * @param resource - The FHIR reesource.
  * @returns A reference resource.
  */
 export function createReference<T extends Resource>(resource: T): Reference<T> {
@@ -52,7 +52,7 @@ export function createReference<T extends Resource>(resource: T): Reference<T> {
 
 /**
  * Returns a reference string for a resource.
- * @param input The FHIR resource or reference.
+ * @param input - The FHIR resource or reference.
  * @returns A reference string of the form resourceType/id.
  */
 export function getReferenceString(input: Reference | Resource): string {
@@ -64,7 +64,7 @@ export function getReferenceString(input: Reference | Resource): string {
 
 /**
  * Returns the ID portion of a reference.
- * @param input A FHIR reference or resource.
+ * @param input - A FHIR reference or resource.
  * @returns The ID portion of a reference.
  */
 export function resolveId(input: Reference | Resource | undefined): string | undefined {
@@ -79,7 +79,7 @@ export function resolveId(input: Reference | Resource | undefined): string | und
 
 /**
  * Parses a reference and returns a tuple of [ResourceType, ID].
- * @param reference A reference to a FHIR resource.
+ * @param reference - A reference to a FHIR resource.
  * @returns A tuple containing the `ResourceType` and the ID of the resource or `undefined` when `undefined` or an invalid reference is passed.
  */
 export function parseReference(reference: Reference): [ResourceType, string] | undefined;
@@ -97,7 +97,7 @@ export function parseReference(reference: Reference | undefined): [ResourceType,
 
 /**
  * Returns true if the resource is a "ProfileResource".
- * @param resource The FHIR resource.
+ * @param resource - The FHIR resource.
  * @returns True if the resource is a "ProfileResource".
  */
 export function isProfileResource(resource: Resource): resource is ProfileResource {
@@ -110,7 +110,7 @@ export function isProfileResource(resource: Resource): resource is ProfileResour
 
 /**
  * Returns a display string for the resource.
- * @param resource The input resource.
+ * @param resource - The input resource.
  * @returns Human friendly display string.
  */
 export function getDisplayString(resource: Resource): string {
@@ -144,7 +144,7 @@ export function getDisplayString(resource: Resource): string {
 
 /**
  * Returns a display string for a profile resource if one is found.
- * @param resource The profile resource.
+ * @param resource - The profile resource.
  * @returns The display name if one is found.
  */
 function getProfileResourceDisplayString(resource: ProfileResource): string | undefined {
@@ -157,7 +157,7 @@ function getProfileResourceDisplayString(resource: ProfileResource): string | un
 
 /**
  * Returns a display string for a device resource if one is found.
- * @param device The device resource.
+ * @param device - The device resource.
  * @returns The display name if one is found.
  */
 function getDeviceDisplayString(device: Device): string | undefined {
@@ -170,7 +170,7 @@ function getDeviceDisplayString(device: Device): string | undefined {
 
 /**
  * Returns an image URL for the resource, if one is available.
- * @param resource The input resource.
+ * @param resource - The input resource.
  * @returns The image URL for the resource or undefined.
  */
 export function getImageSrc(resource: Resource): string | undefined {
@@ -208,7 +208,7 @@ function getPhotoImageSrc(photo: Attachment): string | undefined {
  * Returns a Date property as a Date.
  * When working with JSON objects, Dates are often serialized as ISO-8601 strings.
  * When that happens, we need to safely convert to a proper Date object.
- * @param date The date property value, which could be a string or a Date object.
+ * @param date - The date property value, which could be a string or a Date object.
  * @returns A Date object.
  */
 export function getDateProperty(date: string | undefined): Date | undefined {
@@ -217,8 +217,8 @@ export function getDateProperty(date: string | undefined): Date | undefined {
 
 /**
  * Calculates the age in years from the birth date.
- * @param birthDateStr The birth date or start date in ISO-8601 format YYYY-MM-DD.
- * @param endDateStr Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
+ * @param birthDateStr - The birth date or start date in ISO-8601 format YYYY-MM-DD.
+ * @param endDateStr - Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
  * @returns The age in years, months, and days.
  */
 export function calculateAge(
@@ -259,8 +259,8 @@ export function calculateAge(
  * If the age is greater than or equal to 2 years, then the age is displayed in years.
  * If the age is greater than or equal to 1 month, then the age is displayed in months.
  * Otherwise, the age is displayed in days.
- * @param birthDateStr The birth date or start date in ISO-8601 format YYYY-MM-DD.
- * @param endDateStr Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
+ * @param birthDateStr - The birth date or start date in ISO-8601 format YYYY-MM-DD.
+ * @param endDateStr - Optional end date in ISO-8601 format YYYY-MM-DD. Default value is today.
  * @returns The age string.
  */
 export function calculateAgeString(birthDateStr: string, endDateStr?: string): string | undefined {
@@ -276,7 +276,7 @@ export function calculateAgeString(birthDateStr: string, endDateStr?: string): s
 
 /**
  * Returns all questionnaire answers as a map by link ID.
- * @param response The questionnaire response resource.
+ * @param response - The questionnaire response resource.
  * @returns Questionnaire answers mapped by link ID.
  */
 export function getQuestionnaireAnswers(
@@ -303,7 +303,7 @@ function buildQuestionnaireAnswerItems(
 
 /**
  * Returns an array of  questionnaire answers as a map by link ID.
- * @param response The questionnaire response resource.
+ * @param response - The questionnaire response resource.
  * @returns Questionnaire answer arrays mapped by link ID.
  */
 export function getAllQuestionnaireAnswers(
@@ -316,8 +316,8 @@ export function getAllQuestionnaireAnswers(
 
 /**
  * Recursively builds the questionnaire answer items map.
- * @param items The current questionnaire response items.
- * @param result The cumulative result map of answers.
+ * @param items - The current questionnaire response items.
+ * @param result - The cumulative result map of answers.
  */
 function buildAllQuestionnaireAnswerItems(
   items: QuestionnaireResponseItem[] | undefined,
@@ -339,8 +339,8 @@ function buildAllQuestionnaireAnswerItems(
  * If multiple identifiers exist with the same system, the first one is returned.
  *
  * If the system is not found, then returns undefined.
- * @param resource The resource to check.
- * @param system The identifier system.
+ * @param resource - The resource to check.
+ * @param system - The identifier system.
  * @returns The identifier value if found; otherwise undefined.
  */
 export function getIdentifier(resource: Resource, system: string): string | undefined {
@@ -368,9 +368,9 @@ export function getIdentifier(resource: Resource, system: string): string | unde
  *
  * Otherwise a new identifier is added.
  *
- * @param resource The resource to add the identifier to.
- * @param system The identifier system.
- * @param value The identifier value.
+ * @param resource - The resource to add the identifier to.
+ * @param system - The identifier system.
+ * @param value - The identifier value.
  */
 export function setIdentifier(resource: Resource & { identifier?: Identifier[] }, system: string, value: string): void {
   const identifiers = resource.identifier;
@@ -389,8 +389,8 @@ export function setIdentifier(resource: Resource & { identifier?: Identifier[] }
 
 /**
  * Returns an extension value by extension URLs.
- * @param resource The base resource.
- * @param urls Array of extension URLs.  Each entry represents a nested extension.
+ * @param resource - The base resource.
+ * @param urls - Array of extension URLs.  Each entry represents a nested extension.
  * @returns The extension value if found; undefined otherwise.
  */
 export function getExtensionValue(resource: any, ...urls: string[]): string | undefined {
@@ -407,8 +407,8 @@ export function getExtensionValue(resource: any, ...urls: string[]): string | un
 
 /**
  * Returns an extension by extension URLs.
- * @param resource The base resource.
- * @param urls Array of extension URLs. Each entry represents a nested extension.
+ * @param resource - The base resource.
+ * @param urls - Array of extension URLs. Each entry represents a nested extension.
  * @returns The extension object if found; undefined otherwise.
  */
 export function getExtension(resource: any, ...urls: string[]): Extension | undefined {
@@ -428,8 +428,8 @@ export function getExtension(resource: any, ...urls: string[]): Extension | unde
  * Removes properties with empty string values.
  * Removes objects with zero properties.
  * See: https://www.hl7.org/fhir/json.html
- * @param value The input value.
- * @param pretty Optional flag to pretty-print the JSON.
+ * @param value - The input value.
+ * @param pretty - Optional flag to pretty-print the JSON.
  * @returns The resulting JSON string.
  */
 export function stringify(value: any, pretty?: boolean): string {
@@ -440,8 +440,8 @@ export function stringify(value: any, pretty?: boolean): string {
  * Evaluates JSON key/value pairs for FHIR JSON stringify.
  * Removes properties with empty string values.
  * Removes objects with zero properties.
- * @param k Property key.
- * @param v Property value.
+ * @param k - Property key.
+ * @param v - Property value.
  * @returns The replaced value.
  */
 function stringifyReplacer(k: string, v: any): any {
@@ -450,7 +450,7 @@ function stringifyReplacer(k: string, v: any): any {
 
 /**
  * Returns true if the key is an array key.
- * @param k The property key.
+ * @param k - The property key.
  * @returns True if the key is an array key.
  */
 function isArrayKey(k: string): boolean {
@@ -459,7 +459,7 @@ function isArrayKey(k: string): boolean {
 
 /**
  * Returns true if the value is empty (null, undefined, empty string, or empty object).
- * @param v Any value.
+ * @param v - Any value.
  * @returns True if the value is an empty string or an empty object.
  */
 export function isEmpty(v: any): boolean {
@@ -473,9 +473,9 @@ export function isEmpty(v: any): boolean {
 /**
  * Resource equality.
  * Ignores meta.versionId and meta.lastUpdated.
- * @param object1 The first object.
- * @param object2 The second object.
- * @param path Optional path string.
+ * @param object1 - The first object.
+ * @param object2 - The second object.
+ * @param path - Optional path string.
  * @returns True if the objects are equal.
  */
 export function deepEquals(object1: unknown, object2: unknown, path?: string): boolean {
@@ -541,8 +541,8 @@ function deepEqualsObject(
 /**
  * Checks if object2 includes all fields and values of object1.
  * It doesn't matter if object2 has extra fields.
- * @param value The object to test if contained in pattern.
- * @param pattern The object to test against.
+ * @param value - The object to test if contained in pattern.
+ * @param pattern - The object to test against.
  * @returns True if pattern includes all fields and values of value.
  */
 export function deepIncludes(value: any, pattern: any): boolean {
@@ -584,7 +584,7 @@ function deepIncludesObject(object1: { [key: string]: unknown }, object2: { [key
  *
  * See: https://web.dev/structured-clone/
  * See: https://stackoverflow.com/questions/40488190/how-is-structured-clone-algorithm-different-from-deep-copy
- * @param input The input to clone.
+ * @param input - The input to clone.
  * @returns A deep clone of the input.
  */
 export function deepClone<T>(input: T): T {
@@ -593,7 +593,7 @@ export function deepClone<T>(input: T): T {
 
 /**
  * Returns true if the input string is a UUID.
- * @param input The input string.
+ * @param input - The input string.
  * @returns True if the input string matches the UUID format.
  */
 export function isUUID(input: string): input is `${string}-${string}-${string}-${string}-${string}` {
@@ -602,7 +602,7 @@ export function isUUID(input: string): input is `${string}-${string}-${string}-$
 
 /**
  * Returns true if the input is an object.
- * @param obj The candidate object.
+ * @param obj - The candidate object.
  * @returns True if the input is a non-null non-undefined object.
  */
 export function isObject(obj: unknown): obj is Record<string, unknown> {
@@ -611,7 +611,7 @@ export function isObject(obj: unknown): obj is Record<string, unknown> {
 
 /**
  * Returns true if the input array is an array of strings.
- * @param arr Input array.
+ * @param arr - Input array.
  * @returns True if the input array is an array of strings.
  */
 export function isStringArray(arr: any[]): arr is string[] {
@@ -628,7 +628,7 @@ for (let n = 0; n < 256; n++) {
 /**
  * Converts an ArrayBuffer to hex string.
  * See: https://stackoverflow.com/a/55200387
- * @param arrayBuffer The input array buffer.
+ * @param arrayBuffer - The input array buffer.
  * @returns The resulting hex string.
  */
 export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
@@ -642,7 +642,7 @@ export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
 
 /**
  * Converts an ArrayBuffer to a base-64 encoded string.
- * @param arrayBuffer The input array buffer.
+ * @param arrayBuffer - The input array buffer.
  * @returns The base-64 encoded string.
  */
 export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
@@ -664,8 +664,8 @@ export function isLowerCase(c: string): boolean {
 
 /**
  * Tries to find a code string for a given system within a given codeable concept.
- * @param concept The codeable concept.
- * @param system The system string.
+ * @param concept - The codeable concept.
+ * @param system - The system string.
  * @returns The code if found; otherwise undefined.
  */
 export function getCodeBySystem(concept: CodeableConcept, system: string): string | undefined {
@@ -674,9 +674,9 @@ export function getCodeBySystem(concept: CodeableConcept, system: string): strin
 
 /**
  * Sets a code for a given system within a given codeable concept.
- * @param concept The codeable concept.
- * @param system The system string.
- * @param code The code value.
+ * @param concept - The codeable concept.
+ * @param system - The system string.
+ * @param code - The code value.
  */
 export function setCodeBySystem(concept: CodeableConcept, system: string, code: string): void {
   if (!concept.coding) {
@@ -692,10 +692,10 @@ export function setCodeBySystem(concept: CodeableConcept, system: string, code: 
 
 /**
  * Tries to find an observation interval for the given patient and value.
- * @param definition The observation definition.
- * @param patient The patient.
- * @param value The observation value.
- * @param category Optional interval category restriction.
+ * @param definition - The observation definition.
+ * @param patient - The patient.
+ * @param value - The observation value.
+ * @param category - Optional interval category restriction.
  * @returns The observation interval if found; otherwise undefined.
  */
 export function findObservationInterval(
@@ -714,9 +714,9 @@ export function findObservationInterval(
 
 /**
  * Tries to find an observation reference range for the given patient and condition names.
- * @param definition The observation definition.
- * @param patient The patient.
- * @param names The condition names.
+ * @param definition - The observation definition.
+ * @param patient - The patient.
+ * @param names - The condition names.
  * @returns The observation interval if found; otherwise undefined.
  */
 export function findObservationReferenceRange(
@@ -731,8 +731,8 @@ export function findObservationReferenceRange(
 
 /**
  * Returns true if the patient matches the observation interval.
- * @param interval The observation interval.
- * @param patient The patient.
+ * @param interval - The observation interval.
+ * @param patient - The patient.
  * @returns True if the patient matches the observation interval.
  */
 function observationIntervalMatchesPatient(
@@ -744,8 +744,8 @@ function observationIntervalMatchesPatient(
 
 /**
  * Returns true if the patient gender matches the observation interval.
- * @param interval The observation interval.
- * @param patient The patient.
+ * @param interval - The observation interval.
+ * @param patient - The patient.
  * @returns True if the patient gender matches the observation interval.
  */
 function observationIntervalMatchesGender(interval: ObservationDefinitionQualifiedInterval, patient: Patient): boolean {
@@ -754,8 +754,8 @@ function observationIntervalMatchesGender(interval: ObservationDefinitionQualifi
 
 /**
  * Returns true if the patient age matches the observation interval.
- * @param interval The observation interval.
- * @param patient The patient.
+ * @param interval - The observation interval.
+ * @param patient - The patient.
  * @returns True if the patient age matches the observation interval.
  */
 function observationIntervalMatchesAge(interval: ObservationDefinitionQualifiedInterval, patient: Patient): boolean {
@@ -764,9 +764,9 @@ function observationIntervalMatchesAge(interval: ObservationDefinitionQualifiedI
 
 /**
  * Returns true if the value matches the observation interval.
- * @param interval The observation interval.
- * @param value The observation value.
- * @param precision Optional precision in number of digits.
+ * @param interval - The observation interval.
+ * @param value - The observation value.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the value matches the observation interval.
  */
 function observationIntervalMatchesValue(
@@ -779,9 +779,9 @@ function observationIntervalMatchesValue(
 
 /**
  * Returns true if the value is in the range accounting for precision.
- * @param value The numeric value.
- * @param range The numeric range.
- * @param precision Optional precision in number of digits.
+ * @param value - The numeric value.
+ * @param range - The numeric range.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the value is within the range.
  */
 export function matchesRange(value: number, range: Range, precision?: number): boolean {
@@ -793,8 +793,8 @@ export function matchesRange(value: number, range: Range, precision?: number): b
 
 /**
  * Returns the input number rounded to the specified number of digits.
- * @param a The input number.
- * @param precision The precision in number of digits.
+ * @param a - The input number.
+ * @param precision - The precision in number of digits.
  * @returns The number rounded to the specified number of digits.
  */
 export function preciseRound(a: number, precision: number): number {
@@ -803,9 +803,9 @@ export function preciseRound(a: number, precision: number): number {
 
 /**
  * Returns true if the two numbers are equal to the given precision.
- * @param a The first number.
- * @param b The second number.
- * @param precision Optional precision in number of digits.
+ * @param a - The first number.
+ * @param b - The second number.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the two numbers are equal to the given precision.
  */
 export function preciseEquals(a: number, b: number, precision?: number): boolean {
@@ -814,9 +814,9 @@ export function preciseEquals(a: number, b: number, precision?: number): boolean
 
 /**
  * Returns true if the first number is less than the second number to the given precision.
- * @param a The first number.
- * @param b The second number.
- * @param precision Optional precision in number of digits.
+ * @param a - The first number.
+ * @param b - The second number.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the first number is less than the second number to the given precision.
  */
 export function preciseLessThan(a: number, b: number, precision?: number): boolean {
@@ -825,9 +825,9 @@ export function preciseLessThan(a: number, b: number, precision?: number): boole
 
 /**
  * Returns true if the first number is greater than the second number to the given precision.
- * @param a The first number.
- * @param b The second number.
- * @param precision Optional precision in number of digits.
+ * @param a - The first number.
+ * @param b - The second number.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the first number is greater than the second number to the given precision.
  */
 export function preciseGreaterThan(a: number, b: number, precision?: number): boolean {
@@ -836,9 +836,9 @@ export function preciseGreaterThan(a: number, b: number, precision?: number): bo
 
 /**
  * Returns true if the first number is less than or equal to the second number to the given precision.
- * @param a The first number.
- * @param b The second number.
- * @param precision Optional precision in number of digits.
+ * @param a - The first number.
+ * @param b - The second number.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the first number is less than or equal to the second number to the given precision.
  */
 export function preciseLessThanOrEquals(a: number, b: number, precision?: number): boolean {
@@ -847,9 +847,9 @@ export function preciseLessThanOrEquals(a: number, b: number, precision?: number
 
 /**
  * Returns true if the first number is greater than or equal to the second number to the given precision.
- * @param a The first number.
- * @param b The second number.
- * @param precision Optional precision in number of digits.
+ * @param a - The first number.
+ * @param b - The second number.
+ * @param precision - Optional precision in number of digits.
  * @returns True if the first number is greater than or equal to the second number to the given precision.
  */
 export function preciseGreaterThanOrEquals(a: number, b: number, precision?: number): boolean {
@@ -859,8 +859,8 @@ export function preciseGreaterThanOrEquals(a: number, b: number, precision?: num
 /**
  * Returns an integer representation of the number with the given precision.
  * For example, if precision is 2, then 1.2345 will be returned as 123.
- * @param a The number.
- * @param precision Optional precision in number of digits.
+ * @param a - The number.
+ * @param precision - Optional precision in number of digits.
  * @returns The integer with the given precision.
  */
 function toPreciseInteger(a: number, precision?: number): number {
@@ -901,7 +901,7 @@ export function arrayify<T>(value: T | T[] | undefined): T[] | undefined {
 
 /**
  * Sleeps for the specified number of milliseconds.
- * @param ms Time delay in milliseconds
+ * @param ms - Time delay in milliseconds
  * @returns A promise that resolves after the specified number of milliseconds.
  */
 export const sleep = (ms: number): Promise<void> =>

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -20,23 +20,17 @@ import {
 import { formatHumanName } from './format';
 import { isReference } from './types';
 
-/**
- * @internal
- */
 export type ProfileResource = Patient | Practitioner | RelatedPerson;
 
 /**
  * Allowed values for `code_challenge_method` in a PKCE exchange.
- * @internal
  */
 export type CodeChallengeMethod = 'plain' | 'S256';
 
-interface Code {
+export interface Code {
   code?: CodeableConcept;
 }
-/**
- * @internal
- */
+
 export type ResourceWithCode = Resource & Code;
 
 /**

--- a/packages/core/tsdoc.json
+++ b/packages/core/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/packages/docs/src/components/MedplumCodeBlock.tsx
+++ b/packages/docs/src/components/MedplumCodeBlock.tsx
@@ -61,7 +61,7 @@ export default function MedplumCodeBlock({
 
 /**
  * Returns an map from the block name to the start and stop lines for that block
- * @param codeLines Array of code lines.
+ * @param codeLines - Array of code lines.
  * @returns The code blocks.
  */
 function extractBlocks(codeLines: string[]): Record<string, [number, number]> {

--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -139,6 +139,7 @@ module.exports = {
         definedTags: ['category', 'experimental', 'ts-ignore'],
       },
     ],
+    'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/tag-lines': 'off',
   },

--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -139,7 +139,7 @@ module.exports = {
         definedTags: ['category', 'experimental', 'ts-ignore'],
       },
     ],
-    'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
+    'jsdoc/require-hyphen-before-param-description': ['error', 'always'],
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/tag-lines': 'off',
   },

--- a/packages/examples/src/tutorials/api-basics/publish-and-subscribe.ts
+++ b/packages/examples/src/tutorials/api-basics/publish-and-subscribe.ts
@@ -36,7 +36,7 @@ await medplum.startClientLogin(MY_CLIENT_ID, MY_CLIENT_SECRET);
  * We will use this in the "conditional create".
  * When creating an order, and if you don't know if the patient exists,
  * you can use this MRN to check.
- * @param patientMrn The patient medical record number (MRN).
+ * @param patientMrn - The patient medical record number (MRN).
  */
 async function createServiceRequest(patientMrn: string): Promise<void> {
   // First, create the patient if they don't exist.
@@ -83,7 +83,7 @@ await createServiceRequest('MRN1234');
 // start-block create-specimen
 /**
  * Creates a Specimen for a given ServiceRequest
- * @param serviceRequestId The ServiceRequest ID.
+ * @param serviceRequestId - The ServiceRequest ID.
  */
 async function createSpecimenForServiceRequest(serviceRequestId: string): Promise<void> {
   // First, create the specimen resource

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -18,9 +18,9 @@ import { HttpMethod } from './urlrouter';
  * Processes a FHIR batch request.
  *
  * See: https://www.hl7.org/fhir/http.html#transaction
- * @param router The FHIR router.
- * @param repo The FHIR repository.
- * @param bundle The input bundle.
+ * @param router - The FHIR router.
+ * @param repo - The FHIR repository.
+ * @param bundle - The input bundle.
  * @returns The bundle response.
  */
 export async function processBatch(router: FhirRouter, repo: FhirRepository, bundle: Bundle): Promise<Bundle> {
@@ -36,9 +36,9 @@ class BatchProcessor {
 
   /**
    * Creates a batch processor.
-   * @param router The FHIR router.
-   * @param repo The FHIR repository.
-   * @param bundle The input bundle.
+   * @param router - The FHIR router.
+   * @param repo - The FHIR repository.
+   * @param bundle - The input bundle.
    */
   constructor(
     private readonly router: FhirRouter,
@@ -92,7 +92,7 @@ class BatchProcessor {
 
   /**
    * Processes a single entry from a FHIR batch request.
-   * @param entry The bundle entry.
+   * @param entry - The bundle entry.
    * @returns The bundle entry response.
    */
   private async processBatchEntry(entry: BundleEntry): Promise<BundleEntry> {

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -77,9 +77,9 @@ interface ConnectionEdge {
  * Handles FHIR GraphQL requests.
  *
  * See: https://www.hl7.org/fhir/graphql.html
- * @param req The request details.
- * @param repo The current user FHIR repository.
- * @param router The router for router options.
+ * @param req - The request details.
+ * @param repo - The current user FHIR repository.
+ * @param router - The router for router options.
  * @returns The response.
  */
 export async function graphqlHandler(
@@ -133,7 +133,7 @@ export async function graphqlHandler(
  * Introspection queries ask for the schema, which is expensive.
  *
  * See: https://graphql.org/learn/introspection/
- * @param query The GraphQL query.
+ * @param query - The GraphQL query.
  * @returns True if the query is an introspection query.
  */
 function isIntrospectionQuery(query: string): boolean {
@@ -279,10 +279,10 @@ function buildConnectionType(resourceType: ResourceType, resourceGraphQLType: Gr
  * GraphQL data loader for search requests.
  * The field name should always end with "List" (i.e., "Patient" search uses "PatientList").
  * The search args should be FHIR search parameters.
- * @param source The source/root.  This should always be null for our top level readers.
- * @param args The GraphQL search arguments.
- * @param ctx The GraphQL context.
- * @param info The GraphQL resolve info.  This includes the schema, and additional field details.
+ * @param source - The source/root.  This should always be null for our top level readers.
+ * @param args - The GraphQL search arguments.
+ * @param ctx - The GraphQL context.
+ * @param info - The GraphQL resolve info.  This includes the schema, and additional field details.
  * @returns Promise to read the resoures for the query.
  */
 async function resolveByConnectionApi(
@@ -314,10 +314,10 @@ async function resolveByConnectionApi(
  * GraphQL data loader for ID requests.
  * The field name should always by the resource type.
  * There should always be exactly one argument "id".
- * @param _source The source/root.  This should always be null for our top level readers.
- * @param args The GraphQL search arguments.
- * @param ctx The GraphQL context.
- * @param info The GraphQL resolve info.  This includes the schema, and additional field details.
+ * @param _source - The source/root.  This should always be null for our top level readers.
+ * @param args - The GraphQL search arguments.
+ * @param ctx - The GraphQL context.
+ * @param info - The GraphQL resolve info.  This includes the schema, and additional field details.
  * @returns Promise to read the resoure for the query.
  */
 async function resolveById(
@@ -337,10 +337,10 @@ async function resolveById(
  * GraphQL resolver function for create requests.
  * The field name should end with "Create" (i.e., "PatientCreate" for updating a Patient).
  * The args should include the data to be created for the specified resource type.
- * @param _source The source/root object. In the case of creates, this is typically not used and is thus ignored.
- * @param args The GraphQL arguments, containing the new data for the resource.
- * @param ctx The GraphQL context. This includes the repository where resources are stored.
- * @param info The GraphQL resolve info. This includes the schema, field details, and other query-specific information.
+ * @param _source - The source/root object. In the case of creates, this is typically not used and is thus ignored.
+ * @param args - The GraphQL arguments, containing the new data for the resource.
+ * @param ctx - The GraphQL context. This includes the repository where resources are stored.
+ * @param info - The GraphQL resolve info. This includes the schema, field details, and other query-specific information.
  * @returns A Promise that resolves to the created resource, or undefined if the resource could not be found or updated.
  */
 async function resolveByCreate(
@@ -366,10 +366,10 @@ async function resolveByCreate(
  * GraphQL resolver function for update requests.
  * The field name should end with "Update" (i.e., "PatientUpdate" for updating a Patient).
  * The args should include the data to be updated for the specified resource type.
- * @param _source The source/root object. In the case of updates, this is typically not used and is thus ignored.
- * @param args The GraphQL arguments, containing the new data for the resource.
- * @param ctx The GraphQL context. This includes the repository where resources are stored.
- * @param info The GraphQL resolve info. This includes the schema, field details, and other query-specific information.
+ * @param _source - The source/root object. In the case of updates, this is typically not used and is thus ignored.
+ * @param args - The GraphQL arguments, containing the new data for the resource.
+ * @param ctx - The GraphQL context. This includes the repository where resources are stored.
+ * @param info - The GraphQL resolve info. This includes the schema, field details, and other query-specific information.
  * @returns A Promise that resolves to the updated resource, or undefined if the resource could not be found or updated.
  */
 async function resolveByUpdate(
@@ -397,10 +397,10 @@ async function resolveByUpdate(
  * GraphQL resolver function for delete requests.
  * The field name should end with "Delete" (e.g., "PatientDelete" for deleting a Patient).
  * The args should include the ID of the resource to be deleted.
- * @param _source The source/root object. In the case of deletions, this is typically not used and is thus ignored.
- * @param args The GraphQL arguments, containing the ID of the resource to be deleted.
- * @param ctx The GraphQL context. This includes the repository where resources are stored.
- * @param info The GraphQL resolve info. This includes the schema, field details, and other query-specific information.
+ * @param _source - The source/root object. In the case of deletions, this is typically not used and is thus ignored.
+ * @param args - The GraphQL arguments, containing the ID of the resource to be deleted.
+ * @param ctx - The GraphQL context. This includes the repository where resources are stored.
+ * @param info - The GraphQL resolve info. This includes the schema, field details, and other query-specific information.
  * @returns A Promise that resolves when the resource has been deleted. No value is returned.
  */
 async function resolveByDelete(
@@ -416,7 +416,7 @@ async function resolveByDelete(
 
 /**
  * Custom GraphQL rule that enforces max depth constraint.
- * @param context The validation context.
+ * @param context - The validation context.
  * @returns An ASTVisitor that validates the maximum depth rule.
  */
 const MaxDepthRule = (context: ValidationContext): ASTVisitor => ({

--- a/packages/fhir-router/src/graphql/output-types.ts
+++ b/packages/fhir-router/src/graphql/output-types.ts
@@ -134,7 +134,7 @@ function buildOutputPropertyField(
  *   4. All properties of the list element type.
  *
  * See: https://hl7.org/fhir/R4/graphql.html#list
- * @param fieldTypeName The type name of the field.
+ * @param fieldTypeName - The type name of the field.
  * @returns The arguments for the field.
  */
 function buildListPropertyFieldArgs(fieldTypeName: string): GraphQLFieldConfigArgumentMap {
@@ -172,10 +172,10 @@ function buildListPropertyFieldArgs(fieldTypeName: string): GraphQLFieldConfigAr
 
 /**
  * Builds a field argument for a list property.
- * @param fieldArgs The output argument map.
- * @param fieldKey The key of the field.
- * @param elementDefinition The FHIR element definition of the field.
- * @param elementDefinitionType The FHIR element definition type of the field.
+ * @param fieldArgs - The output argument map.
+ * @param fieldKey - The key of the field.
+ * @param elementDefinition - The FHIR element definition of the field.
+ * @param elementDefinitionType - The FHIR element definition type of the field.
  */
 function buildListPropertyFieldArg(
   fieldArgs: GraphQLFieldConfigArgumentMap,
@@ -227,8 +227,8 @@ function buildListPropertyFieldArg(
  * (except that the "id" argument is prohibited here as nonsensical).
  *
  * See: https://www.hl7.org/fhir/graphql.html#reverse
- * @param resourceType The resource type to build fields for.
- * @param fields The fields object to add fields to.
+ * @param resourceType - The resource type to build fields for.
+ * @param fields - The fields object to add fields to.
  */
 function buildReverseLookupFields(resourceType: ResourceType, fields: GraphQLFieldConfigMap<any, any>): void {
   for (const childResourceType of getResourceTypes()) {
@@ -283,10 +283,10 @@ function getOutputPropertyType(
  * GraphQL resolver for fields.
  * In the common case, this is just a matter of returning the field value from the source object.
  * If the field is a list and the user specifies list arguments, then we can apply those arguments here.
- * @param source The source. This is the object that contains the field.
- * @param args The GraphQL search arguments.
- * @param _ctx The GraphQL context.
- * @param info The GraphQL resolve info.  This includes the field name.
+ * @param source - The source. This is the object that contains the field.
+ * @param args - The GraphQL search arguments.
+ * @param _ctx - The GraphQL context.
+ * @param info - The GraphQL resolve info.  This includes the field name.
  * @returns Promise to read the resoure for the query.
  */
 async function resolveField(source: any, args: any, _ctx: GraphQLContext, info: GraphQLResolveInfo): Promise<any> {
@@ -320,9 +320,9 @@ async function resolveField(source: any, args: any, _ctx: GraphQLContext, info: 
 /**
  * GraphQL data loader for Reference requests.
  * This is a special data loader for following Reference objects.
- * @param source The source/root.  This should always be null for our top level readers.
- * @param _args The GraphQL search arguments.
- * @param ctx The GraphQL context.
+ * @param source - The source/root.  This should always be null for our top level readers.
+ * @param _args - The GraphQL search arguments.
+ * @param ctx - The GraphQL context.
  * @returns Promise to read the resoure(s) for the query.
  */
 async function resolveByReference(source: any, _args: any, ctx: GraphQLContext): Promise<Resource | undefined> {
@@ -339,7 +339,7 @@ async function resolveByReference(source: any, _args: any, ctx: GraphQLContext):
 /**
  * GraphQL type resolver for resources.
  * When loading a resource via reference, GraphQL needs to know the type of the resource.
- * @param resource The loaded resource.
+ * @param resource - The loaded resource.
  * @returns The GraphQL type of the resource.
  */
 function resolveTypeByReference(resource: Resource | undefined): string | undefined {

--- a/packages/fhir-router/src/graphql/utils.ts
+++ b/packages/fhir-router/src/graphql/utils.ts
@@ -98,10 +98,10 @@ export function fhirParamToGraphQLField(code: string): string {
  * GraphQL data loader for search requests.
  * The field name should always end with "List" (i.e., "Patient" search uses "PatientList").
  * The search args should be FHIR search parameters.
- * @param source The source/root.  This should always be null for our top level readers.
- * @param args The GraphQL search arguments.
- * @param ctx The GraphQL context.
- * @param info The GraphQL resolve info.  This includes the schema, and additional field details.
+ * @param source - The source/root.  This should always be null for our top level readers.
+ * @param args - The GraphQL search arguments.
+ * @param ctx - The GraphQL context.
+ * @param info - The GraphQL resolve info.  This includes the schema, and additional field details.
  * @returns Promise to read the resoures for the query.
  */
 export async function resolveBySearch(
@@ -163,7 +163,7 @@ export function buildSearchArgs(resourceType: string): GraphQLFieldConfigArgumen
  * Returns the depth of the GraphQL node in a query.
  * We use "selections" as the representation of depth.
  * As a rough approximation, it's the number of indentations in a well formatted query.
- * @param path The GraphQL node path.
+ * @param path - The GraphQL node path.
  * @returns The "depth" of the node.
  */
 export function getDepth(path: readonly (string | number)[]): number {
@@ -172,8 +172,8 @@ export function getDepth(path: readonly (string | number)[]): number {
 
 /**
  * Returns true if the field is requested in the GraphQL query.
- * @param info The GraphQL resolve info.  This includes the field name.
- * @param fieldName The field name to check.
+ * @param info - The GraphQL resolve info.  This includes the field name.
+ * @param fieldName - The field name to check.
  * @returns True if the field is requested in the GraphQL query.
  */
 export function isFieldRequested(info: GraphQLResolveInfo, fieldName: string): boolean {
@@ -187,7 +187,7 @@ export function isFieldRequested(info: GraphQLResolveInfo, fieldName: string): b
 
 /**
  * Returns an OperationOutcome for GraphQL errors.
- * @param errors Array of GraphQL errors.
+ * @param errors - Array of GraphQL errors.
  * @returns OperationOutcome with the GraphQL errors as OperationOutcome issues.
  */
 export function invalidRequest(errors: readonly GraphQLError[]): OperationOutcome {

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -27,7 +27,7 @@ export interface FhirRepository {
    * Creates a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#create
-   * @param resource The FHIR resource to create.
+   * @param resource - The FHIR resource to create.
    * @returns The created resource.
    */
   createResource<T extends Resource>(resource: T): Promise<T>;
@@ -36,8 +36,8 @@ export interface FhirRepository {
    * Reads a FHIR resource by ID.
    *
    * See: https://www.hl7.org/fhir/http.html#read
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
    * @returns The FHIR resource.
    */
   readResource<T extends Resource>(resourceType: string, id: string): Promise<T>;
@@ -46,7 +46,7 @@ export interface FhirRepository {
    * Reads a FHIR resource by reference.
    *
    * See: https://www.hl7.org/fhir/http.html#read
-   * @param reference The FHIR reference.
+   * @param reference - The FHIR reference.
    * @returns The FHIR resource.
    */
   readReference<T extends Resource>(reference: Reference<T>): Promise<T>;
@@ -55,7 +55,7 @@ export interface FhirRepository {
    * Reads a collection of FHIR resources by reference.
    *
    * See: https://www.hl7.org/fhir/http.html#read
-   * @param references The FHIR references.
+   * @param references - The FHIR references.
    * @returns The FHIR resources.
    */
   readReferences(references: readonly Reference[]): Promise<(Resource | Error)[]>;
@@ -66,8 +66,8 @@ export interface FhirRepository {
    * Results are sorted with oldest versions last
    *
    * See: https://www.hl7.org/fhir/http.html#history
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
    * @returns Operation outcome and a history bundle.
    */
   readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>>;
@@ -76,9 +76,9 @@ export interface FhirRepository {
    * Reads a FHIR resource version.
    *
    * See: https://www.hl7.org/fhir/http.html#vread
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
-   * @param vid The FHIR resource version ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
+   * @param vid - The FHIR resource version ID.
    */
   readVersion<T extends Resource>(resourceType: string, id: string, vid: string): Promise<T>;
 
@@ -86,7 +86,7 @@ export interface FhirRepository {
    * Updates a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#update
-   * @param resource The FHIR resource to update.
+   * @param resource - The FHIR resource to update.
    * @returns The updated resource.
    */
   updateResource<T extends Resource>(resource: T): Promise<T>;
@@ -95,8 +95,8 @@ export interface FhirRepository {
    * Deletes a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#delete
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
    */
   deleteResource(resourceType: string, id: string): Promise<void>;
 
@@ -104,9 +104,9 @@ export interface FhirRepository {
    * Patches a FHIR resource.
    *
    * See: https://www.hl7.org/fhir/http.html#patch
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
-   * @param patch The JSONPatch operations.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
+   * @param patch - The JSONPatch operations.
    * @returns The patched resource.
    */
   patchResource(resourceType: string, id: string, patch: Operation[]): Promise<Resource>;
@@ -115,7 +115,7 @@ export interface FhirRepository {
    * Searches for FHIR resources.
    *
    * See: https://www.hl7.org/fhir/http.html#search
-   * @param searchRequest The FHIR search request.
+   * @param searchRequest - The FHIR search request.
    * @returns The search results.
    */
   search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>>;
@@ -128,7 +128,7 @@ export interface FhirRepository {
    * The return value is the resource, if available; otherwise, undefined.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   * @param searchRequest The FHIR search request.
+   * @param searchRequest - The FHIR search request.
    * @returns Promise to the first search result or undefined.
    */
   searchOne<T extends Resource>(searchRequest: SearchRequest<T>): Promise<T | undefined>;
@@ -141,7 +141,7 @@ export interface FhirRepository {
    * The return value is an array of resources.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   * @param searchRequest The FHIR search request.
+   * @param searchRequest - The FHIR search request.
    * @returns Promise to the array of search results.
    */
   searchResources<T extends Resource>(searchRequest: SearchRequest<T>): Promise<T[]>;
@@ -152,7 +152,7 @@ export abstract class BaseRepository {
    * Searches for FHIR resources.
    *
    * See: https://www.hl7.org/fhir/http.html#search
-   * @param searchRequest The FHIR search request.
+   * @param searchRequest - The FHIR search request.
    * @returns The search results.
    */
   abstract search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>>;
@@ -165,7 +165,7 @@ export abstract class BaseRepository {
    * The return value is the resource, if available; otherwise, undefined.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   * @param searchRequest The FHIR search request.
+   * @param searchRequest - The FHIR search request.
    * @returns Promise to the first search result or undefined.
    */
   async searchOne<T extends Resource>(searchRequest: SearchRequest<T>): Promise<T | undefined> {
@@ -181,7 +181,7 @@ export abstract class BaseRepository {
    * The return value is an array of resources.
    *
    * See FHIR search for full details: https://www.hl7.org/fhir/search.html
-   * @param searchRequest The FHIR search request.
+   * @param searchRequest - The FHIR search request.
    * @returns Promise to the array of search results.
    */
   async searchResources<T extends Resource>(searchRequest: SearchRequest<T>): Promise<T[]> {

--- a/packages/fhir-router/tsdoc.json
+++ b/packages/fhir-router/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/packages/generator/src/docs.ts
+++ b/packages/generator/src/docs.ts
@@ -71,7 +71,7 @@ export async function main(): Promise<void> {
 
 /**
  * Indexes search parameters by "base" resource type.
- * @param searchParams The bundle of SearchParameter resources.
+ * @param searchParams - The bundle of SearchParameter resources.
  * @returns A map from resourceType -> an array of associated SearchParameters
  */
 function indexSearchParameters(searchParams: SearchParameter[]): Record<string, SearchParameter[]> {
@@ -318,7 +318,7 @@ function getInheritance(property: ElementDefinition): { inherited: boolean; base
 
 /**
  * Rewrite internal links from official FHIR site to medplum internal links
- * @param text text which contains internal links
+ * @param text - text which contains internal links
  * @returns returns text with internal links rewritten
  */
 function rewriteLinksText(text: string | undefined): string {
@@ -361,9 +361,9 @@ function rewriteLinksText(text: string | undefined): string {
 
 /**
  * Download a Zip file from the given URL, and unzip to the given path
- * @param downloadURL Source URL
- * @param zipFilePath Destination path for *.zip
- * @param outputFolder Destination path for extracted contents
+ * @param downloadURL - Source URL
+ * @param zipFilePath - Destination path for *.zip
+ * @param outputFolder - Destination path for extracted contents
  */
 async function downloadAndUnzip(downloadURL: string, zipFilePath: string, outputFolder: string): Promise<void> {
   console.info('Downloading FHIR Spec...');
@@ -407,8 +407,8 @@ async function downloadAndUnzip(downloadURL: string, zipFilePath: string, output
 }
 /**
  * For each core FHIR resource type, find the corresponding HTML page and extract the relevant introductory sections.
- * @param htmlDirectory Directory containing HTML files for each resource ([resourceType].html)
- * @param definitions Array of all core FHIR StructureDefinitions
+ * @param htmlDirectory - Directory containing HTML files for each resource ([resourceType].html)
+ * @param definitions - Array of all core FHIR StructureDefinitions
  * @returns A map from resourcename to html description data
  */
 function extractResourceDescriptions(
@@ -471,7 +471,7 @@ function extractResourceDescriptions(
 
 /**
  * Converts local links to FHIR resources from the FHIR site to relative links in the medplum documentation site
- * @param anchorElement An Anchor tag, potentially referring to a resource page (e.g. "appointmentresponse.html")
+ * @param anchorElement - An Anchor tag, potentially referring to a resource page (e.g. "appointmentresponse.html")
  */
 function rewriteHtmlSpecHref(anchorElement: HTMLAnchorElement): void {
   const href = anchorElement.getAttribute('href'); // Get the href attribute of the anchor tag
@@ -565,7 +565,7 @@ function sanitizeNodeContent(node: HTMLElement, window: DOMWindow): string {
 /**
  * Download the "entire fhir spec" as a zip file, and parse the HTML file for each resource to extract the detailed
  * information about usage and scope for each resource
- * @param definitions FHIR core profile definitions
+ * @param definitions - FHIR core profile definitions
  * @returns Map from resource name to extracted HTML data
  */
 async function fetchHtmlSpecContent(

--- a/packages/generator/src/filebuilder.ts
+++ b/packages/generator/src/filebuilder.ts
@@ -57,8 +57,8 @@ export class FileBuilder {
 /**
  * Returns a word-wrapped string.
  * Based on: https://stackoverflow.com/a/38709683
- * @param text Original input string.
- * @param maxLength Width in number of characters.
+ * @param text - Original input string.
+ * @param maxLength - Width in number of characters.
  * @returns Array of lines.
  */
 export function wordWrap(text: string, maxLength: number): string[] {

--- a/packages/hl7/tsdoc.json
+++ b/packages/hl7/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/packages/mock/tsdoc.json
+++ b/packages/mock/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
@@ -14,7 +14,7 @@ export interface MedplumProviderProps {
  * Medplum context includes:
  *   1) medplum - Medplum client library
  *   2) profile - The current user profile (if signed in)
- * @param props The MedplumProvider React props.
+ * @param props - The MedplumProvider React props.
  * @returns The MedplumProvider React node.
  */
 export function MedplumProvider(props: MedplumProviderProps): JSX.Element {
@@ -52,7 +52,7 @@ export function MedplumProvider(props: MedplumProviderProps): JSX.Element {
 
 /**
  * The default "navigate" function which simply uses window.location.href.
- * @param path The path to navigate to.
+ * @param path - The path to navigate to.
  */
 function defaultNavigate(path: string): void {
   window.location.assign(path);

--- a/packages/react-hooks/src/useResource/useResource.ts
+++ b/packages/react-hooks/src/useResource/useResource.ts
@@ -6,8 +6,8 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
 /**
  * React Hook to use a FHIR reference.
  * Handles the complexity of resolving references and caching resources.
- * @param value The resource or reference to resource.
- * @param setOutcome Optional callback to set the OperationOutcome.
+ * @param value - The resource or reference to resource.
+ * @param setOutcome - Optional callback to set the OperationOutcome.
  * @returns The resolved resource.
  */
 export function useResource<T extends Resource>(
@@ -62,8 +62,8 @@ export function useResource<T extends Resource>(
  * If the input value is a resource, returns the resource.
  * If the input value is a reference to a resource available in the cache, returns the resource.
  * Otherwise, returns undefined.
- * @param medplum The medplum client.
- * @param value The resource or reference to resource.
+ * @param medplum - The medplum client.
+ * @param value - The resource or reference to resource.
  * @returns An initial resource if available; undefined otherwise.
  */
 function getInitialResource<T extends Resource>(

--- a/packages/react-hooks/src/useSearch/useSearch.ts
+++ b/packages/react-hooks/src/useSearch/useSearch.ts
@@ -10,8 +10,8 @@ type SearchFn = 'search' | 'searchOne' | 'searchResources';
  *
  * This is a convenience hook for calling the MedplumClient.search() method.
  *
- * @param resourceType The FHIR resource type to search.
- * @param query Optional search parameters.
+ * @param resourceType - The FHIR resource type to search.
+ * @param query - Optional search parameters.
  * @returns A 3-element tuple containing the search result, loading flag, and operation outcome.
  */
 export function useSearch<K extends ResourceType>(
@@ -26,8 +26,8 @@ export function useSearch<K extends ResourceType>(
  *
  * This is a convenience hook for calling the MedplumClient.searchOne() method.
  *
- * @param resourceType The FHIR resource type to search.
- * @param query Optional search parameters.
+ * @param resourceType - The FHIR resource type to search.
+ * @param query - Optional search parameters.
  * @returns A 3-element tuple containing the search result, loading flag, and operation outcome.
  */
 export function useSearchOne<K extends ResourceType>(
@@ -42,8 +42,8 @@ export function useSearchOne<K extends ResourceType>(
  *
  * This is a convenience hook for calling the MedplumClient.searchResources() method.
  *
- * @param resourceType The FHIR resource type to search.
- * @param query Optional search parameters.
+ * @param resourceType - The FHIR resource type to search.
+ * @param query - Optional search parameters.
  * @returns A 3-element tuple containing the search result, loading flag, and operation outcome.
  */
 export function useSearchResources<K extends ResourceType>(

--- a/packages/react-hooks/tsdoc.json
+++ b/packages/react-hooks/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/packages/react/src/AppShell/HeaderSearchInput.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.tsx
@@ -201,8 +201,8 @@ function buildGraphQLQuery(input: string): string {
  * Returns a de-duped and sorted list of resources from the search response.
  * The search request is actually 3+ separate searches, which can include duplicates.
  * This function combines the results, de-dupes, and sorts by relevance.
- * @param response The response from a search query.
- * @param query The user entered search query.
+ * @param response - The response from a search query.
+ * @param query - The user entered search query.
  * @returns The resources to display in the autocomplete.
  */
 function getResourcesFromResponse(response: SearchGraphQLResponse, query: string): HeaderSearchTypes[] {
@@ -221,7 +221,7 @@ function getResourcesFromResponse(response: SearchGraphQLResponse, query: string
 
 /**
  * Removes duplicate resources from an array by ID.
- * @param resources The array of resources with possible duplicates.
+ * @param resources - The array of resources with possible duplicates.
  * @returns The array of resources with no duplicates.
  */
 function dedupeResources(resources: HeaderSearchTypes[]): HeaderSearchTypes[] {
@@ -240,8 +240,8 @@ function dedupeResources(resources: HeaderSearchTypes[]): HeaderSearchTypes[] {
 
 /**
  * Sorts an array of resources by relevance.
- * @param resources The candidate resources.
- * @param query The user entered search string.
+ * @param resources - The candidate resources.
+ * @param query - The user entered search string.
  * @returns The sorted array of resources.
  */
 function sortByRelevance(resources: HeaderSearchTypes[], query: string): HeaderSearchTypes[] {
@@ -253,8 +253,8 @@ function sortByRelevance(resources: HeaderSearchTypes[], query: string): HeaderS
 /**
  * Calculates a relevance score of a candidate resource.
  * Higher scores are better.
- * @param resource The candidate resource.
- * @param query The user entered search string.
+ * @param resource - The candidate resource.
+ * @param query - The user entered search string.
  * @returns The relevance score of the candidate resource.
  */
 function getResourceScore(resource: HeaderSearchTypes, query: string): number {
@@ -278,8 +278,8 @@ function getResourceScore(resource: HeaderSearchTypes, query: string): number {
 /**
  * Calculates a relevance score of a candidate display string.
  * Higher scores are better.
- * @param str The candidate display string.
- * @param query The user entered search string.
+ * @param str - The candidate display string.
+ * @param query - The user entered search string.
  * @returns The relevance score of the candidate string.
  */
 function getStringScore(str: string | undefined, query: string): number {

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -195,9 +195,9 @@ function NavLinkIcon(props: NavLinkIconProps): JSX.Element {
  * However, we ignore some search parameters to support pagination.
  * But we cannot ignore all search parameters, to support separate links based on search filters.
  * So in the end, we use a simple scoring system based on the number of matching query search params.
- * @param currentPathname The web browser current pathname.
- * @param currentSearchParams The web browser current search parameters.
- * @param menus Collection of navbar menus and links.
+ * @param currentPathname - The web browser current pathname.
+ * @param currentSearchParams - The web browser current search parameters.
+ * @param menus - Collection of navbar menus and links.
  * @returns The active link if one is found.
  */
 function getActiveLink(
@@ -233,9 +233,9 @@ function getActiveLink(
  * One means "matches the pathname only".
  * Additional increases for each matching search parameter.
  * Ignores pagination parameters "_count" and "_offset".
- * @param currentPathname The web browser current pathname.
- * @param currentSearchParams The web browser current search parameters.
- * @param linkHref A candidate link href.
+ * @param currentPathname - The web browser current pathname.
+ * @param currentSearchParams - The web browser current search parameters.
+ * @param linkHref - A candidate link href.
  * @returns The link score.
  */
 function getLinkScore(currentPathname: string, currentSearchParams: URLSearchParams, linkHref: string): number {

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -31,7 +31,7 @@ export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {
 
   /**
    * Processes a single file.
-   * @param file The file descriptor.
+   * @param file - The file descriptor.
    */
   function processFile(file: File): void {
     if (!file) {

--- a/packages/react/src/CalendarInput/CalendarInput.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.tsx
@@ -156,8 +156,8 @@ function buildGrid(startDate: Date, slots: Slot[]): OptionalCalendarCell[][] {
 
 /**
  * Returns true if the given date is available for booking.
- * @param day The day to check.
- * @param slots The list of available slots.
+ * @param day - The day to check.
+ * @param slots - The list of available slots.
  * @returns True if there are any available slots for the day.
  */
 function isDayAvailable(day: Date, slots: Slot[]): boolean {

--- a/packages/react/src/CalendarInput/CalendarInput.utils.ts
+++ b/packages/react/src/CalendarInput/CalendarInput.utils.ts
@@ -1,6 +1,6 @@
 /**
  * Returns a month display string (e.g. "January 2020").
- * @param date Any date within the month.
+ * @param date - Any date within the month.
  * @returns The month display string (e.g. "January 2020")
  */
 export function getMonthString(date: Date): string {

--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -19,7 +19,7 @@ export interface DateTimeInputProps {
  * The main purpose is to reconcile time zones.
  * Most of our date/time values are in ISO-8601, which includes a time zone offset.
  * The datetime-local input does not support the time zone offset.
- * @param props The Input props.
+ * @param props - The Input props.
  * @returns The JSX element to render.
  */
 export function DateTimeInput(props: DateTimeInputProps): JSX.Element {

--- a/packages/react/src/DateTimeInput/DateTimeInput.utils.ts
+++ b/packages/react/src/DateTimeInput/DateTimeInput.utils.ts
@@ -2,7 +2,7 @@ import { isValidDate } from '@medplum/core';
 
 /**
  * Converts an ISO-8601 date/time string to a local date/time string.
- * @param isoString The ISO-8601 date/time string to convert.
+ * @param isoString - The ISO-8601 date/time string to convert.
  * @returns The local date/time string.
  */
 export function convertIsoToLocal(isoString: string | undefined): string {
@@ -24,7 +24,7 @@ export function convertIsoToLocal(isoString: string | undefined): string {
 
 /**
  * Converts a local date/time string to an ISO-8601 date/time string.
- * @param localString The local date/time string to convert.
+ * @param localString - The local date/time string to convert.
  * @returns The ISO-8601 date/time string.
  */
 export function convertLocalToIso(localString: string | undefined): string {

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -336,7 +336,7 @@ function ReferenceRangeDisplay(props: ReferenceRangeProps): JSX.Element | null {
 /**
  * Returns true if the observation is critical.
  * See: https://www.hl7.org/fhir/valueset-observation-interpretation.html
- * @param observation The FHIR observation.
+ * @param observation - The FHIR observation.
  * @returns True if the FHIR observation is a critical value.
  */
 function isCritical(observation: Observation): boolean {

--- a/packages/react/src/FhirPathTable/FhirPathTable.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.tsx
@@ -31,7 +31,7 @@ export interface SmartSearchResponse {
 
 /**
  * The FhirPathTable component represents the embeddable search table control.
- * @param props FhirPathTable React props.
+ * @param props - FhirPathTable React props.
  * @returns FhirPathTable React node.
  */
 export function FhirPathTable(props: FhirPathTableProps): JSX.Element {

--- a/packages/react/src/Form/FormUtils.ts
+++ b/packages/react/src/Form/FormUtils.ts
@@ -1,6 +1,6 @@
 /**
  * Parses an HTML form and returns the result as a JavaScript object.
- * @param form The HTML form element.
+ * @param form - The HTML form element.
  * @returns Form values in key value pairs.
  */
 export function parseForm(form: HTMLFormElement): Record<string, string> {
@@ -23,8 +23,8 @@ export function parseForm(form: HTMLFormElement): Record<string, string> {
  * Parses an HTML input element.
  * Sets the name/value pair in the result,
  * but only if the element is enabled and checked.
- * @param result The result builder.
- * @param el The input element.
+ * @param result - The result builder.
+ * @param el - The input element.
  */
 function parseInputElement(result: Record<string, string>, el: HTMLInputElement): void {
   if (el.disabled) {
@@ -43,8 +43,8 @@ function parseInputElement(result: Record<string, string>, el: HTMLInputElement)
 /**
  * Parses an HTML select element.
  * Sets the name/value pair if one is selected.
- * @param result The result builder.
- * @param el The select element.
+ * @param result - The result builder.
+ * @param el - The select element.
  */
 function parseSelectElement(result: Record<string, string>, el: HTMLSelectElement): void {
   result[el.name] = el.value;

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
@@ -464,7 +464,7 @@ let nextId = 1;
  * React needs unique IDs for components for rendering performance.
  * All of the important components in the questionnaire builder have id properties for this:
  * Questionnaire, QuestionnaireItem, and QuestionnaireItemAnswerOption.
- * @param existing Optional existing id which will update nextId.
+ * @param existing - Optional existing id which will update nextId.
  * @returns A unique key.
  */
 function generateId(existing?: string): string {

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -646,7 +646,7 @@ let nextId = 1;
 /**
  * Generates a link ID for an item.
  * Link IDs are required properties on QuestionnaireItem objects.
- * @param prefix The link ID prefix string.
+ * @param prefix - The link ID prefix string.
  * @returns A unique link ID.
  */
 function generateLinkId(prefix: string): string {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -341,7 +341,7 @@ function buildInitialResponseAnswer(answer: QuestionnaireItemInitial): Questionn
  * If the questionnaire has a page extension on the first item, then the number of pages
  * is the number of top level items in the questionnaire.
  *
- * @param questionnaire The questionnaire to get the number of pages for.
+ * @param questionnaire - The questionnaire to get the number of pages for.
  * @returns The number of pages in the questionnaire. Default is 1.
  */
 function getNumberOfPages(questionnaire: Questionnaire): number {

--- a/packages/react/src/RangeInput/RangeInput.tsx
+++ b/packages/react/src/RangeInput/RangeInput.tsx
@@ -12,7 +12,7 @@ export interface RangeInputProps {
 /**
  * Renders a Range input.
  * See: https://www.hl7.org/fhir/datatypes.html#Range
- * @param props Range input properties.
+ * @param props - Range input properties.
  * @returns Range input element.
  */
 export function RangeInput(props: RangeInputProps): JSX.Element {

--- a/packages/react/src/RatioInput/RatioInput.tsx
+++ b/packages/react/src/RatioInput/RatioInput.tsx
@@ -12,7 +12,7 @@ export interface RatioInputProps {
 /**
  * Renders a Ratio input.
  * See: https://www.hl7.org/fhir/datatypes.html#Ratio
- * @param props Ratio input properties.
+ * @param props - Ratio input properties.
  * @returns Ratio input element.
  */
 export function RatioInput(props: RatioInputProps): JSX.Element {

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
@@ -112,8 +112,8 @@ export function ReferenceRangeEditor(props: ReferenceRangeEditorProps): JSX.Elem
 
   /**
    * Add/Remove/Update specific Qualified Intervals
-   * @param groupId The reference range group ID.
-   * @param changedInterval The updated reference range interval.
+   * @param groupId - The reference range group ID.
+   * @param changedInterval - The updated reference range interval.
    */
   function changeInterval(groupId: string, changedInterval: ObservationDefinitionQualifiedInterval): void {
     setIntervalGroups((groups) => {
@@ -260,7 +260,7 @@ interface ReferenceRangeGroupFiltersProps {
 
 /**
  * Render the "filters" section of the IntervalGroup.
- * @param props The ReferenceRangeGroupFilter React props.
+ * @param props - The ReferenceRangeGroupFilter React props.
  * @returns The ReferenceRangeGroupFilter React node.
  */
 function ReferenceRangeGroupFilters(props: ReferenceRangeGroupFiltersProps): JSX.Element {
@@ -366,8 +366,8 @@ function ReferenceRangeGroupFilters(props: ReferenceRangeGroupFiltersProps): JSX
 
 /**
  * Helper function that assigns ids to each qualifiedInterval of an ObservationDefinition
- * @param definition An ObservationDefinition
- * @param setIntervalId React setState function for the intervalId
+ * @param definition - An ObservationDefinition
+ * @param setIntervalId - React setState function for the intervalId
  * @returns The updated observation definition.
  */
 function ensureQualifiedIntervalKeys(
@@ -403,8 +403,8 @@ function ensureQualifiedIntervalKeys(
 /**
  * Group all ObservationDefinitionQualifiedIntervals based on the values of their "filter" properties,
  * so that similar ranges can be grouped together.
- * @param intervals Array of reference range intervals.
- * @param setGroupId Callback to set the group ID.
+ * @param intervals - Array of reference range intervals.
+ * @param setGroupId - Callback to set the group ID.
  * @returns The grouped intervals.
  */
 function groupQualifiedIntervals(
@@ -430,7 +430,7 @@ function groupQualifiedIntervals(
 
 /**
  * Generates a unique string for each set of filter values, so that similarly filtered intervals can be grouped together.
- * @param interval The reference range interval.
+ * @param interval - The reference range interval.
  * @returns A "group key" that corresponds to the value of the interval filter properties.
  */
 function generateGroupKey(interval: ObservationDefinitionQualifiedInterval): string {

--- a/packages/react/src/ResourceInput/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.tsx
@@ -162,7 +162,7 @@ const ItemComponent = forwardRef<HTMLDivElement, any>(({ label, resource, ...oth
  * If the resource type is in SEARCH_CODES, then that value is used.
  * Otherwise, if the resource type is in NAME_RESOURCE_TYPES, then "name" is used.
  * Otherwise, "_id" is used.
- * @param resourceType The FHIR resource type.
+ * @param resourceType - The FHIR resource type.
  * @returns The search parameter to use for the autocomplete input.
  */
 function getSearchParamForResourceType(resourceType: string): string {

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -31,7 +31,7 @@ export interface ResourcePropertyDisplayProps {
 
 /**
  * Low-level component that renders a property from a given resource, given type information.
- * @param props The ResourcePropertyDisplay React props.
+ * @param props - The ResourcePropertyDisplay React props.
  * @returns The ResourcePropertyDisplay React node.
  */
 export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JSX.Element {

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.utils.ts
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.utils.ts
@@ -6,8 +6,8 @@ import { getTypedPropertyValue, TypedValue } from '@medplum/core';
  * For example, "Observation.value[x]" can be "valueString", "valueInteger", "valueQuantity", etc.
  * According to the spec, there can only be one property for a given element definition.
  * This function returns the value and the type.
- * @param context The base context (usually a FHIR resource).
- * @param path The property path.
+ * @param context - The base context (usually a FHIR resource).
+ * @param path - The property path.
  * @returns The value of the property and the property type.
  */
 export function getValueAndType(context: TypedValue, path: string): [any, string] {

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -94,7 +94,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
 
   /**
    * Handles a batch request response.
-   * @param batchResponse The batch response.
+   * @param batchResponse - The batch response.
    */
   const handleBatchResponse = useCallback(
     (batchResponse: PromiseSettledResult<Bundle>[]): void => {
@@ -125,7 +125,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
 
   /**
    * Adds an array of resources to the timeline.
-   * @param resource Resource to add.
+   * @param resource - Resource to add.
    */
   const addResource = useCallback(
     (resource: Resource): void => sortAndSetItems([...itemsRef.current, resource]),
@@ -151,7 +151,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
 
   /**
    * Adds a Communication resource to the timeline.
-   * @param contentString The comment content.
+   * @param contentString - The comment content.
    */
   function createComment(contentString: string): void {
     if (!resource || !props.createCommunication) {
@@ -166,7 +166,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
 
   /**
    * Adds a Media resource to the timeline.
-   * @param attachment The media attachment.
+   * @param attachment - The media attachment.
    */
   function createMedia(attachment: Attachment): void {
     if (!resource || !props.createMedia) {

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -144,7 +144,7 @@ const useStyles = createStyles((theme) => ({
  * The SearchControl component represents the embeddable search table control.
  * It includes the table, rows, headers, sorting, etc.
  * It does not include the field editor, filter editor, pagination buttons.
- * @param props The SearchControl React props.
+ * @param props - The SearchControl React props.
  * @returns The SearchControl React node.
  */
 export function SearchControl(props: SearchControlProps): JSX.Element {
@@ -246,7 +246,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
 
   /**
    * Emits a change event to the optional change listener.
-   * @param newSearch The new search definition.
+   * @param newSearch - The new search definition.
    */
   function emitSearchChange(newSearch: SearchRequest): void {
     if (props.onChange) {
@@ -256,8 +256,8 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
 
   /**
    * Handles a click on a order row.
-   * @param e The click event.
-   * @param resource The FHIR resource.
+   * @param e - The click event.
+   * @param resource - The FHIR resource.
    */
   function handleRowClick(e: React.MouseEvent, resource: Resource): void {
     if (isCheckboxCell(e.target as Element)) {

--- a/packages/react/src/SearchControl/SearchControlField.ts
+++ b/packages/react/src/SearchControl/SearchControlField.ts
@@ -43,7 +43,7 @@ export interface SearchControlField {
 
 /**
  * Returns the collection of field definitions for the search request.
- * @param search The search request definition.
+ * @param search - The search request definition.
  * @returns An array of field definitions.
  */
 export function getFieldDefinitions(search: SearchRequest): SearchControlField[] {
@@ -59,8 +59,8 @@ export function getFieldDefinitions(search: SearchRequest): SearchControlField[]
 /**
  * Return the field definition for a given field name.
  * Field names can be either property names or search parameter codes.
- * @param resourceType The resource type.
- * @param name The search field name (either property name or search parameter code).
+ * @param resourceType - The resource type.
+ * @param name - The search field name (either property name or search parameter code).
  * @returns The field definition.
  */
 function getFieldDefinition(resourceType: string, name: string): SearchControlField {

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -85,8 +85,8 @@ const operatorNames: Record<Operator, string> = {
 
 /**
  * Sets the array of filters.
- * @param definition The original search request.
- * @param filters The new filters.
+ * @param definition - The original search request.
+ * @param filters - The new filters.
  * @returns The updated search request.
  */
 export function setFilters(definition: SearchRequest, filters: Filter[]): SearchRequest {
@@ -100,7 +100,7 @@ export function setFilters(definition: SearchRequest, filters: Filter[]): Search
 
 /**
  * Clears all of the filters.
- * @param definition The original search request.
+ * @param definition - The original search request.
  * @returns The updated search request.
  */
 export function clearFilters(definition: SearchRequest): SearchRequest {
@@ -109,8 +109,8 @@ export function clearFilters(definition: SearchRequest): SearchRequest {
 
 /**
  * Clears all of the filters on a certain field.
- * @param definition The original search request.
- * @param code The field key name to clear filters.
+ * @param definition - The original search request.
+ * @param code - The field key name to clear filters.
  * @returns The updated search request.
  */
 export function clearFiltersOnField(definition: SearchRequest, code: string): SearchRequest {
@@ -122,11 +122,11 @@ export function clearFiltersOnField(definition: SearchRequest, code: string): Se
 
 /**
  * Adds a filter.
- * @param definition The original search request.
- * @param field The field key name.
- * @param op The operation key name.
- * @param value The filter value.
- * @param opt_clear Optional flag to clear filters on the field.
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @param op - The operation key name.
+ * @param value - The filter value.
+ * @param opt_clear - Optional flag to clear filters on the field.
  * @returns The updated search request.
  */
 export function addFilter(
@@ -151,8 +151,8 @@ export function addFilter(
 
 /**
  * Adds a field.
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addField(definition: SearchRequest, field: string): SearchRequest {
@@ -173,8 +173,8 @@ export function addField(definition: SearchRequest, field: string): SearchReques
 
 /**
  * Deletes a filter at the specified index.
- * @param definition The original search request.
- * @param index The filter index.
+ * @param definition - The original search request.
+ * @param index - The filter index.
  * @returns The updated search request.
  */
 export function deleteFilter(definition: SearchRequest, index: number): SearchRequest {
@@ -192,8 +192,8 @@ export function deleteFilter(definition: SearchRequest, index: number): SearchRe
 
 /**
  * Adds a filter that constrains the specified field to "yesterday".
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addYesterdayFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -202,8 +202,8 @@ export function addYesterdayFilter(definition: SearchRequest, field: string): Se
 
 /**
  * Adds a filter that constrains the specified field to "today".
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addTodayFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -212,8 +212,8 @@ export function addTodayFilter(definition: SearchRequest, field: string): Search
 
 /**
  * Adds a filter that constrains the specified field to "tomorrow".
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addTomorrowFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -226,9 +226,9 @@ export function addTomorrowFilter(definition: SearchRequest, field: string): Sea
  * "Today" would be 0.
  * "Yesterday" would be -1.
  * "Tomorrow" would be 1.
- * @param definition The original search request.
- * @param field The field key name.
- * @param delta The number of days from this day.
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @param delta - The number of days from this day.
  * @returns The updated search request.
  */
 function addDayFilter(definition: SearchRequest, field: string, delta: number): SearchRequest {
@@ -245,8 +245,8 @@ function addDayFilter(definition: SearchRequest, field: string, delta: number): 
 
 /**
  * Adds a filter that constrains the specified field to "last month".
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addLastMonthFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -255,8 +255,8 @@ export function addLastMonthFilter(definition: SearchRequest, field: string): Se
 
 /**
  * Adds a filter that constrains the specified field to "this month".
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addThisMonthFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -265,8 +265,8 @@ export function addThisMonthFilter(definition: SearchRequest, field: string): Se
 
 /**
  * Adds a filter that constrains the specified field to "next month".
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addNextMonthFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -279,9 +279,9 @@ export function addNextMonthFilter(definition: SearchRequest, field: string): Se
  * "This month" would be 0.
  * "Last month" would be -1.
  * "Next month" would be 1.
- * @param definition The original search request.
- * @param field The field key name.
- * @param delta The number of months from this month.
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @param delta - The number of months from this month.
  * @returns The updated search request.
  */
 function addMonthFilter(definition: SearchRequest, field: string, delta: number): SearchRequest {
@@ -301,8 +301,8 @@ function addMonthFilter(definition: SearchRequest, field: string, delta: number)
 
 /**
  * Adds a filter that constrains the specified field to the year to date.
- * @param definition The original search request.
- * @param field The field key name.
+ * @param definition - The original search request.
+ * @param field - The field key name.
  * @returns The updated search request.
  */
 export function addYearToDateFilter(definition: SearchRequest, field: string): SearchRequest {
@@ -318,10 +318,10 @@ export function addYearToDateFilter(definition: SearchRequest, field: string): S
 
 /**
  * Adds a filter for a date between two dates (inclusive of both dates).
- * @param definition The original search request.
- * @param field The field key name.
- * @param d1 The start date.
- * @param d2 The end date.
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @param d1 - The start date.
+ * @param d2 - The end date.
  * @returns The updated search request.
  */
 export function addDateFilterBetween(definition: SearchRequest, field: string, d1: Date, d2: Date): SearchRequest {
@@ -333,10 +333,10 @@ export function addDateFilterBetween(definition: SearchRequest, field: string, d
 
 /**
  * Adds a filter for a date before a certain date/time.
- * @param definition The original search request.
- * @param field The field key name.
- * @param op The date/time operation.
- * @param value The date.
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @param op - The date/time operation.
+ * @param value - The date.
  * @returns The updated search request.
  */
 function addDateFilterImpl(definition: SearchRequest, field: string, op: Operator, value: Date): SearchRequest {
@@ -345,9 +345,9 @@ function addDateFilterImpl(definition: SearchRequest, field: string, op: Operato
 
 /**
  * Adds a filter that constrains the specified field to "missing".
- * @param definition The original search request.
- * @param field The field key name.
- * @param value Optional boolean value. Default is true.
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @param value - Optional boolean value. Default is true.
  * @returns The updated search request.
  */
 export function addMissingFilter(definition: SearchRequest, field: string, value = true): SearchRequest {
@@ -356,8 +356,8 @@ export function addMissingFilter(definition: SearchRequest, field: string, value
 
 /**
  * Sets the offset (starting at zero).
- * @param definition The original search request.
- * @param offset The offset number.
+ * @param definition - The original search request.
+ * @param offset - The offset number.
  * @returns The updated search request.
  */
 export function setOffset(definition: SearchRequest, offset: number): SearchRequest {
@@ -373,8 +373,8 @@ export function setOffset(definition: SearchRequest, offset: number): SearchRequ
 
 /**
  * Creates a new search request with the search offset at the specified page.
- * @param definition The search definition.
- * @param page The new page number
+ * @param definition - The search definition.
+ * @param page - The new page number
  * @returns The new search definition.
  */
 export function setPage(definition: SearchRequest, page: number): SearchRequest {
@@ -386,9 +386,9 @@ export function setPage(definition: SearchRequest, page: number): SearchRequest 
 /**
  * Sorts the search by the specified key, and optional direction.
  * Direction defaults to ascending ('asc') if not specified.
- * @param definition The original search request.
- * @param sort The sort key.
- * @param desc Optional descending flag. Default is false.
+ * @param definition - The original search request.
+ * @param sort - The sort key.
+ * @param desc - Optional descending flag. Default is false.
  * @returns The updated search request.
  */
 export function setSort(definition: SearchRequest, sort: string, desc?: boolean): SearchRequest {
@@ -411,8 +411,8 @@ export function setSort(definition: SearchRequest, sort: string, desc?: boolean)
  * Toggles the sort of the search by key.
  * If the search is already sorted by the key, reverses the direction.
  * If the search is not sorted by the key, sort in ascending order.
- * @param definition The original search request.
- * @param key The field key name.
+ * @param definition - The original search request.
+ * @param key - The field key name.
  * @returns The updated search request.
  */
 export function toggleSort(definition: SearchRequest, key: string): SearchRequest {
@@ -442,7 +442,7 @@ export function isSortDescending(definition: SearchRequest): boolean {
 
 /**
  * Returns a list of operators for a search parameter.
- * @param searchParam The search parameter.
+ * @param searchParam - The search parameter.
  * @returns The list of operators that can be used for the search parameter.
  */
 export function getSearchOperators(searchParam: SearchParameter): Operator[] | undefined {
@@ -451,7 +451,7 @@ export function getSearchOperators(searchParam: SearchParameter): Operator[] | u
 
 /**
  * Returns a string representing the operation.
- * @param op The operation code.
+ * @param op - The operation code.
  * @returns A display string for the operation.
  */
 export function getOpString(op: Operator): string {
@@ -460,7 +460,7 @@ export function getOpString(op: Operator): string {
 
 /**
  * Returns a field display name.
- * @param key The field key.
+ * @param key - The field key.
  * @returns The field display name.
  */
 export function buildFieldNameString(key: string): string {
@@ -502,8 +502,8 @@ export function buildFieldNameString(key: string): string {
 
 /**
  * Returns a fragment to be displayed in the search table for the value.
- * @param resource The parent resource.
- * @param field The search code or FHIRPath expression.
+ * @param resource - The parent resource.
+ * @param field - The search code or FHIRPath expression.
  * @returns The fragment to display.
  */
 export function renderValue(resource: Resource, field: SearchControlField): string | JSX.Element | null | undefined {
@@ -536,8 +536,8 @@ export function renderValue(resource: Resource, field: SearchControlField): stri
 
 /**
  * Returns a fragment to be displayed in the search table for a resource property.
- * @param resource The parent resource.
- * @param elementDefinition The property element definition.
+ * @param resource - The parent resource.
+ * @param elementDefinition - The property element definition.
  * @returns A React element or null.
  */
 function renderPropertyValue(resource: Resource, elementDefinition: InternalSchemaElement): JSX.Element | null {
@@ -561,8 +561,8 @@ function renderPropertyValue(resource: Resource, elementDefinition: InternalSche
 
 /**
  * Returns a fragment to be displayed in the search table for a search parameter.
- * @param resource The parent resource.
- * @param searchParam The search parameter.
+ * @param resource - The parent resource.
+ * @param searchParam - The search parameter.
  * @returns A React element or null.
  */
 function renderSearchParameterValue(resource: Resource, searchParam: SearchParameter): JSX.Element | null {

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -26,7 +26,7 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
   /**
    * Handles a key down event on the "available" field.
    * If the user presses enter, it is a shortcut for the "Add" button.
-   * @param e The keyboard event.
+   * @param e - The keyboard event.
    */
   function handleAvailableKeyDown(e: React.KeyboardEvent): void {
     if (e.key === 'Enter') {
@@ -45,7 +45,7 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
   /**
    * Handles a key down event on the "available" field.
    * If the user presses enter, it is a shortcut for the "Add" button.
-   * @param e The keyboard event.
+   * @param e - The keyboard event.
    */
   function handleSelectedKeyDown(e: React.KeyboardEvent): void {
     if (e.key === 'Enter') {
@@ -142,9 +142,9 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
 
   /**
    * Swaps two fields in the search.
-   * @param fields The array of fields.
-   * @param i The index of the first field.
-   * @param j The index of the second field.
+   * @param fields - The array of fields.
+   * @param i - The index of the first field.
+   * @param j - The index of the second field.
    */
   function swapFields(fields: string[], i: number, j: number): void {
     const temp = fields[i];
@@ -251,8 +251,8 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
 /**
  * Returns a list of fields/columns available for a type.
  * The result is the union of properties and search parameters.
- * @param typeSchema The type definition.
- * @param searchParams The search parameters.
+ * @param typeSchema - The type definition.
+ * @param searchParams - The search parameters.
  * @returns A list of fields/columns available for a resource type.
  */
 function getFieldsList(

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -46,7 +46,7 @@ function createValue(input: string): ValueSetExpansionContains {
 /**
  * A low-level component to autocomplete based on a FHIR Valueset.
  * This is the base component for CodeableConceptInput, CodingInput, and CodeInput.
- * @param props The ValueSetAutocomplete React props.
+ * @param props - The ValueSetAutocomplete React props.
  * @returns The ValueSetAutocomplete React node.
  */
 export function ValueSetAutocomplete(props: ValueSetAutocompleteProps): JSX.Element {

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -31,7 +31,7 @@ export interface SignInFormProps extends BaseLoginRequest {
  * 3) Choose profile - If the user has multiple profiles, prompt to choose one
  * 4) Choose scope - If the user has multiple scopes, prompt to choose one
  * 5) Success - Return to the caller with either a code or a redirect
- * @param props The SignInForm React props.
+ * @param props - The SignInForm React props.
  * @returns The SignInForm React node.
  */
 export function SignInForm(props: SignInFormProps): JSX.Element {

--- a/packages/react/src/utils/blame.ts
+++ b/packages/react/src/utils/blame.ts
@@ -34,8 +34,8 @@ export function blame(history: Bundle): BlameRow[] {
 
 /**
  * For each version, update the blame table with revisions.
- * @param table The output blame table.
- * @param versions The array of versions.
+ * @param table - The output blame table.
+ * @param versions - The array of versions.
  */
 function compareVersions(table: BlameRow[], versions: { meta: Meta; lines: string[] }[]): void {
   for (let i = 1; i < versions.length; i++) {
@@ -68,7 +68,7 @@ function compareVersions(table: BlameRow[], versions: { meta: Meta; lines: strin
 
 /**
  * Combine adjacent rows into spans.
- * @param table The output blame table.
+ * @param table - The output blame table.
  */
 function combineSpans(table: BlameRow[]): void {
   let start = 0;

--- a/packages/react/src/utils/date.ts
+++ b/packages/react/src/utils/date.ts
@@ -2,8 +2,8 @@ import { Resource } from '@medplum/fhirtypes';
 
 /**
  * Sorts an array of resources in place by meta.lastUpdated ascending.
- * @param resources Array of resources.
- * @param timelineResource Optional primary resource of a timeline view. If specified, the primary resource will be sorted by meta.lastUpdated descending.
+ * @param resources - Array of resources.
+ * @param timelineResource - Optional primary resource of a timeline view. If specified, the primary resource will be sorted by meta.lastUpdated descending.
  */
 export function sortByDateAndPriority(resources: Resource[], timelineResource?: Resource): void {
   resources.sort((a: Resource, b: Resource): number => {

--- a/packages/react/src/utils/dom.ts
+++ b/packages/react/src/utils/dom.ts
@@ -2,7 +2,7 @@
  * Kills a browser event.
  * Prevents default behavior.
  * Stops event propagation.
- * @param e The event.
+ * @param e - The event.
  */
 export function killEvent(e: Event | React.SyntheticEvent): void {
   e.preventDefault();
@@ -12,7 +12,7 @@ export function killEvent(e: Event | React.SyntheticEvent): void {
 /**
  * Returns true if the element is a checkbox or a table cell containing a checkbox.
  * Table cells containing checkboxes are commonly accidentally clicked.
- * @param el The HTML DOM element.
+ * @param el - The HTML DOM element.
  * @returns True if the element is a checkbox or a table cell containing a checkbox.
  */
 export function isCheckboxCell(el: Element): boolean {

--- a/packages/react/src/utils/recaptcha.ts
+++ b/packages/react/src/utils/recaptcha.ts
@@ -3,7 +3,7 @@ import { createScriptTag } from './script';
 /**
  * Dynamically loads the recaptcha script.
  * We do not want to load the script on page load unless the user needs it.
- * @param siteKey The reCAPTCHA site key, available from the reCAPTCHA admin page.
+ * @param siteKey - The reCAPTCHA site key, available from the reCAPTCHA admin page.
  */
 export function initRecaptcha(siteKey: string): void {
   if (typeof grecaptcha === 'undefined') {
@@ -13,7 +13,7 @@ export function initRecaptcha(siteKey: string): void {
 
 /**
  * Starts a request to generate a recapcha token.
- * @param siteKey The reCAPTCHA site key, available from the reCAPTCHA admin page.
+ * @param siteKey - The reCAPTCHA site key, available from the reCAPTCHA admin page.
  * @returns Promise to a recaptcha token for the current user.
  */
 export function getRecaptcha(siteKey: string): Promise<string> {

--- a/packages/react/src/utils/script.ts
+++ b/packages/react/src/utils/script.ts
@@ -1,7 +1,7 @@
 /**
  * Dynamically creates a script tag for the specified JavaScript file.
- * @param src The JavaScript file URL.
- * @param onload Optional callback for the onload event.
+ * @param src - The JavaScript file URL.
+ * @param onload - Optional callback for the onload event.
  */
 export function createScriptTag(src: string, onload?: () => void): void {
   const head = document.getElementsByTagName('head')[0];

--- a/packages/react/tsdoc.json
+++ b/packages/react/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/packages/server/src/admin/utils.ts
+++ b/packages/server/src/admin/utils.ts
@@ -4,9 +4,9 @@ import { getAuthenticatedContext } from '../context';
 
 /**
  * Verifies that the current user is a project admin.
- * @param req The request.
- * @param res The response.
- * @param next The next handler function.
+ * @param req - The request.
+ * @param res - The response.
+ * @param next - The next handler function.
  */
 export async function verifyProjectAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
   const ctx = getAuthenticatedContext();

--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -12,8 +12,8 @@ import { getRedis } from '../redis';
 /**
  * Handles a new WebSocket connection to the agent service.
  * The agent service executes a bot and returns the result.
- * @param socket The WebSocket connection.
- * @param request The HTTP request.
+ * @param socket - The WebSocket connection.
+ * @param request - The HTTP request.
  */
 export async function handleAgentConnection(socket: ws.WebSocket, request: IncomingMessage): Promise<void> {
   const remoteAddress = request.socket.remoteAddress;
@@ -53,7 +53,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
    * Handles a connect command.
    * This command is sent by the agent to connect to the server.
    * The command includes the access token and bot ID.
-   * @param command The connect command.
+   * @param command - The connect command.
    */
   async function handleConnect(command: any): Promise<void> {
     if (!command.accessToken) {
@@ -87,7 +87,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
   /**
    * Handles a transit command.
    * This command is sent by the agent to transmit a message.
-   * @param command The transmit command.
+   * @param command - The transmit command.
    */
   async function handleTransmit(command: any): Promise<void> {
     if (!agentId) {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -41,9 +41,9 @@ let server: http.Server | undefined = undefined;
 
 /**
  * Sets standard headers for all requests.
- * @param _req The request.
- * @param res The response.
- * @param next The next handler.
+ * @param _req - The request.
+ * @param res - The response.
+ * @param next - The next handler.
  */
 function standardHeaders(_req: Request, res: Response, next: NextFunction): void {
   // Disables all caching
@@ -81,10 +81,10 @@ function standardHeaders(_req: Request, res: Response, next: NextFunction): void
 /**
  * Global error handler.
  * See: https://expressjs.com/en/guide/error-handling.html
- * @param err Unhandled error.
- * @param req The request.
- * @param res The response.
- * @param next The next handler.
+ * @param err - Unhandled error.
+ * @param req - The request.
+ * @param res - The response.
+ * @param next - The next handler.
  */
 function errorHandler(err: any, req: Request, res: Response, next: NextFunction): void {
   if (res.headersSent) {

--- a/packages/server/src/async.ts
+++ b/packages/server/src/async.ts
@@ -6,7 +6,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
  * This is almost the exact same as express-async-handler,
  * except that package is out of date and lacks TypeScript bindings.
  * https://www.npmjs.com/package/express-async-handler/v/1.1.4
- * @param callback The handler.
+ * @param callback - The handler.
  * @returns Async wrapped handler.
  */
 export function asyncWrap(callback: (req: Request, res: Response, next: NextFunction) => Promise<any>): RequestHandler {

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -434,8 +434,8 @@ describe('External', () => {
 
 /**
  * Returns fake tokens to mock the external identity provider.
- * @param email The user email address to include in the ID token.
- * @param sub The user subject to include as the sub claim.
+ * @param email - The user email address to include in the ID token.
+ * @param sub - The user subject to include as the sub claim.
  * @returns Fake tokens to mock the external identity provider.
  */
 function buildTokens(email: string, sub?: string): Record<string, string> {

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -115,7 +115,7 @@ export const externalCallbackHandler = async (req: Request, res: Response): Prom
 
 /**
  * Tries to find the identity provider configuration.
- * @param state The external auth state.
+ * @param state - The external auth state.
  * @returns External identity provider definition if found.
  */
 async function getIdentityProvider(
@@ -140,8 +140,8 @@ async function getIdentityProvider(
 
 /**
  * Returns ID token claims for the authorization code.
- * @param idp The identity provider configuration.
- * @param code The authorization code.
+ * @param idp - The identity provider configuration.
+ * @param code - The authorization code.
  * @returns ID token claims.
  */
 async function verifyCode(idp: IdentityProvider, code: string): Promise<Record<string, unknown>> {

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -36,8 +36,8 @@ export const googleValidators = [
 /**
  * Google authentication request handler.
  * This handles POST requests to /auth/google.
- * @param req The request.
- * @param res The response.
+ * @param req - The request.
+ * @param res - The response.
  */
 export async function googleHandler(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);

--- a/packages/server/src/auth/method.ts
+++ b/packages/server/src/auth/method.ts
@@ -37,7 +37,7 @@ export async function methodHandler(req: Request, res: Response): Promise<void> 
 
 /**
  * Checks if the given email address is configured for external authentication.
- * @param email The user email address.
+ * @param email - The user email address.
  * @returns External auth url if available. Otherwise undefined.
  */
 export async function isExternalAuth(email: string): Promise<{ domain: string; authorizeUrl: string } | undefined> {
@@ -62,7 +62,7 @@ export async function isExternalAuth(email: string): Promise<{ domain: string; a
 
 /**
  * Returns the domain configuration for the given domain name.
- * @param domain The domain name.
+ * @param domain - The domain name.
  * @returns The domain configuration for the domain name if available.
  */
 export async function getDomainConfiguration(domain: string): Promise<DomainConfiguration | undefined> {

--- a/packages/server/src/auth/newpatient.ts
+++ b/packages/server/src/auth/newpatient.ts
@@ -15,8 +15,8 @@ export const newPatientValidators = [
 /**
  * Handles a HTTP request to /auth/newpatient.
  * Requires a partial login.
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function newPatientHandler(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);
@@ -54,10 +54,10 @@ export async function newPatientHandler(req: Request, res: Response): Promise<vo
 
 /**
  * Creates a new patient.
- * @param login The partial login.
- * @param projectId The project ID.
- * @param firstName The patient's first name.
- * @param lastName The patient's last name.
+ * @param login - The partial login.
+ * @param projectId - The project ID.
+ * @param firstName - The patient's first name.
+ * @param lastName - The patient's last name.
  * @returns The new project membership.
  */
 export async function createPatient(

--- a/packages/server/src/auth/newproject.ts
+++ b/packages/server/src/auth/newproject.ts
@@ -23,8 +23,8 @@ export const newProjectValidators = [
  * Handles a HTTP request to /auth/newproject.
  * Requires a partial login.
  * Creates a Project, Profile, ProjectMembership, and default ClientApplication.
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function newProjectHandler(req: Request, res: Response): Promise<void> {
   const errors = validationResult(req);
@@ -56,10 +56,10 @@ export async function newProjectHandler(req: Request, res: Response): Promise<vo
 
 /**
  * Creates a new project.
- * @param login The partial login.
- * @param projectName The new project name.
- * @param firstName The practitioner's first name.
- * @param lastName The practitioner's last name.
+ * @param login - The partial login.
+ * @param projectName - The new project name.
+ * @param firstName - The practitioner's first name.
+ * @param lastName - The practitioner's last name.
  * @returns The new project membership.
  */
 export async function createProject(

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -20,8 +20,8 @@ export const newUserValidators = [
 
 /**
  * Handles a HTTP request to /auth/newuser.
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function newUserHandler(req: Request, res: Response): Promise<void> {
   const config = getConfig();

--- a/packages/server/src/auth/register.ts
+++ b/packages/server/src/auth/register.ts
@@ -34,7 +34,7 @@ export interface RegisterResponse {
 
 /**
  * Registers a new user and/or new project.
- * @param request The register request.
+ * @param request - The register request.
  * @returns The registration response.
  */
 export async function registerNew(request: RegisterRequest): Promise<RegisterResponse> {

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -102,8 +102,8 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
 /**
  * Creates a "password change request" for the user.
  * Returns the URL to the password change request.
- * @param user The user to create the password change request for.
- * @param type The type of password change request.
+ * @param user - The user to create the password change request for.
+ * @param type - The type of password change request.
  * @returns The URL to reset the password.
  */
 export async function resetPassword(user: User, type: 'invite' | 'reset'): Promise<string> {

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -69,8 +69,8 @@ export async function createProjectMembership(
  * Sends a login response to the client.
  * If the user has multiple profiles, sends the list of profiles to choose from.
  * Otherwise, sends the authorization code.
- * @param res The response object.
- * @param login The login details.
+ * @param res - The response object.
+ * @param login - The login details.
  */
 export async function sendLoginResult(res: Response, login: Login): Promise<void> {
   const user = await systemRepo.readReference<User>(login.user as Reference<User>);
@@ -114,8 +114,8 @@ export async function sendLoginResult(res: Response, login: Login): Promise<void
 
 /**
  * Adds a login cookie to the response if this is a OAuth2 client login.
- * @param res The response object.
- * @param login The login details.
+ * @param res - The response object.
+ * @param login - The login details.
  */
 export function sendLoginCookie(res: Response, login: Login): void {
   if (login.client) {
@@ -131,8 +131,8 @@ export function sendLoginCookie(res: Response, login: Login): void {
 
 /**
  * Verifies the recaptcha response from the client.
- * @param secretKey The Recaptcha secret key to use for verification.
- * @param recaptchaToken The Recaptcha response from the client.
+ * @param secretKey - The Recaptcha secret key to use for verification.
+ * @param recaptchaToken - The Recaptcha response from the client.
  * @returns True on success, false on failure.
  */
 export async function verifyRecaptcha(secretKey: string, recaptchaToken: string): Promise<boolean> {
@@ -150,8 +150,8 @@ export async function verifyRecaptcha(secretKey: string, recaptchaToken: string)
 
 /**
  * Returns project ID if clientId is provided.
- * @param clientId clientId from the client
- * @param projectId projectId from the client
+ * @param clientId - clientId from the client
+ * @param projectId - projectId from the client
  * @returns The Project ID
  * @throws OperationOutcomeError
  */
@@ -174,8 +174,8 @@ export async function getProjectIdByClientId(
 
 /**
  * Returns a project by recaptcha site key.
- * @param recaptchaSiteKey reCAPTCHA site key from the client.
- * @param projectId Optional project ID from the client.
+ * @param recaptchaSiteKey - reCAPTCHA site key from the client.
+ * @param projectId - Optional project ID from the client.
  * @returns Project if found, otherwise undefined.
  */
 export function getProjectByRecaptchaSiteKey(
@@ -203,7 +203,7 @@ export function getProjectByRecaptchaSiteKey(
 
 /**
  * Returns the bcrypt hash of the password.
- * @param password The input password.
+ * @param password - The input password.
  * @returns The bcrypt hash of the password.
  */
 export function bcryptHashPassword(password: string): Promise<string> {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -96,7 +96,7 @@ export function getConfig(): MedplumServerConfig {
  * The identifier must start with one of the following prefixes:
  *   1) "file:" string followed by relative path.
  *   2) "aws:" followed by AWS SSM path prefix.
- * @param configName The medplum config identifier.
+ * @param configName - The medplum config identifier.
  * @returns The loaded configuration.
  */
 export async function loadConfig(configName: string): Promise<MedplumServerConfig> {
@@ -175,7 +175,7 @@ function loadEnvConfig(): MedplumServerConfig {
 /**
  * Loads configuration settings from a JSON file.
  * Path relative to the current working directory at runtime.
- * @param path The config file path.
+ * @param path - The config file path.
  * @returns The configuration.
  */
 async function loadFileConfig(path: string): Promise<MedplumServerConfig> {
@@ -184,7 +184,7 @@ async function loadFileConfig(path: string): Promise<MedplumServerConfig> {
 
 /**
  * Loads configuration settings from AWS SSM Parameter Store.
- * @param path The AWS SSM Parameter Store path prefix.
+ * @param path - The AWS SSM Parameter Store path prefix.
  * @returns The loaded configuration.
  */
 async function loadAwsConfig(path: string): Promise<MedplumServerConfig> {
@@ -230,8 +230,8 @@ async function loadAwsConfig(path: string): Promise<MedplumServerConfig> {
 
 /**
  * Returns the AWS Database Secret data as a JSON map.
- * @param region The AWS region.
- * @param secretId Secret ARN
+ * @param region - The AWS region.
+ * @param secretId - Secret ARN
  * @returns The secret data as a JSON map.
  */
 async function loadAwsSecrets(region: string, secretId: string): Promise<Record<string, any> | undefined> {
@@ -247,7 +247,7 @@ async function loadAwsSecrets(region: string, secretId: string): Promise<Record<
 
 /**
  * Adds default values to the config.
- * @param config The input config as loaded from the config file.
+ * @param config - The input config as loaded from the config file.
  * @returns The config with default values added.
  */
 function addDefaults(config: MedplumServerConfig): MedplumServerConfig {

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -6,8 +6,8 @@ const exposedHeaders = ['Content-Location', 'ETag', 'Last-Modified', 'Location']
 
 /**
  * CORS configuration.
- * @param req The express request.
- * @param callback The cors plugin callback.
+ * @param req - The express request.
+ * @param callback - The cors plugin callback.
  */
 export const corsOptions: cors.CorsOptionsDelegate<Request> = (req, callback) => {
   const origin = req.header('Origin');

--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -13,8 +13,8 @@ import { globalLogger } from '../logger';
  * Sends an email using the AWS SES service.
  * Builds the email using nodemailer MailComposer.
  * See options here: https://nodemailer.com/extras/mailcomposer/
- * @param repo The user repository.
- * @param options The MailComposer options.
+ * @param repo - The user repository.
+ * @param options - The MailComposer options.
  */
 export async function sendEmail(repo: Repository, options: Mail.Options): Promise<void> {
   const config = getConfig();
@@ -44,7 +44,7 @@ export async function sendEmail(repo: Repository, options: Mail.Options): Promis
 
 /**
  * Converts nodemailer addresses to an array of strings.
- * @param input nodemailer address input.
+ * @param input - nodemailer address input.
  * @returns Array of string addresses.
  */
 function buildAddresses(input: string | Address | (string | Address)[] | undefined): string[] | undefined {
@@ -59,7 +59,7 @@ function buildAddresses(input: string | Address | (string | Address)[] | undefin
 
 /**
  * Converts a nodemailer address to a string.
- * @param address nodemailer address input.
+ * @param address - nodemailer address input.
  * @returns String address.
  */
 function addressToString(address: Address | string | undefined): string | undefined {
@@ -76,7 +76,7 @@ function addressToString(address: Address | string | undefined): string | undefi
 
 /**
  * Builds a raw email message using nodemailer MailComposer.
- * @param options The nodemailer options.
+ * @param options - The nodemailer options.
  * @returns The raw email message.
  */
 function buildRawMessage(options: Mail.Options): Promise<Uint8Array> {
@@ -94,8 +94,8 @@ function buildRawMessage(options: Mail.Options): Promise<Uint8Array> {
 
 /**
  * Validates an array of nodemailer attachments.
- * @param repo The user repository.
- * @param attachments Optional array of nodemailer attachments.
+ * @param repo - The user repository.
+ * @param attachments - Optional array of nodemailer attachments.
  */
 async function processAttachments(repo: Repository, attachments: Mail.Attachment[] | undefined): Promise<void> {
   if (attachments) {
@@ -107,8 +107,8 @@ async function processAttachments(repo: Repository, attachments: Mail.Attachment
 
 /**
  * Validates a nodemailer attachment.
- * @param repo The user repository.
- * @param attachment The nodemailer attachment.
+ * @param repo - The user repository.
+ * @param attachment - The nodemailer attachment.
  */
 async function processAttachment(repo: Repository, attachment: Mail.Attachment): Promise<void> {
   // MailComposer/nodemailer has many different ways to specify attachments.
@@ -137,8 +137,8 @@ async function processAttachment(repo: Repository, attachment: Mail.Attachment):
 
 /**
  * Sends an email via SMTP.
- * @param smtpConfig The SMTP configuration.
- * @param options The nodemailer options.
+ * @param smtpConfig - The SMTP configuration.
+ * @param options - The nodemailer options.
  */
 async function sendEmailViaSmpt(smtpConfig: MedplumSmtpConfig, options: Mail.Options): Promise<void> {
   const transport = createTransport({
@@ -154,7 +154,7 @@ async function sendEmailViaSmpt(smtpConfig: MedplumSmtpConfig, options: Mail.Opt
 
 /**
  * Sends an email via AWS SES.
- * @param options The nodemailer options.
+ * @param options - The nodemailer options.
  */
 async function sendEmailViaSes(options: Mail.Options): Promise<void> {
   const config = getConfig();

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -16,11 +16,11 @@ import { applySmartScopes } from './smart';
  * Individual instances of the Repository class manage access rights to resources.
  * Login instances contain details about user compartments.
  * This method ensures that the repository is setup correctly.
- * @param login The user login.
- * @param membership The active project membership.
- * @param strictMode Optional flag to enable strict mode for in-depth FHIR schema validation.
- * @param extendedMode Optional flag to enable extended mode for custom Medplum properties.
- * @param checkReferencesOnWrite Optional flag to enable reference checking on write.
+ * @param login - The user login.
+ * @param membership - The active project membership.
+ * @param strictMode - Optional flag to enable strict mode for in-depth FHIR schema validation.
+ * @param extendedMode - Optional flag to enable extended mode for custom Medplum properties.
+ * @param checkReferencesOnWrite - Optional flag to enable reference checking on write.
  * @returns A repository configured for the login details.
  */
 export async function getRepoForLogin(
@@ -47,8 +47,8 @@ export async function getRepoForLogin(
 
 /**
  * Returns the access policy for the login.
- * @param login The user login.
- * @param membership The user membership.
+ * @param login - The user login.
+ * @param membership - The user membership.
  * @returns The finalized access policy.
  */
 export async function getAccessPolicyForLogin(
@@ -77,7 +77,7 @@ export async function getAccessPolicyForLogin(
 
 /**
  * Builds a parameterized compound access policy.
- * @param membership The user project membership.
+ * @param membership - The user project membership.
  * @returns The parameterized compound access policy.
  */
 async function buildAccessPolicy(membership: ProjectMembership): Promise<AccessPolicy> {
@@ -118,8 +118,8 @@ async function buildAccessPolicy(membership: ProjectMembership): Promise<AccessP
 
 /**
  * Reads an access policy and replaces all variables.
- * @param access The access policy and parameters.
- * @param profile The user profile.
+ * @param access - The access policy and parameters.
+ * @param profile - The user profile.
  * @returns The AccessPolicy with variables resolved.
  */
 async function buildAccessPolicyResources(
@@ -147,9 +147,9 @@ async function buildAccessPolicyResources(
 /**
  * Updates the access policy to include project admin rules.
  * This includes ensuring no admin rights for non-admins and restricted access for admins.
- * @param login The user login.
- * @param membership The active project membership.
- * @param accessPolicy The existing access policy.
+ * @param login - The user login.
+ * @param membership - The active project membership.
+ * @param accessPolicy - The existing access policy.
  * @returns Updated access policy with all project admin rules applied.
  */
 function applyProjectAdminAccessPolicy(

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -96,7 +96,7 @@ binaryRouter.get(
  *
  * Unfortunately body-parser will always write the content to a temporary file on local disk.
  * That is not acceptable for multi gigabyte files, which could easily fill up the disk.
- * @param req The HTTP request.
+ * @param req - The HTTP request.
  * @returns The content stream.
  */
 function getContentStream(req: Request): internal.Readable | undefined {

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -56,7 +56,7 @@ export class AddressTable extends LookupTable<Address> {
    *   address-postalcode | postalCode
    *   address-state      | state
    *   addrses-use        | use
-   * @param code The search parameter code.
+   * @param code - The search parameter code.
    * @returns The column name.
    */
   getColumnName(code: string): string {
@@ -71,7 +71,7 @@ export class AddressTable extends LookupTable<Address> {
 
   /**
    * Returns true if the search parameter is an Address parameter.
-   * @param searchParam The search parameter.
+   * @param searchParam - The search parameter.
    * @returns True if the search parameter is an Address parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
@@ -81,8 +81,8 @@ export class AddressTable extends LookupTable<Address> {
   /**
    * Indexes a resource Address values.
    * Attempts to reuse existing Addresses if they are correct.
-   * @param client The database client.
-   * @param resource The resource to index.
+   * @param client - The database client.
+   * @param resource - The resource to index.
    * @returns Promise on completion.
    */
   async indexResource(client: PoolClient, resource: Resource): Promise<void> {

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -29,7 +29,7 @@ export class HumanNameTable extends LookupTable<HumanName> {
 
   /**
    * Returns the column name for the given search parameter.
-   * @param code The search parameter code.
+   * @param code - The search parameter code.
    * @returns The column name.
    */
   getColumnName(code: string): string {
@@ -38,7 +38,7 @@ export class HumanNameTable extends LookupTable<HumanName> {
 
   /**
    * Returns true if the search parameter is an HumanName parameter.
-   * @param searchParam The search parameter.
+   * @param searchParam - The search parameter.
    * @returns True if the search parameter is an HumanName parameter.
    */
   isIndexed(searchParam: SearchParameter): boolean {
@@ -48,8 +48,8 @@ export class HumanNameTable extends LookupTable<HumanName> {
   /**
    * Indexes a resource HumanName values.
    * Attempts to reuse existing identifiers if they are correct.
-   * @param client The database client.
-   * @param resource The resource to index.
+   * @param client - The database client.
+   * @param resource - The resource to index.
    * @returns Promise on completion.
    */
   async indexResource(client: PoolClient, resource: Resource): Promise<void> {
@@ -111,7 +111,7 @@ export class HumanNameTable extends LookupTable<HumanName> {
  *    presentation and use the parts for index/search functionality. For this reason,
  *    applications SHOULD populate the text element for future robustness."
  *
- * @param name The input human name.
+ * @param name - The input human name.
  * @returns A string representation of the human name.
  */
 export function getNameString(name: HumanName): string {

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -25,37 +25,37 @@ import {
 export abstract class LookupTable<T> {
   /**
    * Returns the unique name of the lookup table.
-   * @param resourceType The resource type.
+   * @param resourceType - The resource type.
    * @returns The unique name of the lookup table.
    */
   protected abstract getTableName(resourceType: ResourceType): string;
 
   /**
    * Returns the column name for the given search parameter.
-   * @param code The search parameter code.
+   * @param code - The search parameter code.
    */
   protected abstract getColumnName(code: string): string;
 
   /**
    * Determines if the search parameter is indexed by this index table.
-   * @param searchParam The search parameter.
-   * @param resourceType The resource type.
+   * @param searchParam - The search parameter.
+   * @param resourceType - The resource type.
    * @returns True if the search parameter is indexed.
    */
   abstract isIndexed(searchParam: SearchParameter, resourceType: string): boolean;
 
   /**
    * Indexes the resource in the lookup table.
-   * @param client The database client.
-   * @param resource The resource to index.
+   * @param client - The database client.
+   * @param resource - The resource to index.
    */
   abstract indexResource(client: PoolClient, resource: Resource): Promise<void>;
 
   /**
    * Builds a "where" condition for the select query builder.
-   * @param selectQuery The select query builder.
-   * @param resourceType The FHIR resource type.
-   * @param filter The search filter details.
+   * @param selectQuery - The select query builder.
+   * @param resourceType - The FHIR resource type.
+   * @param filter - The search filter details.
    * @returns The select query where expression.
    */
   buildWhere(selectQuery: SelectQuery, resourceType: ResourceType, filter: Filter): Expression {
@@ -101,9 +101,9 @@ export abstract class LookupTable<T> {
 
   /**
    * Adds "order by" clause to the select query builder.
-   * @param selectQuery The select query builder.
-   * @param resourceType The FHIR resource type.
-   * @param sortRule The sort rule details.
+   * @param selectQuery - The select query builder.
+   * @param resourceType - The FHIR resource type.
+   * @param sortRule - The sort rule details.
    */
   addOrderBy(selectQuery: SelectQuery, resourceType: ResourceType, sortRule: SortRule): void {
     const tableName = this.getTableName(resourceType);
@@ -120,9 +120,9 @@ export abstract class LookupTable<T> {
 
   /**
    * Returns the existing list of indexed addresses.
-   * @param client The database client.
-   * @param resourceType The FHIR resource type.
-   * @param resourceId The FHIR resource ID.
+   * @param client - The database client.
+   * @param resourceType - The FHIR resource type.
+   * @param resourceId - The FHIR resource ID.
    * @returns Promise for the list of indexed addresses.
    */
   protected async getExistingValues(
@@ -141,9 +141,9 @@ export abstract class LookupTable<T> {
 
   /**
    * Inserts values into the lookup table for a resource.
-   * @param client The database client.
-   * @param resourceType The resource type.
-   * @param values The values to insert.
+   * @param client - The database client.
+   * @param resourceType - The resource type.
+   * @param values - The values to insert.
    */
   protected async insertValuesForResource(
     client: Pool | PoolClient,
@@ -159,8 +159,8 @@ export abstract class LookupTable<T> {
 
   /**
    * Deletes the resource from the lookup table.
-   * @param client The database client.
-   * @param resource The resource to delete.
+   * @param client - The database client.
+   * @param resource - The resource to delete.
    */
   async deleteValuesForResource(client: Pool | PoolClient, resource: Resource): Promise<void> {
     const tableName = this.getTableName(resource.resourceType);

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -38,7 +38,7 @@ interface Token {
 export class TokenTable extends LookupTable<Token> {
   /**
    * Returns the table name.
-   * @param resourceType The resource type.
+   * @param resourceType - The resource type.
    * @returns The table name.
    */
   getTableName(resourceType: ResourceType): string {
@@ -55,8 +55,8 @@ export class TokenTable extends LookupTable<Token> {
 
   /**
    * Returns true if the search parameter is an "token" parameter.
-   * @param searchParam The search parameter.
-   * @param resourceType The resource type.
+   * @param searchParam - The search parameter.
+   * @param resourceType - The resource type.
    * @returns True if the search parameter is an "token" parameter.
    */
   isIndexed(searchParam: SearchParameter, resourceType: string): boolean {
@@ -66,8 +66,8 @@ export class TokenTable extends LookupTable<Token> {
   /**
    * Indexes a resource token values.
    * Attempts to reuse existing tokens if they are correct.
-   * @param client The database client.
-   * @param resource The resource to index.
+   * @param client - The database client.
+   * @param resource - The resource to index.
    * @returns Promise on completion.
    */
   async indexResource(client: PoolClient, resource: Resource): Promise<void> {
@@ -100,9 +100,9 @@ export class TokenTable extends LookupTable<Token> {
 
   /**
    * Builds a "where" condition for the select query builder.
-   * @param selectQuery The select query builder.
-   * @param resourceType The resource type.
-   * @param filter The search filter details.
+   * @param selectQuery - The select query builder.
+   * @param resourceType - The resource type.
+   * @param filter - The search filter details.
    * @returns The select query where expression.
    */
   buildWhere(selectQuery: SelectQuery, resourceType: ResourceType, filter: Filter): Expression {
@@ -126,9 +126,9 @@ export class TokenTable extends LookupTable<Token> {
 
   /**
    * Adds "order by" clause to the select query builder.
-   * @param selectQuery The select query builder.
-   * @param resourceType The resource type.
-   * @param sortRule The sort rule details.
+   * @param selectQuery - The select query builder.
+   * @param resourceType - The resource type.
+   * @param sortRule - The sort rule details.
    */
   addOrderBy(selectQuery: SelectQuery, resourceType: ResourceType, sortRule: SortRule): void {
     const tableName = getTableName(resourceType);
@@ -145,8 +145,8 @@ export class TokenTable extends LookupTable<Token> {
 
 /**
  * Returns true if the search parameter is an "token" parameter.
- * @param searchParam The search parameter.
- * @param resourceType The resource type.
+ * @param searchParam - The search parameter.
+ * @param resourceType - The resource type.
  * @returns True if the search parameter is an "token" parameter.
  */
 function isIndexed(searchParam: SearchParameter, resourceType: string): boolean {
@@ -184,7 +184,7 @@ function isIndexed(searchParam: SearchParameter, resourceType: string): boolean 
 
 /**
  * Returns the token table name for the resource type.
- * @param resourceType The FHIR resource type.
+ * @param resourceType - The FHIR resource type.
  * @returns The database table name for the resource type tokens.
  */
 function getTableName(resourceType: ResourceType): string {
@@ -194,7 +194,7 @@ function getTableName(resourceType: ResourceType): string {
 /**
  * Returns a list of all tokens in the resource to be inserted into the database.
  * This includes all values for any SearchParameter using the TokenTable.
- * @param resource The resource being indexed.
+ * @param resource - The resource being indexed.
  * @returns An array of all tokens from the resource to be inserted into the database.
  */
 function getTokens(resource: Resource): Token[] {
@@ -216,9 +216,9 @@ function getTokens(resource: Resource): Token[] {
 
 /**
  * Builds a list of zero or more tokens for a search parameter and resource.
- * @param result The result array where tokens will be added.
- * @param typedResource The typed resource.
- * @param searchParam The search parameter.
+ * @param result - The result array where tokens will be added.
+ * @param typedResource - The typed resource.
+ * @param searchParam - The search parameter.
  */
 function buildTokensForSearchParameter(
   result: Token[],
@@ -233,9 +233,9 @@ function buildTokensForSearchParameter(
 
 /**
  * Builds a list of zero or more tokens for a search parameter and value.
- * @param result The result array where tokens will be added.
- * @param searchParam The search parameter.
- * @param typedValue A typed value to be indexed for the search parameter.
+ * @param result - The result array where tokens will be added.
+ * @param searchParam - The search parameter.
+ * @param typedValue - A typed value to be indexed for the search parameter.
  */
 function buildTokens(result: Token[], searchParam: SearchParameter, typedValue: TypedValue): void {
   const { type, value } = typedValue;
@@ -259,9 +259,9 @@ function buildTokens(result: Token[], searchParam: SearchParameter, typedValue: 
 
 /**
  * Builds an identifier token.
- * @param result The result array where tokens will be added.
- * @param searchParam The search parameter.
- * @param identifier The Identifier object to be indexed.
+ * @param result - The result array where tokens will be added.
+ * @param searchParam - The search parameter.
+ * @param identifier - The Identifier object to be indexed.
  */
 function buildIdentifierToken(result: Token[], searchParam: SearchParameter, identifier: Identifier | undefined): void {
   buildSimpleToken(result, searchParam, identifier?.system, identifier?.value);
@@ -269,9 +269,9 @@ function buildIdentifierToken(result: Token[], searchParam: SearchParameter, ide
 
 /**
  * Builds zero or more CodeableConcept tokens.
- * @param result The result array where tokens will be added.
- * @param searchParam The search parameter.
- * @param codeableConcept The CodeableConcept object to be indexed.
+ * @param result - The result array where tokens will be added.
+ * @param searchParam - The search parameter.
+ * @param codeableConcept - The CodeableConcept object to be indexed.
  */
 function buildCodeableConceptToken(
   result: Token[],
@@ -290,9 +290,9 @@ function buildCodeableConceptToken(
 
 /**
  * Builds a Coding token.
- * @param result The result array where tokens will be added.
- * @param searchParam The search parameter.
- * @param coding The Coding object to be indexed.
+ * @param result - The result array where tokens will be added.
+ * @param searchParam - The search parameter.
+ * @param coding - The Coding object to be indexed.
  */
 function buildCodingToken(result: Token[], searchParam: SearchParameter, coding: Coding | undefined): void {
   if (coding) {
@@ -305,9 +305,9 @@ function buildCodingToken(result: Token[], searchParam: SearchParameter, coding:
 
 /**
  * Builds a ContactPoint token.
- * @param result The result array where tokens will be added.
- * @param searchParam The search parameter.
- * @param contactPoint The ContactPoint object to be indexed.
+ * @param result - The result array where tokens will be added.
+ * @param searchParam - The search parameter.
+ * @param contactPoint - The ContactPoint object to be indexed.
  */
 function buildContactPointToken(
   result: Token[],
@@ -319,10 +319,10 @@ function buildContactPointToken(
 
 /**
  * Builds a simple token.
- * @param result The result array where tokens will be added.
- * @param searchParam The search parameter.
- * @param system The token system.
- * @param value The token value.
+ * @param result - The result array where tokens will be added.
+ * @param searchParam - The search parameter.
+ * @param system - The token system.
+ * @param value - The token value.
  */
 function buildSimpleToken(
   result: Token[],
@@ -345,9 +345,9 @@ function buildSimpleToken(
 
 /**
  * Returns the existing list of indexed tokens.
- * @param client The current database client.
- * @param resourceType The FHIR resource type.
- * @param resourceId The FHIR resource ID.
+ * @param client - The current database client.
+ * @param resourceType - The FHIR resource type.
+ * @param resourceId - The FHIR resource ID.
  * @returns Promise for the list of indexed tokens  .
  */
 async function getExistingValues(client: PoolClient, resourceType: ResourceType, resourceId: string): Promise<Token[]> {
@@ -407,8 +407,8 @@ function buildValueCondition(tableName: string, operator: FhirOperator, value: s
 
 /**
  * Buildes "where" condition for token ":in" operator.
- * @param tableName The token table name / join alias.
- * @param value The value of the ":in" operator.
+ * @param tableName - The token table name / join alias.
+ * @param value - The value of the ":in" operator.
  * @returns The "where" condition.
  */
 function buildInValueSetCondition(tableName: string, value: string): Condition {

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -3,8 +3,8 @@ import { SearchParameter } from '@medplum/fhirtypes';
 
 /**
  * Compares two arrays of objects.
- * @param incoming The incoming array of elements.
- * @param existing The existing array of elements.
+ * @param incoming - The incoming array of elements.
+ * @param existing - The existing array of elements.
  * @returns True if the arrays are equal.  False if they are different.
  */
 export function compareArrays(incoming: any[], existing: any[]): boolean {
@@ -31,7 +31,7 @@ export function compareArrays(incoming: any[], existing: any[]): boolean {
  * However, the FHIR specification does not define an "identifier" search parameter for every resource type.
  *
  * This function derives an "identifier" search parameter from a reference search parameter.
- * @param inputParam The original reference search parameter.
+ * @param inputParam - The original reference search parameter.
  * @returns The derived "identifier" search parameter.
  */
 export function deriveIdentifierSearchParameter(inputParam: SearchParameter): SearchParameter {

--- a/packages/server/src/fhir/lookups/valuesetelement.ts
+++ b/packages/server/src/fhir/lookups/valuesetelement.ts
@@ -92,9 +92,9 @@ export class ValueSetElementTable extends LookupTable<ValueSetExpansionContains>
   /**
    * Recursively adds CodeSystem concepts.
    * See: https://www.hl7.org/fhir/codesystem-definitions.html#CodeSystem.concept
-   * @param codeSystem The CodeSystem.
-   * @param concept The CodeSystem concept.
-   * @param result The output value set concept array.
+   * @param codeSystem - The CodeSystem.
+   * @param concept - The CodeSystem concept.
+   * @param result - The output value set concept array.
    */
   private buildCodeSystemElements(
     codeSystem: CodeSystem,

--- a/packages/server/src/fhir/operations/agentpush.ts
+++ b/packages/server/src/fhir/operations/agentpush.ts
@@ -66,8 +66,8 @@ export const agentPushHandler = asyncWrap(async (req: Request, res: Response) =>
  * If using "/Agent/:id/$execute", then the agent ID is read from the path parameter.
  * If using "/Agent/$execute?identifier=...", then the agent is searched by identifier.
  * Otherwise, returns undefined.
- * @param req The HTTP request.
- * @param repo The repository.
+ * @param req - The HTTP request.
+ * @param repo - The repository.
  * @returns The agent, or undefined if not found.
  */
 async function getAgentForRequest(req: Request, repo: Repository): Promise<Agent | undefined> {

--- a/packages/server/src/fhir/operations/csv.ts
+++ b/packages/server/src/fhir/operations/csv.ts
@@ -23,8 +23,8 @@ import { sendOutcome } from '../outcomes';
 
 /**
  * Handles a CSV export request.
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function csvHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -187,8 +187,8 @@ async function createZipFile(code: string): Promise<Uint8Array> {
 
 /**
  * Returns true if the AWS Lambda exists for the bot name.
- * @param client The AWS Lambda client.
- * @param name The bot name.
+ * @param client - The AWS Lambda client.
+ * @param name - The bot name.
  * @returns True if the bot exists.
  */
 async function lambdaExists(client: LambdaClient, name: string): Promise<boolean> {
@@ -203,9 +203,9 @@ async function lambdaExists(client: LambdaClient, name: string): Promise<boolean
 
 /**
  * Creates a new AWS Lambda for the bot name.
- * @param client The AWS Lambda client.
- * @param name The bot name.
- * @param zipFile The zip file with the bot code.
+ * @param client - The AWS Lambda client.
+ * @param name - The bot name.
+ * @param zipFile - The zip file with the bot code.
  */
 async function createLambda(client: LambdaClient, name: string, zipFile: Uint8Array): Promise<void> {
   const layerVersion = await getLayerVersion(client);
@@ -230,9 +230,9 @@ async function createLambda(client: LambdaClient, name: string, zipFile: Uint8Ar
 
 /**
  * Updates an existing AWS Lambda for the bot name.
- * @param client The AWS Lambda client.
- * @param name The bot name.
- * @param zipFile The zip file with the bot code.
+ * @param client - The AWS Lambda client.
+ * @param name - The bot name.
+ * @param zipFile - The zip file with the bot code.
  */
 async function updateLambda(client: LambdaClient, name: string, zipFile: Uint8Array): Promise<void> {
   // First, make sure the lambda configuration is up to date
@@ -250,8 +250,8 @@ async function updateLambda(client: LambdaClient, name: string, zipFile: Uint8Ar
 
 /**
  * Updates the lambda configuration.
- * @param client The AWS Lambda client.
- * @param name The lambda name.
+ * @param client - The AWS Lambda client.
+ * @param name - The lambda name.
  */
 async function updateLambdaConfig(client: LambdaClient, name: string): Promise<void> {
   const layerVersion = await getLayerVersion(client);
@@ -303,7 +303,7 @@ async function getLambdaConfig(client: LambdaClient, name: string): Promise<GetF
  * Returns the latest layer version for the Medplum bot layer.
  * The first result is the latest version.
  * See: https://stackoverflow.com/a/55752188
- * @param client The AWS Lambda client.
+ * @param client - The AWS Lambda client.
  * @returns The most recent layer version ARN.
  */
 async function getLayerVersion(client: LambdaClient): Promise<string> {

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -36,8 +36,8 @@ interface EvaluateMeasureParameters {
  * 4. location parameter
  *
  * See: https://hl7.org/fhir/measure-operation-evaluate-measure.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function evaluateMeasureHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();
@@ -56,8 +56,8 @@ export async function evaluateMeasureHandler(req: Request, res: Response): Promi
 /**
  * Parses and validates the operation parameters.
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  * @returns The operation parameters if available; otherwise, undefined.
  */
 async function validateParameters(req: Request, res: Response): Promise<EvaluateMeasureParameters | undefined> {
@@ -92,9 +92,9 @@ async function validateParameters(req: Request, res: Response): Promise<Evaluate
 
 /**
  * Evaluates a Measure and returns a MeasureReport.
- * @param repo The current user repository.
- * @param params Validated parameters to the evaluate-measure operation.
- * @param measure The Measure resource.
+ * @param repo - The current user repository.
+ * @param params - Validated parameters to the evaluate-measure operation.
+ * @param measure - The Measure resource.
  * @returns The MeasureReport resource.
  */
 async function evaluateMeasure(
@@ -123,9 +123,9 @@ async function evaluateMeasure(
 
 /**
  * Evaluates a Measure group and returns a MeasureReport group.
- * @param repo The current user repository.
- * @param params Validated parameters to the evaluate-measure operation.
- * @param groupDefinition A group definition from the Measure resource.
+ * @param repo - The current user repository.
+ * @param params - Validated parameters to the evaluate-measure operation.
+ * @param groupDefinition - A group definition from the Measure resource.
  * @returns The populated group element for the MeasureReport resource.
  */
 async function evaluateMeasureGroup(
@@ -146,9 +146,9 @@ async function evaluateMeasureGroup(
 
 /**
  * Evaluates a Measure population and returns a MeasureReport population.
- * @param repo The current user repository.
- * @param params Validated parameters to the evaluate-measure operation.
- * @param populationDefinition A population definition from the Measure resource.
+ * @param repo - The current user repository.
+ * @param params - Validated parameters to the evaluate-measure operation.
+ * @param populationDefinition - A population definition from the Measure resource.
  * @returns The populated population element for the MeasureReport resource.
  */
 async function evaluatePopulation(
@@ -167,9 +167,9 @@ async function evaluatePopulation(
 
 /**
  * Evaluates a FHIR query and returns the count of matching resources.
- * @param repo The current user repository.
- * @param criteria The criteria expression.
- * @param params Validated parameters to the evaluate-measure operation.
+ * @param repo - The current user repository.
+ * @param criteria - The criteria expression.
+ * @param params - Validated parameters to the evaluate-measure operation.
  * @returns The count of matching resources if available; otherwise, undefined.
  */
 async function evaluateCount(

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -114,7 +114,7 @@ export const executeHandler = asyncWrap(async (req: Request, res: Response) => {
  * If using "/Bot/:id/$execute", then the bot ID is read from the path parameter.
  * If using "/Bot/$execute?identifier=...", then the bot is searched by identifier.
  * Otherwise, returns undefined.
- * @param req The HTTP request.
+ * @param req - The HTTP request.
  * @returns The bot, or undefined if not found.
  */
 async function getBotForRequest(req: Request): Promise<Bot | undefined> {
@@ -142,7 +142,7 @@ async function getBotForRequest(req: Request): Promise<Bot | undefined> {
  * Executes a Bot.
  * This method ensures the bot is valid and enabled.
  * This method dispatches to the appropriate execution method.
- * @param request The bot request.
+ * @param request - The bot request.
  * @returns The bot execution result.
  */
 export async function executeBot(request: BotExecutionRequest): Promise<BotExecutionResult> {
@@ -177,7 +177,7 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
 
 /**
  * Returns true if the bot is enabled and bots are enabled for the project.
- * @param bot The bot resource.
+ * @param bot - The bot resource.
  * @returns True if the bot is enabled.
  */
 export async function isBotEnabled(bot: Bot): Promise<boolean> {
@@ -198,7 +198,7 @@ export async function isBotEnabled(bot: Bot): Promise<boolean> {
  * 1. Creating tables in Athena: https://docs.aws.amazon.com/athena/latest/ug/creating-tables.html
  * 2. Partitioning data in Athena: https://docs.aws.amazon.com/athena/latest/ug/partitions.html
  *
- * @param request The bot request.
+ * @param request - The bot request.
  */
 async function writeBotInputToStorage(request: BotExecutionRequest): Promise<void> {
   const { bot, contentType, input } = request;
@@ -256,7 +256,7 @@ async function writeBotInputToStorage(request: BotExecutionRequest): Promise<voi
 
 /**
  * Executes a Bot in an AWS Lambda.
- * @param request The bot request.
+ * @param request - The bot request.
  * @returns The bot execution result.
  */
 async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionResult> {
@@ -311,7 +311,7 @@ async function runInLambda(request: BotExecutionRequest): Promise<BotExecutionRe
  * Returns the AWS Lambda function name for the given bot.
  * By default, the function name is based on the bot ID.
  * If the bot has a custom function, and the server allows it, then that is used instead.
- * @param bot The Bot resource.
+ * @param bot - The Bot resource.
  * @returns The AWS Lambda function name.
  */
 export function getLambdaFunctionName(bot: Bot): string {
@@ -335,7 +335,7 @@ export function getLambdaFunctionName(bot: Bot): string {
  * so we attempt to scrub away all of that extra metadata.
  *
  * See: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-logging.html
- * @param logResult The raw log result from the AWS lambda event.
+ * @param logResult - The raw log result from the AWS lambda event.
  * @returns The parsed log result.
  */
 function parseLambdaLog(logResult: string): string {
@@ -359,7 +359,7 @@ function parseLambdaLog(logResult: string): string {
 
 /**
  * Executes a Bot on the server in a separate Node.js VM.
- * @param request The bot request.
+ * @param request - The bot request.
  * @returns The bot execution result.
  */
 async function runInVmContext(request: BotExecutionRequest): Promise<BotExecutionResult> {
@@ -502,10 +502,10 @@ function getResponseContentType(req: Request): string {
 
 /**
  * Creates an AuditEvent for a subscription attempt.
- * @param request The bot request.
- * @param startTime The time the execution attempt started.
- * @param outcome The outcome code.
- * @param outcomeDesc The outcome description text.
+ * @param request - The bot request.
+ * @param startTime - The time the execution attempt started.
+ * @param outcome - The outcome code.
+ * @param outcomeDesc - The outcome description text.
  */
 async function createAuditEvent(
   request: BotExecutionRequest,

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -15,8 +15,8 @@ import { getAuthenticatedContext } from '../../context';
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html
  * See: https://hl7.org/fhir/R4/async.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function bulkExportHandler(req: Request, res: Response): Promise<void> {
   await startExport(req, res, 'System');
@@ -30,8 +30,8 @@ export async function bulkExportHandler(req: Request, res: Response): Promise<vo
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html#endpoint---all-patients
  * See: https://hl7.org/fhir/R4/async.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function patientExportHandler(req: Request, res: Response): Promise<void> {
   await startExport(req, res, 'Patient');

--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -11,8 +11,8 @@ import { getAuthenticatedContext } from '../../context';
  * Handles an expunge request.
  *
  * Endpoint: [fhir base]/[resourceType]/[id]/$expunge
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function expungeHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();

--- a/packages/server/src/fhir/operations/groupexport.ts
+++ b/packages/server/src/fhir/operations/groupexport.ts
@@ -16,8 +16,8 @@ import { getAuthenticatedContext, getRequestContext } from '../../context';
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html
  * See: https://hl7.org/fhir/R4/async.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function groupExportHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();

--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -20,8 +20,8 @@ import { getAuthenticatedContext } from '../../context';
 /**
  * Handles a Patient everything request.
  * Searches for all resources related to the patient.
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function patientEverythingHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();
@@ -39,8 +39,8 @@ export async function patientEverythingHandler(req: Request, res: Response): Pro
 /**
  * Executes the Patient $everything operation.
  * Searches for all resources related to the patient.
- * @param repo The repository.
- * @param patient The root patient.
+ * @param repo - The repository.
+ * @param patient - The root patient.
  * @returns The patient everything search result bundle.
  */
 export async function getPatientEverything(repo: Repository, patient: Patient): Promise<Bundle> {

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -44,8 +44,8 @@ interface PlanDefinitionApplyParameters {
  * The operation converts a PlanDefinition to a RequestGroup.
  *
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function planDefinitionApplyHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();
@@ -79,8 +79,8 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
 /**
  * Parses and validates the operation parameters.
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  * @returns The operation parameters if available; otherwise, undefined.
  */
 async function validateParameters(req: Request, res: Response): Promise<PlanDefinitionApplyParameters | undefined> {
@@ -111,10 +111,10 @@ async function validateParameters(req: Request, res: Response): Promise<PlanDefi
 
 /**
  * Creates a Task and RequestGroup action for the given PlanDefinition action.
- * @param repo The repository configured for the current user.
- * @param requester The user who requested the plan definition.
- * @param params The apply operation parameters (subject, etc).
- * @param action The PlanDefinition action.
+ * @param repo - The repository configured for the current user.
+ * @param requester - The user who requested the plan definition.
+ * @param params - The apply operation parameters (subject, etc).
+ * @param action - The PlanDefinition action.
  * @returns The RequestGroup action.
  */
 async function createAction(
@@ -131,10 +131,10 @@ async function createAction(
 
 /**
  * Creates a Task and RequestGroup action to complete a Questionnaire.
- * @param repo The repository configured for the current user.
- * @param requester The user who requested the plan definition.
- * @param params The apply operation parameters (subject, etc).
- * @param action The PlanDefinition action.
+ * @param repo - The repository configured for the current user.
+ * @param requester - The user who requested the plan definition.
+ * @param params - The apply operation parameters (subject, etc).
+ * @param action - The PlanDefinition action.
  * @returns The RequestGroup action.
  */
 async function createQuestionnaireTask(
@@ -158,11 +158,11 @@ async function createQuestionnaireTask(
 
 /**
  * Creates a Task and RequestGroup action for a PlanDefinition action.
- * @param repo The repository configured for the current user.
- * @param requester The requester profile.
- * @param params The apply operation parameters (subject, etc).
- * @param action The PlanDefinition action.
- * @param input Optional input details.
+ * @param repo - The repository configured for the current user.
+ * @param requester - The requester profile.
+ * @param params - The apply operation parameters (subject, etc).
+ * @param action - The PlanDefinition action.
+ * @param input - Optional input details.
  * @returns The RequestGroup action.
  */
 async function createTask(

--- a/packages/server/src/fhir/operations/projectclone.ts
+++ b/packages/server/src/fhir/operations/projectclone.ts
@@ -12,8 +12,8 @@ import { getBinaryStorage } from '../storage';
  * Handles a Project clone request.
  *
  * Endpoint: [fhir base]/Project/[id]/$clone
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function projectCloneHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();

--- a/packages/server/src/fhir/operations/resourcegraph.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.ts
@@ -31,8 +31,8 @@ import { getAuthenticatedContext, getRequestContext } from '../../context';
  * The operation fetches all the data related to this resources as defined by a GraphDefinition resource
  *
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export async function resourceGraphHandler(req: Request, res: Response): Promise<void> {
   const ctx = getAuthenticatedContext();
@@ -134,11 +134,11 @@ async function followLinks(
  *    For elem in elements:
  *      If element is reference: follow reference
  *      If element is canonical: search for resources with url===canonical
- * @param repo The repository object for fetching data
- * @param link A link element defined in the GraphDefinition
- * @param target The target types.
- * @param resource The resource for which this GraphDefinition is being applied
- * @param resourceCache A cache of previously fetched resources. Used to prevent redundant reads
+ * @param repo - The repository object for fetching data
+ * @param link - A link element defined in the GraphDefinition
+ * @param target - The target types.
+ * @param resource - The resource for which this GraphDefinition is being applied
+ * @param resourceCache - A cache of previously fetched resources. Used to prevent redundant reads
  * @returns The running list of all the resources found while applying this graph
  */
 async function followFhirPathLink(
@@ -239,10 +239,10 @@ async function followCanonicalElements(
 /**
  * Fetches all resources referenced by this GraphDefinition link,
  * where the link is specified using search parameters
- * @param repo The repository object for fetching data
- * @param resource The resource for which this GraphDefinition is being applied
- * @param link A link element defined in the GraphDefinition
- * @param resourceCache A cache of previously fetched resources. Used to prevent redundant reads
+ * @param repo - The repository object for fetching data
+ * @param resource - The resource for which this GraphDefinition is being applied
+ * @param link - A link element defined in the GraphDefinition
+ * @param resourceCache - A cache of previously fetched resources. Used to prevent redundant reads
  * @returns The running list of all the resources found while applying this graph
  */
 async function followSearchLink(
@@ -277,7 +277,7 @@ async function followSearchLink(
 /**
  * Parses and validates the operation parameters.
  * See: https://www.hl7.org/fhir/resource-operation-graph.html
- * @param req The HTTP request.
+ * @param req - The HTTP request.
  * @returns The operation parameters if available; otherwise, undefined.
  */
 async function validateQueryParameters(req: Request): Promise<GraphDefinition> {

--- a/packages/server/src/fhir/patient.ts
+++ b/packages/server/src/fhir/patient.ts
@@ -30,7 +30,7 @@ export function getPatientCompartments(): CompartmentDefinition {
  * Returns the list of patient compartment search parameters, if the resource type is in a patient compartment.
  * Returns undefined otherwise.
  * See: https://www.hl7.org/fhir/compartmentdefinition-patient.html
- * @param resourceType The resource type.
+ * @param resourceType - The resource type.
  * @returns List of property names if in patient compartment; undefined otherwise.
  */
 export function getPatientCompartmentParams(resourceType: string): string[] | undefined {
@@ -49,7 +49,7 @@ export function getPatientCompartmentParams(resourceType: string): string[] | un
  * then return the patient ID.
  * If the resource is not in a patient compartment (i.e., a StructureDefinition),
  * then return undefined.
- * @param resource The resource to inspect.
+ * @param resource - The resource to inspect.
  * @returns The patient ID if found; undefined otherwise.
  */
 export function getPatients(resource: Resource): Reference<Patient>[] {
@@ -79,7 +79,7 @@ export function getPatients(resource: Resource): Reference<Patient>[] {
 
 /**
  * Tries to return a patient reference from an unknown value.
- * @param value The unknown value.
+ * @param value - The unknown value.
  * @returns The patient reference if found; undefined otherwise.
  */
 function getPatientFromUnknownValue(value: unknown): string | undefined {
@@ -91,7 +91,7 @@ function getPatientFromUnknownValue(value: unknown): string | undefined {
 
 /**
  * Tries to return a patient reference from a FHIR reference.
- * @param reference A FHIR reference.
+ * @param reference - A FHIR reference.
  * @returns The patient reference if found; undefined otherwise.
  */
 function getPatientIdFromReference(reference: Reference): string | undefined {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -335,8 +335,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Results are sorted with oldest versions last
    *
    * See: https://www.hl7.org/fhir/http.html#history
-   * @param resourceType The FHIR resource type.
-   * @param id The FHIR resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The FHIR resource ID.
    * @returns Operation outcome and a history bundle.
    */
   async readHistory<T extends Resource>(resourceType: string, id: string): Promise<Bundle<T>> {
@@ -606,7 +606,7 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Writes the resource to the database.
    * This is a single atomic operation inside of a transaction.
-   * @param resource The resource to write to the database.
+   * @param resource - The resource to write to the database.
    */
   private async writeToDatabase<T extends Resource>(resource: T): Promise<void> {
     // Note: We don't try/catch this because if connecting throws an exception.
@@ -634,9 +634,9 @@ export class Repository extends BaseRepository implements FhirRepository {
    *  - Previous version was deleted, and user is restoring it
    *  - Previous version does not exist, and user does not have permission to create by ID
    *  - Previous version does not exist, and user does have permission to create by ID
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
-   * @param create Flag for "creating" vs "updating".
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
+   * @param create - Flag for "creating" vs "updating".
    * @returns The existing resource, if found.
    */
   private async checkExistingResource<T extends Resource>(
@@ -665,9 +665,9 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Returns true if the resource has too many versions within the specified time period.
-   * @param resourceType The resource type.
-   * @param id The resource ID.
-   * @param create If true, then the resource is being created.
+   * @param resourceType - The resource type.
+   * @param id - The resource ID.
+   * @param create - If true, then the resource is being created.
    * @returns True if the resource has too many versions within the specified time period.
    */
   private async isTooManyVersions(resourceType: string, id: string, create: boolean): Promise<boolean> {
@@ -687,8 +687,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Returns true if the resource is not modified from the existing resource.
-   * @param existing The existing resource.
-   * @param updated The updated resource.
+   * @param existing - The existing resource.
+   * @param updated - The updated resource.
    * @returns True if the resource is not modified.
    */
   private isNotModified(existing: Resource | undefined, updated: Resource): boolean {
@@ -706,7 +706,7 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Rebuilds compartments for all resources of the specified type.
    * This is only available to super admins.
-   * @param resourceType The resource type.
+   * @param resourceType - The resource type.
    */
   async rebuildCompartmentsForResourceType(resourceType: string): Promise<void> {
     if (!this.isSuperAdmin()) {
@@ -734,7 +734,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Reindexes all resources of the specified type.
    * This is only available to the system account.
    * This should not result in any change to resources or history.
-   * @param resourceType The resource type.
+   * @param resourceType - The resource type.
    */
   async reindexResourceType(resourceType: string): Promise<void> {
     if (!this.isSuperAdmin()) {
@@ -758,8 +758,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Reindexes the resource.
    * This is only available to the system and super admin accounts.
    * This should not result in any change to the resource or its history.
-   * @param resourceType The resource type.
-   * @param id The resource ID.
+   * @param resourceType - The resource type.
+   * @param id - The resource ID.
    * @returns Promise to complete.
    */
   async reindexResource<T extends Resource>(resourceType: string, id: string): Promise<void> {
@@ -775,7 +775,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Internal implementation of reindexing a resource.
    * This accepts a resource as a parameter, rather than a resource type and ID.
    * When doing a bulk reindex, this will be more efficient because it avoids unnecessary reads.
-   * @param resource The resource.
+   * @param resource - The resource.
    * @returns The reindexed resource.
    */
   private async reindexResourceImpl<T extends Resource>(resource: T): Promise<void> {
@@ -802,8 +802,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Resends subscriptions for the resource.
    * This is only available to the admin accounts.
    * This should not result in any change to the resource or its history.
-   * @param resourceType The resource type.
-   * @param id The resource ID.
+   * @param resourceType - The resource type.
+   * @param id - The resource ID.
    * @returns Promise to complete.
    */
   async resendSubscriptions<T extends Resource>(resourceType: string, id: string): Promise<void> {
@@ -889,8 +889,8 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Permanently deletes the specified resource and all of its history.
    * This is only available to the system and super admin accounts.
-   * @param resourceType The FHIR resource type.
-   * @param id The resource ID.
+   * @param resourceType - The FHIR resource type.
+   * @param id - The resource ID.
    */
   async expungeResource(resourceType: string, id: string): Promise<void> {
     if (!this.isSuperAdmin()) {
@@ -904,8 +904,8 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Permanently deletes the specified resources and all of its history.
    * This is only available to the system and super admin accounts.
-   * @param resourceType The FHIR resource type.
-   * @param ids The resource IDs.
+   * @param resourceType - The FHIR resource type.
+   * @param ids - The resource IDs.
    */
   async expungeResources(resourceType: string, ids: string[]): Promise<void> {
     if (!this.isSuperAdmin()) {
@@ -919,8 +919,8 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Purges resources of the specified type that were last updated before the specified date.
    * This is only available to the system and super admin accounts.
-   * @param resourceType The FHIR resource type.
-   * @param before The date before which resources should be purged.
+   * @param resourceType - The FHIR resource type.
+   * @param before - The date before which resources should be purged.
    */
   async purgeResources(resourceType: ResourceType, before: string): Promise<void> {
     if (!this.isSuperAdmin()) {
@@ -952,7 +952,7 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Adds filters to ignore soft-deleted resources.
-   * @param builder The select query builder.
+   * @param builder - The select query builder.
    */
   addDeletedFilter(builder: SelectQuery): void {
     builder.where('deleted', Operator.EQUALS, false);
@@ -960,8 +960,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Adds security filters to the select query.
-   * @param builder The select query builder.
-   * @param resourceType The resource type for compartments.
+   * @param builder - The select query builder.
+   * @param resourceType - The resource type for compartments.
    */
   addSecurityFilters(builder: SelectQuery, resourceType: string): void {
     if (this.isSuperAdmin()) {
@@ -975,7 +975,7 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Adds the "project" filter to the select query.
-   * @param builder The select query builder.
+   * @param builder - The select query builder.
    */
   private addProjectFilters(builder: SelectQuery): void {
     if (this.context.project) {
@@ -985,8 +985,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Adds access policy filters to the select query.
-   * @param builder The select query builder.
-   * @param resourceType The resource type being searched.
+   * @param builder - The select query builder.
+   * @param resourceType - The resource type being searched.
    */
   private addAccessPolicyFilters(builder: SelectQuery, resourceType: string): void {
     if (!this.context.accessPolicy?.resource) {
@@ -1025,8 +1025,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Writes the resource to the resource table.
    * This builds all search parameter columns.
    * This does *not* write the version to the history table.
-   * @param client The database client inside the transaction.
-   * @param resource The resource.
+   * @param client - The database client inside the transaction.
+   * @param resource - The resource.
    */
   private async writeResource(client: PoolClient, resource: Resource): Promise<void> {
     const resourceType = resource.resourceType;
@@ -1055,8 +1055,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Writes a version of the resource to the resource history table.
-   * @param client The database client inside the transaction.
-   * @param resource The resource.
+   * @param client - The database client inside the transaction.
+   * @param resource - The resource.
    */
   private async writeResourceVersion(client: PoolClient, resource: Resource): Promise<void> {
     const resourceType = resource.resourceType;
@@ -1078,7 +1078,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * FHIR compartments are used for two purposes.
    * 1) Search narrowing (i.e., /Patient/123/Observation searches within the patient compartment).
    * 2) Access controls.
-   * @param resource The resource.
+   * @param resource - The resource.
    * @returns The list of compartments for the resource.
    */
   private getCompartments(resource: Resource): Reference[] {
@@ -1112,9 +1112,9 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Builds the columns to write for a given resource and search parameter.
    * If nothing to write, then no columns will be added.
    * Some search parameters can result in multiple columns (for example, Reference objects).
-   * @param resource The resource to write.
-   * @param columns The output columns to write.
-   * @param searchParam The search parameter definition.
+   * @param resource - The resource to write.
+   * @param columns - The output columns to write.
+   * @param searchParam - The search parameter definition.
    */
   private buildColumn(resource: Resource, columns: Record<string, any>, searchParam: SearchParameter): void {
     if (
@@ -1145,9 +1145,9 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Builds a single value for a given search parameter.
    * If the search parameter is an array, then this method will be called for each element.
    * If the search parameter is not an array, then this method will be called for the value.
-   * @param searchParam The search parameter definition.
-   * @param details The extra search parameter details.
-   * @param value The FHIR resource value.
+   * @param searchParam - The search parameter definition.
+   * @param details - The extra search parameter details.
+   * @param value - The FHIR resource value.
    * @returns The column value.
    */
   private buildColumnValue(searchParam: SearchParameter, details: SearchParameterDetails, value: any): any {
@@ -1182,7 +1182,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Builds the column value for a date parameter.
    * Tries to parse the date string.
    * Silently ignores failure.
-   * @param value The FHIRPath result.
+   * @param value - The FHIRPath result.
    * @returns The date string if parsed; undefined otherwise.
    */
   private buildDateColumn(value: any): string | undefined {
@@ -1204,7 +1204,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Builds the column value for a date/time parameter.
    * Tries to parse the date string.
    * Silently ignores failure.
-   * @param value The FHIRPath result.
+   * @param value - The FHIRPath result.
    * @returns The date/time string if parsed; undefined otherwise.
    */
   private buildDateTimeColumn(value: any): string | undefined {
@@ -1228,7 +1228,7 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Builds the columns to write for a Reference value.
-   * @param value The property value of the reference.
+   * @param value - The property value of the reference.
    * @returns The reference column value.
    */
   private buildReferenceColumns(value: any): string | undefined {
@@ -1252,7 +1252,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    *  1) The property value is a string, so return directly.
    *  2) The property value is a CodeableConcept.
    *  3) Otherwise fallback to stringify.
-   * @param value The property value of the code.
+   * @param value - The property value of the code.
    * @returns The value to write to the database column.
    */
   private buildTokenColumn(value: any): string | undefined {
@@ -1278,7 +1278,7 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Builds a CodeableConcept column value.
-   * @param value The property value of the code.
+   * @param value - The property value of the code.
    * @returns The value to write to the database column.
    */
   private buildCodeableConceptColumn(value: any): string | undefined {
@@ -1309,7 +1309,7 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Builds a Quantity column value.
-   * @param value The property value of the quantity.
+   * @param value - The property value of the quantity.
    * @returns The numeric value if available; undefined otherwise.
    */
   private buildQuantityColumn(value: any): number | undefined {
@@ -1326,8 +1326,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Writes resources values to the lookup tables.
-   * @param client The database client inside the transaction.
-   * @param resource The resource to index.
+   * @param client - The database client inside the transaction.
+   * @param resource - The resource to index.
    */
   private async writeLookupTables(client: PoolClient, resource: Resource): Promise<void> {
     for (const lookupTable of lookupTables) {
@@ -1337,8 +1337,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Deletes values from lookup tables.
-   * @param client The database client inside the transaction.
-   * @param resource The resource to delete.
+   * @param client - The database client inside the transaction.
+   * @param resource - The resource to delete.
    */
   private async deleteFromLookupTables(client: Pool | PoolClient, resource: Resource): Promise<void> {
     for (const lookupTable of lookupTables) {
@@ -1350,8 +1350,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Returns the last updated timestamp for the resource.
    * During historical data migration, some client applications are allowed
    * to override the timestamp.
-   * @param existing Existing resource if one exists.
-   * @param resource The FHIR resource.
+   * @param existing - Existing resource if one exists.
+   * @param resource - The FHIR resource.
    * @returns The last updated date.
    */
   private getLastUpdated(existing: Resource | undefined, resource: Resource): string {
@@ -1375,7 +1375,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * If it is a public resource type, then returns the public project ID.
    * If it is a protected resource type, then returns the Medplum project ID.
    * Otherwise, by default, return the current context project ID.
-   * @param resource The FHIR resource.
+   * @param resource - The FHIR resource.
    * @returns The project ID.
    */
   private getProjectId(resource: Resource): string | undefined {
@@ -1408,7 +1408,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * and the provided resource includes an author reference,
    * then use the provided value.
    * Otherwise uses the current context profile.
-   * @param resource The FHIR resource.
+   * @param resource - The FHIR resource.
    * @returns The author value.
    */
   private getAuthor(resource: Resource): Reference {
@@ -1427,9 +1427,9 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Returns the author reference string (resourceType/id).
    * If the current context is a ClientApplication, handles "on behalf of".
    * Otherwise uses the current context profile.
-   * @param existing Existing resource if one exists.
-   * @param updated The incoming updated resource.
-   * @param create Flag for when "creating" vs "updating".
+   * @param existing - Existing resource if one exists.
+   * @param updated - The incoming updated resource.
+   * @param create - Flag for when "creating" vs "updating".
    * @returns The account value.
    */
   private async getAccount(
@@ -1491,7 +1491,7 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Determines if the current user can read the specified resource type.
-   * @param resourceType The resource type.
+   * @param resourceType - The resource type.
    * @returns True if the current user can read the specified resource type.
    */
   canReadResourceType(resourceType: string): boolean {
@@ -1511,7 +1511,7 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Determines if the current user can write the specified resource type.
    * This is a preliminary check before evaluating a write operation in depth.
    * If a user cannot write a resource type at all, then don't bother looking up previous versions.
-   * @param resourceType The resource type.
+   * @param resourceType - The resource type.
    * @returns True if the current user can write the specified resource type.
    */
   private canWriteResourceType(resourceType: string): boolean {
@@ -1530,7 +1530,7 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Determines if the current user can write to the specified resource.
    * This is a more in-depth check after building the candidate result of a write operation.
-   * @param resource The resource.
+   * @param resource - The resource.
    * @returns True if the current user can write the specified resource type.
    */
   private canWriteToResource(resource: Resource): boolean {
@@ -1548,8 +1548,8 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Check that a resource can be written in its current form.
-   * @param previous The resource before updates were applied.
-   * @param current The resource as it will be written.
+   * @param previous - The resource before updates were applied.
+   * @param current - The resource as it will be written.
    * @returns True if the current user can write the specified resource type.
    */
   private isResourceWriteable(previous: Resource | undefined, current: Resource): boolean {
@@ -1576,7 +1576,7 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Returns true if the resource is "cache only" and not written to the database.
    * This is a highly specialized use case for internal system resources.
-   * @param resource The candidate resource.
+   * @param resource - The candidate resource.
    * @returns True if the resource should be cached only and not written to the database.
    */
   private isCacheOnly(resource: Resource): boolean {
@@ -1586,7 +1586,7 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Removes hidden fields from a resource as defined by the access policy.
    * This should be called for any "read" operation.
-   * @param input The input resource.
+   * @param input - The input resource.
    * @returns The resource with hidden fields removed.
    */
   removeHiddenFields<T extends Resource>(input: T): T {
@@ -1610,8 +1610,8 @@ export class Repository extends BaseRepository implements FhirRepository {
    * Overwrites readonly fields from a resource as defined by the access policy.
    * If no original (i.e., this is the first version), then blank them out.
    * This should be called for any "write" operation.
-   * @param input The input resource.
-   * @param original The previous version, if it exists.
+   * @param input - The input resource.
+   * @param original - The previous version, if it exists.
    * @returns The resource with restored hidden fields.
    */
   private restoreReadonlyFields<T extends Resource>(input: T, original: T | undefined): T {
@@ -1633,8 +1633,8 @@ export class Repository extends BaseRepository implements FhirRepository {
   /**
    * Removes a field from the input resource.
    * Uses JSONPatch to process the remove operation, which supports nested fields.
-   * @param input The input resource.
-   * @param path The path to the field to remove.
+   * @param input - The input resource.
+   * @param path - The path to the field to remove.
    * @returns The new document with the field removed.
    */
   private removeField<T extends Resource>(input: T, path: string): T {
@@ -1666,11 +1666,11 @@ export class Repository extends BaseRepository implements FhirRepository {
 
   /**
    * Logs an AuditEvent for a restful operation.
-   * @param subtype The AuditEvent subtype.
-   * @param outcome The AuditEvent outcome.
-   * @param description The description.  Can be a string, object, or Error.  Will be normalized to a string.
-   * @param resource Optional resource to associate with the AuditEvent.
-   * @param search Optional search parameters to associate with the AuditEvent.
+   * @param subtype - The AuditEvent subtype.
+   * @param outcome - The AuditEvent outcome.
+   * @param description - The description.  Can be a string, object, or Error.  Will be normalized to a string.
+   * @param resource - Optional resource to associate with the AuditEvent.
+   * @param search - Optional search parameters to associate with the AuditEvent.
    */
   private logEvent(
     subtype: AuditEventSubtype,
@@ -1724,8 +1724,8 @@ export function getLookupTable(resourceType: string, searchParam: SearchParamete
 
 /**
  * Tries to read a cache entry from Redis by resource type and ID.
- * @param resourceType The resource type.
- * @param id The resource ID.
+ * @param resourceType - The resource type.
+ * @param id - The resource ID.
  * @returns The cache entry if found; otherwise, undefined.
  */
 async function getCacheEntry<T extends Resource>(resourceType: string, id: string): Promise<CacheEntry<T> | undefined> {
@@ -1735,7 +1735,7 @@ async function getCacheEntry<T extends Resource>(resourceType: string, id: strin
 
 /**
  * Performs a bulk read of cache entries from Redis.
- * @param references Array of FHIR references.
+ * @param references - Array of FHIR references.
  * @returns Array of cache entries or undefined.
  */
 async function getCacheEntries(references: Reference[]): Promise<(CacheEntry | undefined)[]> {
@@ -1751,7 +1751,7 @@ async function getCacheEntries(references: Reference[]): Promise<(CacheEntry | u
 
 /**
  * Writes a cache entry to Redis.
- * @param resource The resource to cache.
+ * @param resource - The resource to cache.
  */
 async function setCacheEntry(resource: Resource): Promise<void> {
   await getRedis().set(
@@ -1764,8 +1764,8 @@ async function setCacheEntry(resource: Resource): Promise<void> {
 
 /**
  * Deletes a cache entry from Redis.
- * @param resourceType The resource type.
- * @param id The resource ID.
+ * @param resourceType - The resource type.
+ * @param id - The resource ID.
  */
 async function deleteCacheEntry(resourceType: string, id: string): Promise<void> {
   await getRedis().del(getCacheKey(resourceType, id));
@@ -1773,8 +1773,8 @@ async function deleteCacheEntry(resourceType: string, id: string): Promise<void>
 
 /**
  * Deletes cache entries from Redis.
- * @param resourceType The resource type.
- * @param ids The resource IDs.
+ * @param resourceType - The resource type.
+ * @param ids - The resource IDs.
  */
 async function deleteCacheEntries(resourceType: string, ids: string[]): Promise<void> {
   const cacheKeys = ids.map((id) => {
@@ -1786,8 +1786,8 @@ async function deleteCacheEntries(resourceType: string, ids: string[]): Promise<
 
 /**
  * Returns the redis cache key for the given resource type and resource ID.
- * @param resourceType The resource type.
- * @param id The resource ID.
+ * @param resourceType - The resource type.
+ * @param id - The resource ID.
  * @returns The Redis cache key.
  */
 function getCacheKey(resourceType: string, id: string): string {

--- a/packages/server/src/fhir/rewrite.ts
+++ b/packages/server/src/fhir/rewrite.ts
@@ -1,8 +1,8 @@
 import { Binary, Resource } from '@medplum/fhirtypes';
 import { getConfig } from '../config';
+import { getRequestContext } from '../context';
 import { Repository } from './repo';
 import { getPresignedUrl } from './signer';
-import { getRequestContext } from '../context';
 
 /**
  * The target type of the attachment rewrite.
@@ -95,8 +95,8 @@ class Rewriter {
   /**
    * Rewrites an object property.
    * @param keyValue - The key/value pair to rewrite.
-   * @param keyValue."0" The key.
-   * @param keyValue."1" The value.
+   * @param keyValue."0" - The key.
+   * @param keyValue."1" - The value.
    * @returns The rewritten key/value pair.
    */
   async rewriteProperty([key, value]: [string, any]): Promise<[string, any]> {
@@ -113,8 +113,8 @@ class Rewriter {
    * If successful, returns the rewritten URL.
    * Otherwise, returns undefined.
    * @param keyValue - The key/value pair to rewrite.
-   * @param keyValue."0" The key.
-   * @param keyValue."1" The value.
+   * @param keyValue."0" - The key.
+   * @param keyValue."1" - The value.
    * @returns The rewritten URL or undefined.
    */
   async rewriteAttachmentUrl([key, value]: [string, any]): Promise<string | boolean | undefined> {

--- a/packages/server/src/fhir/rewrite.ts
+++ b/packages/server/src/fhir/rewrite.ts
@@ -34,9 +34,9 @@ export enum RewriteMode {
  *
  * Uses the repository to verify that the referenced resources exist and that
  * the current user has permission to read them.
- * @param mode The mode to use when rewriting the attachments.
- * @param repo The repository configured for the current user.
- * @param input The input value (object, array, or primitive).
+ * @param mode - The mode to use when rewriting the attachments.
+ * @param repo - The repository configured for the current user.
+ * @param input - The input value (object, array, or primitive).
  * @returns The rewritten value.
  */
 export async function rewriteAttachments<T>(mode: RewriteMode, repo: Repository, input: T): Promise<T> {
@@ -57,7 +57,7 @@ class Rewriter {
 
   /**
    * Rewrites an object to replace any attachment references with signed URLs.
-   * @param input The input value (object, array, or primitive).
+   * @param input - The input value (object, array, or primitive).
    * @returns The rewritten value.
    */
   async rewriteValue<T>(input: T): Promise<T> {
@@ -94,7 +94,7 @@ class Rewriter {
 
   /**
    * Rewrites an object property.
-   * @param keyValue The key/value pair to rewrite.
+   * @param keyValue - The key/value pair to rewrite.
    * @param keyValue."0" The key.
    * @param keyValue."1" The value.
    * @returns The rewritten key/value pair.
@@ -112,7 +112,7 @@ class Rewriter {
    * Tries to rewrite an attachment URL property.
    * If successful, returns the rewritten URL.
    * Otherwise, returns undefined.
-   * @param keyValue The key/value pair to rewrite.
+   * @param keyValue - The key/value pair to rewrite.
    * @param keyValue."0" The key.
    * @param keyValue."1" The value.
    * @returns The rewritten URL or undefined.
@@ -145,8 +145,8 @@ class Rewriter {
 
   /**
    * Tries to generate a presigned URL for the binary.
-   * @param id The binary ID.
-   * @param versionId Optional binary version ID.
+   * @param id - The binary ID.
+   * @param versionId - Optional binary version ID.
    * @returns The attachment presigned URL.
    */
   async getAttachmentPresignedUrl(id: string, versionId?: string): Promise<string> {
@@ -174,7 +174,7 @@ class Rewriter {
  *   3) Presigned URL (https://storage.medplum.com/binary/123/456?Signature=...)
  *
  * When comparing two binary URLs, we want to compare the binary ID and version ID.
- * @param url The input URL.
+ * @param url - The input URL.
  * @returns The normalized binary ID and version ID.
  */
 function normalizeBinaryUrl(url: string): { id?: string; versionId?: string } {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -102,8 +102,8 @@ export async function searchImpl<T extends Resource>(
 
 /**
  * Returns the bundle entries for a search request.
- * @param repo The repository.
- * @param searchRequest The search request.
+ * @param repo - The repository.
+ * @param searchRequest - The search request.
  * @returns The bundle entries for the search result.
  */
 async function getSearchEntries<T extends Resource>(
@@ -183,10 +183,10 @@ function removeResourceFields(resource: Resource, repo: Repository, searchReques
 
 /**
  * Gets the extra search entries for the _include and _revinclude parameters.
- * @param repo The FHIR repository.
- * @param searchRequest The original search request.
- * @param resources The resources returned by the original search.
- * @param entries The output bundle entries.
+ * @param repo - The FHIR repository.
+ * @param searchRequest - The original search request.
+ * @param resources - The resources returned by the original search.
+ * @param entries - The output bundle entries.
  */
 async function getExtraEntries<T extends Resource>(
   repo: Repository,
@@ -235,9 +235,9 @@ async function getExtraEntries<T extends Resource>(
  * Returns bundle entries for the resources that are included in the search result.
  *
  * See documentation on _include: https://hl7.org/fhir/R4/search.html#include
- * @param repo The repository.
- * @param include The include parameter.
- * @param resources The base search result resources.
+ * @param repo - The repository.
+ * @param include - The include parameter.
+ * @param resources - The base search result resources.
  * @returns The bundle entries for the included resources.
  */
 async function getSearchIncludeEntries(
@@ -291,9 +291,9 @@ async function getSearchIncludeEntries(
  * Returns bundle entries for the resources that are reverse included in the search result.
  *
  * See documentation on _revinclude: https://hl7.org/fhir/R4/search.html#revinclude
- * @param repo The repository.
- * @param revInclude The revInclude parameter.
- * @param resources The base search result resources.
+ * @param repo - The repository.
+ * @param revInclude - The revInclude parameter.
+ * @param resources - The base search result resources.
  * @returns The bundle entries for the reverse included resources.
  */
 async function getSearchRevIncludeEntries(
@@ -337,8 +337,8 @@ async function getSearchRevIncludeEntries(
  * Returns the search bundle links for a search request.
  * At minimum, the 'self' link will be returned.
  * If "count" does not equal zero, then 'first', 'next', and 'previous' links will be included.
- * @param searchRequest The search request.
- * @param hasMore True if there are more entries after the current page.
+ * @param searchRequest - The search request.
+ * @param hasMore - True if there are more entries after the current page.
  * @returns The search bundle links.
  */
 function getSearchLinks(searchRequest: SearchRequest, hasMore: boolean | undefined): BundleLink[] {
@@ -387,8 +387,8 @@ function getSearchUrl(searchRequest: SearchRequest): string {
 /**
  * Returns the total number of matching results for a search request.
  * This ignores page number and page size.
- * @param repo The repository.
- * @param searchRequest The search request.
+ * @param repo - The repository.
+ * @param searchRequest - The search request.
  * @returns The total number of matching results.
  */
 async function getAccurateCount(repo: Repository, searchRequest: SearchRequest): Promise<number> {
@@ -412,9 +412,9 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
  * Returns the estimated number of matching results for a search request.
  * This ignores page number and page size.
  * This uses the estimated row count technique as described here: https://wiki.postgresql.org/wiki/Count_estimate
- * @param repo The repository.
- * @param searchRequest The search request.
- * @param rowCount The number of matching results if found.
+ * @param repo - The repository.
+ * @param searchRequest - The search request.
+ * @param rowCount - The number of matching results if found.
  * @returns The total number of matching results.
  */
 async function getEstimateCount(
@@ -455,8 +455,8 @@ async function getEstimateCount(
 
 /**
  * Adds all search filters as "WHERE" clauses to the query builder.
- * @param selectQuery The select query builder.
- * @param searchRequest The search request.
+ * @param selectQuery - The select query builder.
+ * @param searchRequest - The search request.
  */
 function addSearchFilters(selectQuery: SelectQuery, searchRequest: SearchRequest): void {
   const expr = buildSearchExpression(selectQuery, searchRequest);
@@ -486,9 +486,9 @@ export function buildSearchExpression(selectQuery: SelectQuery, searchRequest: S
 
 /**
  * Builds a single search filter as "WHERE" clause to the query builder.
- * @param selectQuery The select query builder.
- * @param resourceType The type of resources requested.
- * @param filter The search filter.
+ * @param selectQuery - The select query builder.
+ * @param resourceType - The type of resources requested.
+ * @param filter - The search filter.
  * @returns The search query where expression
  */
 function buildSearchFilterExpression(
@@ -532,9 +532,9 @@ function buildSearchFilterExpression(
  * Builds a search filter expression for a normal search parameter.
  *
  * Not any special cases, just a normal search parameter.
- * @param resourceType The FHIR resource type.
- * @param param The FHIR search parameter.
- * @param filter The search filter.
+ * @param resourceType - The FHIR resource type.
+ * @param param - The FHIR search parameter.
+ * @param filter - The search filter.
  * @returns A SQL "WHERE" clause expression.
  */
 function buildNormalSearchFilterExpression(resourceType: string, param: SearchParameter, filter: Filter): Expression {
@@ -564,9 +564,9 @@ function buildNormalSearchFilterExpression(resourceType: string, param: SearchPa
  * Returns true if the search parameter code is a special search parameter.
  *
  * See: https://www.hl7.org/fhir/search.html#all
- * @param selectQuery The select query builder.
- * @param resourceType The type of resources requested.
- * @param filter The search filter.
+ * @param selectQuery - The select query builder.
+ * @param resourceType - The type of resources requested.
+ * @param filter - The search filter.
  * @returns True if the search parameter is a special code.
  */
 function trySpecialSearchParameter(
@@ -641,9 +641,9 @@ function buildFilterParameterComparison(
 
 /**
  * Adds a string search filter as "WHERE" clause to the query builder.
- * @param details The search parameter details.
- * @param operator The search operator.
- * @param values The string values to search against.
+ * @param details - The search parameter details.
+ * @param operator - The search operator.
+ * @param values - The string values to search against.
  * @returns The select query condition.
  */
 function buildStringSearchFilter(details: SearchParameterDetails, operator: Operator, values: string[]): Expression {
@@ -666,10 +666,10 @@ function buildStringSearchFilter(details: SearchParameterDetails, operator: Oper
 
 /**
  * Adds an ID search filter as "WHERE" clause to the query builder.
- * @param resourceType The resource type.
- * @param details The search parameter details.
- * @param operator The search operator.
- * @param values The string values to search against.
+ * @param resourceType - The resource type.
+ * @param details - The search parameter details.
+ * @param operator - The search operator.
+ * @param values - The string values to search against.
  * @returns The select query condition.
  */
 function buildIdSearchFilter(
@@ -698,10 +698,10 @@ function buildIdSearchFilter(
 
 /**
  * Adds a token search filter as "WHERE" clause to the query builder.
- * @param resourceType The resource type.
- * @param details The search parameter details.
- * @param operator The search operator.
- * @param values The string values to search against.
+ * @param resourceType - The resource type.
+ * @param details - The search parameter details.
+ * @param operator - The search operator.
+ * @param values - The string values to search against.
  * @returns The select query condition.
  */
 function buildTokenSearchFilter(
@@ -720,8 +720,8 @@ function buildTokenSearchFilter(
 
 /**
  * Adds a reference search filter as "WHERE" clause to the query builder.
- * @param details The search parameter details.
- * @param values The string values to search against.
+ * @param details - The search parameter details.
+ * @param values - The string values to search against.
  * @returns The select query condition.
  */
 function buildReferenceSearchFilter(details: SearchParameterDetails, values: string[]): Expression {
@@ -738,8 +738,8 @@ function buildReferenceSearchFilter(details: SearchParameterDetails, values: str
 
 /**
  * Adds a date or date/time search filter.
- * @param details The search parameter details.
- * @param filter The search filter.
+ * @param details - The search parameter details.
+ * @param filter - The search filter.
  * @returns The select query condition.
  */
 function buildDateSearchFilter(details: SearchParameterDetails, filter: Filter): Expression {
@@ -752,8 +752,8 @@ function buildDateSearchFilter(details: SearchParameterDetails, filter: Filter):
 
 /**
  * Adds all "order by" clauses to the query builder.
- * @param builder The client query builder.
- * @param searchRequest The search request.
+ * @param builder - The client query builder.
+ * @param searchRequest - The search request.
  */
 function addSortRules(builder: SelectQuery, searchRequest: SearchRequest): void {
   searchRequest.sortRules?.forEach((sortRule) => addOrderByClause(builder, searchRequest, sortRule));
@@ -761,9 +761,9 @@ function addSortRules(builder: SelectQuery, searchRequest: SearchRequest): void 
 
 /**
  * Adds a single "order by" clause to the query builder.
- * @param builder The client query builder.
- * @param searchRequest The search request.
- * @param sortRule The sort rule.
+ * @param builder - The client query builder.
+ * @param searchRequest - The search request.
+ * @param sortRule - The sort rule.
  */
 function addOrderByClause(builder: SelectQuery, searchRequest: SearchRequest, sortRule: SortRule): void {
   if (sortRule.code === '_id') {
@@ -796,7 +796,7 @@ function addOrderByClause(builder: SelectQuery, searchRequest: SearchRequest, so
  * Converts a FHIR search operator into a SQL operator.
  * Only works for simple conversions.
  * For complex conversions, need to build custom SQL.
- * @param fhirOperator The FHIR operator.
+ * @param fhirOperator - The FHIR operator.
  * @returns The equivalent SQL operator.
  */
 function fhirOperatorToSqlOperator(fhirOperator: Operator): SQL {

--- a/packages/server/src/fhir/signer.ts
+++ b/packages/server/src/fhir/signer.ts
@@ -7,7 +7,7 @@ import { getConfig } from '../config';
  *
  * Reference:
  * https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_cloudfront_signer.html
- * @param binary Binary resource.
+ * @param binary - Binary resource.
  * @returns Presigned URL to access the binary data.
  */
 export function getPresignedUrl(binary: Binary): string {

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -18,8 +18,8 @@ export interface SmartScope {
  * Handles requests for the SMART configuration.
  * See: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html
  * See: https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html
- * @param _req The HTTP request.
- * @param res The HTTP response.
+ * @param _req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export function smartConfigurationHandler(_req: Request, res: Response): void {
   const config = getConfig();
@@ -76,8 +76,8 @@ export function smartConfigurationHandler(_req: Request, res: Response): void {
 /**
  * Handles requests for the SMART App Styling.
  * See: https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#styling
- * @param _req The HTTP request.
- * @param res The HTTP response.
+ * @param _req - The HTTP request.
+ * @param res - The HTTP response.
  */
 export function smartStylingHandler(_req: Request, res: Response): void {
   res.status(200).contentType(ContentType.JSON).json({
@@ -98,7 +98,7 @@ export function smartStylingHandler(_req: Request, res: Response): void {
 /**
  * Parses an OAuth scope string into a list of SMART scopes.
  * Only includes SMART scopes, all other scopes are ignored.
- * @param scope The OAuth scope string.
+ * @param scope - The OAuth scope string.
  * @returns Array of SMART scopes.
  */
 export function parseSmartScopes(scope: string | undefined): SmartScope[] {
@@ -125,8 +125,8 @@ export function parseSmartScopes(scope: string | undefined): SmartScope[] {
  * If there are no SMART scopes, the AccessPolicy is returned unmodified.
  * If there is no access policy, a new one is created.
  * Otherwise, the AccessPolicy is modified to only include the SMART scopes.
- * @param accessPolicy The original access policy.
- * @param scope The OAuth scope string.
+ * @param accessPolicy - The original access policy.
+ * @param scope - The OAuth scope string.
  * @returns Updated access policy with the OAuth scope applied.
  */
 export function applySmartScopes(

--- a/packages/server/src/fhir/storage.test.ts
+++ b/packages/server/src/fhir/storage.test.ts
@@ -252,7 +252,7 @@ describe('Storage', () => {
 /**
  * Reads a stream into a string.
  * See: https://stackoverflow.com/a/49428486/2051724
- * @param stream The readable stream.
+ * @param stream - The readable stream.
  * @returns The string contents.
  */
 export function streamToString(stream: internal.Readable): Promise<string> {

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -148,10 +148,10 @@ class S3Storage implements BinaryStorage {
 
   /**
    * Writes a binary blob to S3.
-   * @param binary The binary resource destination.
-   * @param filename Optional binary filename.
-   * @param contentType Optional binary content type.
-   * @param stream The Node.js stream of readable content.
+   * @param binary - The binary resource destination.
+   * @param filename - Optional binary filename.
+   * @param contentType - Optional binary content type.
+   * @param stream - The Node.js stream of readable content.
    * @returns Promise that resolves when the write is complete.
    */
   writeBinary(
@@ -186,9 +186,9 @@ class S3Storage implements BinaryStorage {
    *
    * Learn more:
    * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html
-   * @param key The S3 key.
-   * @param contentType Optional binary content type.
-   * @param stream The Node.js stream of readable content.
+   * @param key - The S3 key.
+   * @param contentType - Optional binary content type.
+   * @param stream - The Node.js stream of readable content.
    */
   async writeFile(key: string, contentType: string | undefined, stream: BinarySource): Promise<void> {
     const upload = new Upload({
@@ -310,8 +310,8 @@ const BLOCKED_CONTENT_TYPES = [
 /**
  * Checks file metadata against blocked lists.
  * Throws an execption if the file metadata is blocked.
- * @param filename The input filename.
- * @param contentType The input content type.
+ * @param filename - The input filename.
+ * @param contentType - The input content type.
  */
 function checkFileMetadata(filename: string | undefined, contentType: string | undefined): void {
   if (checkFileExtension(filename)) {
@@ -324,7 +324,7 @@ function checkFileMetadata(filename: string | undefined, contentType: string | u
 
 /**
  * Checks if the file extension is blocked.
- * @param filename The input filename.
+ * @param filename - The input filename.
  * @returns True if the filename has a blocked file extension.
  */
 function checkFileExtension(filename: string | undefined): boolean {
@@ -342,7 +342,7 @@ function checkFileExtension(filename: string | undefined): boolean {
 
 /**
  * Checks if the content type is blocked.
- * @param contentType The input content type.
+ * @param contentType - The input content type.
  * @returns True if the content type is blocked.
  */
 function checkContentType(contentType: string | undefined): boolean {

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -6,8 +6,8 @@ import { getRedis } from '../redis';
 
 /**
  * Handles a new WebSocket connection to the FHIRCast hub.
- * @param socket The WebSocket connection.
- * @param request The HTTP request.
+ * @param socket - The WebSocket connection.
+ * @param request - The HTTP request.
  */
 export async function handleFhircastConnection(socket: ws.WebSocket, request: IncomingMessage): Promise<void> {
   // TODO: Map URL slug to topic ID

--- a/packages/server/src/hl7/parser.ts
+++ b/packages/server/src/hl7/parser.ts
@@ -7,7 +7,7 @@ export interface HL7BodyParserOptions {
 
 /**
  * Returns an Express middleware handler for parsing HL7 messages.
- * @param options HL7 parser options to specify content types.
+ * @param options - HL7 parser options to specify content types.
  * @returns Express middleware request handler.
  */
 export function hl7BodyParser(options: HL7BodyParserOptions): RequestHandler {

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -43,9 +43,9 @@ export const authorizePostHandler = asyncWrap(async (req: Request, res: Response
  * This is used for both GET and POST requests.
  * We currently only support query string parameters.
  * See: https://openid.net/specs/openid-connect-core-1_0.html#AuthorizationEndpoint
- * @param req The HTTP request.
- * @param res The HTTP response.
- * @param params The params (query string params for GET, form body params for POST).
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
+ * @param params - The params (query string params for GET, form body params for POST).
  * @returns True on success; false on error.
  */
 async function validateAuthorizeRequest(req: Request, res: Response, params: Record<string, any>): Promise<boolean> {
@@ -128,7 +128,7 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
 
 /**
  * Returns true if the audience is valid.
- * @param aud The user provided audience.
+ * @param aud - The user provided audience.
  * @returns True if the audience is valid; false otherwise.
  */
 function isValidAudience(aud: string | undefined): boolean {
@@ -150,8 +150,8 @@ function isValidAudience(aud: string | undefined): boolean {
 
 /**
  * Tries to get an existing login for the current request.
- * @param req The HTTP request.
- * @param client The current client application.
+ * @param req - The HTTP request.
+ * @param client - The current client application.
  * @returns Existing login if found; undefined otherwise.
  */
 async function getExistingLogin(req: Request, client: ClientApplication): Promise<Login | undefined> {
@@ -173,7 +173,7 @@ async function getExistingLogin(req: Request, client: ClientApplication): Promis
 
 /**
  * Tries to get an existing login based on the "id_token_hint" query string parameter.
- * @param req The HTTP request.
+ * @param req - The HTTP request.
  * @returns Existing login if found; undefined otherwise.
  */
 async function getExistingLoginFromIdTokenHint(req: Request): Promise<Login | undefined> {
@@ -201,8 +201,8 @@ async function getExistingLoginFromIdTokenHint(req: Request): Promise<Login | un
 
 /**
  * Tries to get an existing login based on the HTTP cookies.
- * @param req The HTTP request.
- * @param client The current client application.
+ * @param req - The HTTP request.
+ * @param client - The current client application.
  * @returns Existing login if found; undefined otherwise.
  */
 async function getExistingLoginFromCookie(req: Request, client: ClientApplication): Promise<Login | undefined> {
@@ -229,10 +229,10 @@ async function getExistingLoginFromCookie(req: Request, client: ClientApplicatio
 
 /**
  * Sends a redirect back to the client application with error codes and state.
- * @param res The response.
- * @param redirectUri The client redirect URI.  This URI may already have query string parameters.
- * @param error The OAuth/OpenID error code.
- * @param state The client state.
+ * @param res - The response.
+ * @param redirectUri - The client redirect URI.  This URI may already have query string parameters.
+ * @param error - The OAuth/OpenID error code.
+ * @param state - The client state.
  */
 function sendErrorRedirect(res: Response, redirectUri: string, error: string, state: string): void {
   const url = new URL(redirectUri);
@@ -243,9 +243,9 @@ function sendErrorRedirect(res: Response, redirectUri: string, error: string, st
 
 /**
  * Sends a successful redirect.
- * @param req The HTTP request.
- * @param res The HTTP response.
- * @param params The redirect parameters.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
+ * @param params - The redirect parameters.
  */
 function sendSuccessRedirect(req: Request, res: Response, params: Record<string, any>): void {
   const redirectUrl = new URL(getConfig().appBaseUrl + 'oauth');

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -172,7 +172,7 @@ export function getSigningKey(): KeyLike {
 
 /**
  * Generates a secure random string suitable for a client secret or refresh secret.
- * @param size Size of the secret in bytes.  16 recommended for auth codes.  32 recommended for client and refresh secrets.
+ * @param size - Size of the secret in bytes.  16 recommended for auth codes.  32 recommended for client and refresh secrets.
  * @returns Secure random string.
  */
 export function generateSecret(size: number): string {
@@ -181,7 +181,7 @@ export function generateSecret(size: number): string {
 
 /**
  * Generates an ID token JWT.
- * @param claims The ID token claims.
+ * @param claims - The ID token claims.
  * @returns A well-formed JWT that can be used as an ID token.
  */
 export function generateIdToken(claims: MedplumIdTokenClaims): Promise<string> {
@@ -190,7 +190,7 @@ export function generateIdToken(claims: MedplumIdTokenClaims): Promise<string> {
 
 /**
  * Generates an access token JWT.
- * @param claims The access token claims.
+ * @param claims - The access token claims.
  * @returns A well-formed JWT that can be used as an access token.
  */
 export function generateAccessToken(claims: MedplumAccessTokenClaims): Promise<string> {
@@ -199,7 +199,7 @@ export function generateAccessToken(claims: MedplumAccessTokenClaims): Promise<s
 
 /**
  * Generates a refresh token JWT.
- * @param claims The refresh token claims.
+ * @param claims - The refresh token claims.
  * @returns A well-formed JWT that can be used as a refresh token.
  */
 export function generateRefreshToken(claims: MedplumRefreshTokenClaims): Promise<string> {
@@ -208,8 +208,8 @@ export function generateRefreshToken(claims: MedplumRefreshTokenClaims): Promise
 
 /**
  * Generates a JWT.
- * @param exp Expiration time resolved to a time span.
- * @param claims The key/value pairs to include in the payload section.
+ * @param exp - Expiration time resolved to a time span.
+ * @param claims - The key/value pairs to include in the payload section.
  * @returns Promise to generate and sign the JWT.
  */
 async function generateJwt(exp: '1h' | '2w', claims: JWTPayload): Promise<string> {
@@ -228,7 +228,7 @@ async function generateJwt(exp: '1h' | '2w', claims: JWTPayload): Promise<string
 
 /**
  * Decodes and verifies a JWT.
- * @param token The jwt token / bearer token.
+ * @param token - The jwt token / bearer token.
  * @returns Returns the decoded claims on success.
  */
 export async function verifyJwt(token: string): Promise<{ payload: JWTPayload; protectedHeader: JWSHeaderParameters }> {
@@ -247,7 +247,7 @@ export async function verifyJwt(token: string): Promise<{ payload: JWTPayload; p
 /**
  * Returns a public key to verify a JWT.
  * Implements the "JWTVerifyGetKey" interface for jwtVerify.
- * @param protectedHeader The JWT protected header.
+ * @param protectedHeader - The JWT protected header.
  * @returns The public key.
  */
 function getKeyForHeader(protectedHeader: JWSHeaderParameters): KeyLike {

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -78,8 +78,8 @@ export const tokenHandler: RequestHandler = asyncWrap(async (req: Request, res: 
 /**
  * Handles the "Client Credentials" OAuth flow.
  * See: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 async function handleClientCredentials(req: Request, res: Response): Promise<void> {
   const { clientId, clientSecret, error } = await getClientIdAndSecret(req);
@@ -137,8 +137,8 @@ async function handleClientCredentials(req: Request, res: Response): Promise<voi
 /**
  * Handles the "Authorization Code Grant" flow.
  * See: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 async function handleAuthorizationCode(req: Request, res: Response): Promise<void> {
   const { clientId, clientSecret, error } = await getClientIdAndSecret(req);
@@ -231,8 +231,8 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<voi
 /**
  * Handles the "Refresh" flow.
  * See: https://datatracker.ietf.org/doc/html/rfc6749#section-6
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  */
 async function handleRefreshToken(req: Request, res: Response): Promise<void> {
   const refreshToken = req.body.refresh_token;
@@ -307,8 +307,8 @@ async function handleRefreshToken(req: Request, res: Response): Promise<void> {
 /**
  * Handles the "Exchange" flow.
  * See: https://datatracker.ietf.org/doc/html/rfc8693
- * @param req The HTTP request.
- * @param res The HTTP response.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
  * @returns Promise to complete.
  */
 async function handleTokenExchange(req: Request, res: Response): Promise<void> {
@@ -318,11 +318,11 @@ async function handleTokenExchange(req: Request, res: Response): Promise<void> {
 /**
  * Exchanges an existing token for a new set of tokens.
  * See: https://datatracker.ietf.org/doc/html/rfc8693
- * @param req The HTTP request.
- * @param res The HTTP response.
- * @param clientId The client application ID.
- * @param subjectToken The subject token. Only access tokens are currently supported.
- * @param subjectTokenType The subject token type as defined in Section 3.  Only "urn:ietf:params:oauth:token-type:access_token" is currently supported.
+ * @param req - The HTTP request.
+ * @param res - The HTTP response.
+ * @param clientId - The client application ID.
+ * @param subjectToken - The subject token. Only access tokens are currently supported.
+ * @param subjectTokenType - The subject token type as defined in Section 3.  Only "urn:ietf:params:oauth:token-type:access_token" is currently supported.
  */
 export async function exchangeExternalAuthToken(
   req: Request,
@@ -399,7 +399,7 @@ export async function exchangeExternalAuthToken(
  * 3. Form body (client_secret_post)
  *
  * See SMART "token_endpoint_auth_methods_supported"
- * @param req The HTTP request.
+ * @param req - The HTTP request.
  * @returns The client ID and secret on success, or an error message on failure.
  */
 async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
@@ -433,8 +433,8 @@ async function getClientIdAndSecret(req: Request): Promise<ClientIdAndSecret> {
  * 2. https://www.hl7.org/fhir/smart-app-launch/example-backend-services.html#step-2-discovery
  * 3. https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/csimg/obtaining-access-token-using-self-signed-client-assertion.html
  * 4. https://darutk.medium.com/oauth-2-0-client-authentication-4b5f929305d4
- * @param clientAssertionType The client assertion type.
- * @param clientAssertion The client assertion JWT.
+ * @param clientAssertionType - The client assertion type.
+ * @param clientAssertion - The client assertion JWT.
  * @returns The parsed client ID and secret on success, or an error message on failure.
  */
 async function parseClientAssertion(
@@ -498,7 +498,7 @@ async function parseClientAssertion(
 
 /**
  * Tries to parse the client ID and secret from the Authorization header.
- * @param authHeader The Authorizaiton header string.
+ * @param authHeader - The Authorizaiton header string.
  * @returns Client ID and secret on success, or an error message on failure.
  */
 async function parseAuthorizationHeader(authHeader: string): Promise<ClientIdAndSecret> {
@@ -533,9 +533,9 @@ async function validateClientIdAndSecret(
 
 /**
  * Sends a successful token response.
- * @param res The HTTP response.
- * @param login The user login.
- * @param membership The project membership.
+ * @param res - The HTTP response.
+ * @param login - The user login.
+ * @param membership - The project membership.
  */
 async function sendTokenResponse(res: Response, login: Login, membership: ProjectMembership): Promise<void> {
   const config = getConfig();
@@ -571,10 +571,10 @@ async function sendTokenResponse(res: Response, login: Login, membership: Projec
 
 /**
  * Sends an OAuth2 response.
- * @param res The HTTP response.
- * @param error The error code.  See: https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.7
- * @param description The error description.  See: https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.8
- * @param status The HTTP status code.
+ * @param res - The HTTP response.
+ * @param error - The error code.  See: https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.7
+ * @param description - The error description.  See: https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.8
+ * @param status - The HTTP status code.
  * @returns Reference to the HTTP response.
  */
 function sendTokenError(res: Response, error: string, description?: string, status = 400): Response {
@@ -586,9 +586,9 @@ function sendTokenError(res: Response, error: string, description?: string, stat
 
 /**
  * Verifies the code challenge and verifier.
- * @param challenge The code_challenge from the authorization.
- * @param method The code_challenge_method from the authorization.
- * @param verifier The code_verifier from the token request.
+ * @param challenge - The code_challenge from the authorization.
+ * @param method - The code_challenge_method from the authorization.
+ * @param verifier - The code_verifier from the token request.
  * @returns True if the verifier succeeds; false otherwise.
  */
 function verifyCode(challenge: string, method: string, verifier: string): boolean {
@@ -608,7 +608,7 @@ function verifyCode(challenge: string, method: string, verifier: string): boolea
  * The details around '+', '/', and '=' are important for compatibility.
  * See: https://auth0.com/docs/flows/call-your-api-using-the-authorization-code-flow-with-pkce
  * See: packages/client/src/crypto.ts
- * @param code The input code.
+ * @param code - The input code.
  * @returns The base64-url-encoded SHA256 hash.
  */
 export function hashCode(code: string): string {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -107,7 +107,7 @@ export interface GoogleCredentialClaims extends JWTPayload {
 /**
  * Returns the client application by ID.
  * Handles special cases for "built-in" clients.
- * @param clientId The client ID.
+ * @param clientId - The client ID.
  * @returns The client application.
  */
 export async function getClient(clientId: string): Promise<ClientApplication> {
@@ -258,8 +258,8 @@ async function authenticate(request: LoginRequest, user: User): Promise<void> {
  * Ensures that the token is valid.
  * On success, updates the login with the MFA status.
  * On error, throws an error.
- * @param login The login resource.
- * @param token The user supplied MFA token.
+ * @param login - The login resource.
+ * @param token - The user supplied MFA token.
  * @returns The updated login resource.
  */
 export async function verifyMfaToken(login: Login, token: string): Promise<Login> {
@@ -296,7 +296,7 @@ export async function verifyMfaToken(login: Login, token: string): Promise<Login
  * When a user logs in, gather all the available profiles.
  * If there is only one profile, then automatically select it.
  * Otherwise, the user must select a profile.
- * @param login The login resource.
+ * @param login - The login resource.
  * @returns Array of profile resources that the user has access to.
  */
 export async function getMembershipsForLogin(login: Login): Promise<ProjectMembership[]> {
@@ -340,7 +340,7 @@ export async function getMembershipsForLogin(login: Login): Promise<ProjectMembe
 
 /**
  * Returns the project membership for the client application.
- * @param client The client application.
+ * @param client - The client application.
  * @returns The project membership for the client application if found; otherwise undefined.
  */
 export function getClientApplicationMembership(client: ClientApplication): Promise<ProjectMembership | undefined> {
@@ -361,8 +361,8 @@ export function getClientApplicationMembership(client: ClientApplication): Promi
  * Ensures that the login satisfies the project requirements.
  * Most users will only have one membership, so this happens immediately after login.
  * Some users have multiple memberships, so this happens after choosing a profile.
- * @param login The login before the membership is set.
- * @param membershipId The membership to set.
+ * @param login - The login before the membership is set.
+ * @param membershipId - The membership to set.
  * @returns The updated login.
  */
 export async function setLoginMembership(login: Login, membershipId: string): Promise<Login> {
@@ -418,8 +418,8 @@ export async function setLoginMembership(login: Login, membershipId: string): Pr
  * Returns successfully if the login first matches an "allow" rule.
  * Returns successfully if the login does not match any rules.
  * Throws an error if the login matches a "block" rule.
- * @param login The candidate login.
- * @param accessPolicy The access policy for the login.
+ * @param login - The candidate login.
+ * @param accessPolicy - The access policy for the login.
  */
 async function checkIpAccessRules(login: Login, accessPolicy: AccessPolicy | undefined): Promise<void> {
   if (!login.remoteAddress || !accessPolicy?.ipAccessRule) {
@@ -439,8 +439,8 @@ async function checkIpAccessRules(login: Login, accessPolicy: AccessPolicy | und
 
 /**
  * Returns true if the remote address matches the rule value.
- * @param remoteAddress The login remote address.
- * @param ruleValue The IP Access Rule value.
+ * @param remoteAddress - The login remote address.
+ * @param ruleValue - The IP Access Rule value.
  * @returns True if the remote address matches the rule value; otherwise false.
  */
 function matchesIpAccessRule(remoteAddress: string, ruleValue: string): boolean {
@@ -450,8 +450,8 @@ function matchesIpAccessRule(remoteAddress: string, ruleValue: string): boolean 
 /**
  * Sets the login scope.
  * Ensures that the scope is the same or a subset of the originally requested scope.
- * @param login The login before the membership is set.
- * @param scope The scope to set.
+ * @param login - The login before the membership is set.
+ * @param scope - The scope to set.
  * @returns The updated login.
  */
 export async function setLoginScope(login: Login, scope: string): Promise<Login> {
@@ -545,8 +545,8 @@ export async function revokeLogin(login: Login): Promise<void> {
 /**
  * Searches for a user by externalId and project.
  * External ID users are explicitly associated with the project.
- * @param externalId The external ID.
- * @param projectId The project ID.
+ * @param externalId - The external ID.
+ * @param projectId - The project ID.
  * @returns The user if found; otherwise, undefined.
  */
 export async function getUserByExternalId(externalId: string, projectId: string): Promise<User | undefined> {
@@ -589,8 +589,8 @@ export async function getUserByExternalId(externalId: string, projectId: string)
 
 /**
  * Searches for user by email.
- * @param email The email string.
- * @param projectId Optional project ID.
+ * @param email - The email string.
+ * @param projectId - Optional project ID.
  * @returns The user if found; otherwise, undefined.
  */
 export async function getUserByEmail(email: string, projectId: string | undefined): Promise<User | undefined> {
@@ -607,8 +607,8 @@ export async function getUserByEmail(email: string, projectId: string | undefine
 /**
  * Searches for a user by email and project.
  * This will only return users that are explicitly associated with the project.
- * @param email The email string.
- * @param projectId The project ID.
+ * @param email - The email string.
+ * @param projectId - The project ID.
  * @returns The user if found; otherwise, undefined.
  */
 export async function getUserByEmailInProject(email: string, projectId: string): Promise<User | undefined> {
@@ -633,7 +633,7 @@ export async function getUserByEmailInProject(email: string, projectId: string):
 /**
  * Searches for a user by email without a project.
  * This returns users that are not explicitly associated with a project.
- * @param email The email string.
+ * @param email - The email string.
  * @returns The user if found; otherwise, undefined.
  */
 export async function getUserByEmailWithoutProject(email: string): Promise<User | undefined> {
@@ -663,8 +663,8 @@ export async function getUserByEmailWithoutProject(email: string): Promise<User 
  * The built-in function timingSafeEqual requires that buffers are equal length.
  * Per the discussion here: https://github.com/nodejs/node/issues/17178
  * That is considered ok, and does not invalidate the protection from timing attack.
- * @param a First string.
- * @param b Second string.
+ * @param a - First string.
+ * @param b - Second string.
  * @returns True if the strings are equal.
  */
 export function timingSafeEqualStr(a: string, b: string): boolean {
@@ -675,7 +675,7 @@ export function timingSafeEqualStr(a: string, b: string): boolean {
 
 /**
  * Determines if the login request should include a refresh token.
- * @param request The login request.
+ * @param request - The login request.
  * @returns True if the login should include a refresh token.
  */
 function includeRefreshToken(request: LoginRequest): boolean {
@@ -695,8 +695,8 @@ function includeRefreshToken(request: LoginRequest): boolean {
 /**
  * Returns the external identity provider user info for an access token.
  * This can be used to verify the access token and get the user's email address.
- * @param idp The identity provider configuration.
- * @param externalAccessToken The external identity provider access token.
+ * @param idp - The identity provider configuration.
+ * @param externalAccessToken - The external identity provider access token.
  * @returns The user info claims.
  */
 export async function getExternalUserInfo(
@@ -777,7 +777,7 @@ export async function verifyMultipleMatchingException(
 
 /**
  * Verifies the access token and returns the corresponding login, membership, and project.
- * @param accessToken The access token as provided by the client.
+ * @param accessToken - The access token as provided by the client.
  * @returns On success, returns the login, membership, and project. On failure, throws an error.
  */
 export async function getLoginForAccessToken(accessToken: string): Promise<AuthState> {

--- a/packages/server/src/openapi.ts
+++ b/packages/server/src/openapi.ts
@@ -101,9 +101,9 @@ function buildBaseSpec(): OpenAPIObjectWithPaths {
 
 /**
  * Builds the OpenAPI specification details for a FHIR type.
- * @param result The OpenAPI specification output.
- * @param typeName The FHIR type name.
- * @param typeDefinition The FHIR type definition.
+ * @param result - The OpenAPI specification output.
+ * @param typeName - The FHIR type name.
+ * @param typeDefinition - The FHIR type definition.
  */
 function buildFhirType(result: OpenAPIObject, typeName: string, typeDefinition: JSONSchema4): void {
   buildSchema(result, typeName, typeDefinition);
@@ -115,9 +115,9 @@ function buildFhirType(result: OpenAPIObject, typeName: string, typeDefinition: 
 /**
  * Builds the schema for a FHIR type.
  * See: https://swagger.io/specification/#schema-object
- * @param result The OpenAPI specification output.
- * @param typeName The FHIR type name.
- * @param typeDefinition The FHIR type definition.
+ * @param result - The OpenAPI specification output.
+ * @param typeName - The FHIR type name.
+ * @param typeDefinition - The FHIR type definition.
  */
 function buildSchema(result: OpenAPIObject, typeName: string, typeDefinition: JSONSchema4): void {
   ((result.components as ComponentsObject).schemas as SchemaMap)[typeName] = buildObjectSchema(typeDefinition);
@@ -125,7 +125,7 @@ function buildSchema(result: OpenAPIObject, typeName: string, typeDefinition: JS
 
 /**
  * Converts a JSONSchema type definition to an OpenAPI type definition.
- * @param definition The JSONSchema type definition.
+ * @param definition - The JSONSchema type definition.
  * @returns The OpenAPI type definition.
  */
 function buildObjectSchema(definition: JSONSchema4): SchemaObject {
@@ -141,8 +141,8 @@ function buildObjectSchema(definition: JSONSchema4): SchemaObject {
 /**
  * Replaces JSONSchema references with OpenAPI references.
  * Can be used as 2nd parameter in JSON.stringify.
- * @param key The JSON property key.
- * @param value The JSON property value.
+ * @param key - The JSON property key.
+ * @param value - The JSON property value.
  * @returns The updated JSON property value.
  */
 function refReplacer(key: string, value: any): any {
@@ -158,9 +158,9 @@ function refReplacer(key: string, value: any): any {
 /**
  * Builds the tags for a FHIR type.
  * See: https://swagger.io/specification/#tag-object
- * @param result The OpenAPI specification output.
- * @param typeName The FHIR type name.
- * @param typeDefinition The FHIR type definition.
+ * @param result - The OpenAPI specification output.
+ * @param typeName - The FHIR type name.
+ * @param typeDefinition - The FHIR type definition.
  */
 function buildTags(result: OpenAPIObject, typeName: string, typeDefinition: JSONSchema4): void {
   (result.tags as TagObject[]).push({
@@ -174,7 +174,7 @@ function buildTags(result: OpenAPIObject, typeName: string, typeDefinition: JSON
 
 /**
  * Builds the paths for a FHIR resource type.
- * @param result The OpenAPI specification output.
+ * @param result - The OpenAPI specification output.
  */
 function buildPaths(result: OpenAPIObjectWithPaths): void {
   result.paths[`/fhir/R4/{resourceType}`] = {

--- a/packages/server/src/scim/utils.ts
+++ b/packages/server/src/scim/utils.ts
@@ -10,7 +10,7 @@ import { ScimListResponse, ScimUser } from './types';
  *
  * See SCIM 3.4.2 - Query Resources
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.2
- * @param project The project.
+ * @param project - The project.
  * @returns List of SCIM users in the project.
  */
 export async function searchScimUsers(project: Project): Promise<ScimListResponse<ScimUser>> {
@@ -41,9 +41,9 @@ export async function searchScimUsers(project: Project): Promise<ScimListRespons
  *
  * See SCIM 3.3 - Creating Resources
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.3
- * @param invitedBy The user who invited the new user.
- * @param project The project.
- * @param scimUser The new user definition.
+ * @param invitedBy - The user who invited the new user.
+ * @param project - The project.
+ * @param scimUser - The new user definition.
  * @returns The new user.
  */
 export async function createScimUser(
@@ -83,8 +83,8 @@ export async function createScimUser(
  *
  * See SCIM 3.4.1 - Retrieve a Known Resource
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.1
- * @param project The project.
- * @param id The user ID.
+ * @param project - The project.
+ * @param id - The user ID.
  * @returns The user.
  */
 export async function readScimUser(project: Project, id: string): Promise<ScimUser> {
@@ -102,8 +102,8 @@ export async function readScimUser(project: Project, id: string): Promise<ScimUs
  *
  * See SCIM 3.5.1 - Replace a Resource
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.5.1
- * @param project The project.
- * @param scimUser The updated user definition.
+ * @param project - The project.
+ * @param scimUser - The updated user definition.
  * @returns The updated user.
  */
 export async function updateScimUser(project: Project, scimUser: ScimUser): Promise<ScimUser> {
@@ -134,8 +134,8 @@ export async function updateScimUser(project: Project, scimUser: ScimUser): Prom
  *
  * See SCIM 3.4.1 - Retrieve a Known Resource
  * https://www.rfc-editor.org/rfc/rfc7644#section-3.4.1
- * @param project The project.
- * @param id The user ID.
+ * @param project - The project.
+ * @param id - The user ID.
  * @returns The user.
  */
 export async function deleteScimUser(project: Project, id: string): Promise<void> {
@@ -153,7 +153,7 @@ export async function deleteScimUser(project: Project, id: string): Promise<void
  * By default, a SCIM User does not have the equivalent of a FHIR resource type.
  *
  * This function looks for the Medplum extension, which contains the resource type.
- * @param scimUser The SCIM user definition.
+ * @param scimUser - The SCIM user definition.
  * @returns The FHIR profile resource type if found; otherwise, undefined.
  */
 export function getScimUserResourceType(scimUser: ScimUser): 'Patient' | 'Practitioner' | 'RelatedPerson' | undefined {
@@ -166,8 +166,8 @@ export function getScimUserResourceType(scimUser: ScimUser): 'Patient' | 'Practi
 
 /**
  * Converts a Medplum user and project membershipt into a SCIM user.
- * @param user The Medplum user.
- * @param membership The Medplum project membership.
+ * @param user - The Medplum user.
+ * @param membership - The Medplum project membership.
  * @returns The SCIM user.
  */
 export function convertToScimUser(user: User, membership: ProjectMembership): ScimUser {
@@ -195,7 +195,7 @@ export function convertToScimUser(user: User, membership: ProjectMembership): Sc
 
 /**
  * Converts an array of resources into a SCIM ListResponse.
- * @param Resources The list of resources.
+ * @param Resources - The list of resources.
  * @returns The SCIM ListResponse object.
  */
 export function convertToScimListResponse<T>(Resources: T[]): ScimListResponse<T> {

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -153,8 +153,8 @@ export async function addTestUser(
 
 /**
  * Sets up the pwnedPassword mock to handle "Have I Been Pwned" requests.
- * @param pwnedPassword The pwnedPassword mock.
- * @param numPwns The mock value to return. Zero is a safe password.
+ * @param pwnedPassword - The pwnedPassword mock.
+ * @param numPwns - The mock value to return. Zero is a safe password.
  */
 export function setupPwnedPasswordMock(pwnedPassword: jest.Mock, numPwns: number): void {
   pwnedPassword.mockImplementation(async () => numPwns);
@@ -162,8 +162,8 @@ export function setupPwnedPasswordMock(pwnedPassword: jest.Mock, numPwns: number
 
 /**
  * Sets up the fetch mock to handle Recaptcha requests.
- * @param fetch The fetch mock.
- * @param success Whether the mock should return a successful response.
+ * @param fetch - The fetch mock.
+ * @param success - Whether the mock should return a successful response.
  */
 export function setupRecaptchaMock(fetch: jest.Mock, success: boolean): void {
   fetch.mockImplementation(() => ({
@@ -174,8 +174,8 @@ export function setupRecaptchaMock(fetch: jest.Mock, success: boolean): void {
 
 /**
  * Returns true if the resource is in an entry in the bundle.
- * @param bundle A bundle of resources.
- * @param resource The resource to search for.
+ * @param bundle - A bundle of resources.
+ * @param resource - The resource to search for.
  * @returns True if the resource is in the bundle.
  */
 export function bundleContains(bundle: Bundle, resource: Resource): boolean {
@@ -185,7 +185,7 @@ export function bundleContains(bundle: Bundle, resource: Resource): boolean {
 /**
  * Waits for a function to evaluate successfully.
  * Use this to wait for async behaviors without a handle.
- * @param fn Function to call.
+ * @param fn - Function to call.
  */
 export function waitFor(fn: () => Promise<void>): Promise<void> {
   return new Promise((resolve) => {

--- a/packages/server/src/util/cloudwatch.ts
+++ b/packages/server/src/util/cloudwatch.ts
@@ -107,7 +107,7 @@ export class CloudWatchLogger {
    * This method takes the full queue and splits it into acceptable batches.
    *
    * In the common case, one call to processEvents will result in one call to putEvents.
-   * @param logEvents All of the events in the queue at the time of the timer.
+   * @param logEvents - All of the events in the queue at the time of the timer.
    */
   private async processEvents(logEvents: LogEvent[]): Promise<void> {
     // Build batches with  CloudWatch Logs constraints:
@@ -138,7 +138,7 @@ export class CloudWatchLogger {
    * Uploads a batch of events to CloudWatch logs.
    *
    * T?his method assumes that the PutLogEvents constraints are satisfied.
-   * @param logEvents Batch of events for single call to PutLogEvents.
+   * @param logEvents - Batch of events for single call to PutLogEvents.
    */
   private async putEvents(logEvents: LogEvent[]): Promise<void> {
     try {

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -18,7 +18,7 @@ let wsServer: ws.Server | undefined = undefined;
 
 /**
  * Initializes a websocket listener on the given HTTP server.
- * @param server The HTTP server.
+ * @param server - The HTTP server.
  */
 export function initWebSockets(server: http.Server): void {
   wsServer = new ws.Server({
@@ -58,7 +58,7 @@ function getWebSocketPath(path: string): string {
 /**
  * Handles a new WebSocket connection to the echo service.
  * The echo service simply echoes back whatever it receives.
- * @param socket The WebSocket connection.
+ * @param socket - The WebSocket connection.
  */
 async function handleEchoConnection(socket: ws.WebSocket): Promise<void> {
   // Create a redis client for this connection.

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -41,7 +41,7 @@ let worker: Worker<CronJobData> | undefined = undefined;
  * Initializes the Cron worker.
  * Sets up the BullMQ job queue.
  * Sets up the BullMQ worker.
- * @param config The Medplum server config to use.
+ * @param config - The Medplum server config to use.
  */
 export function initCronWorker(config: MedplumServerConfig): void {
   const defaultOptions: QueueBaseOptions = {
@@ -94,7 +94,7 @@ export function getCronQueue(): Queue<CronJobData> | undefined {
 }
 
 /**
- * @param resource The resource that was created or updated.
+ * @param resource - The resource that was created or updated.
  */
 export async function addCronJobs(resource: Resource): Promise<void> {
   const ctx = getRequestContext();
@@ -146,8 +146,8 @@ export async function addCronJobs(resource: Resource): Promise<void> {
 /**
  * Adds a Cron job to the queue, and removes the previous job for bot
  * if it exists
- * @param job The Cron job details.
- * @param repeatable The repeat format that instructs BullMQ when to run the job
+ * @param job - The Cron job details.
+ * @param repeatable - The repeat format that instructs BullMQ when to run the job
  */
 async function addCronJobData(job: CronJobData, repeatable: Repeatable): Promise<void> {
   const ctx = getRequestContext();
@@ -164,7 +164,7 @@ async function addCronJobData(job: CronJobData, repeatable: Repeatable): Promise
 
 /**
  * BullMQ repeat option, which conducts the job has a cron-parser's pattern
- * @param timing The Cron property from the bot, which is a Timing Type.
+ * @param timing - The Cron property from the bot, which is a Timing Type.
  * @returns The cron string.
  */
 export function convertTimingToCron(timing: Timing): string | undefined {

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -35,7 +35,7 @@ let worker: Worker<DownloadJobData> | undefined = undefined;
  * Initializes the download worker.
  * Sets up the BullMQ job queue.
  * Sets up the BullMQ worker.
- * @param config The Medplum server config to use.
+ * @param config - The Medplum server config to use.
  */
 export function initDownloadWorker(config: MedplumServerConfig): void {
   const defaultOptions: QueueBaseOptions = {
@@ -99,7 +99,7 @@ export function getDownloadQueue(): Queue<DownloadJobData> | undefined {
  * at that moment in time.  For each matching download, we enqueue the job.
  * The only purpose of the job is to make the outbound HTTP request,
  * not to re-evaluate the download.
- * @param resource The resource that was created or updated.
+ * @param resource - The resource that was created or updated.
  */
 export async function addDownloadJobs(resource: Resource): Promise<void> {
   for (const attachment of getAttachments(resource)) {
@@ -120,7 +120,7 @@ export async function addDownloadJobs(resource: Resource): Promise<void> {
  *  1) They refer to a fully qualified fhir/R4/Binary/ endpoint.
  *  2) They refer to the Medplum storage URL.
  *  3) They refer to a Binary in canonical form (i.e., "Binary/123").
- * @param url The Media content URL.
+ * @param url - The Media content URL.
  * @returns True if the URL is an external URL.
  */
 function isExternalUrl(url: string | undefined): url is string {
@@ -134,7 +134,7 @@ function isExternalUrl(url: string | undefined): url is string {
 
 /**
  * Adds a download job to the queue.
- * @param job The download job details.
+ * @param job - The download job details.
  */
 async function addDownloadJobData(job: DownloadJobData): Promise<void> {
   const ctx = getRequestContext();
@@ -148,7 +148,7 @@ async function addDownloadJobData(job: DownloadJobData): Promise<void> {
 
 /**
  * Executes a download job.
- * @param job The download job details.
+ * @param job - The download job details.
  */
 export async function execDownloadJob(job: Job<DownloadJobData>): Promise<void> {
   const ctx = getRequestContext();

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -8,7 +8,7 @@ import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } 
 
 /**
  * Initializes all background workers.
- * @param config The config to initialize the workers with. Should contain `redis` and optionally `bullmq` fields.
+ * @param config - The config to initialize the workers with. Should contain `redis` and optionally `bullmq` fields.
  */
 export function initWorkers(config: MedplumServerConfig): void {
   globalLogger.debug('Initializing workers...');
@@ -29,8 +29,8 @@ export async function closeWorkers(): Promise<void> {
 
 /**
  * Adds all background jobs for a given resource.
- * @param resource The resource that was created or updated.
- * @param context The background job context.
+ * @param resource - The resource that was created or updated.
+ * @param context - The background job context.
  */
 export async function addBackgroundJobs(resource: Resource, context: BackgroundJobContext): Promise<void> {
   await addSubscriptionJobs(resource, context);

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -56,7 +56,7 @@ let worker: Worker<SubscriptionJobData> | undefined = undefined;
  * Initializes the subscription worker.
  * Sets up the BullMQ job queue.
  * Sets up the BullMQ worker.
- * @param config The Medplum server config to use.
+ * @param config - The Medplum server config to use.
  */
 export function initSubscriptionWorker(config: MedplumServerConfig): void {
   const defaultOptions: QueueBaseOptions = {
@@ -120,8 +120,8 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
  * at that moment in time.  For each matching subscription, we enqueue the job.
  * The only purpose of the job is to make the outbound HTTP request,
  * not to re-evaluate the subscription.
- * @param resource The resource that was created or updated.
- * @param context The background job context.
+ * @param resource - The resource that was created or updated.
+ * @param context - The background job context.
  */
 export async function addSubscriptionJobs(resource: Resource, context: BackgroundJobContext): Promise<void> {
   const ctx = getRequestContext();
@@ -146,9 +146,9 @@ export async function addSubscriptionJobs(resource: Resource, context: Backgroun
 
 /**
  * Determines if the resource matches the subscription criteria.
- * @param resource The resource that was created or updated.
- * @param subscription The subscription.
- * @param context Background job context.
+ * @param resource - The resource that was created or updated.
+ * @param subscription - The subscription.
+ * @param context - Background job context.
  * @returns True if the resource matches the subscription criteria.
  */
 async function matchesCriteria(
@@ -203,7 +203,7 @@ async function matchesCriteria(
 
 /**
  * Returns true if the subscription channel type is ok to execute.
- * @param subscription The subscription resource.
+ * @param subscription - The subscription resource.
  * @returns True if the subscription channel type is ok to execute.
  */
 function matchesChannelType(subscription: Subscription): boolean {
@@ -224,7 +224,7 @@ function matchesChannelType(subscription: Subscription): boolean {
 
 /**
  * Adds a subscription job to the queue.
- * @param job The subscription job details.
+ * @param job - The subscription job details.
  */
 async function addSubscriptionJobData(job: SubscriptionJobData): Promise<void> {
   const ctx = getRequestContext();
@@ -238,7 +238,7 @@ async function addSubscriptionJobData(job: SubscriptionJobData): Promise<void> {
 
 /**
  * Loads the list of all subscriptions in this repository.
- * @param resource The resource that was created or updated.
+ * @param resource - The resource that was created or updated.
  * @returns The list of all subscriptions in this repository.
  */
 async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
@@ -266,7 +266,7 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
 
 /**
  * Executes a subscription job.
- * @param job The subscription job details.
+ * @param job - The subscription job details.
  */
 export async function execSubscriptionJob(job: Job<SubscriptionJobData>): Promise<void> {
   const { subscriptionId, resourceType, id, versionId } = job.data;
@@ -335,9 +335,9 @@ export async function execSubscriptionJob(job: Job<SubscriptionJobData>): Promis
 
 /**
  * Sends a rest-hook subscription.
- * @param job The subscription job details.
- * @param subscription The subscription.
- * @param resource The resource that triggered the subscription.
+ * @param job - The subscription job details.
+ * @param subscription - The subscription.
+ * @param resource - The resource that triggered the subscription.
  */
 async function sendRestHook(
   job: Job<SubscriptionJobData>,
@@ -393,8 +393,8 @@ async function sendRestHook(
 
 /**
  * Builds a collection of HTTP request headers for the rest-hook subscription.
- * @param subscription The subscription resource.
- * @param resource The trigger resource.
+ * @param subscription - The subscription resource.
+ * @param resource - The trigger resource.
  * @returns The HTTP request headers.
  */
 function buildRestHookHeaders(subscription: Subscription, resource: Resource): HeadersInit {
@@ -425,8 +425,8 @@ function buildRestHookHeaders(subscription: Subscription, resource: Resource): H
 
 /**
  * Executes a Bot subscription.
- * @param subscription The subscription.
- * @param resource The resource that triggered the subscription.
+ * @param subscription - The subscription.
+ * @param resource - The resource that triggered the subscription.
  */
 async function execBot(subscription: Subscription, resource: Resource): Promise<void> {
   const url = subscription.channel?.endpoint as string;
@@ -462,9 +462,9 @@ async function execBot(subscription: Subscription, resource: Resource): Promise<
 
 /**
  * Sends a rest-hook subscription for deleted resource. Extra header is passed and the body is empty.
- * @param job The subscription job details.
- * @param subscription The subscription.
- * @param resource The resource that triggered the subscription to add to the Audit Event.
+ * @param job - The subscription job details.
+ * @param subscription - The subscription.
+ * @param resource - The resource that triggered the subscription to add to the Audit Event.
  */
 async function sendDeleteRestHook(
   job: Job<SubscriptionJobData>,

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -34,12 +34,12 @@ export function findProjectMembership(project: string, profile: Reference): Prom
 
 /**
  * Creates an AuditEvent for a subscription attempt.
- * @param resource The resource that triggered the subscription.
- * @param startTime The time the subscription attempt started.
- * @param outcome The outcome code.
- * @param outcomeDesc The outcome description text.
- * @param subscription Optional rest-hook subscription.
- * @param bot Optional bot that was executed.
+ * @param resource - The resource that triggered the subscription.
+ * @param startTime - The time the subscription attempt started.
+ * @param outcome - The outcome code.
+ * @param outcomeDesc - The outcome description text.
+ * @param subscription - Optional rest-hook subscription.
+ * @param bot - Optional bot that was executed.
  */
 export async function createAuditEvent(
   resource: Resource,

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["@microsoft/api-extractor/extends/tsdoc-base.json"],
+  "tagDefinitions": [
+    {
+      "tagName": "@category",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    }
+  ],
+  "supportForTags": {
+    "@category": true
+  }
+}


### PR DESCRIPTION
Before:

```ts
/*
 * @param myParameter My long description text...
 */
```

After

```ts
/*
 * @param myParameter - My long description text...
 */
```

This is recommended by https://api-extractor.com/

Fixing all current cases

Requiring it in ESLint