### PR TITLE
Link authentication methods to relevant Medplum Client functions

### DIFF
--- a/packages/docs/docs/auth/methods/client-credentials.md
+++ b/packages/docs/docs/auth/methods/client-credentials.md
@@ -66,7 +66,7 @@ On success, the response will be a JSON object with the following properties:
 
 The value of "access_token" can then be used in future requests for authentication.
 
-Alternatively, you can initiate the process in the Medplum Client by using the [`startClientLogin`](/docs/sdk/core.medplumclient.startclientlogin) helper function.
+Alternatively, you can initiate the process in the Medplum Client by using the [`startClientLogin`](/docs/sdk/core.medplumclient.startclientlogin) convenience method.
 
 For more details about OAuth2 Client Credentials Flow:
 

--- a/packages/docs/docs/auth/methods/client-credentials.md
+++ b/packages/docs/docs/auth/methods/client-credentials.md
@@ -66,6 +66,8 @@ On success, the response will be a JSON object with the following properties:
 
 The value of "access_token" can then be used in future requests for authentication.
 
+Alternatively, you can initiate the process in the Medplum Client by using the [`startClientLogin`](/docs/sdk/core.medplumclient.startclientlogin) helper function.
+
 For more details about OAuth2 Client Credentials Flow:
 
 - https://datatracker.ietf.org/doc/html/rfc6749#section-4.4

--- a/packages/docs/docs/auth/methods/external-identity-providers.mdx
+++ b/packages/docs/docs/auth/methods/external-identity-providers.mdx
@@ -43,7 +43,7 @@ Setup your Medplum account:
 
 ## Start the flow
 
-The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a `signInWithExternalAuth` convenience method:
+The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a [`signInWithExternalAuth`](/docs/sdk/core.medplumclient.signinwithexternalauth) convenience method:
 
 <MedplumCodeBlock language="ts" selectBlocks="signInWithExternalAuth" showLineNumbers>
   {ExampleCode}
@@ -53,7 +53,7 @@ The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a `s
 
 When the external identity provider flow redirects back to your web application, it will include a `code` query parameter. This code can be exchanged for a Medplum access token.
 
-The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a `processCode` convenience method:
+The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a [`processCode`](<(/docs/sdk/core.medplumclient.processcode)>) convenience method:
 
 <MedplumCodeBlock language="ts" selectBlocks="processCode" showLineNumbers>
   {ExampleCode}

--- a/packages/docs/docs/auth/methods/google-auth.md
+++ b/packages/docs/docs/auth/methods/google-auth.md
@@ -52,6 +52,8 @@ While setting up your credentials, use the following settings:
 
 When you successfully create the OAuth client, you will receive a **Client ID** and **Client Secret**. Google will present you with the option to "Download JSON". Do this, and save the JSON file for next steps.
 
+You can initiate a login attempt using the Medplum Client with the [`startGoogleLogin`](/docs/sdk/core.medplumclient.startgooglelogin) convenience method.
+
 ## Add Google Client ID to your Project
 
 Go to the [sites](https://app.medplum.com/admin/sites) section of your admin console to set up your domain.

--- a/packages/docs/docs/auth/methods/oauth-auth-code.md
+++ b/packages/docs/docs/auth/methods/oauth-auth-code.md
@@ -54,6 +54,10 @@ The last step of this flow is for your application to trade in the `AUTHORIZATIO
    - `code=AUTHORIZATION_CODE`
 3. Use the `access_token` received in the [response](/docs/api/oauth/token#sample-response) to make future API calls (See the [**Client Credentials tutorial**](./client-credentials) for more details)
 
+:::note Using the Medplum Client
+You can also use the Medplum SDK to initiate this process, using the [`startLogin`](/docs/sdk/core.medplumclient.startlogin) helper function.
+:::
+
 ## See Also
 
 - [Authorize endpoint](/docs/api/oauth/authorize)

--- a/packages/docs/docs/auth/methods/oauth-auth-code.md
+++ b/packages/docs/docs/auth/methods/oauth-auth-code.md
@@ -55,7 +55,7 @@ The last step of this flow is for your application to trade in the `AUTHORIZATIO
 3. Use the `access_token` received in the [response](/docs/api/oauth/token#sample-response) to make future API calls (See the [**Client Credentials tutorial**](./client-credentials) for more details)
 
 :::note Using the Medplum Client
-You can also use the Medplum SDK to initiate this process, using the [`startLogin`](/docs/sdk/core.medplumclient.startlogin) helper function.
+You can also use the Medplum SDK to initiate this process, using either the [`startLogin`](/docs/sdk/core.medplumclient.startlogin) or [`signInWithRedirect`](/docs/sdk/core.medplumclient.signinwithredirect) convenience method.
 :::
 
 ## See Also


### PR DESCRIPTION
This will add links between the authentication methods docs and their relevant helper function. Related to issue #3322 