### PR TITLE
New Schema diff view error fix

### DIFF
--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -138,6 +138,12 @@ describe('FHIRPath utils', () => {
       getTypedPropertyValue(toTypedValue({ resourceType: 'Patient', identifier: [] }), 'identifier')
     ).toBeUndefined();
     expect(getTypedPropertyValue({ type: 'X', value: { x: [] } }, 'x')).toBeUndefined();
+
+    // Property path that is part of multi-type element in schema
+    expect(getTypedPropertyValue({ type: 'Extension', value: { valueBoolean: true } }, 'valueBoolean')).toEqual({
+      type: 'boolean',
+      value: true,
+    });
   });
 
   test('Bundle entries', () => {

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -75,7 +75,10 @@ export function getTypedPropertyValue(input: TypedValue, path: string): TypedVal
 
   const elementDefinition = getElementDefinition(input.type, path);
   if (elementDefinition) {
-    return getTypedPropertyValueWithSchema(input, path, elementDefinition);
+    const typedValue = getTypedPropertyValueWithSchema(input, path, elementDefinition);
+    if (typedValue) {
+      return typedValue;
+    }
   }
 
   return getTypedPropertyValueWithoutSchema(input, path);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -324,6 +324,15 @@ export function getElementDefinition(typeName: string, propertyName: string): In
   if (!typeSchema) {
     return undefined;
   }
+
+  for (const [elementName, element] of Object.entries(typeSchema.elements)) {
+    for (const type of element.type) {
+      if (elementName.replace('[x]', capitalize(type.code)) === propertyName) {
+        return element;
+      }
+    }
+  }
+
   return typeSchema.elements[propertyName] ?? typeSchema.elements[propertyName + '[x]'];
 }
 


### PR DESCRIPTION
Fixes #3469 

Updated `getElementDefinition` to check for multi-type elements (like valueString, valueBoolean).

As I had mentioned in the issue comments that fixing the `getElementDefinition` breaks the code in `getTypedPropertyValue`.
The part that was earlier skipped due to missing case for multi-type elements was now causing issues due to the way `getTypedPropertyValueWithSchema` is implemented.
It works fine for all single type elements but for multi-type, it expects the path to be with [x] (value[x], amount[x] etc) instead of the resolved ones (valueString, valueBoolean etc). 

It returns undefined for resolved cases. So I have added a quick fix for now to check for the typedValue before returning it. This retains the old flow of resolved elements being passed onto the `getTypedPropertyValueWithoutSchema`. 
We can change the `getTypedPropertyValueWithSchema` but that might have an impact elsewhere where input path to `getTypedPropertyValue` includes [x]. So for that we may need to account for both cases.

Added test for `getTypedPropertyValue` for multi-type elements.

Also, I see that we currently don't have any tests for getElementDefinition. I can add those in another PR once these changes are finalised.

Example output - 
![image](https://github.com/medplum/medplum/assets/85165953/71b1e7df-63a3-4570-b276-1a86d031b064)
