### PR TITLE
Stop reviving removed meta properties

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -145,6 +145,23 @@ describe('FHIR Repo', () => {
       expect(patient2.meta?.versionId).not.toEqual(patient1.meta?.versionId);
     }));
 
+  test('Update patient remove meta.profile', () =>
+    withTestContext(async () => {
+      const profileUrl = 'http://example.com/patient-profile';
+      const patient1 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        meta: { profile: [profileUrl] },
+        name: [{ given: ['Update1'], family: 'Update1' }],
+      });
+      expect(patient1.meta?.profile).toEqual(expect.arrayContaining([profileUrl]));
+      expect(patient1.meta?.profile?.length).toEqual(1);
+
+      const patientWithoutProfile = { ...patient1 };
+      delete (patientWithoutProfile.meta as any).profile;
+      const patient2 = await systemRepo.updateResource<Patient>(patientWithoutProfile);
+      expect('profile' in (patient2.meta as any)).toBe(false);
+    }));
+
   test('Update patient no changes', () =>
     withTestContext(async () => {
       const patient1 = await systemRepo.createResource<Patient>({

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -162,6 +162,32 @@ describe('FHIR Repo', () => {
       expect('profile' in (patient2.meta as any)).toBe(false);
     }));
 
+  test.only('meta.project preserved after attempting to remove it', () =>
+    withTestContext(async () => {
+      const clientApp = 'ClientApplication/' + randomUUID();
+      const projectId = randomUUID();
+      const repo = new Repository({
+        extendedMode: true,
+        project: projectId,
+        author: {
+          reference: clientApp,
+        },
+      });
+
+      const patient1 = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Update1'], family: 'Update1' }],
+      });
+      expect(patient1.meta?.project).toBeDefined();
+      expect(patient1.meta?.project).toEqual(projectId);
+
+      const patientWithoutProject = { ...patient1 };
+      delete (patientWithoutProject.meta as any).project;
+      const patient2 = await systemRepo.updateResource<Patient>(patientWithoutProject);
+      expect(patient2.meta?.project).toBeDefined();
+      expect(patient2.meta?.project).toEqual(projectId);
+    }));
+
   test('Update patient no changes', () =>
     withTestContext(async () => {
       const patient1 = await systemRepo.createResource<Patient>({

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -162,7 +162,7 @@ describe('FHIR Repo', () => {
       expect('profile' in (patient2.meta as any)).toBe(false);
     }));
 
-  test.only('meta.project preserved after attempting to remove it', () =>
+  test('meta.project preserved after attempting to remove it', () =>
     withTestContext(async () => {
       const clientApp = 'ClientApplication/' + randomUUID();
       const projectId = randomUUID();

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1362,7 +1362,7 @@ export class Repository extends BaseRepository implements FhirRepository {
       // and the current context is a ClientApplication (i.e., OAuth client credentials),
       // then allow the ClientApplication to set the date.
       const lastUpdated = resource.meta?.lastUpdated;
-      if (lastUpdated && this.canWriteMeta()) {
+      if (lastUpdated && this.canWriteProtectedMeta()) {
         return lastUpdated;
       }
     }
@@ -1394,7 +1394,7 @@ export class Repository extends BaseRepository implements FhirRepository {
     }
 
     const submittedProjectId = updated.meta?.project;
-    if (submittedProjectId && this.canWriteMeta()) {
+    if (submittedProjectId && this.canWriteProtectedMeta()) {
       // If the resource has an project (whether provided or from existing),
       // and the current context is allowed to write meta,
       // then use the provided value.
@@ -1418,7 +1418,7 @@ export class Repository extends BaseRepository implements FhirRepository {
     // and the current context is allowed to write meta,
     // then use the provided value.
     const author = resource.meta?.author;
-    if (author && this.canWriteMeta()) {
+    if (author && this.canWriteProtectedMeta()) {
       return author;
     }
 
@@ -1480,10 +1480,11 @@ export class Repository extends BaseRepository implements FhirRepository {
   }
 
   /**
-   * Determines if the current user can manually set meta fields.
-   * @returns True if the current user can manually set meta fields.
+   * Determines if the current user can manually set certain protected meta fields
+   * such as author, project, lastUpdated, etc.
+   * @returns True if the current user can manually set protected meta fields.
    */
-  private canWriteMeta(): boolean {
+  private canWriteProtectedMeta(): boolean {
     return this.isSuperAdmin();
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -471,10 +471,6 @@ export class Repository extends BaseRepository implements FhirRepository {
 
     const updated = await rewriteAttachments<T>(RewriteMode.REFERENCE, this, {
       ...this.restoreReadonlyFields(resource, existing),
-      meta: {
-        ...existing?.meta,
-        ...resource.meta,
-      },
     });
 
     const resultMeta = {


### PR DESCRIPTION
Title pretty much says it all. Previously, attempting to completely remove `resource.meta.profile` or any other property within a resource's meta resulted in it silently being preserved/restored when updating the resource.

I believe all meta fields expected to exist after an update are recreated later on in the function.