### PR TITLE
Add placeholder value for identifier references

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1239,8 +1239,15 @@ export class Repository extends BaseRepository implements FhirRepository {
         return value;
       }
       if (typeof value === 'object') {
-        // Handle normal "reference" properties
-        return (value as Reference).reference;
+        if (value.reference) {
+          // Handle normal "reference" properties
+          return value.reference;
+        } else if (typeof value.identifier === 'object') {
+          // Handle logical (identifier-only) references by putting a placeholder in the column
+          // NOTE(mattwiller 2023-11-01): This is done to enable searches using the :missing modifier;
+          // actual identifier search matching is handled by the `<ResourceType>_Token` lookup tables
+          return `identifier:${value.identifier.system}|${value.identifier.value}`;
+        }
       }
     }
     return undefined;

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -1512,6 +1512,48 @@ describe('FHIR Search', () => {
       expect(bundleContains(bundle4, serviceRequest2)).toEqual(false);
     }));
 
+  test('Missing with logical (identifier) references', () =>
+    withTestContext(async () => {
+      const patientIdentifier = randomUUID();
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [
+          {
+            system: 'http://example.com/guid',
+            value: patientIdentifier,
+          },
+        ],
+        generalPractitioner: [
+          {
+            identifier: {
+              system: 'http://hl7.org/fhir/sid/us-npi',
+              value: '9876543210',
+            },
+          },
+        ],
+        managingOrganization: {
+          identifier: {
+            system: 'http://hl7.org/fhir/sid/us-npi',
+            value: '0123456789',
+          },
+        },
+      });
+
+      // Test singlet reference column
+      let results = await systemRepo.searchResources(
+        parseSearchDefinition(`Patient?identifier=${patientIdentifier}&organization:missing=false`)
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toEqual(patient.id);
+
+      // Test array reference column
+      results = await systemRepo.searchResources(
+        parseSearchDefinition(`Patient?identifier=${patientIdentifier}&general-practitioner:missing=false`)
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0]?.id).toEqual(patient.id);
+    }));
+
   test('Starts after', () =>
     withTestContext(async () => {
       // Create 2 appointments


### PR DESCRIPTION
Adds a placeholder value to reference columns to allow searches using `:missing` to work correctly.  This will require a reindex for any resource types to work with previously-written resources

Resolves #2540 