### PR TITLE
Fixes #3391 - setup git in preapare-release-yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - name: Setup git
+        run: |
+          git config --global user.email "${{ secrets.MEDPLUM_BOT_EMAIL }}"
+          git config --global user.name "${{ secrets.MEDPLUM_BOT_NAME }}"
       - name: Prepare release
         run: ./scripts/prepare-release.sh
         env:


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/3443

Unfortunately the first attempt failed: 

<img width="651" alt="image" src="https://github.com/medplum/medplum/assets/749094/34fd8514-e73d-43dc-b13a-24ba49ad3282">

Using the fix suggested here: https://stackoverflow.com/questions/62924553/git-doesnt-know-my-name-email-when-github-actions-deploy-r-package-documentatio