### PR TITLE
New resource diff page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56740,6 +56740,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "6.18.0",
+        "rfc6902": "5.0.1",
         "vite": "4.5.0"
       },
       "engines": {
@@ -57134,6 +57135,7 @@
         "jest-each": "29.7.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "rfc6902": "5.0.1",
         "rimraf": "5.0.5",
         "storybook": "7.5.3",
         "typescript": "5.2.2"
@@ -57148,7 +57150,8 @@
         "@mantine/notifications": "^6.0.0",
         "@medplum/core": "*",
         "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "react-dom": "^17.0.2 || ^18.0.0",
+        "rfc6902": "^5.0.1"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -57161,6 +57164,9 @@
           "optional": true
         },
         "@mantine/notifications": {
+          "optional": true
+        },
+        "rfc6902": {
           "optional": true
         }
       }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "6.18.0",
+    "rfc6902": "5.0.1",
     "vite": "4.5.0"
   },
   "engines": {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2003,15 +2003,15 @@ export class MedplumClient extends EventTarget {
     if (!resource.id) {
       throw new Error('Missing id');
     }
-    this.invalidateSearches(resource.resourceType);
     let result = await this.put(this.fhirUrl(resource.resourceType, resource.id), resource, undefined, options);
     if (!result) {
       // On 304 not modified, result will be undefined
       // Return the user input instead
-      // return result ?? resource;
       result = resource;
     }
     this.cacheResource(result);
+    this.invalidateUrl(this.fhirUrl(resource.resourceType, resource.id, '_history'));
+    this.invalidateSearches(resource.resourceType);
     return result;
   }
 

--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -10,7 +10,7 @@ import {
   UnionAtom,
 } from '../fhirpath/atoms';
 import { parseFhirPath } from '../fhirpath/parse';
-import { getElementDefinition, globalSchema, PropertyType } from '../types';
+import { PropertyType, getElementDefinition, globalSchema } from '../types';
 import { InternalSchemaElement } from '../typeschema/types';
 import { capitalize } from '../utils';
 
@@ -261,6 +261,10 @@ function flattenAtom(atom: Atom): Atom[] {
   if (atom instanceof FunctionAtom) {
     if (atom.name === 'where' && !(atom.args[0] instanceof IsAtom)) {
       // Remove all "where" functions other than "where(x as type)"
+      return [];
+    }
+    if (atom.name === 'last') {
+      // Remove all "last" functions
       return [];
     }
   }

--- a/packages/react/esbuild.mjs
+++ b/packages/react/esbuild.mjs
@@ -35,6 +35,7 @@ const options = {
     'react',
     'react-dom',
     'react-router-dom',
+    'rfc6902',
   ],
 };
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -90,6 +90,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "rimraf": "5.0.5",
+    "rfc6902": "5.0.1",
     "storybook": "7.5.3",
     "typescript": "5.2.2"
   },
@@ -100,7 +101,8 @@
     "@mantine/notifications": "^6.0.0",
     "@medplum/core": "*",
     "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react-dom": "^17.0.2 || ^18.0.0",
+    "rfc6902": "^5.0.1"
   },
   "peerDependenciesMeta": {
     "@emotion/react": {
@@ -113,6 +115,9 @@
       "optional": true
     },
     "@mantine/notifications": {
+      "optional": true
+    },
+    "rfc6902": {
       "optional": true
     }
   },

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -1,7 +1,7 @@
 import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { act, render, screen, waitFor } from '@testing-library/react';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { ResourceDiffTable, ResourceDiffTableProps } from './ResourceDiffTable';
 
 const medplum = new MockClient();
@@ -40,7 +40,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Property'));
+    await waitFor(() => screen.getByText('Replace active'));
 
     const removed = screen.getByText('false');
     expect(removed).toBeDefined();

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -1,10 +1,10 @@
 import { createStyles } from '@mantine/core';
-import { getDataType, getPropertyDisplayName, stringify, toTypedValue } from '@medplum/core';
+import { capitalize, evalFhirPathTyped, getSearchParameterDetails, toTypedValue } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
-import { useEffect, useState } from 'react';
 import { useMedplum } from '@medplum/react-hooks';
+import { useEffect, useState } from 'react';
+import { createPatch } from 'rfc6902';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
-import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 
 const useStyles = createStyles((theme) => ({
   root: {
@@ -23,11 +23,15 @@ const useStyles = createStyles((theme) => ({
 
   removed: {
     color: theme.colors.red[7],
+    fontFamily: 'monospace',
     textDecoration: 'line-through',
+    whiteSpace: 'pre-wrap',
   },
 
   added: {
     color: theme.colors.green[7],
+    fontFamily: 'monospace',
+    whiteSpace: 'pre-wrap',
   },
 }));
 
@@ -52,56 +56,62 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
     return null;
   }
 
-  const typeSchema = getDataType(props.original.resourceType);
+  const patch = createPatch(props.original, props.revised);
+  const typedOriginal = [toTypedValue(props.original)];
+  const typedRevised = [toTypedValue(props.revised)];
 
   return (
     <table className={classes.root}>
-      <colgroup>
-        <col style={{ width: '30%' }} />
-        <col style={{ width: '35%' }} />
-        <col style={{ width: '35%' }} />
-      </colgroup>
       <thead>
         <tr>
-          <th>Property</th>
+          <th />
           <th>Before</th>
           <th>After</th>
         </tr>
       </thead>
       <tbody>
-        {Object.entries(typeSchema.elements).map(([key, property]) => {
-          if (key === 'id' || key === 'meta') {
+        {patch.map((op) => {
+          if (op.path.startsWith('/meta')) {
             return null;
           }
 
-          const [originalPropertyValue, originalPropertyType] = getValueAndType(toTypedValue(props.original), key);
-          const [revisedPropertyValue, revisedPropertyType] = getValueAndType(toTypedValue(props.revised), key);
-          if (isEmpty(originalPropertyValue) && isEmpty(revisedPropertyValue)) {
-            return null;
-          }
-
-          if (stringify(originalPropertyValue) === stringify(revisedPropertyValue)) {
-            return null;
-          }
+          const path = op.path;
+          const fhirPath = jsonPathToFhirPath(path);
+          const details = getSearchParameterDetails(props.original.resourceType, {
+            resourceType: 'SearchParameter',
+            base: [props.original.resourceType],
+            code: props.original.resourceType + '.' + fhirPath,
+            expression: props.original.resourceType + '.' + fhirPath,
+          });
+          const property = details?.elementDefinitions?.[0];
+          const isArray = !!property?.isArray;
+          const originalValue = op.op === 'add' ? undefined : evalFhirPathTyped(fhirPath, typedOriginal)?.[0];
+          const revisedValue = op.op === 'remove' ? undefined : evalFhirPathTyped(fhirPath, typedRevised)?.[0];
 
           return (
-            <tr key={key}>
-              <td>{getPropertyDisplayName(key)}</td>
+            <tr key={`op-${op.op}-${op.path}`}>
+              <td>
+                {capitalize(op.op)} {fhirPath}
+              </td>
               <td className={classes.removed}>
-                <ResourcePropertyDisplay
-                  property={property}
-                  propertyType={originalPropertyType}
-                  value={originalPropertyValue}
-                  ignoreMissingValues={true}
-                />
+                {originalValue && (
+                  <ResourcePropertyDisplay
+                    property={property}
+                    propertyType={originalValue.type}
+                    value={fixArray(originalValue.value, isArray)}
+                    ignoreMissingValues={true}
+                  />
+                )}
               </td>
               <td className={classes.added}>
-                <ResourcePropertyDisplay
-                  property={property}
-                  propertyType={revisedPropertyType}
-                  value={revisedPropertyValue}
-                  ignoreMissingValues={true}
-                />
+                {revisedValue && (
+                  <ResourcePropertyDisplay
+                    property={property}
+                    propertyType={revisedValue.type}
+                    value={fixArray(revisedValue.value, isArray)}
+                    ignoreMissingValues={true}
+                  />
+                )}
               </td>
             </tr>
           );
@@ -111,10 +121,31 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
   );
 }
 
-function isEmpty(value: unknown): boolean {
-  return (
-    !value ||
-    (Array.isArray(value) && value.length === 0) ||
-    (typeof value === 'object' && Object.keys(value).length === 0)
-  );
+function jsonPathToFhirPath(path: string): string {
+  const parts = path.split('/').filter(Boolean);
+  let result = '';
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === '-') {
+      result += '.last()';
+    } else if (/^\d+$/.test(part)) {
+      result += `[${part}]`;
+    } else {
+      if (i > 0) {
+        result += '.';
+      }
+      result += part;
+    }
+  }
+  return result;
+}
+
+function fixArray(inputValue: any, isArray: boolean): any {
+  if (Array.isArray(inputValue) && !isArray) {
+    return inputValue[0];
+  }
+  if (!Array.isArray(inputValue) && isArray) {
+    return [inputValue];
+  }
+  return inputValue;
 }


### PR DESCRIPTION
Before: a slow and naive diff implementation which only operated on top-level properties

After: Use the `rfc6902` package (which we already use) to generate a JSONPatch, and then show that JSONPatch in table form.

This is largely motivated by extremely slow diffs on `Questionnaire` timelines.... I have some questionnaires with 100+ questions and 100+ edits, and the page basically locks for 5-10 seconds.  This PR produces much more surgical diffs, which are smaller and faster.

There is one slightly janky piece to this.  I wanted to get feedback on the experience first, before doing a heavy refactor to clean it up.  To properly display the before/after property values, we need to get the property type for a FHIRPath expression.  We have a version of that inside `getSearchParameterDetails()`, which I used here.  It is a hack, which we can certainly clean up.

Before:

<img width="958" alt="image" src="https://github.com/medplum/medplum/assets/749094/9361f3bf-d5a1-4c73-92dd-6850d252b25c">

After:

<img width="957" alt="image" src="https://github.com/medplum/medplum/assets/749094/3a67cc36-4784-433b-ba7d-850a255152a1">
