### PR TITLE
Difficulty filtering by patient as multiselect underflows modal

### DIFF
--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -173,6 +173,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
       rightSection={abortController ? <Loader size={16} /> : null}
       filter={handleFilter}
       creatable
+      withinPortal={true}
     />
   );
 }


### PR DESCRIPTION
**Pull Request Title**: ✨ ADifficulty filtering by patient as multiselect underflows modal ✨

**Description**:

This Pull Request addresses an issue where patient selection for filtering observations was causing a modal overflow.🚀

**Details of Changes**:

The addition of withinPortal={true} to the AsyncAutocomplete component will affect how this component behaves within the codebase. This change is implemented to address the issue of modal overflow when using this component, as described in the pull request description.

🚀 It's important to note that this prop is applicable to versions prior to version 7 of Mantine. This update ensures that the component behaves as intended within the given context.

