### PR TITLE
Fixed warnings in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,20 +88,20 @@ jobs:
           npm run installer
 
       - name: Upload Agent installer
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const fs = require('fs');
             const tag = context.ref.replace("refs/tags/", "");
-            const release = await github.repos.getReleaseByTag({
+            const release = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag
             });
-            await github.repos.uploadReleaseAsset({
+            await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "medplum-agent-win-x64.exe",
+              name: "medplum-agent-installer.exe",
               data: await fs.readFileSync("packages/agent/medplum-agent-installer.exe")
             });

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/agent"
   },
   "license": "Apache-2.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/app"
   },
   "license": "Apache-2.0",

--- a/packages/bot-layer/package.json
+++ b/packages/bot-layer/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/bot-layer"
   },
   "license": "Apache-2.0",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -5,14 +5,11 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/cdk"
   },
   "license": "Apache-2.0",
   "author": "Medplum <hello@medplum.com>",
-  "bin": {
-    "medplum-cdk-init": "./dist/cjs/init.cjs"
-  },
   "scripts": {
     "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs",
     "cdk": "cdk",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/cli"
   },
   "license": "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/core"
   },
   "license": "Apache-2.0",

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/definitions"
   },
   "license": "Apache-2.0",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/docs"
   },
   "license": "Apache-2.0",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/eslint-config"
   },
   "license": "Apache-2.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/examples"
   },
   "license": "Apache-2.0",

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/fhir-router"
   },
   "license": "Apache-2.0",

--- a/packages/fhirtypes/package.json
+++ b/packages/fhirtypes/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/fhirtypes"
   },
   "license": "Apache-2.0",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/generator"
   },
   "license": "Apache-2.0",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/graphiql"
   },
   "license": "Apache-2.0",

--- a/packages/hl7/package.json
+++ b/packages/hl7/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/hl7"
   },
   "license": "Apache-2.0",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/mock"
   },
   "license": "Apache-2.0",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/react-hooks"
   },
   "license": "Apache-2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/react"
   },
   "license": "Apache-2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.medplum.com/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medplum/medplum.git",
+    "url": "git+https://github.com/medplum/medplum.git",
     "directory": "packages/server"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
See recent "Publish" action logs: https://github.com/medplum/medplum/actions/runs/6659864785

1. Upgraded `actions/github-script` from v4 to v6 to fix node12 warning
2. Fixed `npm WARN publish "repository.url" was normalized to "git+https://github.com/medplum/medplum.git"`
3. Removed `medplum-cdk-init` from `@medplum/cdk`