### PR TITLE
Skip choice options with undefined/falsy value in questionnaire

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -352,6 +352,10 @@ function QuestionnaireChoiceRadioInput(props: QuestionnaireChoiceInputProps): JS
         'value'
       ) as TypedValue;
 
+      if (!optionValue?.value) {
+        continue;
+      }
+
       if (initialValue && stringify(optionValue) === stringify(initialValue)) {
         defaultValue = optionName;
       }


### PR DESCRIPTION
Fixes #2991 

This issue seems to be pertaining for all types of  options (not only for Coding type). It is not related to the option type but rather the option value.
Here in our `QuestionnaireFormItem`, the case where optionValue can be undefined is not taken into account.

https://github.com/medplum/medplum/blob/70903e071e13efb44ce38517bd16f18d2e9a8c0f/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx#L350-L358

Hence when someone tries to submit a falsy value, it directly throws out an error on the screen - _Cannot read properties of undefined_.
This happens when we stop the editing in Questionnaire and control goes to `getCurrentRadioAnswer` in `QuestionnaireFormItem`.

https://github.com/medplum/medplum/blob/70903e071e13efb44ce38517bd16f18d2e9a8c0f/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx#L420-L422

Here I have added a condition where these falsy values will be ignored for our final options. This allows the form to be submitted which then goes to the `handleSubmit` where we are able to show a error notification of the same.

https://github.com/medplum/medplum/blob/70903e071e13efb44ce38517bd16f18d2e9a8c0f/packages/app/src/resource/BuilderPage.tsx#L16-L22

Example output -

![image](https://github.com/medplum/medplum/assets/85165953/fb11929f-271b-4fd0-af9f-ed693e5c324b)
