### PR TITLE
Use maxsockets in npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ FROM --platform=$TARGETPLATFORM node:18-slim
 ENV NODE_ENV production
 WORKDIR /usr/src/medplum
 ADD ./medplum-server.tar.gz ./
-RUN npm ci
+RUN npm ci --maxsockets 1
 EXPOSE 5000 8103
 ENTRYPOINT [ "node", "packages/server/dist/index.js" ]


### PR DESCRIPTION
Trying to resolve recent server deploy failures.

See:
* https://github.com/npm/cli/issues/4652#issuecomment-1157594100
* https://github.com/npm/cli/issues/4652#issuecomment-1126672629

