### PR TITLE
Fixes #3215 - external auth fixes for Azure SSO

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -538,6 +538,18 @@ export enum OAuthTokenType {
 
 /**
  * OAuth 2.0 Client Authentication Methods
+ * See: https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ */
+export enum OAuthTokenAuthMethod {
+  ClientSecretBasic = 'client_secret_basic',
+  ClientSecretPost = 'client_secret_post',
+  ClientSecretJwt = 'client_secret_jwt',
+  PrivateKeyJwt = 'private_key_jwt',
+  None = 'none',
+}
+
+/**
+ * OAuth 2.0 Client Authentication Methods
  * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
  */
 export enum OAuthClientAssertionType {

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -11,7 +11,7 @@ import { inflateBaseSchema } from '../base-schema';
 import baseSchema from '../base-schema.json';
 import { getTypedPropertyValue } from '../fhirpath/utils';
 import { OperationOutcomeError, serverError } from '../outcomes';
-import { getElementDefinitionTypeName, isResourceTypeSchema, TypedValue } from '../types';
+import { TypedValue, getElementDefinitionTypeName, isResourceTypeSchema } from '../types';
 import { capitalize, isEmpty } from '../utils';
 
 /**
@@ -183,7 +183,7 @@ class StructureDefinitionParser {
       name: sd.name as ResourceType,
       url: sd.url as string,
       kind: sd.kind,
-      description: sd.description,
+      description: getDescription(sd),
       elements: {},
       constraints: this.parseElementDefinition(this.root).constraints,
       innerTypes: [],
@@ -502,4 +502,18 @@ function hasDefaultExtensionSlice(element: ElementDefinition): boolean {
       discriminators[0].type === 'value' &&
       discriminators[0].path === 'url'
   );
+}
+
+function getDescription(sd: StructureDefinition): string | undefined {
+  let result = sd.description;
+
+  // Many description strings start with an unwanted prefix "Base StructureDefinition for X Type: "
+  // For example:
+  // Base StructureDefinition for Age Type: A duration of time during which an organism (or a process) has existed.
+  // If the description starts with the name of the resource type, remove it.
+  if (result?.startsWith(`Base StructureDefinition for ${sd.name} Type: `)) {
+    result = result.substring(`Base StructureDefinition for ${sd.name} Type: `.length);
+  }
+
+  return result;
 }

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -3672,6 +3672,25 @@
             }
           },
           {
+            "id" : "IdentityProvider.tokenAuthMethod",
+            "path" : "IdentityProvider.tokenAuthMethod",
+            "definition" : "Client Authentication method used by Clients to authenticate to the Authorization Server when using the Token Endpoint. If no method is registered, the default method is client_secret_basic.",
+            "min" : 0,
+            "max" : "1",
+            "base" : {
+              "path" : "IdentityProvider.tokenAuthMethod",
+              "min" : 0,
+              "max" : "1"
+            },
+            "type" : [{
+              "code" : "code"
+            }],
+            "binding" : {
+              "strength" : "required",
+              "valueSet" : "https://medplum.com/fhir/ValueSet/token-endpoint-auth-methods-supported|4.0.1"
+            }
+          },
+          {
             "id" : "IdentityProvider.userInfoUrl",
             "path" : "IdentityProvider.userInfoUrl",
             "definition" : "Remote URL for the external Identity Provider userinfo endpoint.",

--- a/packages/definitions/dist/fhir/r4/valuesets-medplum.json
+++ b/packages/definitions/dist/fhir/r4/valuesets-medplum.json
@@ -607,6 +607,51 @@
           ]
         }
       }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/CodeSystem/token-endpoint-auth-methods-supported",
+      "resource": {
+        "resourceType": "CodeSystem",
+        "id": "token-endpoint-auth-methods-supported",
+        "url": "https://medplum.com/fhir/CodeSystem/token-endpoint-auth-methods-supported",
+        "name": "OAuth2TokenEndpointAuthMethodsSupported",
+        "title": "OAuth 2.0 Token Endpoint Authentication Methods",
+        "status": "active",
+        "description": "Client Authentication methods that are used by Clients to authenticate to the Authorization Server when using the Token Endpoint. During Client Registration, the RP (Client) MAY register a Client Authentication method. If no method is registered, the default method is client_secret_basic.",
+        "valueSet": "https://medplum.com/fhir/ValueSet/token-endpoint-auth-methods-supported",
+        "content": "complete",
+        "concept": [
+          {
+            "code": "client_secret_basic",
+            "display": "client_secret_basic",
+            "definition": "Clients that have received a client_secret value from the Authorization Server authenticate with the Authorization Server in accordance with Section 2.3.1 of OAuth 2.0 RFC6749 using the HTTP Basic authentication scheme."
+          },
+          {
+            "code": "client_secret_post",
+            "display": "client_secret_post",
+            "definition": "Clients that have received a client_secret value from the Authorization Server, authenticate with the Authorization Server in accordance with Section 2.3.1 of OAuth 2.0 [RFC6749] by including the Client Credentials in the request body."
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/ValueSet/token-endpoint-auth-methods-supported",
+      "resource": {
+        "resourceType": "ValueSet",
+        "id": "token-endpoint-auth-methods-supported",
+        "url": "https://medplum.com/fhir/ValueSet/token-endpoint-auth-methods-supported",
+        "name": "OAuth2TokenEndpointAuthMethodsSupported",
+        "title": "OAuth 2.0 Token Endpoint Authentication Methods",
+        "status": "active",
+        "description": "Client Authentication methods that are used by Clients to authenticate to the Authorization Server when using the Token Endpoint. During Client Registration, the RP (Client) MAY register a Client Authentication method. If no method is registered, the default method is client_secret_basic.",
+        "compose": {
+          "include": [
+            {
+              "system": "https://medplum.com/fhir/CodeSystem/token-endpoint-auth-methods-supported"
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/packages/fhirtypes/dist/BackboneElement.d.ts
+++ b/packages/fhirtypes/dist/BackboneElement.d.ts
@@ -5,11 +5,44 @@
 
 import { Extension } from './Extension';
 
+/**
+ * Base definition for all elements that are defined inside a resource -
+ * but not those in a data type.
+ */
 export interface BackboneElement {
 
+  /**
+   * Unique id for the element within a resource (for internal references).
+   * This may be any string value that does not contain spaces.
+   */
   id?: string;
 
+  /**
+   * May be used to represent additional information that is not part of
+   * the basic definition of the element. To make the use of extensions
+   * safe and manageable, there is a strict set of governance  applied to
+   * the definition and use of extensions. Though any implementer can
+   * define an extension, there is a set of requirements that SHALL be met
+   * as part of the definition of the extension.
+   */
   extension?: Extension[];
 
+  /**
+   * May be used to represent additional information that is not part of
+   * the basic definition of the element and that modifies the
+   * understanding of the element in which it is contained and/or the
+   * understanding of the containing element's descendants. Usually
+   * modifier elements provide negation or qualification. To make the use
+   * of extensions safe and manageable, there is a strict set of governance
+   * applied to the definition and use of extensions. Though any
+   * implementer can define an extension, there is a set of requirements
+   * that SHALL be met as part of the definition of the extension.
+   * Applications processing a resource are required to check for modifier
+   * extensions.
+   *
+   * Modifier extensions SHALL NOT change the meaning of any elements on
+   * Resource or DomainResource (including cannot change the meaning of
+   * modifierExtension itself).
+   */
   modifierExtension?: Extension[];
 }

--- a/packages/fhirtypes/dist/Expression.d.ts
+++ b/packages/fhirtypes/dist/Expression.d.ts
@@ -44,7 +44,7 @@ export interface Expression {
   /**
    * The media type of the language for the expression.
    */
-  language?: string;
+  language?: 'text/cql' | 'text/fhirpath' | 'application/x-fhir-query';
 
   /**
    * An expression in the specified language that returns a value.

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -19,6 +19,13 @@ export interface IdentityProvider {
   tokenUrl?: string;
 
   /**
+   * Client Authentication method used by Clients to authenticate to the
+   * Authorization Server when using the Token Endpoint. If no method is
+   * registered, the default method is client_secret_basic.
+   */
+  tokenAuthMethod?: 'client_secret_basic' | 'client_secret_post';
+
+  /**
    * Remote URL for the external Identity Provider userinfo endpoint.
    */
   userInfoUrl?: string;

--- a/packages/fhirtypes/dist/MoneyQuantity.d.ts
+++ b/packages/fhirtypes/dist/MoneyQuantity.d.ts
@@ -6,9 +6,8 @@
 import { Extension } from './Extension';
 
 /**
- * There SHALL be a code if there is a value and it SHALL be an
- * expression of currency.  If system is present, it SHALL be ISO 4217
- * (system = &quot;urn:iso:std:iso:4217&quot; - currency).
+ * An amount of money. With regard to precision, see [Decimal
+ * Precision](datatypes.html#precision)
  */
 export interface MoneyQuantity {
 

--- a/packages/fhirtypes/dist/Reference.d.ts
+++ b/packages/fhirtypes/dist/Reference.d.ts
@@ -6,6 +6,7 @@
 import { Extension } from './Extension';
 import { Identifier } from './Identifier';
 import { Resource } from './Resource';
+import { ResourceType } from './ResourceType';
 
 /**
  * A reference from one resource to another.
@@ -51,7 +52,7 @@ export interface Reference<T extends Resource = Resource> {
    * only allowed for logical models (and can only be used in references in
    * logical models, not resources).
    */
-  type?: string;
+  type?: ResourceType;
 
   /**
    * An identifier for the target resource. This is used when there is no

--- a/packages/fhirtypes/dist/SimpleQuantity.d.ts
+++ b/packages/fhirtypes/dist/SimpleQuantity.d.ts
@@ -6,7 +6,7 @@
 import { Extension } from './Extension';
 
 /**
- * The comparator is not used on a SimpleQuantity
+ * A fixed quantity (no comparator)
  */
 export interface SimpleQuantity {
 

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -26,7 +26,7 @@ export function main(): void {
   writeResourceTypeFile();
 
   for (const type of Object.values(getAllDataTypes())) {
-    if (isResourceTypeSchema(type)) {
+    if (isResourceTypeSchema(type) || type.kind === 'complex-type') {
       writeInterfaceFile(type);
     }
   }
@@ -277,7 +277,7 @@ function getTypeScriptTypeForProperty(
       baseType = 'string';
       binding = property.binding?.valueSet;
       if (binding) {
-        if (binding === 'http://hl7.org/fhir/ValueSet/resource-types|4.0.1') {
+        if (binding.startsWith('http://hl7.org/fhir/ValueSet/resource-types')) {
           baseType = 'ResourceType';
         } else if (
           binding !== 'http://hl7.org/fhir/ValueSet/all-types|4.0.1' &&

--- a/packages/server/src/auth/external.test.ts
+++ b/packages/server/src/auth/external.test.ts
@@ -1,4 +1,5 @@
-import { ClientApplication, DomainConfiguration, ProjectMembership, User } from '@medplum/fhirtypes';
+import { OAuthTokenAuthMethod } from '@medplum/core';
+import { ClientApplication, DomainConfiguration, Project, ProjectMembership, User } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import fetch from 'node-fetch';
@@ -8,8 +9,8 @@ import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
 import { systemRepo } from '../fhir/repo';
-import { registerNew } from './register';
 import { withTestContext } from '../test.setup';
+import { registerNew } from './register';
 
 jest.mock('node-fetch');
 
@@ -19,9 +20,17 @@ const email = `text@${domain}`;
 const domain2 = randomUUID() + '.example.com';
 const redirectUri = `https://${domain}/auth/callback`;
 const externalId = `google-oauth2|${randomUUID()}`;
+const identityProvider = {
+  authorizeUrl: 'https://example.com/oauth2/authorize',
+  tokenUrl: 'https://example.com/oauth2/token',
+  userInfoUrl: 'https://example.com/oauth2/userinfo',
+  clientId: '123',
+  clientSecret: '456',
+};
+
+let project: Project;
 let defaultClient: ClientApplication;
 let externalAuthClient: ClientApplication;
-let subjectAuthClient: ClientApplication;
 
 describe('External', () => {
   beforeAll(() =>
@@ -30,7 +39,7 @@ describe('External', () => {
       await initApp(app, config);
 
       // Create a new project
-      const { project, client } = await registerNew({
+      const registerResult = await registerNew({
         firstName: 'External',
         lastName: 'Text',
         projectName: 'External Test Project',
@@ -39,15 +48,8 @@ describe('External', () => {
         remoteAddress: '5.5.5.5',
         userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/107.0.0.0',
       });
-      defaultClient = client;
-
-      const identityProvider = {
-        authorizeUrl: 'https://example.com/oauth2/authorize',
-        tokenUrl: 'https://example.com/oauth2/token',
-        userInfoUrl: 'https://example.com/oauth2/userinfo',
-        clientId: '123',
-        clientSecret: '456',
-      };
+      project = registerResult.project;
+      defaultClient = registerResult.client;
 
       // Create a domain configuration with external identity provider
       await systemRepo.createResource<DomainConfiguration>({
@@ -73,22 +75,6 @@ describe('External', () => {
       await systemRepo.updateResource<ClientApplication>({
         ...externalAuthClient,
         identityProvider,
-      });
-
-      // Create a new client application with external subject auth
-      subjectAuthClient = await createClient(systemRepo, {
-        project,
-        name: 'Subject Auth Client',
-        redirectUri,
-      });
-
-      // Update client application with external auth
-      await systemRepo.updateResource<ClientApplication>({
-        ...subjectAuthClient,
-        identityProvider: {
-          ...identityProvider,
-          useSubject: true,
-        },
       });
 
       // Invite user with external ID
@@ -325,6 +311,26 @@ describe('External', () => {
   });
 
   test('Subject auth success', async () => {
+    const subjectAuthClient = await withTestContext(async () => {
+      // Create a new client application with external subject auth
+      const client = await createClient(systemRepo, {
+        project,
+        name: 'Subject Auth Client',
+        redirectUri,
+      });
+
+      // Update client application with external auth
+      await systemRepo.updateResource<ClientApplication>({
+        ...client,
+        identityProvider: {
+          ...identityProvider,
+          useSubject: true,
+        },
+      });
+
+      return client;
+    });
+
     const url = appendQueryParams('/auth/external', {
       code: randomUUID(),
       state: JSON.stringify({
@@ -357,6 +363,62 @@ describe('External', () => {
       code_verifier: 'xyz',
     });
     expect(tokenResponse.body.profile.display).toBe('External User');
+  });
+
+  test('Client secret post', async () => {
+    const clientSecretPostClient = await withTestContext(async () => {
+      // Create a new client application with external subject auth
+      const client = await createClient(systemRepo, {
+        project,
+        name: 'Client secret post Client',
+        redirectUri,
+      });
+
+      // Update client application with external auth
+      await systemRepo.updateResource<ClientApplication>({
+        ...client,
+        identityProvider: {
+          ...identityProvider,
+          tokenAuthMethod: OAuthTokenAuthMethod.ClientSecretPost,
+        },
+      });
+
+      return client;
+    });
+
+    const url = appendQueryParams('/auth/external', {
+      code: randomUUID(),
+      // state: JSON.stringify({ redirectUri, clientId: externalAuthClient.id }),
+      state: JSON.stringify({
+        redirectUri,
+        clientId: clientSecretPostClient.id,
+        codeChallenge: 'xyz',
+        codeChallengeMethod: 'plain',
+      }),
+    });
+
+    // Mock the external identity provider
+    (fetch as unknown as jest.Mock).mockImplementation(() => ({
+      status: 200,
+      json: () => buildTokens(email),
+    }));
+
+    // Simulate the external identity provider callback
+    const res = await request(app).get(url);
+    expect(res.status).toBe(302);
+
+    const redirect = new URL(res.header.location);
+    expect(redirect.host).toEqual(domain);
+    expect(redirect.pathname).toEqual('/auth/callback');
+    expect(redirect.searchParams.get('code')).toBeTruthy();
+
+    const code = redirect.searchParams.get('code');
+    const tokenResponse = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'authorization_code',
+      code,
+      code_verifier: 'xyz',
+    });
+    expect(tokenResponse.body.profile.display).toBe('External Text');
   });
 
   test('Legacy User.externalId support', async () => {

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -1,4 +1,12 @@
-import { badRequest, ContentType, OAuthGrantType, OperationOutcomeError, parseJWTPayload } from '@medplum/core';
+import {
+  badRequest,
+  ContentType,
+  encodeBase64,
+  OAuthGrantType,
+  OAuthTokenAuthMethod,
+  OperationOutcomeError,
+  parseJWTPayload,
+} from '@medplum/core';
 import { ClientApplication, IdentityProvider } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Request, Response } from 'express';
@@ -48,7 +56,7 @@ export const externalCallbackHandler = async (req: Request, res: Response): Prom
     return;
   }
 
-  const userInfo = await verifyCode(idp, code);
+  const userInfo = await verifyExternalCode(idp, code, body.codeChallenge);
 
   let email: string | undefined = undefined;
   let externalId: string | undefined = undefined;
@@ -142,24 +150,40 @@ async function getIdentityProvider(
  * Returns ID token claims for the authorization code.
  * @param idp - The identity provider configuration.
  * @param code - The authorization code.
+ * @param codeVerifier - The code verifier.
  * @returns ID token claims.
  */
-async function verifyCode(idp: IdentityProvider, code: string): Promise<Record<string, unknown>> {
-  const auth = Buffer.from(idp.clientId + ':' + idp.clientSecret).toString('base64');
+async function verifyExternalCode(
+  idp: IdentityProvider,
+  code: string,
+  codeVerifier: string | undefined
+): Promise<Record<string, unknown>> {
+  const headers: HeadersInit = {
+    Accept: ContentType.JSON,
+    'Content-Type': ContentType.FORM_URL_ENCODED,
+  };
 
   const params = new URLSearchParams();
   params.append('grant_type', OAuthGrantType.AuthorizationCode);
   params.append('redirect_uri', getConfig().baseUrl + 'auth/external');
   params.append('code', code);
 
+  if (codeVerifier) {
+    params.append('code_verifier', codeVerifier);
+  }
+
+  if (idp.tokenAuthMethod === OAuthTokenAuthMethod.ClientSecretPost) {
+    params.append('client_id', idp.clientId as string);
+    params.append('client_secret', idp.clientSecret as string);
+  } else {
+    // Default to client_secret_basic
+    headers.Authorization = `Basic ${encodeBase64(idp.clientId + ':' + idp.clientSecret)}`;
+  }
+
   try {
     const response = await fetch(idp.tokenUrl as string, {
       method: 'POST',
-      headers: {
-        Accept: ContentType.JSON,
-        Authorization: `Basic ${auth}`,
-        'Content-Type': ContentType.FORM_URL_ENCODED,
-      },
+      headers,
       body: params.toString(),
     });
 

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -3,7 +3,7 @@
  * https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html
  */
 
-import { ContentType, deepClone, OAuthGrantType } from '@medplum/core';
+import { ContentType, deepClone, OAuthGrantType, OAuthTokenAuthMethod } from '@medplum/core';
 import { AccessPolicy, AccessPolicyResource } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getConfig } from '../config';
@@ -37,7 +37,11 @@ export function smartConfigurationHandler(_req: Request, res: Response): void {
         OAuthGrantType.TokenExchange,
       ],
       token_endpoint: config.tokenUrl,
-      token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'private_key_jwt'],
+      token_endpoint_auth_methods_supported: [
+        OAuthTokenAuthMethod.ClientSecretBasic,
+        OAuthTokenAuthMethod.ClientSecretPost,
+        OAuthTokenAuthMethod.PrivateKeyJwt,
+      ],
       token_endpoint_auth_signing_alg_values_supported: ['RS256', 'RS384', 'ES384'],
       scopes_supported: [
         'patient/*.rs',

--- a/packages/server/src/wellknown.ts
+++ b/packages/server/src/wellknown.ts
@@ -1,7 +1,7 @@
+import { OAuthGrantType, OAuthTokenAuthMethod } from '@medplum/core';
 import { Request, Response, Router } from 'express';
 import { getConfig } from './config';
 import { getJwks } from './oauth/keys';
-import { OAuthGrantType } from '@medplum/core';
 
 export const wellKnownRouter = Router();
 
@@ -27,7 +27,11 @@ wellKnownRouter.get('/openid-configuration', (_req: Request, res: Response) => {
     response_types_supported: ['code', 'id_token', 'token id_token'],
     subject_types_supported: ['pairwise', 'public'],
     scopes_supported: ['openid', 'profile', 'email', 'phone', 'address'],
-    token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+    token_endpoint_auth_methods_supported: [
+      OAuthTokenAuthMethod.ClientSecretBasic,
+      OAuthTokenAuthMethod.ClientSecretPost,
+      OAuthTokenAuthMethod.PrivateKeyJwt,
+    ],
     request_object_signing_alg_values_supported: ['none'],
   });
 });


### PR DESCRIPTION
Main fixes:
1. Added `tokenAuthMethod` property to `IdentityProvider` which allows users to set `client_secret_basic` (default, use `Authorization` header) or `client_secret_post` (include `client_id` and `client_secret` in the form body).
2. Added `code_verifier` to external auth check.  I'm not 100% certain that this is correct.  This may require some trial and error.

Additional fixes:
1. It turns out that there was a regression in our code generator for `BackboneElement` types, and we have not been re-generating them for a while.  Needed to fix that in order to update `IdentityProvider.d.ts`
2. It turns out our description strings were different.  Previously pulled from `StructureDefinition.snapshot.element.definition`, now pulled from `StructureDefinition.description`.  There were some subtle differences, which caused a big mess in type definitions, so I fixed that.
3. Updated our `.well-known` definitions to include all supported auth methods.