### PR TITLE
feat(client/fhircast): add `DiagnosticReport-{update,select}` events

### DIFF
--- a/examples/medplum-fhircast-demo/src/components/Subscriber.tsx
+++ b/examples/medplum-fhircast-demo/src/components/Subscriber.tsx
@@ -9,7 +9,7 @@ import TopicLoader from './TopicLoader';
 
 type FhircastMessageDisplayProps = {
   eventNo: number;
-  message: FhircastMessagePayload;
+  message: FhircastMessagePayload<'patient-open'>;
 };
 
 function FhircastMessageLabel(props: FhircastMessageDisplayProps): JSX.Element {
@@ -74,7 +74,7 @@ export default function Subscriber(): JSX.Element {
   const [currentPatientId, setCurrentPatientId] = useState<string>();
   const [topic, setTopic] = useState<string>();
   const [subRequest, setSubRequest] = useState<SubscriptionRequest>();
-  const [fhirCastMessages, setFhircastMessages] = useState<FhircastMessagePayload[]>([]);
+  const [fhircastMessages, setFhircastMessages] = useState<FhircastMessagePayload<'patient-open'>[]>([]);
   const [eventCount, setEventCount] = useState(0);
 
   const clientId = useClientId();
@@ -92,13 +92,23 @@ export default function Subscriber(): JSX.Element {
       // unset subRequest (closing WS connection) when the topic is unset (cannot reuse websocket anyways since endpoint contains a slug)
       setSubRequest(undefined);
     }
-  }, [topic, clientId, medplum]);
+  }, [topic, medplum]);
 
   const handleFhircastMessage = useCallback((fhircastMessage: FhircastMessagePayload) => {
+    if (fhircastMessage.event['hub.event'] !== 'patient-open') {
+      console.error("Received unexpected event type! Ignoring all events except for 'patient-open'");
+      return;
+    }
+
     // Get the patient ID from the first context of the event
-    const patientId = fhircastMessage.event.context[0].resource.id as string;
+    const patientId = (fhircastMessage as FhircastMessagePayload<'patient-open'>).event.context[0].resource
+      .id as string;
+
     setCurrentPatientId(patientId);
-    setFhircastMessages((s: FhircastMessagePayload[]) => [fhircastMessage, ...s]);
+    setFhircastMessages((s: FhircastMessagePayload<'patient-open'>[]) => [
+      fhircastMessage as FhircastMessagePayload<'patient-open'>,
+      ...s,
+    ]);
     setEventCount((s) => s + 1);
   }, []);
 
@@ -123,7 +133,7 @@ export default function Subscriber(): JSX.Element {
         <Text>Current topic: {topic ?? 'No topic'}</Text>
         <Text>Current patient: {currentPatientId ?? 'No current patient'}</Text>
       </Stack>
-      {fhirCastMessages.length ? (
+      {fhircastMessages.length ? (
         <>
           <Divider />
           <Stack pt={20}>
@@ -131,7 +141,7 @@ export default function Subscriber(): JSX.Element {
               Events
             </Title>
             <Accordion title="Events">
-              {fhirCastMessages.slice(0, 5).map((message, i) => {
+              {fhircastMessages.slice(0, 5).map((message, i) => {
                 return <FhircastMessageDisplay key={message.id} message={message} eventNo={eventCount - i} />;
               })}
             </Accordion>

--- a/packages/core/src/client-fhircast.test.ts
+++ b/packages/core/src/client-fhircast.test.ts
@@ -168,7 +168,7 @@ describe('FHIRcast', () => {
         client.fhircastPublish(
           'abc123',
           'patient-open',
-          createFhircastMessageContext<'patient-open'>('Patient', 'patient-123')
+          createFhircastMessageContext<'patient-open'>('patient', 'Patient', 'patient-123')
         )
       ).resolves;
       expect(fetch).toBeCalledWith(
@@ -183,8 +183,8 @@ describe('FHIRcast', () => {
       // Multiple contexts
       await expect(
         client.fhircastPublish('def456', 'imagingstudy-open', [
-          createFhircastMessageContext<'imagingstudy-open'>('Patient', 'patient-123'),
-          createFhircastMessageContext<'imagingstudy-open'>('ImagingStudy', 'imagingstudy-456'),
+          createFhircastMessageContext<'imagingstudy-open'>('patient', 'Patient', 'patient-123'),
+          createFhircastMessageContext<'imagingstudy-open'>('study', 'ImagingStudy', 'imagingstudy-456'),
         ])
       ).resolves;
       expect(fetch).toBeCalledWith(
@@ -199,8 +199,8 @@ describe('FHIRcast', () => {
       // 'diagnosticreport-open' requires both a report and a patient
       await expect(
         client.fhircastPublish('xyz-789', 'diagnosticreport-open', [
-          createFhircastMessageContext<'diagnosticreport-open'>('DiagnosticReport', 'report-987'),
-          createFhircastMessageContext<'diagnosticreport-open'>('Patient', 'patient-123'),
+          createFhircastMessageContext<'diagnosticreport-open'>('report', 'DiagnosticReport', 'report-987'),
+          createFhircastMessageContext<'diagnosticreport-open'>('patient', 'Patient', 'patient-123'),
         ])
       ).resolves;
       expect(fetch).toBeCalledWith(
@@ -221,7 +221,7 @@ describe('FHIRcast', () => {
         client.fhircastPublish(
           '',
           'patient-open',
-          createFhircastMessageContext<'patient-open'>('Patient', 'patient-123')
+          createFhircastMessageContext<'patient-open'>('patient', 'Patient', 'patient-123')
         )
       ).rejects.toBeInstanceOf(OperationOutcomeError);
       await expect(
@@ -229,8 +229,12 @@ describe('FHIRcast', () => {
         client.fhircastPublish('abc123', 'patient-open', {})
       ).rejects.toBeInstanceOf(OperationOutcomeError);
       await expect(
-        // @ts-expect-error Invalid event
-        client.fhircastPublish('abc123', 'random-event', createFhircastMessageContext('Patient', 'patient-123'))
+        client.fhircastPublish(
+          'abc123',
+          // @ts-expect-error Invalid event
+          'random-event',
+          createFhircastMessageContext<'patient-open'>('patient', 'Patient', 'patient-123')
+        )
       ).rejects.toBeInstanceOf(OperationOutcomeError);
 
       // 'diagnosticreport-open' requires both a report and a patient
@@ -238,7 +242,7 @@ describe('FHIRcast', () => {
         client.fhircastPublish(
           'xyz-789',
           'diagnosticreport-open',
-          createFhircastMessageContext<'diagnosticreport-open'>('DiagnosticReport', 'report-987')
+          createFhircastMessageContext<'diagnosticreport-open'>('report', 'DiagnosticReport', 'report-987')
         )
       ).rejects.toBeInstanceOf(OperationOutcomeError);
     });

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -183,7 +183,7 @@ describe('createFhircastMessagePayload', () => {
     const topic = 'abc123';
     const event = 'patient-open';
     const resourceId = 'patient-123';
-    const context = createFhircastMessageContext<typeof event>('Patient', resourceId);
+    const context = createFhircastMessageContext<typeof event>('patient', 'Patient', resourceId);
 
     const messagePayload = createFhircastMessagePayload(topic, event, context);
 
@@ -201,9 +201,9 @@ describe('createFhircastMessagePayload', () => {
     const topic = 'abc123';
     const event = 'imagingstudy-open';
     const resourceId1 = 'patient-123';
-    const context1 = createFhircastMessageContext<typeof event>('Patient', resourceId1);
+    const context1 = createFhircastMessageContext<typeof event>('patient', 'Patient', resourceId1);
     const resourceId2 = 'imagingstudy-456';
-    const context2 = createFhircastMessageContext<typeof event>('ImagingStudy', resourceId2);
+    const context2 = createFhircastMessageContext<typeof event>('study', 'ImagingStudy', resourceId2);
 
     const messagePayload = createFhircastMessagePayload(topic, event, [context1, context2]);
 
@@ -222,9 +222,9 @@ describe('createFhircastMessagePayload', () => {
     const topic = 'abc123';
     const event = 'patient-open';
     const resourceId1 = 'patient-123';
-    const context1 = createFhircastMessageContext<typeof event>('Patient', resourceId1);
+    const context1 = createFhircastMessageContext<typeof event>('patient', 'Patient', resourceId1);
     const resourceId2 = 'encounter-456';
-    const context2 = createFhircastMessageContext<typeof event>('Encounter', resourceId2);
+    const context2 = createFhircastMessageContext<typeof event>('encounter', 'Encounter', resourceId2);
 
     const messagePayload = createFhircastMessagePayload(topic, event, [context1, context2]);
 
@@ -259,8 +259,8 @@ describe('createFhircastMessagePayload', () => {
         123,
         'imagingstudy-open',
         [
-          createFhircastMessageContext<'imagingstudy-open'>('Patient', 'patient-123'),
-          createFhircastMessageContext<'imagingstudy-open'>('ImagingStudy', 'imagingstudy-123'),
+          createFhircastMessageContext<'imagingstudy-open'>('patient', 'Patient', 'patient-123'),
+          createFhircastMessageContext<'imagingstudy-open'>('study', 'ImagingStudy', 'imagingstudy-123'),
         ]
       )
     ).toThrowError(OperationOutcomeError);
@@ -273,8 +273,8 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid event, must be one of the enumerated FHIRcast events
         'imagingstudy-create',
         [
-          createFhircastMessageContext<'imagingstudy-open'>('Patient', 'patient-123'),
-          createFhircastMessageContext<'imagingstudy-open'>('ImagingStudy', 'imagingstudy-123'),
+          createFhircastMessageContext<'imagingstudy-open'>('patient', 'Patient', 'patient-123'),
+          createFhircastMessageContext<'imagingstudy-open'>('study', 'ImagingStudy', 'imagingstudy-123'),
         ]
       )
     ).toThrowError(OperationOutcomeError);
@@ -420,7 +420,7 @@ describe('FhircastConnection', () => {
     const message = createFhircastMessagePayload(
       'abc123',
       'patient-open',
-      createFhircastMessageContext<'patient-open'>('Patient', 'patient-123')
+      createFhircastMessageContext<'patient-open'>('patient', 'Patient', 'patient-123')
     ) satisfies FhircastMessagePayload<'patient-open'>;
 
     const handler = (event: FhircastMessageEvent): void => {

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -1,12 +1,15 @@
 import WS from 'jest-websocket-mock';
 import {
+  FHIRCAST_EVENT_VERSION_REQUIRED,
   FhircastConnectEvent,
   FhircastConnection,
   FhircastDisconnectEvent,
   FhircastMessageEvent,
   FhircastMessagePayload,
   SubscriptionRequest,
+  assertContextVersionOptional,
   createFhircastMessagePayload,
+  isContextVersionRequired,
   serializeFhircastSubscriptionRequest,
   validateFhircastSubscriptionRequest,
 } from '.';
@@ -594,5 +597,27 @@ describe('FhircastConnection', () => {
           endpoint: 'ws://localhost:1234',
         })
     ).toThrowError(OperationOutcomeError);
+  });
+});
+
+describe('isContextVersionRequired', () => {
+  test('Version required: true', () => {
+    expect(FHIRCAST_EVENT_VERSION_REQUIRED.includes('diagnosticreport-update')).toEqual(true);
+    expect(isContextVersionRequired('diagnosticreport-update')).toEqual(true);
+  });
+  test('Version required: false', () => {
+    expect((FHIRCAST_EVENT_VERSION_REQUIRED as readonly string[]).includes('patient-open')).toEqual(false);
+    expect(isContextVersionRequired('patient-open')).toEqual(false);
+  });
+});
+
+describe('assertContextVersionOptional', () => {
+  test('Version optional: true', () => {
+    expect((FHIRCAST_EVENT_VERSION_REQUIRED as readonly string[]).includes('patient-open')).toEqual(false);
+    expect(() => assertContextVersionOptional('patient-open')).not.toThrow();
+  });
+  test('Version optional: false', () => {
+    expect(FHIRCAST_EVENT_VERSION_REQUIRED.includes('diagnosticreport-update')).toEqual(true);
+    expect(() => assertContextVersionOptional('diagnosticreport-update')).toThrowError(OperationOutcomeError);
   });
 });

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -381,6 +381,48 @@ describe('createFhircastMessagePayload', () => {
       ])
     ).toThrowError(OperationOutcomeError);
   });
+
+  test('Valid `DiagnosticReport-select` event', () => {
+    const messagePayload = createFhircastMessagePayload('abc-123', 'diagnosticreport-select', [
+      { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-123' } },
+      { key: 'select', resources: [{ resourceType: 'Observation', id: 'observation-123' }] },
+    ]);
+
+    expect(messagePayload).toBeDefined();
+    expect(messagePayload).toEqual<FhircastMessagePayload>({
+      id: expect.any(String),
+      timestamp: expect.any(String),
+      event: { 'hub.topic': 'abc-123', 'hub.event': 'diagnosticreport-select', context: expect.any(Object) },
+    });
+    expect(new Date(messagePayload.timestamp).toISOString()).toEqual(messagePayload.timestamp);
+    expect(messagePayload.event.context[0]).toBeDefined();
+  });
+
+  test('Using single resource context for multi-resource context', () => {
+    expect(() =>
+      createFhircastMessagePayload('abc-123', 'diagnosticreport-select', [
+        { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-123' } },
+        // @ts-expect-error Should have an array of resources at 'resources'
+        { key: 'select', resource: { resourceType: 'Bundle', id: 'bundle-123' } },
+      ])
+    ).toThrowError(OperationOutcomeError);
+  });
+
+  test('Valid `DiagnosticReport-update` event', () => {
+    const messagePayload = createFhircastMessagePayload('abc-123', 'diagnosticreport-update', [
+      { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-123' } },
+      { key: 'updates', resource: { resourceType: 'Bundle', id: 'bundle-123' } },
+    ]);
+
+    expect(messagePayload).toBeDefined();
+    expect(messagePayload).toEqual<FhircastMessagePayload>({
+      id: expect.any(String),
+      timestamp: expect.any(String),
+      event: { 'hub.topic': 'abc-123', 'hub.event': 'diagnosticreport-update', context: expect.any(Object) },
+    });
+    expect(new Date(messagePayload.timestamp).toISOString()).toEqual(messagePayload.timestamp);
+    expect(messagePayload.event.context[0]).toBeDefined();
+  });
 });
 
 describe('FhircastConnection', () => {

--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -332,9 +332,6 @@ function validateFhircastContext<EventName extends FhircastEventName>(
   keySchema: FhircastEventContextDetails,
   keysSeen: Map<FhircastEventContextKey<EventName>, number>
 ): void {
-  if (!(context.key && typeof context.key === 'string')) {
-    throw new OperationOutcomeError(validationError(`context[${i}] is invalid. Context must contain a key.`));
-  }
   keysSeen.set(context.key, (keysSeen.get(context.key) ?? 0) + 1);
 
   // Cases:
@@ -359,7 +356,9 @@ function validateFhircastContext<EventName extends FhircastEventName>(
     if (!resources) {
       throw new OperationOutcomeError(
         validationError(
-          `context[${i}] is invalid. context[${i}] for the '${event}' with key '${context.key}' should contain an array of resources on the key 'resources'.`
+          `context[${i}] is invalid. context[${i}] for the '${event}' with key '${String(
+            context.key
+          )}' should contain an array of resources on the key 'resources'.`
         )
       );
     }

--- a/packages/core/src/fhircast/test-utils.test.ts
+++ b/packages/core/src/fhircast/test-utils.test.ts
@@ -5,7 +5,7 @@ import { createFhircastMessageContext } from './test-utils';
 describe('FHIRcast Test Utils', () => {
   describe('createFhircastMessageContext', () => {
     test('Valid inputs', () => {
-      expect(createFhircastMessageContext<'patient-open'>('Patient', 'patient-123')).toEqual<
+      expect(createFhircastMessageContext<'patient-open'>('patient', 'Patient', 'patient-123')).toEqual<
         FhircastEventContext<'patient-open'>
       >({
         key: 'patient',
@@ -15,7 +15,7 @@ describe('FHIRcast Test Utils', () => {
         },
       });
 
-      expect(createFhircastMessageContext<'imagingstudy-open'>('ImagingStudy', 'imagingstudy-456')).toEqual<
+      expect(createFhircastMessageContext<'imagingstudy-open'>('study', 'ImagingStudy', 'imagingstudy-456')).toEqual<
         FhircastEventContext<'imagingstudy-open'>
       >({
         key: 'study',
@@ -34,9 +34,13 @@ describe('FHIRcast Test Utils', () => {
         OperationOutcomeError
       );
       // @ts-expect-error Resource ID needs to be a string
-      expect(() => createFhircastMessageContext<'patient-open'>('Patient', 123)).toThrowError(OperationOutcomeError);
+      expect(() => createFhircastMessageContext<'patient-open'>('patient', 'Patient', 123)).toThrowError(
+        OperationOutcomeError
+      );
       // Resource ID needs a length
-      expect(() => createFhircastMessageContext<'patient-open'>('Patient', '')).toThrowError(OperationOutcomeError);
+      expect(() => createFhircastMessageContext<'patient-open'>('patient', 'Patient', '')).toThrowError(
+        OperationOutcomeError
+      );
     });
   });
 });

--- a/packages/core/src/fhircast/test-utils.ts
+++ b/packages/core/src/fhircast/test-utils.ts
@@ -1,5 +1,4 @@
 import {
-  FHIRCAST_CONTEXT_KEY_REVERSE_LOOKUP,
   FhircastEventContext,
   FhircastEventContextKey,
   FhircastEventName,
@@ -11,17 +10,12 @@ import { OperationOutcomeError, validationError } from '../outcomes';
 export function createFhircastMessageContext<
   EventName extends FhircastEventName = FhircastEventName,
   K extends FhircastEventContextKey<EventName> = FhircastEventContextKey<EventName>,
->(resourceType: FhircastEventResourceType<EventName, K>, resourceId: string): FhircastEventContext<EventName> {
-  if (!FHIRCAST_CONTEXT_KEY_REVERSE_LOOKUP[resourceType]) {
-    throw new OperationOutcomeError(
-      validationError(`resourceType must be one of: ${Object.keys(FHIRCAST_CONTEXT_KEY_REVERSE_LOOKUP).join(', ')}`)
-    );
-  }
+>(key: K, resourceType: FhircastEventResourceType<EventName, K>, resourceId: string): FhircastEventContext<EventName> {
   if (!(resourceId && typeof resourceId === 'string')) {
     throw new OperationOutcomeError(validationError('Must provide a resourceId.'));
   }
   return {
-    key: FHIRCAST_CONTEXT_KEY_REVERSE_LOOKUP[resourceType] as unknown as K,
+    key,
     resource: {
       resourceType,
       id: resourceId,

--- a/packages/core/src/fhircast/test-utils.ts
+++ b/packages/core/src/fhircast/test-utils.ts
@@ -4,13 +4,18 @@ import {
   FhircastEventName,
   FhircastEventResource,
   FhircastEventResourceType,
+  FhircastValidContextForEvent,
 } from '.';
 import { OperationOutcomeError, validationError } from '../outcomes';
 
 export function createFhircastMessageContext<
   EventName extends FhircastEventName = FhircastEventName,
   K extends FhircastEventContextKey<EventName> = FhircastEventContextKey<EventName>,
->(key: K, resourceType: FhircastEventResourceType<EventName, K>, resourceId: string): FhircastEventContext<EventName> {
+>(
+  key: K,
+  resourceType: FhircastEventResourceType<EventName, K>,
+  resourceId: string
+): FhircastValidContextForEvent<EventName> {
   if (!(resourceId && typeof resourceId === 'string')) {
     throw new OperationOutcomeError(validationError('Must provide a resourceId.'));
   }

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -30,6 +30,8 @@ publicRoutes.get('/.well-known/fhircast-configuration', (_req: Request, res: Res
       'encounter-close',
       'diagnosticreport-open',
       'diagnosticreport-close',
+      'diagnosticreport-select',
+      'diagnosticreport-update',
     ],
     getCurrentSupport: true,
     websocketSupport: true,


### PR DESCRIPTION
## What this PR does
* Adds both the `DiagnosticReport-update` and `DiagnosticReport-select` events to the client.
* Adds infrastructure for event payloads with contexts containing keys with `resources` instead of `resource` (see: https://build.fhir.org/ig/HL7/fhircast-docs/3-6-4-DiagnosticReport-select.html#:~:text=Contains%20zero%20or,is%20now%20unselected)
* Makes the types around keys in contexts more narrow
* Adds `resourceType: '*'` in event table to allow for escape hatch
* Improves test coverage further around `FHIRcast` related parts of the codebase
* Closes #3138


## TODO after this PR
* Add `priorVersionId` to `DiagnosticReport-update` on the Hub-distributed  version. See: https://build.fhir.org/ig/HL7/fhircast-docs/3-6-3-DiagnosticReport-update.html#diagnosticreport-update-event-example