### PR TITLE
Improve examples in the include search docs

### DIFF
--- a/packages/docs/docs/search/includes.mdx
+++ b/packages/docs/docs/search/includes.mdx
@@ -198,7 +198,7 @@ In some cases you may want to search for a [`Patient`](/docs/api/fhir/resources/
 
 ```mermaid
 flowchart TD
-    subgraph Searh Results
+    subgraph Search Results
         A(Patient/lisa-simpson)
     end
 
@@ -241,7 +241,7 @@ However, some models use the [`RelatedPerson`](/docs/api/fhir/resources/relatedp
 
 ```mermaid
 flowchart TD
-    subgraph Searh Results
+    subgraph Search Results
         A(Patient/lisa-simpson)
     end
 

--- a/packages/docs/docs/search/includes.mdx
+++ b/packages/docs/docs/search/includes.mdx
@@ -37,9 +37,12 @@ For example, the search query described above for `Observation`, `Patient`, and 
     <MedplumCodeBlock language="ts" selectBlocks="searchIncludes">
       {ExampleCode}
     </MedplumCodeBlock>
-
   </TabItem>
-
+  <TabItem value="cli" label="CLI">
+    <MedplumCodeBlock language="ts" selectBlocks="searchIncludesCli">
+      {ExampleCode}
+    </MedplumCodeBlock>
+  </TabItem>
   <TabItem value="curl" label="cURL">
     <MedplumCodeBlock language="bash" selectBlocks="searchIncludesCurl">
       {ExampleCode}
@@ -106,9 +109,12 @@ to search for `Observation` resources, plus the `Patient` resources they refer t
     <MedplumCodeBlock language="ts" selectBlocks="searchIncludeIterate">
       {ExampleCode}
     </MedplumCodeBlock>
-
   </TabItem>
-
+  <TabItem value="cli" label="CLI">
+    <MedplumCodeBlock language="ts" selectBlocks="searchIncludeIterateCli">
+      {ExampleCode}
+    </MedplumCodeBlock>
+  </TabItem>
   <TabItem value="curl" label="cURL">
     <MedplumCodeBlock language="bash" selectBlocks="searchIncludeIterateCurl">
       {ExampleCode}
@@ -183,3 +189,111 @@ flowchart TD
 ```
 
 :::
+
+## Additional Examples
+
+### Searching for a related person
+
+In some cases you may want to search for a [`Patient`](/docs/api/fhir/resources/patient) as well as any `RelatedPerson` resources they may have.
+
+<details>
+  <summary>Example: Get a `Patient` and their `RelatedPerson`</summary>
+  <Tabs groupId="language">
+    <TabItem value="ts" label="TypeScript">
+      <MedplumCodeBlock language="ts" selectBlocks="relatedPersonTs">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="cli" label="CLI">
+      <MedplumCodeBlock language="ts" selectBlocks="relatedPersonCli">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="curl" label="cURL">
+      <MedplumCodeBlock language="bash" selectBlocks="relatedPersonCurl">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+  </Tabs>
+</details>
+
+In this example we search for a [`Patient`](/docs/api/fhir/resources/patient), and `_revinclude=RelatedPerson:patient` includes any [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) resources that references one of the patients in our results.
+
+However, depending on how you model family relationships, this may not work. Some models use the [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) as a link between two patients (for more details see [approach #3 of Family Relationships guide](/docs/fhir-datastore/family-relationships#approach-3)).
+
+<details>
+  <summary>Example: Get a `Patient` and their `RelatedPerson` modeled as a `Patient`</summary>
+  <Tabs groupId="language">
+    <TabItem value="ts" label="TypeScript">
+      <MedplumCodeBlock language="ts" selectBlocks="relatedPersonPatientTs">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="cli" label="CLI">
+      <MedplumCodeBlock language="ts" selectBlocks="relatedPersonPatientCli">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="curl" label="cURL">
+      <MedplumCodeBlock language="bash" selectBlocks="relatedPersonPatientCurl">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+  </Tabs>
+</details>
+
+The first part of this example is the same as the previous, but we also use `_revinclude:iterate=Patient:link`. Using `:iterate` allows us to use `_revinclude` to search for any [`Patient`](/docs/api/fhir/resources/patient) resources that are referenced by the [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) on the `link` search parameter.
+
+### Searching for practitioners at a specific location
+
+A common use case is searching for any [`Practitioner`](/docs/api/fhir/resources/practitioner) and [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources at a specific location. This can be necessary to ensure that the proper care can be provided at a given hospital or clinic.
+
+<details>
+  <summary>Example: Find all practitioners and roles at a specific location</summary>
+  <Tabs groupId="language">
+    <TabItem value="ts" label="TypeScript">
+      <MedplumCodeBlock language="ts" selectBlocks="locationPractitionerRoleTs">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="cli" label="CLI">
+      <MedplumCodeBlock language="ts" selectBlocks="locationPractitionerRoleCli">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="curl" label="cURL">
+      <MedplumCodeBlock language="bash" selectBlocks="locationPractitionerRoleCurl">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+  </Tabs>
+</details>
+
+In this example, we search for a [`Location`](/docs/api/fhir/resources/location) resource, then use `_revinclude=PractitionerRole:location` to get all [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources that reference the [`Location`](/docs/api/fhir/resources/location) using the `location` search parameter. We then iterate on the [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources using `_include:iterate=PractitionerRole:practitioner`. This will include all the [`Practitioner`](/docs/api/fhir/resources/practitioner) resources referenced by the `practitioner` search parameter of the returned [`PractitionerRoles`](/docs/api/fhir/resources/practitionerrole).
+
+### Searching for a patient's care team
+
+You may want to search for the [`CareTeam`](/docs/api/fhir/resources/careteam) of a [`Patient`](/docs/api/fhir/resources/patient), including all the members involved in the care.
+
+<details>
+  <summary>Example: Search for all members of the `CareTeam` of a `Patient`</summary>
+  <Tabs groupId="language">
+    <TabItem value="ts" label="TypeScript">
+      <MedplumCodeBlock language="ts" selectBlocks="careTeamTs">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="cli" label="CLI">
+      <MedplumCodeBlock language="ts" selectBlocks="careTeamCli">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+    <TabItem value="curl" label="cURL">
+      <MedplumCodeBlock language="bash" selectBlocks="careTeamCurl">
+        {ExampleCode}
+      </MedplumCodeBlock>
+    </TabItem>
+  </Tabs>
+</details>
+
+In this example we search for a [`Patient`](/docs/api/fhir/resources/patient), then use `_revinclude=CareTeam:patient` to search for a [`CareTeam`](/docs/api/fhir/resources/careteam) resource that references our results using the `patient` search parameter. We then iterate on the [`CareTeam`](/docs/api/fhir/resources/careteam) with `_include:iterate=CareTeam:participant` to search for all participants of the team.

--- a/packages/docs/docs/search/includes.mdx
+++ b/packages/docs/docs/search/includes.mdx
@@ -194,7 +194,22 @@ flowchart TD
 
 ### Searching for a related person
 
-In some cases you may want to search for a [`Patient`](/docs/api/fhir/resources/patient) as well as any `RelatedPerson` resources they may have.
+In some cases you may want to search for a [`Patient`](/docs/api/fhir/resources/patient) as well as any [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) resources they may have. This is often used in pediatric care when you need to retrieve a [`Patient`](/docs/api/fhir/resources/patient) and their parent in the same search. See the [family relationships guide](/docs/fhir-datastore/family-relationships) for more details.
+
+```mermaid
+flowchart TD
+    subgraph Searh Results
+        A(Patient/lisa-simpson)
+    end
+
+    subgraph _revinclude
+        B(RelatedPerson/marge-simpson)
+        C(RelatedPerson/homer-simpson)
+    end
+
+    B --> |patient| A
+    C --> |patient| A
+```
 
 <details>
   <summary>Example: Get a `Patient` and their `RelatedPerson`</summary>
@@ -217,9 +232,34 @@ In some cases you may want to search for a [`Patient`](/docs/api/fhir/resources/
   </Tabs>
 </details>
 
-In this example we search for a [`Patient`](/docs/api/fhir/resources/patient), and `_revinclude=RelatedPerson:patient` includes any [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) resources that references one of the patients in our results.
+In this example we:
 
-However, depending on how you model family relationships, this may not work. Some models use the [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) as a link between two patients (for more details see [approach #3 of Family Relationships guide](/docs/fhir-datastore/family-relationships#approach-3)).
+- Search for a root [`Patient`](/docs/api/fhir/resources/patient) resource
+- We then use `_revinclude=RelatedPerson:patient` to include any [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) resources that reference one of the patients in our results.
+
+However, some models use the [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) as a link between two patients (for more details see [approach #3 of Family Relationships guide](/docs/fhir-datastore/family-relationships#approach-3)).
+
+```mermaid
+flowchart TD
+    subgraph Searh Results
+        A(Patient/lisa-simpson)
+    end
+
+    subgraph _revinclude
+        B(RelatedPerson/marge-lisa)
+        C(RelatedPerson/homer-lisa)
+    end
+
+    subgraph _revinclude:iterate
+        D(Patient/marge-simpson)
+        E(Patient/homer-simpson)
+    end
+
+    B --> |patient| A
+    C --> |patient| A
+    D --> |link| B
+    E --> |link| C
+```
 
 <details>
   <summary>Example: Get a `Patient` and their `RelatedPerson` modeled as a `Patient`</summary>
@@ -242,11 +282,36 @@ However, depending on how you model family relationships, this may not work. Som
   </Tabs>
 </details>
 
-The first part of this example is the same as the previous, but we also use `_revinclude:iterate=Patient:link`. Using `:iterate` allows us to use `_revinclude` to search for any [`Patient`](/docs/api/fhir/resources/patient) resources that are referenced by the [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) on the `link` search parameter.
+This example is similar to the first, but includes an additional step.
+
+- We search for the root [`Patient`](/docs/api/fhir/resources/patient) resource
+- We use `_revinclude=RelatedPerson:patient` to again get any [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) resources that reference our results. In this case they are only representing a link between the two [`Patient`](/docs/api/fhir/resources/patient) resources.
+- We then use `_revinclude:iterate=Patient:link` to iterate on the [`RelatedPerson`](/docs/api/fhir/resources/relatedperson) resources and get any [`Patient`](/docs/api/fhir/resources/patient) resources that reference them on the `link` element. In this scenario, these are the parents.
 
 ### Searching for practitioners at a specific location
 
-A common use case is searching for any [`Practitioner`](/docs/api/fhir/resources/practitioner) and [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources at a specific location. This can be necessary to ensure that the proper care can be provided at a given hospital or clinic.
+A common use case is searching for any [`Practitioner`](/docs/api/fhir/resources/practitioner) and [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources at a specific location. This can be necessary when the same physician provides care at multiple locations. See the [provider organizations guide](/docs/fhir-datastore/provider-directory/provider-organizations) for more details.
+
+```mermaid
+flowchart TD
+    subgraph Search Results
+        A(Location/example-location)
+    end
+
+    subgraph _revinclude
+        B(PractitionerRole/1)
+        C(PractitionerRole/2)
+    end
+
+    subgraph _include:iterate
+        D(Practitioner/dr-alice-smith)
+        E(Practitioner/dr-gregory-house)
+    end
+
+    B & C--> |location| A
+    B --> |practitioner| D
+    C --> |practitioner| E
+```
 
 <details>
   <summary>Example: Find all practitioners and roles at a specific location</summary>
@@ -269,11 +334,34 @@ A common use case is searching for any [`Practitioner`](/docs/api/fhir/resources
   </Tabs>
 </details>
 
-In this example, we search for a [`Location`](/docs/api/fhir/resources/location) resource, then use `_revinclude=PractitionerRole:location` to get all [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources that reference the [`Location`](/docs/api/fhir/resources/location) using the `location` search parameter. We then iterate on the [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources using `_include:iterate=PractitionerRole:practitioner`. This will include all the [`Practitioner`](/docs/api/fhir/resources/practitioner) resources referenced by the `practitioner` search parameter of the returned [`PractitionerRoles`](/docs/api/fhir/resources/practitionerrole).
+In this example, we:
+
+- Search for a root [`Location`](/docs/api/fhir/resources/location) resource.
+- We then use `_revinclude=PractitionerRole:location` to get all [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources that reference the [`Location`](/docs/api/fhir/resources/location) using the `location` search parameter.
+- Next, we iterate on the [`PractitionerRole`](/docs/api/fhir/resources/practitionerrole) resources using `_include:iterate=PractitionerRole:practitioner`. This will include all the [`Practitioner`](/docs/api/fhir/resources/practitioner) resources referenced by the `practitioner` search parameter of the returned [`PractitionerRoles`](/docs/api/fhir/resources/practitionerrole).
 
 ### Searching for a patient's care team
 
-You may want to search for the [`CareTeam`](/docs/api/fhir/resources/careteam) of a [`Patient`](/docs/api/fhir/resources/patient), including all the members involved in the care.
+You may want to display a [`Patient`](/docs/api/fhir/resources/patient) resource as well as a list of all the members of their [`CareTeam`](/docs/api/fhir/resources/careteam) on one page.
+
+```mermaid
+flowchart TD
+    subgraph Search Results
+       A(Patient/homer-simpson)
+    end
+
+    subgraph _revinclude
+        B(CareTeam/homer-care-team)
+    end
+
+    subgraph _include:iterate
+        C(Practitioner/dr-alice-smith)
+        D(Organization/example-hospital)
+    end
+
+    B --> |patient| A
+    B --> |member| C & D
+```
 
 <details>
   <summary>Example: Search for all members of the `CareTeam` of a `Patient`</summary>
@@ -296,4 +384,8 @@ You may want to search for the [`CareTeam`](/docs/api/fhir/resources/careteam) o
   </Tabs>
 </details>
 
-In this example we search for a [`Patient`](/docs/api/fhir/resources/patient), then use `_revinclude=CareTeam:patient` to search for a [`CareTeam`](/docs/api/fhir/resources/careteam) resource that references our results using the `patient` search parameter. We then iterate on the [`CareTeam`](/docs/api/fhir/resources/careteam) with `_include:iterate=CareTeam:participant` to search for all participants of the team.
+In this example we:
+
+- Search for a root [`Patient`](/docs/api/fhir/resources/patient) resource.
+- Then we use `_revinclude=CareTeam:patient` to search for a [`CareTeam`](/docs/api/fhir/resources/careteam) resource that references our results using the `patient` search parameter.
+- We then iterate on the [`CareTeam`](/docs/api/fhir/resources/careteam) with `_include:iterate=CareTeam:participant` to search for all members of the team.

--- a/packages/examples/src/search/includes.ts
+++ b/packages/examples/src/search/includes.ts
@@ -4,8 +4,14 @@ import { Resource } from '@medplum/fhirtypes';
 const medplum = new MedplumClient();
 
 /*
+  // start-block searchIncludesCli
+  medplum get 'Observation?code=78012-2&_include=Observation:patient&_revinclude=Provenance:target'
+  // end-block searchIncludesCli
+
   // start-block searchIncludesCurl
-  curl https://api.medplum.com/fhir/R4/Observation?code=78012-2&_include=Observation:patient&_revinclude=Provenance:target
+  curl 'https://api.medplum.com/fhir/R4/Observation?code=78012-2&_include=Observation:patient&_revinclude=Provenance:target' \
+    -H 'authorization: Bearer $ACCESS_TOKEN' \
+    -H 'content-type: application/fhir+json' \
   // end-block searchIncludesCurl
 */
 
@@ -106,8 +112,14 @@ let response: Resource[] =
 // end-block includesResponse
 
 /*
+  // start-block searchIncludeIterateCli
+  medplum get 'Observation?code=78012-2&_include=Observation:patient&_include:iterate=Patient:general-practitioner'
+  // end-block searchIncludeIterateCli
+
   // start-block searchIncludeIterateCurl
-  curl https://api.medplum.com/fhir/R4/Observation?code=78012-2&_include=Observation:patient&_include:iterate=Patient:general-practitioner
+  curl 'https://api.medplum.com/fhir/R4/Observation?code=78012-2&_include=Observation:patient&_include:iterate=Patient:general-practitioner' \
+    -H 'authorization: Bearer $ACCESS_TOKEN' \
+    -H 'content-type: application/fhir+json' \
   // end-block searchIncludeIterateCurl
 */
 
@@ -193,5 +205,84 @@ response =
     },
   ];
 // end-block iterateResponse
+
+// start-block relatedPersonTs
+await medplum.searchResources('Patient', {
+  _id: 'lisa-simpson',
+  _revinclude: 'RelatedPerson:patient',
+});
+// end-block relatedPersonTs
+
+/*
+// start-block relatedPersonCli
+medplum get 'Patient?_id=lisa-simpson&_revinclude=RelatedPerson:patient'
+// end-block relatedPersonCli
+
+// start-block relatedPersonCurl
+curl 'https://api.medplum.com/fhir/R4/Patient?_id=lisa-simpson&_revinclude=RelatedPerson:patient' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block relatedPersonCurl
+*/
+
+// start-block relatedPersonPatientTs
+await medplum.searchResources('Patient', {
+  _id: 'lisa-simpson',
+  _revinclude: 'RelatedPerson:patient',
+  '_revinclude:iterate': 'Patient:link',
+});
+// end-block relatedPersonPatientTs
+
+/*
+// start-block relatedPersonPatientCli
+medplum get 'Patient?_id=lisa-simpson&_revinclude=RelatedPerson:patient&_revinclude:iterate=Patient:link'
+// end-block relatedPersonPatientCli
+
+// start-block relatedPersonPatientCurl
+curl 'https://api.medplum.com/fhir/R4/Patient?_id=lisa-simpson&_revinclude=RelatedPerson:patient&_revinclude:iterate=Patient:link' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block relatedPersonPatientCurl
+*/
+
+// start-block locationPractitionerRoleTs
+await medplum.searchResources('Location', {
+  _id: 'example-location',
+  _revinclude: 'PractitionerRole:location',
+  '_include:iterate': 'PractitionerRole:practitioner',
+});
+// end-block locationPractitionerRoleTs
+
+/*
+// start-block locationPractitionerRoleCli
+medplum get ‘Location?_id=example-location&_revinclude=PractitionerRole:location&_include:iterate=PractitionerRole:practitioner’
+// end-block locationPractitionerRoleCli
+
+// start-block locationPractitionerRoleCurl
+curl 'https://api.medplum.com/fhir/R4/Location?_id=example-location&_revinclude=PractitionerRole:location&_include:iterate=PractitionerRole:practitioner' \
+  -H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block locationPractitionerRoleCurl
+*/
+
+// start-block careTeamTs
+await medplum.searchResources('Patient', {
+  _id: 'homer-simpson',
+  _revinclude: 'CareTeam:patient',
+  '_include:iterate': 'CareTeam:participant',
+});
+// end-block careTeamTs
+
+/*
+// start-block careTeamCli
+medplum get 'Patient?_id=homer-simpson&_revinclude=CareTeam:patient&_include:iterate=CareTeam:participant'
+// end-block careTeamCli
+
+// start-block careTeamCurl
+curl 'https://api.medplum.com/fhir/R4/Patient?_id=homer-simpson&_revinclude=CareTeam:patient&_include:iterate=CareTeam:participant' \
+	-H 'authorization: Bearer $ACCESS_TOKEN' \
+  -H 'content-type: application/fhir+json' \
+// end-block careTeamCurl
+*/
 
 console.log(response); // Needed to make the example compile, so `response` isn't unused


### PR DESCRIPTION
This will provide more examples in the include search docs of how to use the `_include`, `_revinclude`, and `:iterate` parameters/modifier. It also adds CLI examples to the existing examples. This is related to issue #3355 