### PR TITLE
Fix npm ci on Windows runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,20 +109,8 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --force
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent


### PR DESCRIPTION
Last publish step failed: https://github.com/medplum/medplum/actions/runs/7146451123/job/19465886902

I tried re-running the job, but it failed in the same way.

I interpret that as an issue with npm node_modules caching.  We've never experienced that on Linux builders, so I'm assuming it's a Windows issue.