### PR TITLE
Enables creating new bots/clients from the UI

### DIFF
--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -7,7 +7,7 @@ import { randomUUID } from 'crypto';
 import React, { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
-import { getDefaultFields, getNewResourceEndpoint } from './HomePage.utils';
+import { getDefaultFields, getNewResourceEndpoint, canCreate } from './HomePage.utils';
 
 async function setup(url = '/Patient', medplum = new MockClient()): Promise<void> {
   await act(async () => {
@@ -266,16 +266,25 @@ describe('HomePage', () => {
   });
 
   test.each([
-    ['Patient', false, '/Patient/new'],
-    ['Patient', true, '/Patient/new'],
-    ['Practitioner', false, '/Practitioner/new'],
-    ['Practitioner', true, '/Practitioner/new'],
+    ['Patient', '/Patient/new'],
+    ['Practitioner', '/Practitioner/new'],
 
-    ['Bot', false, ''],
-    ['Bot', true, '/admin/bots/new'],
-    ['ClientApplication', false, ''],
-    ['ClientApplication', true, '/admin/clients/new'],
-  ])('the endpoint for creating a resource %s, user is project admin: %s, should be => %s', (resource, isProjectAdmin, expected) => {
-    expect(getNewResourceEndpoint(resource, isProjectAdmin)).toBe(expected);
+    ['Bot', '/admin/bots/new'],
+    ['ClientApplication', '/admin/clients/new'],
+  ])('the endpoint for creating a resource %s, should be => %s', (resource, expected) => {
+    expect(getNewResourceEndpoint(resource)).toBe(expected);
+  });
+
+  test.each([
+    ['Patient', true, true],
+    ['Patient', false, true],
+    ['Practitioner', true, true],
+
+    ['Bot', true, true],
+    ['Bot', false, false],
+    ['ClientApplication', true, true],
+    ['ClientApplication', false, false],
+  ])('canCreate for Resource: %s, and user isProjectAdmin:%s should return => %s', (resource, isProjectAdmin, expected) => {
+    expect(canCreate(resource, isProjectAdmin)).toBe(expected);
   });
 });

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -5,7 +5,7 @@ import { ResourceType } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { addSearchValues, canCreate, getTransactionBundle, saveLastSearch } from './HomePage.utils';
+import { addSearchValues, getNewResourceEndpoint, getTransactionBundle, saveLastSearch } from './HomePage.utils';
 import { exportJsonFile } from './utils';
 
 const useStyles = createStyles((theme) => {
@@ -50,6 +50,8 @@ export function HomePage(): JSX.Element {
     return <Loading />;
   }
 
+  const newEndpoint = getNewResourceEndpoint(search.resourceType, medplum.isProjectAdmin());
+
   return (
     <Paper shadow="xs" m="md" p="xs" className={classes.paper}>
       <MemoizedSearchControl
@@ -61,13 +63,7 @@ export function HomePage(): JSX.Element {
         onChange={(e) => {
           navigate(`/${search.resourceType}${formatSearchQuery(e.definition)}`);
         }}
-        onNew={
-          canCreate(search.resourceType)
-            ? () => {
-                navigate(`/${search.resourceType}/new`);
-              }
-            : undefined
-        }
+        onNew={(newEndpoint) ? () => navigate(newEndpoint) : undefined}
         onExportCsv={() => {
           const url = medplum.fhirUrl(search.resourceType, '$csv') + formatSearchQuery(search);
           medplum

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -5,7 +5,7 @@ import { ResourceType } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { addSearchValues, getNewResourceEndpoint, getTransactionBundle, saveLastSearch } from './HomePage.utils';
+import { addSearchValues, canCreate, getNewResourceEndpoint, getTransactionBundle, saveLastSearch } from './HomePage.utils';
 import { exportJsonFile } from './utils';
 
 const useStyles = createStyles((theme) => {
@@ -50,8 +50,6 @@ export function HomePage(): JSX.Element {
     return <Loading />;
   }
 
-  const newEndpoint = getNewResourceEndpoint(search.resourceType, medplum.isProjectAdmin());
-
   return (
     <Paper shadow="xs" m="md" p="xs" className={classes.paper}>
       <MemoizedSearchControl
@@ -63,7 +61,9 @@ export function HomePage(): JSX.Element {
         onChange={(e) => {
           navigate(`/${search.resourceType}${formatSearchQuery(e.definition)}`);
         }}
-        onNew={(newEndpoint) ? () => navigate(newEndpoint) : undefined}
+        onNew={canCreate(search.resourceType, medplum.isProjectAdmin()) ? () => {
+          navigate(getNewResourceEndpoint(search.resourceType))
+        } : undefined}
         onExportCsv={() => {
           const url = medplum.fhirUrl(search.resourceType, '$csv') + formatSearchQuery(search);
           medplum

--- a/packages/app/src/HomePage.utils.ts
+++ b/packages/app/src/HomePage.utils.ts
@@ -118,6 +118,24 @@ export function canCreate(resourceType: string): boolean {
   return resourceType !== 'Bot' && resourceType !== 'ClientApplication';
 }
 
+export function getNewResourceEndpoint(resourceType: string, isProjectAdmin: boolean): string {
+  if (canCreate(resourceType)) {
+    return `/${resourceType}/new`;
+  }
+
+  if (isProjectAdmin) {
+    if (resourceType === 'Bot') {
+      return `/admin/bots/new`;
+    }
+
+    if (resourceType === 'ClientApplication') {
+      return `/admin/clients/new`;
+    }
+  }
+
+  return '';
+}
+
 export async function getTransactionBundle(search: SearchRequest, medplum: MedplumClient): Promise<Bundle> {
   const transactionBundleSearch: SearchRequest = {
     resourceType: search.resourceType,

--- a/packages/app/src/HomePage.utils.ts
+++ b/packages/app/src/HomePage.utils.ts
@@ -114,26 +114,20 @@ export function saveLastSearch(search: SearchRequest): void {
   localStorage.setItem(search.resourceType + '-defaultSearch', JSON.stringify(search));
 }
 
-export function canCreate(resourceType: string): boolean {
-  return resourceType !== 'Bot' && resourceType !== 'ClientApplication';
+export function canCreate(resourceType: string, isProjectAdmin: boolean): boolean {
+  return (resourceType !== 'Bot' && resourceType !== 'ClientApplication') || isProjectAdmin;
 }
 
-export function getNewResourceEndpoint(resourceType: string, isProjectAdmin: boolean): string {
-  if (canCreate(resourceType)) {
-    return `/${resourceType}/new`;
+export function getNewResourceEndpoint(resourceType: string): string {
+  if (resourceType === 'Bot') {
+    return `/admin/bots/new`;
   }
 
-  if (isProjectAdmin) {
-    if (resourceType === 'Bot') {
-      return `/admin/bots/new`;
-    }
-
-    if (resourceType === 'ClientApplication') {
-      return `/admin/clients/new`;
-    }
+  if (resourceType === 'ClientApplication') {
+    return `/admin/clients/new`;
   }
 
-  return '';
+  return `/${resourceType}/new`;
 }
 
 export async function getTransactionBundle(search: SearchRequest, medplum: MedplumClient): Promise<Bundle> {


### PR DESCRIPTION
This commit enables the button for creating new bots and client applications. The correct URLs for creating these 2 resources are behind admin routes.

Fixes #2888