### PR TITLE
Show language and text fields in form when nested

### DIFF
--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -1,6 +1,6 @@
 import { getPropertyDisplayName, tryGetDataType, TypedValue } from '@medplum/core';
 import React from 'react';
-import { DEFAULT_IGNORED_PROPERTIES } from '../constants';
+import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { DescriptionList, DescriptionListEntry } from '../DescriptionList/DescriptionList';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
@@ -42,6 +42,9 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
       {Object.entries(typeSchema.elements).map((entry) => {
         const [key, property] = entry;
         if (DEFAULT_IGNORED_PROPERTIES.includes(key)) {
+          return null;
+        }
+        if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && property.path.split('.').length === 2) {
           return null;
         }
         const [propertyValue, propertyType] = getValueAndType(typedValue, key);

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -3,7 +3,7 @@ import { getPropertyDisplayName, tryGetDataType } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import React, { useState } from 'react';
 import { CheckboxFormSection } from '../CheckboxFormSection/CheckboxFormSection';
-import { DEFAULT_IGNORED_PROPERTIES } from '../constants';
+import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { FormSection } from '../FormSection/FormSection';
 import { setPropertyValue } from '../ResourceForm/ResourceForm.utils';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
@@ -38,6 +38,9 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
     <Stack>
       {Object.entries(typeSchema.elements).map(([key, property]) => {
         if (key === 'id' || DEFAULT_IGNORED_PROPERTIES.includes(key)) {
+          return null;
+        }
+        if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && property.path.split('.').length === 2) {
           return null;
         }
         if (!property.type) {

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,9 +1,5 @@
-export const DEFAULT_IGNORED_PROPERTIES = [
-  'meta',
-  'implicitRules',
-  'language',
-  'text',
-  'contained',
-  'extension',
-  'modifierExtension',
-];
+export const DEFAULT_IGNORED_PROPERTIES = ['meta', 'implicitRules', 'contained', 'extension', 'modifierExtension'];
+
+// Ignored only when they are top-level properties
+// e.g. Patient.language is ignored, but Patient.communication.language is not ignored
+export const DEFAULT_IGNORED_NON_NESTED_PROPERTIES = ['language', 'text'];


### PR DESCRIPTION
These fields are generally hidden in the edit form since they are part of the base `Resource` and `DomainResource` types and are rarely used. However, when the fields are nested as in the case of `Patient.communication.language`, they should be displayed.

**Before**
![Screenshot 2023-11-09 at 1 31 24 PM](https://github.com/medplum/medplum/assets/933303/309902a3-4d1f-46b3-973a-07df7218d95f)


**After**
![Screenshot 2023-11-09 at 1 30 41 PM](https://github.com/medplum/medplum/assets/933303/618c8f97-f378-4947-aeba-6f5f5d6a8cbd)
