### PR TITLE
Implement ConceptMap translate operation

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -651,6 +651,9 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
 }
 
 export function capitalize(word: string): string {
+  if (!word) {
+    return '';
+  }
   return word.charAt(0).toUpperCase() + word.substring(1);
 }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     "dev": "ts-node-dev --poll --respawn --transpile-only src/index.ts",
     "prestart": "tsc",
     "start": "node dist/index.js",
-    "test": "jest --runInBand src/fhir/operations/conceptmaptranslate.test.ts"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.458.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
     "dev": "ts-node-dev --poll --respawn --transpile-only src/index.ts",
     "prestart": "tsc",
     "start": "node dist/index.js",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand src/fhir/operations/conceptmaptranslate.test.ts"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.458.0",

--- a/packages/server/src/fhir/operations/README.md
+++ b/packages/server/src/fhir/operations/README.md
@@ -27,7 +27,8 @@ Utility functions that use the `OperationDefinition` to automate implementation 
 
 ```ts
 import { parseInputParameters, sendOutputParameters } from './utils/parameters';
-import { created, OperationDefinition, Reference } from '@medplum/core';
+import { created } from '@medplum/core';
+import { Reference, OperationDefinition } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 
 const operation: OperationDefinition = {
@@ -57,7 +58,7 @@ interface ProjectInitParameters {
   ownerEmail?: string;
 }
 
-export function projectInitHandler(req: Request, res: Response): void {
+export async function projectInitHandler(req: Request, res: Response): Promise<void> {
   const params = parseInputParameters<ProjectInitParameters>(operation, req);
 
   // Handle operation business logic...

--- a/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
@@ -382,7 +382,7 @@ describe('ConceptMap $translate', () => {
     });
   });
 
-  test('Not found by URL', async () => {
+  test.each(['url', 'source'])('Not found by %s', async (paramName) => {
     const res = await request(app)
       .post(`/fhir/R4/ConceptMap/$translate`)
       .set('Authorization', 'Bearer ' + accessToken)
@@ -390,7 +390,7 @@ describe('ConceptMap $translate', () => {
       .send({
         resourceType: 'Parameters',
         parameter: [
-          { name: 'url', valueUri: conceptMap.url + 'BAD' },
+          { name: paramName, valueUri: conceptMap.url + 'BAD' },
           { name: 'coding', valueCoding: { system, code } },
         ],
       });

--- a/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
@@ -557,7 +557,7 @@ describe('ConceptMap $translate', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({
         resourceType: 'Parameters',
-        parameter: [{ name: 'coding', valueCoding: { code } }],
+        parameter: [{ name: 'codeableConcept', valueCodeableConcept: { coding: [{ code }] } }],
       });
     expect(res2.status).toBe(200);
 

--- a/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
@@ -1,0 +1,276 @@
+import express from 'express';
+import { loadTestConfig } from '../../config';
+import { initApp, shutdownApp } from '../../app';
+import { initTestAuth } from '../../test.setup';
+import request from 'supertest';
+import { ContentType } from '@medplum/core';
+import { ConceptMap, OperationOutcome, Parameters, ParametersParameter } from '@medplum/fhirtypes';
+
+const app = express();
+
+describe('ConceptMap $translate', () => {
+  const system = 'http://example.com/private-codes';
+  const code = 'FSH';
+
+  let accessToken: string;
+  let conceptMap: ConceptMap;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+  });
+
+  beforeEach(async () => {
+    accessToken = await initTestAuth();
+    expect(accessToken).toBeDefined();
+
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'ConceptMap',
+        url: 'http://example.com/concept-map',
+        status: 'active',
+        group: [
+          {
+            source: system,
+            target: 'http://loinc.org',
+            element: [
+              {
+                code,
+                target: [
+                  {
+                    display: 'Follitropin Qn',
+                    equivalence: 'equivalent',
+                    code: '15067-2',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    expect(res.status).toEqual(201);
+    conceptMap = res.body as ConceptMap;
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test.each<[string, ParametersParameter[]]>([
+    [
+      'with system and code',
+      [
+        { name: 'system', valueUri: system },
+        { name: 'code', valueCode: code },
+      ],
+    ],
+    ['with coding', [{ name: 'coding', valueCoding: { system, code } }]],
+    ['with CodeableConcept', [{ name: 'codeableConcept', valueCodeableConcept: { coding: [{ system, code }] } }]],
+  ])('Success %s', async (_format, params) => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: params,
+      });
+    expect(res.status).toBe(200);
+
+    const output = (res.body as Parameters).parameter;
+    expect(output?.find((p) => p.name === 'result')?.valueBoolean).toEqual(true);
+    const matches = output?.filter((p) => p.name === 'match');
+    expect(matches).toHaveLength(1);
+    expect(matches?.[0]).toMatchObject<ParametersParameter>({
+      name: 'match',
+      part: [
+        {
+          name: 'equivalence',
+          valueCode: 'equivalent',
+        },
+        {
+          name: 'concept',
+          valueCoding: {
+            system: 'http://loinc.org',
+            code: '15067-2',
+            display: 'Follitropin Qn',
+          },
+        },
+      ],
+    });
+  });
+
+  test('Lookup by URL', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'url', valueUri: conceptMap.url },
+          { name: 'coding', valueCoding: { system, code } },
+        ],
+      });
+    expect(res.status).toBe(200);
+
+    const output = (res.body as Parameters).parameter;
+    expect(output?.find((p) => p.name === 'result')?.valueBoolean).toEqual(true);
+    const matches = output?.filter((p) => p.name === 'match');
+    expect(matches).toHaveLength(1);
+    expect(matches?.[0]).toMatchObject<ParametersParameter>({
+      name: 'match',
+      part: [
+        {
+          name: 'equivalence',
+          valueCode: 'equivalent',
+        },
+        {
+          name: 'concept',
+          valueCoding: {
+            system: 'http://loinc.org',
+            code: '15067-2',
+            display: 'Follitropin Qn',
+          },
+        },
+      ],
+    });
+  });
+
+  test('No match', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'coding', valueCoding: { system, code: 'BAD' } }],
+      });
+    expect(res.status).toBe(200);
+
+    const output = (res.body as Parameters).parameter;
+    expect(output).toHaveLength(1);
+    expect(output?.[0]).toMatchObject<ParametersParameter>({
+      name: 'result',
+      valueBoolean: false,
+    });
+  });
+
+  test('No map specified', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'coding', valueCoding: { system, code } }],
+      });
+    expect(res.status).toBe(400);
+
+    expect(res.body).toMatchObject<OperationOutcome>({
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          details: { text: 'No ConceptMap specified' },
+        },
+      ],
+    });
+  });
+
+  test('Code without system', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'code', valueCode: 'BAD' }],
+      });
+    expect(res.status).toBe(400);
+
+    expect(res.body).toMatchObject<OperationOutcome>({
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          details: { text: `Missing required 'system' input parameter with 'code' parameter` },
+        },
+      ],
+    });
+  });
+
+  test('Ambiguous coding provided', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'coding', valueCoding: { system, code } },
+          { name: 'system', valueUri: system },
+          { name: 'code', valueCode: 'BAD' },
+        ],
+      });
+    expect(res.status).toBe(400);
+
+    expect(res.body).toMatchObject<OperationOutcome>({
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          details: { text: `Ambiguous input: multiple source codings provided` },
+        },
+      ],
+    });
+  });
+
+  test('No source coding', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/${conceptMap.id}/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+      });
+    expect(res.status).toBe(400);
+
+    expect(res.body).toMatchObject<OperationOutcome>({
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          details: {
+            text: `No source provided: 'code'+'system', 'coding', or 'codeableConcept' input parameter is required`,
+          },
+        },
+      ],
+    });
+  });
+
+  test('Not found by URL', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/ConceptMap/$translate`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          { name: 'url', valueUri: conceptMap.url + 'BAD' },
+          { name: 'coding', valueCoding: { system, code } },
+        ],
+      });
+    expect(res.status).toBe(404);
+
+    expect(res.body).toMatchObject<OperationOutcome>({
+      resourceType: 'OperationOutcome',
+      issue: [
+        {
+          details: {
+            text: `Not found`,
+          },
+        },
+      ],
+    });
+  });
+});

--- a/packages/server/src/fhir/operations/conceptmaptranslate.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.ts
@@ -123,7 +123,7 @@ function translateCodes(sourceCodes: Record<string, string[]>, groups: ConceptMa
         (m) =>
           m.target?.map((target) => ({
             equivalence: target.equivalence,
-            coding: {
+            concept: {
               system: group.target,
               code: target.code,
               display: target.display,

--- a/packages/server/src/fhir/operations/conceptmaptranslate.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.ts
@@ -1,0 +1,141 @@
+import { parseInputParameters, sendOutputParameters } from './utils/parameters';
+import { Operator, allOk, badRequest, notFound } from '@medplum/core';
+import { Request, Response } from 'express';
+import { getOperationDefinition } from './definitions';
+import { CodeableConcept, Coding, ConceptMap, ConceptMapGroup, OperationOutcome } from '@medplum/fhirtypes';
+import { getAuthenticatedContext } from '../../context';
+import { sendOutcome } from '../outcomes';
+
+const operation = getOperationDefinition('ConceptMap', 'translate');
+
+type ConceptMapTranslateParameters = {
+  url?: string;
+  code?: string;
+  system?: string;
+  version?: string;
+  coding?: Coding;
+  codeableConcept?: CodeableConcept;
+  target?: string;
+  targetsystem?: string;
+  reverse?: boolean;
+};
+
+type Match = {
+  equivalence?: string;
+  concept?: Coding;
+};
+
+type ConceptMapTranslateOutput = {
+  result: boolean;
+  message?: string;
+  match?: Match[];
+};
+
+export async function conceptMapTranslateHandler(req: Request, res: Response): Promise<void> {
+  const params = parseInputParameters<ConceptMapTranslateParameters>(operation, req);
+
+  const map = await lookupConceptMap({ id: req.params.id, url: params.url });
+  if (isOutcome(map)) {
+    sendOutcome(res, map);
+    return;
+  } else if (!map.group) {
+    sendOutcome(res, badRequest('ConceptMap does not specify a mapping group', 'ConceptMap.group'));
+    return;
+  }
+
+  const sourceCodes = constructSourceSet(params);
+  if (isOutcome(sourceCodes)) {
+    sendOutcome(res, sourceCodes);
+    return;
+  }
+
+  const matches = translateCodes(sourceCodes, map.group);
+  const result = matches.length > 0;
+  await sendOutputParameters(operation, res, allOk, {
+    result,
+    match: result ? matches : undefined,
+  } as ConceptMapTranslateOutput);
+}
+
+async function lookupConceptMap({ id, url }: { id?: string; url?: string }): Promise<ConceptMap | OperationOutcome> {
+  const ctx = getAuthenticatedContext();
+  if (id) {
+    return ctx.repo.readResource('ConceptMap', id);
+  } else if (url) {
+    const result = await ctx.repo.searchOne<ConceptMap>({
+      resourceType: 'ConceptMap',
+      filters: [{ code: 'url', operator: Operator.EQUALS, value: url }],
+      sortRules: [{ code: 'version', descending: true }],
+    });
+    if (!result) {
+      return notFound;
+    }
+    return result;
+  } else {
+    return badRequest('No ConceptMap specified');
+  }
+}
+
+function constructSourceSet(params: ConceptMapTranslateParameters): Record<string, string[]> | OperationOutcome {
+  if (params.code && !params.coding && !params.codeableConcept) {
+    if (!params.system) {
+      return badRequest(`Missing required 'system' input parameter with 'code' parameter`);
+    }
+    return { [params.system ?? '']: [params.code] };
+  } else if (params.coding && !params.code && !params.codeableConcept) {
+    return { [params.coding.system ?? '']: [params.coding.code ?? ''] };
+  } else if (params.codeableConcept && !params.code && !params.coding) {
+    return indexCodes(params.codeableConcept);
+  } else if (params.code || params.coding || params.codeableConcept) {
+    return badRequest('Ambiguous input: multiple source codings provided');
+  } else {
+    return badRequest(
+      `No source provided: 'code'+'system', 'coding', or 'codeableConcept' input parameter is required`
+    );
+  }
+}
+
+function indexCodes(concept: CodeableConcept): Record<string, string[]> {
+  const result: Record<string, string[]> = Object.create(null);
+  if (!concept.coding?.length) {
+    return result;
+  }
+
+  for (const { system, code } of concept.coding) {
+    if (!code) {
+      continue;
+    }
+    const key = system ?? '';
+    result[key] = result[key] ? [...result[key], code] : [code];
+  }
+  return result;
+}
+
+function translateCodes(sourceCodes: Record<string, string[]>, groups: ConceptMapGroup[]): Match[] {
+  const matches: Match[] = [];
+  for (const [system, codes] of Object.entries(sourceCodes)) {
+    for (const group of groups.filter((g) => g.source === system)) {
+      const mappings = group.element?.filter((m) => codes.includes(m.code as string));
+      if (!mappings?.length) {
+        continue;
+      }
+      const mappedCodes: Match[] = mappings.flatMap(
+        (m) =>
+          m.target?.map((target) => ({
+            equivalence: target.equivalence,
+            coding: {
+              system: group.target,
+              code: target.code,
+              display: target.display,
+            },
+          })) ?? []
+      );
+      matches.push(...mappedCodes);
+    }
+  }
+  return matches;
+}
+
+function isOutcome(obj: any): obj is OperationOutcome {
+  return obj.resourceType === 'OperationOutcome';
+}

--- a/packages/server/src/fhir/operations/conceptmaptranslate.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.ts
@@ -128,7 +128,7 @@ function indexCodes(concept: CodeableConcept): Record<string, string[]> {
 function translateCodes(sourceCodes: Record<string, string[]>, groups: ConceptMapGroup[]): Match[] {
   const matches: Match[] = [];
   for (const [system, codes] of Object.entries(sourceCodes)) {
-    for (const group of groups.filter((g) => g.source === system)) {
+    for (const group of groups.filter((g) => (g.source ?? '') === system)) {
       let mappings: Match[] | undefined = group.element
         ?.filter((m) => codes.includes(m.code as string))
         .flatMap(

--- a/packages/server/src/fhir/operations/definitions.ts
+++ b/packages/server/src/fhir/operations/definitions.ts
@@ -1,0 +1,17 @@
+import { OperationOutcomeError, serverError } from '@medplum/core';
+import { readJson } from '@medplum/definitions';
+import { Bundle, OperationDefinition, ResourceType, StructureDefinition } from '@medplum/fhirtypes';
+
+const operationDefinitions = (
+  readJson('fhir/r4/profiles-resources.json') as Bundle<StructureDefinition | OperationDefinition>
+).entry
+  ?.filter((e) => e.resource?.resourceType === 'OperationDefinition')
+  ?.map((e) => e.resource as OperationDefinition);
+
+export function getOperationDefinition(resourceType: ResourceType, code: string): OperationDefinition {
+  const opDef = operationDefinitions?.find((od) => od.resource?.includes(resourceType) && od.code === code);
+  if (!opDef) {
+    throw new OperationOutcomeError(serverError(new Error('OperationDefinition not found')));
+  }
+  return opDef;
+}

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -43,7 +43,6 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
   }
 
   const input = req.body;
-
   const inputParameters = input.resourceType === 'Parameters' ? (input as Parameters) : undefined;
   if (inputParameters) {
     validateResource(inputParameters);
@@ -152,5 +151,5 @@ export async function sendOutputParameters(
 }
 
 function makeParameter(param: OperationDefinitionParameter, value: any): ParametersParameter {
-  return { name: param.name, ['value' + param.type]: value };
+  return { name: param.name, ['value' + capitalize(param.type as string)]: value };
 }

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -151,5 +151,15 @@ export async function sendOutputParameters(
 }
 
 function makeParameter(param: OperationDefinitionParameter, value: any): ParametersParameter {
+  if (param.part) {
+    const parts: ParametersParameter[] = [];
+    for (const part of param.part) {
+      const nestedValue = value[part.name ?? ''];
+      if (nestedValue !== undefined) {
+        parts.push(makeParameter(part, nestedValue));
+      }
+    }
+    return { name: param.name, part: parts };
+  }
   return { name: param.name, ['value' + capitalize(param.type as string)]: value };
 }

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -27,6 +27,7 @@ import { rewriteAttachments, RewriteMode } from './rewrite';
 import { getFullUrl } from './search';
 import { smartConfigurationHandler, smartStylingHandler } from './smart';
 import { projectInitHandler } from './operations/projectinit';
+import { conceptMapTranslateHandler } from './operations/conceptmaptranslate';
 
 export const fhirRouter = Router();
 
@@ -92,6 +93,9 @@ protectedRoutes.post('/Project/:id/([$]|%24)clone', asyncWrap(projectCloneHandle
 
 // Project $init
 protectedRoutes.post('/Project/([$]|%24)init', asyncWrap(projectInitHandler));
+
+// ConceptMap $translate
+protectedRoutes.post('/ConceptMap/:id/([$]|%24)translate', asyncWrap(conceptMapTranslateHandler));
 
 // ValueSet $expand operation
 protectedRoutes.get('/ValueSet/([$]|%24)expand', expandOperator);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -95,6 +95,7 @@ protectedRoutes.post('/Project/:id/([$]|%24)clone', asyncWrap(projectCloneHandle
 protectedRoutes.post('/Project/([$]|%24)init', asyncWrap(projectInitHandler));
 
 // ConceptMap $translate
+protectedRoutes.post('/ConceptMap/([$]|%24)translate', asyncWrap(conceptMapTranslateHandler));
 protectedRoutes.post('/ConceptMap/:id/([$]|%24)translate', asyncWrap(conceptMapTranslateHandler));
 
 // ValueSet $expand operation


### PR DESCRIPTION
Adding the `$translate` operation on `ConceptMap` resources, available either as:
- `POST ConceptMap/:id/$translate` to translate using a given ConceptMap
- `POST ConceptMap/$translate` to use the `url` or `source` parameters to look up the ConceptMap

Currently, only simple enumerated mappings are supported via `ConceptMap.group`

Resolves #3344 