### PR TITLE
chore(package.json): add `private: true` to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "root",
   "version": "2.1.20",
+  "private": true,
   "workspaces": [
     "packages/*",
     "examples/*"


### PR DESCRIPTION
Required for `yarn` to work with the monorepo: https://classic.yarnpkg.com/lang/en/docs/workspaces/#:~:text=Note%20that%20the%20private%3A%20true%20is%20required!%20Workspaces%20are%20not%20meant%20to%20be%20published%2C%20so%20we%E2%80%99ve%20added%20this%20safety%20measure%20to%20make%20sure%20that%20nothing%20can%20accidentally%20expose%20them.

This prevents publishing the `root` package to NPM, which kind of makes sense.

May help in resolving #3389 ?