### PR TITLE
Fix assign-pull-request action for outside contributors

### DIFF
--- a/.github/workflows/assign-pull-request.yml
+++ b/.github/workflows/assign-pull-request.yml
@@ -20,10 +20,20 @@ jobs:
             });
 
             if (pr.data.assignees.length === 0) {
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                assignees: [context.actor],
-              });
+              try {
+                await github.rest.issues.checkUserCanBeAssigned({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  assignee: context.actor,
+                });
+
+                await github.rest.issues.addAssignees({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  assignees: [context.actor],
+                });
+              } catch (err) {
+                console.error(`Cannot assign PR #${context.issue.number} to ${context.actor}: ${err.message}`);
+              }
             }


### PR DESCRIPTION
See this PR from an external contributor: https://github.com/medplum/medplum/pull/3456

<img width="643" alt="image" src="https://github.com/medplum/medplum/assets/749094/0f07c730-3380-4e10-ac00-e7440e439a9f">

<img width="666" alt="image" src="https://github.com/medplum/medplum/assets/749094/85f27d32-cdf3-4813-8c96-d367d44606ee">

This PR first checks if the user can be assigned using [`checkUserCanBeAssigned`](https://octokit.github.io/rest.js/v20), and wraps everything in a `try` / `catch`.