### PR TITLE
Fix "Id" capitolization issue in field selector

### DIFF
--- a/packages/react/src/SearchControl/SearchUtils.test.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.test.tsx
@@ -482,6 +482,9 @@ describe('SearchUtils', () => {
   test('buildFieldName', () => {
     expect(buildFieldNameString('id')).toBe('ID');
     expect(buildFieldNameString('Id')).toBe('ID');
+    expect(buildFieldNameString('_id')).toBe('ID');
+    expect(buildFieldNameString('_Id')).toBe('ID');
+
     expect(buildFieldNameString('meta.versionId')).toBe('Version ID');
     expect(buildFieldNameString('_lastUpdated')).toBe('Last Updated');
     expect(buildFieldNameString('name')).toBe('Name');

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -471,11 +471,6 @@ export function buildFieldNameString(key: string): string {
     tmp = tmp.split('.').pop() as string;
   }
 
-  // Special case for ID
-  if (tmp === 'id' || tmp === 'Id') {
-    return 'ID';
-  }
-
   // Special case for Version ID
   if (tmp === 'versionId') {
     return 'Version ID';
@@ -495,6 +490,11 @@ export function buildFieldNameString(key: string): string {
 
   // Trim
   tmp = tmp.trim();
+
+  // Special case for ID
+  if (tmp.toLowerCase() === 'id') {
+    return 'ID';
+  }
 
   // Capitalize the first letter of each word
   return tmp.split(/\s/).map(capitalize).join(' ');

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -277,7 +277,7 @@ function getFieldsList(
       if (!keys.has(code) && !names.has(name)) {
         result.push(code);
         keys.add(code);
-        names.add(buildFieldNameString(code));
+        names.add(name);
       }
     }
   }


### PR DESCRIPTION
Fixes #2891.

The `_id` version of the id field wasn't being handled in `buildFieldNameString`.

There was a related issue in `SearchFieldEditor` that this addresses as well where "ID" and "Id" would both be available:

![Screenshot 2023-11-02 at 11 52 14 AM](https://github.com/medplum/medplum/assets/933303/a28d876b-4b1a-4684-ba21-319d04fe153f)

Even with this change, it's still possible to (maunally) add both `_id` and `id` to the list of fields shown, e.g. [http://localhost:3000/Patient?_fields=_id,id](http://localhost:3000/Patient?_fields=_id,id). This doesn't seem like too big of a deal, but wanted to call it out.

