### PR TITLE
Improve cross linking to `$clone` operation docs

### DIFF
--- a/packages/docs/docs/bots/unit-testing-bots.mdx
+++ b/packages/docs/docs/bots/unit-testing-bots.mdx
@@ -117,6 +117,10 @@ This example searches for all `Patient` resources named 'Alex'. It also uses the
 
 A transaction `Bundle` can be used directly in a batch request, and can be passed as an argument to `executeBatch` on your `MockClient`. This allows you to easily create test resoures from already existing data.
 
+#### Cloning an Existing Projects
+
+If you want to clone an existing project into a new environment, you can use the `$clone` operation. For more details [see the Projects guide](/docs/access/projects##cloning-and-expunging-projects).
+
 ### Invoke your Bot
 
 After setting up your mock resources, you can invoke your bot by calling your bot's handler function. See the ["Bot Basics" tutorial](/docs/bots/bot-basics#editing-a-bot) for more information about the arguments to `handler`

--- a/packages/docs/docs/fhir-datastore/create-fhir-data.mdx
+++ b/packages/docs/docs/fhir-datastore/create-fhir-data.mdx
@@ -23,6 +23,10 @@ These three requirements will need to be in place to connect
   {ExampleCode}
 </MedplumCodeBlock>
 
+:::tip Cloning an existing project
+If you have an existing project, and want to copy your data to a new environment (for example to a staging environment), this can easily be done using the `$clone` operation. For more details [ee the Projects guide](/docs/access/projects##cloning-and-expunging-projects).
+:::
+
 ## Example App - Simple Lab Results Workflow
 
 This example represents a common healthcare workflow, creating an order for lab tests (a.k.a `ServiceRequest` in FHIR) for patients and when the lab test is complete creating results (a.k.a. `Observation` and `DiagnosticReport` in FHIR) that correspond to the original `ServiceRequest`.

--- a/packages/docs/docs/fhir-datastore/fhir-batch-requests.mdx
+++ b/packages/docs/docs/fhir-datastore/fhir-batch-requests.mdx
@@ -8,6 +8,10 @@ import ExampleCode from '!!raw-loader!@site/..//examples/src/fhir-datastore/fhir
 
 FHIR allows users to create batch requests to bundle multiple API calls into a single HTTP request. Batch requests can improve speed and efficiency and can reduce HTTP traffic when working with many resources.
 
+:::tip Cloning a project
+If you want to create a copy of a project, say for a new environment, this can be done using the `$clone` operation rather than by creating a batch request. For more details [see the Projects guide](/docs/access/projects##cloning-and-expunging-projects).
+:::
+
 ## How to Perform a Batch Request
 
 Batch requests are modeled using the `Bundle` resource by setting `Bundle.type` to `"batch"`.


### PR DESCRIPTION
This will add links to the `$clone` operation docs from different docs about creating data. Related to issue #3360 