### PR TITLE
Fix outdated client `cacheTime` docs

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -180,7 +180,7 @@ export interface MedplumClientOptions {
   /**
    * The length of time in milliseconds to cache resources.
    *
-   * Default value is 10000 (10 seconds).
+   * Default value is 60000 (60 seconds).
    *
    * Cache time of zero disables all caching.
    *


### PR DESCRIPTION
The default client cache for the client appears to be 60 seconds - not 10 seconds as documented in the client options.

Here is the definition in the client:

https://github.com/medplum/medplum/blob/30050b411dbd58b52733e61e14e03abedc2d5873/packages/core/src/client.ts#L86

It appears that the underlying value was changed [in this PR](https://github.com/medplum/medplum/pull/775/files#diff-858339789c798051d9c13620bffce8ce860e7ad8ba18dba1c8711eb1f7d51a55) without the associated docs being updated. (cc @codyebberson)