### PR TITLE
Added wget to agent installer publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Install NSIS
         run: choco install nsis
 
+      - name: Install Wget
+        run: choco install wget
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
The most recent publish action failed due to missing `wget`: https://github.com/medplum/medplum/actions/runs/7096951089/job/19316275462