### PR TITLE
Create example bots that use a shared code library

### DIFF
--- a/examples/medplum-demo-bots/esbuild-script.js
+++ b/examples/medplum-demo-bots/esbuild-script.js
@@ -1,0 +1,34 @@
+import esbuild from 'esbuild';
+import { glob } from 'glob';
+
+// Find all TypeScript files in your source directory
+const entryPoints = glob.sync('./src/**/*.ts').filter((file) => !file.endsWith('test.ts'));
+
+const external = ['form-data', 'node-fetch', 'pdfmake', 'ssh2', 'ssh2-sftp-client', 'dotenv', '@medplum/core'];
+
+// Define the esbuild options
+const esbuildOptions = {
+  entryPoints: entryPoints,
+  bundle: true, // Bundle imported functions
+  outdir: './dist', // Output directory for compiled files
+  platform: 'node', // or 'node', depending on your target platform
+  loader: {
+    '.ts': 'ts', // Load TypeScript files
+  },
+  resolveExtensions: ['.ts'],
+  external,
+  format: 'cjs', // Set output format as ECMAScript modules
+  target: 'es2020', // Set the target ECMAScript version
+  tsconfig: 'tsconfig.json',
+};
+
+// Build using esbuild
+esbuild
+  .build(esbuildOptions)
+  .then(() => {
+    console.log('Build completed successfully!');
+  })
+  .catch((error) => {
+    console.error('Build failed:', JSON.stringify(error, null, 2));
+    process.exit(1);
+  });

--- a/examples/medplum-demo-bots/esbuild-script.mjs
+++ b/examples/medplum-demo-bots/esbuild-script.mjs
@@ -1,3 +1,8 @@
+/* global console */
+/* global process */
+/* eslint no-console: "off" */
+/*eslint no-process-exit: "off"*/
+
 import esbuild from 'esbuild';
 import { glob } from 'glob';
 

--- a/examples/medplum-demo-bots/medplum.config.json
+++ b/examples/medplum-demo-bots/medplum.config.json
@@ -74,13 +74,13 @@
     },
     {
       "name": "welcome-patient",
-      "id": "c7c4c2a2-d5fc-43e9-b892-37b94149f541",
+      "id": "",
       "source": "./src/bots-with-shared-library/welcome-patient.ts",
       "dist": "./dist/bots-with-shared-library/welcome-patient.js"
     },
     {
       "name": "goodbye-patient",
-      "id": "3d123930-aa11-49eb-96fa-ac928d3eac3d",
+      "id": "",
       "source": "./src/bots-with-shared-library/goodbye-patient.ts",
       "dist": "./dist/bots-with-shared-library/welcome-patient.js"
     }

--- a/examples/medplum-demo-bots/medplum.config.json
+++ b/examples/medplum-demo-bots/medplum.config.json
@@ -71,6 +71,18 @@
       "id": "",
       "source": "src/deduplication/merge-matching-patients.ts",
       "dist": "dist/deduplication/merge-matching-patients.js"
+    },
+    {
+      "name": "welcome-patient",
+      "id": "c7c4c2a2-d5fc-43e9-b892-37b94149f541",
+      "source": "./src/bots-with-shared-library/welcome-patient.ts",
+      "dist": "./dist/bots-with-shared-library/welcome-patient.js"
+    },
+    {
+      "name": "goodbye-patient",
+      "id": "3d123930-aa11-49eb-96fa-ac928d3eac3d",
+      "source": "./src/bots-with-shared-library/goodbye-patient.ts",
+      "dist": "./dist/bots-with-shared-library/welcome-patient.js"
     }
   ]
 }

--- a/examples/medplum-demo-bots/package.json
+++ b/examples/medplum-demo-bots/package.json
@@ -39,6 +39,7 @@
     "@vitest/coverage-v8": "0.34.6",
     "@vitest/ui": "0.34.6",
     "form-data": "4.0.0",
+    "glob": "^10.3.10",
     "node-fetch": "2.7.0",
     "pdfmake": "0.2.8",
     "ssh2-sftp-client": "9.1.0",

--- a/examples/medplum-demo-bots/package.json
+++ b/examples/medplum-demo-bots/package.json
@@ -4,8 +4,10 @@
   "description": "Medplum Demo Bots",
   "license": "Apache-2.0",
   "author": "Medplum <hello@medplum.com>",
+  "type": "module",
   "scripts": {
-    "build": "tsc",
+    "clean": "rimraf dist",
+    "build": "npm run clean && npm run lint && tsc && node esbuild-script.js",
     "lint": "eslint src/",
     "prettier": "prettier --write .",
     "test": "vitest run",

--- a/examples/medplum-demo-bots/package.json
+++ b/examples/medplum-demo-bots/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run lint && tsc && node esbuild-script.js",
+    "build": "npm run clean && npm run lint && tsc && node esbuild-script.mjs",
     "lint": "eslint src/",
     "prettier": "prettier --write .",
     "test": "vitest run",

--- a/examples/medplum-demo-bots/src/bots-with-shared-library/goodbye-patient.test.ts
+++ b/examples/medplum-demo-bots/src/bots-with-shared-library/goodbye-patient.test.ts
@@ -1,0 +1,22 @@
+import { Patient } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { test, expect } from 'vitest';
+import { handler } from './goodbye-patient';
+
+const medplum = new MockClient();
+
+test('Say goodbye', async () => {
+  const patient: Patient = await medplum.createResource({
+    resourceType: 'Patient',
+    name: [
+      {
+        given: ['Homer'],
+        family: 'Simpson',
+      },
+    ],
+  });
+
+  const goodbyeMessage = await handler(medplum, { input: patient, contentType: 'text/plain', secrets: {} });
+  expect(goodbyeMessage).toBeDefined();
+  expect(goodbyeMessage).toEqual('Goodbye Homer Simpson');
+});

--- a/examples/medplum-demo-bots/src/bots-with-shared-library/goodbye-patient.ts
+++ b/examples/medplum-demo-bots/src/bots-with-shared-library/goodbye-patient.ts
@@ -1,0 +1,9 @@
+import { MedplumClient, BotEvent } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { getPatientName } from './helpers';
+
+export async function handler(medplum: MedplumClient, event: BotEvent): Promise<any> {
+  const patient = event.input as Patient;
+  const patientName = getPatientName(patient);
+  return `Goodbye ${patientName}`;
+}

--- a/examples/medplum-demo-bots/src/bots-with-shared-library/helpers.ts
+++ b/examples/medplum-demo-bots/src/bots-with-shared-library/helpers.ts
@@ -1,0 +1,7 @@
+import { Patient } from '@medplum/fhirtypes';
+
+export function getPatientName(patient: Patient): string {
+  const firstName = patient.name?.[0]?.given?.[0];
+  const lastName = patient.name?.[0]?.family;
+  return `${firstName} ${lastName}`;
+}

--- a/examples/medplum-demo-bots/src/bots-with-shared-library/welcome-patient.test.ts
+++ b/examples/medplum-demo-bots/src/bots-with-shared-library/welcome-patient.test.ts
@@ -1,0 +1,22 @@
+import { MockClient } from '@medplum/mock';
+import { handler } from './welcome-patient';
+import { test, expect } from 'vitest';
+import { Patient } from '@medplum/fhirtypes';
+
+const medplum = new MockClient();
+
+test('Welcome Patient', async () => {
+  const patient: Patient = await medplum.createResource({
+    resourceType: 'Patient',
+    name: [
+      {
+        given: ['Marge'],
+        family: 'Simpson',
+      },
+    ],
+  });
+
+  const welcomeMessage = await handler(medplum, { input: patient, secrets: {}, contentType: 'text/plain' });
+  expect(welcomeMessage).toBeDefined();
+  expect(welcomeMessage).toEqual('Welcome Marge Simpson');
+});

--- a/examples/medplum-demo-bots/src/bots-with-shared-library/welcome-patient.ts
+++ b/examples/medplum-demo-bots/src/bots-with-shared-library/welcome-patient.ts
@@ -1,0 +1,9 @@
+import { BotEvent, MedplumClient } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { getPatientName } from './helpers';
+
+export async function handler(medplum: MedplumClient, event: BotEvent): Promise<any> {
+  const patient = event.input as Patient;
+  const patientName = getPatientName(patient);
+  return `Welcome ${patientName}`;
+}

--- a/examples/medplum-demo-bots/tsconfig.json
+++ b/examples/medplum-demo-bots/tsconfig.json
@@ -25,7 +25,9 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": true,
     "allowJs": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "isolatedModules": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/examples/medplum-demo-bots/tsconfig.json
+++ b/examples/medplum-demo-bots/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "lib": ["esnext", "DOM"],
+    "lib": ["esnext"],
     "types": ["vitest/globals"],
     "target": "es2018",
     "module": "commonjs",

--- a/examples/medplum-demo-bots/tsconfig.json
+++ b/examples/medplum-demo-bots/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "lib": ["esnext"],
+    "lib": ["esnext", "DOM"],
     "types": ["vitest/globals"],
     "target": "es2018",
     "module": "commonjs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -290,12 +290,96 @@
         "@vitest/coverage-v8": "0.34.6",
         "@vitest/ui": "0.34.6",
         "form-data": "4.0.0",
+        "glob": "^10.3.10",
         "node-fetch": "2.7.0",
         "pdfmake": "0.2.8",
         "ssh2-sftp-client": "9.1.0",
         "stripe": "14.5.0",
         "typescript": "5.3.2",
         "vitest": "0.34.6"
+      }
+    },
+    "examples/medplum-demo-bots/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "examples/medplum-demo-bots/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/medplum-demo-bots/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/medplum-demo-bots/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/medplum-demo-bots/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "examples/medplum-demo-bots/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "examples/medplum-fhircast-demo": {


### PR DESCRIPTION
This updates the build system in the medplum-demo-bots directory to use esbuild so that bots can import functions from a shared library. It also provides two very simple example bots that share a function between them.