### PR TITLE
Update undefined string condition in ResourcePropertyInputs

### DIFF
--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -38,7 +38,10 @@ export interface ResourcePropertyInputProps {
 
 export function ResourcePropertyInput(props: ResourcePropertyInputProps): JSX.Element {
   const property = props.property;
-  const propertyType = props.defaultPropertyType ?? property.type[0].code;
+  const propertyType =
+    props.defaultPropertyType && props.defaultPropertyType !== 'undefined'
+      ? props.defaultPropertyType
+      : property.type[0].code;
   const name = props.name;
   const value = props.defaultValue;
 


### PR DESCRIPTION
Fixes #3463 

The problem is because a **string propertyType** is returned from getValueAndType which is used in BackboneElementInput.

https://github.com/medplum/medplum/blob/63d62d922ceb3271582cbba3afe5a77d5008a52c/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.utils.ts#L13

https://github.com/medplum/medplum/blob/63d62d922ceb3271582cbba3afe5a77d5008a52c/packages/react/src/BackboneElementInput/BackboneElementInput.tsx#L50

And therefore this check in the ResourcePropertyInput is not enough and would fail for the **'undefined' string** _(not type)_
https://github.com/medplum/medplum/blob/63d62d922ceb3271582cbba3afe5a77d5008a52c/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx#L41

I have updated it to now check for both undefined type as well as string.
Now this would behave as an AttachmentArrayInput instead of being a ResourceArrayInput with multiple AttachmentInputs.
This also prevents multiple empty uploads as seen in the first picture below.

Before -
![image](https://github.com/medplum/medplum/assets/85165953/282b6961-4cfb-4967-8fab-b992445bec11)

After -
![image](https://github.com/medplum/medplum/assets/85165953/f97fa71f-71f3-4fea-9432-c321e09a68dd)
