### PR TITLE
Don't show copy button for ID if its empty/missing

### DIFF
--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -1,5 +1,12 @@
 import { ActionIcon, Box, CopyButton, Tooltip } from '@mantine/core';
-import { formatDateTime, formatPeriod, formatTiming, InternalSchemaElement, PropertyType } from '@medplum/core';
+import {
+  formatDateTime,
+  formatPeriod,
+  formatTiming,
+  InternalSchemaElement,
+  isEmpty,
+  PropertyType,
+} from '@medplum/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import React from 'react';
 import { AddressDisplay } from '../AddressDisplay/AddressDisplay';
@@ -42,15 +49,17 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     return (
       <Box component="div" sx={{ display: 'flex', gap: 3, alignItems: 'center' }}>
         {value}
-        <CopyButton value={value} timeout={2000}>
-          {({ copied, copy }) => (
-            <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="right">
-              <ActionIcon color={copied ? 'teal' : 'gray'} onClick={copy}>
-                {copied ? <IconCheck size="1rem" /> : <IconCopy size="1rem" />}
-              </ActionIcon>
-            </Tooltip>
-          )}
-        </CopyButton>
+        {!isEmpty(value) && (
+          <CopyButton value={value} timeout={2000}>
+            {({ copied, copy }) => (
+              <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="right">
+                <ActionIcon color={copied ? 'teal' : 'gray'} onClick={copy}>
+                  {copied ? <IconCheck size="1rem" /> : <IconCopy size="1rem" />}
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </CopyButton>
+        )}
       </Box>
     );
   }


### PR DESCRIPTION
Reduces visual clutter when you'd just be copying a value of `undefined`

**Before**
![Screenshot 2023-11-09 at 1 38 49 PM](https://github.com/medplum/medplum/assets/933303/c55a8d6e-e79b-4b2e-9b1c-2477772574d3)


**After**
![Screenshot 2023-11-09 at 1 39 16 PM](https://github.com/medplum/medplum/assets/933303/4c6284a6-c767-4a2a-a129-3f7791df3099)
