### PR TITLE
Fix broken links identified by Ahrefs

### DIFF
--- a/packages/docs/blog/2023-08-08-system-strings.md
+++ b/packages/docs/blog/2023-08-08-system-strings.md
@@ -138,7 +138,7 @@ Now if we add the system string to our search, we can do a targeted query for Bo
 GET [base]/Patient?identifier=http://hospital-2.org|12345
 ```
 
-See our [search guide](docs/search/basic-search#token) for more information about searching with `system` strings.
+See our [search guide](/docs/search/basic-search#token) for more information about searching with `system` strings.
 
 ## CodeableConcepts
 

--- a/packages/docs/docs/cli/external-fhir-servers.md
+++ b/packages/docs/docs/cli/external-fhir-servers.md
@@ -238,7 +238,7 @@ medplum bulk export -p bcda-sandbox -e Group/all
 
 ## Next Steps
 
-The Medplum CLI uses Medplum [TypescriptSDK](/docs/sdk) to power the functionality. Once the external connection is working and you have tested some of the basic scenarios, it is recommended to build out your integration as a [bot](docs/bots) to enable your event driven or [cron-based](/docs/bots/bot-cron-job) workflow.
+The Medplum CLI uses Medplum [TypescriptSDK](/docs/sdk) to power the functionality. Once the external connection is working and you have tested some of the basic scenarios, it is recommended to build out your integration as a [bot](/docs/bots) to enable your event driven or [cron-based](/docs/bots/bot-cron-job) workflow.
 
 ## Related Resources
 

--- a/packages/docs/docs/fhir-datastore/family-relationships/family-relationships.mdx
+++ b/packages/docs/docs/fhir-datastore/family-relationships/family-relationships.mdx
@@ -293,7 +293,7 @@ Some examples of abstract groups are:
 - A generalized population of patients for a clinical trial.
 - A herd of animals for veterinary use cases.
 
-Adding a [Group](/docs/api/fhir/resources/group) resource for your families an orthogonal choice to Approaches #1-3. You may choose to model the individual relationships via [RelatedPersons](/docs/api/fhir/resources/relatedperson) _and_ also consolidate the entire family into a group. If modeling family groups is important, Medplum recommends modeling all the individuals as [`Patients`](docs/api/fhir/resources/patient), and then referencing them in the `Group.member.entity` array. If required, [`Patients`](docs/api/fhir/resources/patient) can also belong to more than one [`Group`](docs/api/fhir/resources/group)
+Adding a [Group](/docs/api/fhir/resources/group) resource for your families an orthogonal choice to Approaches #1-3. You may choose to model the individual relationships via [RelatedPersons](/docs/api/fhir/resources/relatedperson) _and_ also consolidate the entire family into a group. If modeling family groups is important, Medplum recommends modeling all the individuals as [`Patients`](/docs/api/fhir/resources/patient), and then referencing them in the `Group.member.entity` array. If required, [`Patients`](/docs/api/fhir/resources/patient) can also belong to more than one [`Group`](/docs/api/fhir/resources/group)
 
 In the case of abstract groups, you can use the `Group.quantity` field to record the size of the group, which may be important for analytics or billing workflows.
 

--- a/vercel.json
+++ b/vercel.json
@@ -42,6 +42,10 @@
       "destination": "/docs/access/access-policies"
     },
     {
+      "source": "/docs/auth/authentication-integration-patterns",
+      "destination": "/docs/auth/methods"
+    },
+    {
       "source": "/docs/auth/:page(oauth-auth-code|client-credentials|google-auth|external-identity-providers|external-ids|token-exchange)",
       "destination": "/docs/auth/methods/:page*"
     },


### PR DESCRIPTION
Our SEO tool, Ahrefs, found some broken links that were not detected by the docusaurus build system. Attempting to clean those up in this PR