### PR TITLE
Fixes #3391 - github action for prepare-release.sh

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/medplum/projects/1
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}
       - uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/medplum/projects/3
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}
           labeled: customer

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,20 @@
+name: Prepare release
+
+on: workflow_dispatch
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Prepare release
+        run: ./scripts/prepare-release.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Bonus: using `MEDPLUM_BOT_GITHUB_ACCESS_TOKEN` in `add-issue-to-project.yml` so it shows up as @medplumbot  rather than @codyebberson 