### PR TITLE
Fix `:missing` modifier for token search params

### DIFF
--- a/packages/server/src/fhir/lookups/token.test.ts
+++ b/packages/server/src/fhir/lookups/token.test.ts
@@ -279,6 +279,42 @@ describe('Identifier Lookup Table', () => {
       expect(bundleContains(searchResult1, patient2)).toBe(true);
     }));
 
+  test('Missing', () =>
+    withTestContext(async () => {
+      const identifier = randomUUID();
+      const name = randomUUID();
+
+      const patient1 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: name }],
+      });
+
+      const patient2 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Bob'], family: name }],
+        telecom: [{ system: 'email', value: identifier + 'xyz' }],
+      });
+
+      const searchResult1 = await systemRepo.search({
+        resourceType: 'Patient',
+        filters: [
+          {
+            code: 'email',
+            operator: Operator.MISSING,
+            value: 'true',
+          },
+          {
+            code: 'name',
+            operator: Operator.EQUALS,
+            value: name,
+          },
+        ],
+      });
+      expect(searchResult1.entry?.length).toEqual(1);
+      expect(bundleContains(searchResult1, patient1)).toBe(true);
+      expect(bundleContains(searchResult1, patient2)).toBe(false);
+    }));
+
   test('Search comma separated identifier exact', () =>
     withTestContext(async () => {
       const identifier1 = randomUUID();

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -208,27 +208,24 @@ function shouldCompareTokenValue(operator: FhirOperator): boolean {
  * @returns True if the filter requires a token row to exist AFTER the join has been performed
  */
 function shouldTokenRowExist(filter: Filter): boolean {
-  let shouldTokenExist = true;
   if (shouldCompareTokenValue(filter.operator)) {
     // If the filter is "not equals", then we're looking for ID=null
     // If the filter is "equals", then we're looking for ID!=null
     if (filter.operator === FhirOperator.NOT || filter.operator === FhirOperator.NOT_EQUALS) {
-      shouldTokenExist = false;
+      return false;
     }
   } else if (filter.operator === FhirOperator.MISSING) {
     // Missing = true means that there should not be a row
     switch (filter.value) {
       case 'true':
-        shouldTokenExist = false;
-        break;
+        return false;
       case 'false':
-        shouldTokenExist = true;
-        break;
+        return true;
       default:
         throw new OperationOutcomeError(badRequest("Search filter ':missing' must have a value of 'true' or 'false'"));
     }
   }
-  return shouldTokenExist;
+  return true;
 }
 
 /**

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -122,8 +122,6 @@ export class TokenTable extends LookupTable<Token> {
 
     selectQuery.leftJoin(tableName, joinName, joinOnExpression);
 
-    // If the filter is "not equals", then we're looking for ID=null
-    // If the filter is "equals", then we're looking for ID!=null
     const sqlOperator = shouldTokenRowExist(filter) ? '!=' : '=';
     return new Condition(new Column(joinName, 'resourceId'), sqlOperator, null);
   }
@@ -212,7 +210,8 @@ function shouldCompareTokenValue(filter: Filter): boolean {
 function shouldTokenRowExist(filter: Filter): boolean {
   let shouldTokenExist = true;
   if (shouldCompareTokenValue(filter)) {
-    // If we are performing a "not equals" operation, then there will not be a row after performing the join
+    // If the filter is "not equals", then we're looking for ID=null
+    // If the filter is "equals", then we're looking for ID!=null
     if (filter.operator === FhirOperator.NOT || filter.operator === FhirOperator.NOT_EQUALS) {
       shouldTokenExist = false;
     }

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -197,9 +197,9 @@ function shouldCompareTokenValue(filter: Filter): boolean {
     case FhirOperator.NOT_IN:
     case FhirOperator.IDENTIFIER:
       return false;
+    default:
+      return true;
   }
-
-  return true;
 }
 
 /**


### PR DESCRIPTION
Fixes #3217 

Example search: `Patient?email:missing=true`

## Before


```sql
SELECT    "Patient"."id",
          "Patient"."content"
FROM      "Patient"
LEFT JOIN "Patient_Token" AS "T1"
ON        (
                    "Patient"."id"="T1"."resourceId"
          AND       "T1"."code"=$1
          AND       "T1"."value"=$2)
WHERE     (
                    "Patient"."deleted"=$3
          AND       (
                              "Patient"."compartments" IS NOT NULL
                    AND       "Patient"."compartments"&&array[$4,$5]::uuid[])
          AND       "T1"."resourceId" IS NOT NULL)
GROUP BY  "Patient"."id"
ORDER BY  "Patient"."lastUpdated" DESC limit 21
```

## After
```sql
SELECT    "Patient"."id",
          "Patient"."content"
FROM      "Patient"
LEFT JOIN "Patient_Token" AS "T1"
ON        (
                    "Patient"."id"="T1"."resourceId"
          AND       "T1"."code"=$1)
WHERE     (
                    "Patient"."deleted"=$3
          AND       (
                              "Patient"."compartments" IS NOT NULL
                    AND       "Patient"."compartments"&&array[$4,$5]::uuid[])
          AND       "T1"."resourceId" IS NULL)
GROUP BY  "Patient"."id"
ORDER BY  "Patient"."lastUpdated" DESC limit 21
```
