### PR TITLE
feat(fhircast): add `FHIRcast` OAuth 2.0 scopes

### DIFF
--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -23,8 +23,16 @@ class Redis {
     return keys.map((key) => this.values.get(key));
   }
 
-  async set(key: string, value: string): Promise<void> {
+  async set(key: string, value: string, ...args: (string | number)[]): Promise<undefined | null | string> {
+    let oldValue;
+    if (args.includes('GET')) {
+      oldValue = this.values.get(key);
+    }
+    if (args.includes('NX') && this.values.has(key)) {
+      return oldValue;
+    }
     this.values.set(key, value);
+    return oldValue;
   }
 
   async del(key: string | string[]): Promise<void> {

--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -26,7 +26,7 @@ class Redis {
   async set(key: string, value: string, ...args: (string | number)[]): Promise<undefined | null | string> {
     let oldValue;
     if (args.includes('GET')) {
-      oldValue = this.values.get(key);
+      oldValue = this.values.get(key) ?? null; // `ioredis` returns `null` when key didn't previously exist
     }
     if (args.includes('NX') && this.values.has(key)) {
       return oldValue;

--- a/packages/server/src/fhircast/utils.test.ts
+++ b/packages/server/src/fhircast/utils.test.ts
@@ -1,0 +1,33 @@
+import { generateId } from '@medplum/core';
+import { loadTestConfig } from '../config';
+import { closeRedis, getRedis, initRedis } from '../redis';
+import { getTopicForUser } from './utils';
+
+jest.mock('ioredis');
+
+describe('FHIRcast Utils', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    initRedis(config.redis);
+    expect(getRedis()).toBeDefined();
+  });
+
+  afterAll(() => {
+    closeRedis();
+  });
+
+  describe('getTopicForUser', () => {
+    test("User doesn't have an existing topic", async () => {
+      const userId = generateId();
+      await expect(getTopicForUser(userId)).resolves.toBeDefined();
+    });
+
+    test('User has existing topic', async () => {
+      const userId = generateId();
+      const topic = generateId();
+      await getRedis().set(`::fhircast::topic:${userId}`, topic);
+
+      await expect(getTopicForUser(userId)).resolves.toBe(topic);
+    });
+  });
+});

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -1,0 +1,14 @@
+import { generateId } from '@medplum/core';
+import { getRedis } from '../redis';
+
+export async function getTopicForUser(userId: string): Promise<string> {
+  const newTopic = generateId();
+  const topicKey = `::fhircast::topic:${userId}`;
+
+  // Sets the topic key to the new topic if it doesn't exist, then gets either existing or the new topic
+  // 3600 seconds is the configured expiry time for the associated token, so this should work
+  // Per the spec, the lease time of a subscription should not exceed the topic expiry time
+  const topic = await getRedis().set(topicKey, newTopic, 'EX', 3600, 'NX', 'GET');
+  // If topic is null, it means there was no value at the given key, so we should return the new topic
+  return topic || newTopic;
+}

--- a/packages/server/src/fhircast/utils.ts
+++ b/packages/server/src/fhircast/utils.ts
@@ -7,7 +7,8 @@ export async function getTopicForUser(userId: string): Promise<string> {
 
   // Sets the topic key to the new topic if it doesn't exist, then gets either existing or the new topic
   // 3600 seconds is the configured expiry time for the associated token, so this should work
-  // Per the spec, the lease time of a subscription should not exceed the topic expiry time
+  // Per the spec, the lease time of a subscription should not exceed the token expiry time
+  // Source: https://fhircast.org/specification/STU2/#session-discovery:~:text=.%20If%20using%20OAuth%202.0%2C%20the%20Hub%20SHALL%20limit%20the%20subscription%20lease%20seconds%20to%20be%20less%20than%20or%20equal%20to%20the%20access%20token%27s%20expiration.
   const topic = await getRedis().set(topicKey, newTopic, 'EX', 3600, 'NX', 'GET');
   // If topic is null, it means there was no value at the given key, so we should return the new topic
   return topic || newTopic;

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1606,6 +1606,33 @@ describe('OAuth2 Token', () => {
     expect(res.body.error).toBe('invalid_request');
     expect(res.body.error_description).toBe('Invalid subject_token_type');
   });
+
+  test('FHIRcast scopes added to client credentials flow', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'client_credentials',
+      client_id: client.id,
+      client_secret: client.secret,
+      scope: 'openid fhircast/Patient-open.read',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+    expect(res.body.access_token).toBeDefined();
+    expect(res.body['hub.topic']).toBeDefined();
+    expect(res.body['hub.url']).toBeDefined();
+  });
+
+  test('FHIRcast scopes NOT added - should not have Hub topic or URL', async () => {
+    const res = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'client_credentials',
+      client_id: client.id,
+      client_secret: client.secret,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+    expect(res.body.access_token).toBeDefined();
+    expect(res.body['hub.topic']).not.toBeDefined();
+    expect(res.body['hub.url']).not.toBeDefined();
+  });
 });
 
 class MockJoseMultipleMatchingError extends Error {


### PR DESCRIPTION
## What this PR does
* Adds `hub.topic` and `hub.url` to token response when `FHIRcast` scopes are passed into token request
* Adds `getTopicForUser` util for `FHIRcast`
* Adds some more nuanced mocking behavior to `ioredis` mock (for advanced `ioredis.set` behavior)
* Adds tests
* Closes #3254