### PR TITLE
process.env replacement broken with Vite aliases

### DIFF
--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -52,5 +52,6 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
  * @returns The input type for the current environment.
  */
 function getInputType(): string {
+  console.log('NODE_ENV gets special handling and works fine', { NODE_ENV: process.env.NODE_ENV });
   return process.env.NODE_ENV === 'test' ? 'text' : 'datetime-local';
 }

--- a/packages/react/src/GoogleButton/GoogleButton.utils.ts
+++ b/packages/react/src/GoogleButton/GoogleButton.utils.ts
@@ -5,9 +5,20 @@ export function getGoogleClientId(clientId: string | undefined): string | undefi
 
   if (typeof window !== 'undefined') {
     const origin = window.location.protocol + '//' + window.location.host;
-    const authorizedOrigins = process.env.GOOGLE_AUTH_ORIGINS?.split(',') ?? [];
-    if (authorizedOrigins.includes(origin)) {
-      return process.env.GOOGLE_CLIENT_ID;
+
+    try {
+      const authorizedOrigins = process.env.GOOGLE_AUTH_ORIGINS?.split(',') ?? [];
+
+      if (authorizedOrigins.includes(origin)) {
+        return process.env.GOOGLE_CLIENT_ID;
+      }
+    } catch (e) {
+      if (e instanceof ReferenceError) {
+        // static replacement of process.env.GOOGLE_AUTH_ORIGINS by Vite did not occur,
+        // https://vitejs.dev/guide/env-and-mode.html
+        return undefined;
+      }
+      throw e;
     }
   }
 


### PR DESCRIPTION
Repro: Logout and go to http://localhost:3000/signin. You'll see `process is not defined`

`process.env.NODE_ENV` apparently gets special handling and continues to work in the `DateTimeInput`; e.g. when specifying specifying the start or end time on http://localhost:3000/Appointment/new.