### PR TITLE
Agent request response

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -67,6 +67,8 @@ export class App {
           case 'agent:transmit:request':
             this.pushMessage(command);
             break;
+          default:
+            this.log.error(`Unknown message type: ${command.type}`);
         }
       } catch (err) {
         this.log.error(`WebSocket error: ${normalizeErrorString(err)}`);

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -1,9 +1,9 @@
-import { Hl7Message, MedplumClient, normalizeErrorString } from '@medplum/core';
+import { AgentMessage, AgentTransmitRequest, Hl7Message, MedplumClient, normalizeErrorString } from '@medplum/core';
 import { AgentChannel, Endpoint, Reference } from '@medplum/fhirtypes';
 import { Hl7Client } from '@medplum/hl7';
 import { EventLogger } from 'node-windows';
 import WebSocket from 'ws';
-import { Channel, QueueItem } from './channel';
+import { Channel } from './channel';
 import { AgentDicomChannel } from './dicom';
 import { AgentHl7Channel } from './hl7';
 
@@ -11,9 +11,9 @@ export class App {
   static instance: App;
   readonly log: EventLogger;
   readonly webSocket: WebSocket;
-  readonly webSocketQueue: QueueItem[] = [];
+  readonly webSocketQueue: AgentMessage[] = [];
   readonly channels = new Map<string, Channel>();
-  readonly hl7Queue: QueueItem[] = [];
+  readonly hl7Queue: AgentMessage[] = [];
   live = false;
 
   constructor(
@@ -37,13 +37,11 @@ export class App {
     this.webSocket.binaryType = 'nodebuffer';
     this.webSocket.addEventListener('error', (err) => this.log.error(err.message));
     this.webSocket.addEventListener('open', () => {
-      this.webSocket.send(
-        JSON.stringify({
-          type: 'connect',
-          accessToken: medplum.getAccessToken(),
-          agentId,
-        })
-      );
+      this.sendToWebSocket({
+        type: 'agent:connect:request',
+        accessToken: medplum.getAccessToken() as string,
+        agentId,
+      });
     });
 
     this.webSocket.addEventListener('message', (e) => {
@@ -51,16 +49,22 @@ export class App {
         const data = e.data as Buffer;
         const str = data.toString('utf8');
         this.log.info(`Received from WebSocket: ${str.replaceAll('\r', '\n')}`);
-        const command = JSON.parse(str);
+        const command = JSON.parse(str) as AgentMessage;
         switch (command.type) {
+          // @ts-expect-error - Deprecated message type
           case 'connected':
+          case 'agent:connect:response':
             this.live = true;
             this.trySendToWebSocket();
             break;
+          // @ts-expect-error - Deprecated message type
           case 'transmit':
+          case 'agent:transmit:response':
             this.addToHl7Queue(command);
             break;
+          // @ts-expect-error - Deprecated message type
           case 'push':
+          case 'agent:transmit:request':
             this.pushMessage(command);
             break;
         }
@@ -104,12 +108,12 @@ export class App {
     this.log.info('Medplum service stopped successfully');
   }
 
-  addToWebSocketQueue(message: QueueItem): void {
+  addToWebSocketQueue(message: AgentMessage): void {
     this.webSocketQueue.push(message);
     this.trySendToWebSocket();
   }
 
-  addToHl7Queue(message: QueueItem): void {
+  addToHl7Queue(message: AgentMessage): void {
     this.hl7Queue.push(message);
     this.trySendToHl7Connection();
   }
@@ -119,13 +123,7 @@ export class App {
       while (this.webSocketQueue.length > 0) {
         const msg = this.webSocketQueue.shift();
         if (msg) {
-          this.webSocket.send(
-            JSON.stringify({
-              type: 'transmit',
-              accessToken: this.medplum.getAccessToken(),
-              ...msg,
-            })
-          );
+          this.sendToWebSocket(msg);
         }
       }
     }
@@ -134,7 +132,7 @@ export class App {
   private trySendToHl7Connection(): void {
     while (this.hl7Queue.length > 0) {
       const msg = this.hl7Queue.shift();
-      if (msg) {
+      if (msg && msg.type === 'agent:transmit:response') {
         const channel = this.channels.get(msg.channel);
         if (channel) {
           channel.sendToRemote(msg);
@@ -143,7 +141,16 @@ export class App {
     }
   }
 
-  private pushMessage(message: QueueItem): void {
+  private sendToWebSocket(message: AgentMessage): void {
+    this.webSocket.send(JSON.stringify(message));
+  }
+
+  private pushMessage(message: AgentTransmitRequest): void {
+    if (!message.remote) {
+      this.log.error('Missing remote address');
+      return;
+    }
+
     const address = new URL(message.remote);
     const client = new Hl7Client({
       host: address.hostname,

--- a/packages/agent/src/channel.ts
+++ b/packages/agent/src/channel.ts
@@ -1,11 +1,7 @@
-export interface QueueItem {
-  channel: string;
-  remote: string;
-  body: string;
-}
+import { AgentTransmitResponse } from '@medplum/core';
 
 export interface Channel {
   start(): void;
   stop(): void;
-  sendToRemote(message: QueueItem): void;
+  sendToRemote(message: AgentTransmitResponse): void;
 }

--- a/packages/agent/src/dicom.ts
+++ b/packages/agent/src/dicom.ts
@@ -1,8 +1,8 @@
-import { normalizeErrorString } from '@medplum/core';
+import { AgentTransmitResponse, normalizeErrorString } from '@medplum/core';
 import { AgentChannel, Endpoint } from '@medplum/fhirtypes';
 import * as dimse from 'dcmjs-dimse';
 import { App } from './app';
-import { Channel, QueueItem } from './channel';
+import { Channel } from './channel';
 
 export class AgentDicomChannel implements Channel {
   static instance: AgentDicomChannel;
@@ -31,7 +31,7 @@ export class AgentDicomChannel implements Channel {
     this.app.log.info('Channel stopped successfully');
   }
 
-  sendToRemote(msg: QueueItem): void {
+  sendToRemote(msg: AgentTransmitResponse): void {
     throw new Error(`sendToRemote not implemented (${JSON.stringify(msg)})`);
   }
 }
@@ -87,6 +87,8 @@ class DcmjsDimseScp extends dimse.Scp {
   ): void {
     try {
       App.instance.addToWebSocketQueue({
+        type: 'agent:transmit:request',
+        accessToken: App.instance.medplum.getAccessToken() as string,
         channel: AgentDicomChannel.instance.definition.name as string,
         remote: 'foo',
         body: JSON.stringify(request.getDataset()),

--- a/packages/agent/src/dicom.ts
+++ b/packages/agent/src/dicom.ts
@@ -1,4 +1,4 @@
-import { AgentTransmitResponse, normalizeErrorString } from '@medplum/core';
+import { AgentTransmitResponse, ContentType, normalizeErrorString } from '@medplum/core';
 import { AgentChannel, Endpoint } from '@medplum/fhirtypes';
 import * as dimse from 'dcmjs-dimse';
 import { App } from './app';
@@ -91,6 +91,7 @@ class DcmjsDimseScp extends dimse.Scp {
         accessToken: App.instance.medplum.getAccessToken() as string,
         channel: AgentDicomChannel.instance.definition.name as string,
         remote: 'foo',
+        contentType: ContentType.JSON,
         body: JSON.stringify(request.getDataset()),
       });
     } catch (err) {

--- a/packages/agent/src/hl7.test.ts
+++ b/packages/agent/src/hl7.test.ts
@@ -33,23 +33,23 @@ describe('HL7', () => {
     mockServer.on('connection', (socket) => {
       socket.on('message', (data) => {
         const command = JSON.parse((data as Buffer).toString('utf8'));
-        if (command.type === 'connect') {
+        if (command.type === 'agent:connect:request') {
           socket.send(
             Buffer.from(
               JSON.stringify({
-                type: 'connected',
+                type: 'agent:connect:response',
               })
             )
           );
         }
 
-        if (command.type === 'transmit') {
+        if (command.type === 'agent:transmit:request') {
           const hl7Message = Hl7Message.parse(command.body);
           const ackMessage = hl7Message.buildAck();
           socket.send(
             Buffer.from(
               JSON.stringify({
-                type: 'transmit',
+                type: 'agent:transmit:response',
                 channel: command.channel,
                 remote: command.remote,
                 body: ackMessage.toString(),
@@ -105,11 +105,11 @@ describe('HL7', () => {
       mySocket = socket;
       socket.on('message', (data) => {
         const command = JSON.parse((data as Buffer).toString('utf8'));
-        if (command.type === 'connect') {
+        if (command.type === 'agent:connect:request') {
           socket.send(
             Buffer.from(
               JSON.stringify({
-                type: 'connected',
+                type: 'agent:connect:response',
               })
             )
           );
@@ -160,7 +160,7 @@ describe('HL7', () => {
     wsClient.send(
       Buffer.from(
         JSON.stringify({
-          type: 'push',
+          type: 'agent:transmit:request',
           body:
             'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
             'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-\r' +

--- a/packages/agent/src/hl7.ts
+++ b/packages/agent/src/hl7.ts
@@ -1,4 +1,4 @@
-import { AgentTransmitResponse, Hl7Message, normalizeErrorString } from '@medplum/core';
+import { AgentTransmitResponse, ContentType, Hl7Message, normalizeErrorString } from '@medplum/core';
 import { AgentChannel, Endpoint } from '@medplum/fhirtypes';
 import { Hl7Connection, Hl7MessageEvent, Hl7Server } from '@medplum/hl7';
 import { App } from './app';
@@ -66,6 +66,7 @@ export class AgentHl7ChannelConnection {
         accessToken: this.channel.app.medplum.getAccessToken() as string,
         channel: this.channel.definition.name as string,
         remote: this.remote,
+        contentType: ContentType.HL7_V2,
         body: event.message.toString(),
       });
     } catch (err) {

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -24,13 +24,14 @@ export interface AgentConnectResponse extends BaseAgentMessage {
 export interface AgentTransmitRequest extends BaseAgentRequestMessage {
   type: 'agent:transmit:request';
   channel: string;
-  remote?: string;
+  remote: string;
   body: string;
 }
 
 export interface AgentTransmitResponse extends BaseAgentMessage {
   type: 'agent:transmit:response';
   channel: string;
+  remote: string;
   body: string;
 }
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1,0 +1,42 @@
+export interface BaseAgentMessage {
+  type: string;
+}
+
+export interface BaseAgentRequestMessage extends BaseAgentMessage {
+  accessToken: string;
+  callback?: string;
+}
+
+export interface AgentError extends BaseAgentMessage {
+  type: 'agent:error';
+  body: string;
+}
+
+export interface AgentConnectRequest extends BaseAgentRequestMessage {
+  type: 'agent:connect:request';
+  agentId: string;
+}
+
+export interface AgentConnectResponse extends BaseAgentMessage {
+  type: 'agent:connect:response';
+}
+
+export interface AgentTransmitRequest extends BaseAgentRequestMessage {
+  type: 'agent:transmit:request';
+  channel: string;
+  remote?: string;
+  body: string;
+}
+
+export interface AgentTransmitResponse extends BaseAgentMessage {
+  type: 'agent:transmit:response';
+  channel: string;
+  body: string;
+}
+
+export type AgentMessage =
+  | AgentError
+  | AgentConnectRequest
+  | AgentConnectResponse
+  | AgentTransmitRequest
+  | AgentTransmitResponse;

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1,10 +1,10 @@
 export interface BaseAgentMessage {
   type: string;
+  callback?: string;
 }
 
 export interface BaseAgentRequestMessage extends BaseAgentMessage {
-  accessToken: string;
-  callback?: string;
+  accessToken?: string;
 }
 
 export interface AgentError extends BaseAgentMessage {
@@ -23,15 +23,17 @@ export interface AgentConnectResponse extends BaseAgentMessage {
 
 export interface AgentTransmitRequest extends BaseAgentRequestMessage {
   type: 'agent:transmit:request';
-  channel: string;
+  channel?: string;
   remote: string;
+  contentType: string;
   body: string;
 }
 
 export interface AgentTransmitResponse extends BaseAgentMessage {
   type: 'agent:transmit:response';
-  channel: string;
+  channel?: string;
   remote: string;
+  contentType: string;
   body: string;
 }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2316,22 +2316,25 @@ export class MedplumClient extends EventTarget {
    * @param destination - The destination device.
    * @param body - The message body.
    * @param contentType - Optional message content type.
+   * @param waitForResponse - Optional wait for response flag.
    * @param options - Optional fetch options.
-   * @returns Promise to the operation outcome.
+   * @returns Promise to the result. If waiting for response, the result is the response body. Otherwise, it is an operation outcome.
    */
   pushToAgent(
     agent: Agent | Reference<Agent>,
     destination: Device | Reference<Device>,
     body: any,
     contentType?: string,
+    waitForResponse?: boolean,
     options?: RequestInit
-  ): Promise<OperationOutcome> {
+  ): Promise<any> {
     return this.post(
       this.fhirUrl('Agent', resolveId(agent) as string, '$push'),
       {
         destination: getReferenceString(destination),
         body,
         contentType,
+        waitForResponse,
       },
       ContentType.FHIR_JSON,
       options

--- a/packages/core/src/contenttype.ts
+++ b/packages/core/src/contenttype.ts
@@ -3,6 +3,7 @@
  */
 export const ContentType = {
   CSS: 'text/css',
+  DICOM: 'application/dicom',
   FAVICON: 'image/vnd.microsoft.icon',
   FHIR_JSON: 'application/fhir+json',
   FORM_URL_ENCODED: 'application/x-www-form-urlencoded',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './access';
+export * from './agent';
 export * from './base-schema';
 export * from './base64';
 export * from './bundle';

--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -1,16 +1,16 @@
+const values = new Map<string, string>();
 const subscribers = new Map<string, Set<Redis>>();
 
 class Redis {
-  private values: Map<string, string>;
-  private listeners: Map<string, ((...args: any[]) => void)[]>;
+  private callback?: (...args: any[]) => void;
 
-  constructor(readonly config: any) {
-    this.values = new Map<string, string>();
-    this.listeners = new Map<string, ((...args: any[]) => void)[]>();
-  }
+  constructor(readonly config: any) {}
 
   on(event: string, callback: (...args: any[]) => void): void {
-    this.listeners.set(event, [callback]);
+    if (event !== 'message') {
+      throw new Error('ioredis mock only supports message events');
+    }
+    this.callback = callback;
   }
 
   async ping(): Promise<string> {
@@ -18,40 +18,40 @@ class Redis {
   }
 
   async get(key: string): Promise<string | undefined> {
-    return this.values.get(key);
+    return values.get(key);
   }
 
   async mget(...keys: string[]): Promise<(string | undefined)[]> {
-    return keys.map((key) => this.values.get(key));
+    return keys.map((key) => values.get(key));
   }
 
   async set(key: string, value: string, ...args: (string | number)[]): Promise<undefined | null | string> {
     let oldValue;
     if (args.includes('GET')) {
-      oldValue = this.values.get(key) ?? null; // `ioredis` returns `null` when key didn't previously exist
+      oldValue = values.get(key) ?? null; // `ioredis` returns `null` when key didn't previously exist
     }
-    if (args.includes('NX') && this.values.has(key)) {
+    if (args.includes('NX') && values.has(key)) {
       return oldValue;
     }
-    this.values.set(key, value);
+    values.set(key, value);
     return oldValue;
   }
 
   async del(key: string | string[]): Promise<void> {
     if (Array.isArray(key)) {
       key.forEach((k) => {
-        this.values.delete(k);
+        values.delete(k);
       });
       return;
     }
-    this.values.delete(key);
+    values.delete(key);
   }
 
   async publish(channel: string, message: string): Promise<void> {
-    const listeners = this.listeners.get('message');
-    if (listeners) {
-      listeners.forEach((listener) => {
-        listener(channel, message);
+    const set = subscribers.get(channel);
+    if (set) {
+      set.forEach((subscriber) => {
+        subscriber.callback?.(channel, message);
       });
     }
   }
@@ -76,13 +76,13 @@ class Redis {
     }
   }
 
-  duplicate(): this {
-    // return new Redis(this.config);
-    return this;
+  duplicate(): Redis {
+    return new Redis(this.config);
   }
 
   disconnect(): void {
     // Disconnects
+    this.callback = undefined;
   }
 
   async pubsub(command: string, channel: string): Promise<unknown[]> {

--- a/packages/server/src/agent/websockets.test.ts
+++ b/packages/server/src/agent/websockets.test.ts
@@ -1,4 +1,4 @@
-import { allOk, ContentType, getReferenceString } from '@medplum/core';
+import { allOk, ContentType, getReferenceString, Hl7Message } from '@medplum/core';
 import { Agent, Bot, Device } from '@medplum/fhirtypes';
 import express from 'express';
 import { Server } from 'http';
@@ -113,7 +113,7 @@ describe('Agent WebSockets', () => {
         })
       )
       .expectText(
-        /{"type":"agent:transmit:response","channel":"test","remote":"0.0.0.0:57000","body":"MSH[^"]+ACK[^"]+"}/
+        /{"type":"agent:transmit:response","channel":"test","remote":"0.0.0.0:57000","contentType":"x-application\/hl7-v2\+er7","body":"MSH[^"]+ACK[^"]+"}/
       )
       .close()
       .expectClosed();
@@ -299,7 +299,99 @@ describe('Agent WebSockets', () => {
         expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
         expect(res.body).toMatchObject(allOk);
       })
-      .expectText(/{"type":"push",.+,"body":"MSH[^"]+ADT1[^"]+"}/)
+      .expectText(/{"type":"agent:transmit:request",.+,"body":"MSH[^"]+ADT1[^"]+"}/)
+      .close()
+      .expectClosed();
+  });
+
+  test('Push and wait for response timeout', async () => {
+    await request(server)
+      .ws('/ws/agent')
+      .sendText(
+        JSON.stringify({
+          type: 'agent:connect:request',
+          accessToken,
+          agentId: agent.id,
+        })
+      )
+      .expectText('{"type":"agent:connect:response"}')
+      .exec(async () => {
+        // Send a message that will never be responded to
+        // Wait for the timeout
+        const res = await request(server)
+          .post(`/fhir/R4/Agent/${agent.id}/$push`)
+          .set('Content-Type', ContentType.JSON)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send({
+            waitForResponse: true,
+            destination: getReferenceString(device),
+            contentType: ContentType.HL7_V2,
+            body:
+              'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
+              'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-\r' +
+              'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
+              'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-',
+          });
+        expect(res.status).toBe(400);
+        expect(res.body.issue[0].details.text).toBe('Timeout');
+      })
+      .close()
+      .expectClosed();
+  });
+
+  test('Push and wait for response success', async () => {
+    let pushRequest: any = undefined;
+    let pushResponse: any = undefined;
+
+    await request(server)
+      .ws('/ws/agent')
+      .sendText(
+        JSON.stringify({
+          type: 'agent:connect:request',
+          accessToken,
+          agentId: agent.id,
+        })
+      )
+      .expectText('{"type":"agent:connect:response"}')
+      .exec(async () => {
+        // Send the request but do not wait for the response
+        pushRequest = request(server)
+          .post(`/fhir/R4/Agent/${agent.id}/$push`)
+          .set('Content-Type', ContentType.JSON)
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send({
+            waitForResponse: true,
+            channel: 'test',
+            destination: getReferenceString(device),
+            contentType: ContentType.HL7_V2,
+            body:
+              'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
+              'PID|||PATID1234^5^M11||JONES^WILLIAM^A^III||19610615|M-\r' +
+              'NK1|1|JONES^BARBARA^K|SPO|||||20011105\r' +
+              'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-',
+          });
+        pushRequest.then(() => true);
+      })
+      .expectText((str) => {
+        const message = JSON.parse(str);
+        expect(message.type).toBe('agent:transmit:request');
+        expect(message.remote).toBe(device.url);
+        expect(message.callback).toBeDefined();
+        pushResponse = JSON.stringify({
+          type: 'agent:transmit:response',
+          callback: message.callback,
+          contentType: ContentType.HL7_V2,
+          body: Hl7Message.parse(message.body).buildAck().toString(),
+        });
+        return true;
+      })
+      .exec((ws) => ws.send(pushResponse))
+      .exec(async () => {
+        const res = await pushRequest;
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toBe('x-application/hl7-v2+er7; charset=utf-8');
+        expect(res.text).toMatch(/MSH.*ACK.*\r/);
+      })
       .close()
       .expectClosed();
   });

--- a/packages/server/src/agent/websockets.test.ts
+++ b/packages/server/src/agent/websockets.test.ts
@@ -92,16 +92,16 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"connected"}')
+      .expectText('{"type":"agent:connect:response"}')
       // Now transmit, should succeed
       .sendText(
         JSON.stringify({
-          type: 'transmit',
+          type: 'agent:transmit:request',
           accessToken,
           channel: 'test',
           remote: '0.0.0.0:57000',
@@ -112,7 +112,9 @@ describe('Agent WebSockets', () => {
             'PV1|1|I|2000^2012^01||||004777^LEBAUER^SIDNEY^J.|||SUR||-||1|A0-',
         })
       )
-      .expectText(/{"type":"transmit","channel":"test","remote":"0.0.0.0:57000","body":"MSH[^"]+ACK[^"]+"}/)
+      .expectText(
+        /{"type":"agent:transmit:response","channel":"test","remote":"0.0.0.0:57000","body":"MSH[^"]+ACK[^"]+"}/
+      )
       .close()
       .expectClosed();
   });
@@ -121,7 +123,7 @@ describe('Agent WebSockets', () => {
     await request(server)
       .ws('/ws/agent')
       .sendText('<html></html>')
-      .expectText(/{"type":"error","body":"Unexpected token/)
+      .expectText(/{"type":"agent:error","body":"Unexpected token/)
       .close()
       .expectClosed();
   });
@@ -131,11 +133,11 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"error","body":"Missing access token"}')
+      .expectText('{"type":"agent:error","body":"Missing access token"}')
       .close()
       .expectClosed();
   });
@@ -145,11 +147,11 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
         })
       )
-      .expectText('{"type":"error","body":"Missing agent ID"}')
+      .expectText('{"type":"agent:error","body":"Missing agent ID"}')
       .close()
       .expectClosed();
   });
@@ -166,7 +168,7 @@ describe('Agent WebSockets', () => {
           body: 'MSH|...',
         })
       )
-      .expectText('{"type":"error","body":"Not connected"}')
+      .expectText('{"type":"agent:error","body":"Not connected"}')
       .close()
       .expectClosed();
   });
@@ -176,12 +178,12 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"connected"}')
+      .expectText('{"type":"agent:connect:response"}')
       .sendText(
         JSON.stringify({
           type: 'transmit',
@@ -190,7 +192,7 @@ describe('Agent WebSockets', () => {
           body: 'MSH|...',
         })
       )
-      .expectText('{"type":"error","body":"Missing access token"}')
+      .expectText('{"type":"agent:error","body":"Missing access token"}')
       .close()
       .expectClosed();
   });
@@ -200,12 +202,12 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"connected"}')
+      .expectText('{"type":"agent:connect:response"}')
       .sendText(
         JSON.stringify({
           type: 'transmit',
@@ -214,7 +216,7 @@ describe('Agent WebSockets', () => {
           body: 'MSH|...',
         })
       )
-      .expectText('{"type":"error","body":"Missing channel"}')
+      .expectText('{"type":"agent:error","body":"Missing channel"}')
       .close()
       .expectClosed();
   });
@@ -224,12 +226,12 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"connected"}')
+      .expectText('{"type":"agent:connect:response"}')
       .sendText(
         JSON.stringify({
           type: 'transmit',
@@ -239,7 +241,7 @@ describe('Agent WebSockets', () => {
           body: 'MSH|...',
         })
       )
-      .expectText('{"type":"error","body":"Channel not found"}')
+      .expectText('{"type":"agent:error","body":"Channel not found"}')
       .close()
       .expectClosed();
   });
@@ -249,12 +251,12 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"connected"}')
+      .expectText('{"type":"agent:connect:response"}')
       .sendText(
         JSON.stringify({
           type: 'transmit',
@@ -263,7 +265,7 @@ describe('Agent WebSockets', () => {
           remote: '0.0.0.0:57000',
         })
       )
-      .expectText('{"type":"error","body":"Missing body"}')
+      .expectText('{"type":"agent:error","body":"Missing body"}')
       .close()
       .expectClosed();
   });
@@ -273,12 +275,12 @@ describe('Agent WebSockets', () => {
       .ws('/ws/agent')
       .sendText(
         JSON.stringify({
-          type: 'connect',
+          type: 'agent:connect:request',
           accessToken,
           agentId: agent.id,
         })
       )
-      .expectText('{"type":"connected"}')
+      .expectText('{"type":"agent:connect:response"}')
       .exec(async () => {
         const res = await request(server)
           .post(`/fhir/R4/Agent/${agent.id}/$push`)

--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -1,4 +1,11 @@
-import { ContentType, getReferenceString, normalizeErrorString } from '@medplum/core';
+import {
+  AgentConnectRequest,
+  AgentMessage,
+  AgentTransmitRequest,
+  ContentType,
+  getReferenceString,
+  normalizeErrorString,
+} from '@medplum/core';
 import { Agent, Bot, Reference } from '@medplum/fhirtypes';
 import { AsyncLocalStorage } from 'async_hooks';
 import { IncomingMessage } from 'http';
@@ -29,24 +36,29 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
     'message',
     AsyncLocalStorage.bind(async (data: ws.RawData) => {
       try {
-        const command = JSON.parse((data as Buffer).toString('utf8'));
+        const command = JSON.parse((data as Buffer).toString('utf8')) as AgentMessage;
         switch (command.type) {
+          // @ts-expect-error - Deprecated message type
           case 'connect':
+          case 'agent:connect:request':
             await handleConnect(command);
             break;
 
+          // @ts-expect-error - Deprecated message type
           case 'transmit':
+          case 'agent:transmit:request':
             await handleTransmit(command);
             break;
         }
       } catch (err) {
-        socket.send(JSON.stringify({ type: 'error', body: normalizeErrorString(err) }));
+        sendError(normalizeErrorString(err));
       }
     })
   );
 
   socket.on('close', () => {
     redisSubscriber?.disconnect();
+    redisSubscriber = undefined;
   });
 
   /**
@@ -55,18 +67,18 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
    * The command includes the access token and bot ID.
    * @param command - The connect command.
    */
-  async function handleConnect(command: any): Promise<void> {
+  async function handleConnect(command: AgentConnectRequest): Promise<void> {
     if (!command.accessToken) {
-      sendError(socket, 'Missing access token');
+      sendError('Missing access token');
       return;
     }
 
     if (!command.agentId) {
-      sendError(socket, 'Missing agent ID');
+      sendError('Missing agent ID');
       return;
     }
 
-    agentId = command.agentId as string;
+    agentId = command.agentId;
 
     const { login, project, membership } = await getLoginForAccessToken(command.accessToken);
     const repo = await getRepoForLogin(login, membership, project.strictMode, true, project.checkReferencesOnWrite);
@@ -81,7 +93,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
     });
 
     // Send connected message
-    socket.send(JSON.stringify({ type: 'connected' }));
+    sendMessage({ type: 'agent:connect:response' });
   }
 
   /**
@@ -89,24 +101,24 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
    * This command is sent by the agent to transmit a message.
    * @param command - The transmit command.
    */
-  async function handleTransmit(command: any): Promise<void> {
+  async function handleTransmit(command: AgentTransmitRequest): Promise<void> {
     if (!agentId) {
-      sendError(socket, 'Not connected');
+      sendError('Not connected');
       return;
     }
 
     if (!command.accessToken) {
-      sendError(socket, 'Missing access token');
+      sendError('Missing access token');
       return;
     }
 
     if (!command.channel) {
-      sendError(socket, 'Missing channel');
+      sendError('Missing channel');
       return;
     }
 
     if (!command.body) {
-      sendError(socket, 'Missing body');
+      sendError('Missing body');
       return;
     }
 
@@ -115,7 +127,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
     const agent = await repo.readResource<Agent>('Agent', agentId);
     const channel = agent?.channel?.find((c) => c.name === command.channel);
     if (!channel) {
-      socket.send(JSON.stringify({ type: 'error', body: 'Channel not found' }));
+      sendError('Channel not found');
       return;
     }
 
@@ -131,18 +143,19 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
       forwardedFor: command.remote,
     });
 
-    socket.send(
-      JSON.stringify({
-        type: 'transmit',
-        channel: command.channel,
-        remote: command.remote,
-        body: result.returnValue,
-      }),
-      { binary: false }
-    );
+    sendMessage({
+      type: 'agent:transmit:response',
+      channel: command.channel,
+      remote: command.remote,
+      body: result.returnValue,
+    });
   }
-}
 
-function sendError(socket: ws.WebSocket, body: string): void {
-  socket.send(JSON.stringify({ type: 'error', body }));
+  function sendMessage(message: AgentMessage): void {
+    socket.send(JSON.stringify(message), { binary: false });
+  }
+
+  function sendError(body: string): void {
+    sendMessage({ type: 'agent:error', body });
+  }
 }

--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -50,6 +50,13 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
             await handleTransmit(command);
             break;
 
+          case 'agent:transmit:response':
+            if (command.callback) {
+              const redis = getRedis();
+              await redis.publish(command.callback, JSON.stringify(command));
+            }
+            break;
+
           default:
             sendError(`Unknown message type: ${command.type}`);
         }
@@ -150,6 +157,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
       type: 'agent:transmit:response',
       channel: command.channel,
       remote: command.remote,
+      contentType: ContentType.HL7_V2,
       body: result.returnValue,
     });
   }

--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -49,6 +49,9 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
           case 'agent:transmit:request':
             await handleTransmit(command);
             break;
+
+          default:
+            sendError(`Unknown message type: ${command.type}`);
         }
       } catch (err) {
         sendError(normalizeErrorString(err));

--- a/packages/server/src/fhir/operations/agentpush.ts
+++ b/packages/server/src/fhir/operations/agentpush.ts
@@ -82,8 +82,7 @@ export const agentPushHandler = asyncWrap(async (req: Request, res: Response) =>
   }
 
   // Otherwise, open a new redis connection in "subscribe" state
-  // message.callback = getReferenceString(agent) + '-' + randomUUID();
-  message.callback = randomUUID();
+  message.callback = getReferenceString(agent) + '-' + randomUUID();
 
   const redisSubscriber = getRedis().duplicate();
   await redisSubscriber.subscribe(message.callback);


### PR DESCRIPTION
Support "request" and "response" pattern for Agent push messages.

Also includes proper types for a bunch of the message types -- the first implementation included too many `any` types, so this tightens all of that up.