### PR TITLE
Update all projects to use api-extractor for type definitions

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -7,8 +7,11 @@ dist/docs/
 dist/types/
 dist/types.d.ts
 src/
-babel.config.json
+api-extractor.json
+babel.config.cjs
 esbuild.mjs
 jest.config.json
+test.setup.cjs
+tsdoc.json
 tsconfig.build.json
 tsconfig.json

--- a/packages/definitions/.npmignore
+++ b/packages/definitions/.npmignore
@@ -3,6 +3,7 @@ dist/**/*.test.d.ts
 dist/**/*.test.js
 dist/**/*.test.js.map
 src/
+babel.config.json
 jest.config.json
 tsconfig.build.json
 tsconfig.json

--- a/packages/expo-polyfills/.npmignore
+++ b/packages/expo-polyfills/.npmignore
@@ -4,8 +4,14 @@
 __mocks__
 __tests__
 
-/babel.config.js
-/android/src/androidTest/
-/android/src/test/
-/android/build/
-/example/
+android/src/androidTest/
+android/src/test/
+android/build/
+dist/types/
+dist/types.d.ts
+example/
+api-extractor.json
+babel.config.cjs
+esbuild.mjs
+jest.config.json
+tsconfig.*

--- a/packages/expo-polyfills/api-extractor.json
+++ b/packages/expo-polyfills/api-extractor.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../api-extractor.json"
+}

--- a/packages/expo-polyfills/package.json
+++ b/packages/expo-polyfills/package.json
@@ -9,8 +9,9 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "scripts": {
+    "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.cts && cp dist/types.d.ts dist/esm/index.d.mts",
     "test": "jest --runInBand",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs",
+    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf ./build"
   },
   "keywords": [

--- a/packages/fhir-router/.npmignore
+++ b/packages/fhir-router/.npmignore
@@ -5,8 +5,10 @@ dist/**/*.test.js.map
 dist/types/
 dist/types.d.ts
 src/
+api-extractor.json
 babel.config.json
 esbuild.mjs
 jest.config.json
 tsconfig.build.json
 tsconfig.json
+tsdoc.json

--- a/packages/hl7/.npmignore
+++ b/packages/hl7/.npmignore
@@ -5,8 +5,10 @@ dist/**/*.test.js.map
 dist/types/
 dist/types.d.ts
 src/
+api-extractor.json
 babel.config.json
 esbuild.mjs
 jest.config.json
 tsconfig.build.json
 tsconfig.json
+tsdoc.json

--- a/packages/mock/.npmignore
+++ b/packages/mock/.npmignore
@@ -5,8 +5,10 @@ dist/**/*.test.js.map
 dist/types/
 dist/types.d.ts
 src/
+api-extractor.json
 babel.config.json
 esbuild.mjs
 jest.config.json
 tsconfig.build.json
 tsconfig.json
+tsdoc.json

--- a/packages/react-hooks/.npmignore
+++ b/packages/react-hooks/.npmignore
@@ -8,8 +8,10 @@ public/
 src/
 .env
 .env.defaults
+api-extractor.json
 babel.config.json
 esbuild.mjs
 jest.config.json
 tsconfig.build.json
 tsconfig.json
+tsdoc.json

--- a/packages/react/.npmignore
+++ b/packages/react/.npmignore
@@ -10,8 +10,9 @@ src/
 storybook-static/
 .env
 .env.defaults
-babel.config.json
+api-extractor.json
+babel.config.cjs
 esbuild.mjs
 jest.config.json
-tsconfig.build.json
-tsconfig.json
+tsconfig.*
+tsdoc.json


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/3152 we started using `api-extractor` to generate type definitions.

Unfortunately `expo-polyfills` was added around the same time, so it did not have the same type generator pattern.

This PR aligns all projects to use the same `api-extractor` pattern.

--------

While researching this bug, I found a bunch of unwanted files in our published output (i.e., `babel.config.json`, `jest.config.json`, etc), so I also added them to `.npmignore` files.

Alternatively, I wonder if we should switch back to using the `files` property in `package.json`.