### PR TITLE
Use react-jsx transform

### DIFF
--- a/examples/foomedical/src/components/InfoButton.tsx
+++ b/examples/foomedical/src/components/InfoButton.tsx
@@ -1,4 +1,5 @@
 import { createStyles, Group, UnstyledButton } from '@mantine/core';
+import { ReactNode } from 'react';
 
 const useStyles = createStyles((theme) => ({
   button: {
@@ -18,7 +19,7 @@ const useStyles = createStyles((theme) => ({
 
 export interface InfoButtonProps {
   onClick?: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function InfoButton(props: InfoButtonProps): JSX.Element {

--- a/examples/foomedical/src/components/InfoSection.tsx
+++ b/examples/foomedical/src/components/InfoSection.tsx
@@ -1,5 +1,5 @@
 import { Card, CloseButton, createStyles, Title } from '@mantine/core';
-import React from 'react';
+import { ReactNode } from 'react';
 
 const useStyles = createStyles((theme) => ({
   titleSection: {
@@ -16,7 +16,7 @@ const useStyles = createStyles((theme) => ({
 
 interface InfoSectionProps {
   title: string | JSX.Element;
-  children: React.ReactNode;
+  children: ReactNode;
   onButtonClick?: (id: string) => void;
   resourceType?: string;
   id?: string;

--- a/examples/foomedical/src/components/SideMenu.tsx
+++ b/examples/foomedical/src/components/SideMenu.tsx
@@ -1,5 +1,5 @@
 import { createStyles, getStylesRef, Title } from '@mantine/core';
-import React from 'react';
+import { Fragment } from 'react';
 import { NavLink } from 'react-router-dom';
 
 export interface SubMenuProps {
@@ -70,7 +70,7 @@ export function SideMenu(props: SideMenuProps): JSX.Element {
         {props.title}
       </Title>
       {props.menu.map((item) => (
-        <React.Fragment key={item.href}>
+        <Fragment key={item.href}>
           <NavLink to={item.href} end className={({ isActive }) => cx(classes.link, isActive && classes.linkActive)}>
             <span>{item.name}</span>
           </NavLink>
@@ -81,7 +81,7 @@ export function SideMenu(props: SideMenuProps): JSX.Element {
               </NavLink>
             </div>
           ))}
-        </React.Fragment>
+        </Fragment>
       ))}
     </div>
   );

--- a/examples/medplum-chart-demo/src/App.tsx
+++ b/examples/medplum-chart-demo/src/App.tsx
@@ -1,6 +1,6 @@
 import { AppShell, ErrorBoundary, Loading, Logo, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconUser } from '@tabler/icons-react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { HomePage } from './pages/HomePage';
 import { LandingPage } from './pages/LandingPage';

--- a/examples/medplum-chart-demo/src/components/chart/Allergies.tsx
+++ b/examples/medplum-chart-demo/src/components/chart/Allergies.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { createReference } from '@medplum/core';
 import { AllergyIntolerance, CodeableConcept, Encounter, Patient } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, CodeableConceptInput, Form, useMedplum } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export interface AllergiesProps {
   patient: Patient;

--- a/examples/medplum-chart-demo/src/components/chart/Medications.tsx
+++ b/examples/medplum-chart-demo/src/components/chart/Medications.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { createReference } from '@medplum/core';
 import { CodeableConcept, Encounter, MedicationRequest, Patient } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, CodeableConceptInput, Form, useMedplum } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export interface MedicationsProps {
   patient: Patient;

--- a/examples/medplum-chart-demo/src/components/chart/ProblemList.tsx
+++ b/examples/medplum-chart-demo/src/components/chart/ProblemList.tsx
@@ -15,7 +15,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { createReference } from '@medplum/core';
 import { Condition, Encounter, Patient } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, Form, useMedplum } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 
 export interface ProblemListProps {
   patient: Patient;
@@ -62,14 +62,14 @@ export function ProblemList(props: ProblemListProps): JSX.Element {
       {problems.length > 0 ? (
         <Grid gutter="xs">
           {problems.map((problem) => (
-            <React.Fragment key={problem.id}>
+            <Fragment key={problem.id}>
               <Grid.Col span={2}>{problem.onsetDateTime?.substring(0, 4)}</Grid.Col>
               <Grid.Col span={10}>
                 <Badge key={problem.id} maw="100%">
                   <CodeableConceptDisplay value={problem.code} />
                 </Badge>
               </Grid.Col>
-            </React.Fragment>
+            </Fragment>
           ))}
         </Grid>
       ) : (

--- a/examples/medplum-chart-demo/src/components/chart/SmokingStatus.tsx
+++ b/examples/medplum-chart-demo/src/components/chart/SmokingStatus.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { createReference } from '@medplum/core';
 import { Encounter, Observation, Patient } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, Form, useMedplum } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 // Smoking Status widget
 // See: https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-smokingstatus.html

--- a/examples/medplum-chart-demo/src/components/chart/Vitals.tsx
+++ b/examples/medplum-chart-demo/src/components/chart/Vitals.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { generateId } from '@medplum/core';
 import { Encounter, Observation, Patient } from '@medplum/fhirtypes';
 import { Form, QuantityDisplay, useMedplum } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   createCompoundObservation,
   createLoincCode,

--- a/examples/medplum-chart-demo/src/components/soapnote/SoapNote.tsx
+++ b/examples/medplum-chart-demo/src/components/soapnote/SoapNote.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Text } from '@mantine/core';
 import { Questionnaire, QuestionnaireResponse, Task } from '@medplum/fhirtypes';
 import { Document, QuestionnaireForm, useMedplum } from '@medplum/react';
 import { IconCircleCheck } from '@tabler/icons-react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 export function SoapNote(): JSX.Element {

--- a/examples/medplum-chart-demo/src/components/tasks/DiagnosticReportTask.tsx
+++ b/examples/medplum-chart-demo/src/components/tasks/DiagnosticReportTask.tsx
@@ -2,7 +2,7 @@ import { Button, Flex, Modal } from '@mantine/core';
 import { DiagnosticReport, Task } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, DiagnosticReportDisplay, useMedplum } from '@medplum/react';
 import { IconCircleCheck } from '@tabler/icons-react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { TaskCellProps } from './TaskList';
 
 export function DiagnosticReportModal(props: TaskCellProps): JSX.Element {

--- a/examples/medplum-chart-demo/src/components/tasks/QuestionnaireTask.tsx
+++ b/examples/medplum-chart-demo/src/components/tasks/QuestionnaireTask.tsx
@@ -4,7 +4,7 @@ import { getTypedPropertyValue, TypedValue } from '@medplum/core';
 import { Questionnaire, QuestionnaireResponse, QuestionnaireResponseItem, Task } from '@medplum/fhirtypes';
 import { QuestionnaireForm, ResourcePropertyDisplay, useMedplum } from '@medplum/react';
 import { IconCircleCheck } from '@tabler/icons-react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { TaskCellProps } from './TaskList';
 
 export function QuestionnaireTask(props: TaskCellProps): JSX.Element {

--- a/examples/medplum-chart-demo/src/components/tasks/TaskList.tsx
+++ b/examples/medplum-chart-demo/src/components/tasks/TaskList.tsx
@@ -11,7 +11,7 @@ import {
   useResource,
 } from '@medplum/react';
 import { IconFilePencil, IconHeart, IconListCheck, IconReportMedical } from '@tabler/icons-react';
-import React, { useEffect, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { DiagnosticReportModal } from './DiagnosticReportTask';
 import { QuestionnaireTask, ResponseDisplay } from './QuestionnaireTask';
@@ -32,7 +32,7 @@ interface TaskItemProps {
   task: Task;
   resource: Resource;
   profile?: Reference;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function TaskList(): JSX.Element | null {
@@ -62,10 +62,10 @@ export function TaskList(): JSX.Element | null {
       <Box>
         <Timeline>
           {tasks.map((task, idx) => (
-            <React.Fragment key={idx}>
+            <Fragment key={idx}>
               <FocusTimeline key={task.id} task={task} />
               {idx !== tasks.length - 1 ? <Divider w="100%" /> : null}
-            </React.Fragment>
+            </Fragment>
           ))}
         </Timeline>
       </Box>

--- a/examples/medplum-chart-demo/src/main.tsx
+++ b/examples/medplum-chart-demo/src/main.tsx
@@ -1,7 +1,7 @@
 import { MantineProvider, MantineThemeOverride } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
@@ -33,7 +33,7 @@ const theme: MantineThemeOverride = {
 const container = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter>
       <MedplumProvider medplum={medplum}>
         <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
@@ -41,5 +41,5 @@ root.render(
         </MantineProvider>
       </MedplumProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/examples/medplum-chart-demo/src/pages/HomePage.tsx
+++ b/examples/medplum-chart-demo/src/pages/HomePage.tsx
@@ -2,7 +2,6 @@ import { Title } from '@mantine/core';
 import { getReferenceString } from '@medplum/core';
 import { Practitioner } from '@medplum/fhirtypes';
 import { Document, ResourceName, SearchControl, useMedplumNavigate, useMedplumProfile } from '@medplum/react';
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 /**

--- a/examples/medplum-chart-demo/src/pages/LandingPage.tsx
+++ b/examples/medplum-chart-demo/src/pages/LandingPage.tsx
@@ -1,6 +1,5 @@
 import { Anchor, Button, Stack, Text, Title } from '@mantine/core';
 import { Document } from '@medplum/react';
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 export function LandingPage(): JSX.Element {

--- a/examples/medplum-chart-demo/src/pages/PatientPage.tsx
+++ b/examples/medplum-chart-demo/src/pages/PatientPage.tsx
@@ -2,7 +2,7 @@ import { Flex, Loader } from '@mantine/core';
 import { getReferenceString } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { useResource } from '@medplum/react';
-import React from 'react';
+import { Fragment } from 'react';
 import { useParams } from 'react-router-dom';
 import { PatientChart } from '../components/chart/PatientChart';
 import { SoapNote } from '../components/soapnote/SoapNote';
@@ -16,12 +16,12 @@ export function PatientPage(): JSX.Element {
   }
 
   return (
-    <React.Fragment key={getReferenceString(patient)}>
+    <Fragment key={getReferenceString(patient)}>
       <Flex gap="xs" justify="center" align="flex-start" direction="row">
         <PatientChart />
         <TaskList />
         <SoapNote />
       </Flex>
-    </React.Fragment>
+    </Fragment>
   );
 }

--- a/examples/medplum-chart-demo/src/pages/ResourcePage.tsx
+++ b/examples/medplum-chart-demo/src/pages/ResourcePage.tsx
@@ -2,7 +2,7 @@ import { Title } from '@mantine/core';
 import { getDisplayString, getReferenceString } from '@medplum/core';
 import { Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceTable, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 /**

--- a/examples/medplum-chart-demo/src/pages/SearchPage.tsx
+++ b/examples/medplum-chart-demo/src/pages/SearchPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '@medplum/core';
 import { UserConfiguration } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const useStyles = createStyles((theme) => {

--- a/examples/medplum-chart-demo/src/pages/SignInPage.tsx
+++ b/examples/medplum-chart-demo/src/pages/SignInPage.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Logo, SignInForm } from '@medplum/react';
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export function SignInPage(): JSX.Element {

--- a/examples/medplum-fhircast-demo/src/main.tsx
+++ b/examples/medplum-fhircast-demo/src/main.tsx
@@ -1,7 +1,7 @@
 import { MantineProvider, MantineThemeOverride } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
@@ -36,7 +36,7 @@ const medplum = new MedplumClient({
 });
 
 ReactDOM.createRoot(root).render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter>
       <MedplumProvider medplum={medplum}>
         <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
@@ -44,5 +44,5 @@ ReactDOM.createRoot(root).render(
         </MantineProvider>
       </MedplumProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/examples/medplum-hello-world/src/App.tsx
+++ b/examples/medplum-hello-world/src/App.tsx
@@ -1,6 +1,6 @@
 import { AppShell, ErrorBoundary, Loading, Logo, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconUser } from '@tabler/icons-react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 import { PatientHistory } from './components/PatientHistory';
 import { PatientOverview } from './components/PatientOverview';

--- a/examples/medplum-hello-world/src/components/PatientHistory.tsx
+++ b/examples/medplum-hello-world/src/components/PatientHistory.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Document, ResourceHistoryTable } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function PatientHistory(): JSX.Element {

--- a/examples/medplum-hello-world/src/components/PatientOverview.tsx
+++ b/examples/medplum-hello-world/src/components/PatientOverview.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Document, ResourceTable } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 /*

--- a/examples/medplum-hello-world/src/components/Timeline.tsx
+++ b/examples/medplum-hello-world/src/components/Timeline.tsx
@@ -1,5 +1,4 @@
 import { PatientTimeline } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 /*

--- a/examples/medplum-hello-world/src/main.tsx
+++ b/examples/medplum-hello-world/src/main.tsx
@@ -1,7 +1,7 @@
 import { MantineProvider, MantineThemeOverride } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
@@ -33,7 +33,7 @@ const theme: MantineThemeOverride = {
 const container = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter>
       <MedplumProvider medplum={medplum}>
         <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
@@ -41,5 +41,5 @@ root.render(
         </MantineProvider>
       </MedplumProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/examples/medplum-hello-world/src/pages/HomePage.tsx
+++ b/examples/medplum-hello-world/src/pages/HomePage.tsx
@@ -2,7 +2,6 @@ import { Title } from '@mantine/core';
 import { getReferenceString } from '@medplum/core';
 import { Practitioner } from '@medplum/fhirtypes';
 import { Document, ResourceName, SearchControl, useMedplumNavigate, useMedplumProfile } from '@medplum/react';
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 /**

--- a/examples/medplum-hello-world/src/pages/LandingPage.tsx
+++ b/examples/medplum-hello-world/src/pages/LandingPage.tsx
@@ -1,6 +1,5 @@
 import { Anchor, Button, Stack, Text, Title } from '@mantine/core';
 import { Document } from '@medplum/react';
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 export function LandingPage(): JSX.Element {

--- a/examples/medplum-hello-world/src/pages/PatientHeader.tsx
+++ b/examples/medplum-hello-world/src/pages/PatientHeader.tsx
@@ -2,7 +2,6 @@ import { createStyles } from '@mantine/core';
 import { calculateAgeString } from '@medplum/core';
 import { Patient, Reference } from '@medplum/fhirtypes';
 import { HumanNameDisplay, MedplumLink, ResourceAvatar, useResource } from '@medplum/react';
-import React from 'react';
 
 const useStyles = createStyles((theme) => ({
   root: {

--- a/examples/medplum-hello-world/src/pages/PatientPage.tsx
+++ b/examples/medplum-hello-world/src/pages/PatientPage.tsx
@@ -2,7 +2,7 @@ import { Loader, Tabs } from '@mantine/core';
 import { capitalize, getReferenceString } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { useResource } from '@medplum/react';
-import React from 'react';
+import { Fragment } from 'react';
 import { Link, Outlet, useParams } from 'react-router-dom';
 import { PatientHeader } from './PatientHeader';
 
@@ -14,7 +14,7 @@ export function PatientPage(): JSX.Element {
   }
 
   return (
-    <React.Fragment key={getReferenceString(patient)}>
+    <Fragment key={getReferenceString(patient)}>
       <PatientHeader patient={patient} />
       <Tabs>
         <Tabs.List bg="white">
@@ -24,7 +24,7 @@ export function PatientPage(): JSX.Element {
         </Tabs.List>
       </Tabs>
       <Outlet />
-    </React.Fragment>
+    </Fragment>
   );
 }
 

--- a/examples/medplum-hello-world/src/pages/ResourcePage.tsx
+++ b/examples/medplum-hello-world/src/pages/ResourcePage.tsx
@@ -2,7 +2,7 @@ import { Title } from '@mantine/core';
 import { getDisplayString, getReferenceString } from '@medplum/core';
 import { Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceTable, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 /**

--- a/examples/medplum-hello-world/src/pages/SignInPage.tsx
+++ b/examples/medplum-hello-world/src/pages/SignInPage.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Logo, SignInForm } from '@medplum/react';
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export function SignInPage(): JSX.Element {

--- a/examples/medplum-nextjs-demo/app/layout.tsx
+++ b/examples/medplum-nextjs-demo/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { ReactNode } from 'react';
 import Root from './root';
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout(props: { children: React.ReactNode }): JSX.Element {
+export default function RootLayout(props: { children: ReactNode }): JSX.Element {
   const { children } = props;
 
   return (

--- a/examples/medplum-nextjs-demo/app/root.tsx
+++ b/examples/medplum-nextjs-demo/app/root.tsx
@@ -3,6 +3,7 @@
 import { MantineProvider } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
+import { ReactNode } from 'react';
 
 const medplum = new MedplumClient({
   // Uncomment this to run against the server on your localhost
@@ -15,7 +16,7 @@ const medplum = new MedplumClient({
   fetch: (url: string, options?: any) => fetch(url, options),
 });
 
-export default function Root(props: { children: React.ReactNode }): JSX.Element {
+export default function Root(props: { children: ReactNode }): JSX.Element {
   return (
     <MantineProvider withGlobalStyles withNormalizeCSS>
       <MedplumProvider medplum={medplum}>{props.children}</MedplumProvider>

--- a/examples/medplum-task-demo/src/App.tsx
+++ b/examples/medplum-task-demo/src/App.tsx
@@ -1,6 +1,6 @@
 import { Anchor, AppShell, Button, Group, Header, Loader, Text } from '@mantine/core';
 import { ErrorBoundary, Logo, useMedplum } from '@medplum/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { Link, Route, Routes } from 'react-router-dom';
 import { HomePage } from './HomePage';
 import { LandingPage } from './LandingPage';

--- a/examples/medplum-task-demo/src/HomePage.tsx
+++ b/examples/medplum-task-demo/src/HomePage.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Loader, Modal, NativeSelect, Paper, SimpleGrid, Stack, TextInput } from '@mantine/core';
 import { Location, PractitionerRole, Task, TaskRestriction } from '@medplum/fhirtypes';
 import { convertLocalToIso, DateTimeInput, Form, FormSection, useMedplum } from '@medplum/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { TaskList } from './TaskList';
 
 /*

--- a/examples/medplum-task-demo/src/LandingPage.tsx
+++ b/examples/medplum-task-demo/src/LandingPage.tsx
@@ -1,6 +1,5 @@
 import { Anchor } from '@mantine/core';
 import { Document } from '@medplum/react';
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 export function LandingPage(): JSX.Element {

--- a/examples/medplum-task-demo/src/ResourcePage.tsx
+++ b/examples/medplum-task-demo/src/ResourcePage.tsx
@@ -2,7 +2,6 @@ import { Anchor, Loader } from '@mantine/core';
 import { getDisplayString } from '@medplum/core';
 import { Document, ResourceTable, useResource } from '@medplum/react';
 import { IconExternalLink } from '@tabler/icons-react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function ResourcePage(): JSX.Element | null {

--- a/examples/medplum-task-demo/src/SignInPage.tsx
+++ b/examples/medplum-task-demo/src/SignInPage.tsx
@@ -1,5 +1,4 @@
 import { Logo, SignInForm } from '@medplum/react';
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export function SignInPage(): JSX.Element {

--- a/examples/medplum-task-demo/src/TaskList.tsx
+++ b/examples/medplum-task-demo/src/TaskList.tsx
@@ -1,6 +1,5 @@
 import { Paper, Table, Text, Title } from '@mantine/core';
 import { Task } from '@medplum/fhirtypes';
-import React from 'react';
 import { TaskRow } from './TaskRow';
 import { scoreTask } from './utils';
 

--- a/examples/medplum-task-demo/src/TaskRow.tsx
+++ b/examples/medplum-task-demo/src/TaskRow.tsx
@@ -1,10 +1,10 @@
 import { Tooltip, UnstyledButton } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
-import { createReference, formatDateTime, getDisplayString, MedplumClient, PatchOperation } from '@medplum/core';
+import { MedplumClient, PatchOperation, createReference, formatDateTime, getDisplayString } from '@medplum/core';
 import { Practitioner, Task } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleX, IconEdit, IconUser, IconUserSearch } from '@tabler/icons-react';
-import React, { useCallback } from 'react';
+import { MouseEvent, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useStyles } from './TaskRow.styles';
 import { formatDueDate, getShortName, getTaskColor } from './utils';
@@ -26,7 +26,7 @@ export function TaskRow(props: TaskRowProps): JSX.Element {
   const { classes, cx } = useStyles();
 
   const assignToMe = useCallback(
-    async (e: React.MouseEvent): Promise<void> => {
+    async (e: MouseEvent): Promise<void> => {
       e.stopPropagation();
       e.preventDefault();
       await testAndUpdateTask(medplum, task, 'accepted', profile);
@@ -42,7 +42,7 @@ export function TaskRow(props: TaskRowProps): JSX.Element {
   );
 
   const markAsCompleted = useCallback(
-    async (e: React.MouseEvent): Promise<void> => {
+    async (e: MouseEvent): Promise<void> => {
       e.stopPropagation();
       e.preventDefault();
       await testAndUpdateTask(medplum, task, 'completed');
@@ -58,7 +58,7 @@ export function TaskRow(props: TaskRowProps): JSX.Element {
   );
 
   const editTask = useCallback(
-    async (e: React.MouseEvent): Promise<void> => {
+    async (e: MouseEvent): Promise<void> => {
       e.stopPropagation();
       e.preventDefault();
       window.open(`https://app.medplum.com/Task/${task.id}`, '_blank', 'noopener,noreferrer');
@@ -67,7 +67,7 @@ export function TaskRow(props: TaskRowProps): JSX.Element {
   );
 
   const cancelTask = useCallback(
-    async (e: React.MouseEvent): Promise<void> => {
+    async (e: MouseEvent): Promise<void> => {
       e.stopPropagation();
       e.preventDefault();
       await testAndUpdateTask(medplum, task, 'cancelled');

--- a/examples/medplum-task-demo/src/main.tsx
+++ b/examples/medplum-task-demo/src/main.tsx
@@ -2,7 +2,7 @@ import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { App } from './App';
@@ -17,7 +17,7 @@ const medplum = new MedplumClient({
 const container = document.getElementById('root') as HTMLDivElement;
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter>
       <MedplumProvider medplum={medplum}>
         <MantineProvider withGlobalStyles withNormalizeCSS>
@@ -26,5 +26,5 @@ root.render(
         </MantineProvider>
       </MedplumProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/examples/medplum-task-demo/tsconfig.json
+++ b/examples/medplum-task-demo/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/packages/app/babel.config.json
+++ b/packages/app/babel.config.json
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["@babel/preset-env", { "targets": { "node": "current" } }],
-    "@babel/preset-react",
+    ["@babel/preset-react", { "runtime": "automatic" }],
     "@babel/preset-typescript",
     "babel-preset-vite"
   ]

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -2,7 +2,6 @@ import { MantineProvider } from '@mantine/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { App } from './App';
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -17,7 +17,7 @@ import {
   IconStar,
   IconWebhook,
 } from '@tabler/icons-react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { BatchPage } from './BatchPage';
 import { BulkAppPage } from './BulkAppPage';

--- a/packages/app/src/BatchPage.test.tsx
+++ b/packages/app/src/BatchPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, RenderResult, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { BatchPage } from './BatchPage';
 

--- a/packages/app/src/BatchPage.tsx
+++ b/packages/app/src/BatchPage.tsx
@@ -5,7 +5,7 @@ import { convertToTransactionBundle, normalizeErrorString } from '@medplum/core'
 import { Bundle } from '@medplum/fhirtypes';
 import { Document, Form, useMedplum } from '@medplum/react';
 import { IconCheck, IconUpload, IconX } from '@tabler/icons-react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 const DEFAULT_VALUE = `{"resourceType": "Bundle"}`;
 

--- a/packages/app/src/BulkAppPage.test.tsx
+++ b/packages/app/src/BulkAppPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/BulkAppPage.tsx
+++ b/packages/app/src/BulkAppPage.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Document, Loading, MedplumLink, useSearchResources } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function BulkAppPage(): JSX.Element {

--- a/packages/app/src/ChangePasswordPage.test.tsx
+++ b/packages/app/src/ChangePasswordPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ChangePasswordPage } from './ChangePasswordPage';
 
 const medplum = new MockClient();

--- a/packages/app/src/ChangePasswordPage.tsx
+++ b/packages/app/src/ChangePasswordPage.tsx
@@ -2,7 +2,7 @@ import { Button, Center, Group, PasswordInput, Stack, Title } from '@mantine/cor
 import { normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, Form, getErrorsForInput, Logo, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export function ChangePasswordPage(): JSX.Element {
   const medplum = useMedplum();

--- a/packages/app/src/CreateResourcePage.test.tsx
+++ b/packages/app/src/CreateResourcePage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/CreateResourcePage.tsx
+++ b/packages/app/src/CreateResourcePage.tsx
@@ -1,5 +1,5 @@
 import { Paper, ScrollArea, Tabs, Text } from '@mantine/core';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
 
 const tabs = ['Form', 'JSON'];

--- a/packages/app/src/ErrorPage.tsx
+++ b/packages/app/src/ErrorPage.tsx
@@ -1,6 +1,5 @@
 import { Anchor, Stack, Text, Title } from '@mantine/core';
 import { Document } from '@medplum/react';
-import React from 'react';
 
 export function ErrorPage(): JSX.Element {
   return (

--- a/packages/app/src/FormPage.test.tsx
+++ b/packages/app/src/FormPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/FormPage.tsx
+++ b/packages/app/src/FormPage.tsx
@@ -9,7 +9,7 @@ import {
   Resource,
 } from '@medplum/fhirtypes';
 import { Document, Loading, MedplumLink, QuestionnaireForm, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { PatientHeader } from './components/PatientHeader';
 import { ResourceHeader } from './components/ResourceHeader';

--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -4,7 +4,7 @@ import { MockClient } from '@medplum/mock';
 import { Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { randomUUID } from 'crypto';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 import { RESOURCE_TYPE_CREATION_PATHS, getDefaultFields } from './HomePage.utils';

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { formatSearchQuery, normalizeErrorString, parseSearchDefinition, SearchRequest } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { addSearchValues, getTransactionBundle, RESOURCE_TYPE_CREATION_PATHS, saveLastSearch } from './HomePage.utils';
 import { exportJsonFile } from './utils';

--- a/packages/app/src/MfaPage.test.tsx
+++ b/packages/app/src/MfaPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/MfaPage.tsx
+++ b/packages/app/src/MfaPage.tsx
@@ -2,7 +2,7 @@ import { Button, Center, Group, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { Document, Form, useMedplum } from '@medplum/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export function MfaPage(): JSX.Element | null {
   const medplum = useMedplum();

--- a/packages/app/src/OAuthPage.test.tsx
+++ b/packages/app/src/OAuthPage.test.tsx
@@ -2,7 +2,6 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import crypto from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';

--- a/packages/app/src/OAuthPage.tsx
+++ b/packages/app/src/OAuthPage.tsx
@@ -1,7 +1,6 @@
 import { Title } from '@mantine/core';
 import { CodeChallengeMethod } from '@medplum/core';
 import { Logo, SignInForm } from '@medplum/react';
-import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { getConfig } from './config';
 

--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -3,7 +3,6 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import crypto from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';

--- a/packages/app/src/RegisterPage.tsx
+++ b/packages/app/src/RegisterPage.tsx
@@ -1,7 +1,7 @@
 import { Alert, Title } from '@mantine/core';
 import { Document, Logo, RegisterForm, useMedplum } from '@medplum/react';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getConfig, isRegisterEnabled } from './config';
 

--- a/packages/app/src/ResetPasswordPage.test.tsx
+++ b/packages/app/src/ResetPasswordPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResetPasswordPage } from './ResetPasswordPage';
 import { getConfig } from './config';

--- a/packages/app/src/ResetPasswordPage.tsx
+++ b/packages/app/src/ResetPasswordPage.tsx
@@ -12,7 +12,7 @@ import {
   OperationOutcomeAlert,
   useMedplum,
 } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getConfig } from './config';
 

--- a/packages/app/src/SecurityPage.test.tsx
+++ b/packages/app/src/SecurityPage.test.tsx
@@ -3,7 +3,6 @@ import { Notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/SecurityPage.tsx
+++ b/packages/app/src/SecurityPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '@medplum/core';
 import { HumanName, UserConfiguration } from '@medplum/fhirtypes';
 import { DescriptionList, DescriptionListEntry, Document, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface UserSession {

--- a/packages/app/src/SetPasswordPage.test.tsx
+++ b/packages/app/src/SetPasswordPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/SetPasswordPage.tsx
+++ b/packages/app/src/SetPasswordPage.tsx
@@ -2,7 +2,7 @@ import { Button, Center, Group, PasswordInput, Stack, Title } from '@mantine/cor
 import { badRequest, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, Form, getErrorsForInput, Logo, MedplumLink, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 export function SetPasswordPage(): JSX.Element {

--- a/packages/app/src/SignInPage.test.tsx
+++ b/packages/app/src/SignInPage.test.tsx
@@ -2,7 +2,6 @@ import { DrAliceSmith, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import crypto from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -1,6 +1,6 @@
 import { Title } from '@mantine/core';
 import { Logo, SignInForm, useMedplumProfile } from '@medplum/react';
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { getConfig, isRegisterEnabled } from './config';
 

--- a/packages/app/src/SmartSearchPage.test.tsx
+++ b/packages/app/src/SmartSearchPage.test.tsx
@@ -2,7 +2,7 @@ import { PropertyType } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { FhirPathTableField, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
 

--- a/packages/app/src/SmartSearchPage.tsx
+++ b/packages/app/src/SmartSearchPage.tsx
@@ -1,5 +1,5 @@
 import { MemoizedFhirPathTable, FhirPathTableField } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 export function SmartSearchPage(): JSX.Element | null {

--- a/packages/app/src/admin/AccessPolicyInput.tsx
+++ b/packages/app/src/admin/AccessPolicyInput.tsx
@@ -1,7 +1,6 @@
 import { createReference, isResource } from '@medplum/core';
 import { AccessPolicy, Reference } from '@medplum/fhirtypes';
 import { ResourceInput } from '@medplum/react';
-import React from 'react';
 
 export interface AccessPolicyInputProps {
   readonly name: string;

--- a/packages/app/src/admin/BotsPage.tsx
+++ b/packages/app/src/admin/BotsPage.tsx
@@ -1,6 +1,5 @@
 import { Group, Title } from '@mantine/core';
 import { MedplumLink } from '@medplum/react';
-import React from 'react';
 import { MemberTable } from './MembersTable';
 
 export function BotsPage(): JSX.Element {

--- a/packages/app/src/admin/ClientsPage.tsx
+++ b/packages/app/src/admin/ClientsPage.tsx
@@ -1,6 +1,5 @@
 import { Group, Title } from '@mantine/core';
 import { MedplumLink } from '@medplum/react';
-import React from 'react';
 import { MemberTable } from './MembersTable';
 
 export function ClientsPage(): JSX.Element {

--- a/packages/app/src/admin/CreateBotPage.test.tsx
+++ b/packages/app/src/admin/CreateBotPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/CreateBotPage.tsx
+++ b/packages/app/src/admin/CreateBotPage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { AccessPolicy, Bot, OperationOutcome, Reference } from '@medplum/fhirtypes';
 import { Form, FormSection, getErrorsForInput, MedplumLink, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { getProjectId } from '../utils';
 import { AccessPolicyInput } from './AccessPolicyInput';
 

--- a/packages/app/src/admin/CreateClientPage.test.tsx
+++ b/packages/app/src/admin/CreateClientPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/CreateClientPage.tsx
+++ b/packages/app/src/admin/CreateClientPage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { AccessPolicy, ClientApplication, OperationOutcome, Reference } from '@medplum/fhirtypes';
 import { Form, FormSection, getErrorsForInput, MedplumLink, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { getProjectId } from '../utils';
 import { AccessPolicyInput } from './AccessPolicyInput';
 

--- a/packages/app/src/admin/EditMembershipPage.test.tsx
+++ b/packages/app/src/admin/EditMembershipPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/EditMembershipPage.tsx
+++ b/packages/app/src/admin/EditMembershipPage.tsx
@@ -2,7 +2,7 @@ import { Button, Checkbox, Group, Stack, Title } from '@mantine/core';
 import { normalizeOperationOutcome } from '@medplum/core';
 import { AccessPolicy, OperationOutcome, ProjectMembership, Reference, UserConfiguration } from '@medplum/fhirtypes';
 import { Form, FormSection, MedplumLink, ResourceBadge, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getProjectId } from '../utils';
 import { AccessPolicyInput } from './AccessPolicyInput';

--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/InvitePage.tsx
+++ b/packages/app/src/admin/InvitePage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { InviteRequest, isOperationOutcome, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { AccessPolicy, OperationOutcome, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Form, FormSection, MedplumLink, ResourceInput, getErrorsForInput, useMedplum } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { AccessPolicyInput } from './AccessPolicyInput';
 
 export function InvitePage(): JSX.Element {

--- a/packages/app/src/admin/MembersTable.tsx
+++ b/packages/app/src/admin/MembersTable.tsx
@@ -1,7 +1,7 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { MemoizedSearchControl, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getProjectId } from '../utils';
 

--- a/packages/app/src/admin/PatientsPage.tsx
+++ b/packages/app/src/admin/PatientsPage.tsx
@@ -1,6 +1,5 @@
 import { Group, Title } from '@mantine/core';
 import { MedplumLink } from '@medplum/react';
-import React from 'react';
 import { MemberTable } from './MembersTable';
 
 export function PatientsPage(): JSX.Element {

--- a/packages/app/src/admin/ProjectDetailsPage.tsx
+++ b/packages/app/src/admin/ProjectDetailsPage.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { DescriptionList, DescriptionListEntry, useMedplum } from '@medplum/react';
-import React from 'react';
 import { getProjectId } from '../utils';
 
 export function ProjectDetailsPage(): JSX.Element {

--- a/packages/app/src/admin/ProjectPage.test.tsx
+++ b/packages/app/src/admin/ProjectPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/ProjectPage.tsx
+++ b/packages/app/src/admin/ProjectPage.tsx
@@ -1,6 +1,6 @@
 import { Paper, ScrollArea, Tabs } from '@mantine/core';
 import { Document, useMedplum } from '@medplum/react';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { InfoBar } from '../components/InfoBar';
 import { getProjectId } from '../utils';

--- a/packages/app/src/admin/SecretsPage.test.tsx
+++ b/packages/app/src/admin/SecretsPage.test.tsx
@@ -3,7 +3,6 @@ import { Notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/SecretsPage.tsx
+++ b/packages/app/src/admin/SecretsPage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { InternalSchemaElement, deepClone, getElementDefinition } from '@medplum/core';
 import { ProjectSecret } from '@medplum/fhirtypes';
 import { ResourcePropertyInput, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { getProjectId } from '../utils';
 
 export function SecretsPage(): JSX.Element {
@@ -34,7 +34,7 @@ export function SecretsPage(): JSX.Element {
     <form
       noValidate
       autoComplete="off"
-      onSubmit={(e: React.FormEvent) => {
+      onSubmit={(e: FormEvent) => {
         e.preventDefault();
         medplum
           .post(`admin/projects/${projectId}/secrets`, secrets)

--- a/packages/app/src/admin/SitesPage.test.tsx
+++ b/packages/app/src/admin/SitesPage.test.tsx
@@ -3,7 +3,6 @@ import { Notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/SitesPage.tsx
+++ b/packages/app/src/admin/SitesPage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { InternalSchemaElement, deepClone, getElementDefinition, normalizeOperationOutcome } from '@medplum/core';
 import { ProjectSite } from '@medplum/fhirtypes';
 import { ResourcePropertyInput, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { getProjectId } from '../utils';
 
 export function SitesPage(): JSX.Element {
@@ -34,7 +34,7 @@ export function SitesPage(): JSX.Element {
     <form
       noValidate
       autoComplete="off"
-      onSubmit={(e: React.FormEvent) => {
+      onSubmit={(e: FormEvent) => {
         e.preventDefault();
         medplum
           .post(`admin/projects/${projectId}/sites`, sites)

--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -3,7 +3,6 @@ import { Notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -11,7 +11,6 @@ import {
   useMedplum,
 } from '@medplum/react';
 import { IconCheck, IconX } from '@tabler/icons-react';
-import React from 'react';
 
 export function SuperAdminPage(): JSX.Element {
   const medplum = useMedplum();

--- a/packages/app/src/admin/UserConfigurationInput.tsx
+++ b/packages/app/src/admin/UserConfigurationInput.tsx
@@ -1,7 +1,6 @@
 import { createReference, isResource } from '@medplum/core';
 import { Reference, UserConfiguration } from '@medplum/fhirtypes';
 import { ResourceInput } from '@medplum/react';
-import React from 'react';
 
 export interface UserConfigurationInputProps {
   readonly name: string;

--- a/packages/app/src/admin/UsersPage.tsx
+++ b/packages/app/src/admin/UsersPage.tsx
@@ -1,6 +1,5 @@
 import { Group, Title } from '@mantine/core';
 import { MedplumLink } from '@medplum/react';
-import React from 'react';
 import { MemberTable } from './MembersTable';
 
 export function UsersPage(): JSX.Element {

--- a/packages/app/src/components/InfoBar.tsx
+++ b/packages/app/src/components/InfoBar.tsx
@@ -1,5 +1,5 @@
 import { createStyles, ScrollArea } from '@mantine/core';
-import React from 'react';
+import { ReactNode } from 'react';
 
 const useStyles = createStyles((theme) => ({
   root: {
@@ -30,7 +30,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 export interface InfoBarProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function InfoBar(props: InfoBarProps): JSX.Element {
@@ -43,7 +43,7 @@ export function InfoBar(props: InfoBarProps): JSX.Element {
 }
 
 export interface InfoBarEntryProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 InfoBar.Entry = function InfoBarEntry(props: InfoBarEntryProps): JSX.Element {
@@ -52,7 +52,7 @@ InfoBar.Entry = function InfoBarEntry(props: InfoBarEntryProps): JSX.Element {
 };
 
 export interface InfoBarKeyProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 InfoBar.Key = function InfoBarEntry(props: InfoBarKeyProps): JSX.Element {
@@ -61,7 +61,7 @@ InfoBar.Key = function InfoBarEntry(props: InfoBarKeyProps): JSX.Element {
 };
 
 export interface InfoBarValueProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 InfoBar.Value = function InfoBarEntry(props: InfoBarValueProps): JSX.Element {

--- a/packages/app/src/components/PatientHeader.test.tsx
+++ b/packages/app/src/components/PatientHeader.test.tsx
@@ -2,7 +2,6 @@ import { Identifier, Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { PatientHeader } from './PatientHeader';
 import { getDefaultColor } from './PatientHeader.utils';

--- a/packages/app/src/components/PatientHeader.tsx
+++ b/packages/app/src/components/PatientHeader.tsx
@@ -1,7 +1,6 @@
 import { calculateAgeString } from '@medplum/core';
 import { Patient, Reference } from '@medplum/fhirtypes';
 import { HumanNameDisplay, MedplumLink, ResourceAvatar, useResource } from '@medplum/react';
-import React from 'react';
 import { InfoBar } from './InfoBar';
 import { getDefaultColor } from './PatientHeader.utils';
 

--- a/packages/app/src/components/QuickServiceRequests.tsx
+++ b/packages/app/src/components/QuickServiceRequests.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { getReferenceString, normalizeErrorString } from '@medplum/core';
 import { BundleEntry, Patient, Reference, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { MedplumLink, sortByDateAndPriority, useMedplum, useResource } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getPatient } from '../utils';
 
 const useStyles = createStyles((theme) => ({

--- a/packages/app/src/components/QuickStatus.test.tsx
+++ b/packages/app/src/components/QuickStatus.test.tsx
@@ -2,7 +2,6 @@ import { getReferenceString } from '@medplum/core';
 import { ExampleUserConfiguration, HomerServiceRequest, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/components/QuickStatus.tsx
+++ b/packages/app/src/components/QuickStatus.tsx
@@ -1,7 +1,6 @@
 import { createStyles, NativeSelect } from '@mantine/core';
 import { Reference, ValueSet } from '@medplum/fhirtypes';
 import { useResource } from '@medplum/react';
-import React from 'react';
 
 const useStyles = createStyles(() => ({
   container: {

--- a/packages/app/src/components/ResourceHeader.test.tsx
+++ b/packages/app/src/components/ResourceHeader.test.tsx
@@ -3,7 +3,6 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { randomUUID } from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceHeader } from './ResourceHeader';
 

--- a/packages/app/src/components/ResourceHeader.tsx
+++ b/packages/app/src/components/ResourceHeader.tsx
@@ -1,7 +1,7 @@
 import { getDisplayString, getReferenceString } from '@medplum/core';
 import { CodeableConcept, Identifier, Reference, Resource } from '@medplum/fhirtypes';
 import { MedplumLink, useResource } from '@medplum/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { InfoBar } from './InfoBar';
 
 export interface ResourceHeaderProps {
@@ -14,7 +14,7 @@ export function ResourceHeader(props: ResourceHeaderProps): JSX.Element | null {
     return null;
   }
 
-  const entries: { key: string; value: string | React.ReactNode | undefined }[] = [
+  const entries: { key: string; value: string | ReactNode | undefined }[] = [
     { key: 'Type', value: <MedplumLink to={`/${resource.resourceType}`}>{resource.resourceType}</MedplumLink> },
   ];
 

--- a/packages/app/src/components/SpecimenHeader.test.tsx
+++ b/packages/app/src/components/SpecimenHeader.test.tsx
@@ -2,7 +2,6 @@ import { Specimen } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { SpecimenHeader } from './SpecimenHeader';
 

--- a/packages/app/src/components/SpecimenHeader.tsx
+++ b/packages/app/src/components/SpecimenHeader.tsx
@@ -1,7 +1,6 @@
 import { formatDateTime } from '@medplum/core';
 import { Reference, Specimen } from '@medplum/fhirtypes';
 import { useResource } from '@medplum/react';
-import React from 'react';
 import { InfoBar } from './InfoBar';
 
 export interface SpecimenHeaderProps {

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -2,9 +2,9 @@ import { MantineProvider, MantineThemeOverride } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react';
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { App } from './App';
 import { getConfig } from './config';
 
@@ -62,14 +62,14 @@ export async function initApp(): Promise<void> {
 
   const root = createRoot(document.getElementById('root') as HTMLElement);
   root.render(
-    <React.StrictMode>
+    <StrictMode>
       <MedplumProvider medplum={medplum} navigate={navigate}>
         <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
           <Notifications position="bottom-right" />
           <RouterProvider router={router} />
         </MantineProvider>
       </MedplumProvider>
-    </React.StrictMode>
+    </StrictMode>
   );
 }
 

--- a/packages/app/src/lab/AssaysPage.test.tsx
+++ b/packages/app/src/lab/AssaysPage.test.tsx
@@ -2,7 +2,6 @@ import { ObservationDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AssaysPage } from './AssaysPage';
 

--- a/packages/app/src/lab/AssaysPage.tsx
+++ b/packages/app/src/lab/AssaysPage.tsx
@@ -2,7 +2,7 @@ import { Table } from '@mantine/core';
 import { capitalize, formatRange } from '@medplum/core';
 import { ObservationDefinition, ObservationDefinitionQualifiedInterval } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, Loading, RangeDisplay, useSearchResources } from '@medplum/react';
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 
 export function AssaysPage(): JSX.Element {
   const [assays] = useSearchResources('ObservationDefinition', '_count=100');

--- a/packages/app/src/lab/PanelsPage.test.tsx
+++ b/packages/app/src/lab/PanelsPage.test.tsx
@@ -3,7 +3,6 @@ import { ActivityDefinition, ObservationDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { PanelsPage } from './PanelsPage';
 

--- a/packages/app/src/lab/PanelsPage.tsx
+++ b/packages/app/src/lab/PanelsPage.tsx
@@ -1,7 +1,6 @@
 import { Table } from '@mantine/core';
 import { ObservationDefinition } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, Loading, useSearchResources } from '@medplum/react';
-import React from 'react';
 
 export function PanelsPage(): JSX.Element {
   const [panels] = useSearchResources('ActivityDefinition', '_count=100');

--- a/packages/app/src/resource/ApplyPage.tsx
+++ b/packages/app/src/resource/ApplyPage.tsx
@@ -1,6 +1,5 @@
 import { PlanDefinition, ResourceType } from '@medplum/fhirtypes';
 import { Document, useResource } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 import { PlanDefinitionApplyForm } from './PlanDefinitionApplyForm';
 

--- a/packages/app/src/resource/AppsPage.test.tsx
+++ b/packages/app/src/resource/AppsPage.test.tsx
@@ -4,7 +4,7 @@ import { forbidden, OperationOutcomeError } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/AppsPage.tsx
+++ b/packages/app/src/resource/AppsPage.tsx
@@ -3,7 +3,6 @@ import { showNotification } from '@mantine/notifications';
 import { createReference, getReferenceString, normalizeErrorString } from '@medplum/core';
 import { ClientApplication, Patient, Reference, ResourceType, SmartAppLaunch } from '@medplum/fhirtypes';
 import { Document, Loading, MedplumLink, useMedplum, useResource, useSearchResources } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function AppsPage(): JSX.Element | null {

--- a/packages/app/src/resource/AuditEventPage.test.tsx
+++ b/packages/app/src/resource/AuditEventPage.test.tsx
@@ -3,7 +3,6 @@ import { AuditEvent, Bot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/AuditEventPage.tsx
+++ b/packages/app/src/resource/AuditEventPage.tsx
@@ -1,7 +1,7 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, MemoizedSearchControl } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function AuditEventPage(): JSX.Element | null {

--- a/packages/app/src/resource/BlamePage.tsx
+++ b/packages/app/src/resource/BlamePage.tsx
@@ -1,6 +1,5 @@
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceBlame, useMedplum } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function BlamePage(): JSX.Element | null {

--- a/packages/app/src/resource/BotEditor.test.tsx
+++ b/packages/app/src/resource/BotEditor.test.tsx
@@ -5,7 +5,6 @@ import { Bot } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/BotEditor.tsx
+++ b/packages/app/src/resource/BotEditor.tsx
@@ -4,7 +4,7 @@ import { ContentType, isUUID, MedplumClient, normalizeErrorString, PatchOperatio
 import { Bot } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react';
 import { IconCloudUpload, IconDeviceFloppy, IconPlayerPlay } from '@tabler/icons-react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { SyntheticEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { sendCommand } from '../utils';
 import { BotRunner } from './BotRunner';
@@ -79,7 +79,7 @@ export function BotEditor(): JSX.Element | null {
   }, [contentType, fhirInput, hl7Input]);
 
   const saveBot = useCallback(
-    async (e: React.SyntheticEvent) => {
+    async (e: SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
       setLoading(true);
@@ -112,7 +112,7 @@ export function BotEditor(): JSX.Element | null {
   );
 
   const deployBot = useCallback(
-    async (e: React.SyntheticEvent) => {
+    async (e: SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
       setLoading(true);
@@ -130,7 +130,7 @@ export function BotEditor(): JSX.Element | null {
   );
 
   const executeBot = useCallback(
-    async (e: React.SyntheticEvent) => {
+    async (e: SyntheticEvent) => {
       e.preventDefault();
       e.stopPropagation();
       setLoading(true);

--- a/packages/app/src/resource/BotRunner.tsx
+++ b/packages/app/src/resource/BotRunner.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { RefObject } from 'react';
 
 export interface BotRunnerProps {
   className?: string;
-  iframeRef?: React.RefObject<HTMLIFrameElement>;
+  iframeRef?: RefObject<HTMLIFrameElement>;
   testId?: string;
   minHeight?: string;
   onChange?: (value: string) => void;

--- a/packages/app/src/resource/BuilderPage.test.tsx
+++ b/packages/app/src/resource/BuilderPage.test.tsx
@@ -4,7 +4,7 @@ import { PlanDefinition, Questionnaire } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/BuilderPage.tsx
+++ b/packages/app/src/resource/BuilderPage.tsx
@@ -2,7 +2,7 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, PlanDefinitionBuilder, QuestionnaireBuilder, useMedplum } from '@medplum/react';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { cleanResource } from './utils';
 

--- a/packages/app/src/resource/ChecklistPage.tsx
+++ b/packages/app/src/resource/ChecklistPage.tsx
@@ -1,7 +1,6 @@
 import { resolveId } from '@medplum/core';
 import { RequestGroup, ResourceType } from '@medplum/fhirtypes';
 import { Document, RequestGroupDisplay, useResource } from '@medplum/react';
-import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function ChecklistPage(): JSX.Element | null {

--- a/packages/app/src/resource/CodeEditor.tsx
+++ b/packages/app/src/resource/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from 'react';
+import { RefObject } from 'react';
 import { sendCommand } from '../utils';
 
 export interface CodeEditorProps {

--- a/packages/app/src/resource/DeletePage.tsx
+++ b/packages/app/src/resource/DeletePage.tsx
@@ -3,7 +3,6 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, useMedplum } from '@medplum/react';
-import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function DeletePage(): JSX.Element {

--- a/packages/app/src/resource/DetailsPage.tsx
+++ b/packages/app/src/resource/DetailsPage.tsx
@@ -1,6 +1,5 @@
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceTable, useResource } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function DetailsPage(): JSX.Element | null {

--- a/packages/app/src/resource/EditPage.test.tsx
+++ b/packages/app/src/resource/EditPage.test.tsx
@@ -4,7 +4,7 @@ import { Practitioner } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/EditPage.tsx
+++ b/packages/app/src/resource/EditPage.tsx
@@ -2,7 +2,7 @@ import { showNotification } from '@mantine/notifications';
 import { deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceForm, useMedplum } from '@medplum/react';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { cleanResource } from './utils';
 

--- a/packages/app/src/resource/FormCreatePage.tsx
+++ b/packages/app/src/resource/FormCreatePage.tsx
@@ -1,6 +1,6 @@
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, ResourceForm } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useCreateResource } from './useCreateResource';
 

--- a/packages/app/src/resource/HistoryPage.tsx
+++ b/packages/app/src/resource/HistoryPage.tsx
@@ -1,6 +1,5 @@
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceHistoryTable, useMedplum } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function HistoryPage(): JSX.Element | null {

--- a/packages/app/src/resource/JsonCreatePage.tsx
+++ b/packages/app/src/resource/JsonCreatePage.tsx
@@ -2,7 +2,7 @@ import { stringify } from '@medplum/core';
 import { Button, Group, JsonInput } from '@mantine/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, Form, OperationOutcomeAlert } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useCreateResource } from './useCreateResource';
 

--- a/packages/app/src/resource/JsonPage.test.tsx
+++ b/packages/app/src/resource/JsonPage.test.tsx
@@ -3,7 +3,7 @@ import { Notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/JsonPage.tsx
+++ b/packages/app/src/resource/JsonPage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString, stringify } from '@medplum/core';
 import { OperationOutcome, ResourceType } from '@medplum/fhirtypes';
 import { Document, Form, OperationOutcomeAlert, useMedplum, useResource } from '@medplum/react';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { cleanResource } from './utils';
 

--- a/packages/app/src/resource/PlanDefinitionApplyForm.tsx
+++ b/packages/app/src/resource/PlanDefinitionApplyForm.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Stack, Text, Title } from '@mantine/core';
 import { PlanDefinition, Reference, RequestGroup } from '@medplum/fhirtypes';
 import { CodeableConceptDisplay, Form, FormSection, MedplumLink, ReferenceInput, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export interface PlanDefinitionApplyFormProps {
   readonly planDefinition: PlanDefinition;

--- a/packages/app/src/resource/PreviewPage.tsx
+++ b/packages/app/src/resource/PreviewPage.tsx
@@ -2,7 +2,6 @@ import { Alert, Anchor } from '@mantine/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, QuestionnaireForm, useResource } from '@medplum/react';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function PreviewPage(): JSX.Element | null {

--- a/packages/app/src/resource/QuestionnaireBotsPage.tsx
+++ b/packages/app/src/resource/QuestionnaireBotsPage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { getReferenceString, normalizeErrorString } from '@medplum/core';
 import { Bot, Resource, Subscription } from '@medplum/fhirtypes';
 import { Document, ResourceInput, ResourceName, useMedplum } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 export function QuestionnaireBotsPage(): JSX.Element {

--- a/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';

--- a/packages/app/src/resource/QuestionnaireResponsePage.tsx
+++ b/packages/app/src/resource/QuestionnaireResponsePage.tsx
@@ -1,6 +1,6 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { Document, MemoizedSearchControl } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function QuestionnaireResponsePage(): JSX.Element | null {

--- a/packages/app/src/resource/ReferenceRangesPage.test.tsx
+++ b/packages/app/src/resource/ReferenceRangesPage.test.tsx
@@ -4,7 +4,7 @@ import { ObservationDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/ReferenceRangesPage.tsx
+++ b/packages/app/src/resource/ReferenceRangesPage.tsx
@@ -2,7 +2,7 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { ObservationDefinition, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, ReferenceRangeEditor, useMedplum, useResource } from '@medplum/react';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { cleanResource } from './utils';
 

--- a/packages/app/src/resource/ReportPage.tsx
+++ b/packages/app/src/resource/ReportPage.tsx
@@ -1,6 +1,5 @@
 import { DiagnosticReport, MeasureReport, ResourceType } from '@medplum/fhirtypes';
 import { DiagnosticReportDisplay, Document, useResource, MeasureReportDisplay } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function ReportPage(): JSX.Element | null {

--- a/packages/app/src/resource/ResourcePage.test.tsx
+++ b/packages/app/src/resource/ResourcePage.test.tsx
@@ -5,7 +5,7 @@ import { Bot, Practitioner } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -3,7 +3,7 @@ import { showNotification } from '@mantine/notifications';
 import { getReferenceString, isGone, normalizeErrorString } from '@medplum/core';
 import { OperationOutcome, Resource, ResourceType, ServiceRequest } from '@medplum/fhirtypes';
 import { Document, OperationOutcomeAlert, useMedplum, useResource } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import { PatientHeader } from '../components/PatientHeader';
 import { QuickServiceRequests } from '../components/QuickServiceRequests';

--- a/packages/app/src/resource/ResourceVersionPage.test.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/ResourceVersionPage.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.tsx
@@ -1,7 +1,7 @@
 import { Paper, Tabs, Text, Title } from '@mantine/core';
 import { Bundle, BundleEntry, OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Container, Document, Loading, MedplumLink, ResourceDiff, useMedplum } from '@medplum/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function ResourceVersionPage(): JSX.Element {

--- a/packages/app/src/resource/SubscriptionsPage.test.tsx
+++ b/packages/app/src/resource/SubscriptionsPage.test.tsx
@@ -3,7 +3,6 @@ import { Bot, Subscription } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
 

--- a/packages/app/src/resource/SubscriptionsPage.tsx
+++ b/packages/app/src/resource/SubscriptionsPage.tsx
@@ -1,7 +1,7 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, MemoizedSearchControl } from '@medplum/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export function SubscriptionsPage(): JSX.Element | null {

--- a/packages/app/src/resource/TimelinePage.tsx
+++ b/packages/app/src/resource/TimelinePage.tsx
@@ -1,6 +1,5 @@
 import { ResourceType } from '@medplum/fhirtypes';
 import { DefaultResourceTimeline, EncounterTimeline, PatientTimeline, ServiceRequestTimeline } from '@medplum/react';
-import React from 'react';
 import { useParams } from 'react-router-dom';
 
 export function TimelinePage(): JSX.Element | null {

--- a/packages/docs/src/components/BrowserOnlyTabs.tsx
+++ b/packages/docs/src/components/BrowserOnlyTabs.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import Tabs, { Props } from '@theme/Tabs';
 

--- a/packages/docs/src/components/Card.tsx
+++ b/packages/docs/src/components/Card.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styles from './Card.module.css';
 
 export interface CardProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function Card(props: CardProps): JSX.Element {

--- a/packages/docs/src/components/CardButton.tsx
+++ b/packages/docs/src/components/CardButton.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styles from './CardButton.module.css';
 
 export interface CardButtonProps {
   href: string;
   alt: string;
   target?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function CardButton(props: CardButtonProps): JSX.Element {

--- a/packages/docs/src/components/CardContainer.tsx
+++ b/packages/docs/src/components/CardContainer.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styles from './CardContainer.module.css';
 
 export interface CardContainerProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function CardContainer(props: CardContainerProps): JSX.Element {

--- a/packages/docs/src/components/Container.tsx
+++ b/packages/docs/src/components/Container.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import { ReactNode } from 'react';
 
 export interface ContainerProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function Container(props: ContainerProps): JSX.Element {

--- a/packages/docs/src/components/HomepageCallout.tsx
+++ b/packages/docs/src/components/HomepageCallout.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './HomepageCallout.module.css';
 
 type HomepageCalloutProps = {

--- a/packages/docs/src/components/ProfileCard.tsx
+++ b/packages/docs/src/components/ProfileCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import GitHubSvg from './github.svg';
 import LinkedInSvg from './linkedin.svg';
 import styles from './ProfileCard.module.css';

--- a/packages/docs/src/components/ResourceTables.tsx
+++ b/packages/docs/src/components/ResourceTables.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { buildTypeName } from '@medplum/core';
 import styles from './ResourceTables.module.css';
 

--- a/packages/docs/src/components/StorybookFrame.tsx
+++ b/packages/docs/src/components/StorybookFrame.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export function StorybookFrame(): JSX.Element {
   const host = window.location.host;
   const hostname = window.location.hostname;

--- a/packages/docs/src/components/landing/AnimatedCircle.tsx
+++ b/packages/docs/src/components/landing/AnimatedCircle.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import './animations.css';
 

--- a/packages/docs/src/components/landing/AnimatedInfinity.tsx
+++ b/packages/docs/src/components/landing/AnimatedInfinity.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useInView } from 'react-intersection-observer';
 import './animations.css';
 

--- a/packages/docs/src/components/landing/FeatureGrid.tsx
+++ b/packages/docs/src/components/landing/FeatureGrid.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { CSSProperties, ReactNode } from 'react';
 import styles from './FeatureGrid.module.css';
 
 export interface FeatureGridProps {
   columns: number;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function FeatureGrid(props: FeatureGridProps): JSX.Element {
   return (
-    <div className={styles.featureGrid} style={{ '--columns': props.columns } as React.CSSProperties}>
+    <div className={styles.featureGrid} style={{ '--columns': props.columns } as CSSProperties}>
       {props.children}
     </div>
   );
@@ -17,7 +17,7 @@ export function FeatureGrid(props: FeatureGridProps): JSX.Element {
 export interface FeatureProps {
   imgSrc: string;
   title: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function Feature(props: FeatureProps): JSX.Element {

--- a/packages/docs/src/components/landing/HeroSection.tsx
+++ b/packages/docs/src/components/landing/HeroSection.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Container } from '../Container';
 import { Jumbotron } from './Jumbotron';
 import styles from './LandingPage.module.css';

--- a/packages/docs/src/components/landing/Jumbotron.tsx
+++ b/packages/docs/src/components/landing/Jumbotron.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styles from './Jumbotron.module.css';
 
 export interface JumbotronProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function Jumbotron(props: JumbotronProps): JSX.Element {

--- a/packages/docs/src/components/landing/LandingPage.tsx
+++ b/packages/docs/src/components/landing/LandingPage.tsx
@@ -1,5 +1,5 @@
 import Layout from '@theme/Layout';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Card } from '../Card';
 import { CardButton } from '../CardButton';
 import { CardContainer } from '../CardContainer';

--- a/packages/docs/src/components/landing/LogoScroller.tsx
+++ b/packages/docs/src/components/landing/LogoScroller.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './LogoScroller.module.css';
 
 export function LogoScroller(): JSX.Element {

--- a/packages/docs/src/components/landing/Section.tsx
+++ b/packages/docs/src/components/landing/Section.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styles from './Section.module.css';
 
 export interface SectionProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function Section(props: SectionProps): JSX.Element {

--- a/packages/docs/src/components/landing/SectionHeader.tsx
+++ b/packages/docs/src/components/landing/SectionHeader.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styles from './SectionHeader.module.css';
 
 export interface SectionHeaderProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function SectionHeader(props: SectionHeaderProps): JSX.Element {

--- a/packages/docs/src/components/landing/TestimonialHeader.tsx
+++ b/packages/docs/src/components/landing/TestimonialHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styles from './TestimonialHeader.module.css';
 
 export interface TestimonialHeaderProps {

--- a/packages/docs/src/pages/about.tsx
+++ b/packages/docs/src/pages/about.tsx
@@ -1,5 +1,4 @@
 import Layout from '@theme/Layout';
-import React from 'react';
 import { Card } from '../components/Card';
 import { CardContainer } from '../components/CardContainer';
 import { Container } from '../components/Container';

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { LandingPage } from '../components/landing/LandingPage';
 
 export default function IndexPage(): JSX.Element {

--- a/packages/docs/src/pages/pricing.tsx
+++ b/packages/docs/src/pages/pricing.tsx
@@ -1,5 +1,4 @@
 import Layout from '@theme/Layout';
-import React from 'react';
 import { Container } from '../components/Container';
 import styles from './pricing.module.css';
 

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -2,6 +2,7 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "jsx": "react-jsx"
   }
 }

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -1,16 +1,16 @@
 import { GraphiQLPlugin } from '@graphiql/react';
 import { FetcherParams, SyncExecutionResult } from '@graphiql/toolkit';
 import { MantineProvider, MantineThemeOverride, Title } from '@mantine/core';
-import { decodeBase64, encodeBase64, getDisplayString, MedplumClient, ProfileResource } from '@medplum/core';
+import { MedplumClient, ProfileResource, decodeBase64, encodeBase64, getDisplayString } from '@medplum/core';
 import { Logo, MedplumProvider, SignInForm, useMedplumProfile } from '@medplum/react';
 import GraphiQL from 'graphiql';
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { getConfig } from './config';
 
 import 'regenerator-runtime/runtime.js';
 
 import 'graphiql/graphiql.css';
+import { StrictMode } from 'react';
 
 const HELP_TEXT = `# Welcome to Medplum GraphiQL
 #
@@ -165,11 +165,11 @@ export function App(): JSX.Element {
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <MedplumProvider medplum={medplum}>
       <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
         <App />
       </MantineProvider>
     </MedplumProvider>
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/packages/react-hooks/babel.config.json
+++ b/packages/react-hooks/babel.config.json
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["@babel/preset-env", { "targets": { "node": "current" } }],
-    "@babel/preset-react",
+    ["@babel/preset-react", { "runtime": "automatic" }],
     "@babel/preset-typescript"
   ]
 }

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
@@ -1,7 +1,6 @@
 import { getDisplayString, MedplumClient, ProfileResource } from '@medplum/core';
 import { MockAsyncClientStorage, MockClient } from '@medplum/mock';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MedplumProvider } from './MedplumProvider';
 import { useMedplum, useMedplumContext, useMedplumNavigate, useMedplumProfile } from './MedplumProvider.context';
 

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
@@ -1,11 +1,11 @@
 import { MedplumClient } from '@medplum/core';
-import React, { useEffect, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { MepdlumNavigateFunction, reactContext } from './MedplumProvider.context';
 
 export interface MedplumProviderProps {
   medplum: MedplumClient;
   navigate?: MepdlumNavigateFunction;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 /**

--- a/packages/react-hooks/src/useResource/useResource.test.tsx
+++ b/packages/react-hooks/src/useResource/useResource.test.tsx
@@ -2,7 +2,7 @@ import { createReference } from '@medplum/core';
 import { OperationOutcome, Reference, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React, { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
 import { useResource } from './useResource';
@@ -22,7 +22,7 @@ describe('useResource', () => {
     console.error = jest.fn();
   });
 
-  async function setup(children: React.ReactNode): Promise<void> {
+  async function setup(children: ReactNode): Promise<void> {
     const medplum = new MockClient();
     await act(async () => {
       render(

--- a/packages/react-hooks/src/useSearch/useSearch.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearch.test.tsx
@@ -1,7 +1,7 @@
 import { operationOutcomeToString } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
 import { useSearch } from './useSearch';
@@ -22,7 +22,7 @@ describe('useSearch hooks', () => {
     console.error = jest.fn();
   });
 
-  async function setup(children: React.ReactNode): Promise<void> {
+  async function setup(children: ReactNode): Promise<void> {
     const medplum = new MockClient();
     await act(async () => {
       render(

--- a/packages/react-hooks/src/useSearch/useSearchOne.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearchOne.test.tsx
@@ -1,7 +1,7 @@
 import { operationOutcomeToString } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
 import { useSearchOne } from './useSearch';
@@ -22,7 +22,7 @@ describe('useSearch hooks', () => {
     console.error = jest.fn();
   });
 
-  async function setup(children: React.ReactNode): Promise<void> {
+  async function setup(children: ReactNode): Promise<void> {
     const medplum = new MockClient();
     await act(async () => {
       render(

--- a/packages/react-hooks/src/useSearch/useSearchResources.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearchResources.test.tsx
@@ -2,7 +2,7 @@ import { operationOutcomeToString } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
 import { useSearchResources } from './useSearch';
@@ -23,7 +23,7 @@ describe('useSearch hooks', () => {
     console.error = jest.fn();
   });
 
-  async function setup(children: React.ReactNode): Promise<void> {
+  async function setup(children: ReactNode): Promise<void> {
     const medplum = new MockClient();
     await act(async () => {
       render(

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -1,7 +1,6 @@
 import { MantineProvider, MantineThemeOverride } from '@mantine/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 export const parameters = {

--- a/packages/react/babel.config.cjs
+++ b/packages/react/babel.config.cjs
@@ -1,5 +1,9 @@
 module.exports = {
-  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-react', '@babel/preset-typescript'],
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript',
+  ],
   plugins: [
     function () {
       return {

--- a/packages/react/src/AddressDisplay/AddressDisplay.stories.tsx
+++ b/packages/react/src/AddressDisplay/AddressDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AddressDisplay } from './AddressDisplay';
 

--- a/packages/react/src/AddressDisplay/AddressDisplay.test.tsx
+++ b/packages/react/src/AddressDisplay/AddressDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { AddressDisplay } from './AddressDisplay';
 
 describe('AddressDisplay', () => {

--- a/packages/react/src/AddressDisplay/AddressDisplay.tsx
+++ b/packages/react/src/AddressDisplay/AddressDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatAddress } from '@medplum/core';
 import { Address } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface AddressDisplayProps {
   value?: Address;

--- a/packages/react/src/AddressInput/AddressInput.stories.tsx
+++ b/packages/react/src/AddressInput/AddressInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AddressInput } from './AddressInput';
 

--- a/packages/react/src/AddressInput/AddressInput.test.tsx
+++ b/packages/react/src/AddressInput/AddressInput.test.tsx
@@ -1,6 +1,5 @@
 import { Address } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { AddressInput } from './AddressInput';
 
 describe('AddressInput', () => {

--- a/packages/react/src/AddressInput/AddressInput.tsx
+++ b/packages/react/src/AddressInput/AddressInput.tsx
@@ -1,6 +1,6 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Address } from '@medplum/fhirtypes';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 function getLine(address: Address, index: number): string {
   return address.line && address.line.length > index ? address.line[index] : '';

--- a/packages/react/src/AnnotationInput/AnnotationInput.stories.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.stories.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { Annotation } from '@medplum/fhirtypes';
 import { DrAliceSmith } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AnnotationInput } from './AnnotationInput';
 

--- a/packages/react/src/AnnotationInput/AnnotationInput.test.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { AnnotationInput, AnnotationInputProps } from './AnnotationInput';
 
 const medplum = new MockClient();

--- a/packages/react/src/AnnotationInput/AnnotationInput.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.tsx
@@ -2,7 +2,7 @@ import { TextInput } from '@mantine/core';
 import { createReference } from '@medplum/core';
 import { Annotation } from '@medplum/fhirtypes';
 import { useMedplumProfile } from '@medplum/react-hooks';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 export interface AnnotationInputProps {
   name: string;

--- a/packages/react/src/AppShell/AppShell.stories.tsx
+++ b/packages/react/src/AppShell/AppShell.stories.tsx
@@ -9,7 +9,6 @@ import {
   IconReceipt2,
   IconSettings,
 } from '@tabler/icons-react';
-import React from 'react';
 import { Logo } from '../Logo/Logo';
 import { AppShell } from './AppShell';
 

--- a/packages/react/src/AppShell/AppShell.test.tsx
+++ b/packages/react/src/AppShell/AppShell.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Logo } from '../Logo/Logo';
 import { AppShell } from './AppShell';

--- a/packages/react/src/AppShell/AppShell.tsx
+++ b/packages/react/src/AppShell/AppShell.tsx
@@ -1,20 +1,20 @@
 import { AppShell as MantineAppShell, useMantineTheme } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { useMedplum, useMedplumProfile } from '@medplum/react-hooks';
-import React, { Suspense, useEffect, useState } from 'react';
+import { ReactNode, Suspense, useEffect, useState } from 'react';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { Loading } from '../Loading/Loading';
 import { Header } from './Header';
 import { Navbar, NavbarMenu } from './Navbar';
 
 export interface AppShellProps {
-  logo: React.ReactNode;
+  logo: ReactNode;
   pathname?: string;
   searchParams?: URLSearchParams;
   headerSearchDisabled?: boolean;
   version?: string;
   menus?: NavbarMenu[];
-  children: React.ReactNode;
+  children: ReactNode;
   displayAddBookmark?: boolean;
   resourceTypeSearchDisabled?: boolean;
 }

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Logo } from '../Logo/Logo';
 import { Header } from './Header';

--- a/packages/react/src/AppShell/Header.tsx
+++ b/packages/react/src/AppShell/Header.tsx
@@ -3,7 +3,7 @@ import { formatHumanName, getReferenceString, ProfileResource } from '@medplum/c
 import { HumanName } from '@medplum/fhirtypes';
 import { useMedplumContext } from '@medplum/react-hooks';
 import { IconChevronDown, IconLogout, IconSettings, IconSwitchHorizontal } from '@tabler/icons-react';
-import React, { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { HumanNameDisplay } from '../HumanNameDisplay/HumanNameDisplay';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { HeaderSearchInput } from './HeaderSearchInput';
@@ -57,7 +57,7 @@ export interface HeaderProps {
   pathname?: string;
   searchParams?: URLSearchParams;
   headerSearchDisabled?: boolean;
-  logo: React.ReactNode;
+  logo: ReactNode;
   version?: string;
   navbarToggle: () => void;
 }

--- a/packages/react/src/AppShell/HeaderSearchInput.test.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.test.tsx
@@ -2,7 +2,6 @@ import { HomerServiceRequest, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { randomUUID } from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { HeaderSearchInput } from './HeaderSearchInput';
 

--- a/packages/react/src/AppShell/HeaderSearchInput.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.tsx
@@ -3,7 +3,7 @@ import { formatHumanName, getDisplayString, getReferenceString, isUUID } from '@
 import { Patient, ServiceRequest } from '@medplum/fhirtypes';
 import { useMedplum, useMedplumNavigate } from '@medplum/react-hooks';
 import { IconSearch } from '@tabler/icons-react';
-import React, { forwardRef, useCallback } from 'react';
+import { forwardRef, useCallback } from 'react';
 import { AsyncAutocomplete, AsyncAutocompleteOption } from '../AsyncAutocomplete/AsyncAutocomplete';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 

--- a/packages/react/src/AppShell/Navbar.test.tsx
+++ b/packages/react/src/AppShell/Navbar.test.tsx
@@ -2,7 +2,6 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { IconStar } from '@tabler/icons-react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { Navbar } from './Navbar';
 
 const medplum = new MockClient();

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -1,7 +1,7 @@
 import { Button, createStyles, Navbar as MantineNavbar, ScrollArea, Space, Text } from '@mantine/core';
 import { useMedplumNavigate } from '@medplum/react-hooks';
 import { IconPlus } from '@tabler/icons-react';
-import React, { useState } from 'react';
+import { Fragment, MouseEventHandler, ReactNode, SyntheticEvent, useState } from 'react';
 import { BookmarkDialog } from '../BookmarkDialog/BookmarkDialog';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
@@ -84,7 +84,7 @@ export function Navbar(props: NavbarProps): JSX.Element {
   const activeLink = getActiveLink(props.pathname, props.searchParams, props.menus);
   const [bookmarkDialogVisible, setBookmarkDialogVisible] = useState(false);
 
-  function onLinkClick(e: React.SyntheticEvent, to: string): void {
+  function onLinkClick(e: SyntheticEvent, to: string): void {
     e.stopPropagation();
     e.preventDefault();
     navigate(to);
@@ -115,7 +115,7 @@ export function Navbar(props: NavbarProps): JSX.Element {
           )}
           <MantineNavbar.Section grow>
             {props.menus?.map((menu) => (
-              <React.Fragment key={`menu-${menu.title}`}>
+              <Fragment key={`menu-${menu.title}`}>
                 <Text className={classes.menuTitle}>{menu.title}</Text>
                 {menu.links?.map((link) => (
                   <NavbarLink
@@ -128,7 +128,7 @@ export function Navbar(props: NavbarProps): JSX.Element {
                     <span>{link.label}</span>
                   </NavbarLink>
                 ))}
-              </React.Fragment>
+              </Fragment>
             ))}
             {props.displayAddBookmark && (
               <Button
@@ -160,8 +160,8 @@ export function Navbar(props: NavbarProps): JSX.Element {
 interface NavbarLinkProps {
   to: string;
   active: boolean;
-  onClick: React.MouseEventHandler;
-  children: React.ReactNode;
+  onClick: MouseEventHandler;
+  children: ReactNode;
 }
 
 function NavbarLink(props: NavbarLinkProps): JSX.Element {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -1,7 +1,7 @@
 import { Loader, MultiSelect, MultiSelectProps, SelectItem } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { killEvent } from '../utils/dom';
 
 export interface AsyncAutocompleteOption<T> extends SelectItem {
@@ -120,7 +120,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent): void => {
+    (e: KeyboardEvent): void => {
       if (e.key === 'Enter') {
         if (!timerRef.current && !abortControllerRef.current) {
           killEvent(e);

--- a/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.stories.tsx
+++ b/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Attachment } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AttachmentArrayDisplay } from './AttachmentArrayDisplay';
 

--- a/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
+++ b/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
@@ -1,5 +1,4 @@
 import { Attachment } from '@medplum/fhirtypes';
-import React from 'react';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 
 export interface AttachmentArrayDisplayProps {

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.stories.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AttachmentArrayInput } from './AttachmentArrayInput';
 

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.test.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { AttachmentArrayInput, AttachmentArrayInputProps } from './AttachmentArrayInput';
 
 const medplum = new MockClient();

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
@@ -1,7 +1,7 @@
 import { ActionIcon } from '@mantine/core';
 import { Attachment } from '@medplum/fhirtypes';
 import { IconCircleMinus, IconCloudUpload } from '@tabler/icons-react';
-import React, { useRef, useState } from 'react';
+import { MouseEvent, useRef, useState } from 'react';
 import { AttachmentButton } from '../AttachmentButton/AttachmentButton';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { killEvent } from '../utils/dom';
@@ -42,7 +42,7 @@ export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Elem
               <ActionIcon
                 title="Remove"
                 size="sm"
-                onClick={(e: React.MouseEvent) => {
+                onClick={(e: MouseEvent) => {
                   killEvent(e);
                   const copy = values.slice();
                   copy.splice(index, 1);

--- a/packages/react/src/AttachmentButton/AttachmentButton.stories.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.stories.tsx
@@ -1,7 +1,6 @@
 import { ActionIcon, Button } from '@mantine/core';
 import { Meta } from '@storybook/react';
 import { IconCloudUpload } from '@tabler/icons-react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AttachmentButton } from './AttachmentButton';
 

--- a/packages/react/src/AttachmentButton/AttachmentButton.test.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.test.tsx
@@ -3,13 +3,13 @@ import { Attachment } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { AttachmentButton } from './AttachmentButton';
 
 const medplum = new MockClient();
 
 describe('AttachmentButton', () => {
-  const setup = (children: React.ReactNode): void => {
+  const setup = (children: ReactNode): void => {
     render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
   };
 

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -1,6 +1,6 @@
 import { Attachment, Binary, OperationOutcome } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import React, { useRef } from 'react';
+import { ChangeEvent, MouseEvent, ReactNode, useRef } from 'react';
 import { killEvent } from '../utils/dom';
 import { normalizeOperationOutcome } from '@medplum/core';
 
@@ -9,19 +9,19 @@ export interface AttachmentButtonProps {
   onUploadStart?: () => void;
   onUploadProgress?: (e: ProgressEvent) => void;
   onUploadError?: (outcome: OperationOutcome) => void;
-  children(props: { onClick(e: React.MouseEvent): void }): React.ReactNode;
+  children(props: { onClick(e: MouseEvent): void }): ReactNode;
 }
 
 export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {
   const medplum = useMedplum();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  function onClick(e: React.MouseEvent): void {
+  function onClick(e: MouseEvent): void {
     killEvent(e);
     fileInputRef.current?.click();
   }
 
-  function onFileChange(e: React.ChangeEvent): void {
+  function onFileChange(e: ChangeEvent): void {
     killEvent(e);
     const files = (e.target as HTMLInputElement).files;
     if (files) {

--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.stories.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Attachment } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { AttachmentDisplay } from './AttachmentDisplay';
 

--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.test.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.test.tsx
@@ -1,7 +1,6 @@
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { AttachmentDisplay, AttachmentDisplayProps } from './AttachmentDisplay';
 
 function mockFetch(url: string, options: any): Promise<any> {

--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.tsx
@@ -1,6 +1,5 @@
 import { Anchor } from '@mantine/core';
 import { Attachment } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface AttachmentDisplayProps {
   value?: Attachment;

--- a/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { AttachmentInput } from './AttachmentInput';
 import { Document } from '../Document/Document';
 

--- a/packages/react/src/AttachmentInput/AttachmentInput.test.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { AttachmentInput, AttachmentInputProps } from './AttachmentInput';
 
 const medplum = new MockClient();

--- a/packages/react/src/AttachmentInput/AttachmentInput.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mantine/core';
 import { Attachment } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import { AttachmentButton } from '../AttachmentButton/AttachmentButton';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { killEvent } from '../utils/dom';
@@ -27,7 +27,7 @@ export function AttachmentInput(props: AttachmentInputProps): JSX.Element {
       <>
         <AttachmentDisplay value={value} maxWidth={200} />
         <Button
-          onClick={(e: React.MouseEvent) => {
+          onClick={(e: MouseEvent) => {
             killEvent(e);
             setValueWrapper(undefined);
           }}

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.stories.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { PatientContact } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { BackboneElementDisplay } from './BackboneElementDisplay';
 

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { BackboneElementDisplay, BackboneElementDisplayProps } from './BackboneElementDisplay';
 

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -1,5 +1,4 @@
 import { getPropertyDisplayName, tryGetDataType, TypedValue } from '@medplum/core';
-import React from 'react';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { DescriptionList, DescriptionListEntry } from '../DescriptionList/DescriptionList';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.stories.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { BackboneElementInput } from './BackboneElementInput';
 

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
@@ -2,7 +2,6 @@ import { globalSchema, InternalSchemaElement, TypeInfo } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { BackboneElementInput, BackboneElementInputProps } from './BackboneElementInput';
 

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -1,7 +1,7 @@
 import { Stack } from '@mantine/core';
 import { getPropertyDisplayName, tryGetDataType } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { CheckboxFormSection } from '../CheckboxFormSection/CheckboxFormSection';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { FormSection } from '../FormSection/FormSection';

--- a/packages/react/src/BookmarkDialog/BookmarkDialog.test.tsx
+++ b/packages/react/src/BookmarkDialog/BookmarkDialog.test.tsx
@@ -3,7 +3,6 @@ import { UserConfiguration } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { BookmarkDialog } from './BookmarkDialog';
 
 jest.mock('@mantine/notifications');

--- a/packages/react/src/BookmarkDialog/BookmarkDialog.tsx
+++ b/packages/react/src/BookmarkDialog/BookmarkDialog.tsx
@@ -3,7 +3,6 @@ import { showNotification } from '@mantine/notifications';
 import { deepClone, normalizeErrorString } from '@medplum/core';
 import { UserConfiguration } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import React from 'react';
 import { Form } from '../Form/Form';
 
 interface BookmarkDialogProps {

--- a/packages/react/src/CalendarInput/CalendarInput.stories.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.stories.tsx
@@ -1,6 +1,5 @@
 import { Slot } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { CalendarInput } from './CalendarInput';
 

--- a/packages/react/src/CalendarInput/CalendarInput.test.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.test.tsx
@@ -1,6 +1,5 @@
 import { Slot } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { CalendarInput } from './CalendarInput';
 import { getMonthString, getStartMonth } from './CalendarInput.utils';
 

--- a/packages/react/src/CalendarInput/CalendarInput.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.tsx
@@ -1,6 +1,6 @@
 import { Button, createStyles, Group } from '@mantine/core';
 import { Slot } from '@medplum/fhirtypes';
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { getMonthString, getStartMonth } from './CalendarInput.utils';
 
 const useStyles = createStyles((theme) => ({

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -1,12 +1,12 @@
 import { Group, Input } from '@mantine/core';
-import React from 'react';
+import { ReactNode } from 'react';
 
 export interface CheckboxFormSectionProps {
   htmlFor?: string;
   title?: string;
   description?: string;
   withAsterisk?: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Element {

--- a/packages/react/src/CodeInput/CodeInput.stories.tsx
+++ b/packages/react/src/CodeInput/CodeInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { CodeInput } from './CodeInput';
 

--- a/packages/react/src/CodeInput/CodeInput.test.tsx
+++ b/packages/react/src/CodeInput/CodeInput.test.tsx
@@ -1,7 +1,7 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { CodeInput } from './CodeInput';
 
 const medplum = new MockClient();
@@ -19,7 +19,7 @@ describe('CodeInput', () => {
     jest.useRealTimers();
   });
 
-  async function setup(child: React.ReactNode): Promise<void> {
+  async function setup(child: ReactNode): Promise<void> {
     await act(async () => {
       render(<MedplumProvider medplum={medplum}>{child}</MedplumProvider>);
     });

--- a/packages/react/src/CodeInput/CodeInput.tsx
+++ b/packages/react/src/CodeInput/CodeInput.tsx
@@ -1,5 +1,5 @@
 import { ValueSetExpansionContains } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodeInputProps {

--- a/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.stories.tsx
+++ b/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { CodeableConceptDisplay } from './CodeableConceptDisplay';
 import { Document } from '../Document/Document';
 

--- a/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.test.tsx
+++ b/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { CodeableConceptDisplay } from './CodeableConceptDisplay';
 
 describe('CodeableConceptDisplay', () => {

--- a/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.tsx
+++ b/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatCodeableConcept } from '@medplum/core';
 import { CodeableConcept } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface CodeableConceptDisplayProps {
   value?: CodeableConcept;

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.stories.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { CodeableConceptInput } from './CodeableConceptInput';
 

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
@@ -2,7 +2,7 @@ import { CodeableConcept } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { CodeableConceptInput } from './CodeableConceptInput';
 
 const medplum = new MockClient();
@@ -20,7 +20,7 @@ describe('CodeableConceptInput', () => {
     jest.useRealTimers();
   });
 
-  async function setup(child: React.ReactNode): Promise<void> {
+  async function setup(child: ReactNode): Promise<void> {
     await act(async () => {
       render(<MedplumProvider medplum={medplum}>{child}</MedplumProvider>);
     });

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
@@ -1,5 +1,5 @@
 import { CodeableConcept, ValueSetExpansionContains } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodeableConceptInputProps {

--- a/packages/react/src/CodingDisplay/CodingDisplay.stories.tsx
+++ b/packages/react/src/CodingDisplay/CodingDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Coding } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { CodingDisplay } from './CodingDisplay';
 

--- a/packages/react/src/CodingDisplay/CodingDisplay.test.tsx
+++ b/packages/react/src/CodingDisplay/CodingDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { CodingDisplay } from './CodingDisplay';
 
 describe('CodingDisplay', () => {

--- a/packages/react/src/CodingDisplay/CodingDisplay.tsx
+++ b/packages/react/src/CodingDisplay/CodingDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatCoding } from '@medplum/core';
 import { Coding } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface CodingDisplayProps {
   value?: Coding;

--- a/packages/react/src/CodingInput/CodingInput.stories.tsx
+++ b/packages/react/src/CodingInput/CodingInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { CodingInput } from './CodingInput';
 

--- a/packages/react/src/CodingInput/CodingInput.test.tsx
+++ b/packages/react/src/CodingInput/CodingInput.test.tsx
@@ -1,7 +1,7 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { CodingInput } from './CodingInput';
 
 const medplum = new MockClient();
@@ -19,7 +19,7 @@ describe('CodingInput', () => {
     jest.useRealTimers();
   });
 
-  async function setup(child: React.ReactNode): Promise<void> {
+  async function setup(child: ReactNode): Promise<void> {
     await act(async () => {
       render(<MedplumProvider medplum={medplum}>{child}</MedplumProvider>);
     });

--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -1,5 +1,5 @@
 import { Coding, ValueSetExpansionContains } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodingInputProps {

--- a/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.stories.tsx
+++ b/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { ContactDetail } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ContactDetailDisplay } from './ContactDetailDisplay';
 

--- a/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.test.tsx
+++ b/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { ContactDetailDisplay } from './ContactDetailDisplay';
 
 describe('ContactDetailDisplay', () => {

--- a/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.tsx
+++ b/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.tsx
@@ -1,5 +1,4 @@
 import { ContactDetail } from '@medplum/fhirtypes';
-import React from 'react';
 import { ContactPointDisplay } from '../ContactPointDisplay/ContactPointDisplay';
 
 export interface ContactDetailDisplayProps {

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.stories.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.stories.tsx
@@ -1,6 +1,5 @@
 import { ContactDetail } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ContactDetailInput } from './ContactDetailInput';
 

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.test.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.test.tsx
@@ -1,7 +1,6 @@
 import { stringify } from '@medplum/core';
 import { ContactDetail } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ContactDetailInput } from './ContactDetailInput';
 
 describe('ContactDetailInput', () => {

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.tsx
@@ -1,6 +1,6 @@
 import { Group, TextInput } from '@mantine/core';
 import { ContactDetail, ContactPoint } from '@medplum/fhirtypes';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { ContactPointInput } from '../ContactPointInput/ContactPointInput';
 
 export interface ContactDetailInputProps {

--- a/packages/react/src/ContactPointDisplay/ContactPointDisplay.stories.tsx
+++ b/packages/react/src/ContactPointDisplay/ContactPointDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { ContactPoint } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ContactPointDisplay } from './ContactPointDisplay';
 

--- a/packages/react/src/ContactPointDisplay/ContactPointDisplay.test.tsx
+++ b/packages/react/src/ContactPointDisplay/ContactPointDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { ContactPointDisplay } from './ContactPointDisplay';
 
 describe('ContactPointDisplay', () => {

--- a/packages/react/src/ContactPointDisplay/ContactPointDisplay.tsx
+++ b/packages/react/src/ContactPointDisplay/ContactPointDisplay.tsx
@@ -1,5 +1,4 @@
 import { ContactPoint } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface ContactPointDisplayProps {
   value?: ContactPoint;

--- a/packages/react/src/ContactPointInput/ContactPointInput.stories.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.stories.tsx
@@ -1,6 +1,5 @@
 import { ContactPoint } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ContactPointInput } from './ContactPointInput';
 

--- a/packages/react/src/ContactPointInput/ContactPointInput.test.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.test.tsx
@@ -1,7 +1,6 @@
 import { stringify } from '@medplum/core';
 import { ContactPoint } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ContactPointInput } from './ContactPointInput';
 
 describe('ContactPointInput', () => {

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -1,6 +1,6 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { ContactPoint } from '@medplum/fhirtypes';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 export interface ContactPointInputProps {
   name: string;

--- a/packages/react/src/Container/Container.tsx
+++ b/packages/react/src/Container/Container.tsx
@@ -1,5 +1,4 @@
 import { Container as MantineContainer, ContainerProps, createStyles } from '@mantine/core';
-import React from 'react';
 
 const useStyles = createStyles(() => ({
   root: {

--- a/packages/react/src/DateTimeInput/DateTimeInput.stories.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { DateTimeInput } from './DateTimeInput';
 

--- a/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
@@ -1,6 +1,5 @@
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { DateTimeInput } from './DateTimeInput';
 import { convertIsoToLocal, convertLocalToIso } from './DateTimeInput.utils';
 

--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@mantine/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React from 'react';
+import { ChangeEvent } from 'react';
 import { getErrorsForInput } from '../utils/outcomes';
 import { convertIsoToLocal, convertLocalToIso } from './DateTimeInput.utils';
 
@@ -35,7 +35,7 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
       defaultValue={convertIsoToLocal(props.defaultValue)}
       autoFocus={props.autoFocus}
       error={getErrorsForInput(props.outcome, props.name)}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange={(e: ChangeEvent<HTMLInputElement>) => {
         if (props.onChange) {
           const newValue = e.currentTarget.value;
           props.onChange(convertLocalToIso(newValue));

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.stories.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.stories.tsx
@@ -1,7 +1,7 @@
 import { DiagnosticReport } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';
 import { DefaultResourceTimeline } from './DefaultResourceTimeline';
 

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
@@ -3,7 +3,6 @@ import { DiagnosticReport, Patient } from '@medplum/fhirtypes';
 import { ExampleSubscription, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { DefaultResourceTimeline, DefaultResourceTimelineProps } from './DefaultResourceTimeline';
 

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.tsx
@@ -1,6 +1,5 @@
 import { MedplumClient } from '@medplum/core';
 import { Reference, Resource, ResourceType } from '@medplum/fhirtypes';
-import React from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface DefaultResourceTimelineProps {

--- a/packages/react/src/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Panel } from '../Panel/Panel';
 import { DescriptionList, DescriptionListEntry } from './DescriptionList';
 

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -1,5 +1,5 @@
 import { createStyles } from '@mantine/core';
-import React from 'react';
+import { ReactNode } from 'react';
 
 const useStyles = createStyles((theme) => ({
   root: {
@@ -25,7 +25,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 export interface DescriptionListProps {
-  children: React.ReactNode;
+  children: ReactNode;
   compact?: boolean;
 }
 
@@ -37,7 +37,7 @@ export function DescriptionList(props: DescriptionListProps): JSX.Element {
 
 export interface DescriptionListEntryProps {
   term: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function DescriptionListEntry(props: DescriptionListEntryProps): JSX.Element {

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.stories.tsx
@@ -3,7 +3,7 @@ import { Observation, Reference, Specimen } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport } from '@medplum/mock';
 import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';
 import {
   HealthGorillaDiagnosticReport,

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
@@ -3,7 +3,6 @@ import { DiagnosticReport } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import {
   HealthGorillaDiagnosticReport,

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -10,7 +10,7 @@ import {
   Specimen,
 } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CodeableConceptDisplay } from '../CodeableConceptDisplay/CodeableConceptDisplay';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { NoteDisplay } from '../NoteDisplay/NoteDisplay';

--- a/packages/react/src/Document/Document.stories.tsx
+++ b/packages/react/src/Document/Document.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 
 export default {

--- a/packages/react/src/Document/Document.tsx
+++ b/packages/react/src/Document/Document.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Container } from '../Container/Container';
 import { Panel, PanelProps } from '../Panel/Panel';
 

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.stories.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerEncounter } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { EncounterTimeline } from './EncounterTimeline';
 
 export default {

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.test.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { HomerEncounter, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { EncounterTimeline, EncounterTimelineProps } from './EncounterTimeline';
 

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
@@ -1,6 +1,5 @@
 import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Encounter, Reference, ResourceType } from '@medplum/fhirtypes';
-import React from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface EncounterTimelineProps {

--- a/packages/react/src/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ErrorBoundary } from './ErrorBoundary';
 

--- a/packages/react/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { ErrorBoundary } from './ErrorBoundary';
 
 function ErrorComponent(): JSX.Element {

--- a/packages/react/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Alert } from '@mantine/core';
 import { normalizeErrorString } from '@medplum/core';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React, { ErrorInfo, ReactNode } from 'react';
+import { Component, ErrorInfo, ReactNode } from 'react';
 
 export interface ErrorBoundaryProps {
   children: ReactNode;
@@ -15,7 +15,7 @@ export interface ErrorBoundaryState {
  * ErrorBoundary is a React component that handles errors in its child components.
  * See: https://reactjs.org/docs/error-boundaries.html
  */
-export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState;
 
   constructor(props: ErrorBoundaryProps) {

--- a/packages/react/src/ExtensionInput/ExtensionInput.stories.tsx
+++ b/packages/react/src/ExtensionInput/ExtensionInput.stories.tsx
@@ -1,6 +1,5 @@
 import { Extension } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ExtensionInput } from './ExtensionInput';
 

--- a/packages/react/src/ExtensionInput/ExtensionInput.test.tsx
+++ b/packages/react/src/ExtensionInput/ExtensionInput.test.tsx
@@ -1,6 +1,5 @@
 import { Identifier } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ExtensionInput } from './ExtensionInput';
 
 describe('ExtensionInput', () => {

--- a/packages/react/src/ExtensionInput/ExtensionInput.tsx
+++ b/packages/react/src/ExtensionInput/ExtensionInput.tsx
@@ -1,7 +1,6 @@
 import { JsonInput } from '@mantine/core';
 import { stringify } from '@medplum/core';
 import { Extension } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface ExtensionInputProps {
   name: string;

--- a/packages/react/src/FhirPathDisplay/FhirPathDisplay.stories.tsx
+++ b/packages/react/src/FhirPathDisplay/FhirPathDisplay.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FhirPathDisplay, FhirPathDisplayProps } from './FhirPathDisplay';
 import { PropertyType } from '@medplum/core';
 import { HomerServiceRequest, HomerSimpson } from '@medplum/mock';

--- a/packages/react/src/FhirPathDisplay/FhirPathDisplay.test.tsx
+++ b/packages/react/src/FhirPathDisplay/FhirPathDisplay.test.tsx
@@ -2,7 +2,6 @@ import { PropertyType } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { FhirPathDisplay } from './FhirPathDisplay';
 
 describe('FhirPathDisplay', () => {

--- a/packages/react/src/FhirPathDisplay/FhirPathDisplay.tsx
+++ b/packages/react/src/FhirPathDisplay/FhirPathDisplay.tsx
@@ -1,6 +1,5 @@
 import { evalFhirPath } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
-import React from 'react';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 
 export interface FhirPathDisplayProps {

--- a/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
@@ -2,7 +2,6 @@ import { PropertyType } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { FhirPathTable, FhirPathTableField, FhirPathTableProps } from './FhirPathTable';
 

--- a/packages/react/src/FhirPathTable/FhirPathTable.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.tsx
@@ -2,7 +2,7 @@ import { Button, Loader, Table } from '@mantine/core';
 import { normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, Resource } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import React, { useEffect, useRef, useState } from 'react';
+import { ChangeEvent, MouseEvent, memo, useEffect, useRef, useState } from 'react';
 import { FhirPathDisplay } from '../FhirPathDisplay/FhirPathDisplay';
 import { SearchClickEvent } from '../SearchControl/SearchControl';
 import { isCheckboxCell, killEvent } from '../utils/dom';
@@ -56,7 +56,7 @@ export function FhirPathTable(props: FhirPathTableProps): JSX.Element {
       .catch((err) => setOutcome(normalizeOperationOutcome(err)));
   }, [medplum, query]);
 
-  function handleSingleCheckboxClick(e: React.ChangeEvent, id: string): void {
+  function handleSingleCheckboxClick(e: ChangeEvent, id: string): void {
     e.stopPropagation();
 
     const el = e.target as HTMLInputElement;
@@ -70,7 +70,7 @@ export function FhirPathTable(props: FhirPathTableProps): JSX.Element {
     setSelected(newSelected);
   }
 
-  function handleAllCheckboxClick(e: React.ChangeEvent): void {
+  function handleAllCheckboxClick(e: ChangeEvent): void {
     e.stopPropagation();
 
     const el = e.target as HTMLInputElement;
@@ -100,7 +100,7 @@ export function FhirPathTable(props: FhirPathTableProps): JSX.Element {
     return true;
   }
 
-  function handleRowClick(e: React.MouseEvent, resource: Resource): void {
+  function handleRowClick(e: MouseEvent, resource: Resource): void {
     if (isCheckboxCell(e.target as Element)) {
       // Ignore clicks on checkboxes
       return;
@@ -201,4 +201,4 @@ export function FhirPathTable(props: FhirPathTableProps): JSX.Element {
   );
 }
 
-export const MemoizedFhirPathTable = React.memo(FhirPathTable);
+export const MemoizedFhirPathTable = memo(FhirPathTable);

--- a/packages/react/src/Form/Form.stories.tsx
+++ b/packages/react/src/Form/Form.stories.tsx
@@ -1,7 +1,6 @@
 import { Button, NativeSelect, Stack } from '@mantine/core';
 import { HumanName } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { HumanNameInput } from '../HumanNameInput/HumanNameInput';
 import { Form } from './Form';

--- a/packages/react/src/Form/Form.tsx
+++ b/packages/react/src/Form/Form.tsx
@@ -1,10 +1,10 @@
-import React, { CSSProperties } from 'react';
+import { CSSProperties, ReactNode, SyntheticEvent } from 'react';
 import { parseForm } from './FormUtils';
 
 export interface FormProps {
   onSubmit?: (formData: Record<string, string>) => void;
   style?: CSSProperties;
-  children?: React.ReactNode;
+  children?: ReactNode;
   testid?: string;
 }
 
@@ -13,7 +13,7 @@ export function Form(props: FormProps): JSX.Element {
     <form
       style={props.style}
       data-testid={props.testid}
-      onSubmit={(e: React.SyntheticEvent) => {
+      onSubmit={(e: SyntheticEvent) => {
         e.preventDefault();
         const formData = parseForm(e.target as HTMLFormElement);
         if (props.onSubmit) {

--- a/packages/react/src/FormSection/FormSection.stories.tsx
+++ b/packages/react/src/FormSection/FormSection.stories.tsx
@@ -1,7 +1,6 @@
 import { Button, MultiSelect, NativeSelect, Stack } from '@mantine/core';
 import { HumanName } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { Form } from '../Form/Form';
 import { HumanNameInput } from '../HumanNameInput/HumanNameInput';

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -1,6 +1,6 @@
 import { Input } from '@mantine/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React from 'react';
+import { ReactNode } from 'react';
 import { getErrorsForInput } from '../utils/outcomes';
 
 export interface FormSectionProps {
@@ -9,7 +9,7 @@ export interface FormSectionProps {
   description?: string;
   withAsterisk?: boolean;
   outcome?: OperationOutcome;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function FormSection(props: FormSectionProps): JSX.Element {

--- a/packages/react/src/GoogleButton/GoogleButton.stories.tsx
+++ b/packages/react/src/GoogleButton/GoogleButton.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { GoogleButton } from './GoogleButton';
 

--- a/packages/react/src/GoogleButton/GoogleButton.tsx
+++ b/packages/react/src/GoogleButton/GoogleButton.tsx
@@ -1,6 +1,6 @@
 import { GoogleCredentialResponse } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createScriptTag } from '../utils/script';
 
 interface GoogleApi {

--- a/packages/react/src/HumanNameDisplay/HumanNameDisplay.stories.tsx
+++ b/packages/react/src/HumanNameDisplay/HumanNameDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { HumanName } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { HumanNameDisplay } from './HumanNameDisplay';
 

--- a/packages/react/src/HumanNameDisplay/HumanNameDisplay.test.tsx
+++ b/packages/react/src/HumanNameDisplay/HumanNameDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { HumanNameDisplay } from './HumanNameDisplay';
 
 describe('HumanNameDisplay', () => {

--- a/packages/react/src/HumanNameDisplay/HumanNameDisplay.tsx
+++ b/packages/react/src/HumanNameDisplay/HumanNameDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatHumanName, HumanNameFormatOptions } from '@medplum/core';
 import { HumanName } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface HumanNameDisplayProps {
   value?: HumanName;

--- a/packages/react/src/HumanNameInput/HumanNameInput.stories.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.stories.tsx
@@ -1,6 +1,5 @@
 import { HumanName } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { HumanNameInput } from './HumanNameInput';
 

--- a/packages/react/src/HumanNameInput/HumanNameInput.test.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.test.tsx
@@ -1,6 +1,5 @@
 import { HumanName } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { HumanNameInput } from './HumanNameInput';
 
 describe('HumanNameInput', () => {

--- a/packages/react/src/HumanNameInput/HumanNameInput.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.tsx
@@ -1,6 +1,6 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { HumanName } from '@medplum/fhirtypes';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 export interface HumanNameInputProps {
   name: string;

--- a/packages/react/src/IdentifierDisplay/IdentifierDisplay.stories.tsx
+++ b/packages/react/src/IdentifierDisplay/IdentifierDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Identifier } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { IdentifierDisplay } from './IdentifierDisplay';
 

--- a/packages/react/src/IdentifierDisplay/IdentifierDisplay.tsx
+++ b/packages/react/src/IdentifierDisplay/IdentifierDisplay.tsx
@@ -1,5 +1,4 @@
 import { Identifier } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface IdentifierDisplayProps {
   value?: Identifier;

--- a/packages/react/src/IdentifierInput/IdentifierInput.stories.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.stories.tsx
@@ -1,6 +1,5 @@
 import { Identifier } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { IdentifierInput } from './IdentifierInput';
 

--- a/packages/react/src/IdentifierInput/IdentifierInput.test.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.test.tsx
@@ -1,6 +1,5 @@
 import { Identifier } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { IdentifierInput } from './IdentifierInput';
 
 describe('IdentifierInput', () => {

--- a/packages/react/src/IdentifierInput/IdentifierInput.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.tsx
@@ -1,6 +1,6 @@
 import { Group, TextInput } from '@mantine/core';
 import { Identifier } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 export interface IdentifierInputProps {
   name: string;

--- a/packages/react/src/Loading/Loading.tsx
+++ b/packages/react/src/Loading/Loading.tsx
@@ -1,5 +1,4 @@
 import { Center, Loader } from '@mantine/core';
-import React from 'react';
 
 export function Loading(): JSX.Element {
   return (

--- a/packages/react/src/Logo/Logo.stories.tsx
+++ b/packages/react/src/Logo/Logo.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Logo } from './Logo';
 
 export default {

--- a/packages/react/src/Logo/Logo.test.tsx
+++ b/packages/react/src/Logo/Logo.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { Logo } from './Logo';
 
 describe('Logo', () => {

--- a/packages/react/src/Logo/Logo.tsx
+++ b/packages/react/src/Logo/Logo.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export interface LogoProps {
   size: number;
   fill?: string;

--- a/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.stories.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.stories.tsx
@@ -1,9 +1,9 @@
+import { Measure } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';
 import { MeasureReportDisplay } from './MeasureReportDisplay';
-import { useMedplum } from '@medplum/react-hooks';
-import { Measure } from '@medplum/fhirtypes';
 
 export default {
   title: 'Medplum/MeasureReportDisplay',
@@ -21,8 +21,8 @@ function createMeasure(title: string, url: string, subtitle?: string): Measure {
 
 export const Basic = (): JSX.Element => {
   const medplum = useMedplum();
-  const [loaded, setLoaded] = React.useState(false);
-  const [measure, setMeasure] = React.useState<Measure | undefined>();
+  const [loaded, setLoaded] = useState(false);
+  const [measure, setMeasure] = useState<Measure | undefined>();
 
   useEffect(() => {
     (async (): Promise<boolean> => {
@@ -64,8 +64,8 @@ export const Basic = (): JSX.Element => {
 
 export const Multiple = (): JSX.Element => {
   const medplum = useMedplum();
-  const [loaded, setLoaded] = React.useState(false);
-  const [measure, setMeasure] = React.useState<Measure | undefined>();
+  const [loaded, setLoaded] = useState(false);
+  const [measure, setMeasure] = useState<Measure | undefined>();
 
   useEffect(() => {
     (async (): Promise<boolean> => {
@@ -118,8 +118,8 @@ export const Multiple = (): JSX.Element => {
 
 export const WithPopulation = (): JSX.Element => {
   const medplum = useMedplum();
-  const [loaded, setLoaded] = React.useState(false);
-  const [measure, setMeasure] = React.useState<Measure | undefined>();
+  const [loaded, setLoaded] = useState(false);
+  const [measure, setMeasure] = useState<Measure | undefined>();
 
   useEffect(() => {
     (async (): Promise<boolean> => {

--- a/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.test.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { MockClient } from '@medplum/mock';
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { MeasureReportDisplay, MeasureReportDisplayProps } from './MeasureReportDisplay';
 import { MemoryRouter } from 'react-router-dom';

--- a/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.tsx
@@ -1,7 +1,6 @@
 import { Box, SimpleGrid } from '@mantine/core';
 import { MeasureReport, MeasureReportGroup, Reference } from '@medplum/fhirtypes';
 import { useResource, useSearchOne } from '@medplum/react-hooks';
-import React from 'react';
 import { MeasureReportGroupDisplay, MeasureTitle } from './MeasureReportGroupDisplay/MeasureReportGroupDisplay';
 
 export interface MeasureReportDisplayProps {

--- a/packages/react/src/MeasureReportDisplay/MeasureReportGroupDisplay/MeasureReportGroupDisplay.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportGroupDisplay/MeasureReportGroupDisplay.tsx
@@ -1,7 +1,6 @@
 import { Box, Flex, Group, Paper, RingProgress, Text, Title } from '@mantine/core';
 import { formatCodeableConcept } from '@medplum/core';
 import { Measure, MeasureReportGroup } from '@medplum/fhirtypes';
-import React from 'react';
 import { QuantityDisplay } from '../../QuantityDisplay/QuantityDisplay';
 
 interface MeasureReportGroupDisplayProps {

--- a/packages/react/src/MedplumLink/MedplumLink.stories.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { MedplumLink } from './MedplumLink';
 

--- a/packages/react/src/MedplumLink/MedplumLink.test.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.test.tsx
@@ -1,7 +1,7 @@
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumLink } from './MedplumLink';
 
@@ -25,7 +25,7 @@ const medplum = new MedplumClient({
   fetch: mockFetch,
 });
 
-function setup(ui: React.ReactElement): void {
+function setup(ui: ReactElement): void {
   Object.defineProperty(window, 'location', {
     value: {
       assign: jest.fn(),

--- a/packages/react/src/MedplumLink/MedplumLink.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.tsx
@@ -2,15 +2,15 @@ import { Anchor, TextProps } from '@mantine/core';
 import { isReference, isResource } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplumNavigate } from '@medplum/react-hooks';
-import React from 'react';
+import { MouseEvent, MouseEventHandler, ReactNode } from 'react';
 import { killEvent } from '../utils/dom';
 
 export interface MedplumLinkProps extends TextProps {
   to?: Resource | Reference | string;
   suffix?: string;
   label?: string;
-  onClick?: React.MouseEventHandler;
-  children: React.ReactNode;
+  onClick?: MouseEventHandler;
+  children: ReactNode;
 }
 
 export function MedplumLink(props: MedplumLinkProps): JSX.Element {
@@ -26,7 +26,7 @@ export function MedplumLink(props: MedplumLinkProps): JSX.Element {
     <Anchor
       href={href}
       aria-label={label}
-      onClick={(e: React.MouseEvent) => {
+      onClick={(e: MouseEvent) => {
         killEvent(e);
         if (onClick) {
           onClick(e);

--- a/packages/react/src/MoneyDisplay/MoneyDisplay.stories.tsx
+++ b/packages/react/src/MoneyDisplay/MoneyDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Money } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { MoneyDisplay } from './MoneyDisplay';
 

--- a/packages/react/src/MoneyDisplay/MoneyDisplay.test.tsx
+++ b/packages/react/src/MoneyDisplay/MoneyDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MoneyDisplay } from './MoneyDisplay';
 
 describe('MoneyDisplay', () => {

--- a/packages/react/src/MoneyDisplay/MoneyDisplay.tsx
+++ b/packages/react/src/MoneyDisplay/MoneyDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatMoney } from '@medplum/core';
 import { Money } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface MoneyDisplayProps {
   value?: Money;

--- a/packages/react/src/MoneyInput/MoneyInput.stories.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { MoneyInput } from './MoneyInput';
 

--- a/packages/react/src/MoneyInput/MoneyInput.test.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.test.tsx
@@ -1,6 +1,5 @@
 import { Money } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MoneyInput } from './MoneyInput';
 
 describe('MoneyInput', () => {

--- a/packages/react/src/MoneyInput/MoneyInput.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.tsx
@@ -1,7 +1,7 @@
 import { NativeSelect, TextInput } from '@mantine/core';
 import { Money } from '@medplum/fhirtypes';
 import { IconCurrencyDollar } from '@tabler/icons-react';
-import React, { useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 
 /*
  * Based on: https://github.com/mantinedev/ui.mantine.dev/blob/master/components/CurrencyInput/CurrencyInput.tsx
@@ -43,7 +43,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
   );
 
   const handleCurrencyChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
+    (e: ChangeEvent<HTMLSelectElement>) => {
       setValueWrapper({
         ...value,
         currency: e.currentTarget.value,
@@ -53,7 +53,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
   );
 
   const handleValueChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: ChangeEvent<HTMLInputElement>) => {
       setValueWrapper({
         ...value,
         value: e.currentTarget.valueAsNumber,

--- a/packages/react/src/NoteDisplay/NoteDisplay.stories.tsx
+++ b/packages/react/src/NoteDisplay/NoteDisplay.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { CreatinineObservation } from '../stories/referenceLab';
 import { NoteDisplay } from './NoteDisplay';

--- a/packages/react/src/NoteDisplay/NoteDisplay.test.tsx
+++ b/packages/react/src/NoteDisplay/NoteDisplay.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { NoteDisplay, NoteDisplayProps } from './NoteDisplay';
 

--- a/packages/react/src/NoteDisplay/NoteDisplay.tsx
+++ b/packages/react/src/NoteDisplay/NoteDisplay.tsx
@@ -1,6 +1,5 @@
 import { Blockquote, createStyles, Stack } from '@mantine/core';
 import { Annotation } from '@medplum/fhirtypes';
-import React from 'react';
 
 const useStyles = createStyles((theme) => ({
   noteBody: { fontSize: theme.fontSizes.sm },

--- a/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.stories.tsx
+++ b/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { OperationOutcomeAlert } from './OperationOutcomeAlert';
 

--- a/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
+++ b/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
@@ -2,7 +2,6 @@ import { Alert } from '@mantine/core';
 import { operationOutcomeIssueToString } from '@medplum/core';
 import { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React from 'react';
 
 export interface OperationOutcomeAlertProps {
   outcome?: OperationOutcome;

--- a/packages/react/src/Panel/Panel.stories.tsx
+++ b/packages/react/src/Panel/Panel.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { Panel } from './Panel';
 

--- a/packages/react/src/Panel/Panel.tsx
+++ b/packages/react/src/Panel/Panel.tsx
@@ -1,5 +1,4 @@
 import { createStyles, Paper, PaperProps, useComponentDefaultProps } from '@mantine/core';
-import React from 'react';
 
 export interface PanelStylesParams {
   width?: number;

--- a/packages/react/src/PatientTimeline/PatientTimeline.stories.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { PatientTimeline } from './PatientTimeline';
 
 export default {

--- a/packages/react/src/PatientTimeline/PatientTimeline.test.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { PatientTimeline, PatientTimelineProps } from './PatientTimeline';
 

--- a/packages/react/src/PatientTimeline/PatientTimeline.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.tsx
@@ -1,6 +1,6 @@
 import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Patient, Reference, ResourceType } from '@medplum/fhirtypes';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface PatientTimelineProps {

--- a/packages/react/src/PeriodInput/PeriodInput.stories.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { PeriodInput } from './PeriodInput';
 

--- a/packages/react/src/PeriodInput/PeriodInput.test.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.test.tsx
@@ -1,6 +1,5 @@
 import { Period } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { PeriodInput } from './PeriodInput';
 
 const startDateTime = '2021-01-01T00:00:00.000Z';

--- a/packages/react/src/PeriodInput/PeriodInput.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@mantine/core';
 import { Period } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 
 export interface PeriodInputProps {

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.stories.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.stories.tsx
@@ -1,6 +1,6 @@
 import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';
 import {
   Covid19AssessmentQuestionnaire,

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
@@ -1,7 +1,6 @@
 import { ExampleWorkflowPlanDefinition, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { PlanDefinitionBuilder, PlanDefinitionBuilderProps } from './PlanDefinitionBuilder';
 

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
@@ -2,7 +2,7 @@ import { Anchor, Button, createStyles, NativeSelect, Stack, TextInput } from '@m
 import { getReferenceString, InternalSchemaElement } from '@medplum/core';
 import { PlanDefinition, PlanDefinitionAction, Reference, ResourceType } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import React, { useEffect, useRef, useState } from 'react';
+import { MouseEvent, SyntheticEvent, useEffect, useRef, useState } from 'react';
 import { Form } from '../Form/Form';
 import { FormSection } from '../FormSection/FormSection';
 import { ReferenceDisplay } from '../ReferenceDisplay/ReferenceDisplay';
@@ -165,7 +165,7 @@ function ActionArrayBuilder(props: ActionArrayBuilderProps): JSX.Element {
       <div className={classes.bottomActions}>
         <Anchor
           href="#"
-          onClick={(e: React.MouseEvent) => {
+          onClick={(e: MouseEvent) => {
             killEvent(e);
             addAction({ id: generateId() });
           }}
@@ -194,12 +194,12 @@ function ActionBuilder(props: ActionBuilderProps): JSX.Element {
   const editing = props.selectedKey === props.action.id;
   const hovering = props.hoverKey === props.action.id;
 
-  function onClick(e: React.SyntheticEvent): void {
+  function onClick(e: SyntheticEvent): void {
     e.stopPropagation();
     props.setSelectedKey(props.action.id);
   }
 
-  function onHover(e: React.SyntheticEvent): void {
+  function onHover(e: SyntheticEvent): void {
     killEvent(e);
     props.setHoverKey(props.action.id);
   }
@@ -228,7 +228,7 @@ function ActionBuilder(props: ActionBuilderProps): JSX.Element {
       <div className={classes.bottomActions}>
         <Anchor
           href="#"
-          onClick={(e: React.MouseEvent) => {
+          onClick={(e: MouseEvent) => {
             e.preventDefault();
             props.onRemove();
           }}

--- a/packages/react/src/QuantityDisplay/QuantityDisplay.stories.tsx
+++ b/packages/react/src/QuantityDisplay/QuantityDisplay.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { QuantityDisplay } from './QuantityDisplay';
 

--- a/packages/react/src/QuantityDisplay/QuantityDisplay.test.tsx
+++ b/packages/react/src/QuantityDisplay/QuantityDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { QuantityDisplay } from './QuantityDisplay';
 
 describe('QuantityDisplay', () => {

--- a/packages/react/src/QuantityDisplay/QuantityDisplay.tsx
+++ b/packages/react/src/QuantityDisplay/QuantityDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatQuantity } from '@medplum/core';
 import { Quantity } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface QuantityDisplayProps {
   value?: Quantity;

--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { QuantityInput } from './QuantityInput';
 

--- a/packages/react/src/QuantityInput/QuantityInput.test.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.test.tsx
@@ -1,6 +1,5 @@
 import { Quantity } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { QuantityInput } from './QuantityInput';
 
 describe('QuantityInput', () => {

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -1,6 +1,6 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Quantity } from '@medplum/fhirtypes';
-import React, { useState, WheelEvent } from 'react';
+import { useState, WheelEvent } from 'react';
 
 export interface QuantityInputProps {
   name: string;

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.stories.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { QuestionnaireBuilder } from './QuestionnaireBuilder';
 

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { QuestionnaireItemType } from '../utils/questionnaire';
 import { QuestionnaireBuilder, QuestionnaireBuilderProps } from './QuestionnaireBuilder';
 

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -21,7 +21,7 @@ import {
 } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { IconArrowDown, IconArrowUp } from '@tabler/icons-react';
-import React, { useEffect, useRef, useState } from 'react';
+import { MouseEvent, SyntheticEvent, useEffect, useRef, useState } from 'react';
 import { Form } from '../Form/Form';
 import { QuestionnaireFormItem } from '../QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
@@ -196,12 +196,12 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
   const itemRef = useRef<T>();
   itemRef.current = props.item;
 
-  function onClick(e: React.SyntheticEvent): void {
+  function onClick(e: SyntheticEvent): void {
     killEvent(e);
     props.setSelectedKey(props.item.id);
   }
 
-  function onHover(e: React.SyntheticEvent): void {
+  function onHover(e: SyntheticEvent): void {
     killEvent(e);
     props.setHoverKey(props.item.id);
   }
@@ -359,7 +359,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
             {!props.isFirst && (
               <Anchor
                 href="#"
-                onClick={(e: React.MouseEvent) => {
+                onClick={(e: MouseEvent) => {
                   e.preventDefault();
                   if (props.onMoveUp) {
                     props.onMoveUp();
@@ -372,7 +372,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
             {!props.isLast && (
               <Anchor
                 href="#"
-                onClick={(e: React.MouseEvent) => {
+                onClick={(e: MouseEvent) => {
                   e.preventDefault();
                   if (props.onMoveDown) {
                     props.onMoveDown();
@@ -390,7 +390,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
           <>
             <Anchor
               href="#"
-              onClick={(e: React.MouseEvent) => {
+              onClick={(e: MouseEvent) => {
                 e.preventDefault();
                 addItem({
                   id: generateId(),
@@ -404,7 +404,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
             </Anchor>
             <Anchor
               href="#"
-              onClick={(e: React.MouseEvent) => {
+              onClick={(e: MouseEvent) => {
                 e.preventDefault();
                 addItem({
                   id: generateId(),
@@ -421,7 +421,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
         {isResource && (
           <Anchor
             href="#"
-            onClick={(e: React.MouseEvent) => {
+            onClick={(e: MouseEvent) => {
               e.preventDefault();
               addItem(createPage());
             }}
@@ -433,7 +433,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
           <>
             <Anchor
               href="#"
-              onClick={(e: React.MouseEvent) => {
+              onClick={(e: MouseEvent) => {
                 e.preventDefault();
                 if (props.onRepeatable) {
                   props.onRepeatable(item);
@@ -444,7 +444,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
             </Anchor>
             <Anchor
               href="#"
-              onClick={(e: React.MouseEvent) => {
+              onClick={(e: MouseEvent) => {
                 e.preventDefault();
                 if (props.onRemove) {
                   props.onRemove();
@@ -482,7 +482,7 @@ function AnswerBuilder(props: AnswerBuilderProps): JSX.Element {
       <Box display="flex">
         <Anchor
           href="#"
-          onClick={(e: React.SyntheticEvent) => {
+          onClick={(e: SyntheticEvent) => {
             killEvent(e);
             props.onChange({
               ...props.item,
@@ -501,7 +501,7 @@ function AnswerBuilder(props: AnswerBuilderProps): JSX.Element {
         <Space w="lg" />
         <Anchor
           href="#"
-          onClick={(e: React.SyntheticEvent) => {
+          onClick={(e: SyntheticEvent) => {
             killEvent(e);
             props.onChange({
               ...props.item,
@@ -565,7 +565,7 @@ function AnswerOptionsInput(props: AnswerOptionsInputProps): JSX.Element {
             <div>
               <Anchor
                 href="#"
-                onClick={(e: React.SyntheticEvent) => {
+                onClick={(e: SyntheticEvent) => {
                   killEvent(e);
                   props.onChange({
                     ...props.item,
@@ -610,7 +610,7 @@ function ReferenceProfiles(props: ReferenceTypeProps): JSX.Element {
             />
             <Anchor
               href="#"
-              onClick={(e: React.SyntheticEvent) => {
+              onClick={(e: SyntheticEvent) => {
                 killEvent(e);
                 props.onChange(
                   setQuestionnaireItemReferenceTargetTypes(
@@ -627,7 +627,7 @@ function ReferenceProfiles(props: ReferenceTypeProps): JSX.Element {
       })}
       <Anchor
         href="#"
-        onClick={(e: React.SyntheticEvent) => {
+        onClick={(e: SyntheticEvent) => {
           killEvent(e);
           props.onChange(setQuestionnaireItemReferenceTargetTypes(props.item, [...targetTypes, '' as ResourceType]));
         }}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { QuestionnaireForm } from './QuestionnaireForm';
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -5,7 +5,6 @@ import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { randomUUID } from 'crypto';
 import each from 'jest-each';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { QuestionnaireItemType } from '../utils/questionnaire';
 import { QuestionnaireForm, QuestionnaireFormProps } from './QuestionnaireForm';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -8,7 +8,7 @@ import {
   Reference,
 } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Form } from '../Form/Form';
 import { buildInitialResponse, getNumberOfPages, isQuestionEnabled } from '../utils/questionnaire';
 import { QuestionnairePageSequence } from './QuestionnaireFormComponents/QuestionnaireFormPageSequence';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormComponents/QuestionnaireFormGroup.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormComponents/QuestionnaireFormGroup.tsx
@@ -1,6 +1,6 @@
 import { Anchor, Stack, Title } from '@mantine/core';
 import { QuestionnaireItem, QuestionnaireResponseItem } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { QuestionnaireItemType, buildInitialResponseItem } from '../../utils/questionnaire';
 import { QuestionnaireRepeatableItem } from '../QuestionnaireFormItem/QuestionnaireRepeatableItem';
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormComponents/QuestionnaireFormPageSequence.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormComponents/QuestionnaireFormPageSequence.tsx
@@ -1,6 +1,5 @@
 import { Button, Group, Stack, Stepper } from '@mantine/core';
 import { QuestionnaireItem, QuestionnaireResponse, QuestionnaireResponseItem } from '@medplum/fhirtypes';
-import React from 'react';
 import { QuestionnaireItemType } from '../../utils/questionnaire';
 import { QuestionnaireRepeatableItem } from '../QuestionnaireFormItem/QuestionnaireRepeatableItem';
 import { QuestionnaireRepeatedGroup } from './QuestionnaireFormGroup';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -16,7 +16,7 @@ import {
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
 } from '@medplum/fhirtypes';
-import React, { ChangeEvent } from 'react';
+import { ChangeEvent } from 'react';
 import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
 import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
 import { CodingInput } from '../../CodingInput/CodingInput';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireRepeatableItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireRepeatableItem.tsx
@@ -1,6 +1,6 @@
 import { Anchor } from '@mantine/core';
 import { QuestionnaireItem, QuestionnaireResponseItem } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FormSection } from '../../FormSection/FormSection';
 import { QuestionnaireItemType } from '../../utils/questionnaire';
 import { QuestionnaireFormItem } from './QuestionnaireFormItem';

--- a/packages/react/src/RangeDisplay/RangeDisplay.stories.tsx
+++ b/packages/react/src/RangeDisplay/RangeDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Range } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { RangeDisplay } from './RangeDisplay';
 

--- a/packages/react/src/RangeDisplay/RangeDisplay.test.tsx
+++ b/packages/react/src/RangeDisplay/RangeDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { RangeDisplay } from './RangeDisplay';
 
 describe('RangeDisplay', () => {

--- a/packages/react/src/RangeDisplay/RangeDisplay.tsx
+++ b/packages/react/src/RangeDisplay/RangeDisplay.tsx
@@ -1,6 +1,5 @@
 import { formatRange } from '@medplum/core';
 import { Range } from '@medplum/fhirtypes';
-import React from 'react';
 
 export interface RangeDisplayProps {
   value?: Range;

--- a/packages/react/src/RangeInput/RangeInput.stories.tsx
+++ b/packages/react/src/RangeInput/RangeInput.stories.tsx
@@ -1,6 +1,5 @@
 import { Range } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { RangeInput } from './RangeInput';
 

--- a/packages/react/src/RangeInput/RangeInput.test.tsx
+++ b/packages/react/src/RangeInput/RangeInput.test.tsx
@@ -1,6 +1,5 @@
 import { Range } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { RangeInput } from './RangeInput';
 
 describe('RangeInput', () => {

--- a/packages/react/src/RangeInput/RangeInput.tsx
+++ b/packages/react/src/RangeInput/RangeInput.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@mantine/core';
 import { Range } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
 
 export interface RangeInputProps {

--- a/packages/react/src/RatioDisplay/RatioDisplay.stories.tsx
+++ b/packages/react/src/RatioDisplay/RatioDisplay.stories.tsx
@@ -1,6 +1,5 @@
 import { Ratio } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { RatioDisplay } from './RatioDisplay';
 

--- a/packages/react/src/RatioDisplay/RatioDisplay.test.tsx
+++ b/packages/react/src/RatioDisplay/RatioDisplay.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { RatioDisplay } from './RatioDisplay';
 
 describe('RatioDisplay', () => {

--- a/packages/react/src/RatioDisplay/RatioDisplay.tsx
+++ b/packages/react/src/RatioDisplay/RatioDisplay.tsx
@@ -1,5 +1,4 @@
 import { Ratio } from '@medplum/fhirtypes';
-import React from 'react';
 import { QuantityDisplay } from '../QuantityDisplay/QuantityDisplay';
 
 export interface RatioDisplayProps {

--- a/packages/react/src/RatioInput/RatioInput.stories.tsx
+++ b/packages/react/src/RatioInput/RatioInput.stories.tsx
@@ -1,6 +1,5 @@
 import { Ratio } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { RatioInput } from './RatioInput';
 

--- a/packages/react/src/RatioInput/RatioInput.test.tsx
+++ b/packages/react/src/RatioInput/RatioInput.test.tsx
@@ -1,6 +1,5 @@
 import { Ratio } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { RatioInput } from './RatioInput';
 
 describe('RatioInput', () => {

--- a/packages/react/src/RatioInput/RatioInput.tsx
+++ b/packages/react/src/RatioInput/RatioInput.tsx
@@ -1,6 +1,6 @@
 import { Group } from '@mantine/core';
 import { Ratio } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
 
 export interface RatioInputProps {

--- a/packages/react/src/ReferenceDisplay/ReferenceDisplay.stories.tsx
+++ b/packages/react/src/ReferenceDisplay/ReferenceDisplay.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ReferenceDisplay } from './ReferenceDisplay';
 

--- a/packages/react/src/ReferenceDisplay/ReferenceDisplay.test.tsx
+++ b/packages/react/src/ReferenceDisplay/ReferenceDisplay.test.tsx
@@ -2,13 +2,13 @@ import { Reference } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ReferenceDisplay } from './ReferenceDisplay';
 
 const medplum = new MockClient();
 
-function setup(ui: React.ReactElement): void {
+function setup(ui: ReactElement): void {
   render(
     <MemoryRouter>
       <MedplumProvider medplum={medplum}>{ui}</MedplumProvider>

--- a/packages/react/src/ReferenceDisplay/ReferenceDisplay.tsx
+++ b/packages/react/src/ReferenceDisplay/ReferenceDisplay.tsx
@@ -1,6 +1,5 @@
 import { stringify } from '@medplum/core';
 import { Reference } from '@medplum/fhirtypes';
-import React from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface ReferenceDisplayProps {

--- a/packages/react/src/ReferenceInput/ReferenceInput.stories.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ReferenceInput } from './ReferenceInput';
 

--- a/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ReferenceInput, ReferenceInputProps } from './ReferenceInput';
 
 const medplum = new MockClient();

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -1,7 +1,7 @@
 import { Group, NativeSelect } from '@mantine/core';
 import { createReference } from '@medplum/core';
 import { Reference, Resource, ResourceType } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ResourceInput } from '../ResourceInput/ResourceInput';
 import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
 

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.stories.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { ReferenceRangeEditor } from './ReferenceRangeEditor';

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.test.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.test.tsx
@@ -3,7 +3,7 @@ import { ObservationDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { StrictMode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { HDLDefinition, TestosteroneDefinition } from '../stories/referenceLab';
 import { ReferenceRangeEditor, ReferenceRangeEditorProps } from './ReferenceRangeEditor';
@@ -13,13 +13,13 @@ const medplum = new MockClient();
 async function setup(args: ReferenceRangeEditorProps): Promise<void> {
   await act(async () => {
     render(
-      <React.StrictMode>
+      <StrictMode>
         <MemoryRouter>
           <MedplumProvider medplum={medplum}>
             <ReferenceRangeEditor {...args} />
           </MedplumProvider>
         </MemoryRouter>
-      </React.StrictMode>
+      </StrictMode>
     );
   });
 }

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
@@ -2,7 +2,7 @@ import { ActionIcon, Button, createStyles, Divider, Group, NativeSelect, Stack, 
 import { formatRange, getCodeBySystem } from '@medplum/core';
 import { CodeableConcept, ObservationDefinition, ObservationDefinitionQualifiedInterval } from '@medplum/fhirtypes';
 import { IconCircleMinus, IconCirclePlus } from '@tabler/icons-react';
-import React, { useEffect, useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 import { Container } from '../Container/Container';
 import { Form } from '../Form/Form';
 import { RangeInput } from '../RangeInput/RangeInput';
@@ -72,7 +72,7 @@ export function ReferenceRangeEditor(props: ReferenceRangeEditorProps): JSX.Elem
       <ActionIcon
         title="Add Group"
         size="sm"
-        onClick={(e: React.MouseEvent) => {
+        onClick={(e: MouseEvent) => {
           killEvent(e);
           addGroup({ id: `group-id-${groupId}`, filters: {} as IntervalGroup['filters'], intervals: [] });
           setGroupId((id) => id + 1);

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.stories.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.stories.tsx
@@ -1,7 +1,7 @@
 import { ExampleWorkflowRequestGroup } from '@medplum/mock';
 import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Document } from '../Document/Document';
 import {
   Covid19AssessmentTask,

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.test.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.test.tsx
@@ -1,13 +1,13 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { RequestGroupDisplay } from './RequestGroupDisplay';
 
 const medplum = new MockClient();
 
-async function setup(ui: React.ReactElement): Promise<void> {
+async function setup(ui: ReactElement): Promise<void> {
   await act(async () => {
     render(
       <MemoryRouter>

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.tsx
@@ -3,7 +3,7 @@ import { formatDateTime, getReferenceString } from '@medplum/core';
 import { Bundle, BundleEntry, Reference, RequestGroup, Resource, Task } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { IconCheckbox, IconSquare } from '@tabler/icons-react';
-import React, { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { ResourceName } from '../ResourceName/ResourceName';
 import { StatusBadge } from '../StatusBadge/StatusBadge';
 
@@ -37,7 +37,7 @@ export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Elemen
         const taskInput = task?.input?.[0]?.valueReference;
         const taskOutput = task?.output?.[0]?.valueReference;
         return (
-          <React.Fragment key={`action-${index}`}>
+          <Fragment key={`action-${index}`}>
             <Grid.Col span={1} p="md">
               {task?.status === 'completed' ? <IconCheckbox /> : <IconSquare color="gray" />}
             </Grid.Col>
@@ -60,7 +60,7 @@ export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Elemen
                 <Button onClick={() => props.onEdit(task, taskInput, taskOutput)}>Edit</Button>
               )}
             </Grid.Col>
-          </React.Fragment>
+          </Fragment>
         );
       })}
     </Grid>

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,5 +1,4 @@
 import { InternalSchemaElement } from '@medplum/core';
-import React from 'react';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 
 export interface ResourceArrayDisplayProps {

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.test.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.test.tsx
@@ -1,6 +1,5 @@
 import { InternalSchemaElement } from '@medplum/core';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ResourceArrayInput } from './ResourceArrayInput';
 
 const property: InternalSchemaElement = {

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -1,7 +1,7 @@
 import { ActionIcon, Group, Stack } from '@mantine/core';
 import { InternalSchemaElement } from '@medplum/core';
 import { IconCircleMinus, IconCirclePlus } from '@tabler/icons-react';
-import React, { useRef, useState } from 'react';
+import { MouseEvent, useRef, useState } from 'react';
 import { ResourcePropertyInput } from '../ResourcePropertyInput/ResourcePropertyInput';
 import { killEvent } from '../utils/dom';
 
@@ -49,7 +49,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
             <ActionIcon
               title="Remove"
               size="sm"
-              onClick={(e: React.MouseEvent) => {
+              onClick={(e: MouseEvent) => {
                 killEvent(e);
                 const copy = [...(valuesRef.current as any[])];
                 copy.splice(index, 1);
@@ -67,7 +67,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
             title="Add"
             size="sm"
             color="green"
-            onClick={(e: React.MouseEvent) => {
+            onClick={(e: MouseEvent) => {
               killEvent(e);
               const copy = [...(valuesRef.current as any[])];
               copy.push(undefined);

--- a/packages/react/src/ResourceAvatar/ResourceAvatar.stories.tsx
+++ b/packages/react/src/ResourceAvatar/ResourceAvatar.stories.tsx
@@ -1,7 +1,6 @@
 import { Anchor } from '@mantine/core';
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceAvatar } from './ResourceAvatar';
 

--- a/packages/react/src/ResourceAvatar/ResourceAvatar.test.tsx
+++ b/packages/react/src/ResourceAvatar/ResourceAvatar.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceAvatar, ResourceAvatarProps } from './ResourceAvatar';
 

--- a/packages/react/src/ResourceAvatar/ResourceAvatar.tsx
+++ b/packages/react/src/ResourceAvatar/ResourceAvatar.tsx
@@ -2,7 +2,6 @@ import { Avatar, AvatarProps } from '@mantine/core';
 import { getDisplayString, getImageSrc } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { useResource } from '@medplum/react-hooks';
-import React from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface ResourceAvatarProps extends AvatarProps {

--- a/packages/react/src/ResourceBadge/ResourceBadge.stories.tsx
+++ b/packages/react/src/ResourceBadge/ResourceBadge.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceBadge } from './ResourceBadge';
 

--- a/packages/react/src/ResourceBadge/ResourceBadge.test.tsx
+++ b/packages/react/src/ResourceBadge/ResourceBadge.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceBadge, ResourceBadgeProps } from './ResourceBadge';
 

--- a/packages/react/src/ResourceBadge/ResourceBadge.tsx
+++ b/packages/react/src/ResourceBadge/ResourceBadge.tsx
@@ -1,6 +1,5 @@
 import { Group } from '@mantine/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
-import React from 'react';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceName } from '../ResourceName/ResourceName';
 

--- a/packages/react/src/ResourceBlame/ResourceBlame.stories.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceBlame } from './ResourceBlame';
 

--- a/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceBlame, ResourceBlameProps } from './ResourceBlame';
 import { getTimeString } from './ResourceBlame.utils';

--- a/packages/react/src/ResourceBlame/ResourceBlame.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.tsx
@@ -1,7 +1,7 @@
 import { createStyles } from '@mantine/core';
 import { Bundle, Resource, ResourceType } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceBadge } from '../ResourceBadge/ResourceBadge';
 import { blame } from '../utils/blame';

--- a/packages/react/src/ResourceDiff/ResourceDiff.stories.tsx
+++ b/packages/react/src/ResourceDiff/ResourceDiff.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceDiff } from './ResourceDiff';
 

--- a/packages/react/src/ResourceDiff/ResourceDiff.test.tsx
+++ b/packages/react/src/ResourceDiff/ResourceDiff.test.tsx
@@ -1,6 +1,5 @@
 import { Patient } from '@medplum/fhirtypes';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { ResourceDiff } from './ResourceDiff';
 
 describe('ResourceDiff', () => {

--- a/packages/react/src/ResourceDiff/ResourceDiff.tsx
+++ b/packages/react/src/ResourceDiff/ResourceDiff.tsx
@@ -1,7 +1,6 @@
 import { createStyles } from '@mantine/core';
 import { stringify } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
-import React from 'react';
 import { Delta, diff } from '../utils/diff';
 
 const useStyles = createStyles((theme) => ({

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.stories.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.stories.tsx
@@ -1,7 +1,6 @@
 import { Patient } from '@medplum/fhirtypes';
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceDiffTable } from './ResourceDiffTable';
 

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -1,7 +1,6 @@
 import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ResourceDiffTable, ResourceDiffTableProps } from './ResourceDiffTable';
 

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -1,7 +1,7 @@
 import { createStyles } from '@mantine/core';
 import { getDataType, getPropertyDisplayName, stringify, toTypedValue } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMedplum } from '@medplum/react-hooks';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';

--- a/packages/react/src/ResourceForm/ResourceForm.stories.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.stories.tsx
@@ -1,6 +1,5 @@
 import { DrAliceSmith, HomerSimpson, TestOrganization } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceForm } from './ResourceForm';
 

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { Patient, Specimen } from '@medplum/fhirtypes';
 import { HomerObservation1, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { convertIsoToLocal, convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ResourceForm, ResourceFormProps } from './ResourceForm';

--- a/packages/react/src/ResourceForm/ResourceForm.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.tsx
@@ -2,7 +2,7 @@ import { Button, Group, Stack, TextInput } from '@mantine/core';
 import { deepClone } from '@medplum/core';
 import { OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import React, { useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { BackboneElementInput } from '../BackboneElementInput/BackboneElementInput';
 import { FormSection } from '../FormSection/FormSection';
 
@@ -37,7 +37,7 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
     <form
       noValidate
       autoComplete="off"
-      onSubmit={(e: React.FormEvent) => {
+      onSubmit={(e: FormEvent) => {
         e.preventDefault();
         if (props.onSubmit) {
           props.onSubmit(value);

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.stories.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceHistoryTable } from './ResourceHistoryTable';
 

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
@@ -1,7 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceHistoryTable, ResourceHistoryTableProps } from './ResourceHistoryTable';
 

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.tsx
@@ -2,7 +2,7 @@ import { Table } from '@mantine/core';
 import { formatDateTime, normalizeErrorString } from '@medplum/core';
 import { Bundle, BundleEntry, Resource, ResourceType } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceBadge } from '../ResourceBadge/ResourceBadge';
 

--- a/packages/react/src/ResourceInput/ResourceInput.stories.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.stories.tsx
@@ -1,7 +1,6 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceInput } from './ResourceInput';
 

--- a/packages/react/src/ResourceInput/ResourceInput.test.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.test.tsx
@@ -1,6 +1,5 @@
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ResourceInput, ResourceInputProps } from './ResourceInput';
 

--- a/packages/react/src/ResourceInput/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.tsx
@@ -2,7 +2,7 @@ import { Group, Text } from '@mantine/core';
 import { getDisplayString, getReferenceString } from '@medplum/core';
 import { OperationOutcome, Patient, Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import React, { forwardRef, useCallback, useState } from 'react';
+import { forwardRef, useCallback, useState } from 'react';
 import { AsyncAutocomplete, AsyncAutocompleteOption } from '../AsyncAutocomplete/AsyncAutocomplete';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 

--- a/packages/react/src/ResourceName/ResourceName.stories.tsx
+++ b/packages/react/src/ResourceName/ResourceName.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceName } from './ResourceName';
 

--- a/packages/react/src/ResourceName/ResourceName.test.tsx
+++ b/packages/react/src/ResourceName/ResourceName.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ResourceName, ResourceNameProps } from './ResourceName';
 

--- a/packages/react/src/ResourceName/ResourceName.tsx
+++ b/packages/react/src/ResourceName/ResourceName.tsx
@@ -2,7 +2,7 @@ import { Text, TextProps } from '@mantine/core';
 import { getDisplayString, isOk, normalizeErrorString } from '@medplum/core';
 import { OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
 import { useResource } from '@medplum/react-hooks';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface ResourceNameProps extends TextProps {

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.stories.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.stories.tsx
@@ -2,7 +2,6 @@ import { PropertyType } from '@medplum/core';
 import { Attachment } from '@medplum/fhirtypes';
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -16,10 +16,10 @@ import {
   SubscriptionChannel,
 } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { render, screen } from '@testing-library/react';
-import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 const medplum = new MockClient();
@@ -33,7 +33,7 @@ const baseProperty: Omit<InternalSchemaElement, 'type'> = {
   path: '',
 };
 describe('ResourcePropertyDisplay', () => {
-  function setup(children: React.ReactNode): void {
+  function setup(children: ReactNode): void {
     render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
   }
 

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -8,7 +8,6 @@ import {
   PropertyType,
 } from '@medplum/core';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
-import React from 'react';
 import { AddressDisplay } from '../AddressDisplay/AddressDisplay';
 import { AttachmentArrayDisplay } from '../AttachmentArrayDisplay/AttachmentArrayDisplay';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.stories.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.stories.tsx
@@ -1,7 +1,6 @@
 import { PropertyType } from '@medplum/core';
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourcePropertyInput } from './ResourcePropertyInput';
 

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.test.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.test.tsx
@@ -15,7 +15,6 @@ import {
 } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { convertIsoToLocal, convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ResourcePropertyInput, ResourcePropertyInputProps } from './ResourcePropertyInput';

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, Group, NativeSelect, Textarea, TextInput } from '@mantine/core';
 import { capitalize, InternalSchemaElement, PropertyType } from '@medplum/core';
 import { ElementDefinitionType, OperationOutcome } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { AddressInput } from '../AddressInput/AddressInput';
 import { AnnotationInput } from '../AnnotationInput/AnnotationInput';
 import { AttachmentArrayInput } from '../AttachmentArrayInput/AttachmentArrayInput';

--- a/packages/react/src/ResourceTable/ResourceTable.stories.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerObservation1, HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import {
   Covid19NasalSpecimen,

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -1,6 +1,5 @@
 import { MockClient } from '@medplum/mock';
 import { act, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ResourceTable, ResourceTableProps } from './ResourceTable';
 

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -1,6 +1,6 @@
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
 
 export interface ResourceTableProps {

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.stories.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.stories.tsx
@@ -2,7 +2,6 @@ import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Bundle, Encounter, ResourceType } from '@medplum/fhirtypes';
 import { HomerEncounter } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ResourceTimeline } from './ResourceTimeline';
 

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
@@ -2,7 +2,6 @@ import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Bundle, Encounter, Resource, ResourceType } from '@medplum/fhirtypes';
 import { HomerEncounter, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ResourceTimeline, ResourceTimelineProps } from './ResourceTimeline';

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -26,7 +26,7 @@ import {
   IconPinnedOff,
   IconTrash,
 } from '@tabler/icons-react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AttachmentButton } from '../AttachmentButton/AttachmentButton';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { DiagnosticReportDisplay } from '../DiagnosticReportDisplay/DiagnosticReportDisplay';

--- a/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
+++ b/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
@@ -1,5 +1,5 @@
 import { ResourceType } from '@medplum/fhirtypes';
-import React, { useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { CodeInput } from '../CodeInput/CodeInput';
 
 export interface ResourceTypeInputProps {

--- a/packages/react/src/Scheduler/Scheduler.stories.tsx
+++ b/packages/react/src/Scheduler/Scheduler.stories.tsx
@@ -1,6 +1,5 @@
 import { DrAliceSmithSchedule, ExampleQuestionnaire } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { Scheduler } from './Scheduler';
 

--- a/packages/react/src/Scheduler/Scheduler.test.tsx
+++ b/packages/react/src/Scheduler/Scheduler.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { Reference, Schedule } from '@medplum/fhirtypes';
 import { DrAliceSmithSchedule, ExampleQuestionnaire, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { Scheduler } from './Scheduler';

--- a/packages/react/src/Scheduler/Scheduler.tsx
+++ b/packages/react/src/Scheduler/Scheduler.tsx
@@ -2,7 +2,7 @@ import { Button, createStyles, Stack, Text } from '@mantine/core';
 import { getReferenceString, isReference } from '@medplum/core';
 import { Questionnaire, QuestionnaireResponse, Reference, Schedule, Slot } from '@medplum/fhirtypes';
 import { useResource, useSearchResources } from '@medplum/react-hooks';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { CalendarInput } from '../CalendarInput/CalendarInput';
 import { getStartMonth } from '../CalendarInput/CalendarInput.utils';
 import { QuestionnaireForm } from '../QuestionnaireForm/QuestionnaireForm';

--- a/packages/react/src/SearchControl/SearchControl.stories.tsx
+++ b/packages/react/src/SearchControl/SearchControl.stories.tsx
@@ -1,6 +1,6 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { Meta } from '@storybook/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { SearchControl } from './SearchControl';
 
 export default {

--- a/packages/react/src/SearchControl/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl/SearchControl.test.tsx
@@ -1,7 +1,6 @@
 import { Operator } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { SearchControl, SearchControlProps } from './SearchControl';

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -20,6 +20,7 @@ import {
   SearchParameter,
   UserConfiguration,
 } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
 import {
   IconAdjustmentsHorizontal,
   IconBoxMultiple,
@@ -30,9 +31,8 @@ import {
   IconTableExport,
   IconTrash,
 } from '@tabler/icons-react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, memo, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { Container } from '../Container/Container';
-import { useMedplum } from '@medplum/react-hooks';
 import { SearchExportDialog } from '../SearchExportDialog/SearchExportDialog';
 import { SearchFieldEditor } from '../SearchFieldEditor/SearchFieldEditor';
 import { SearchFilterEditor } from '../SearchFilterEditor/SearchFilterEditor';
@@ -63,9 +63,9 @@ export class SearchLoadEvent extends Event {
 
 export class SearchClickEvent extends Event {
   readonly resource: Resource;
-  readonly browserEvent: React.MouseEvent;
+  readonly browserEvent: MouseEvent;
 
-  constructor(resource: Resource, browserEvent: React.MouseEvent) {
+  constructor(resource: Resource, browserEvent: MouseEvent) {
     super('click');
     this.resource = resource;
     this.browserEvent = browserEvent;
@@ -200,7 +200,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
     loadResults();
   }, [loadResults]);
 
-  function handleSingleCheckboxClick(e: React.ChangeEvent, id: string): void {
+  function handleSingleCheckboxClick(e: ChangeEvent, id: string): void {
     e.stopPropagation();
 
     const el = e.target as HTMLInputElement;
@@ -214,7 +214,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
     setState({ ...stateRef.current, selected: newSelected });
   }
 
-  function handleAllCheckboxClick(e: React.ChangeEvent): void {
+  function handleAllCheckboxClick(e: ChangeEvent): void {
     e.stopPropagation();
 
     const el = e.target as HTMLInputElement;
@@ -259,7 +259,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
    * @param e - The click event.
    * @param resource - The FHIR resource.
    */
-  function handleRowClick(e: React.MouseEvent, resource: Resource): void {
+  function handleRowClick(e: MouseEvent, resource: Resource): void {
     if (isCheckboxCell(e.target as Element)) {
       // Ignore clicks on checkboxes
       return;
@@ -599,7 +599,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
   );
 }
 
-export const MemoizedSearchControl = React.memo(SearchControl);
+export const MemoizedSearchControl = memo(SearchControl);
 
 interface FilterDescriptionProps {
   readonly resourceType: string;

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -9,7 +9,6 @@ import {
   SearchRequest,
 } from '@medplum/core';
 import { Resource, SearchParameter } from '@medplum/fhirtypes';
-import React from 'react';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 import { SearchControlField } from './SearchControlField';

--- a/packages/react/src/SearchExportDialog/SearchExportDialog.stories.tsx
+++ b/packages/react/src/SearchExportDialog/SearchExportDialog.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { SearchExportDialog } from './SearchExportDialog';
 
 export default {

--- a/packages/react/src/SearchExportDialog/SearchExportDialog.test.tsx
+++ b/packages/react/src/SearchExportDialog/SearchExportDialog.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { ExportButton, SearchExportDialog } from './SearchExportDialog';
 
 describe('SearchExportDialog', () => {

--- a/packages/react/src/SearchExportDialog/SearchExportDialog.tsx
+++ b/packages/react/src/SearchExportDialog/SearchExportDialog.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Modal, Text } from '@mantine/core';
-import React from 'react';
 
 interface SearchExportDialogProps {
   visible: boolean;

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.stories.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.stories.tsx
@@ -1,6 +1,6 @@
 import { SearchRequest } from '@medplum/core';
 import { Meta } from '@storybook/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { SearchFieldEditor } from './SearchFieldEditor';
 
 export default {

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.test.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.test.tsx
@@ -1,7 +1,6 @@
 import { SearchRequest } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { SearchFieldEditor } from './SearchFieldEditor';
 
 describe('SearchFieldEditor', () => {

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Modal, MultiSelect, Stack } from '@mantine/core';
 import { InternalTypeSchema, SearchRequest, getDataType, getSearchParameters, stringify } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { buildFieldNameString } from '../SearchControl/SearchUtils';
 
 export interface SearchFieldEditorProps {

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
@@ -1,13 +1,13 @@
 import { Operator, SearchRequest } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
 import { SearchFilterEditor } from './SearchFilterEditor';
 
 const medplum = new MockClient();
 
-async function setup(child: React.ReactNode): Promise<void> {
+async function setup(child: ReactNode): Promise<void> {
   await act(async () => {
     render(<MedplumProvider medplum={medplum}>{child}</MedplumProvider>);
   });

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Modal, NativeSelect } from '@mantine/core';
 import { Filter, getSearchParameters, Operator, SearchRequest, stringify } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   addFilter,
   buildFieldNameString,

--- a/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
+++ b/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
@@ -1,7 +1,7 @@
 import { Button, Grid, Modal } from '@mantine/core';
 import { Filter } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Form } from '../Form/Form';
 import { SearchFilterValueInput } from '../SearchFilterValueInput/SearchFilterValueInput';
 

--- a/packages/react/src/SearchFilterValueDisplay/SearchFilterValueDisplay.tsx
+++ b/packages/react/src/SearchFilterValueDisplay/SearchFilterValueDisplay.tsx
@@ -6,7 +6,6 @@ import {
   Operator,
   SearchParameterType,
 } from '@medplum/core';
-import React from 'react';
 import { ResourceName } from '../ResourceName/ResourceName';
 
 export interface SearchFilterValueDisplayProps {

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
@@ -1,15 +1,15 @@
 import { globalSchema } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
-import { convertIsoToLocal } from '../DateTimeInput/DateTimeInput.utils';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { convertIsoToLocal } from '../DateTimeInput/DateTimeInput.utils';
 import { SearchFilterValueInput } from './SearchFilterValueInput';
 
 const medplum = new MockClient();
 
-function setup(child: React.ReactNode): void {
+function setup(child: ReactNode): void {
   render(<MedplumProvider medplum={medplum}>{child}</MedplumProvider>);
 }
 

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
@@ -1,7 +1,6 @@
 import { Checkbox, TextInput } from '@mantine/core';
 import { getSearchParameterDetails, SearchParameterType } from '@medplum/core';
 import { Quantity, Reference, SearchParameter } from '@medplum/fhirtypes';
-import React from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../ReferenceInput/ReferenceInput';

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -3,7 +3,6 @@ import { Filter, globalSchema, Operator, SearchRequest } from '@medplum/core';
 import { ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { getFieldDefinitions } from '../SearchControl/SearchControlField';

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
@@ -17,7 +17,6 @@ import {
   IconSortDescending,
   IconX,
 } from '@tabler/icons-react';
-import React from 'react';
 import {
   addLastMonthFilter,
   addMissingFilter,

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.stories.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.stories.tsx
@@ -1,6 +1,5 @@
 import { HomerServiceRequest } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ServiceRequestTimeline } from './ServiceRequestTimeline';
 

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
@@ -3,7 +3,6 @@ import { Communication } from '@medplum/fhirtypes';
 import { HomerServiceRequest, HomerSimpson, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { randomUUID } from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ServiceRequestTimeline, ServiceRequestTimelineProps } from './ServiceRequestTimeline';

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.tsx
@@ -1,6 +1,5 @@
 import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Group, Patient, Reference, ResourceType, ServiceRequest } from '@medplum/fhirtypes';
-import React from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface ServiceRequestTimelineProps {

--- a/packages/react/src/StatusBadge/StatusBadge.stories.tsx
+++ b/packages/react/src/StatusBadge/StatusBadge.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { StatusBadge } from './StatusBadge';
 

--- a/packages/react/src/StatusBadge/StatusBadge.test.tsx
+++ b/packages/react/src/StatusBadge/StatusBadge.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { StatusBadge } from './StatusBadge';
 
 describe('StatusBadge', () => {

--- a/packages/react/src/StatusBadge/StatusBadge.tsx
+++ b/packages/react/src/StatusBadge/StatusBadge.tsx
@@ -1,5 +1,4 @@
 import { Badge, DefaultMantineColor } from '@mantine/core';
-import React from 'react';
 
 /*
  * Request status: https://hl7.org/fhir/valueset-request-status.html

--- a/packages/react/src/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.stories.tsx
@@ -1,7 +1,6 @@
 import { createReference } from '@medplum/core';
 import { DrAliceSmith } from '@medplum/mock';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Timeline, TimelineItem } from './Timeline';
 
 export default {

--- a/packages/react/src/Timeline/Timeline.test.tsx
+++ b/packages/react/src/Timeline/Timeline.test.tsx
@@ -1,7 +1,6 @@
 import { Communication } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { Timeline, TimelineItem } from './Timeline';

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -2,7 +2,7 @@ import { ActionIcon, Group, Menu, Text } from '@mantine/core';
 import { formatDateTime, getReferenceString } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { IconDots } from '@tabler/icons-react';
-import React from 'react';
+import { ReactNode } from 'react';
 import { Container } from '../Container/Container';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
@@ -11,7 +11,7 @@ import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceName } from '../ResourceName/ResourceName';
 
 export interface TimelineProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export function Timeline(props: TimelineProps): JSX.Element {
@@ -23,7 +23,7 @@ export interface TimelineItemProps extends PanelProps {
   profile?: Reference;
   dateTime?: string;
   padding?: boolean;
-  popupMenuItems?: React.ReactNode;
+  popupMenuItems?: ReactNode;
 }
 
 export function TimelineItem(props: TimelineItemProps): JSX.Element {

--- a/packages/react/src/TimingInput/TimingInput.stories.tsx
+++ b/packages/react/src/TimingInput/TimingInput.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { TimingInput } from './TimingInput';
 

--- a/packages/react/src/TimingInput/TimingInput.test.tsx
+++ b/packages/react/src/TimingInput/TimingInput.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { TimingInput } from './TimingInput';
 
 describe('TimingInput', () => {

--- a/packages/react/src/TimingInput/TimingInput.tsx
+++ b/packages/react/src/TimingInput/TimingInput.tsx
@@ -1,7 +1,7 @@
 import { Button, Chip, Group, Modal, NativeSelect, Stack, Switch, TextInput } from '@mantine/core';
 import { formatTiming } from '@medplum/core';
 import { Timing, TimingRepeat } from '@medplum/fhirtypes';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 import { FormSection } from '../FormSection/FormSection';
 

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.stories.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { Document } from '../Document/Document';
 import { ValueSetAutocomplete } from './ValueSetAutocomplete';
 

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { ValueSetExpansionContains } from '@medplum/fhirtypes';
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import {
   AsyncAutocomplete,
   AsyncAutocompleteOption,

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -7,11 +7,11 @@ import {
   normalizeOperationOutcome,
 } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React, { useCallback, useState } from 'react';
+import { useMedplum } from '@medplum/react-hooks';
+import { ReactNode, useCallback, useState } from 'react';
 import { Form } from '../Form/Form';
 import { GoogleButton } from '../GoogleButton/GoogleButton';
 import { getGoogleClientId } from '../GoogleButton/GoogleButton.utils';
-import { useMedplum } from '@medplum/react-hooks';
 import { OperationOutcomeAlert } from '../OperationOutcomeAlert/OperationOutcomeAlert';
 import { getErrorsForInput, getIssuesForExpression } from '../utils/outcomes';
 
@@ -21,7 +21,7 @@ export interface AuthenticationFormProps extends BaseLoginRequest {
   readonly onForgotPassword?: () => void;
   readonly onRegister?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
-  readonly children?: React.ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function AuthenticationForm(props: AuthenticationFormProps): JSX.Element {
@@ -40,7 +40,7 @@ export interface EmailFormProps extends BaseLoginRequest {
   readonly onRegister?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
   readonly setEmail: (email: string) => void;
-  readonly children?: React.ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function EmailForm(props: EmailFormProps): JSX.Element {
@@ -128,7 +128,7 @@ export interface PasswordFormProps extends BaseLoginRequest {
   readonly email: string;
   readonly onForgotPassword?: () => void;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
-  readonly children?: React.ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function PasswordForm(props: PasswordFormProps): JSX.Element {

--- a/packages/react/src/auth/ChooseProfileForm.tsx
+++ b/packages/react/src/auth/ChooseProfileForm.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Center, Group, Stack, Text, Title, UnstyledButton } from '@mantine/core';
 import { LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, ProjectMembership } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Logo } from '../Logo/Logo';
 import { useMedplum } from '@medplum/react-hooks';
 import { OperationOutcomeAlert } from '../OperationOutcomeAlert/OperationOutcomeAlert';

--- a/packages/react/src/auth/ChooseScopeForm.tsx
+++ b/packages/react/src/auth/ChooseScopeForm.tsx
@@ -1,6 +1,5 @@
 import { Button, Center, Checkbox, Group, Stack, Title } from '@mantine/core';
 import { LoginAuthenticationResponse } from '@medplum/core';
-import React from 'react';
 import { Form } from '../Form/Form';
 import { Logo } from '../Logo/Logo';
 import { useMedplum } from '@medplum/react-hooks';

--- a/packages/react/src/auth/MfaForm.tsx
+++ b/packages/react/src/auth/MfaForm.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Center, Group, Stack, TextInput, Title } from '@mantine/core';
 import { LoginAuthenticationResponse, normalizeErrorString } from '@medplum/core';
 import { IconAlertCircle } from '@tabler/icons-react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Form } from '../Form/Form';
 import { Logo } from '../Logo/Logo';
 import { useMedplum } from '@medplum/react-hooks';

--- a/packages/react/src/auth/NewProjectForm.tsx
+++ b/packages/react/src/auth/NewProjectForm.tsx
@@ -1,7 +1,7 @@
 import { Anchor, Button, Center, Group, Stack, Text, TextInput, Title } from '@mantine/core';
 import { LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Form } from '../Form/Form';
 import { Logo } from '../Logo/Logo';
 import { useMedplum } from '@medplum/react-hooks';

--- a/packages/react/src/auth/NewUserForm.tsx
+++ b/packages/react/src/auth/NewUserForm.tsx
@@ -1,11 +1,11 @@
 import { Anchor, Button, Center, Checkbox, Divider, Group, PasswordInput, Stack, Text, TextInput } from '@mantine/core';
 import { GoogleCredentialResponse, LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React, { useEffect, useState } from 'react';
+import { useMedplum } from '@medplum/react-hooks';
+import { ReactNode, useEffect, useState } from 'react';
 import { Form } from '../Form/Form';
 import { GoogleButton } from '../GoogleButton/GoogleButton';
 import { getGoogleClientId } from '../GoogleButton/GoogleButton.utils';
-import { useMedplum } from '@medplum/react-hooks';
 import { OperationOutcomeAlert } from '../OperationOutcomeAlert/OperationOutcomeAlert';
 import { getErrorsForInput, getIssuesForExpression } from '../utils/outcomes';
 import { getRecaptcha, initRecaptcha } from '../utils/recaptcha';
@@ -15,7 +15,7 @@ export interface NewUserFormProps {
   readonly clientId?: string;
   readonly googleClientId?: string;
   readonly recaptchaSiteKey?: string;
-  readonly children?: React.ReactNode;
+  readonly children?: ReactNode;
   readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
 }
 

--- a/packages/react/src/auth/RegisterForm.stories.tsx
+++ b/packages/react/src/auth/RegisterForm.stories.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { RegisterForm } from '../auth/RegisterForm';
 import { Logo } from '../Logo/Logo';
 

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -2,7 +2,6 @@ import { Title } from '@mantine/core';
 import { allOk, GoogleCredentialResponse, MedplumClient } from '@medplum/core';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { randomUUID, webcrypto } from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { MedplumProvider } from '@medplum/react-hooks';

--- a/packages/react/src/auth/RegisterForm.tsx
+++ b/packages/react/src/auth/RegisterForm.tsx
@@ -1,8 +1,8 @@
 import { LoginAuthenticationResponse, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
-import React, { useEffect, useState } from 'react';
-import { Document } from '../Document/Document';
 import { useMedplum } from '@medplum/react-hooks';
+import { ReactNode, useEffect, useState } from 'react';
+import { Document } from '../Document/Document';
 import { NewProjectForm } from './NewProjectForm';
 import { NewUserForm } from './NewUserForm';
 
@@ -12,7 +12,7 @@ export interface RegisterFormProps {
   readonly clientId?: string;
   readonly googleClientId?: string;
   readonly recaptchaSiteKey?: string;
-  readonly children?: React.ReactNode;
+  readonly children?: ReactNode;
   readonly onSuccess: () => void;
 }
 

--- a/packages/react/src/auth/SignInForm.stories.tsx
+++ b/packages/react/src/auth/SignInForm.stories.tsx
@@ -1,6 +1,5 @@
 import { Title } from '@mantine/core';
 import { Meta } from '@storybook/react';
-import React from 'react';
 import { SignInForm } from './SignInForm';
 import { Logo } from '../Logo/Logo';
 

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -2,7 +2,6 @@ import { Title } from '@mantine/core';
 import { allOk, badRequest, GoogleCredentialResponse, MedplumClient } from '@medplum/core';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import crypto from 'crypto';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { MedplumProvider } from '@medplum/react-hooks';

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -1,9 +1,9 @@
 import { showNotification } from '@mantine/notifications';
 import { BaseLoginRequest, LoginAuthenticationResponse, normalizeErrorString } from '@medplum/core';
 import { ProjectMembership } from '@medplum/fhirtypes';
-import React, { useCallback, useEffect, useState } from 'react';
-import { Document } from '../Document/Document';
 import { useMedplum } from '@medplum/react-hooks';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { Document } from '../Document/Document';
 import { AuthenticationForm } from './AuthenticationForm';
 import { ChooseProfileForm } from './ChooseProfileForm';
 import { ChooseScopeForm } from './ChooseScopeForm';
@@ -19,7 +19,7 @@ export interface SignInFormProps extends BaseLoginRequest {
   readonly onForgotPassword?: () => void;
   readonly onRegister?: () => void;
   readonly onCode?: (code: string) => void;
-  readonly children?: React.ReactNode;
+  readonly children?: ReactNode;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2021",
     "module": "commonjs",
     "moduleResolution": "node",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "newLine": "lf",
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
Use [the new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) in all React projects.

In practical terms:
* In `tsconfig.json`, use `"jsx": "react-jsx"` rather than `"jsx": "react"`
* Remove all `import React from 'react';` declarations

References
* https://medplum.slack.com/archives/C051SKJKZ50/p1700094668578869
* https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
* https://stackoverflow.com/questions/67776707/ts-config-jsx-reactjsx-vs-react