### PR TITLE
Adjust limit for chained searches

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -876,8 +876,8 @@ function buildEqualityCondition(
 }
 
 function buildChainedSearch(selectQuery: SelectQuery, resourceType: string, param: ChainedSearchParameter): void {
-  if (param.chain.length > 5) {
-    throw new OperationOutcomeError(badRequest('Search chains longer than five links are not supported'));
+  if (param.chain.length > 3) {
+    throw new OperationOutcomeError(badRequest('Search chains longer than three links are not currently supported'));
   }
 
   let currentResourceType = resourceType;


### PR DESCRIPTION
Pending some work to make chained search more efficient, a more conservative limit on chain length will help prevent large queries from affecting system stability