### PR TITLE
More support for FHIR Mapping Language

### DIFF
--- a/packages/core/src/fhirlexer/parse.ts
+++ b/packages/core/src/fhirlexer/parse.ts
@@ -156,7 +156,9 @@ export class Parser {
     }
     if (expectedId && this.peek()?.id !== expectedId) {
       const actual = this.peek() as Token;
-      throw Error(`Expected ${expectedId} but got "${actual.id}" at line ${actual.line} column ${actual.column}.`);
+      throw Error(
+        `Expected ${expectedId} but got "${actual.id}" (${actual.value}) at line ${actual.line} column ${actual.column}.`
+      );
     }
     if (expectedValue && this.peek()?.value !== expectedValue) {
       const actual = this.peek() as Token;

--- a/packages/core/src/fhirmapper/parse.ts
+++ b/packages/core/src/fhirmapper/parse.ts
@@ -6,11 +6,12 @@ import {
   StructureMapGroupRuleDependent,
   StructureMapGroupRuleSource,
   StructureMapGroupRuleTarget,
+  StructureMapGroupRuleTargetParameter,
   StructureMapStructure,
 } from '@medplum/fhirtypes';
-import { Parser } from '../fhirlexer/parse';
+import { Atom, Parser } from '../fhirlexer/parse';
 import { FunctionAtom, LiteralAtom, SymbolAtom } from '../fhirpath/atoms';
-import { initFhirPathParserBuilder, OperatorPrecedence } from '../fhirpath/parse';
+import { OperatorPrecedence, initFhirPathParserBuilder } from '../fhirpath/parse';
 import { tokenize } from './tokenize';
 
 class StructureMapParser {
@@ -18,15 +19,12 @@ class StructureMapParser {
   constructor(readonly parser: Parser) {}
 
   parse(): StructureMap {
-    // 'map' url '=' identifier
-    // map "http://hl7.org/fhir/StructureMap/tutorial" = tutorial
-    this.parser.consume('Symbol', 'map');
-    this.structureMap.url = this.parser.consume('String').value;
-    this.parser.consume('=');
-    this.structureMap.name = this.parser.consume().value;
     while (this.parser.hasMore()) {
       const next = this.parser.peek()?.value;
       switch (next) {
+        case 'map':
+          this.parseMap();
+          break;
         case 'uses':
           this.parseUses();
           break;
@@ -44,6 +42,15 @@ class StructureMapParser {
       }
     }
     return this.structureMap;
+  }
+
+  private parseMap(): void {
+    // 'map' url '=' identifier
+    // map "http://hl7.org/fhir/StructureMap/tutorial" = tutorial
+    this.parser.consume('Symbol', 'map');
+    this.structureMap.url = this.parser.consume('String').value;
+    this.parser.consume('=');
+    this.structureMap.name = this.parser.consume().value;
   }
 
   private parseUses(): void {
@@ -184,13 +191,9 @@ class StructureMapParser {
     const result: StructureMapGroupRuleSource = {};
 
     const context = this.parseRuleContext();
-    if (context.includes('.')) {
-      const parts = context.split('.');
-      result.context = parts[0];
-      result.element = parts[1];
-    } else {
-      result.context = context;
-    }
+    const parts = context.split('.');
+    result.context = parts[0];
+    result.element = parts[1];
 
     if (this.parser.hasMore() && this.parser.peek()?.value === ':') {
       this.parser.consume(':');
@@ -198,8 +201,9 @@ class StructureMapParser {
     }
 
     if (this.parser.hasMore() && this.parser.peek()?.value === 'default') {
-      this.parser.consume('default');
-      this.parser.consumeAndParse();
+      this.parser.consume('Symbol', 'default');
+      // this.parser.consumeAndParse();
+      result.defaultValueString = this.parser.consume('String').value;
     }
 
     if (
@@ -215,6 +219,11 @@ class StructureMapParser {
     if (this.parser.peek()?.value === 'as') {
       this.parser.consume('Symbol', 'as');
       result.variable = this.parser.consume().value;
+    }
+
+    if (this.parser.peek()?.value === 'log') {
+      this.parser.consume('Symbol', 'log');
+      result.logMessage = this.parser.consume('String').value;
     }
 
     if (this.parser.peek()?.value === 'where') {
@@ -245,14 +254,10 @@ class StructureMapParser {
     const result: StructureMapGroupRuleTarget = {};
 
     const context = this.parseRuleContext();
-    if (context.includes('.')) {
-      const parts = context.split('.');
-      result.contextType = 'variable';
-      result.context = parts[0];
-      result.element = parts[1];
-    } else {
-      result.context = context;
-    }
+    const parts = context.split('.');
+    result.contextType = 'variable';
+    result.context = parts[0];
+    result.element = parts[1];
 
     if (this.parser.peek()?.value === '=') {
       this.parser.consume('=');
@@ -287,7 +292,7 @@ class StructureMapParser {
     } else if (transformFhirPath instanceof LiteralAtom) {
       this.parseRuleTargetLiteral(result, transformFhirPath);
     } else {
-      throw new Error(`Unexpected FHIRPath: ${transformFhirPath}`);
+      result.parameter = [{ valueId: transformFhirPath.toString() }];
     }
   }
 
@@ -296,39 +301,13 @@ class StructureMapParser {
   }
 
   private parseRuleTargetFunction(result: StructureMapGroupRuleTarget, functionAtom: FunctionAtom): void {
-    const functionName = functionAtom.name;
-    switch (functionName) {
-      case 'create':
-        result.parameter = [
-          {
-            valueString: (functionAtom.args[0] as LiteralAtom).value.value as string,
-          },
-        ];
-        break;
-
-      case 'translate':
-        result.parameter = [{}];
-        break;
-
-      default:
-        throw new Error('Unknown target function: ' + functionName);
-    }
+    // https://hl7.org/fhir/r4/valueset-map-transform.html
+    result.transform = functionAtom.name as 'copy';
+    result.parameter = functionAtom.args?.map(atomToParameter);
   }
 
   private parseRuleTargetLiteral(result: StructureMapGroupRuleTarget, literalAtom: LiteralAtom): void {
-    switch (literalAtom.value.type) {
-      case 'boolean':
-        result.parameter = [{ valueBoolean: literalAtom.value.value as boolean }];
-        break;
-      case 'decimal':
-        result.parameter = [{ valueDecimal: literalAtom.value.value as number }];
-        break;
-      case 'string':
-        result.parameter = [{ valueString: literalAtom.value.value as string }];
-        break;
-      default:
-        throw new Error('Unknown target literal type: ' + literalAtom.value.type);
-    }
+    result.parameter = [literalToParameter(literalAtom)];
   }
 
   private parseRuleContext(): string {
@@ -355,6 +334,31 @@ class StructureMapParser {
       this.parser.consume();
     }
     this.parser.consume('}');
+  }
+}
+
+function atomToParameter(atom: Atom): StructureMapGroupRuleTargetParameter {
+  if (atom instanceof SymbolAtom) {
+    return { valueId: atom.name };
+  }
+  if (atom instanceof LiteralAtom) {
+    return literalToParameter(atom);
+  }
+  throw new Error('Unexpected atom: ' + atom.constructor.name);
+}
+
+function literalToParameter(literalAtom: LiteralAtom): StructureMapGroupRuleTargetParameter {
+  switch (literalAtom.value.type) {
+    case 'boolean':
+      return { valueBoolean: literalAtom.value.value as boolean };
+    case 'decimal':
+      return { valueDecimal: literalAtom.value.value as number };
+    case 'integer':
+      return { valueInteger: literalAtom.value.value as number };
+    case 'string':
+      return { valueString: literalAtom.value.value as string };
+    default:
+      throw new Error('Unknown target literal type: ' + literalAtom.value.type);
   }
 }
 

--- a/packages/core/src/fhirmapper/transform.test.ts
+++ b/packages/core/src/fhirmapper/transform.test.ts
@@ -1,0 +1,133 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+describe('FHIR Mapper transform', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('Simplest possible transform', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step1
+
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a as a -> tgt.a = a "rule_a";
+      }
+    `;
+
+    const input = { a: 'a' };
+    const expected = { a: 'a' };
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toMatchObject(expected);
+  });
+
+  test('Fields with different names', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step2
+
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a1 as b -> tgt.a2 = b;
+      }
+    `;
+
+    const input = { a1: 'a' };
+    const expected = { a2: 'a' };
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toMatchObject(expected);
+  });
+
+  test('Length restriction truncate', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step3
+
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a2 as a -> tgt.a2 = truncate(a, 3); // just cut it off at 3 characters
+      }
+    `;
+
+    const input = { a2: 'abcdef' };
+    const expected = { a2: 'abc' };
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toMatchObject(expected);
+  });
+
+  test('Length restriction ignore', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step3
+
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a2 as a where a2.length() <= 3 -> tgt.a2 = a; // ignore it
+      }
+    `;
+
+    const input1 = { a2: 'abcdef' };
+    const expected1 = { a2: undefined };
+    const actual1 = structureMapTransform(parseMappingLanguage(map), input1);
+    expect(actual1).toMatchObject(expected1);
+
+    const input2 = { a2: 'abc' };
+    const expected2 = { a2: 'abc' };
+    const actual2 = structureMapTransform(parseMappingLanguage(map), input2);
+    expect(actual2).toMatchObject(expected2);
+  });
+
+  test('Length restriction error', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step3
+
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a2 as a check a2.length() <= 3 -> tgt.a2 = a; // error if it's longer than 20 characters
+      }
+    `;
+
+    const input1 = { a2: 'abcdef' };
+    try {
+      structureMapTransform(parseMappingLanguage(map), input1);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toBe('Check failed: a2.length() <= 3');
+    }
+
+    const input2 = { a2: 'abc' };
+    const expected2 = { a2: 'abc' };
+    const actual2 = structureMapTransform(parseMappingLanguage(map), input2);
+    expect(actual2).toMatchObject(expected2);
+  });
+
+  test('Set to primitive integer', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step4
+
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a3 as a -> tgt.a3 = 123;
+      }
+    `;
+
+    const input = { a3: 1 };
+    const expected = { a3: 123 };
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toMatchObject(expected);
+  });
+});

--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -1,0 +1,167 @@
+import {
+  StructureMap,
+  StructureMapGroup,
+  StructureMapGroupInput,
+  StructureMapGroupRule,
+  StructureMapGroupRuleSource,
+  StructureMapGroupRuleTarget,
+} from '@medplum/fhirtypes';
+import { evalFhirPathTyped } from '../fhirpath/parse';
+import { getTypedPropertyValue, toJsBoolean, toTypedValue } from '../fhirpath/utils';
+
+interface TransformContext {
+  parent?: TransformContext;
+  variables?: Record<string, any>;
+}
+
+export function structureMapTransform(structureMap: StructureMap, input: any): any {
+  return evalStructureMap({}, structureMap, input);
+}
+
+function evalStructureMap(ctx: TransformContext, structureMap: StructureMap, input: any): any {
+  const groups = structureMap.group as StructureMapGroup[];
+  for (const group of groups) {
+    input = evalGroup(ctx, group, input);
+  }
+  return input;
+}
+
+function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: any): any {
+  let sourceInput = undefined;
+  let targetInput = undefined;
+
+  for (const input of group.input as StructureMapGroupInput[]) {
+    if (input.mode === 'source') {
+      sourceInput = input;
+    }
+    if (input.mode === 'target') {
+      targetInput = input;
+    }
+  }
+
+  if (!sourceInput) {
+    throw new Error('Missing source input');
+  }
+
+  if (!targetInput) {
+    throw new Error('Missing target input');
+  }
+
+  const variables: Record<string, any> = {};
+  const result = {};
+
+  if (sourceInput) {
+    variables[sourceInput.name as string] = input;
+  }
+
+  if (targetInput) {
+    variables[targetInput.name as string] = result;
+  }
+
+  const newContext: TransformContext = { parent: ctx, variables };
+
+  for (const rule of group.rule as StructureMapGroupRule[]) {
+    evalRule(newContext, rule);
+  }
+
+  return result;
+}
+
+function evalRule(ctx: TransformContext, rule: StructureMapGroupRule): void {
+  for (const source of rule.source as StructureMapGroupRuleSource[]) {
+    evalSource(ctx, source);
+  }
+  for (const target of rule.target as StructureMapGroupRuleTarget[]) {
+    evalTarget(ctx, target);
+  }
+}
+
+function evalSource(ctx: TransformContext, source: StructureMapGroupRuleSource): void {
+  const sourceContext = getVariable(ctx, source.context as string);
+  const sourceElement = source.element as string;
+  const sourceValue = evalFhirPathTyped(sourceElement, [toTypedValue(sourceContext)]);
+  if (!sourceValue || sourceValue.length === 0) {
+    return;
+  }
+
+  if (source.condition) {
+    const conditionExpression = source.condition as string;
+    const conditionInput = [toTypedValue(sourceContext)];
+    const conditionVariables = { [source.variable as string]: sourceValue[0] };
+    const conditionResult = evalFhirPathTyped(conditionExpression, conditionInput, conditionVariables);
+    if (!toJsBoolean(conditionResult)) {
+      return;
+    }
+  }
+
+  if (source.check) {
+    const checkExpression = source.check as string;
+    const checkInput = [toTypedValue(sourceContext)];
+    const checkVariables = { [source.variable as string]: sourceValue[0] };
+    const checkResult = evalFhirPathTyped(checkExpression, checkInput, checkVariables);
+    if (!toJsBoolean(checkResult)) {
+      throw new Error('Check failed: ' + checkExpression);
+    }
+  }
+
+  if (!ctx.variables) {
+    ctx.variables = {};
+  }
+
+  ctx.variables[source.variable as string] = sourceValue[0].value;
+}
+
+function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
+  switch (target.transform as string) {
+    case 'copy':
+      evalCopy(ctx, target);
+      break;
+    case 'truncate':
+      evalTruncate(ctx, target);
+      break;
+    default:
+      throw new Error('Unsupported transform: ' + target.transform);
+  }
+}
+
+function evalCopy(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
+  const targetContext = getVariable(ctx, target.context as string);
+  const targetElement = target.element as string;
+  let targetParameter = getTypedPropertyValue(
+    { type: 'StructureMapGroupRuleTargetParameter', value: target.parameter?.[0] },
+    'value'
+  );
+  if (Array.isArray(targetParameter)) {
+    targetParameter = targetParameter[0];
+  }
+  if (!targetParameter) {
+    return;
+  }
+  let targetValue = targetParameter.value;
+  if (targetParameter.type === 'id') {
+    targetValue = getVariable(ctx, targetParameter.value as string);
+  }
+  targetContext[targetElement] = targetValue;
+}
+
+function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
+  const targetContext = getVariable(ctx, target.context as string);
+  const targetElement = target.element as string;
+  let targetValue = getVariable(ctx, target.parameter?.[0]?.valueId as string);
+  const targetLength = target.parameter?.[1]?.valueInteger as number;
+  if (targetValue && typeof targetValue === 'string') {
+    targetValue = targetValue.substring(0, targetLength);
+  }
+  targetContext[targetElement] = targetValue;
+}
+
+function getVariable(ctx: TransformContext, name: string): any {
+  const value = ctx.variables?.[name];
+  if (value) {
+    return value;
+  }
+  if (ctx.parent) {
+    return getVariable(ctx.parent, name);
+  }
+  return undefined;
+}

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1,6 +1,6 @@
 import { Reference } from '@medplum/fhirtypes';
 import { Atom, AtomContext } from '../fhirlexer/parse';
-import { isResource, PropertyType, TypedValue } from '../types';
+import { PropertyType, TypedValue, isResource } from '../types';
 import { calculateAge } from '../utils';
 import { DotAtom, SymbolAtom } from './atoms';
 import { parseDateString } from './date';

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -131,7 +131,11 @@ export function initFhirPathParserBuilder(): ParserBuilder {
       parse: (_, token) => new LiteralAtom({ type: PropertyType.Quantity, value: parseQuantity(token.value) }),
     })
     .registerPrefix('Number', {
-      parse: (_, token) => new LiteralAtom({ type: PropertyType.decimal, value: parseFloat(token.value) }),
+      parse: (_, token) =>
+        new LiteralAtom({
+          type: token.value.includes('.') ? PropertyType.decimal : PropertyType.integer,
+          value: parseFloat(token.value),
+        }),
     })
     .registerPrefix('true', { parse: () => new LiteralAtom({ type: PropertyType.boolean, value: true }) })
     .registerPrefix('false', { parse: () => new LiteralAtom({ type: PropertyType.boolean, value: false }) })


### PR DESCRIPTION
In service of https://github.com/medplum/medplum/issues/3005

* Parse rule source log
* Parse rule source default
* Parse more parameter types (TBH, the spec is unfortunately awkward here - I wish they would have just allowed you to use a FHIRPath expression fully)
* Added first draft of `structureMapTransform()` method
* Added example tests of the first half of the [FHIR Mapping Language Tutorial](https://build.fhir.org/mapping-tutorial.html)

The ultimate goal here is to use the FHIR Mapping Language to convert CCDA-to-FHIR and FHIR-to-CCDA.  That will be an imperfect conversion, but it seems like the best starting point.

In particular, [hl7ch/cda-fhir-maps](https://github.com/hl7ch/cda-fhir-maps) looks like an excellent starting point. (Apache-2.0 license)

FHIR Mapping Language is not used in our production server at this time, so this is a low risk change.