### PR TITLE
Fix highlighting of default tab

### DIFF
--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -52,9 +52,10 @@ export function ResourcePage(): JSX.Element | null {
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
   const value = useResource(reference, setOutcome);
   const tabs = getTabs(resourceType);
-  const defaultTab = tabs[0].toLowerCase();
-  const tab = window.location.pathname.split('/').pop();
-  const [currentTab, setCurrentTab] = useState<string>(tab ?? defaultTab);
+  const [currentTab, setCurrentTab] = useState<string>(() => {
+    const tab = window.location.pathname.split('/').pop();
+    return tab && tabs.map((t) => t.toLowerCase()).includes(tab) ? tab : tabs[0].toLowerCase();
+  });
 
   async function restoreResource(): Promise<void> {
     const historyBundle = await medplum.readHistory(resourceType, id);


### PR DESCRIPTION
Navigate to a resource and notice that the first tab isn't highlighted as active until clicked on.

Previously, the resources ID was being considered as the default tab due to the way location.pathname was being split. 