### PR TITLE
Fixes #3484 Fixes #3485 - agent properties file

### DIFF
--- a/packages/agent/installer.nsi
+++ b/packages/agent/installer.nsi
@@ -185,9 +185,17 @@ Function InstallApp
     File dist\${SERVICE_FILE_NAME}
     File README.md
 
+    # Create the agent.properties config file
+    FileOpen $9 agent.properties w
+    FileWrite $9 "baseUrl=$baseUrl$\r$\n"
+    FileWrite $9 "clientId=$clientId$\r$\n"
+    FileWrite $9 "clientSecret=$clientSecret$\r$\n"
+    FileWrite $9 "agentId=$agentId$\r$\n"
+    FileClose $9
+
     # Create the service
     DetailPrint "Creating service..."
-    ExecWait "shawl-v1.3.0-win64.exe add --name $\"${SERVICE_NAME}$\" -- $\"$INSTDIR\${SERVICE_FILE_NAME}$\" $\"$baseUrl$\" $\"$clientId$\" $\"$clientSecret$\" $\"$agentId$\"" $1
+    ExecWait "shawl-v1.3.0-win64.exe add --name $\"${SERVICE_NAME}$\" --cwd $\"$INSTDIR$\" -- $\"$INSTDIR\${SERVICE_FILE_NAME}$\"" $1
     DetailPrint "Exit code $1"
 
     # Set service display name

--- a/packages/agent/src/main.test.ts
+++ b/packages/agent/src/main.test.ts
@@ -1,0 +1,49 @@
+import { App } from './app';
+import { main } from './main';
+import fs from 'fs';
+
+describe('Main', () => {
+  beforeEach(() => {
+    console.log = jest.fn();
+    jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    jest.spyOn(App.prototype, 'start').mockImplementation(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('Missing arguments', () => {
+    main(['node', 'index.js']).catch(console.log);
+    expect(console.log).toHaveBeenCalledWith('Missing arguments');
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  test('Command line arguments success', () => {
+    main(['node', 'index.js', 'http://example.com', 'clientId', 'clientSecret', 'agentId']).catch(console.log);
+    expect(console.log).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+
+  test('Empty properties file', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue('');
+    main([]).catch(console.log);
+    expect(console.log).toHaveBeenCalledWith('Missing arguments');
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  test('Properties file success', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest
+      .spyOn(fs, 'readFileSync')
+      .mockReturnValue(
+        ['baseUrl=http://example.com', 'clientId=clientId', 'clientSecret=clientSecret', 'agentId=agentId'].join('\n')
+      );
+    main(['node', 'index.js']).catch(console.log);
+    expect(console.log).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -1,6 +1,6 @@
 import { MedplumClient } from '@medplum/core';
-import { App } from './app';
 import { existsSync, readFileSync } from 'fs';
+import { App } from './app';
 
 interface Args {
   baseUrl: string;
@@ -60,7 +60,7 @@ function readPropertiesFile(fileName: string): Args {
     readFileSync(fileName)
       .toString()
       .split('\n')
-      .map((line) => line.split('='))
+      .map((line) => line.split('=').map((s) => s.trim()))
   );
 }
 


### PR DESCRIPTION
The Medplum Agent takes 4 input parameters:
1. `baseUrl` - the base URL of the Medplum API server to connect to
2. `clientId` - the client ID for credentials
3. `clientSecret` - the client secret for credentials
4. `agentId` - the `Agent` ID of the agent definition

The goal is to try to keep as much of the configuration as possible inside the `Agent` resource.  At present, this is the minimal set to get things running.

(Aside: Theoretically, we could make `Agent` into a resource type capable of acting as an identity, similar to `User` and `ClientApplication`.  That's out of scope for now.)

Before: The only way to specify the 4 input parameters was as command line arguments:

```
medplum-agent https://api.medplum.com/ MY_CLIENT_ID MY_CLIENT_SECRET MY_AGENT_ID
```

In the case of the Windows installer, those values were ultimately stored in the Windows Registry in the service definition.  But that was cumbersome for users who need to update the values.

After: There are 2 ways to specify the 4 input parameters.

1. Command line arguments, exactly as before
2. An `agent.properties` file in the current working directory
