### PR TITLE
Fix icons in batch page - prevent overriding by loading

### DIFF
--- a/packages/app/src/BatchPage.tsx
+++ b/packages/app/src/BatchPage.tsx
@@ -17,6 +17,7 @@ interface ShowNotificationProps {
   icon?: JSX.Element | null;
   withCloseButton?: boolean;
   method?: 'show' | 'update';
+  loading?: boolean;
 }
 
 function showNotification({
@@ -27,10 +28,11 @@ function showNotification({
   icon,
   withCloseButton = false,
   method = 'show',
+  loading,
 }: ShowNotificationProps): void {
   notifications[method]({
     id,
-    loading: true,
+    loading,
     title,
     message,
     color,
@@ -53,6 +55,7 @@ export function BatchPage(): JSX.Element {
         title: 'Batch Upload in Progress',
         message: 'Your batch data is being uploaded. This may take a moment...',
         method: 'show',
+        loading: true,
       });
 
       try {


### PR DESCRIPTION
Fixes #3455 

- Added loading field in ShowNotificationProps interface (loading=true only for batch upload in progress)

Before-
![image](https://github.com/medplum/medplum/assets/85165953/3c05a132-2e27-4df3-97db-de6a97baf2f9)

![image](https://github.com/medplum/medplum/assets/85165953/eec0371c-1f65-4556-9d96-506acfecbb80)

After-
![image](https://github.com/medplum/medplum/assets/85165953/6b1b3012-6af5-449b-8766-2d1914a375e9)

![image](https://github.com/medplum/medplum/assets/85165953/eb456516-6aa8-4a65-91bd-93b793673c3e)
