### PR TITLE
Fixes #3370 - add back explicit types in package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,9 +31,16 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
+  "types": "dist/esm/index.d.mts",
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "files": [

--- a/packages/expo-polyfills/package.json
+++ b/packages/expo-polyfills/package.json
@@ -19,11 +19,18 @@
   "license": "Apache-2.0",
   "author": "Medplum <hello@medplum.com>",
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/cjs/index.d.cts",
   "files": [
     "dist/cjs",
     "dist/esm"

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -30,11 +30,18 @@
   "author": "Medplum <hello@medplum.com>",
   "sideEffects": false,
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/cjs/index.d.cts",
   "files": [
     "dist/cjs",
     "dist/esm"

--- a/packages/hl7/package.json
+++ b/packages/hl7/package.json
@@ -30,11 +30,18 @@
   "author": "Medplum <hello@medplum.com>",
   "sideEffects": false,
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/cjs/index.d.cts",
   "files": [
     "dist/cjs",
     "dist/esm"

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -30,11 +30,18 @@
   "author": "Medplum <hello@medplum.com>",
   "sideEffects": false,
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/cjs/index.d.cts",
   "files": [
     "dist/cjs",
     "dist/esm"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -34,11 +34,18 @@
   "author": "Medplum <hello@medplum.com>",
   "sideEffects": false,
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/cjs/index.d.cts",
   "files": [
     "dist/cjs",
     "dist/esm"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,11 +35,18 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs"
+    "import": {
+      "types": "./dist/esm/index.d.mts",
+      "default": "./dist/esm/index.mjs"
+    },
+    "require": {
+      "types": "./dist/cjs/index.d.cts",
+      "default": "./dist/cjs/index.cjs"
+    }
   },
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
+  "types": "dist/esm/index.d.mts",
   "files": [
     ".env.defaults",
     "dist/cjs",


### PR DESCRIPTION
`arethetypeswrong` still works:

<img width="319" alt="image" src="https://github.com/medplum/medplum/assets/749094/b225b4ac-8c34-4b3e-90b8-d401d87baae3">
