### PR TITLE
Fixed - Project specific reset password

### DIFF
--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -57,16 +57,29 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
     }
   }
 
-  const user = await systemRepo.searchOne<User>({
-    resourceType: 'User',
-    filters: [
-      {
-        code: 'email',
-        operator: Operator.EXACT,
-        value: email,
-      },
-    ],
+// Define filters for searching users
+const filters = [
+  {
+    code: 'email',
+    operator: Operator.EXACT,
+    value: email, // Set the email value for exact matching
+  },
+];
+
+// If a specific project is associated with the request, add a project filter
+if (req.body.projectId) {
+  filters.push({
+    code: 'project',
+    operator: Operator.EQUALS,
+    value: 'Project/' + req.body.projectId, // Set the project value for equality matching
   });
+}
+
+// Search for a user based on the defined filters
+const user = await systemRepo.searchOne<User>({
+  resourceType: 'User',
+  filters,
+});
 
   if (!user) {
     // Per OWASP guidelines, send "ok" to prevent account enumeration attack

--- a/packages/server/src/auth/resetpassword.ts
+++ b/packages/server/src/auth/resetpassword.ts
@@ -57,29 +57,36 @@ export async function resetPasswordHandler(req: Request, res: Response): Promise
     }
   }
 
-// Define filters for searching users
-const filters = [
-  {
-    code: 'email',
-    operator: Operator.EXACT,
-    value: email, // Set the email value for exact matching
-  },
-];
+  // Define filters for searching users
+  const filters = [
+    {
+      code: 'email',
+      operator: Operator.EXACT,
+      value: email, // Set the email value for exact matching
+    },
+  ];
 
-// If a specific project is associated with the request, add a project filter
-if (req.body.projectId) {
-  filters.push({
-    code: 'project',
-    operator: Operator.EQUALS,
-    value: 'Project/' + req.body.projectId, // Set the project value for equality matching
+  // If a specific project is associated with the request, add a project filter
+  if (req.body.projectId) {
+    filters.push({
+      code: 'project',
+      operator: Operator.EQUALS,
+      value: 'Project/' + req.body.projectId, // Set the project value for equality matching
+    });
+  } else {
+    // If project id not found in the request body then project should not present in the user
+    filters.push({
+      code: 'project',
+      operator: Operator.MISSING,
+      value: 'true',
+    });
+  }
+
+  // Search for a user based on the defined filters
+  const user = await systemRepo.searchOne<User>({
+    resourceType: 'User',
+    filters,
   });
-}
-
-// Search for a user based on the defined filters
-const user = await systemRepo.searchOne<User>({
-  resourceType: 'User',
-  filters,
-});
 
   if (!user) {
     // Per OWASP guidelines, send "ok" to prevent account enumeration attack


### PR DESCRIPTION
### Description

This pull request addresses the project-specific reset password issue in the Medplum project. Specifically, the fix involves adding the project to the user filters to resolve the reset password issue. 

### Test Cases

I have run test cases for the resetPassword functionality. However, I've identified an issue with the `Reset Password › Custom reCAPTCHA site key success` test case. Upon investigation, it appears that the test is failing because the `projectId` is provided in the request body, but the associated project is missing in the user resource. The root cause is that the project is not assigned to the user resource at the time of creating the user. 
[Test - Reset Password › Custom reCAPTCHA site key success](https://github.com/medplum/medplum/blob/01fdd05735ad1794884c349a876e68df01fe44b2/packages/server/src/auth/resetpassword.test.ts#L199-L245).

### Action Items

- [x] Fix the reset password issue by adding the project to the user filters.
- [ ] Review by @rahul1 and @codyebberson.

Please look at it and take it forward.

@rahul1 @codyebberson

#3340