### PR TITLE
Fix bug in deepIncludes

### DIFF
--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -218,6 +218,76 @@ describe('FHIR resource validation', () => {
     expect(() => validateResource(observation, observationProfile)).not.toThrow();
   });
 
+  test('Valid resource under constraining profile with additional non-constrained fields', () => {
+    const observation: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      category: [
+        {
+          coding: [
+            {
+              code: 'vital-signs',
+              system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+            },
+          ],
+        },
+      ],
+      code: {
+        coding: [
+          {
+            code: '85354-9',
+            system: LOINC,
+          },
+        ],
+      },
+      subject: {
+        reference: 'Patient/example',
+      },
+      effectiveDateTime: '2023-05-31T17:03:45-07:00',
+      component: [
+        {
+          dataAbsentReason: {
+            coding: [
+              {
+                code: '8480-6',
+                system: LOINC,
+              },
+            ],
+          },
+          code: {
+            coding: [
+              {
+                code: '8480-6',
+                system: LOINC,
+                display: 'Systolic blood pressure', // This is the extra content
+              },
+            ],
+          },
+        },
+        {
+          dataAbsentReason: {
+            coding: [
+              {
+                code: '8480-6',
+                system: LOINC,
+              },
+            ],
+          },
+          code: {
+            coding: [
+              {
+                code: '8462-4',
+                system: LOINC,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(() => validateResource(observation, observationProfile)).not.toThrow();
+  });
+
   test('Invalid cardinality', () => {
     const observation: Observation = {
       resourceType: 'Observation',

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -541,8 +541,13 @@ describe('Core Utils', () => {
     expect(deepIncludes({ value: 1 }, { value: {} })).toEqual(false);
     expect(deepIncludes({ value: {} }, { value: {} })).toEqual(true);
     expect(deepIncludes({ value: { x: 1 } }, { value: { x: 1 } })).toEqual(true);
-    expect(deepIncludes({ value: { x: 1, y: '2' } }, { value: { x: 1, y: '2', z: 4 } })).toEqual(true);
-    expect(deepIncludes([{ value: 1 }, { value: 2 }], [{ value: 2 }, { value: 1 }, { y: 6 }])).toEqual(true);
+
+    expect(deepIncludes({ value: { x: 1, y: '2' } }, { value: { x: 1, y: '2', z: 4 } })).toEqual(false);
+    expect(deepIncludes({ value: { x: 1, y: '2', z: 4 } }, { value: { x: 1, y: '2' } })).toEqual(true);
+
+    expect(deepIncludes([{ value: 1 }, { value: 2 }], [{ value: 2 }, { value: 1 }, { y: 6 }])).toEqual(false);
+    expect(deepIncludes([{ value: 2 }, { value: 1 }, { y: 6 }], [{ value: 1 }, { value: 2 }])).toEqual(true);
+
     expect(deepIncludes([{ value: 1 }], { value: 1 })).toEqual(false);
     expect(deepIncludes([{ value: 1 }], [{ y: 2, z: 3 }])).toEqual(false);
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -545,6 +545,17 @@ describe('Core Utils', () => {
     expect(deepIncludes([{ value: 1 }, { value: 2 }], [{ value: 2 }, { value: 1 }, { y: 6 }])).toEqual(true);
     expect(deepIncludes([{ value: 1 }], { value: 1 })).toEqual(false);
     expect(deepIncludes([{ value: 1 }], [{ y: 2, z: 3 }])).toEqual(false);
+
+    const value = {
+      type: 'CodeableConcept',
+      value: {
+        coding: [{ system: 'http://loinc.org', code: '8480-6', display: 'Systolic blood pressure' }],
+        text: 'Systolic blood pressure',
+      },
+    };
+    const pattern = { type: 'CodeableConcept', value: { coding: [{ system: 'http://loinc.org', code: '8480-6' }] } };
+    expect(deepIncludes(value, pattern)).toEqual(true);
+    expect(deepIncludes(pattern, value)).toEqual(false);
   });
 
   test('deepClone', () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -558,7 +558,12 @@ describe('Core Utils', () => {
         text: 'Systolic blood pressure',
       },
     };
-    const pattern = { type: 'CodeableConcept', value: { coding: [{ system: 'http://loinc.org', code: '8480-6' }] } };
+    const pattern = {
+      type: 'CodeableConcept',
+      value: {
+        coding: [{ system: 'http://loinc.org', code: '8480-6' }],
+      },
+    };
     expect(deepIncludes(value, pattern)).toEqual(true);
     expect(deepIncludes(pattern, value)).toEqual(false);
   });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -533,11 +533,11 @@ function deepEqualsObject(
 }
 
 /**
- * Checks if object2 includes all fields and values of object1.
- * It doesn't matter if object2 has extra fields.
- * @param value - The object to test if contained in pattern.
- * @param pattern - The object to test against.
- * @returns True if pattern includes all fields and values of value.
+ * Checks if value includes all fields and values of pattern.
+ * It doesn't matter if value has extra fields, values, etc.
+ * @param value - The object being tested against pattern.
+ * @param pattern - The object pattern/shape checked to exist within value.
+ * @returns True if value includes all fields and values of pattern.
  */
 export function deepIncludes(value: any, pattern: any): boolean {
   if (isEmpty(value)) {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -560,12 +560,14 @@ export function deepIncludes(value: any, pattern: any): boolean {
   return value === pattern;
 }
 
-function deepIncludesArray(array1: any[], array2: any[]): boolean {
-  return array1.every((value1) => array2.some((value2) => deepIncludes(value1, value2)));
+function deepIncludesArray(value: any[], pattern: any[]): boolean {
+  return pattern.every((patternVal) => value.some((valueVal) => deepIncludes(valueVal, patternVal)));
 }
 
-function deepIncludesObject(object1: { [key: string]: unknown }, object2: { [key: string]: unknown }): boolean {
-  return Object.entries(object1).every(([key, value]) => key in object2 && deepIncludes(value, object2[key]));
+function deepIncludesObject(value: { [key: string]: unknown }, pattern: { [key: string]: unknown }): boolean {
+  return Object.entries(pattern).every(
+    ([patternKey, patternVal]) => patternKey in value && deepIncludes(value[patternKey], patternVal)
+  );
 }
 
 /**


### PR DESCRIPTION
While testing profiles, noticed that slice validation was not working if a resource's slice value contained extra values not included in the pattern used by the slice's discriminator.