### PR TITLE
Use bash in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,7 @@ jobs:
         run: npm run build -- --filter=@medplum/agent
 
       - name: Build Agent installer
+        shell: bash
         run: ./scripts/build-agent-installer.sh
         env:
           SM_HOST: ${{ secrets.SM_HOST }}


### PR DESCRIPTION
New publish step failed: https://github.com/medplum/medplum/actions/runs/7095980728/job/19313759661

The logs are unclear, but I believe it is due to running on PowerShell by default.  This PR specifies bash.

Tested here: https://github.com/codyebberson/windows-runner-test