### PR TITLE
HMR app on react changes

### DIFF
--- a/examples/foomedical/package.json
+++ b/examples/foomedical/package.json
@@ -36,7 +36,6 @@
     "@tabler/icons-react": "2.39.0",
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/react": "14.0.0",
-    "@types/grecaptcha": "3.0.5",
     "@types/jest": "29.5.5",
     "@types/node": "20.8.6",
     "@types/react": "18.2.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
         "@tabler/icons-react": "2.39.0",
         "@testing-library/jest-dom": "6.1.4",
         "@testing-library/react": "14.0.0",
-        "@types/grecaptcha": "3.0.5",
         "@types/jest": "29.5.5",
         "@types/node": "20.8.6",
         "@types/react": "18.2.28",
@@ -19695,12 +19694,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/grecaptcha": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/grecaptcha/-/grecaptcha-3.0.5.tgz",
-      "integrity": "sha512-FyrF9WpBz34ZIqLu49kK+wL2NXgBOqeiWOinx7VW5AS01o0F1uejhfpQ6RHlm5sOyEbR7viIC7mSUzUC09NAIQ==",
-      "dev": true
     },
     "node_modules/@types/hast": {
       "version": "2.3.6",
@@ -52579,7 +52572,6 @@
         "@tabler/icons-react": "2.39.0",
         "@testing-library/jest-dom": "6.1.4",
         "@testing-library/react": "14.0.0",
-        "@types/grecaptcha": "3.0.5",
         "@types/react": "18.2.28",
         "@types/react-dom": "18.2.13",
         "react": "18.2.0",
@@ -52631,9 +52623,6 @@
         "cdk-nag": "2.27.162",
         "cdk-serverless-clamscan": "2.5.115",
         "constructs": "10.3.0"
-      },
-      "bin": {
-        "medplum-cdk-init": "dist/cjs/init.cjs"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -38,7 +38,6 @@
     "@tabler/icons-react": "2.39.0",
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/react": "14.0.0",
-    "@types/grecaptcha": "3.0.5",
     "@types/react": "18.2.28",
     "@types/react-dom": "18.2.13",
     "react": "18.2.0",

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "module": "esnext",
     "lib": ["esnext", "dom", "dom.iterable"],
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "paths": {
+      "@medplum/react": ["../react/src"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "./jest.setup.ts"]
 }

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -4,6 +4,7 @@ import { copyFileSync, existsSync } from 'fs';
 import { defineConfig } from 'vite';
 import packageJson from './package.json' assert { type: 'json' };
 import { execSync } from 'child_process';
+import path from 'path';
 
 if (!existsSync('.env')) {
   copyFileSync('.env.defaults', '.env');
@@ -21,5 +22,10 @@ export default defineConfig({
   publicDir: 'static',
   build: {
     sourcemap: true,
+  },
+  resolve: {
+    alias: {
+      '@medplum/react': path.resolve(__dirname, '../react/src'),
+    },
   },
 });

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,10 +1,10 @@
 /// <reference types="vite/client" />
 import react from '@vitejs/plugin-react';
+import { execSync } from 'child_process';
 import { copyFileSync, existsSync } from 'fs';
+import path from 'path';
 import { defineConfig } from 'vite';
 import packageJson from './package.json' assert { type: 'json' };
-import { execSync } from 'child_process';
-import path from 'path';
 
 if (!existsSync('.env')) {
   copyFileSync('.env.defaults', '.env');

--- a/packages/react/src/utils/recaptcha.ts
+++ b/packages/react/src/utils/recaptcha.ts
@@ -1,6 +1,9 @@
 import { createScriptTag } from './script';
 
-declare let grecaptcha: undefined | ReCaptchaV2.ReCaptcha;
+// reCAPTCHA type definitions do not work with Vite project aliasing.
+// Project aliasing is more valuable than type definitions,
+// so cheating and using `any` here.
+declare let grecaptcha: any;
 
 /**
  * Dynamically loads the recaptcha script.
@@ -20,17 +23,9 @@ export function initRecaptcha(siteKey: string): void {
  */
 export function getRecaptcha(siteKey: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    if (typeof grecaptcha === 'undefined') {
-      reject(new Error('grecaptcha not found'));
-      return;
-    }
-
-    // a strongly typed reference to appease typescript within the ready callback
-    const grecaptchaClient: ReCaptchaV2.ReCaptcha = grecaptcha;
-
-    grecaptchaClient.ready(async () => {
+    grecaptcha.ready(async () => {
       try {
-        resolve(await grecaptchaClient.execute(siteKey, { action: 'submit' }));
+        resolve(await grecaptcha.execute(siteKey, { action: 'submit' }));
       } catch (err) {
         reject(err);
       }

--- a/packages/react/src/utils/recaptcha.ts
+++ b/packages/react/src/utils/recaptcha.ts
@@ -1,5 +1,7 @@
 import { createScriptTag } from './script';
 
+declare let grecaptcha: undefined | ReCaptchaV2.ReCaptcha;
+
 /**
  * Dynamically loads the recaptcha script.
  * We do not want to load the script on page load unless the user needs it.
@@ -18,9 +20,17 @@ export function initRecaptcha(siteKey: string): void {
  */
 export function getRecaptcha(siteKey: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    grecaptcha.ready(async () => {
+    if (typeof grecaptcha === 'undefined') {
+      reject(new Error('grecaptcha not found'));
+      return;
+    }
+
+    // a strongly typed reference to appease typescript within the ready callback
+    const grecaptchaClient: ReCaptchaV2.ReCaptcha = grecaptcha;
+
+    grecaptchaClient.ready(async () => {
       try {
-        resolve(await grecaptcha.execute(siteKey, { action: 'submit' }));
+        resolve(await grecaptchaClient.execute(siteKey, { action: 'submit' }));
       } catch (err) {
         reject(err);
       }


### PR DESCRIPTION
Building on @mattlong's POC here: https://github.com/medplum/medplum/pull/3211

I couldn't get `@types/grecaptcha` to work with Vite aliasing.  Vite aliasing seems more valuable than those type definitions (we only use it in a couple places), so I'm inclined to push this through.

I was curious if we could go ahead and do this for all monorepo dependencies, most notably `@medplum/core`.  Unfortunately, the answer is "not yet", because `@medplum/core` is not yet using ESM in source.  For example, it still has references to `process.env` rather than `import.meta.env`.  ESM is a slippery slope, and has often caused issues with `@medplum/server`, so I'm leaving it alone for now.  Exciting future prospects though.