### PR TITLE
Use maxsockets=1 in all github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Deploy
     runs-on: ubuntu-latest
+    if: github.repository == 'medplum/medplum'
     env:
       NODE_VERSION: '18'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -33,27 +34,23 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --maxsockets 1
       - name: Build
         run: npm run build:fast
       - name: Configure AWS Credentials
-        if: github.repository == 'medplum/medplum'
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Docker Hub
-        if: github.repository == 'medplum/medplum'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Setup Docker Buildx
-        if: github.repository == 'medplum/medplum'
         uses: docker/setup-buildx-action@v2
       - name: Deploy
-        if: github.repository == 'medplum/medplum'
         run: ./scripts/cicd-deploy.sh
         env:
           APP_BUCKET: ${{ secrets.APP_BUCKET }}

--- a/.github/workflows/prettier-fmt.yml
+++ b/.github/workflows/prettier-fmt.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-
       - id: install
         name: Install prettier
-        run: npm ci
+        run: npm ci --maxsockets 1
       - name: Run prettier
         id: fmt
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
             {"text": "Starting publish: ${{ github.ref_name }}"}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --maxsockets 1
 
       - name: Build
         run: npm run build:all
@@ -110,7 +110,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci --force
+        run: npm ci --maxsockets 1
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --maxsockets 1
       - name: Build
         run: npm run build:fast
       - name: Configure AWS Credentials

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ node --version
 npm --version
 
 # Install
-[ ! -d "node_modules" ] && npm ci
+[ ! -d "node_modules" ] && npm ci --maxsockets 1
 
 # Build
 npm run build:all


### PR DESCRIPTION
The `build_agent` step in `publish.yml` has consistently failed recently.

The exact error message is: https://github.com/medplum/medplum/actions/runs/7152021898/job/19476903517

```
Run npm ci --force
npm WARN using --force Recommended protections disabled.
npm ERR! code EEXIST
npm ERR! syscall open
npm ERR! path C:\npm\cache\_cacache\tmp\00a7029a
npm ERR! errno -4075
npm ERR! EEXIST: file already exists, open 'C:\npm\cache\_cacache\tmp\00a7029a'
npm ERR! File exists: C:\npm\cache\_cacache\tmp\00a7029a
npm ERR! Remove the existing file and try again, or run npm
npm ERR! with --force to overwrite files recklessly.

npm ERR! A complete log of this run can be found in: C:\npm\cache\_logs\2023-12-09T[15](https://github.com/medplum/medplum/actions/runs/7152021898/job/19476903517#step:7:16)_25_28_[21](https://github.com/medplum/medplum/actions/runs/7152021898/job/19476903517#step:7:22)0Z-debug-0.log
Error: Process completed with exit code 1.
```

However, [this issue](https://github.com/npm/cli/issues/3079) suggests that the error message is misleading, and the root cause is network connectivity issues

That reminded me of a recent change we made to `Dockerfile` to use the `maxsockets` flag.  See https://github.com/medplum/medplum/pull/3472

I tried it on my personal fork, and it worked correctly: https://github.com/codyebberson/medplum/actions/runs/7153609079/job/19480242796

So now this PR adds `maxsockets` to all calls to `npm ci` run by Github Actions 🤷‍♂️ 