### PR TITLE
feat: Pass resource to Repository logEvent on error

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -195,7 +195,7 @@ export class Repository extends BaseRepository implements FhirRepository {
       this.logEvent(CreateInteraction, AuditEventOutcome.Success, undefined, result);
       return result;
     } catch (err) {
-      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err);
+      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, resource);
       throw err;
     }
   }
@@ -440,7 +440,7 @@ export class Repository extends BaseRepository implements FhirRepository {
       this.logEvent(UpdateInteraction, AuditEventOutcome.Success, undefined, result);
       return result;
     } catch (err) {
-      this.logEvent(UpdateInteraction, AuditEventOutcome.MinorFailure, err);
+      this.logEvent(UpdateInteraction, AuditEventOutcome.MinorFailure, err, resource);
       throw err;
     }
   }


### PR DESCRIPTION
## Why
* `logAuditEvent` optionally supports passing a `Resource` but Repository doesn't take advantage of this in two places where it would be valuable: error cases for `createResource` and `updateResource`
* This is valuable because when an Update fails due to a validation in a Batch Transaction, being able to determine which resource failed to update is helpful
* More context for this PR available in this Discord discussion: https://discord.com/channels/905144809105260605/1149410163808284713

## What
* Pass resource to `this.logEvent` on the error cases for `createResource` and `updateResource`