### PR TITLE
Added redirects for common search landing pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -48,6 +48,14 @@
     {
       "source": "/docs/auth/okta-auth",
       "destination": "/docs/auth/methods/domain-level-identity-providers"
+    },
+    {
+      "source": "/docs/sdk/modules",
+      "destination": "/docs/sdk/core"
+    },
+    {
+      "source": "/docs/sdk/classes/MedplumClient",
+      "destination": "/docs/sdk/core.medplumclient"
     }
   ]
 }


### PR DESCRIPTION
These pages were 2 of our most common search landing pages.

In https://github.com/medplum/medplum/pull/3172 we replaced typedoc with api-documenter

This PR adds redirects for the 2 common pages.