### PR TITLE
Improve linking for using binary data

### DIFF
--- a/packages/docs/docs/charting/external-documents.md
+++ b/packages/docs/docs/charting/external-documents.md
@@ -18,7 +18,7 @@ See the [`DocumentReference` API guide](/docs/api/fhir/resources/documentreferen
 
 This is a similar process to [creating a PDF file from a Bot ](/docs/bots/creating-a-pdf).
 
-First, upload the binary file as a [`Binary`](/docs/api/fhir/resources/binary) resource. Then, create the corresponding `DocumentReference` as a pointer.
+First, upload the binary file as a [`Binary`](/docs/api/fhir/resources/binary) resource. Then, create the corresponding `DocumentReference` as a pointer. For more details on using [`Binary`] resources see the [Binary Data guide](/docs/fhir-datastore/binary-data#referencing-a-binary-in-an-attachment).
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">

--- a/packages/docs/docs/fhir-datastore/binary-data.mdx
+++ b/packages/docs/docs/fhir-datastore/binary-data.mdx
@@ -95,6 +95,10 @@ const communication = await medplum.createResource('Communication', {
 });
 ```
 
+:::caution Attachment Data
+When creating an [`Attachment`](/docs/api/fhir/datatypes/attachment), we recommend that you _do not_ use the `data` field to provide the full binary data string. This can make the attachment very large and can cause issues when making HTTP requests. See the [Handling External Files guide](/docs/charting/external-documents#example-creating-a-documentreference-for-a-binary-file) for an example of how to upload and reference [`Binary`](/docs/api/fhir/resources/binary) resources.
+:::
+
 ## Consuming a FHIR `Binary` in an Application
 
 In a normal FHIR server, when reading a FHIR resource that references a `Binary`, you'd receive a URL to the `Binary` resource.


### PR DESCRIPTION
This will provide clarity on how to use binary data as attachments and link between the binary data guide and the handling external files guide. Related to issue #3405 