### PR TITLE
Fix permissions on add-issue-to-project action

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
The `add-issue-to-project` action currently fails on PR's from external contributors.

Example: https://github.com/medplum/medplum/actions/runs/7109207223

The problem is that the `pull_request` trigger runs in an unprivileged context.  The `pull_request_target` trigger uses the code from `main`, and is therefore allowed access to `secrets`.

See more: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target