### PR TITLE
Fixes #3451 Fixes #3461 - subscription retry update

### DIFF
--- a/packages/docs/docs/subscriptions/subscription-extensions.md
+++ b/packages/docs/docs/subscriptions/subscription-extensions.md
@@ -199,6 +199,8 @@ If your subscription failed or threw an error, you can configure it to attempt t
 
 To add an attempt number, use the `https://medplum.com/fhir/StructureDefinition/subscription-max-attempts` extension with the valueInteger set to a number between 1-18.
 
+The default number of attempts is 3.
+
 ```json
 {
   "resourceType": "Subscription",


### PR DESCRIPTION
1. Change default number of retries from 18 to 3
2. On each failure, decrease the job priority

--------

Tested, confirmed stopped after 3 retries:

<img width="757" alt="image" src="https://github.com/medplum/medplum/assets/749094/4f9c4783-cf16-4418-8027-9bf8122bf75a">
