### PR TITLE
feat(fhircast): add `fhircastGetContext`, split `STU2` and `STU3`

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -39,6 +39,7 @@ import { ContentType } from './contenttype';
 import { encryptSHA256, getRandomString } from './crypto';
 import { EventTarget } from './eventtarget';
 import {
+  CurrentContext,
   FhircastConnection,
   FhircastEventContext,
   FhircastEventName,
@@ -3192,6 +3193,17 @@ export class MedplumClient extends EventTarget {
       createFhircastMessagePayload<typeof event>(topic, event, context),
       ContentType.JSON
     );
+  }
+
+  /**
+   * Gets the current context of the given FHIRcast `topic`.
+   *
+   * @category FHIRcast
+   * @param topic - The topic to get the current context for. Usually a UUID.
+   * @returns A Promise which resolves to the `CurrentContext` for the given topic.
+   */
+  async fhircastGetContext(topic: string): Promise<CurrentContext> {
+    return this.get(`/fhircast/STU3/${topic}`);
   }
 
   /**

--- a/packages/core/src/fhircast/index.ts
+++ b/packages/core/src/fhircast/index.ts
@@ -1,4 +1,4 @@
-import { Resource } from '@medplum/fhirtypes';
+import { Resource, ResourceType } from '@medplum/fhirtypes';
 import { generateId } from '../crypto';
 import { TypedEventTarget } from '../eventtarget';
 import { OperationOutcomeError, validationError } from '../outcomes';
@@ -41,6 +41,7 @@ export function assertContextVersionOptional(event: string): asserts event is Fh
 }
 
 export type FhircastEventName = keyof typeof FHIRCAST_EVENT_NAMES;
+export type FhircastResourceEventName = Exclude<FhircastEventName, 'syncerror'>;
 export type FhircastResourceType = (typeof FHIRCAST_RESOURCE_TYPES)[number];
 
 export type FhircastEventContextDetails = {
@@ -128,6 +129,12 @@ export type SubscriptionRequest = {
   events: FhircastEventName[];
   topic: string;
   endpoint: string;
+};
+
+export type CurrentContext<EventName extends FhircastResourceEventName = FhircastResourceEventName> = {
+  'context.type': ResourceType | '';
+  'context.versionId'?: string;
+  context: FhircastEventContext<EventName>[];
 };
 
 export type PendingSubscriptionRequest = Omit<SubscriptionRequest, 'endpoint'>;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -21,7 +21,7 @@ import { sendOutcome } from './fhir/outcomes';
 import { fhirRouter } from './fhir/routes';
 import { initBinaryStorage } from './fhir/storage';
 import { loadStructureDefinitions } from './fhir/structure';
-import { fhircastRouter } from './fhircast/routes';
+import { fhircastSTU2Router, fhircastSTU3Router } from './fhircast/routes';
 import { healthcheckHandler } from './healthcheck';
 import { hl7BodyParser } from './hl7/parser';
 import { globalLogger } from './logger';
@@ -168,7 +168,8 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
   apiRouter.use('/dicom/PS3/', dicomRouter);
   apiRouter.use('/email/v1/', emailRouter);
   apiRouter.use('/fhir/R4/', fhirRouter);
-  apiRouter.use('/fhircast/STU3/', fhircastRouter);
+  apiRouter.use('/fhircast/STU2/', fhircastSTU2Router);
+  apiRouter.use('/fhircast/STU3/', fhircastSTU3Router);
   apiRouter.use('/oauth2/', oauthRouter);
   apiRouter.use('/scim/v2/', scimRouter);
   apiRouter.use('/storage/', storageRouter);

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -1,4 +1,4 @@
-import { FhircastMessagePayload, badRequest, generateId } from '@medplum/core';
+import { FhircastMessagePayload, FhircastResourceType, badRequest, generateId } from '@medplum/core';
 import { Request, Response, Router } from 'express';
 import { body, validationResult } from 'express-validator';
 import { asyncWrap } from '../async';
@@ -7,32 +7,54 @@ import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { authenticateRequest } from '../oauth/middleware';
 import { getRedis } from '../redis';
 
-export const fhircastRouter = Router();
+export const fhircastSTU2Router = Router();
+export const fhircastSTU3Router = Router();
 
-const publicRoutes = Router();
-fhircastRouter.use(publicRoutes);
+const publicSTU2Routes = Router();
+const publicSTU3Routes = Router();
 
-const protectedRoutes = Router().use(authenticateRequest);
-fhircastRouter.use(protectedRoutes);
+fhircastSTU2Router.use(publicSTU2Routes);
+fhircastSTU3Router.use(publicSTU3Routes);
 
-publicRoutes.get('/.well-known/fhircast-configuration', (_req: Request, res: Response) => {
+const protectedCommonRoutes = Router().use(authenticateRequest);
+fhircastSTU2Router.use(protectedCommonRoutes);
+fhircastSTU3Router.use(protectedCommonRoutes);
+
+const protectedSTU2Routes = Router();
+const protectedSTU3Routes = Router();
+
+fhircastSTU2Router.use(protectedSTU2Routes);
+fhircastSTU3Router.use(protectedSTU3Routes);
+
+const eventsSupported = [
+  'syncerror',
+  'heartbeat',
+  'userlogout',
+  'userhibernate',
+  'Patient-open',
+  'Patient-close',
+  'ImagingStudy-open',
+  'ImagingStudy-close',
+  'Encounter-open',
+  'Encounter-close',
+  'DiagnosticReport-open',
+  'DiagnosticReport-close',
+  'DiagnosticReport-select',
+  'DiagnosticReport-update',
+];
+
+publicSTU2Routes.get('/.well-known/fhircast-configuration', (_req: Request, res: Response) => {
   res.status(200).json({
-    eventsSupported: [
-      'syncerror',
-      'heartbeat',
-      'userlogout',
-      'userhibernate',
-      'Patient-open',
-      'Patient-close',
-      'ImagingStudy-open',
-      'ImagingStudy-close',
-      'Encounter-open',
-      'Encounter-close',
-      'DiagnosticReport-open',
-      'DiagnosticReport-close',
-      'DiagnosticReport-select',
-      'DiagnosticReport-update',
-    ],
+    eventsSupported,
+    websocketSupport: true,
+    webhookSupport: false,
+    fhircastVersion: 'STU2',
+  });
+});
+
+publicSTU3Routes.get('/.well-known/fhircast-configuration', (_req: Request, res: Response) => {
+  res.status(200).json({
+    eventsSupported,
     getCurrentSupport: true,
     websocketSupport: true,
     webhookSupport: false,
@@ -41,7 +63,7 @@ publicRoutes.get('/.well-known/fhircast-configuration', (_req: Request, res: Res
 });
 
 // Register a new subscription
-protectedRoutes.post(
+protectedCommonRoutes.post(
   '/',
   [
     body('hub.channel.type').notEmpty().withMessage('Missing hub.channel.type'),
@@ -82,7 +104,7 @@ protectedRoutes.post(
 );
 
 // Publish an event to the hub topic
-protectedRoutes.post(
+protectedCommonRoutes.post(
   '/:topic',
   [
     body('id').notEmpty().withMessage('Missing event ID'),
@@ -124,7 +146,7 @@ protectedRoutes.post(
 );
 
 // Get the current subscription status
-protectedRoutes.get(
+protectedSTU2Routes.get(
   '/:topic',
   asyncWrap(async (req: Request, res: Response) => {
     const latestEventStr = await getRedis().get(`::fhircast::${req.params.topic}::latest::`);
@@ -134,5 +156,27 @@ protectedRoutes.get(
       return;
     }
     res.status(200).json(JSON.parse(latestEventStr).event.context);
+  })
+);
+
+protectedSTU3Routes.get(
+  '/:topic',
+  asyncWrap(async (req: Request, res: Response) => {
+    const latestEventStr = await getRedis().get(`::fhircast::${req.params.topic}::latest::`);
+    if (!latestEventStr) {
+      // Source: https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html#:~:text=The%20following%20example%20shows%20the%20returned%20structure%20when%20no%20context%20is%20established%3A
+      res.status(200).json({
+        'context.type': '',
+        context: [],
+      });
+      return;
+    }
+    const { event } = JSON.parse(latestEventStr) as FhircastMessagePayload;
+    const anchorResource = event['hub.event'].split('-')[0] as FhircastResourceType;
+    res.status(200).json({
+      'context.type': anchorResource,
+      'context.versionId': event['context.versionId'] as string,
+      context: event.context,
+    });
   })
 );


### PR DESCRIPTION
## What this PR does
* Adds `fhircastGetContext` util to `MedplumClient`
* Splits out `STU2` and `STU3` routes for `FHIRcast`
* Closes #3270 and #3276

## TODO:
* Merge #3289 before this