### PR TITLE
feat(@medplum/core) Add `AbortSignal` support to client's `createBinary` and `createAttachment` methods

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1795,7 +1795,7 @@ export class MedplumClient extends EventTarget {
    * @param filename - Optional filename for the binary.
    * @param contentType - Content type for the binary.
    * @param onProgress - Optional callback for progress events.
-   * @param signal - Optional AbortSignal to short-circuit the request.
+   * @param signal - Optional AbortSignal to abort the request.
    * @returns The result of the create operation.
    */
   async createAttachment(
@@ -1836,7 +1836,7 @@ export class MedplumClient extends EventTarget {
    * @param filename - Optional filename for the binary.
    * @param contentType - Content type for the binary.
    * @param onProgress - Optional callback for progress events.
-   * @param signal - Optional AbortSignal to short-circuit the request.
+   * @param signal - Optional AbortSignal to abort the request.
    * @returns The result of the create operation.
    */
   createBinary(

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1794,8 +1794,8 @@ export class MedplumClient extends EventTarget {
    * @param data - The binary data to upload.
    * @param filename - Optional filename for the binary.
    * @param contentType - Content type for the binary.
-   * @param onProgress - Optional callback for progress events.
-   * @param signal - Optional AbortSignal to abort the request.
+   * @param onProgress - Optional callback for progress events. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
+   * @param options - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
    * @returns The result of the create operation.
    */
   async createAttachment(
@@ -1803,9 +1803,9 @@ export class MedplumClient extends EventTarget {
     filename: string | undefined,
     contentType: string,
     onProgress?: (e: ProgressEvent) => void,
-    signal?: AbortSignal
+    options?: RequestInit
   ): Promise<Attachment> {
-    const binary = await this.createBinary(data, filename, contentType, onProgress, signal);
+    const binary = await this.createBinary(data, filename, contentType, onProgress, options);
     return {
       contentType,
       url: binary.url,
@@ -1835,8 +1835,8 @@ export class MedplumClient extends EventTarget {
    * @param data - The binary data to upload.
    * @param filename - Optional filename for the binary.
    * @param contentType - Content type for the binary.
-   * @param onProgress - Optional callback for progress events.
-   * @param signal - Optional AbortSignal to abort the request.
+   * @param onProgress - Optional callback for progress events. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
+   * @param options - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
    * @returns The result of the create operation.
    */
   createBinary(
@@ -1844,7 +1844,7 @@ export class MedplumClient extends EventTarget {
     filename: string | undefined,
     contentType: string,
     onProgress?: (e: ProgressEvent) => void,
-    signal?: AbortSignal
+    options?: RequestInit
   ): Promise<Binary> {
     const url = this.fhirUrl('Binary');
     if (filename) {
@@ -1852,9 +1852,9 @@ export class MedplumClient extends EventTarget {
     }
 
     if (onProgress) {
-      return this.uploadwithProgress(url, data, contentType, onProgress, signal);
+      return this.uploadwithProgress(url, data, contentType, onProgress, options);
     } else {
-      return this.post(url, data, contentType, { signal });
+      return this.post(url, data, contentType, options);
     }
   }
 
@@ -1863,7 +1863,7 @@ export class MedplumClient extends EventTarget {
     data: BinarySource,
     contentType: string,
     onProgress: (e: ProgressEvent) => void,
-    signal?: AbortSignal
+    options?: RequestInit
   ): Promise<any> {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
@@ -1871,9 +1871,9 @@ export class MedplumClient extends EventTarget {
       // Ensure the 'abort' event listener is removed from the signal to prevent memory leaks,
       // especially in scenarios where there is a long-lived signal across multiple requests.
       const handleSignalAbort = (): void => xhr.abort();
-      signal?.addEventListener('abort', handleSignalAbort);
+      options?.signal?.addEventListener('abort', handleSignalAbort);
       const sendResult = (result: any): void => {
-        signal?.removeEventListener('abort', handleSignalAbort);
+        options?.signal?.removeEventListener('abort', handleSignalAbort);
 
         if (result instanceof Error) {
           reject(result);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1795,15 +1795,17 @@ export class MedplumClient extends EventTarget {
    * @param filename - Optional filename for the binary.
    * @param contentType - Content type for the binary.
    * @param onProgress - Optional callback for progress events.
+   * @param signal - Optional AbortSignal to short-circuit the request.
    * @returns The result of the create operation.
    */
   async createAttachment(
     data: BinarySource,
     filename: string | undefined,
     contentType: string,
-    onProgress?: (e: ProgressEvent) => void
+    onProgress?: (e: ProgressEvent) => void,
+    signal?: AbortSignal
   ): Promise<Attachment> {
-    const binary = await this.createBinary(data, filename, contentType, onProgress);
+    const binary = await this.createBinary(data, filename, contentType, onProgress, signal);
     return {
       contentType,
       url: binary.url,
@@ -1834,13 +1836,15 @@ export class MedplumClient extends EventTarget {
    * @param filename - Optional filename for the binary.
    * @param contentType - Content type for the binary.
    * @param onProgress - Optional callback for progress events.
+   * @param signal - Optional AbortSignal to short-circuit the request.
    * @returns The result of the create operation.
    */
   createBinary(
     data: BinarySource,
     filename: string | undefined,
     contentType: string,
-    onProgress?: (e: ProgressEvent) => void
+    onProgress?: (e: ProgressEvent) => void,
+    signal?: AbortSignal
   ): Promise<Binary> {
     const url = this.fhirUrl('Binary');
     if (filename) {
@@ -1848,9 +1852,9 @@ export class MedplumClient extends EventTarget {
     }
 
     if (onProgress) {
-      return this.uploadwithProgress(url, data, contentType, onProgress);
+      return this.uploadwithProgress(url, data, contentType, onProgress, signal);
     } else {
-      return this.post(url, data, contentType);
+      return this.post(url, data, contentType, { signal });
     }
   }
 
@@ -1858,13 +1862,29 @@ export class MedplumClient extends EventTarget {
     url: URL,
     data: BinarySource,
     contentType: string,
-    onProgress: (e: ProgressEvent) => void
+    onProgress: (e: ProgressEvent) => void,
+    signal?: AbortSignal
   ): Promise<any> {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
+
+      // Ensure the 'abort' event listener is removed from the signal to prevent memory leaks,
+      // especially in scenarios where there is a long-lived signal across multiple requests.
+      const handleSignalAbort = (): void => xhr.abort();
+      signal?.addEventListener('abort', handleSignalAbort);
+      const sendResult = (result: any): void => {
+        signal?.removeEventListener('abort', handleSignalAbort);
+
+        if (result instanceof Error) {
+          reject(result);
+        } else {
+          resolve(result);
+        }
+      };
+
       xhr.responseType = 'json';
-      xhr.onabort = () => reject(new Error('Request aborted'));
-      xhr.onerror = () => reject(new Error('Request error'));
+      xhr.onabort = () => sendResult(new Error('Request aborted'));
+      xhr.onerror = () => sendResult(new Error('Request error'));
 
       if (onProgress) {
         xhr.upload.onprogress = (e) => onProgress(e);
@@ -1873,9 +1893,9 @@ export class MedplumClient extends EventTarget {
 
       xhr.onload = () => {
         if (xhr.status >= 200 && xhr.status < 300) {
-          resolve(xhr.response);
+          sendResult(xhr.response);
         } else {
-          reject(new OperationOutcomeError(normalizeOperationOutcome(xhr.response || xhr.statusText)));
+          sendResult(new OperationOutcomeError(normalizeOperationOutcome(xhr.response || xhr.statusText)));
         }
       };
 


### PR DESCRIPTION
Add `AbortSignal` support to `createBinary` and `createAttachment` by exposing an optional `signal: AbortSignal` that is propagated to the clients fetch interface as well as the `XMLHttpRequest`