### PR TITLE
Redirect to next from signin page if already authenticated

### DIFF
--- a/packages/app/src/SignInPage.test.tsx
+++ b/packages/app/src/SignInPage.test.tsx
@@ -1,4 +1,4 @@
-import { MockClient } from '@medplum/mock';
+import { DrAliceSmith, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import crypto from 'crypto';
@@ -7,14 +7,16 @@ import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';
 import { getConfig } from './config';
+import { type MedplumClient } from '@medplum/core';
 
-const medplum = new MockClient();
+// logged out
+const medplum = new MockClient({ profile: null });
 
 describe('SignInPage', () => {
-  function setup(url = '/signin'): void {
+  function setup(url = '/signin', medplumClient: MedplumClient = medplum): void {
     render(
       <MemoryRouter initialEntries={[url]} initialIndex={0}>
-        <MedplumProvider medplum={medplum}>
+        <MedplumProvider medplum={medplumClient}>
           <AppRoutes />
         </MedplumProvider>
       </MemoryRouter>
@@ -113,5 +115,44 @@ describe('SignInPage', () => {
 
     await waitFor(() => screen.getByText('Batch Create'));
     expect(screen.getByText('Batch Create')).toBeInTheDocument();
+  });
+
+  test('Redirects to homepage if bad next', async () => {
+    setup('/signin?next=https%3A%2F%2Fevil.com');
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Email *'), { target: { value: 'admin@example.com' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Password *'), { target: { value: 'password' } });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    });
+
+    // should redirect to the homepage
+    await waitFor(() => screen.getByTestId('search-control'));
+    expect(screen.getByTestId('search-control')).toBeDefined();
+  });
+
+  test('Automatically redirects to next if logged in', async () => {
+    setup('/signin?next=/batch', new MockClient({ profile: DrAliceSmith }));
+
+    await waitFor(() => screen.getByText('Batch Create'));
+    expect(screen.getByText('Batch Create')).toBeInTheDocument();
+  });
+
+  test('Automatically redirects to homepage if bad next', async () => {
+    setup('/signin?next=https%3A%2F%2Fevil.com', new MockClient({ profile: DrAliceSmith }));
+
+    // should redirect to the homepage
+    await waitFor(() => screen.getByTestId('search-control'));
+    expect(screen.getByTestId('search-control')).toBeDefined();
   });
 });

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -18,10 +18,10 @@ export function SignInPage(): JSX.Element {
   }, [searchParams, navigate]);
 
   useEffect(() => {
-    if (profile) {
+    if (profile && searchParams.has('next')) {
       navigateToNext();
     }
-  }, [profile, navigateToNext]);
+  }, [profile, searchParams, navigateToNext]);
 
   return (
     <SignInForm

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -1,11 +1,11 @@
 import { Title } from '@mantine/core';
-import { Logo, SignInForm, useMedplum } from '@medplum/react';
+import { Logo, SignInForm, useMedplumProfile } from '@medplum/react';
 import React, { useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { getConfig, isRegisterEnabled } from './config';
 
 export function SignInPage(): JSX.Element {
-  const medplum = useMedplum();
+  const profile = useMedplumProfile();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const config = getConfig();
@@ -18,10 +18,10 @@ export function SignInPage(): JSX.Element {
   }, [searchParams, navigate]);
 
   useEffect(() => {
-    if (medplum.getProfile()) {
+    if (profile) {
       navigateToNext();
     }
-  }, [medplum, navigateToNext]);
+  }, [profile, navigateToNext]);
 
   return (
     <SignInForm

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -65,6 +65,11 @@ import {
 
 export interface MockClientOptions extends MedplumClientOptions {
   readonly debug?: boolean;
+  /**
+   * Override currently logged in user. Specifying null results in
+   * MedplumContext.profile returning undefined as if no one were logged in.
+   */
+  readonly profile?: ReturnType<MedplumClient['getProfile']> | null;
 }
 
 export class MockClient extends MedplumClient {
@@ -73,6 +78,7 @@ export class MockClient extends MedplumClient {
   readonly client: MockFetchClient;
   readonly debug: boolean;
   activeLoginOverride?: LoginState;
+  private readonly profile: ReturnType<MedplumClient['getProfile']>;
 
   constructor(clientOptions?: MockClientOptions) {
     const router = new FhirRouter();
@@ -96,6 +102,8 @@ export class MockClient extends MedplumClient {
     this.router = router;
     this.repo = repo;
     this.client = client;
+    // if null is specified, treat it as if no one is logged in
+    this.profile = clientOptions?.profile === null ? undefined : clientOptions?.profile ?? DrAliceSmith;
     this.debug = !!clientOptions?.debug;
   }
 
@@ -104,8 +112,8 @@ export class MockClient extends MedplumClient {
     this.activeLoginOverride = undefined;
   }
 
-  getProfile(): ProfileResource {
-    return DrAliceSmith;
+  getProfile(): ProfileResource | undefined {
+    return this.profile;
   }
 
   getUserConfiguration(): UserConfiguration | undefined {


### PR DESCRIPTION
Fixes #3282 

While I was there, I added a bit of validation of the `next` param to avoid maliciously-crafted redirect URLs.