### PR TITLE
Add example of how to use optional --base-url flag

### DIFF
--- a/packages/docs/docs/cli/index.md
+++ b/packages/docs/docs/cli/index.md
@@ -60,6 +60,10 @@ By default, the `medplum` command uses the Medplum hosted API at "https://api.me
 - `--authorizeUrl <authorizeUrl>`
   - FHIR server authorize url
 
+```bash
+medplum get --base-url https://api.example.com 'Patient/homer-simpson'
+```
+
 ### Auth
 
 #### `login`


### PR DESCRIPTION
This will add an example of how to use the optional --base-url flag with the Medplum CLI. This is related to issue #3184 