### PR TITLE
`getExternalAuthRedirectUri` Should Respect Scope Parameter

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -544,6 +544,22 @@ describe('Client', () => {
         )
       ).toThrow();
     });
+
+    test('should respect scope parameter', async () => {
+      const result = client.getExternalAuthRedirectUri(
+        'https://auth.example.com/authorize',
+        'external-client-123',
+        'https://me.example.com',
+        {
+          clientId: 'medplum-client-123',
+          scope: "profile email foo",
+        },
+        false
+      );
+
+      const { searchParams } = new URL(result);
+      expect(searchParams.get('scope')).toBe('profile email foo');
+    });
   });
 
   test('New project success', async () => {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -552,7 +552,7 @@ describe('Client', () => {
         'https://me.example.com',
         {
           clientId: 'medplum-client-123',
-          scope: "profile email foo",
+          scope: 'profile email foo',
         },
         false
       );

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1191,7 +1191,7 @@ export class MedplumClient extends EventTarget {
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('client_id', clientId);
     url.searchParams.set('redirect_uri', redirectUri);
-    url.searchParams.set('scope', 'openid profile email');
+    url.searchParams.set('scope', loginRequest.scope ?? 'openid profile email');
     url.searchParams.set('state', JSON.stringify(loginRequest));
 
     if (pkceEnabled) {


### PR DESCRIPTION
Closes #3531

* Scope defaults to `openid profile email` if `loginRequest.scope` is undefined, otherwise it is set to the provided value.
* Added test to assert this is true