### PR TITLE
Profile snapshot operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20260,8 +20260,7 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -21881,6 +21880,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -26830,6 +26837,21 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/diff2html": {
+      "version": "3.4.45",
+      "resolved": "https://registry.npmjs.org/diff2html/-/diff2html-3.4.45.tgz",
+      "integrity": "sha512-1SxsjYZYbxX0GGMYJJM7gM0SpMSHqzvvG0UJVROCDpz4tylH2T+EGiinm2boDmTrMlLueVxGfKNxGNLZ9zDlkQ==",
+      "dependencies": {
+        "diff": "5.1.0",
+        "hogan.js": "3.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "highlight.js": "11.8.0"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -30088,6 +30110,292 @@
       "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
       "dev": true
     },
+    "node_modules/fhir": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.12.0.tgz",
+      "integrity": "sha512-N+eLuUbYjvjX5NlZPhE08OVrsJJhulQKkVWnW1M3HpNvreWC1yVvoF8ptmGzlvtDZRCrNrBArfLklphFO2L0oA==",
+      "bundleDependencies": [
+        "lodash",
+        "path",
+        "q",
+        "xml-js"
+      ],
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "path": "^0.12.7",
+        "q": "^1.4.1",
+        "randomatic": "^3.1.0",
+        "xml-js": "^1.6.8"
+      }
+    },
+    "node_modules/fhir-package-loader": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
+      "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "chalk": "^4.1.2",
+        "commander": "^8.3.0",
+        "fs-extra": "^10.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.5.4",
+        "tar": "^5.0.11",
+        "temp": "^0.9.1",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "fpl": "dist/app.js"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/fhir-package-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/fhir-package-loader/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/tar": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.11.tgz",
+      "integrity": "sha512-E6q48d5y4XSCD+Xmwc0yc8lXuyDK38E0FB8N4S/drQRtXOMUhfhDxbB0xr2KKDhNfO51CFmoa6Oz00nAkWsjnA==",
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^2.1.0",
+        "minipass": "^3.1.3",
+        "minizlib": "^2.1.2",
+        "mkdirp": "^0.5.5",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/fhir-package-loader/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/fhir/node_modules/inherits": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/fhir/node_modules/lodash": {
+      "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/fhir/node_modules/path": {
+      "version": "0.12.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "node_modules/fhir/node_modules/process": {
+      "version": "0.11.10",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/fhir/node_modules/q": {
+      "version": "1.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/fhir/node_modules/sax": {
+      "version": "1.2.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/fhir/node_modules/util": {
+      "version": "0.10.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/fhir/node_modules/xml-js": {
+      "version": "1.6.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
     "node_modules/fhirpath": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-3.9.0.tgz",
@@ -30409,7 +30717,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -31027,6 +31334,213 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fsh-sushi": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.5.0.tgz",
+      "integrity": "sha512-Qd5ka92bwbWlH5fSYbFVZRTNn3QO+moXnARn2jCZ+S2veYDfkwkIys6BOUSQV6e0unm98zkk/DMmDHohhA0Z3A==",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "antlr4": "~4.13.1",
+        "axios": "^0.21.4",
+        "chalk": "^3.0.0",
+        "commander": "^8.2.0",
+        "fhir": "^4.9.0",
+        "fhir-package-loader": "^0.6.0",
+        "fs-extra": "^8.1.0",
+        "html-minifier-terser": "5.1.1",
+        "https-proxy-agent": "^5.0.0",
+        "ini": "^1.3.8",
+        "junk": "^3.1.0",
+        "lodash": "^4.17.21",
+        "readline-sync": "^1.4.10",
+        "sanitize-filename": "^1.6.3",
+        "sax": "^1.2.4",
+        "temp": "^0.9.1",
+        "title-case": "^3.0.2",
+        "valid-url": "^1.0.9",
+        "winston": "^3.3.3",
+        "yaml": "^1.9.2"
+      },
+      "bin": {
+        "sushi": "dist/app.js"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/antlr4": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1.tgz",
+      "integrity": "sha512-kiXTspaRYvnIArgE97z5YVVf/cDVQABr3abFRR6mE7yesLMkgu4ujuyV/sgxafQ8wgve0DJQUJ38Z8tkgA2izA==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/clean-css": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/fsh-sushi/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/html-minifier-terser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+      "dependencies": {
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
+        "he": "^1.2.0",
+        "param-case": "^3.0.3",
+        "relateurl": "^0.2.7",
+        "terser": "^4.6.3"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/html-minifier-terser/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/fsh-sushi/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+    },
+    "node_modules/fsh-sushi/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/terser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/fsh-sushi/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -31588,6 +32102,285 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gofsh": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gofsh/-/gofsh-2.2.0.tgz",
+      "integrity": "sha512-yC+M2Bc3aoyePc0XOvLPRknB37D/wGU2VKuyLQSv8xfFZkl3yXlgUkwvTUULYBbYXCxNNZZQodK+YtyxeE3rRg==",
+      "dependencies": {
+        "antlr4": "~4.8.0",
+        "chalk": "^4.1.0",
+        "commander": "^6.0.0",
+        "diff": "^5.0.0",
+        "diff2html": "^3.1.18",
+        "fhir": "^4.10.0",
+        "fhir-package-loader": "^0.5.0",
+        "flat": "^5.0.2",
+        "fs-extra": "^9.0.1",
+        "fsh-sushi": "^3.5.0",
+        "ini": "^1.3.8",
+        "lodash": "^4.17.21",
+        "readline-sync": "^1.4.10",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.5.4",
+        "temp": "^0.9.1",
+        "text-table": "^0.2.0",
+        "toposort": "^2.0.2",
+        "valid-url": "^1.0.9",
+        "winston": "^3.3.3",
+        "yaml": "^1.10.0"
+      },
+      "bin": {
+        "gofsh": "dist/app.js"
+      }
+    },
+    "node_modules/gofsh/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/gofsh/node_modules/antlr4": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+    },
+    "node_modules/gofsh/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/gofsh/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/gofsh/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/gofsh/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/gofsh/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gofsh/node_modules/fhir-package-loader": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
+      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "chalk": "^4.1.2",
+        "commander": "^8.3.0",
+        "fs-extra": "^10.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lodash": "^4.17.21",
+        "semver": "^7.5.4",
+        "tar": "^5.0.11",
+        "temp": "^0.9.1",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "fpl": "dist/app.js"
+      }
+    },
+    "node_modules/gofsh/node_modules/fhir-package-loader/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/gofsh/node_modules/fhir-package-loader/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gofsh/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gofsh/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/gofsh/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gofsh/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/gofsh/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/gofsh/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gofsh/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gofsh/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/gofsh/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gofsh/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gofsh/node_modules/tar": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.11.tgz",
+      "integrity": "sha512-E6q48d5y4XSCD+Xmwc0yc8lXuyDK38E0FB8N4S/drQRtXOMUhfhDxbB0xr2KKDhNfO51CFmoa6Oz00nAkWsjnA==",
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^2.1.0",
+        "minipass": "^3.1.3",
+        "minizlib": "^2.1.2",
+        "mkdirp": "^0.5.5",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/gofsh/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/gofsh/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/gofsh/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/gopd": {
@@ -32159,6 +32952,15 @@
         "node": ">= 16.0.0"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -32171,6 +32973,41 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^1.0.1"
+      }
+    },
+    "node_modules/hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==",
+      "dependencies": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "bin": {
+        "hulk": "bin/hulk"
+      }
+    },
+    "node_modules/hogan.js/node_modules/mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hogan.js/node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -36649,6 +37486,14 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/junk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
+      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -37768,6 +38613,11 @@
       "peerDependencies": {
         "react": ">= 0.14.0"
       }
+    },
+    "node_modules/math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "node_modules/md5": {
       "version": "2.3.0",
@@ -46868,6 +47718,27 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dependencies": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/randomatic/node_modules/is-number": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -48239,7 +49110,6 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
       "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -49344,6 +50214,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
     "node_modules/sax": {
       "version": "1.1.6",
@@ -50679,7 +51557,6 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -52128,7 +53005,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-      "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -52149,7 +53025,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -52161,7 +53036,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -52551,6 +53425,14 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/title-case": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
+      "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/tlds": {
       "version": "1.240.0",
       "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.240.0.tgz",
@@ -52614,6 +53496,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
     },
     "node_modules/totalist": {
       "version": "3.0.1",
@@ -52704,6 +53591,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-api-utils": {
@@ -53953,6 +54848,11 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -56349,6 +57249,8 @@
         "express": "4.18.2",
         "express-rate-limit": "7.1.5",
         "express-validator": "7.0.1",
+        "fsh-sushi": "^3.5.0",
+        "gofsh": "^2.2.0",
         "graphql": "16.8.1",
         "hibp": "13.0.0",
         "http-graceful-shutdown": "^3.1.13",

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -172,7 +172,7 @@ class StructureDefinitionParser {
    * @throws Throws when the StructureDefinition does not have a populated `snapshot` field
    */
   constructor(sd: StructureDefinition) {
-    if (!sd.snapshot?.element || sd.snapshot.element.length === 0) {
+    if (!sd.snapshot?.element?.length) {
       throw new Error(`No snapshot defined for StructureDefinition '${sd.name}'`);
     }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -49,6 +49,8 @@
     "express": "4.18.2",
     "express-rate-limit": "7.1.5",
     "express-validator": "7.0.1",
+    "fsh-sushi": "^3.5.0",
+    "gofsh": "^2.2.0",
     "graphql": "16.8.1",
     "hibp": "13.0.0",
     "http-graceful-shutdown": "^3.1.13",

--- a/packages/server/src/fhir/operations/snapshot.test.ts
+++ b/packages/server/src/fhir/operations/snapshot.test.ts
@@ -1,0 +1,433 @@
+import express from 'express';
+import { loadTestConfig } from '../../config';
+import { initApp } from '../../app';
+import { initTestAuth } from '../../test.setup';
+import { Observation, StructureDefinition } from '@medplum/fhirtypes';
+import request from 'supertest';
+import { ContentType } from '@medplum/core';
+
+const app = express();
+
+const vitalSignsProfile: StructureDefinition = {
+  resourceType: 'StructureDefinition',
+  id: 'us-core-vital-signs',
+  url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs',
+  version: '6.1.0',
+  name: 'USCoreVitalSignsProfile',
+  title: 'US Core Vital Signs Profile',
+  status: 'active',
+  experimental: false,
+  date: '2020-11-17',
+  fhirVersion: '4.0.1',
+  kind: 'resource',
+  abstract: false,
+  type: 'Observation',
+  baseDefinition: 'http://hl7.org/fhir/StructureDefinition/vitalsigns',
+  derivation: 'constraint',
+  differential: {
+    element: [
+      {
+        id: 'Observation',
+        path: 'Observation',
+        short: 'US Core Vital Signs Profile',
+      },
+      {
+        id: 'Observation.category',
+        path: 'Observation.category',
+        slicing: {
+          discriminator: [
+            { type: 'value', path: 'coding.code' },
+            { type: 'value', path: 'coding.system' },
+          ],
+          ordered: false,
+          rules: 'open',
+        },
+        min: 1,
+        max: '*',
+        type: [{ code: 'CodeableConcept' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.category:VSCat',
+        path: 'Observation.category',
+        sliceName: 'VSCat',
+        min: 1,
+        max: '1',
+        type: [{ code: 'CodeableConcept' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.category:VSCat.coding',
+        path: 'Observation.category.coding',
+        min: 1,
+        max: '*',
+        type: [{ code: 'Coding' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.category:VSCat.coding.system',
+        path: 'Observation.category.coding.system',
+        min: 1,
+        max: '1',
+        type: [{ code: 'uri' }],
+        fixedUri: 'http://terminology.hl7.org/CodeSystem/observation-category',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.category:VSCat.coding.code',
+        path: 'Observation.category.coding.code',
+        min: 1,
+        max: '1',
+        type: [{ code: 'code' }],
+        fixedCode: 'vital-signs',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.code',
+        path: 'Observation.code',
+        mustSupport: true,
+        binding: {
+          strength: 'extensible',
+          description: 'The vital sign codes from the base FHIR and US Core Vital Signs.',
+          valueSet: 'http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs',
+        },
+      },
+      {
+        id: 'Observation.subject',
+        path: 'Observation.subject',
+        type: [
+          {
+            code: 'Reference',
+            targetProfile: ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'],
+          },
+        ],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.effective[x]',
+        path: 'Observation.effective[x]',
+        type: [{ code: 'dateTime' }, { code: 'Period' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.value[x]',
+        path: 'Observation.value[x]',
+        definition: 'Vital Signs value are typically recorded using the Quantity data type.',
+        type: [
+          { code: 'Quantity' },
+          { code: 'CodeableConcept' },
+          { code: 'string' },
+          { code: 'boolean' },
+          { code: 'integer' },
+          { code: 'Range' },
+          { code: 'Ratio' },
+          { code: 'SampledData' },
+          { code: 'time' },
+          { code: 'dateTime' },
+          { code: 'Period' },
+        ],
+        mustSupport: true,
+        binding: {
+          strength: 'extensible',
+          description: 'Common UCUM units for recording Vital Signs.',
+          valueSet: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1',
+        },
+      },
+      {
+        id: 'Observation.component.code',
+        path: 'Observation.component.code',
+        mustSupport: true,
+        binding: {
+          strength: 'extensible',
+          description: 'The vital sign codes from the base FHIR and US Core Vital Signs.',
+          valueSet: 'http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs',
+        },
+      },
+      {
+        id: 'Observation.component.value[x]',
+        path: 'Observation.component.value[x]',
+        type: [
+          { code: 'Quantity' },
+          { code: 'CodeableConcept' },
+          { code: 'string' },
+          { code: 'boolean' },
+          { code: 'integer' },
+          { code: 'Range' },
+          { code: 'Ratio' },
+          { code: 'SampledData' },
+          { code: 'time' },
+          { code: 'dateTime' },
+          { code: 'Period' },
+        ],
+        mustSupport: true,
+        binding: {
+          strength: 'extensible',
+          description: 'Common UCUM units for recording Vital Signs.',
+          valueSet: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1',
+        },
+      },
+    ],
+  },
+};
+
+const bloodPressureProfile: StructureDefinition = {
+  resourceType: 'StructureDefinition',
+  id: 'us-core-blood-pressure',
+  url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure',
+  version: '6.1.0',
+  name: 'USCoreBloodPressureProfile',
+  title: 'US Core Blood Pressure Profile',
+  status: 'active',
+  experimental: false,
+  date: '2022-04-20',
+  fhirVersion: '4.0.1',
+  kind: 'resource',
+  abstract: false,
+  type: 'Observation',
+  baseDefinition: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs',
+  derivation: 'constraint',
+  differential: {
+    element: [
+      {
+        id: 'Observation',
+        path: 'Observation',
+        short: 'US Core Blood Pressure Profile',
+      },
+      {
+        id: 'Observation.code',
+        path: 'Observation.code',
+        type: [{ code: 'CodeableConcept' }],
+        patternCodeableConcept: { coding: [{ system: 'http://loinc.org', code: '85354-9' }] },
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component',
+        path: 'Observation.component',
+        slicing: {
+          discriminator: [{ type: 'pattern', path: 'code' }],
+          ordered: false,
+          rules: 'open',
+        },
+        min: 2,
+        max: '*',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic',
+        path: 'Observation.component',
+        sliceName: 'systolic',
+        min: 1,
+        max: '1',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic.code',
+        path: 'Observation.component.code',
+        min: 1,
+        max: '1',
+        patternCodeableConcept: { coding: [{ system: 'http://loinc.org', code: '8480-6' }] },
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic.valueQuantity',
+        path: 'Observation.component.valueQuantity',
+        type: [{ code: 'Quantity' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic.valueQuantity.value',
+        path: 'Observation.component.valueQuantity.value',
+        min: 1,
+        max: '1',
+        type: [{ code: 'decimal' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic.valueQuantity.unit',
+        path: 'Observation.component.valueQuantity.unit',
+        min: 1,
+        max: '1',
+        type: [{ code: 'string' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic.valueQuantity.system',
+        path: 'Observation.component.valueQuantity.system',
+        min: 1,
+        max: '1',
+        type: [{ code: 'uri' }],
+        fixedUri: 'http://unitsofmeasure.org',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:systolic.valueQuantity.code',
+        path: 'Observation.component.valueQuantity.code',
+        min: 1,
+        max: '1',
+        type: [{ code: 'code' }],
+        fixedCode: 'mm[Hg]',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic',
+        path: 'Observation.component',
+        sliceName: 'diastolic',
+        min: 1,
+        max: '1',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic.code',
+        path: 'Observation.component.code',
+        min: 1,
+        max: '1',
+        patternCodeableConcept: { coding: [{ system: 'http://loinc.org', code: '8462-4' }] },
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic.valueQuantity',
+        path: 'Observation.component.valueQuantity',
+        type: [{ code: 'Quantity' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic.valueQuantity.value',
+        path: 'Observation.component.valueQuantity.value',
+        min: 1,
+        max: '1',
+        type: [{ code: 'decimal' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic.valueQuantity.unit',
+        path: 'Observation.component.valueQuantity.unit',
+        min: 1,
+        max: '1',
+        type: [{ code: 'string' }],
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic.valueQuantity.system',
+        path: 'Observation.component.valueQuantity.system',
+        min: 1,
+        max: '1',
+        type: [{ code: 'uri' }],
+        fixedUri: 'http://unitsofmeasure.org',
+        mustSupport: true,
+      },
+      {
+        id: 'Observation.component:diastolic.valueQuantity.code',
+        path: 'Observation.component.valueQuantity.code',
+        min: 1,
+        max: '1',
+        type: [{ code: 'code' }],
+        fixedCode: 'mm[Hg]',
+        mustSupport: true,
+      },
+    ],
+  },
+};
+
+const observation: Observation = {
+  meta: {
+    profile: ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure'],
+  },
+  status: 'final',
+  category: [
+    {
+      coding: [
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/observation-category',
+          code: 'vital-signs',
+          display: 'vital-signs',
+        },
+      ],
+    },
+  ],
+  code: {
+    coding: [
+      {
+        system: 'http://loinc.org',
+        code: '8867-4',
+        display: 'Heart rate',
+      },
+    ],
+    text: 'Heart rate',
+  },
+  subject: {
+    reference: 'Patient/991299df-7662-42ff-a203-c6b0adbdefee',
+  },
+  encounter: {
+    reference: 'Encounter/55e5d713-b960-4f76-b087-a5bcfa5f6fd4',
+  },
+  effectiveDateTime: '2003-07-10T19:33:18-04:00',
+  issued: '2003-07-10T19:33:18.715-04:00',
+  dataAbsentReason: {
+    coding: [
+      {
+        system: 'http://terminology.hl7.org/CodeSystem/data-absent-reason',
+        code: 'unknown',
+        display: 'Unknown',
+      },
+    ],
+    text: 'Unknown',
+  },
+  resourceType: 'Observation',
+};
+
+describe('StructureDefinition $snapshot', () => {
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+  });
+
+  test('Snapshot generation', async () => {
+    const accessToken = await initTestAuth();
+    expect(accessToken).toBeDefined();
+
+    const res = await request(app)
+      .post(`/fhir/R4/StructureDefinition`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send(vitalSignsProfile);
+    expect(res.status).toEqual(201);
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/StructureDefinition`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send(bloodPressureProfile);
+    expect(res2.status).toEqual(201);
+
+    const res3 = await request(app)
+      .post(`/fhir/R4/Observation`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send(observation);
+    expect(res3.status).toEqual(400);
+    expect(res3.body.issue?.[0]?.details?.text).toEqual(
+      `No snapshot defined for StructureDefinition 'USCoreBloodPressureProfile'`
+    );
+
+    const res4 = await request(app)
+      .post(`/fhir/R4/StructureDefinition/$snapshot`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'url', valueString: bloodPressureProfile.url }],
+      });
+    expect(res4.status).toEqual(200);
+    expect(res4.body.snapshot).toBeDefined();
+
+    const res5 = await request(app)
+      .post(`/fhir/R4/Observation`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send(observation);
+    expect(res5.status).toEqual(400);
+    expect(res5.body.issue).toHaveLength(2);
+    expect(res5.body.issue?.[0]?.expression?.[0]).toEqual('Observation.code');
+    expect(res5.body.issue?.[1]?.expression?.[0]).toEqual('Observation.component');
+  });
+});

--- a/packages/server/src/fhir/operations/snapshot.ts
+++ b/packages/server/src/fhir/operations/snapshot.ts
@@ -25,7 +25,10 @@ export async function snapshotHandler(req: Request, res: Response): Promise<void
     def = await ctx.repo.searchOne<StructureDefinition>({
       resourceType: 'StructureDefinition',
       filters: [{ code: 'url', operator: Operator.EQUALS, value: params.url }],
-      sortRules: [{ code: 'version', descending: true }],
+      sortRules: [
+        { code: 'version', descending: true },
+        { code: '_lastUpdated', descending: true },
+      ],
     });
   }
   if (!def) {

--- a/packages/server/src/fhir/operations/snapshot.ts
+++ b/packages/server/src/fhir/operations/snapshot.ts
@@ -1,0 +1,83 @@
+import { StructureDefinition } from '@medplum/fhirtypes';
+import { getOperationDefinition } from './definitions';
+import { Request, Response } from 'express';
+import { getAuthenticatedContext } from '../../context';
+import { parseInputParameters, sendOutputParameters } from './utils/parameters';
+import { OperationOutcomeError, Operator, allOk, badRequest, isResourceType } from '@medplum/core';
+import { sendOutcome } from '../outcomes';
+import { sushiImport, sushiExport, fhirdefs, utils } from 'fsh-sushi';
+import * as gofsh from 'gofsh/dist/index';
+
+const operation = getOperationDefinition('StructureDefinition', 'snapshot');
+
+type SnapshotParameters = {
+  url?: string;
+};
+
+export async function snapshotHandler(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
+  const params = parseInputParameters<SnapshotParameters>(operation, req);
+
+  let def: StructureDefinition | undefined;
+  if (req.params.id) {
+    def = await ctx.repo.readResource<StructureDefinition>('StructureDefinition', req.params.id);
+  } else if (params.url) {
+    def = await ctx.repo.searchOne<StructureDefinition>({
+      resourceType: 'StructureDefinition',
+      filters: [{ code: 'url', operator: Operator.EQUALS, value: params.url }],
+      sortRules: [{ code: 'version', descending: true }],
+    });
+  }
+  if (!def) {
+    sendOutcome(res, badRequest('No StructureDefinition specified'));
+    return;
+  }
+
+  if (!def.snapshot?.element?.length) {
+    // Generate profile snapshot
+    const docs = await resolveDependencies(await fhirToFsh(def));
+    const tank = new sushiImport.FSHTank(docs, {
+      FSHOnly: true,
+      fhirVersion: ['4.0.1'],
+      canonical: 'http://example.com/fsh',
+    });
+    const baseDefs = new fhirdefs.FHIRDefinitions();
+    await utils.loadAutomaticDependencies('4.0.1', [], baseDefs);
+    await utils.loadExternalDependencies(baseDefs, { fhirVersion: ['4.0.1'], canonical: 'http://example.com' });
+    const compiled = sushiExport.exportFHIR(tank, baseDefs);
+    const profile = compiled.profiles.pop();
+    def = { ...def, snapshot: (profile?.toJSON(true) as StructureDefinition).snapshot };
+    await ctx.repo.updateResource(def);
+  }
+  await sendOutputParameters(operation, res, allOk, def);
+}
+
+async function resolveDependencies(docs: sushiImport.FSHDocument[]): Promise<sushiImport.FSHDocument[]> {
+  const ctx = getAuthenticatedContext();
+  const deps: sushiImport.FSHDocument[] = [];
+  for (const d of docs) {
+    deps.push(d);
+    for (const profile of d.profiles.values()) {
+      if (profile.parent) {
+        if (isResourceType(profile.parent)) {
+          continue;
+        }
+        const parent = await ctx.repo.searchOne<StructureDefinition>({
+          resourceType: 'StructureDefinition',
+          filters: [{ code: 'url', operator: Operator.EQUALS, value: profile.parent }],
+          sortRules: [{ code: 'version', descending: true }],
+        });
+        if (!parent) {
+          throw new OperationOutcomeError(badRequest('Unable to locate profile dependency: ' + profile.parent));
+        }
+        deps.push(...(await resolveDependencies(await fhirToFsh(parent))));
+      }
+    }
+  }
+  return deps;
+}
+
+async function fhirToFsh(def: StructureDefinition): Promise<sushiImport.FSHDocument[]> {
+  const fsh = await gofsh.gofshClient.fhirToFsh([def], { style: 'string', logLevel: 'silent' });
+  return sushiImport.importText([new sushiImport.RawFSH(fsh.fsh as string)]);
+}

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -28,6 +28,7 @@ import { getFullUrl } from './search';
 import { smartConfigurationHandler, smartStylingHandler } from './smart';
 import { projectInitHandler } from './operations/projectinit';
 import { conceptMapTranslateHandler } from './operations/conceptmaptranslate';
+import { snapshotHandler } from './operations/snapshot';
 
 export const fhirRouter = Router();
 
@@ -97,6 +98,10 @@ protectedRoutes.post('/Project/([$]|%24)init', asyncWrap(projectInitHandler));
 // ConceptMap $translate
 protectedRoutes.post('/ConceptMap/([$]|%24)translate', asyncWrap(conceptMapTranslateHandler));
 protectedRoutes.post('/ConceptMap/:id/([$]|%24)translate', asyncWrap(conceptMapTranslateHandler));
+
+// StructureDefinition $snapshot
+protectedRoutes.post('/StructureDefinition/([$]|%24)snapshot', asyncWrap(snapshotHandler));
+protectedRoutes.post('/StructureDefinition/:id/([$]|%24)snapshot', asyncWrap(snapshotHandler));
 
 // ValueSet $expand operation
 protectedRoutes.get('/ValueSet/([$]|%24)expand', expandOperator);


### PR DESCRIPTION
Adding experimental support for the `StructureDefinition/$snapshot` operation, which populates the `snapshot` necessary for resource validation from a set of source profile differentials.  Locally, this take ~10s to run to generate the US Core Blood pressure profile, which recursively specializes `USCoreBloodPressure` -> `USCoreVitalSigns` -> `vitalsigns` -> `Observation`