### PR TITLE
Adding links from "User Admin Guide" to the '/invite' API

### DIFF
--- a/packages/docs/docs/api/project-admin/invite.md
+++ b/packages/docs/docs/api/project-admin/invite.md
@@ -8,8 +8,8 @@ import TabItem from '@theme/TabItem';
 Invite a new user to the project. This will perform the following actions:
 
 1. Search for an existing user with the provided `email`, if given
-2. Search for an existing profile resource ([`Patient``](/docs/api/fhir/resources/patient), [`Practitioner`](/docs/api/fhir/resources/practitioner), or [`RelatedPerson`](/docs/api/fhir/resources/relatedperson))
-3. Create a new User, if no existing User was found,
+2. Search for an existing profile resource ([`Patient`](/docs/api/fhir/resources/patient), [`Practitioner`](/docs/api/fhir/resources/practitioner), or [`RelatedPerson`](/docs/api/fhir/resources/relatedperson))
+3. Create a new [`User`](/docs/api/fhir/medplum/user), if no existing [`User`](/docs/api/fhir/medplum/user) was found,
    1. Set the password if `password` is given
    2. Generate a password reset url
 4. Create a new profile resource, if no existing profile was found
@@ -30,6 +30,16 @@ Invite a new user to the project. This will perform the following actions:
   membership?: Partial<ProjectMembership>;
 }
 ```
+
+| parameter               | description                                                                                                                                                                                                                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resourceType`          | The [User's](/docs/api/fhir/medplum/user) [profile resourceType](/docs/auth/user-management-guide#profiles)                                                                                                                                                                                        |
+| `firstName`, `lastName` | The first and last names that will be assigned to user's [profile resource](/docs/auth/user-management-guide#profiles). Ignored if a profile resource already exists                                                                                                                               |
+| `email`                 | The email address assigned to the [User](/docs/api/fhir/medplum/user). Used to identify users within each project                                                                                                                                                                                  |
+| `externalId`            | The unique id provided by external identity provider (if applicable). See [Using External Ids](/docs/auth/methods/external-ids)                                                                                                                                                                    |
+| `password`              | The [User's](/docs/api/fhir/medplum/user) password                                                                                                                                                                                                                                                 |
+| `sendEmail`             | If `true`, send an invite email to the user. If self-hosting, see our [guide on setting up SES](/docs/self-hosting/install-on-aws#setup-ses)                                                                                                                                                       |
+| `membership`            | Used to override any fields of the resulting [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership) resource. Common use cases include: <ul><li>Setting [Access Policies](/docs/access/access-policies) upon invite </li><li>Overriding the default `ProjectMembership.profile`</li></ul> |
 
 ### Constraints
 
@@ -185,5 +195,6 @@ Returns the [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership) asso
 
 ## See Also
 
+- [User Admin Guide](/docs/auth/user-management-guide)
 - [Invite a new user](https://www.medplum.com/docs/app/invite)
 - [Custom Emails](https://www.medplum.com/docs/auth/custom-emails)

--- a/packages/docs/docs/auth/user-management-guide/user-management-guide.md
+++ b/packages/docs/docs/auth/user-management-guide/user-management-guide.md
@@ -313,7 +313,7 @@ It is important to spread the original `ProjectMembership` to ensure that you ar
 
 ## Invite via API
 
-Inviting users can be done programmatically using the `/invite` endpoint
+Inviting users can be done programmatically using the [`/invite` endpoint](/docs/api/project-admin/invite).
 
 Prepare JSON payload:
 
@@ -321,7 +321,7 @@ Prepare JSON payload:
   {ExampleCode}
 </MedplumCodeBlock>
 
-Then POST to the `/invite` endpoint:
+Then POST to the [`/invite` endpoint](/docs/api/project-admin/invite):
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">
@@ -341,7 +341,7 @@ Then POST to the `/invite` endpoint:
   </TabItem>
 </Tabs>
 
-The `/invite` endpoint creates a [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership). The `ProjectMembership` resource includes additional properties to customize the user experience. The `/invite` endpoint accepts a partial `ProjectMembership` in the `membership` property where you can provide membership details.
+The [`/invite` endpoint](/docs/api/project-admin/invite) creates a [`ProjectMembership`](/docs/api/fhir/medplum/projectmembership). The `ProjectMembership` resource includes additional properties to customize the user experience. The [`/invite` endpoint](/docs/api/project-admin/invite) accepts a partial `ProjectMembership` in the `membership` property where you can provide membership details.
 
 For example, use `admin: true` to make the new user a project administrator:
 
@@ -354,6 +354,8 @@ Or use the `access` property to specify a user's `AccessPolicy` with optional pa
 <MedplumCodeBlock language="ts" selectBlocks="prepareJsonAccessPolicy">
   {ExampleCode}
 </MedplumCodeBlock>
+
+For more information, see the [`/invite` endpoint API docs](/docs/api/project-admin/invite)
 
 See [Access Control](/docs/access/access-policies) for more details.
 


### PR DESCRIPTION
Small docs change to link from the examples of `/invite` the to comprehensive docs