### PR TITLE
Github Action for staging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,67 @@
+name: Staging
+
+concurrency:
+  group: ci-staging-${{ github.sha }}
+  cancel-in-progress: false
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: Staging
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: '18'
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: 'medplum'
+      TURBO_REMOTE_ONLY: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Cache node modules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build:fast
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.STAGING_AWS_REGION }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.STAGING_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.STAGING_DOCKERHUB_TOKEN }}
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Deploy App
+        run: ./scripts/deploy-app.sh
+        env:
+          APP_BUCKET: ${{ secrets.STAGING_APP_BUCKET }}
+          AWS_REGION: ${{ secrets.STAGING_AWS_REGION }}
+          GOOGLE_CLIENT_ID: ${{ secrets.STAGING_GOOGLE_CLIENT_ID }}
+          MEDPLUM_BASE_URL: ${{ secrets.STAGING_MEDPLUM_BASE_URL }}
+          RECAPTCHA_SITE_KEY: ${{ secrets.STAGING_RECAPTCHA_SITE_KEY }}
+      - name: Deploy Server
+        run: ./scripts/deploy-server.sh
+        env:
+          AWS_REGION: ${{ secrets.STAGING_AWS_REGION }}
+          DOCKERHUB_REPOSITORY: ${{ secrets.STAGING_DOCKERHUB_REPOSITORY }}
+          ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
+          ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}


### PR DESCRIPTION
This adds a `workflow_dispatch` action to deploy to staging.

The idea is that Medplum developers will be able to:

1. Go to "Actions"
2. Then "Staging"
3. Then "Run workflow"
4. Choose the branch to deploy
5. Click "Run workflow"

And tada, staging deploys 🎉 

In the future, I'd like to also connect this to PR comments or Slack commands, but that can come later.

The following secrets have been configured:

```
STAGING_APP_BUCKET=app.staging.medplum.dev
STAGING_GOOGLE_CLIENT_ID=659647315343-c0p9rkl3pq38q18r13bkrchs4iqjogv1.apps.googleusercontent.com
STAGING_MEDPLUM_BASE_URL=https://api.staging.medplum.dev/
STAGING_RECAPTCHA_SITE_KEY=6LdA2QopAAAAAO12EVgHwyhWkqQCM0kD7tv9MI5P
STAGING_AWS_ACCESS_KEY_ID
STAGING_AWS_SECRET_ACCESS_KEY
STAGING_AWS_REGION=us-west-2
STAGING_DOCKERHUB_REPOSITORY=medplum/medplum-server-staging
STAGING_DOCKERHUB_USERNAME
STAGING_DOCKERHUB_TOKEN
STAGING_ECS_CLUSTER
STAGING_ECS_SERVICE
```