### PR TITLE
Move Coveralls to separate Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,6 @@ jobs:
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload code coverage
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,0 +1,42 @@
+name: Coveralls
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+jobs:
+  coveralls:
+    name: Coveralls
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: 'Download code coverage'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "medplum-code-coverage"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/medplum-code-coverage.zip`, Buffer.from(download.data));
+      - name: 'Unzip code coverage'
+        run: unzip medplum-code-coverage.zip -d coverage
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The "Build" Github Action has been quadruple-submitting to Coveralls.  While suboptimal, it was fine until recently.  Now Coveralls seems to return errors if there are multiple submissions in rapid succession.

For example: https://github.com/medplum/medplum/actions/runs/6773161683/job/18414711651?pr=3239

<img width="914" alt="image" src="https://github.com/medplum/medplum/assets/749094/fd99ee3d-2423-4524-891c-9be22b92a37d">

This PR moves Coveralls to a separate Github Action.  It is modelled after Sonar, so it should run in a similar fashion, only once after a successful "Build" step.

You may be wondering why we use Coveralls when Sonar is a superset of functionality, and that is a good question.  We were told that Coveralls badge is a signal boost in the NPM recommendation algorithm.  I don't have any concrete evidence that is true.  If Coveralls ever becomes too much of a problem, I'd be ok to remove it.