### PR TITLE
feat(fhircast/hub): add `context.versionId` to `DiagnosticReport-open`

### DIFF
--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -155,6 +155,7 @@ export type FhircastEventPayload<EventName extends FhircastEventName = FhircastE
   'hub.topic': string;
   'hub.event': EventName;
   context: FhircastEventContext<EventName>[];
+  'context.versionId'?: string;
 };
 
 export type FhircastMessagePayload<EventName extends FhircastEventName = FhircastEventName> = {


### PR DESCRIPTION
## What this PR does
* Adds `context.versionId` to the `FhircastMessagePayload` that the `Hub` forwards to `Subscribers`
* Closes #3170

## Significance
This allows for `Subscribers` to track open event contexts by their version, enabling `DiagnosticReport-update` (see: #3138)

Depends on #3181 