### PR TITLE
Add cli option - do not write bot to config

### DIFF
--- a/packages/cli/src/bot.test.ts
+++ b/packages/cli/src/bot.test.ts
@@ -294,6 +294,28 @@ describe('CLI Bots', () => {
     expect(console.log).toBeCalledWith(expect.stringMatching('Error while creating new bot'));
   });
 
+  test('Create bot do not write to config', async () => {
+    // No bot config
+    (fs.existsSync as unknown as jest.Mock).mockReturnValue(false);
+    (fs.readFileSync as unknown as jest.Mock).mockReturnValue('');
+    (fs.writeFileSync as unknown as jest.Mock).mockImplementation(() => {});
+
+    await main([
+      'node',
+      'index.js',
+      'bot',
+      'create',
+      'test-bot',
+      '1',
+      'src/hello-world.ts',
+      'dist/src/hello-world.ts',
+      '--no-write-config',
+    ]);
+    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
+    expect(fs.existsSync).toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+  });
+
   // Deprecated bot commands
 
   test('Deprecate Deploy bot missing name', async () => {

--- a/packages/cli/src/bots.ts
+++ b/packages/cli/src/bots.ts
@@ -40,10 +40,11 @@ botCreateCommand
   .arguments('<botName> <projectId> <sourceFile> <distFile>')
   .description('Creating a bot')
   .option('--runtime-version <runtimeVersion>', 'Runtime version (awslambda, vmcontext)')
+  .option('--no-write-config', 'Do not write bot to config')
   .action(async (botName, projectId, sourceFile, distFile, options) => {
     const medplum = await createMedplumClient(options);
 
-    await createBot(medplum, botName, projectId, sourceFile, distFile, options.runtimeVersion);
+    await createBot(medplum, botName, projectId, sourceFile, distFile, options.runtimeVersion, !!options.writeConfig);
   });
 
 export async function botWrapper(medplum: MedplumClient, botName: string, deploy = false): Promise<void> {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -93,7 +93,8 @@ export async function createBot(
   projectId: string,
   sourceFile: string,
   distFile: string,
-  runtimeVersion?: string
+  runtimeVersion?: string,
+  writeConfig?: boolean
 ): Promise<void> {
   try {
     const body = {
@@ -114,7 +115,9 @@ export async function createBot(
     await deployBot(medplum, botConfig as MedplumBotConfig, bot);
     console.log(`Success! Bot created: ${bot.id}`);
 
-    addBotToConfig(botConfig);
+    if (writeConfig) {
+      addBotToConfig(botConfig);
+    }
   } catch (err) {
     console.log('Error while creating new bot: ' + err);
   }


### PR DESCRIPTION
Fixes #3121 

- Added cli option --no-write-config. in bot.ts. When enabled, bots are not written to medplum.config.json file.
- Added test in bot.test.ts.

Without option -
![image](https://github.com/medplum/medplum/assets/85165953/13490f25-dd3c-4590-a47d-15c74c10ac8e)

With --no-write-config -
![image](https://github.com/medplum/medplum/assets/85165953/a1929b29-b1f0-445c-8f59-62071f3b21ec)
