### PR TITLE
⚠️ Required fields in FHIR type definitions

### DIFF
--- a/examples/foomedical/src/pages/GetCarePage.tsx
+++ b/examples/foomedical/src/pages/GetCarePage.tsx
@@ -11,6 +11,7 @@ export function GetCare(): JSX.Element {
         schedule={schedule as Schedule}
         questionnaire={{
           resourceType: 'Questionnaire',
+          status: 'active',
           name: 'Test',
           item: [
             {

--- a/examples/medplum-demo-bots/src/candid-health/send-to-candid.test.ts
+++ b/examples/medplum-demo-bots/src/candid-health/send-to-candid.test.ts
@@ -444,7 +444,10 @@ describe('Candid Health Tests', () => {
     await handler(medplum, {
       input: encounter,
       contentType: 'application/fhir+json',
-      secrets: { CANDID_API_KEY: { valueString: '123' }, CANDID_API_SECRET: { valueString: 'ABC' } },
+      secrets: {
+        CANDID_API_KEY: { name: 'CANDID_API_KEY', valueString: '123' },
+        CANDID_API_SECRET: { name: 'CANDID_API_SECRET', valueString: 'ABC' },
+      },
     });
 
     const body = JSON.parse(vi.mocked(fetch).mock?.lastCall?.[1]?.body?.toString() || '{}');

--- a/examples/medplum-demo-bots/src/candid-health/sync-candid-tasks.ts
+++ b/examples/medplum-demo-bots/src/candid-health/sync-candid-tasks.ts
@@ -28,6 +28,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
     const encounter = await medplum.createResourceIfNoneExist(
       {
         resourceType: 'Encounter',
+        status: 'finished',
+        class: { code: 'inpatient' },
         identifier: [
           {
             system: 'https://joincandidhealth.com/encounter/id',
@@ -40,6 +42,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
     await medplum.createResourceIfNoneExist(
       {
         resourceType: 'Task',
+        status: 'in-progress',
+        intent: 'order',
         identifier: [
           {
             system: 'https://api-staging.joincandidhealth.com/task/id',

--- a/examples/medplum-demo-bots/src/create-pdf.ts
+++ b/examples/medplum-demo-bots/src/create-pdf.ts
@@ -14,6 +14,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
   // Create a Media, representing an attachment
   const media = await medplum.createResource({
     resourceType: 'Media',
+    status: 'completed',
     content: {
       contentType: 'application/pdf',
       url: 'Binary/' + binary.id,

--- a/examples/medplum-demo-bots/src/deduplication/merge-matching-patients.test.ts
+++ b/examples/medplum-demo-bots/src/deduplication/merge-matching-patients.test.ts
@@ -1,5 +1,5 @@
 import { ContentType, MedplumClient, createReference, getStatus, isOperationOutcome } from '@medplum/core';
-import { OperationOutcome, Patient, PatientLink, ServiceRequest } from '@medplum/fhirtypes';
+import { OperationOutcome, Patient, ServiceRequest } from '@medplum/fhirtypes';
 import { Mock, vi } from 'vitest';
 import {
   linkPatientRecords,
@@ -72,7 +72,7 @@ describe('Deduplication', () => {
       resourceType: 'Patient',
       id: 'target',
       name: [{ given: ['Lisa'], family: 'Simpson' }],
-      link: [{ other: createReference({ resourceType: 'Patient', id: '123' }), type: 'seealso' }] as PatientLink,
+      link: [{ other: [createReference({ resourceType: 'Patient', id: '123' })], type: 'seealso' }],
     } as Patient;
 
     const result = linkPatientRecords(srcPatient, targetPatient);

--- a/examples/medplum-demo-bots/src/eligibility-check-opkit.test.ts
+++ b/examples/medplum-demo-bots/src/eligibility-check-opkit.test.ts
@@ -67,6 +67,7 @@ test.skip('Success', async () => {
   const input: Coverage = {
     resourceType: 'Coverage',
     id: '52e9f3e8-0b9d-47ca-b1af-1f9750c0e7c6',
+    beneficiary: createReference(patient),
     subscriber: createReference(patient),
     payor: [createReference(org)],
     subscriberId: '123',

--- a/examples/medplum-demo-bots/src/eligibility-check-opkit.ts
+++ b/examples/medplum-demo-bots/src/eligibility-check-opkit.ts
@@ -47,12 +47,15 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
     return true;
   }
 
-  let coverageEligibilityReq: CoverageEligibilityRequest = await medplum.createResource({
+  let coverageEligibilityReq: CoverageEligibilityRequest = await medplum.createResource<CoverageEligibilityRequest>({
     resourceType: 'CoverageEligibilityRequest',
+    status: 'active',
+    purpose: ['validation', 'benefits'],
+    created: new Date().toISOString(),
     provider: createReference(provider),
     patient: createReference(patient),
     insurer: createReference(organization),
-    insurance: [createReference(coverage)],
+    insurance: [{ coverage: createReference(coverage) }],
   });
 
   const providerNpi = provider.identifier?.find((identifier) => identifier.system === 'http://hl7.org/fhir/sid/us-npi')
@@ -269,9 +272,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
     return item;
   };
 
-  coverageEligibilityReq = await medplum.updateResource({
-    resourceType: 'CoverageEligibilityRequest',
-    id: coverageEligibilityReq.id,
+  coverageEligibilityReq = await medplum.updateResource<CoverageEligibilityRequest>({
+    ...coverageEligibilityReq,
     identifier: [
       {
         system: 'https://api.opkit.co/v1/eligibility_inquiries/',
@@ -288,9 +290,10 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
     ],
   });
 
-  const coverageEligibilityResponse: CoverageEligibilityResponse = await medplum.createResource({
+  const coverageEligibilityResponse = await medplum.createResource<CoverageEligibilityResponse>({
     resourceType: 'CoverageEligibilityResponse',
     status: isPlanActive ? 'active' : 'cancelled',
+    created: new Date().toISOString(),
     outcome: 'complete',
     purpose: ['validation', 'benefits'],
     request: createReference(coverageEligibilityReq),

--- a/examples/medplum-demo-bots/src/finalize-reports.test.ts
+++ b/examples/medplum-demo-bots/src/finalize-reports.test.ts
@@ -64,6 +64,7 @@ describe('Finalize Report', async () => {
     const report: DiagnosticReport = await medplum.createResource({
       resourceType: 'DiagnosticReport',
       status: 'preliminary',
+      code: { text: 'Body Mass Index' },
       result: [createReference(observation)],
     });
     // end-block create-resources
@@ -128,6 +129,7 @@ describe('Finalize Report', async () => {
     const report: DiagnosticReport = await medplum.createResource({
       resourceType: 'DiagnosticReport',
       status: 'preliminary',
+      code: { text: 'Body Mass Index' },
       result: [createReference(observation)],
     });
 

--- a/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
@@ -593,7 +593,7 @@ class HealthGorillaRequestGroupBuilder {
         const coverageRef = accountCoverage?.coverage;
         if (coverageRef) {
           const medplumCoverage = await medplum.readReference(coverageRef);
-          const resultCoverage: Coverage = {
+          const resultCoverage: Partial<Coverage> = {
             ...medplumCoverage,
             id: 'coverage' + this.coverages.length,
             beneficiary: createReference(this.patient),
@@ -602,7 +602,7 @@ class HealthGorillaRequestGroupBuilder {
           };
 
           ((resultAccount.coverage as AccountCoverage[])[i].coverage as Reference).reference = '#' + resultCoverage.id;
-          this.coverages = append(this.coverages, resultCoverage);
+          this.coverages = append(this.coverages, resultCoverage as Coverage);
 
           if (medplumCoverage.payor) {
             for (const payorRef of medplumCoverage.payor) {

--- a/examples/medplum-demo-bots/src/lab-integration/read-oru-message.test.ts
+++ b/examples/medplum-demo-bots/src/lab-integration/read-oru-message.test.ts
@@ -28,10 +28,10 @@ import { handler, processOruMessage } from './read-oru-message';
 dotenv.config();
 
 const CONNECTION_DETAILS = {
-  SFTP_USER: { valueString: 'user' },
-  SFTP_HOST: { valueString: '111111.server.transfer.us-east-1.amazonaws.com' },
-  SFTP_PRIVATE_KEY: { valueString: 'abcd' },
-  SFTP_ENVIRONMENT: { valueString: 'test' },
+  SFTP_USER: { name: 'SFTP_USER', valueString: 'user' },
+  SFTP_HOST: { name: 'SFTP_HOST', valueString: '111111.server.transfer.us-east-1.amazonaws.com' },
+  SFTP_PRIVATE_KEY: { name: 'SFTP_PRIVATE_KEY', valueString: 'abcd' },
+  SFTP_ENVIRONMENT: { name: 'SFTP_ENVIRONMENT', valueString: 'test' },
 };
 
 vi.mock('ssh2-sftp-client');
@@ -124,7 +124,7 @@ describe('Read from Partner Lab', () => {
 
   test.skip('Test Connection', async (ctx: any) => {
     await handler(ctx.medplum, {
-      input: { resourceType: 'QuestionnaireResponse' },
+      input: { resourceType: 'QuestionnaireResponse', status: 'completed' },
       contentType: 'string',
       secrets: { ...CONNECTION_DETAILS },
     } as BotEvent<QuestionnaireResponse>);
@@ -377,7 +377,7 @@ describe('Read from Partner Lab', () => {
     });
 
     await handler(medplum, {
-      input: { resourceType: 'QuestionnaireResponse' },
+      input: { resourceType: 'QuestionnaireResponse', status: 'completed' },
       contentType: 'string',
       secrets: { ...CONNECTION_DETAILS },
     } as BotEvent<QuestionnaireResponse>);

--- a/examples/medplum-demo-bots/src/lab-integration/read-oru-message.ts
+++ b/examples/medplum-demo-bots/src/lab-integration/read-oru-message.ts
@@ -161,9 +161,10 @@ export async function processOruMessage(
   let observations = processObxSegments(message, serviceRequest, performer);
 
   // If there's an existing report, just update it with the new values
-  const report = existingReport || {
+  const report: DiagnosticReport = existingReport ?? {
     resourceType: 'DiagnosticReport',
-    code: serviceRequest.code,
+    status: 'preliminary',
+    code: serviceRequest.code as CodeableConcept,
     subject: serviceRequest.subject,
     basedOn: [createReference(serviceRequest)],
     performer: [createReference(performer)],

--- a/examples/medplum-demo-bots/src/lab-integration/send-orm-message.test.ts
+++ b/examples/medplum-demo-bots/src/lab-integration/send-orm-message.test.ts
@@ -8,9 +8,9 @@ import { createOrmMessage, handler } from './send-orm-message';
 dotenv.config();
 
 const CONNECTION_DETAILS = {
-  SFTP_USER: { valueString: 'user' },
-  SFTP_HOST: { valueString: '123456.transfer.us-east-1.amazonaws.com' },
-  SFTP_PRIVATE_KEY: { valueString: process.env.PRIVATE_KEY },
+  SFTP_USER: { name: 'SFTP_USER', valueString: 'user' },
+  SFTP_HOST: { name: 'SFTP_HOST', valueString: '123456.transfer.us-east-1.amazonaws.com' },
+  SFTP_PRIVATE_KEY: { name: 'SFTP_PRIVATE_KEY', valueString: process.env.PRIVATE_KEY },
 };
 
 vi.mock('ssh2-sftp-client');

--- a/examples/medplum-demo-bots/src/patient-intake.test.ts
+++ b/examples/medplum-demo-bots/src/patient-intake.test.ts
@@ -9,6 +9,7 @@ test('Success', async () => {
   const medplum = new MockClient();
   const input: QuestionnaireResponse = {
     resourceType: 'QuestionnaireResponse',
+    status: 'completed',
     item: [
       { linkId: 'firstName', answer: [{ valueString: 'John' }] },
       { linkId: 'lastName', answer: [{ valueString: 'Smith' }] },
@@ -24,6 +25,7 @@ test('Missing first name', async () => {
   console.log = vi.fn();
   const input: QuestionnaireResponse = {
     resourceType: 'QuestionnaireResponse',
+    status: 'completed',
     item: [
       { linkId: 'firstName', answer: [{ valueString: '' }] },
       { linkId: 'lastName', answer: [{ valueString: 'Smith' }] },
@@ -39,6 +41,7 @@ test('Missing last name', async () => {
   console.log = vi.fn();
   const input: QuestionnaireResponse = {
     resourceType: 'QuestionnaireResponse',
+    status: 'completed',
     item: [
       { linkId: 'firstName', answer: [{ valueString: 'John' }] },
       { linkId: 'lastName', answer: [{ valueString: '' }] },

--- a/examples/medplum-demo-bots/src/patient-intake.ts
+++ b/examples/medplum-demo-bots/src/patient-intake.ts
@@ -32,6 +32,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
   // Create an order (FHIR ServiceRequest)
   const order = await medplum.createResource<ServiceRequest>({
     resourceType: 'ServiceRequest',
+    status: 'active',
+    intent: 'order',
     subject: createReference(patient),
     code: {
       text: 'Order for a test',
@@ -42,6 +44,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
   if (answers['comment']?.valueString) {
     await medplum.createResource<Communication>({
       resourceType: 'Communication',
+      status: 'completed',
       basedOn: [createReference(order)],
       subject: createReference(patient),
       payload: [

--- a/examples/medplum-demo-bots/src/questionnaire-bots/conditions-list/conditions-list-questionnaire.test.ts
+++ b/examples/medplum-demo-bots/src/questionnaire-bots/conditions-list/conditions-list-questionnaire.test.ts
@@ -78,6 +78,7 @@ test('Success', async () => {
   const encounter = await medplum.createResource({
     resourceType: 'Encounter',
     status: 'in-progress',
+    class: { code: 'ambulatory' },
     subject: createReference(HomerSimpson),
     participant: [{ individual: createReference(DrAliceSmith) }], // Dr. Alice Smith is the Practitioner who performed the encounter
   });

--- a/examples/medplum-demo-bots/src/sample-account-setup.ts
+++ b/examples/medplum-demo-bots/src/sample-account-setup.ts
@@ -227,7 +227,9 @@ async function ensureSlots(medplum: MedplumClient, schedule: Schedule, slotDate:
     slotDate.setHours(hour, 0, 0, 0);
     await medplum.createResource({
       resourceType: 'Slot',
+      status: 'free',
       start: slotDate.toISOString(),
+      end: new Date(slotDate.getTime() + 30 * 60 * 1000).toISOString(),
       schedule: createReference(schedule),
     });
   }
@@ -347,6 +349,7 @@ async function createCarePlan(medplum: MedplumClient, patient: Patient, tasks: T
 function createA1CObservation(patient: Patient): Observation {
   return {
     resourceType: 'Observation',
+    status: 'final',
     subject: createReference(patient),
     code: {
       text: 'Hemoglobin A1c',
@@ -767,6 +770,7 @@ function createHeartRateObservation(patient: Patient, date: Date): Observation {
 function createWelcomeMessage(patient: Patient, practitioner: Practitioner): Communication {
   return {
     resourceType: 'Communication',
+    status: 'completed',
     subject: createReference(patient),
     recipient: [createReference(patient)],
     sender: createReference(practitioner),

--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -1,4 +1,4 @@
-import { allOk, createReference, sleep } from '@medplum/core';
+import { ContentType, allOk, createReference, sleep } from '@medplum/core';
 import { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { Client, Server } from 'mock-socket';
@@ -45,6 +45,8 @@ describe('App', () => {
 
     const agent = await medplum.createResource<Agent>({
       resourceType: 'Agent',
+      name: 'Test Agent',
+      status: 'active',
     });
 
     const app = new App(medplum, agent.id as string);
@@ -101,6 +103,8 @@ describe('App', () => {
 
     const agent = await medplum.createResource<Agent>({
       resourceType: 'Agent',
+      name: 'Test Agent',
+      status: 'active',
     });
 
     const app = new App(medplum, agent.id as string);
@@ -146,7 +150,10 @@ describe('App', () => {
 
     const endpoint = await medplum.createResource<Endpoint>({
       resourceType: 'Endpoint',
+      status: 'active',
       address: '', // invalid empty address
+      connectionType: { code: ContentType.HL7_V2 },
+      payloadType: [{ coding: [{ code: ContentType.HL7_V2 }] }],
     });
 
     const mockServer = new Server('wss://example.com/ws/agent');
@@ -168,6 +175,8 @@ describe('App', () => {
 
     const agent = await medplum.createResource<Agent>({
       resourceType: 'Agent',
+      status: 'active',
+      name: 'Test Agent',
       channel: [
         {
           name: 'test',
@@ -197,7 +206,10 @@ describe('App', () => {
 
     const endpoint = await medplum.createResource<Endpoint>({
       resourceType: 'Endpoint',
+      status: 'active',
       address: 'foo:', // unsupported protocol
+      connectionType: { code: ContentType.HL7_V2 },
+      payloadType: [{ coding: [{ code: ContentType.HL7_V2 }] }],
     });
 
     const mockServer = new Server('wss://example.com/ws/agent');
@@ -219,6 +231,8 @@ describe('App', () => {
 
     const agent = await medplum.createResource<Agent>({
       resourceType: 'Agent',
+      status: 'active',
+      name: 'Test Agent',
       channel: [
         {
           name: 'test',

--- a/packages/agent/src/dicom.test.ts
+++ b/packages/agent/src/dicom.test.ts
@@ -25,7 +25,7 @@ describe('DICOM', () => {
     endpoint = await medplum.createResource<Endpoint>({
       resourceType: 'Endpoint',
       address: 'dicom://0.0.0.0:8104',
-    });
+    } as Endpoint);
   });
 
   test('C-ECHO and C-STORE', async () => {
@@ -55,7 +55,7 @@ describe('DICOM', () => {
           targetReference: createReference(bot),
         },
       ],
-    });
+    } as Agent);
 
     const app = new App(medplum, agent.id as string);
     await app.start();

--- a/packages/agent/src/hl7.test.ts
+++ b/packages/agent/src/hl7.test.ts
@@ -1,4 +1,4 @@
-import { allOk, createReference, Hl7Message, sleep } from '@medplum/core';
+import { allOk, ContentType, createReference, Hl7Message, sleep } from '@medplum/core';
 import { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
 import { Hl7Client, Hl7Server } from '@medplum/hl7';
 import { MockClient } from '@medplum/mock';
@@ -23,7 +23,10 @@ describe('HL7', () => {
 
     endpoint = await medplum.createResource<Endpoint>({
       resourceType: 'Endpoint',
+      status: 'active',
       address: 'mllp://0.0.0.0:57000',
+      connectionType: { code: ContentType.HL7_V2 },
+      payloadType: [{ coding: [{ code: ContentType.HL7_V2 }] }],
     });
   });
 
@@ -69,7 +72,7 @@ describe('HL7', () => {
           targetReference: createReference(bot),
         },
       ],
-    });
+    } as Agent);
 
     const app = new App(medplum, agent.id as string);
     await app.start();
@@ -121,11 +124,12 @@ describe('HL7', () => {
       resourceType: 'Agent',
       channel: [
         {
+          name: 'test',
           endpoint: createReference(endpoint),
           targetReference: createReference(bot),
         },
       ],
-    });
+    } as Agent);
 
     // Start an HL7 listener
     const hl7Messages = [];

--- a/packages/app/src/FormPage.tsx
+++ b/packages/app/src/FormPage.tsx
@@ -59,7 +59,7 @@ export function FormPage(): JSX.Element {
       .executeBatch(requestBundle)
       .then((bundle: Bundle) => {
         if (bundle.entry?.[0]?.response?.status !== '200') {
-          setError(bundle.entry?.[0]?.response as OperationOutcome);
+          setError(bundle.entry?.[0]?.response?.outcome as OperationOutcome);
         } else {
           setQuestionnaire(bundle.entry[0]?.resource as Questionnaire);
           setSubject(bundle.entry[1]?.resource as Resource);

--- a/packages/app/src/components/ResourceHeader.test.tsx
+++ b/packages/app/src/components/ResourceHeader.test.tsx
@@ -1,4 +1,4 @@
-import { Coding, Identifier, Reference, Resource } from '@medplum/fhirtypes';
+import { Coding, Identifier, Reference, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { randomUUID } from 'crypto';
@@ -7,6 +7,17 @@ import { act, render, screen, waitFor } from '../test-utils/render';
 import { ResourceHeader } from './ResourceHeader';
 
 const medplum = new MockClient();
+
+const baseServiceRequest: ServiceRequest = {
+  resourceType: 'ServiceRequest',
+  status: 'active',
+  intent: 'order',
+  identifier: [
+    { system: 'abc', value: '456' },
+    { system: 'def', value: '789' },
+  ],
+  subject: { reference: 'Patient/123' },
+};
 
 describe('ResourceHeader', () => {
   async function setup(resource: Resource | Reference): Promise<void> {
@@ -50,7 +61,7 @@ describe('ResourceHeader', () => {
     const id = randomUUID();
 
     await setup({
-      resourceType: 'ServiceRequest',
+      ...baseServiceRequest,
       id,
       identifier: [
         { system: 'abc', value: '456' },
@@ -90,7 +101,7 @@ describe('ResourceHeader', () => {
     const id = randomUUID();
 
     await setup({
-      resourceType: 'ServiceRequest',
+      ...baseServiceRequest,
       id,
       identifier: [null as unknown as Identifier],
     });
@@ -102,7 +113,7 @@ describe('ResourceHeader', () => {
     const id = randomUUID();
 
     await setup({
-      resourceType: 'ServiceRequest',
+      ...baseServiceRequest,
       id,
       identifier: [{ value: 'abc' }],
     });
@@ -115,7 +126,7 @@ describe('ResourceHeader', () => {
     const id = randomUUID();
 
     await setup({
-      resourceType: 'ServiceRequest',
+      ...baseServiceRequest,
       id,
       identifier: [{ system: 'abc' }],
     });
@@ -128,7 +139,7 @@ describe('ResourceHeader', () => {
     const id = randomUUID();
 
     await setup({
-      resourceType: 'ServiceRequest',
+      ...baseServiceRequest,
       id,
       code: { text: 'TEST_CODE' },
       category: [{ text: 'TEST_CATEGORY' }],

--- a/packages/app/src/resource/AuditEventPage.test.tsx
+++ b/packages/app/src/resource/AuditEventPage.test.tsx
@@ -33,7 +33,7 @@ describe('AuditEventPage', () => {
           },
         },
       ],
-    });
+    } as AuditEvent);
 
     // load bot page
     await act(async () => {
@@ -71,7 +71,7 @@ describe('AuditEventPage', () => {
           },
         },
       ],
-    });
+    } as AuditEvent);
 
     // directly load bot audit event page
     await act(async () => {

--- a/packages/app/src/resource/BuilderPage.test.tsx
+++ b/packages/app/src/resource/BuilderPage.test.tsx
@@ -37,7 +37,7 @@ describe('BuilderPage', () => {
   test('PlanDefinition builder', async () => {
     const planDefinition = await medplum.createResource<PlanDefinition>({
       resourceType: 'PlanDefinition',
-    });
+    } as PlanDefinition);
 
     await setup(`/PlanDefinition/${planDefinition.id}/builder`);
     await waitFor(() => screen.getByRole('button', { name: 'Save' }));
@@ -52,7 +52,7 @@ describe('BuilderPage', () => {
   test('Questionnaire builder', async () => {
     const questionnaire = await medplum.createResource<Questionnaire>({
       resourceType: 'Questionnaire',
-    });
+    } as Questionnaire);
 
     await setup(`/Questionnaire/${questionnaire.id}/builder`);
     await waitFor(() => screen.getByRole('button', { name: 'Save' }));

--- a/packages/app/src/resource/QuestionnaireBotsPage.tsx
+++ b/packages/app/src/resource/QuestionnaireBotsPage.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { getReferenceString, normalizeErrorString } from '@medplum/core';
-import { Bot, Resource, Subscription } from '@medplum/fhirtypes';
+import { Bot, Subscription } from '@medplum/fhirtypes';
 import { Document, ResourceInput, ResourceName, useMedplum } from '@medplum/react';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -9,7 +9,7 @@ import { useParams } from 'react-router-dom';
 export function QuestionnaireBotsPage(): JSX.Element {
   const medplum = useMedplum();
   const { id } = useParams() as { id: string };
-  const [connectBot, setConnectBot] = useState<Resource | undefined>();
+  const [connectBot, setConnectBot] = useState<Bot | undefined>();
   const [updated, setUpdated] = useState<number>(0);
   const subscriptions = medplum
     .searchResources('Subscription', 'status=active&_count=100')
@@ -22,7 +22,7 @@ export function QuestionnaireBotsPage(): JSX.Element {
         .createResource({
           resourceType: 'Subscription',
           status: 'active',
-          reason: (connectBot as Bot).name,
+          reason: `Connect bot ${connectBot.name} to questionnaire responses`,
           criteria: 'QuestionnaireResponse?questionnaire=Questionnaire/' + id,
           channel: {
             type: 'rest-hook',
@@ -54,7 +54,7 @@ export function QuestionnaireBotsPage(): JSX.Element {
       <hr />
       <Title>Connect to bot</Title>
       <Group>
-        <ResourceInput name="bot" resourceType="Bot" onChange={setConnectBot} />
+        <ResourceInput name="bot" resourceType="Bot" onChange={(r) => setConnectBot(r as Bot)} />
         <Button onClick={connectToBot}>Connect</Button>
       </Group>
       <div style={{ display: 'none' }}>{updated}</div>

--- a/packages/app/src/resource/SubscriptionsPage.test.tsx
+++ b/packages/app/src/resource/SubscriptionsPage.test.tsx
@@ -66,6 +66,7 @@ describe('SubscriptionsPage', () => {
       resourceType: 'Subscription',
       reason: 'test',
       status: 'active',
+      criteria: 'Patient',
       channel: {
         type: 'rest-hook',
         endpoint: `${getReferenceString(bot)}`,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -226,12 +226,8 @@ export function safeTarExtractor(destinationDir: string): internal.Writable {
 
 export function getUnsupportedExtension(): Extension {
   return {
-    extension: [
-      {
-        url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
-        valueCode: 'unsupported',
-      },
-    ],
+    url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+    valueCode: 'unsupported',
   };
 }
 

--- a/packages/core/src/access.test.ts
+++ b/packages/core/src/access.test.ts
@@ -1,5 +1,5 @@
 import { readJson } from '@medplum/definitions';
-import { AccessPolicy, Bundle, SearchParameter } from '@medplum/fhirtypes';
+import { AccessPolicy, Bundle, Communication, Observation, SearchParameter } from '@medplum/fhirtypes';
 import {
   AccessPolicyInteraction,
   canReadResourceType,
@@ -86,8 +86,8 @@ describe('Access', () => {
     expect(canWriteResource(wildcardPolicy, { resourceType: 'Patient' })).toBe(true);
 
     expect(canWriteResource(restrictedPolicy, { resourceType: 'Patient' })).toBe(false);
-    expect(canWriteResource(restrictedPolicy, { resourceType: 'Observation' })).toBe(true);
-    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication' })).toBe(false);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Observation' } as Observation)).toBe(true);
+    expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication' } as Communication)).toBe(false);
     expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication', status: 'in-progress' })).toBe(true);
     expect(canWriteResource(restrictedPolicy, { resourceType: 'Communication', status: 'completed' })).toBe(false);
   });
@@ -108,8 +108,11 @@ describe('Access', () => {
       satisfiedAccessPolicy({ resourceType: 'Patient' }, AccessPolicyInteraction.UPDATE, restrictedPolicy)
     ).toBeUndefined();
     expect(
-      satisfiedAccessPolicy({ resourceType: 'Observation' }, AccessPolicyInteraction.UPDATE, restrictedPolicy)
-        ?.resourceType
+      satisfiedAccessPolicy(
+        { resourceType: 'Observation' } as Observation,
+        AccessPolicyInteraction.UPDATE,
+        restrictedPolicy
+      )?.resourceType
     ).toEqual('Observation');
     expect(
       satisfiedAccessPolicy(

--- a/packages/core/src/base-schema.json
+++ b/packages/core/src/base-schema.json
@@ -841,14 +841,20 @@
       "maxDosePerAdministration": {
         "type": [
           {
-            "code": "Quantity"
+            "code": "Quantity",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            ]
           }
         ]
       },
       "maxDosePerLifetime": {
         "type": [
           {
-            "code": "Quantity"
+            "code": "Quantity",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            ]
           }
         ]
       }
@@ -1747,7 +1753,7 @@
         "min": 1,
         "type": [
           {
-            "code": "string"
+            "code": "uri"
           }
         ]
       },
@@ -2674,14 +2680,20 @@
       "low": {
         "type": [
           {
-            "code": "Quantity"
+            "code": "Quantity",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            ]
           }
         ]
       },
       "high": {
         "type": [
           {
-            "code": "Quantity"
+            "code": "Quantity",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            ]
           }
         ]
       }
@@ -2860,7 +2872,10 @@
         "min": 1,
         "type": [
           {
-            "code": "Quantity"
+            "code": "Quantity",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+            ]
           }
         ]
       },

--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -188,6 +188,7 @@ describe('Bundle tests', () => {
     test('Ignore unrecognized references', () => {
       const inputBundle: Bundle = {
         resourceType: 'Bundle',
+        type: 'searchset',
         entry: [
           {
             fullUrl: 'https://example.com/Specimen/xyz',
@@ -202,6 +203,7 @@ describe('Bundle tests', () => {
       const result = convertToTransactionBundle(inputBundle);
       expect(result).toMatchObject({
         resourceType: 'Bundle',
+        type: 'transaction',
         entry: [
           {
             resource: {
@@ -236,15 +238,21 @@ describe('Bundle tests', () => {
     test('Contained observations', () => {
       const input: DiagnosticReport = {
         resourceType: 'DiagnosticReport',
+        status: 'final',
+        code: { text: 'test' },
         contained: [
           {
             resourceType: 'Observation',
             id: '123',
+            status: 'final',
+            code: { text: 'test' },
             hasMember: [{ reference: '#456' }],
           },
           {
             resourceType: 'Observation',
             id: '456',
+            status: 'final',
+            code: { text: 'test' },
           },
         ],
         result: [{ reference: '#123' }],

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -1,4 +1,4 @@
-import { Bundle, BundleEntry, Resource } from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, BundleEntryRequest, Resource } from '@medplum/fhirtypes';
 import { generateId } from './crypto';
 import { isReference } from './types';
 import { deepClone } from './utils';
@@ -94,7 +94,7 @@ export function reorderBundle(bundle: Bundle): Bundle {
       const putEntry: BundleEntry = {
         ...originalEntry,
         request: {
-          ...originalEntry.request,
+          ...(originalEntry.request as BundleEntryRequest),
           method: 'PUT',
         },
       };

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -22,6 +22,11 @@ import { ProfileResource, createReference } from './utils';
 
 const patientStructureDefinition: StructureDefinition = {
   resourceType: 'StructureDefinition',
+  url: 'http://example.com/patient',
+  status: 'active',
+  kind: 'resource',
+  abstract: false,
+  type: 'Patient',
   name: 'Patient',
   snapshot: {
     element: [
@@ -43,6 +48,10 @@ const patientStructureDefinition: StructureDefinition = {
 const patientSearchParameter: SearchParameter = {
   resourceType: 'SearchParameter',
   id: 'Patient-name',
+  url: 'http://example.com/Patient-name',
+  status: 'active',
+  description: 'Search by name',
+  type: 'string',
   base: ['Patient'],
   code: 'name',
   name: 'name',
@@ -1554,7 +1563,10 @@ describe('Client', () => {
   test('Create comment on Encounter', async () => {
     const fetch = mockFetch(200, (_url, options) => JSON.parse(options.body));
     const client = new MedplumClient({ fetch });
-    const result = await client.createComment({ resourceType: 'Encounter', id: '999' }, 'Hello world');
+    const result = await client.createComment(
+      { resourceType: 'Encounter', id: '999', status: 'arrived', class: { code: 'test' } },
+      'Hello world'
+    );
     expect(result).toBeDefined();
     expect(result.basedOn).toBeDefined();
     expect(result.encounter).toBeDefined();
@@ -1569,7 +1581,16 @@ describe('Client', () => {
   test('Create comment on ServiceRequest', async () => {
     const fetch = mockFetch(200, (_url, options) => JSON.parse(options.body));
     const client = new MedplumClient({ fetch });
-    const result = await client.createComment({ resourceType: 'ServiceRequest', id: '999' }, 'Hello world');
+    const result = await client.createComment(
+      {
+        resourceType: 'ServiceRequest',
+        id: '999',
+        status: 'active',
+        intent: 'order',
+        subject: { reference: 'Patient/123' },
+      },
+      'Hello world'
+    );
     expect(result).toBeDefined();
     expect(result.basedOn).toBeDefined();
     expect(fetch).toBeCalledWith(

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -86,7 +86,11 @@ const DEFAULT_RESOURCE_CACHE_SIZE = 1000;
 const DEFAULT_CACHE_TIME = 60000; // 60 seconds
 const BINARY_URL_PREFIX = 'Binary/';
 
-const system: Device = { resourceType: 'Device', id: 'system', deviceName: [{ name: 'System' }] };
+const system: Device = {
+  resourceType: 'Device',
+  id: 'system',
+  deviceName: [{ type: 'model-name', name: 'System' }],
+};
 
 /**
  * The MedplumClientOptions interface defines configuration options for MedplumClient.
@@ -2045,6 +2049,7 @@ export class MedplumClient extends EventTarget {
     return this.createResource<Communication>(
       {
         resourceType: 'Communication',
+        status: 'completed',
         basedOn: [createReference(resource)],
         encounter,
         subject,

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -262,7 +262,11 @@ describe('createFhircastMessagePayload', () => {
     expect(
       createFhircastMessagePayload('abc-123', 'syncerror', {
         key: 'operationoutcome',
-        resource: { resourceType: 'OperationOutcome', id: 'patient-123' },
+        resource: {
+          resourceType: 'OperationOutcome',
+          id: 'patient-123',
+          issue: [{ severity: 'error', code: 'processing' }],
+        },
       })
     ).toEqual<FhircastMessagePayload<'syncerror'>>({
       id: expect.any(String),
@@ -376,8 +380,24 @@ describe('createFhircastMessagePayload', () => {
       // Should throw because keys must be unique
       createFhircastMessagePayload('abc-123', 'ImagingStudy-open', [
         { key: 'patient', resource: { resourceType: 'Patient', id: 'patient-123' } },
-        { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-456' } },
-        { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-789' } },
+        {
+          key: 'study',
+          resource: {
+            resourceType: 'ImagingStudy',
+            id: 'imagingstudy-456',
+            status: 'available',
+            subject: { reference: 'Patient/patient-123' },
+          },
+        },
+        {
+          key: 'study',
+          resource: {
+            resourceType: 'ImagingStudy',
+            id: 'imagingstudy-789',
+            status: 'available',
+            subject: { reference: 'Patient/patient-123' },
+          },
+        },
       ])
     ).toThrowError(OperationOutcomeError);
     expect(() =>
@@ -412,11 +432,23 @@ describe('createFhircastMessagePayload', () => {
 
   test('Valid `DiagnosticReport-open` event w/ multiple studies', () => {
     const payload = createFhircastMessagePayload('abc-123', 'DiagnosticReport-open', [
-      { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-789' } },
+      {
+        key: 'report',
+        resource: { resourceType: 'DiagnosticReport', id: 'report-789', status: 'final', code: { text: 'test' } },
+      },
       { key: 'patient', resource: { resourceType: 'Patient', id: 'patient-123' } },
-      { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-123' } },
-      { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-456' } },
-      { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-789' } },
+      {
+        key: 'study',
+        resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-123', status: 'available', subject: {} },
+      },
+      {
+        key: 'study',
+        resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-456', status: 'available', subject: {} },
+      },
+      {
+        key: 'study',
+        resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-789', status: 'available', subject: {} },
+      },
     ]);
     expect(payload).toEqual<FhircastMessagePayload<'DiagnosticReport-open'>>({
       id: expect.any(String),
@@ -429,18 +461,33 @@ describe('createFhircastMessagePayload', () => {
   test('Invalid `DiagnosticReport-open` event w/ multiple reports', () => {
     expect(() =>
       createFhircastMessagePayload('abc-123', 'DiagnosticReport-open', [
-        { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-789' } },
-        { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-789' } },
+        {
+          key: 'report',
+          resource: { resourceType: 'DiagnosticReport', id: 'report-789', status: 'final', code: { text: 'test' } },
+        },
+        {
+          key: 'report',
+          resource: { resourceType: 'DiagnosticReport', id: 'report-789', status: 'final', code: { text: 'test' } },
+        },
         { key: 'patient', resource: { resourceType: 'Patient', id: 'patient-123' } },
-        { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-123' } },
+        {
+          key: 'study',
+          resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-123', status: 'available', subject: {} },
+        },
       ])
     ).toThrowError(OperationOutcomeError);
   });
 
   test('Valid `DiagnosticReport-select` event', () => {
     const messagePayload = createFhircastMessagePayload('abc-123', 'DiagnosticReport-select', [
-      { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-123' } },
-      { key: 'select', resources: [{ resourceType: 'Observation', id: 'observation-123' }] },
+      {
+        key: 'report',
+        resource: { resourceType: 'DiagnosticReport', id: 'report-123', status: 'final', code: { text: 'test' } },
+      },
+      {
+        key: 'select',
+        resources: [{ resourceType: 'Observation', id: 'observation-123', status: 'final', code: { text: 'test' } }],
+      },
     ]);
 
     expect(messagePayload).toBeDefined();
@@ -456,7 +503,10 @@ describe('createFhircastMessagePayload', () => {
   test('Using single resource context for multi-resource context', () => {
     expect(() =>
       createFhircastMessagePayload('abc-123', 'DiagnosticReport-select', [
-        { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-123' } },
+        {
+          key: 'report',
+          resource: { resourceType: 'DiagnosticReport', id: 'report-123', status: 'final', code: { text: 'test' } },
+        },
         // @ts-expect-error Should have an array of resources at 'resources'
         { key: 'select', resource: { resourceType: 'Bundle', id: 'bundle-123' } },
       ])
@@ -468,8 +518,11 @@ describe('createFhircastMessagePayload', () => {
       'abc-123',
       'DiagnosticReport-update',
       [
-        { key: 'report', resource: { resourceType: 'DiagnosticReport', id: 'report-123' } },
-        { key: 'updates', resource: { resourceType: 'Bundle', id: 'bundle-123' } },
+        {
+          key: 'report',
+          resource: { resourceType: 'DiagnosticReport', id: 'report-123', status: 'final', code: { text: 'test' } },
+        },
+        { key: 'updates', resource: { resourceType: 'Bundle', id: 'bundle-123', type: 'searchset' } },
       ],
       generateId()
     );

--- a/packages/core/src/fhircast/test-utils.test.ts
+++ b/packages/core/src/fhircast/test-utils.test.ts
@@ -1,3 +1,4 @@
+import { ImagingStudy } from '@medplum/fhirtypes';
 import { FhircastEventContext } from '.';
 import { OperationOutcomeError } from '../outcomes';
 import { createFhircastMessageContext } from './test-utils';
@@ -22,7 +23,7 @@ describe('FHIRcast Test Utils', () => {
         resource: {
           resourceType: 'ImagingStudy',
           id: 'imagingstudy-456',
-        },
+        } as ImagingStudy & { id: string },
       });
     });
 

--- a/packages/core/src/fhirmapper/parse.test.ts
+++ b/packages/core/src/fhirmapper/parse.test.ts
@@ -28,6 +28,7 @@ describe('FHIR Mapping Language parser', () => {
       resourceType: 'StructureMap',
       url: 'http://hl7.org/fhir/StructureMap/tutorial',
       name: 'tutorial',
+      status: 'active',
       structure: [
         {
           url: 'http://hl7.org/fhir/StructureDefinition/tutorial-left',

--- a/packages/core/src/fhirpath/atoms.test.ts
+++ b/packages/core/src/fhirpath/atoms.test.ts
@@ -84,11 +84,15 @@ describe('Atoms', () => {
   test('AsAtom', () => {
     const obs1: Observation = {
       resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'abc' },
       valueQuantity: { value: 100, unit: 'mg' },
     };
 
     const obs2: Observation = {
       resourceType: 'Observation',
+      status: 'final',
+      code: { text: 'abc' },
       valueCodeableConcept: { coding: [{ code: 'xyz' }] },
     };
 

--- a/packages/core/src/fhirpath/parse.test.ts
+++ b/packages/core/src/fhirpath/parse.test.ts
@@ -1,13 +1,5 @@
 import { readJson } from '@medplum/definitions';
-import {
-  AuditEvent,
-  Bundle,
-  BundleEntry,
-  Observation,
-  Patient,
-  SearchParameter,
-  ServiceRequest,
-} from '@medplum/fhirtypes';
+import { Bundle, BundleEntry, Observation, Patient, SearchParameter } from '@medplum/fhirtypes';
 import { PropertyType } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { evalFhirPath, evalFhirPathTyped, parseFhirPath } from './parse';
@@ -370,7 +362,7 @@ describe('FHIRPath parser', () => {
   });
 
   test('Eval FHIRPath resolve function', () => {
-    const observation: Observation = {
+    const observation = {
       resourceType: 'Observation',
       subject: {
         reference: 'Patient/123',
@@ -388,7 +380,7 @@ describe('FHIRPath parser', () => {
   });
 
   test('Resolve is resourceType', () => {
-    const auditEvent: AuditEvent = {
+    const auditEvent = {
       resourceType: 'AuditEvent',
       entity: [
         {
@@ -404,7 +396,7 @@ describe('FHIRPath parser', () => {
   });
 
   test('Resolve is not resourceType', () => {
-    const auditEvent: AuditEvent = {
+    const auditEvent = {
       resourceType: 'AuditEvent',
       entity: [
         {
@@ -540,7 +532,7 @@ describe('FHIRPath parser', () => {
   });
 
   test('Choice of type', () => {
-    const observations: Observation[] = [
+    const observations = [
       {
         resourceType: 'Observation',
         valueQuantity: { value: 100, unit: 'mg' },
@@ -572,20 +564,20 @@ describe('FHIRPath parser', () => {
         resourceType: 'Observation',
         code: { coding: [{ code: 'ALB' }] },
         valueQuantity: { value: 120, unit: 'ng/dL' },
-      },
+      } as Observation,
       {
         resourceType: 'Observation',
         code: { coding: [{ code: 'HBA1C' }] },
         valueQuantity: { value: 5, unit: '%' },
-      },
+      } as Observation,
     ];
 
     // This is an example of how FHIR GraphQL returns embedded searches.
     // The "ObservationList" is not a real property, but a search result.
-    const serviceRequest: ServiceRequest = {
+    const serviceRequest = {
       resourceType: 'ServiceRequest',
       ObservationList: observations,
-    } as ServiceRequest;
+    };
 
     const query = "ObservationList.where(code.coding[0].code='HBA1C').value";
     const result = evalFhirPathTyped(query, [toTypedValue(serviceRequest)]);

--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -150,6 +150,7 @@ describe('FHIRPath utils', () => {
   test('Bundle entries', () => {
     const bundle: Bundle = {
       resourceType: 'Bundle',
+      type: 'searchset',
       entry: [
         {
           resource: {

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -1,3 +1,4 @@
+import { Observation } from '@medplum/fhirtypes';
 import { UCUM } from './constants';
 import {
   formatAddress,
@@ -391,17 +392,20 @@ test('Format Coding', () => {
 
 test('Format Observation value', () => {
   expect(formatObservationValue(undefined)).toBe('');
-  expect(formatObservationValue({})).toBe('');
-  expect(formatObservationValue({ resourceType: 'Observation', valueString: 'foo' })).toBe('foo');
-  expect(formatObservationValue({ resourceType: 'Observation', valueCodeableConcept: { text: 'foo' } })).toBe('foo');
-  expect(formatObservationValue({ resourceType: 'Observation', valueQuantity: { value: 123, unit: 'mg' } })).toBe(
-    '123 mg'
-  );
+  expect(formatObservationValue({} as Observation)).toBe('');
+  expect(formatObservationValue({ resourceType: 'Observation', valueString: 'foo' } as Observation)).toBe('foo');
+  expect(
+    formatObservationValue({ resourceType: 'Observation', valueCodeableConcept: { text: 'foo' } } as Observation)
+  ).toBe('foo');
+  expect(
+    formatObservationValue({ resourceType: 'Observation', valueQuantity: { value: 123, unit: 'mg' } } as Observation)
+  ).toBe('123 mg');
   expect(
     formatObservationValue({
       resourceType: 'Observation',
       component: [
         {
+          code: { text: 'foo' },
           valueQuantity: {
             value: 110,
             unit: 'mmHg',
@@ -409,6 +413,7 @@ test('Format Observation value', () => {
           },
         },
         {
+          code: { text: 'bar' },
           valueQuantity: {
             value: 75,
             unit: 'mmHg',
@@ -416,6 +421,6 @@ test('Format Observation value', () => {
           },
         },
       ],
-    })
+    } as Observation)
   ).toBe('110 mmHg / 75 mmHg');
 });

--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -1,3 +1,4 @@
+import { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import {
   accepted,
   allOk,
@@ -109,22 +110,25 @@ describe('Outcomes', () => {
   });
 
   test('operationOutcomeToString', () => {
-    expect(operationOutcomeToString({ resourceType: 'OperationOutcome' })).toEqual('Unknown error');
+    expect(operationOutcomeToString({ resourceType: 'OperationOutcome' } as OperationOutcome)).toEqual('Unknown error');
     expect(
-      operationOutcomeToString({ resourceType: 'OperationOutcome', issue: [{ details: { text: 'foo' } }] })
+      operationOutcomeToString({
+        resourceType: 'OperationOutcome',
+        issue: [{ details: { text: 'foo' } } as OperationOutcomeIssue],
+      })
     ).toEqual('foo');
     expect(
       operationOutcomeToString({
         resourceType: 'OperationOutcome',
-        issue: [{ details: { text: 'foo' }, expression: ['bar'] }],
+        issue: [{ details: { text: 'foo' }, expression: ['bar'] } as OperationOutcomeIssue],
       })
     ).toEqual('foo (bar)');
     expect(
       operationOutcomeToString({
         resourceType: 'OperationOutcome',
         issue: [
-          { details: { text: 'error1' }, expression: ['expr1'] },
-          { details: { text: 'error2' }, expression: ['expr2'] },
+          { details: { text: 'error1' }, expression: ['expr1'] } as OperationOutcomeIssue,
+          { details: { text: 'error2' }, expression: ['expr2'] } as OperationOutcomeIssue,
         ],
       })
     ).toEqual('error1 (expr1); error2 (expr2)');

--- a/packages/core/src/search/details.test.ts
+++ b/packages/core/src/search/details.test.ts
@@ -2,7 +2,7 @@ import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { globalSchema, indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
-import { getSearchParameterDetails, SearchParameterType } from './details';
+import { SearchParameterType, getSearchParameterDetails } from './details';
 
 const searchParamsBundle = readJson('fhir/r4/search-parameters.json');
 const medplumSearchParamsBundle = readJson('fhir/r4/search-parameters-medplum.json');
@@ -74,7 +74,7 @@ describe('SearchParameterDetails', () => {
       code: 'test',
       type: 'string',
       expression: 'OtherType.test',
-    };
+    } as SearchParameter;
 
     const details = getSearchParameterDetails('Patient', missingExpressionParam);
     expect(details).toBeDefined();
@@ -87,7 +87,7 @@ describe('SearchParameterDetails', () => {
       code: 'unknown',
       type: 'string',
       expression: 'Patient.unknown',
-    };
+    } as SearchParameter;
 
     expect(() => getSearchParameterDetails('Patient', missingExpressionParam)).toThrow();
   });
@@ -98,7 +98,7 @@ describe('SearchParameterDetails', () => {
       code: 'name-unknown',
       type: 'string',
       expression: 'Patient.name.select()',
-    };
+    } as SearchParameter;
 
     expect(() => getSearchParameterDetails('Patient', missingExpressionParam)).toThrow();
   });
@@ -109,7 +109,7 @@ describe('SearchParameterDetails', () => {
       code: 'unhandled-function',
       type: 'string',
       expression: 'Patient.name.unknown',
-    };
+    } as SearchParameter;
 
     expect(() => getSearchParameterDetails('Patient', missingExpressionParam)).toThrow();
   });

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -1,9 +1,19 @@
 import { readJson } from '@medplum/definitions';
-import { ActivityDefinition, Bundle, Observation, Patient, Practitioner, SearchParameter } from '@medplum/fhirtypes';
+import {
+  ActivityDefinition,
+  Bundle,
+  DiagnosticReport,
+  Observation,
+  Patient,
+  Practitioner,
+  QuestionnaireResponse,
+  SearchParameter,
+  ServiceRequest,
+} from '@medplum/fhirtypes';
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { matchesSearchRequest } from './match';
-import { Operator, parseSearchDefinition, SearchRequest } from './search';
+import { Operator, SearchRequest, parseSearchDefinition } from './search';
 
 // Dimensions:
 // 1. Search parameter type
@@ -22,9 +32,13 @@ describe('Search matching', () => {
   });
 
   test('Matches resource type', () => {
-    expect(matchesSearchRequest({ resourceType: 'Observation' }, { resourceType: 'Observation' })).toBe(true);
+    expect(matchesSearchRequest({ resourceType: 'Observation' } as Observation, { resourceType: 'Observation' })).toBe(
+      true
+    );
     expect(matchesSearchRequest({ resourceType: 'Patient' }, { resourceType: 'Patient' })).toBe(true);
-    expect(matchesSearchRequest({ resourceType: 'Observation' }, { resourceType: 'Patient' })).toBe(false);
+    expect(matchesSearchRequest({ resourceType: 'Observation' } as Observation, { resourceType: 'Patient' })).toBe(
+      false
+    );
     expect(matchesSearchRequest({ resourceType: 'Patient' }, { resourceType: 'Observation' })).toBe(false);
   });
 
@@ -37,10 +51,10 @@ describe('Search matching', () => {
     ).toBe(true);
 
     expect(
-      matchesSearchRequest(
-        { resourceType: 'Observation', id: '123' },
-        { resourceType: 'Observation', filters: [{ code: '_id', operator: Operator.EQUALS, value: '456' }] }
-      )
+      matchesSearchRequest({ resourceType: 'Observation', id: '123' } as Observation, {
+        resourceType: 'Observation',
+        filters: [{ code: '_id', operator: Operator.EQUALS, value: '456' }],
+      })
     ).toBe(false);
   });
 
@@ -105,7 +119,7 @@ describe('Search matching', () => {
   });
 
   test('Reference filter', () => {
-    const resource: Observation = { resourceType: 'Observation', subject: { reference: 'Patient/123' } };
+    const resource: Observation = { resourceType: 'Observation', subject: { reference: 'Patient/123' } } as Observation;
     const search = {
       resourceType: 'Observation',
       filters: [{ code: 'subject', operator: Operator.EQUALS, value: 'Patient/123' }],
@@ -127,7 +141,7 @@ describe('Search matching', () => {
   });
 
   test('Empty reference filter', () => {
-    const resource: Observation = { resourceType: 'Observation' };
+    const resource: Observation = { resourceType: 'Observation' } as Observation;
     const search = {
       resourceType: 'Observation',
       filters: [{ code: 'subject', operator: Operator.EQUALS, value: '' }],
@@ -151,7 +165,7 @@ describe('Search matching', () => {
   test('Canonical reference filter', () => {
     expect(
       matchesSearchRequest(
-        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' } as QuestionnaireResponse,
         {
           resourceType: 'QuestionnaireResponse',
           filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/123' }],
@@ -159,17 +173,14 @@ describe('Search matching', () => {
       )
     ).toBe(true);
     expect(
-      matchesSearchRequest(
-        { resourceType: 'QuestionnaireResponse' },
-        {
-          resourceType: 'QuestionnaireResponse',
-          filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/123' }],
-        }
-      )
+      matchesSearchRequest({ resourceType: 'QuestionnaireResponse' } as QuestionnaireResponse, {
+        resourceType: 'QuestionnaireResponse',
+        filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/123' }],
+      })
     ).toBe(false);
     expect(
       matchesSearchRequest(
-        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' } as QuestionnaireResponse,
         {
           resourceType: 'QuestionnaireResponse',
           filters: [{ code: 'questionnaire', operator: Operator.EQUALS, value: 'Questionnaire/456' }],
@@ -178,7 +189,7 @@ describe('Search matching', () => {
     ).toBe(false);
     expect(
       matchesSearchRequest(
-        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' } as QuestionnaireResponse,
         {
           resourceType: 'QuestionnaireResponse',
           filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/123' }],
@@ -186,17 +197,14 @@ describe('Search matching', () => {
       )
     ).toBe(false);
     expect(
-      matchesSearchRequest(
-        { resourceType: 'QuestionnaireResponse' },
-        {
-          resourceType: 'QuestionnaireResponse',
-          filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/123' }],
-        }
-      )
+      matchesSearchRequest({ resourceType: 'QuestionnaireResponse' } as QuestionnaireResponse, {
+        resourceType: 'QuestionnaireResponse',
+        filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/123' }],
+      })
     ).toBe(true);
     expect(
       matchesSearchRequest(
-        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' },
+        { resourceType: 'QuestionnaireResponse', questionnaire: 'Questionnaire/123' } as QuestionnaireResponse,
         {
           resourceType: 'QuestionnaireResponse',
           filters: [{ code: 'questionnaire', operator: Operator.NOT_EQUALS, value: 'Questionnaire/456' }],
@@ -244,7 +252,10 @@ describe('Search matching', () => {
   });
 
   test('URI filter', () => {
-    const activityDefinition: ActivityDefinition = { resourceType: 'ActivityDefinition', url: 'http://example.com' };
+    const activityDefinition: ActivityDefinition = {
+      resourceType: 'ActivityDefinition',
+      url: 'http://example.com',
+    } as ActivityDefinition;
 
     expect(
       matchesSearchRequest(activityDefinition, {
@@ -263,37 +274,31 @@ describe('Search matching', () => {
   describe('Token', () => {
     test('equals', () => {
       expect(
-        matchesSearchRequest(
-          { resourceType: 'Observation', code: { text: 'foo' } },
-          { resourceType: 'Observation', filters: [{ code: 'code', operator: Operator.EQUALS, value: 'foo' }] }
-        )
+        matchesSearchRequest({ resourceType: 'Observation', code: { text: 'foo' } } as Observation, {
+          resourceType: 'Observation',
+          filters: [{ code: 'code', operator: Operator.EQUALS, value: 'foo' }],
+        })
       ).toBe(true);
       expect(
-        matchesSearchRequest(
-          { resourceType: 'Observation', code: { text: 'foo' } },
-          { resourceType: 'Observation', filters: [{ code: 'code', operator: Operator.EQUALS, value: 'George' }] }
-        )
+        matchesSearchRequest({ resourceType: 'Observation', code: { text: 'foo' } } as Observation, {
+          resourceType: 'Observation',
+          filters: [{ code: 'code', operator: Operator.EQUALS, value: 'George' }],
+        })
       ).toBe(false);
     });
 
     test('not equals', () => {
       expect(
-        matchesSearchRequest(
-          { resourceType: 'Observation', code: { text: 'foo' } },
-          {
-            resourceType: 'Observation',
-            filters: [{ code: 'code', operator: Operator.NOT_EQUALS, value: 'foo' }],
-          }
-        )
+        matchesSearchRequest({ resourceType: 'Observation', code: { text: 'foo' } } as Observation, {
+          resourceType: 'Observation',
+          filters: [{ code: 'code', operator: Operator.NOT_EQUALS, value: 'foo' }],
+        })
       ).toBe(false);
       expect(
-        matchesSearchRequest(
-          { resourceType: 'Observation', code: { text: 'foo' } },
-          {
-            resourceType: 'Observation',
-            filters: [{ code: 'code', operator: Operator.NOT_EQUALS, value: 'George' }],
-          }
-        )
+        matchesSearchRequest({ resourceType: 'Observation', code: { text: 'foo' } } as Observation, {
+          resourceType: 'Observation',
+          filters: [{ code: 'code', operator: Operator.NOT_EQUALS, value: 'George' }],
+        })
       ).toBe(true);
     });
 
@@ -302,25 +307,25 @@ describe('Search matching', () => {
       // "DiagnosticReport?status=cancelled"
       expect(
         matchesSearchRequest(
-          { resourceType: 'DiagnosticReport', status: 'preliminary' },
+          { resourceType: 'DiagnosticReport', status: 'preliminary' } as DiagnosticReport,
           parseSearchDefinition('DiagnosticReport?status=cancelled')
         )
       ).toBe(false);
       expect(
         matchesSearchRequest(
-          { resourceType: 'DiagnosticReport', status: 'preliminary' },
+          { resourceType: 'DiagnosticReport', status: 'preliminary' } as DiagnosticReport,
           parseSearchDefinition('DiagnosticReport?status:not=cancelled')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
-          { resourceType: 'DiagnosticReport', status: 'cancelled' },
+          { resourceType: 'DiagnosticReport', status: 'cancelled' } as DiagnosticReport,
           parseSearchDefinition('DiagnosticReport?status=cancelled')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
-          { resourceType: 'DiagnosticReport', status: 'cancelled' },
+          { resourceType: 'DiagnosticReport', status: 'cancelled' } as DiagnosticReport,
           parseSearchDefinition('DiagnosticReport?status:not=cancelled')
         )
       ).toBe(false);
@@ -329,25 +334,25 @@ describe('Search matching', () => {
       // "ServiceRequest?order-detail=VOIDED,CANCELLED"
       expect(
         matchesSearchRequest(
-          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'ORDERED' }] },
+          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'ORDERED' }] } as ServiceRequest,
           parseSearchDefinition('ServiceRequest?order-detail=VOIDED,CANCELLED')
         )
       ).toBe(false);
       expect(
         matchesSearchRequest(
-          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'ORDERED' }] },
+          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'ORDERED' }] } as ServiceRequest,
           parseSearchDefinition('ServiceRequest?order-detail:not=VOIDED,CANCELLED')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
-          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'VOIDED' }] },
+          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'VOIDED' }] } as ServiceRequest,
           parseSearchDefinition('ServiceRequest?order-detail=VOIDED,CANCELLED')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
-          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'VOIDED' }] },
+          { resourceType: 'ServiceRequest', orderDetail: [{ text: 'VOIDED' }] } as ServiceRequest,
           parseSearchDefinition('ServiceRequest?order-detail:not=VOIDED,CANCELLED')
         )
       ).toBe(false);

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -3,6 +3,7 @@ import {
   CodeableConcept,
   Coding,
   ContactPoint,
+  ElementDefinition,
   Extension,
   HumanName,
   Identifier,
@@ -12,6 +13,7 @@ import {
 } from '@medplum/fhirtypes';
 import { LOINC, UCUM } from './constants';
 import {
+  TypedValue,
   getElementDefinitionFromElements,
   getElementDefinitionTypeName,
   getPathDisplayName,
@@ -19,7 +21,6 @@ import {
   isReference,
   isResource,
   stringifyTypedValue,
-  TypedValue,
 } from './types';
 
 describe('Type Utils', () => {
@@ -44,7 +45,7 @@ describe('Type Utils', () => {
   });
 
   test('getElementDefinitionTypeName', () => {
-    expect(getElementDefinitionTypeName({ type: [{ code: 'string' }] })).toEqual('string');
+    expect(getElementDefinitionTypeName({ type: [{ code: 'string' }] } as ElementDefinition)).toEqual('string');
     expect(getElementDefinitionTypeName({ path: 'Patient.address', type: [{ code: 'Address' }] })).toEqual('Address');
     expect(getElementDefinitionTypeName({ path: 'Patient.contact', type: [{ code: 'BackboneElement' }] })).toEqual(
       'PatientContact'
@@ -60,7 +61,7 @@ describe('Type Utils', () => {
     expect(
       getElementDefinitionTypeName({
         path: 'Questionnaire.item.item',
-        base: { path: 'Questionnaire.item' },
+        base: { path: 'Questionnaire.item', min: 0, max: '*' },
         type: [{ code: 'Element' }],
       })
     ).toEqual('QuestionnaireItem');

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -2,10 +2,12 @@ import { readJson } from '@medplum/definitions';
 import {
   Account,
   Appointment,
+  AppointmentParticipant,
   Binary,
   Bundle,
   CodeSystem,
   Condition,
+  DiagnosticReport,
   Extension,
   HumanName,
   ImplementationGuide,
@@ -777,7 +779,7 @@ describe('Legacy tests for parity checking', () => {
 
   test('Required properties', () => {
     try {
-      validateResource({ resourceType: 'DiagnosticReport' });
+      validateResource({ resourceType: 'DiagnosticReport' } as unknown as DiagnosticReport);
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -1001,13 +1003,13 @@ describe('Legacy tests for parity checking', () => {
   });
 
   test('id', () => {
-    const ig: ImplementationGuide = {
+    const ig = {
       resourceType: 'ImplementationGuide',
       name: 'x',
       status: 'active',
       fhirVersion: ['4.0.1'],
       url: 'https://example.com',
-    };
+    } as ImplementationGuide;
 
     ig.packageId = 123 as unknown as string;
     expect(() => validateResource(ig)).toThrowError(
@@ -1151,7 +1153,7 @@ describe('Legacy tests for parity checking', () => {
       validateResource({
         resourceType: 'Appointment',
         status: 'booked',
-        participant: [{ type: [{ text: 'x' }] }], // "status" is required
+        participant: [{ type: [{ text: 'x' }] } as AppointmentParticipant], // "status" is required
       });
       fail('Expected error');
     } catch (err) {

--- a/packages/examples/src/billing/insurance-eligibility-checks.ts
+++ b/packages/examples/src/billing/insurance-eligibility-checks.ts
@@ -7,6 +7,7 @@ const eligibilityCheck: CoverageEligibilityRequest =
     id: 'coverage-validation-request',
     status: 'active',
     purpose: ['validation'],
+    created: '2021-01-01T00:00:00.000Z',
     patient: {
       reference: 'Patient/homer-simpson',
     },
@@ -55,6 +56,7 @@ const generalBenefitsCheckRequest: CoverageEligibilityRequest =
     id: 'general-benefits-check',
     status: 'active',
     purpose: ['benefits', 'discovery'],
+    created: '2021-01-01T00:00:00.000Z',
     patient: {
       reference: 'Patient/jane-doe',
     },
@@ -93,6 +95,7 @@ const eligibilityResponse: CoverageEligibilityResponse =
     resourceType: 'CoverageEligibilityResponse',
     status: 'active',
     purpose: ['validation'],
+    created: '2021-01-01T00:00:00.000Z',
     patient: {
       reference: 'Patient/homer-simpson',
     },
@@ -173,6 +176,7 @@ const generalBenefitsCheckResponse: CoverageEligibilityResponse =
     resourceType: 'CoverageEligibilityResponse',
     status: 'active',
     purpose: ['benefits', 'discovery'],
+    created: '2021-01-01T00:00:00.000Z',
     patient: {
       reference: 'Patient/jane-doe',
     },

--- a/packages/examples/src/careplans/reference-ranges.ts
+++ b/packages/examples/src/careplans/reference-ranges.ts
@@ -289,6 +289,7 @@ const jane: Patient = {
 
 const janeTestosterone: Observation = {
   resourceType: 'Observation',
+  status: 'final',
   code: {
     coding: [
       {

--- a/packages/examples/src/communications/organizing-communications.ts
+++ b/packages/examples/src/communications/organizing-communications.ts
@@ -142,7 +142,7 @@ curl 'https://api.medplum.com/fhir/R4/Communication?encounter:missing=false&_inc
 // end-block searchFilteredEncountersCurl
 */
 
-const communicationThread: Communication[] = [
+const communicationThread: Partial<Communication>[] = [
   // start-block communicationGroupedThread
   {
     resourceType: 'Communication',
@@ -173,6 +173,7 @@ const communicationThread: Communication[] = [
         resource: {
           resourceType: 'Communication',
           id: 'example-parent-communication',
+          status: 'completed',
         },
       },
     ],
@@ -197,6 +198,7 @@ const communicationThread: Communication[] = [
         resource: {
           resourceType: 'Communication',
           id: 'example-parent-communication',
+          status: 'completed',
         },
       },
     ],
@@ -205,6 +207,7 @@ const communicationThread: Communication[] = [
         resource: {
           resourceType: 'Communication',
           id: 'example-message-1',
+          status: 'completed',
         },
       },
     ],
@@ -229,6 +232,7 @@ const communicationThread: Communication[] = [
         resource: {
           resourceType: 'Communication',
           id: 'example-parent-communication',
+          status: 'completed',
         },
       },
     ],
@@ -237,6 +241,7 @@ const communicationThread: Communication[] = [
         resource: {
           resourceType: 'Communication',
           id: 'example-message-2',
+          status: 'completed',
         },
       },
     ],
@@ -251,6 +256,7 @@ const categoryExampleCommunications: Communication =
   {
     resourceType: 'Communication',
     id: 'example-communication',
+    status: 'completed',
     category: [
       {
         text: 'Doctor',

--- a/packages/examples/src/fhir-datastore/fhir-batch-requests.ts
+++ b/packages/examples/src/fhir-datastore/fhir-batch-requests.ts
@@ -249,6 +249,7 @@ const internalReference: Bundle =
         resource: {
           resourceType: 'Encounter',
           status: 'finished',
+          class: { code: 'ambulatory' },
           subject: {
             // highlight-next-line
             reference: 'urn:uuid:f7c8d72c-e02a-4baf-ba04-038c9f753a1c',

--- a/packages/examples/src/fhir-datastore/patient-deduplication/matching.ts
+++ b/packages/examples/src/fhir-datastore/patient-deduplication/matching.ts
@@ -7,6 +7,7 @@ const dedupeAssessment: RiskAssessment =
   {
     resourceType: 'RiskAssessment',
     id: 'homer-simpson-match-risk-assessment',
+    status: 'final',
     subject: {
       reference: 'Patient/homer-simpson',
     },
@@ -47,6 +48,8 @@ const doNotMatchList: List =
   {
     resourceType: 'List',
     id: 'homer-simpson-do-not-match-list',
+    status: 'current',
+    mode: 'snapshot',
     subject: {
       reference: 'Patient/homer-simpson',
     },

--- a/packages/examples/src/medications/representing-prescriptions-and-medication-orders.ts
+++ b/packages/examples/src/medications/representing-prescriptions-and-medication-orders.ts
@@ -7,6 +7,7 @@ const instructions: MedicationRequest =
   // start-block dispenseInstructions
   {
     resourceType: 'MedicationRequest',
+    status: 'active',
     intent: 'order',
     subject: {
       reference: 'Patient/homer-simpson',
@@ -58,6 +59,7 @@ const dosageInstruction: MedicationRequest =
   // start-block dosageInstructions
   {
     resourceType: 'MedicationRequest',
+    status: 'active',
     intent: 'order',
     subject: {
       reference: 'Patient/homer-simpson',
@@ -121,7 +123,7 @@ const dosageInstruction: MedicationRequest =
   };
 // end-block dosageInstructions
 
-const prescription: MedicationRequest =
+const prescription: Partial<MedicationRequest> =
   // start-block prescriptionRequest
   {
     resourceType: 'MedicationRequest',
@@ -139,7 +141,7 @@ const prescription: MedicationRequest =
   };
 // end-block prescriptionRequest
 
-const medicalOrder: MedicationRequest =
+const medicalOrder: Partial<MedicationRequest> =
   // start-block orderRequest
   {
     resourceType: 'MedicationRequest',

--- a/packages/examples/src/questionnaires/questionnaires-and-responses.ts
+++ b/packages/examples/src/questionnaires/questionnaires-and-responses.ts
@@ -272,6 +272,7 @@ const response: QuestionnaireResponse =
   {
     resourceType: 'QuestionnaireResponse',
     id: 'homer-simpson-conditional-response',
+    status: 'completed',
     questionnaire: 'http://example.org/Questionnaires/conditional-questionnaire',
     subject: {
       reference: 'Patient/homer-simpson',

--- a/packages/examples/src/search/includes.ts
+++ b/packages/examples/src/search/includes.ts
@@ -54,6 +54,7 @@ let response: Resource[] =
     {
       resourceType: 'Provenance',
       id: '1',
+      recorded: '2022-12-21T01:55:34.799Z',
       target: [{ reference: 'Observation/1' }],
       agent: [{ who: { reference: 'Practitioner/49d111f2-ae37-47bb-b8ee-2281d024501f' } }],
     },
@@ -74,6 +75,7 @@ let response: Resource[] =
     {
       resourceType: 'Provenance',
       id: '2',
+      recorded: '2022-12-21T01:55:34.799Z',
       target: [{ reference: 'Observation/2' }],
       agent: [{ who: { reference: 'Practitioner/49d111f2-ae37-47bb-b8ee-2281d024501f' } }],
     },
@@ -105,6 +107,7 @@ let response: Resource[] =
     {
       resourceType: 'Provenance',
       id: '3',
+      recorded: '2022-12-21T01:55:34.799Z',
       target: [{ reference: 'Observation/3' }],
       agent: [{ who: { reference: 'Practitioner/49d111f2-ae37-47bb-b8ee-2281d024501f' } }],
     },

--- a/packages/examples/src/tutorials/api-basics/create-fhir-data.ts
+++ b/packages/examples/src/tutorials/api-basics/create-fhir-data.ts
@@ -63,6 +63,8 @@ console.log('Created Patient', patient.id);
 // start-block create-service-request
 const serviceRequestData: ServiceRequest = {
   resourceType: 'ServiceRequest',
+  status: 'active',
+  intent: 'order',
   subject: createReference(patient), // link this ServiceRequest to the Patient
   code: {
     coding: [

--- a/packages/examples/src/tutorials/api-basics/publish-and-subscribe.ts
+++ b/packages/examples/src/tutorials/api-basics/publish-and-subscribe.ts
@@ -59,6 +59,8 @@ async function createServiceRequest(patientMrn: string): Promise<void> {
 
   const serviceRequest = await medplum.createResource({
     resourceType: 'ServiceRequest',
+    status: 'active',
+    intent: 'order',
     subject: createReference(patient),
     code: {
       coding: [
@@ -134,6 +136,7 @@ async function createReport(patientId: string, serviceRequestId: string): Promis
   // Create the first Observation resource.
   const observation: Observation = await medplum.createResource({
     resourceType: 'Observation',
+    status: 'final',
     basedOn: [createReference(serviceRequest)],
     subject: createReference(patient),
     code: {
@@ -156,6 +159,7 @@ async function createReport(patientId: string, serviceRequestId: string): Promis
   // Create a DiagnosticReport resource.
   const report: DiagnosticReport = await medplum.createResource({
     resourceType: 'DiagnosticReport',
+    status: 'final',
     basedOn: [
       {
         reference: serviceRequestId,

--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -12,8 +12,10 @@ import {
 import { readJson } from '@medplum/definitions';
 import {
   AllergyIntolerance,
+  Binary,
   Bundle,
   BundleEntry,
+  BundleEntryRequest,
   Observation,
   OperationOutcome,
   Patient,
@@ -40,7 +42,7 @@ describe('Batch', () => {
 
   test('Process batch with missing bundle type', async () => {
     try {
-      await processBatch(router, repo, { resourceType: 'Bundle' });
+      await processBatch(router, repo, { resourceType: 'Bundle' } as Bundle);
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -237,7 +239,7 @@ describe('Batch', () => {
           },
           resource: {
             resourceType: 'Observation',
-          },
+          } as Observation,
         },
       ],
     });
@@ -754,7 +756,7 @@ describe('Batch', () => {
           },
           resource: {
             resourceType: 'Binary',
-          },
+          } as Binary,
         },
       ],
     });
@@ -844,7 +846,7 @@ describe('Batch', () => {
         {
           request: {
             url: 'Patient',
-          },
+          } as BundleEntryRequest,
           resource: {
             resourceType: 'Patient',
           },
@@ -894,7 +896,7 @@ describe('Batch', () => {
         {
           request: {
             method: 'POST',
-          },
+          } as BundleEntryRequest,
           resource: {
             resourceType: 'Patient',
           },

--- a/packages/fhir-router/src/graphql/graphql.test.ts
+++ b/packages/fhir-router/src/graphql/graphql.test.ts
@@ -40,7 +40,7 @@ describe('GraphQL', () => {
     getRootSchema();
 
     // Create a profile picture
-    binary = await repo.createResource<Binary>({ resourceType: 'Binary' });
+    binary = await repo.createResource<Binary>({ resourceType: 'Binary' } as Binary);
 
     // Creat a simple patient
     patient = await repo.createResource<Patient>({
@@ -1228,7 +1228,7 @@ describe('GraphQL', () => {
       facility: {
         display: 'test',
       },
-    });
+    } as ExplanationOfBenefit);
     const request: FhirRequest = {
       method: 'POST',
       pathname: '/fhir/R4/$graphql',

--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -73,7 +73,7 @@ describe('MemoryRepository', () => {
 
   test('Count and offset', async () => {
     for (let i = 0; i < 10; i++) {
-      await repo.createResource<Observation>({ resourceType: 'Observation' });
+      await repo.createResource<Observation>({ resourceType: 'Observation' } as Observation);
     }
 
     const bundle = await repo.search({ resourceType: 'Observation', offset: 1, count: 1 });

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -84,13 +84,13 @@ export interface AccessPolicyIpAccessRule {
    * An IP Access rule will apply a certain action to incoming traffic
    * based on the visitor IP address or IP range.
    */
-  value?: string;
+  value: string;
 
   /**
    * Access rule can perform one of the following actions: &quot;allow&quot; |
    * &quot;block&quot;.
    */
-  action?: 'allow' | 'block';
+  action: 'allow' | 'block';
 }
 
 /**
@@ -101,7 +101,7 @@ export interface AccessPolicyResource {
   /**
    * The resource type.
    */
-  resourceType?: string;
+  resourceType: string;
 
   /**
    * DEPRECATED Optional compartment restriction for the resource type.

--- a/packages/fhirtypes/dist/Account.d.ts
+++ b/packages/fhirtypes/dist/Account.d.ts
@@ -113,7 +113,7 @@ export interface Account {
   /**
    * Indicates whether the account is presently used/usable or not.
    */
-  status?: 'active' | 'inactive' | 'entered-in-error' | 'on-hold' | 'unknown';
+  status: 'active' | 'inactive' | 'entered-in-error' | 'on-hold' | 'unknown';
 
   /**
    * Categorizes the account for reporting and searching purposes.
@@ -218,7 +218,7 @@ export interface AccountCoverage {
    * the sequence of the coverages in the account could be important when
    * processing billing.
    */
-  coverage?: Reference<Coverage>;
+  coverage: Reference<Coverage>;
 
   /**
    * The priority of the coverage in the context of this account.
@@ -270,7 +270,7 @@ export interface AccountGuarantor {
   /**
    * The entity who is responsible.
    */
-  party?: Reference<Patient | RelatedPerson | Organization>;
+  party: Reference<Patient | RelatedPerson | Organization>;
 
   /**
    * A guarantor may be placed on credit hold or otherwise have their role

--- a/packages/fhirtypes/dist/ActivityDefinition.d.ts
+++ b/packages/fhirtypes/dist/ActivityDefinition.d.ts
@@ -166,7 +166,7 @@ export interface ActivityDefinition {
    * The status of this activity definition. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this activity definition is authored
@@ -521,12 +521,12 @@ export interface ActivityDefinitionDynamicValue {
    * multiple-cardinality sub-elements (see the [Simple FHIRPath
    * Profile](fhirpath.html#simple) for full details).
    */
-  path?: string;
+  path: string;
 
   /**
    * An expression specifying the value of the customized element.
    */
-  expression?: Expression;
+  expression: Expression;
 }
 
 /**
@@ -572,7 +572,7 @@ export interface ActivityDefinitionParticipant {
   /**
    * The type of participant in the action.
    */
-  type?: 'patient' | 'practitioner' | 'related-person' | 'device';
+  type: 'patient' | 'practitioner' | 'related-person' | 'device';
 
   /**
    * The role the participant should play in performing the described

--- a/packages/fhirtypes/dist/AdverseEvent.d.ts
+++ b/packages/fhirtypes/dist/AdverseEvent.d.ts
@@ -128,7 +128,7 @@ export interface AdverseEvent {
    * Note that this is independent of whether anyone was affected or harmed
    * or how severely.
    */
-  actuality?: 'actual' | 'potential';
+  actuality: 'actual' | 'potential';
 
   /**
    * The overall type of event, intended for search and filtering purposes.
@@ -144,7 +144,7 @@ export interface AdverseEvent {
   /**
    * This subject or group impacted by the event.
    */
-  subject?: Reference<Patient | Group | Practitioner | RelatedPerson>;
+  subject: Reference<Patient | Group | Practitioner | RelatedPerson>;
 
   /**
    * The Encounter during which AdverseEvent was created or to which the
@@ -283,7 +283,7 @@ export interface AdverseEventSuspectEntity {
    * be a substance, medication, medication administration, medication
    * statement or a device.
    */
-  instance?: Reference<Immunization | Procedure | Substance | Medication | MedicationAdministration | MedicationStatement | Device>;
+  instance: Reference<Immunization | Procedure | Substance | Medication | MedicationAdministration | MedicationStatement | Device>;
 
   /**
    * Information on the possible cause of the event.

--- a/packages/fhirtypes/dist/Agent.d.ts
+++ b/packages/fhirtypes/dist/Agent.d.ts
@@ -55,12 +55,12 @@ export interface Agent {
   /**
    * The human readable friendly name of the agent.
    */
-  name?: string;
+  name: string;
 
   /**
    * The status of the agent.
    */
-  status?: 'active' | 'off' | 'error';
+  status: 'active' | 'off' | 'error';
 
   /**
    * Optional device resource representing the device running the agent.
@@ -88,13 +88,13 @@ export interface AgentChannel {
   /**
    * The channel name.
    */
-  name?: string;
+  name: string;
 
   /**
    * The channel endpoint definition including protocol and network binding
    * details.
    */
-  endpoint?: Reference<Endpoint>;
+  endpoint: Reference<Endpoint>;
 
   /**
    * The target resource where channel messages will be delivered.
@@ -115,7 +115,7 @@ export interface AgentSetting {
   /**
    * The setting name.
    */
-  name?: string;
+  name: string;
 
   /**
    * The setting value.

--- a/packages/fhirtypes/dist/AllergyIntolerance.d.ts
+++ b/packages/fhirtypes/dist/AllergyIntolerance.d.ts
@@ -162,7 +162,7 @@ export interface AllergyIntolerance {
   /**
    * The patient who has the allergy or intolerance.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The encounter when the allergy or intolerance was asserted.
@@ -296,7 +296,7 @@ export interface AllergyIntoleranceReaction {
    * Clinical symptoms and/or signs that are observed or associated with
    * the adverse reaction event.
    */
-  manifestation?: CodeableConcept[];
+  manifestation: CodeableConcept[];
 
   /**
    * Text description about the reaction as a whole, including details of

--- a/packages/fhirtypes/dist/Annotation.d.ts
+++ b/packages/fhirtypes/dist/Annotation.d.ts
@@ -50,5 +50,5 @@ export interface Annotation {
   /**
    * The text of the annotation in markdown format.
    */
-  text?: string;
+  text: string;
 }

--- a/packages/fhirtypes/dist/Appointment.d.ts
+++ b/packages/fhirtypes/dist/Appointment.d.ts
@@ -121,7 +121,7 @@ export interface Appointment {
    * their own participation status which indicates their involvement in
    * the process, however this status indicates the shared status.
    */
-  status?: 'proposed' | 'pending' | 'booked' | 'arrived' | 'fulfilled' | 'cancelled' | 'noshow' | 'entered-in-error' | 'checked-in' | 'waitlist';
+  status: 'proposed' | 'pending' | 'booked' | 'arrived' | 'fulfilled' | 'cancelled' | 'noshow' | 'entered-in-error' | 'checked-in' | 'waitlist';
 
   /**
    * The coded reason for the appointment being cancelled. This is often
@@ -245,7 +245,7 @@ export interface Appointment {
   /**
    * List of participants involved in the appointment.
    */
-  participant?: AppointmentParticipant[];
+  participant: AppointmentParticipant[];
 
   /**
    * A set of date ranges (potentially including times) that the
@@ -321,7 +321,7 @@ export interface AppointmentParticipant {
   /**
    * Participation status of the actor.
    */
-  status?: 'accepted' | 'declined' | 'tentative' | 'needs-action';
+  status: 'accepted' | 'declined' | 'tentative' | 'needs-action';
 
   /**
    * Participation period of the actor.

--- a/packages/fhirtypes/dist/AppointmentResponse.d.ts
+++ b/packages/fhirtypes/dist/AppointmentResponse.d.ts
@@ -112,7 +112,7 @@ export interface AppointmentResponse {
   /**
    * Appointment that this response is replying to.
    */
-  appointment?: Reference<Appointment>;
+  appointment: Reference<Appointment>;
 
   /**
    * Date/Time that the appointment is to take place, or requested new
@@ -145,7 +145,7 @@ export interface AppointmentResponse {
    * When the status is accepted, the times can either be the time of the
    * appointment (as a confirmation of the time) or can be empty.
    */
-  participantStatus?: 'accepted' | 'declined' | 'tentative' | 'needs-action';
+  participantStatus: 'accepted' | 'declined' | 'tentative' | 'needs-action';
 
   /**
    * Additional comments about the appointment.

--- a/packages/fhirtypes/dist/AsyncJob.d.ts
+++ b/packages/fhirtypes/dist/AsyncJob.d.ts
@@ -44,12 +44,12 @@ export interface AsyncJob {
   /**
    * The status of the request.
    */
-  status?: 'accepted' | 'active' | 'completed' | 'error';
+  status: 'accepted' | 'active' | 'completed' | 'error';
 
   /**
    * Indicates the server's time when the query is requested.
    */
-  requestTime?: string;
+  requestTime: string;
 
   /**
    * Indicates the server's time when the query is run. The response SHOULD
@@ -63,5 +63,5 @@ export interface AsyncJob {
    * The full URL of the original kick-off request. In the case of a POST
    * request, this URL will not include the request parameters.
    */
-  request?: string;
+  request: string;
 }

--- a/packages/fhirtypes/dist/AuditEvent.d.ts
+++ b/packages/fhirtypes/dist/AuditEvent.d.ts
@@ -107,7 +107,7 @@ export interface AuditEvent {
    * program, rule, policy, function code, application name or URL. It
    * identifies the performed function.
    */
-  type?: Coding;
+  type: Coding;
 
   /**
    * Identifier for the category of event.
@@ -128,7 +128,7 @@ export interface AuditEvent {
   /**
    * The time when the event was recorded.
    */
-  recorded?: string;
+  recorded: string;
 
   /**
    * Indicates whether the event succeeded or failed.
@@ -150,12 +150,12 @@ export interface AuditEvent {
    * An actor taking an active role in the event or activity that is
    * logged.
    */
-  agent?: AuditEventAgent[];
+  agent: AuditEventAgent[];
 
   /**
    * The system that is reporting the event.
    */
-  source?: AuditEventSource;
+  source: AuditEventSource;
 
   /**
    * Specific instances of data or objects that have been accessed.
@@ -239,7 +239,7 @@ export interface AuditEventAgent {
    * Indicator that the user is or is not the requestor, or initiator, for
    * the event being audited.
    */
-  requestor?: boolean;
+  requestor: boolean;
 
   /**
    * Where the event occurred.
@@ -460,7 +460,7 @@ export interface AuditEventEntityDetail {
   /**
    * The type of extra detail provided in the value.
    */
-  type?: string;
+  type: string;
 
   /**
    * The  value of the extra detail.
@@ -523,7 +523,7 @@ export interface AuditEventSource {
   /**
    * Identifier of the source where the event was detected.
    */
-  observer?: Reference<PractitionerRole | Practitioner | Organization | Device | Patient | RelatedPerson>;
+  observer: Reference<PractitionerRole | Practitioner | Organization | Device | Patient | RelatedPerson>;
 
   /**
    * Code specifying the type of source where event originated.

--- a/packages/fhirtypes/dist/Basic.d.ts
+++ b/packages/fhirtypes/dist/Basic.d.ts
@@ -110,7 +110,7 @@ export interface Basic {
    * Identifies the 'type' of resource - equivalent to the resource name
    * for other resources.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * Identifies the patient, practitioner, device or any other resource

--- a/packages/fhirtypes/dist/Binary.d.ts
+++ b/packages/fhirtypes/dist/Binary.d.ts
@@ -49,7 +49,7 @@ export interface Binary {
    * MimeType of the binary content represented as a standard MimeType (BCP
    * 13).
    */
-  contentType?: string;
+  contentType: string;
 
   /**
    * This element identifies another resource that can be used as a proxy

--- a/packages/fhirtypes/dist/BodyStructure.d.ts
+++ b/packages/fhirtypes/dist/BodyStructure.d.ts
@@ -138,5 +138,5 @@ export interface BodyStructure {
   /**
    * The person to which the body site belongs.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 }

--- a/packages/fhirtypes/dist/BulkDataExport.d.ts
+++ b/packages/fhirtypes/dist/BulkDataExport.d.ts
@@ -45,12 +45,12 @@ export interface BulkDataExport {
   /**
    * The status of the request.
    */
-  status?: 'accepted' | 'active' | 'completed' | 'error';
+  status: 'accepted' | 'active' | 'completed' | 'error';
 
   /**
    * Indicates the server's time when the query is requested.
    */
-  requestTime?: string;
+  requestTime: string;
 
   /**
    * Indicates the server's time when the query is run. The response SHOULD
@@ -64,7 +64,7 @@ export interface BulkDataExport {
    * The full URL of the original Bulk Data kick-off request. In the case
    * of a POST request, this URL will not include the request parameters.
    */
-  request?: string;
+  request: string;
 
   /**
    * Indicates whether downloading the generated files requires the same
@@ -101,14 +101,14 @@ export interface BulkDataExportDeleted {
   /**
    * The FHIR resource type that is contained in the file.
    */
-  type?: ResourceType;
+  type: ResourceType;
 
   /**
    * The absolute path to the file. The format of the file SHOULD reflect
    * that requested in the _outputFormat parameter of the initial kick-off
    * request.
    */
-  url?: string;
+  url: string;
 }
 
 /**
@@ -120,14 +120,14 @@ export interface BulkDataExportError {
   /**
    * The FHIR resource type that is contained in the file.
    */
-  type?: ResourceType;
+  type: ResourceType;
 
   /**
    * The absolute path to the file. The format of the file SHOULD reflect
    * that requested in the _outputFormat parameter of the initial kick-off
    * request.
    */
-  url?: string;
+  url: string;
 }
 
 /**
@@ -140,12 +140,12 @@ export interface BulkDataExportOutput {
   /**
    * The FHIR resource type that is contained in the file.
    */
-  type?: ResourceType;
+  type: ResourceType;
 
   /**
    * The absolute path to the file. The format of the file SHOULD reflect
    * that requested in the _outputFormat parameter of the initial kick-off
    * request.
    */
-  url?: string;
+  url: string;
 }

--- a/packages/fhirtypes/dist/Bundle.d.ts
+++ b/packages/fhirtypes/dist/Bundle.d.ts
@@ -55,7 +55,7 @@ export interface Bundle<T extends Resource = Resource> {
   /**
    * Indicates the purpose of this bundle - how it is intended to be used.
    */
-  type?: 'document' | 'message' | 'transaction' | 'transaction-response' | 'batch' | 'batch-response' | 'history' | 'searchset' | 'collection';
+  type: 'document' | 'message' | 'transaction' | 'transaction-response' | 'batch' | 'batch-response' | 'history' | 'searchset' | 'collection';
 
   /**
    * The date/time that the bundle was assembled - i.e. when the resources
@@ -221,13 +221,13 @@ export interface BundleEntryRequest {
    * this entry. In a history bundle, this indicates the HTTP action that
    * occurred.
    */
-  method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  method: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
   /**
    * The URL for this entry, relative to the root (the address to which the
    * request is posted).
    */
-  url?: string;
+  url: string;
 
   /**
    * If the ETag values match, return a 304 Not Modified status. See the
@@ -304,7 +304,7 @@ export interface BundleEntryResponse {
    * start with a 3 digit HTTP code (e.g. 404) and may contain the standard
    * HTTP description associated with the status code.
    */
-  status?: string;
+  status: string;
 
   /**
    * The location header created by processing this operation, populated if
@@ -430,10 +430,10 @@ export interface BundleLink {
    * A name which details the functional use for this link - see
    * [http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1](http://www.iana.org/assignments/link-relations/link-relations.xhtml#link-relations-1).
    */
-  relation?: string;
+  relation: string;
 
   /**
    * The reference details for the link.
    */
-  url?: string;
+  url: string;
 }

--- a/packages/fhirtypes/dist/CapabilityStatement.d.ts
+++ b/packages/fhirtypes/dist/CapabilityStatement.d.ts
@@ -139,7 +139,7 @@ export interface CapabilityStatement {
    * The status of this capability statement. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this capability statement is authored
@@ -155,7 +155,7 @@ export interface CapabilityStatement {
    * change when the substantive content of the capability statement
    * changes.
    */
-  date?: string;
+  date: string;
 
   /**
    * The name of the organization or individual that published the
@@ -212,7 +212,7 @@ export interface CapabilityStatement {
    * instance of software) or a class of implementation (e.g. a desired
    * purchase).
    */
-  kind?: 'instance' | 'capability' | 'requirements';
+  kind: 'instance' | 'capability' | 'requirements';
 
   /**
    * Reference to a canonical URL of another CapabilityStatement that this
@@ -252,14 +252,14 @@ export interface CapabilityStatement {
    * describes (which SHALL be the same as the FHIR version of the
    * CapabilityStatement itself). There is no default value.
    */
-  fhirVersion?: '0.01' | '0.05' | '0.06' | '0.11' | '0.0.80' | '0.0.81' | '0.0.82' | '0.4.0' | '0.5.0' | '1.0.0' |
+  fhirVersion: '0.01' | '0.05' | '0.06' | '0.11' | '0.0.80' | '0.0.81' | '0.0.82' | '0.4.0' | '0.5.0' | '1.0.0' |
       '1.0.1' | '1.0.2' | '1.1.0' | '1.4.0' | '1.6.0' | '1.8.0' | '3.0.0' | '3.0.1' | '3.3.0' | '3.5.0' | '4.0.0' | '4.0.1';
 
   /**
    * A list of the formats supported by this implementation using their
    * content types.
    */
-  format?: string[];
+  format: string[];
 
   /**
    * A list of the patch formats supported by this implementation using
@@ -333,7 +333,7 @@ export interface CapabilityStatementDocument {
    * Mode of this document declaration - whether an application is a
    * producer or consumer.
    */
-  mode?: 'producer' | 'consumer';
+  mode: 'producer' | 'consumer';
 
   /**
    * A description of how the application supports or uses the specified
@@ -346,7 +346,7 @@ export interface CapabilityStatementDocument {
    * A profile on the document Bundle that constrains which resources are
    * present, and their contents.
    */
-  profile?: string;
+  profile: string;
 }
 
 /**
@@ -395,7 +395,7 @@ export interface CapabilityStatementImplementation {
    * Information about the specific installation that this capability
    * statement relates to.
    */
-  description?: string;
+  description: string;
 
   /**
    * An absolute base URL for the implementation.  This forms the base for
@@ -523,13 +523,13 @@ export interface CapabilityStatementMessagingEndpoint {
    * A list of the messaging transport protocol(s) identifiers, supported
    * by this endpoint.
    */
-  protocol?: Coding;
+  protocol: Coding;
 
   /**
    * The network address of the endpoint. For solutions that do not use
    * network addresses for routing, it can be just an identifier.
    */
-  address?: string;
+  address: string;
 }
 
 /**
@@ -577,13 +577,13 @@ export interface CapabilityStatementMessagingSupportedMessage {
    * The mode of this event declaration - whether application is sender or
    * receiver.
    */
-  mode?: 'sender' | 'receiver';
+  mode: 'sender' | 'receiver';
 
   /**
    * Points to a message definition that identifies the messaging event,
    * message structure, allowed responses, etc.
    */
-  definition?: string;
+  definition: string;
 }
 
 /**
@@ -630,7 +630,7 @@ export interface CapabilityStatementRest {
    * Identifies whether this portion of the statement is describing the
    * ability to initiate or receive restful operations.
    */
-  mode?: 'client' | 'server';
+  mode: 'client' | 'server';
 
   /**
    * Information about the system's restful capabilities that apply across
@@ -720,7 +720,7 @@ export interface CapabilityStatementRestInteraction {
   /**
    * A coded identifier of the operation, supported by the system.
    */
-  code?: 'transaction' | 'batch' | 'search-system' | 'history-system';
+  code: 'transaction' | 'batch' | 'search-system' | 'history-system';
 
   /**
    * Guidance specific to the implementation of this operation, such as
@@ -774,7 +774,7 @@ export interface CapabilityStatementRestResource {
   /**
    * A type of resource exposed via the restful interface.
    */
-  type?: ResourceType;
+  type: ResourceType;
 
   /**
    * A specification of the profile that describes the solution's overall
@@ -926,7 +926,7 @@ export interface CapabilityStatementRestResourceInteraction {
   /**
    * Coded identifier of the operation, supported by the system resource.
    */
-  code?: 'read' | 'vread' | 'update' | 'patch' | 'delete' | 'history-instance' | 'history-type' | 'create' | 'search-type';
+  code: 'read' | 'vread' | 'update' | 'patch' | 'delete' | 'history-instance' | 'history-type' | 'create' | 'search-type';
 
   /**
    * Guidance specific to the implementation of this operation, such as
@@ -984,7 +984,7 @@ export interface CapabilityStatementRestResourceOperation {
    * prefixed with $ and used in the URL. For a query, this is the name
    * used in the _query parameter when the query is called.
    */
-  name?: string;
+  name: string;
 
   /**
    * Where the formal definition can be found. If a server references the
@@ -997,7 +997,7 @@ export interface CapabilityStatementRestResourceOperation {
    * 'base' of the original OperationDefinition.  The custom definition
    * would describe the specific subset of functionality supported.
    */
-  definition?: string;
+  definition: string;
 
   /**
    * Documentation that describes anything special about the operation
@@ -1052,7 +1052,7 @@ export interface CapabilityStatementRestResourceSearchParam {
   /**
    * The name of the search parameter used in the interface.
    */
-  name?: string;
+  name: string;
 
   /**
    * An absolute URI that is a formal reference to where this parameter was
@@ -1069,7 +1069,7 @@ export interface CapabilityStatementRestResourceSearchParam {
    * The type of value a search parameter refers to, and how the content is
    * interpreted.
    */
-  type?: 'number' | 'date' | 'string' | 'token' | 'reference' | 'composite' | 'quantity' | 'uri' | 'special';
+  type: 'number' | 'date' | 'string' | 'token' | 'reference' | 'composite' | 'quantity' | 'uri' | 'special';
 
   /**
    * This allows documentation of any distinct behaviors about how the
@@ -1181,7 +1181,7 @@ export interface CapabilityStatementSoftware {
   /**
    * Name the software is known by.
    */
-  name?: string;
+  name: string;
 
   /**
    * The version identifier for the software covered by this statement.

--- a/packages/fhirtypes/dist/CarePlan.d.ts
+++ b/packages/fhirtypes/dist/CarePlan.d.ts
@@ -168,13 +168,13 @@ export interface CarePlan {
    * Indicates whether the plan is currently being acted upon, represents
    * future intentions or is now a historical record.
    */
-  status?: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Indicates the level of authority/intentionality associated with the
    * care plan and where the care plan fits into the workflow chain.
    */
-  intent?: 'proposal' | 'plan' | 'order' | 'option';
+  intent: 'proposal' | 'plan' | 'order' | 'option';
 
   /**
    * Identifies what &quot;kind&quot; of plan this is to support differentiation
@@ -197,7 +197,7 @@ export interface CarePlan {
    * Identifies the patient or group whose intended care is described by
    * the plan.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The Encounter during which this CarePlan was created or to which the
@@ -439,7 +439,7 @@ export interface CarePlanActivityDetail {
   /**
    * Identifies what progress is being made for the specific activity.
    */
-  status?: 'not-started' | 'scheduled' | 'in-progress' | 'on-hold' | 'completed' | 'cancelled' | 'stopped' | 'unknown' | 'entered-in-error';
+  status: 'not-started' | 'scheduled' | 'in-progress' | 'on-hold' | 'completed' | 'cancelled' | 'stopped' | 'unknown' | 'entered-in-error';
 
   /**
    * Provides reason why the activity isn't yet started, is on hold, was

--- a/packages/fhirtypes/dist/CatalogEntry.d.ts
+++ b/packages/fhirtypes/dist/CatalogEntry.d.ts
@@ -119,13 +119,13 @@ export interface CatalogEntry {
   /**
    * Whether the entry represents an orderable item.
    */
-  orderable?: boolean;
+  orderable: boolean;
 
   /**
    * The item in a catalog or definition.
    */
-  referencedItem?: Reference<Medication | Device | Organization | Practitioner | PractitionerRole | HealthcareService
-      | ActivityDefinition | PlanDefinition | SpecimenDefinition | ObservationDefinition | Binary>;
+  referencedItem: Reference<Medication | Device | Organization | Practitioner | PractitionerRole | HealthcareService |
+      ActivityDefinition | PlanDefinition | SpecimenDefinition | ObservationDefinition | Binary>;
 
   /**
    * Used in supporting related concepts, e.g. NDC to RxNorm.
@@ -221,10 +221,10 @@ export interface CatalogEntryRelatedEntry {
    * The type of relation to the related item: child, parent,
    * packageContent, containerPackage, usedIn, uses, requires, etc.
    */
-  relationtype?: 'triggers' | 'is-replaced-by';
+  relationtype: 'triggers' | 'is-replaced-by';
 
   /**
    * The reference to the related item.
    */
-  item?: Reference<CatalogEntry>;
+  item: Reference<CatalogEntry>;
 }

--- a/packages/fhirtypes/dist/ChargeItem.d.ts
+++ b/packages/fhirtypes/dist/ChargeItem.d.ts
@@ -143,7 +143,7 @@ export interface ChargeItem {
   /**
    * The current state of the ChargeItem.
    */
-  status?: 'planned' | 'billable' | 'not-billable' | 'aborted' | 'billed' | 'entered-in-error' | 'unknown';
+  status: 'planned' | 'billable' | 'not-billable' | 'aborted' | 'billed' | 'entered-in-error' | 'unknown';
 
   /**
    * ChargeItems can be grouped to larger ChargeItems covering the whole
@@ -154,13 +154,13 @@ export interface ChargeItem {
   /**
    * A code that identifies the charge, like a billing code.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The individual or set of individuals the action is being or was
    * performed on.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The encounter or episode of care that establishes the context for this
@@ -334,5 +334,5 @@ export interface ChargeItemPerformer {
    * The device, practitioner, etc. who performed or participated in the
    * service.
    */
-  actor?: Reference<Practitioner | PractitionerRole | Organization | CareTeam | Patient | Device | RelatedPerson>;
+  actor: Reference<Practitioner | PractitionerRole | Organization | CareTeam | Patient | Device | RelatedPerson>;
 }

--- a/packages/fhirtypes/dist/ChargeItemDefinition.d.ts
+++ b/packages/fhirtypes/dist/ChargeItemDefinition.d.ts
@@ -113,7 +113,7 @@ export interface ChargeItemDefinition {
    * SHALL remain the same when the charge item definition is stored on
    * different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * A formal identifier that is used to identify this charge item
@@ -164,7 +164,7 @@ export interface ChargeItemDefinition {
   /**
    * The current state of the ChargeItemDefinition.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this charge item definition is
@@ -439,7 +439,7 @@ export interface ChargeItemDefinitionPropertyGroupPriceComponent {
   /**
    * This code identifies the type of the component.
    */
-  type?: 'base' | 'surcharge' | 'deduction' | 'discount' | 'tax' | 'informational';
+  type: 'base' | 'surcharge' | 'deduction' | 'discount' | 'tax' | 'informational';
 
   /**
    * A code that identifies the component. Codes may be used to

--- a/packages/fhirtypes/dist/Claim.d.ts
+++ b/packages/fhirtypes/dist/Claim.d.ts
@@ -123,13 +123,13 @@ export interface Claim {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * The category of claim, e.g. oral, pharmacy, vision, institutional,
    * professional.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * A finer grained suite of claim type codes which may convey additional
@@ -145,14 +145,14 @@ export interface Claim {
    * or requesting the non-binding adjudication of the listed products and
    * services which could be provided in the future.
    */
-  use?: 'claim' | 'preauthorization' | 'predetermination';
+  use: 'claim' | 'preauthorization' | 'predetermination';
 
   /**
    * The party to whom the professional services and/or products have been
    * supplied or are being considered and for whom actual or forecast
    * reimbursement is sought.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The period for which charges are being submitted.
@@ -162,7 +162,7 @@ export interface Claim {
   /**
    * The date this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * Individual who created the claim, predetermination or
@@ -179,13 +179,13 @@ export interface Claim {
    * The provider which is responsible for the claim, predetermination or
    * preauthorization.
    */
-  provider?: Reference<Practitioner | PractitionerRole | Organization>;
+  provider: Reference<Practitioner | PractitionerRole | Organization>;
 
   /**
    * The provider-required urgency of processing the request. Typical
    * values include: stat, routine deferred.
    */
-  priority?: CodeableConcept;
+  priority: CodeableConcept;
 
   /**
    * A code to indicate whether and for whom funds are to be reserved for
@@ -254,7 +254,7 @@ export interface Claim {
    * Financial instruments for reimbursement for the health care products
    * and services specified on the claim.
    */
-  insurance?: ClaimInsurance[];
+  insurance: ClaimInsurance[];
 
   /**
    * Details of an accident which resulted in injuries which required the
@@ -319,7 +319,7 @@ export interface ClaimAccident {
    * Date of an accident event  related to the products and services
    * contained in the claim.
    */
-  date?: string;
+  date: string;
 
   /**
    * The type or context of the accident event for the purposes of
@@ -382,12 +382,12 @@ export interface ClaimCareTeam {
   /**
    * A number to uniquely identify care team entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * Member of the team who provided the product or service.
    */
-  provider?: Reference<Practitioner | PractitionerRole | Organization>;
+  provider: Reference<Practitioner | PractitionerRole | Organization>;
 
   /**
    * The party who is billing and/or responsible for the claimed products
@@ -451,7 +451,7 @@ export interface ClaimDiagnosis {
   /**
    * A number to uniquely identify diagnosis entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The nature of illness or problem in a coded form or as a reference to
@@ -529,13 +529,13 @@ export interface ClaimInsurance {
    * A number to uniquely identify insurance entries and provide a sequence
    * of coverages to convey coordination of benefit order.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * A flag to indicate that this Coverage is to be used for adjudication
    * of this claim when set to true.
    */
-  focal?: boolean;
+  focal: boolean;
 
   /**
    * The business identifier to be used when the claim is sent for
@@ -549,7 +549,7 @@ export interface ClaimInsurance {
    * to locate the patient's actual coverage within the insurer's
    * information system.
    */
-  coverage?: Reference<Coverage>;
+  coverage: Reference<Coverage>;
 
   /**
    * A business agreement number established between the provider and the
@@ -615,7 +615,7 @@ export interface ClaimItem {
   /**
    * A number to uniquely identify item entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * CareTeam members related to this service or product.
@@ -655,7 +655,7 @@ export interface ClaimItem {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -794,7 +794,7 @@ export interface ClaimItemDetail {
   /**
    * A number to uniquely identify item entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The type of revenue or cost center providing the product and/or
@@ -813,7 +813,7 @@ export interface ClaimItemDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -908,7 +908,7 @@ export interface ClaimItemDetailSubDetail {
   /**
    * A number to uniquely identify item entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The type of revenue or cost center providing the product and/or
@@ -927,7 +927,7 @@ export interface ClaimItemDetailSubDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -1016,7 +1016,7 @@ export interface ClaimPayee {
   /**
    * Type of Party to be reimbursed: subscriber, provider, other.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Reference to the individual or organization to whom any payment will
@@ -1069,7 +1069,7 @@ export interface ClaimProcedure {
   /**
    * A number to uniquely identify procedure entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * When the condition was observed or the relative ranking.
@@ -1201,13 +1201,13 @@ export interface ClaimSupportingInfo {
   /**
    * A number to uniquely identify supporting information entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The general class of the information supplied: information; exception;
    * accident, employment; onset, etc.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * System and code pertaining to the specific information regarding

--- a/packages/fhirtypes/dist/ClaimResponse.d.ts
+++ b/packages/fhirtypes/dist/ClaimResponse.d.ts
@@ -114,14 +114,14 @@ export interface ClaimResponse {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * A finer grained suite of claim type codes which may convey additional
    * information such as Inpatient vs Outpatient and/or a specialty
    * service.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * A finer grained suite of claim type codes which may convey additional
@@ -137,25 +137,25 @@ export interface ClaimResponse {
    * or requesting the non-binding adjudication of the listed products and
    * services which could be provided in the future.
    */
-  use?: 'claim' | 'preauthorization' | 'predetermination';
+  use: 'claim' | 'preauthorization' | 'predetermination';
 
   /**
    * The party to whom the professional services and/or products have been
    * supplied or are being considered and for whom actual for facast
    * reimbursement is sought.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The date this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * The party responsible for authorization, adjudication and
    * reimbursement.
    */
-  insurer?: Reference<Organization>;
+  insurer: Reference<Organization>;
 
   /**
    * The provider which is responsible for the claim, predetermination or
@@ -172,7 +172,7 @@ export interface ClaimResponse {
    * The outcome of the claim, predetermination, or preauthorization
    * processing.
    */
-  outcome?: 'queued' | 'complete' | 'error' | 'partial';
+  outcome: 'queued' | 'complete' | 'error' | 'partial';
 
   /**
    * A human readable description of the status of the adjudication.
@@ -332,7 +332,7 @@ export interface ClaimResponseAddItem {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -418,7 +418,7 @@ export interface ClaimResponseAddItem {
   /**
    * The adjudication results.
    */
-  adjudication?: ClaimResponseItemAdjudication[];
+  adjudication: ClaimResponseItemAdjudication[];
 
   /**
    * The second-tier service adjudications for payor added services.
@@ -471,7 +471,7 @@ export interface ClaimResponseAddItemDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -514,7 +514,7 @@ export interface ClaimResponseAddItemDetail {
   /**
    * The adjudication results.
    */
-  adjudication?: ClaimResponseItemAdjudication[];
+  adjudication: ClaimResponseItemAdjudication[];
 
   /**
    * The third-tier service adjudications for payor added services.
@@ -567,7 +567,7 @@ export interface ClaimResponseAddItemDetailSubDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -610,7 +610,7 @@ export interface ClaimResponseAddItemDetailSubDetail {
   /**
    * The adjudication results.
    */
-  adjudication?: ClaimResponseItemAdjudication[];
+  adjudication: ClaimResponseItemAdjudication[];
 }
 
 /**
@@ -678,7 +678,7 @@ export interface ClaimResponseError {
    * An error code, from a specified code system, which details why the
    * claim could not be adjudicated.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 }
 
 /**
@@ -726,13 +726,13 @@ export interface ClaimResponseInsurance {
    * A number to uniquely identify insurance entries and provide a sequence
    * of coverages to convey coordination of benefit order.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * A flag to indicate that this Coverage is to be used for adjudication
    * of this claim when set to true.
    */
-  focal?: boolean;
+  focal: boolean;
 
   /**
    * Reference to the insurance card level information contained in the
@@ -740,7 +740,7 @@ export interface ClaimResponseInsurance {
    * to locate the patient's actual coverage within the insurer's
    * information system.
    */
-  coverage?: Reference<Coverage>;
+  coverage: Reference<Coverage>;
 
   /**
    * A business agreement number established between the provider and the
@@ -799,7 +799,7 @@ export interface ClaimResponseItem {
   /**
    * A number to uniquely reference the claim item entries.
    */
-  itemSequence?: number;
+  itemSequence: number;
 
   /**
    * The numbers associated with notes below which apply to the
@@ -812,7 +812,7 @@ export interface ClaimResponseItem {
    * adjudication of the detail items. If this item is a simple product or
    * service then this is the result of the adjudication of this item.
    */
-  adjudication?: ClaimResponseItemAdjudication[];
+  adjudication: ClaimResponseItemAdjudication[];
 
   /**
    * A claim detail. Either a simple (a product or service) or a 'group' of
@@ -871,7 +871,7 @@ export interface ClaimResponseItemAdjudication {
    * amounts paid by other coverages; and, the benefit payable for this
    * item.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * A code supporting the understanding of the adjudication result and
@@ -935,7 +935,7 @@ export interface ClaimResponseItemDetail {
   /**
    * A number to uniquely reference the claim detail entry.
    */
-  detailSequence?: number;
+  detailSequence: number;
 
   /**
    * The numbers associated with notes below which apply to the
@@ -946,7 +946,7 @@ export interface ClaimResponseItemDetail {
   /**
    * The adjudication results.
    */
-  adjudication?: ClaimResponseItemAdjudication[];
+  adjudication: ClaimResponseItemAdjudication[];
 
   /**
    * A sub-detail adjudication of a simple product or service.
@@ -997,7 +997,7 @@ export interface ClaimResponseItemDetailSubDetail {
   /**
    * A number to uniquely reference the claim sub-detail entry.
    */
-  subDetailSequence?: number;
+  subDetailSequence: number;
 
   /**
    * The numbers associated with notes below which apply to the
@@ -1055,7 +1055,7 @@ export interface ClaimResponsePayment {
    * Whether this represents partial or complete payment of the benefits
    * payable.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Total amount of all adjustments to this payment included in this
@@ -1077,7 +1077,7 @@ export interface ClaimResponsePayment {
   /**
    * Benefits payable less any payment adjustment.
    */
-  amount?: Money;
+  amount: Money;
 
   /**
    * Issuer's unique identifier for the payment instrument.
@@ -1139,7 +1139,7 @@ export interface ClaimResponseProcessNote {
   /**
    * The explanation or description associated with the processing.
    */
-  text?: string;
+  text: string;
 
   /**
    * A code to define the language used in the text of the note.
@@ -1195,10 +1195,10 @@ export interface ClaimResponseTotal {
    * amounts paid by other coverages, and the benefit payable for this
    * item.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * Monetary total amount associated with the category.
    */
-  amount?: Money;
+  amount: Money;
 }

--- a/packages/fhirtypes/dist/ClinicalImpression.d.ts
+++ b/packages/fhirtypes/dist/ClinicalImpression.d.ts
@@ -125,7 +125,7 @@ export interface ClinicalImpression {
   /**
    * Identifies the workflow status of the assessment.
    */
-  status?: 'in-progress' | 'completed' | 'entered-in-error';
+  status: 'in-progress' | 'completed' | 'entered-in-error';
 
   /**
    * Captures the reason for the current state of the ClinicalImpression.
@@ -146,7 +146,7 @@ export interface ClinicalImpression {
   /**
    * The patient or group of individuals assessed as part of this record.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The Encounter during which this ClinicalImpression was created or to
@@ -346,7 +346,7 @@ export interface ClinicalImpressionInvestigation {
    * but the list is not constrained, and others such groups such as
    * (exposure|family|travel|nutritional) history may be used.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * A record of a specific investigation that was undertaken.

--- a/packages/fhirtypes/dist/CodeSystem.d.ts
+++ b/packages/fhirtypes/dist/CodeSystem.d.ts
@@ -143,7 +143,7 @@ export interface CodeSystem {
    * The date (and optionally time) when the code system resource was
    * created or revised.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this code system is authored for
@@ -240,7 +240,7 @@ export interface CodeSystem {
    * The extent of the content of the code system (the concepts and codes
    * it defines) are represented in this resource instance.
    */
-  content?: 'not-present' | 'example' | 'fragment' | 'complete' | 'supplement';
+  content: 'not-present' | 'example' | 'fragment' | 'complete' | 'supplement';
 
   /**
    * The canonical URL of the code system that this code system supplement
@@ -321,7 +321,7 @@ export interface CodeSystemConcept {
    * A code - a text symbol - that uniquely identifies the concept within
    * the code system.
    */
-  code?: string;
+  code: string;
 
   /**
    * A human readable string that is the recommended default way to present
@@ -410,7 +410,7 @@ export interface CodeSystemConceptDesignation {
   /**
    * The text value for this designation.
    */
-  value?: string;
+  value: string;
 }
 
 /**
@@ -456,7 +456,7 @@ export interface CodeSystemConceptProperty {
   /**
    * A code that is a reference to CodeSystem.property.code.
    */
-  code?: string;
+  code: string;
 
   /**
    * The value of this property.
@@ -539,7 +539,7 @@ export interface CodeSystemFilter {
    * The code that identifies this filter when it is used as a filter in
    * [ValueSet](valueset.html#).compose.include.filter.
    */
-  code?: string;
+  code: string;
 
   /**
    * A description of how or why the filter is used.
@@ -549,12 +549,12 @@ export interface CodeSystemFilter {
   /**
    * A list of operators that can be used with the filter.
    */
-  operator?: ('=' | 'is-a' | 'descendent-of' | 'is-not-a' | 'regex' | 'in' | 'not-in' | 'generalizes' | 'exists')[];
+  operator: ('=' | 'is-a' | 'descendent-of' | 'is-not-a' | 'regex' | 'in' | 'not-in' | 'generalizes' | 'exists')[];
 
   /**
    * A description of what the value for the filter should be.
    */
-  value?: string;
+  value: string;
 }
 
 /**
@@ -603,7 +603,7 @@ export interface CodeSystemProperty {
    * internally (in CodeSystem.concept.property.code) and also externally,
    * such as in property filters.
    */
-  code?: string;
+  code: string;
 
   /**
    * Reference to the formal meaning of the property. One possible source
@@ -623,5 +623,5 @@ export interface CodeSystemProperty {
    * code defined by the code system (e.g. a reference to another defined
    * concept).
    */
-  type?: 'code' | 'Coding' | 'string' | 'integer' | 'boolean' | 'dateTime' | 'decimal';
+  type: 'code' | 'Coding' | 'string' | 'integer' | 'boolean' | 'dateTime' | 'decimal';
 }

--- a/packages/fhirtypes/dist/Communication.d.ts
+++ b/packages/fhirtypes/dist/Communication.d.ts
@@ -150,7 +150,7 @@ export interface Communication {
   /**
    * The status of the transmission.
    */
-  status?: 'preparation' | 'in-progress' | 'not-done' | 'on-hold' | 'stopped' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'preparation' | 'in-progress' | 'not-done' | 'on-hold' | 'stopped' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Captures the reason for the current state of the Communication.

--- a/packages/fhirtypes/dist/CommunicationRequest.d.ts
+++ b/packages/fhirtypes/dist/CommunicationRequest.d.ts
@@ -140,7 +140,7 @@ export interface CommunicationRequest {
   /**
    * The status of the proposal or order.
    */
-  status?: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Captures the reason for the current state of the CommunicationRequest.

--- a/packages/fhirtypes/dist/CompartmentDefinition.d.ts
+++ b/packages/fhirtypes/dist/CompartmentDefinition.d.ts
@@ -103,7 +103,7 @@ export interface CompartmentDefinition {
    * SHALL remain the same when the compartment definition is stored on
    * different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * The identifier that is used to identify this version of the
@@ -121,13 +121,13 @@ export interface CompartmentDefinition {
    * name should be usable as an identifier for the module by machine
    * processing applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * The status of this compartment definition. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this compartment definition is
@@ -182,12 +182,12 @@ export interface CompartmentDefinition {
   /**
    * Which compartment this definition describes.
    */
-  code?: 'Patient' | 'Encounter' | 'RelatedPerson' | 'Practitioner' | 'Device';
+  code: 'Patient' | 'Encounter' | 'RelatedPerson' | 'Practitioner' | 'Device';
 
   /**
    * Whether the search syntax is supported,.
    */
-  search?: boolean;
+  search: boolean;
 
   /**
    * Information about how a resource is related to the compartment.
@@ -238,7 +238,7 @@ export interface CompartmentDefinitionResource {
   /**
    * The name of a resource supported by the server.
    */
-  code?: ResourceType;
+  code: ResourceType;
 
   /**
    * The name of a search parameter that represents the link to the

--- a/packages/fhirtypes/dist/Composition.d.ts
+++ b/packages/fhirtypes/dist/Composition.d.ts
@@ -119,14 +119,14 @@ export interface Composition {
    * The workflow/clinical status of this composition. The status is a
    * marker for the clinical standing of the document.
    */
-  status?: 'preliminary' | 'final' | 'amended' | 'entered-in-error';
+  status: 'preliminary' | 'final' | 'amended' | 'entered-in-error';
 
   /**
    * Specifies the particular kind of composition (e.g. History and
    * Physical, Discharge Summary, Progress Note). This usually equates to
    * the purpose of making the composition.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * A categorization for the type of the composition - helps for indexing
@@ -153,18 +153,18 @@ export interface Composition {
    * The composition editing time, when the composition was last logically
    * changed by the author.
    */
-  date?: string;
+  date: string;
 
   /**
    * Identifies who is responsible for the information in the composition,
    * not necessarily who typed it in.
    */
-  author?: Reference<Practitioner | PractitionerRole | Device | Patient | RelatedPerson | Organization>[];
+  author: Reference<Practitioner | PractitionerRole | Device | Patient | RelatedPerson | Organization>[];
 
   /**
    * Official human-readable label for the composition.
    */
-  title?: string;
+  title: string;
 
   /**
    * The code specifying the level of confidentiality of the Composition.
@@ -245,7 +245,7 @@ export interface CompositionAttester {
   /**
    * The type of attestation the authenticator offers.
    */
-  mode?: 'personal' | 'professional' | 'legal' | 'official';
+  mode: 'personal' | 'professional' | 'legal' | 'official';
 
   /**
    * When the composition was attested by the party.
@@ -368,7 +368,7 @@ export interface CompositionRelatesTo {
    * The type of relationship that this composition has with anther
    * composition or document.
    */
-  code?: 'replaces' | 'transforms' | 'signs' | 'appends';
+  code: 'replaces' | 'transforms' | 'signs' | 'appends';
 
   /**
    * The target composition/document of this relationship.

--- a/packages/fhirtypes/dist/ConceptMap.d.ts
+++ b/packages/fhirtypes/dist/ConceptMap.d.ts
@@ -140,7 +140,7 @@ export interface ConceptMap {
    * The status of this concept map. Enables tracking the life-cycle of the
    * content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this concept map is authored for
@@ -305,7 +305,7 @@ export interface ConceptMapGroup {
    * Mappings for an individual concept in the source to one or more
    * concepts in the target.
    */
-  element?: ConceptMapGroupElement[];
+  element: ConceptMapGroupElement[];
 
   /**
    * What to do when there is no mapping for the source concept. &quot;Unmapped&quot;
@@ -429,7 +429,7 @@ export interface ConceptMapGroupElementTarget {
    * the dependencies and products). The equivalence is read from target to
    * source (e.g. the target is 'wider' than the source).
    */
-  equivalence?: 'relatedto' | 'equivalent' | 'equal' | 'wider' | 'subsumes' | 'narrower' | 'specializes' | 'inexact' | 'unmatched' | 'disjoint';
+  equivalence: 'relatedto' | 'equivalent' | 'equal' | 'wider' | 'subsumes' | 'narrower' | 'specializes' | 'inexact' | 'unmatched' | 'disjoint';
 
   /**
    * A description of status/issues in mapping that conveys additional
@@ -502,7 +502,7 @@ export interface ConceptMapGroupElementTargetDependsOn {
    * an element somewhere that is labeled to correspond with a code system
    * property.
    */
-  property?: string;
+  property: string;
 
   /**
    * An absolute URI that identifies the code system of the dependency code
@@ -514,7 +514,7 @@ export interface ConceptMapGroupElementTargetDependsOn {
    * Identity (code or path) or the element/item/ValueSet/text that the map
    * depends on / refers to.
    */
-  value?: string;
+  value: string;
 
   /**
    * The display for the code. The display is only provided to help editors
@@ -573,7 +573,7 @@ export interface ConceptMapGroupUnmapped {
    * fixed code (a default code), or alternatively, a reference to a
    * different concept map can be provided (by canonical URL).
    */
-  mode?: 'provided' | 'fixed' | 'other-map';
+  mode: 'provided' | 'fixed' | 'other-map';
 
   /**
    * The fixed code to use when the mode = 'fixed'  - all unmapped codes

--- a/packages/fhirtypes/dist/Condition.d.ts
+++ b/packages/fhirtypes/dist/Condition.d.ts
@@ -149,7 +149,7 @@ export interface Condition {
    * Indicates the patient or group who the condition record is associated
    * with.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The Encounter during which this Condition was created or to which the

--- a/packages/fhirtypes/dist/Consent.d.ts
+++ b/packages/fhirtypes/dist/Consent.d.ts
@@ -117,19 +117,19 @@ export interface Consent {
   /**
    * Indicates the current state of this consent.
    */
-  status?: 'draft' | 'proposed' | 'active' | 'rejected' | 'inactive' | 'entered-in-error';
+  status: 'draft' | 'proposed' | 'active' | 'rejected' | 'inactive' | 'entered-in-error';
 
   /**
    * A selector of the type of consent being presented: ADR, Privacy,
    * Treatment, Research.  This list is now extensible.
    */
-  scope?: CodeableConcept;
+  scope: CodeableConcept;
 
   /**
    * A classification of the type of consents found in the statement. This
    * element supports indexing and retrieval of consent statements.
    */
-  category?: CodeableConcept[];
+  category: CodeableConcept[];
 
   /**
    * The patient/healthcare consumer to whom this consent applies.
@@ -405,14 +405,14 @@ export interface ConsentProvisionActor {
    * How the individual is involved in the resources content that is
    * described in the exception.
    */
-  role?: CodeableConcept;
+  role: CodeableConcept;
 
   /**
    * The resource that identifies the actor. To identify actors by type,
    * use group to identify a set of actors by some property they share
    * (e.g. 'admitting officers').
    */
-  reference?: Reference<Device | Group | CareTeam | Organization | Patient | Practitioner | RelatedPerson | PractitionerRole>;
+  reference: Reference<Device | Group | CareTeam | Organization | Patient | Practitioner | RelatedPerson | PractitionerRole>;
 }
 
 /**
@@ -460,13 +460,13 @@ export interface ConsentProvisionData {
    * How the resource reference is interpreted when testing consent
    * restrictions.
    */
-  meaning?: 'instance' | 'related' | 'dependents' | 'authoredby';
+  meaning: 'instance' | 'related' | 'dependents' | 'authoredby';
 
   /**
    * A reference to a specific resource that defines which resources are
    * covered by this consent.
    */
-  reference?: Reference<Resource>;
+  reference: Reference<Resource>;
 }
 
 /**
@@ -514,7 +514,7 @@ export interface ConsentVerification {
   /**
    * Has the instruction been verified.
    */
-  verified?: boolean;
+  verified: boolean;
 
   /**
    * Who verified the instruction (Patient, Relative or other Authorized

--- a/packages/fhirtypes/dist/Contract.d.ts
+++ b/packages/fhirtypes/dist/Contract.d.ts
@@ -408,7 +408,7 @@ export interface ContractContentDefinition {
    * application for a contract such as an insurance policy or benefits
    * under a program, e.g., workers compensation.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Detailed Precusory content type.
@@ -434,7 +434,7 @@ export interface ContractContentDefinition {
    * executable | executed | negotiable | offered | policy | rejected |
    * renewed | revoked | resolved | terminated.
    */
-  publicationStatus?: 'amended' | 'appended' | 'cancelled' | 'disputed' | 'entered-in-error' | 'executable' |
+  publicationStatus: 'amended' | 'appended' | 'cancelled' | 'disputed' | 'entered-in-error' | 'executable' |
       'executed' | 'negotiable' | 'offered' | 'policy' | 'rejected' | 'renewed' | 'revoked' | 'resolved' | 'terminated';
 
   /**
@@ -657,17 +657,17 @@ export interface ContractSigner {
   /**
    * Role of this Contract signer, e.g. notary, grantee.
    */
-  type?: Coding;
+  type: Coding;
 
   /**
    * Party which is a signator to this Contract.
    */
-  party?: Reference<Organization | Patient | Practitioner | PractitionerRole | RelatedPerson>;
+  party: Reference<Organization | Patient | Practitioner | PractitionerRole | RelatedPerson>;
 
   /**
    * Legally binding Contract DSIG signature contents in Base64.
    */
-  signature?: Signature[];
+  signature: Signature[];
 }
 
 /**
@@ -766,7 +766,7 @@ export interface ContractTerm {
    * The matter of concern in the context of this provision of the
    * agrement.
    */
-  offer?: ContractTermOffer;
+  offer: ContractTermOffer;
 
   /**
    * Contract Term Asset List.
@@ -835,7 +835,7 @@ export interface ContractTermAction {
    * Activity or service obligation to be done or not done, performed or
    * not performed, effectuated or not by this Contract term.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Entity of the action.
@@ -846,7 +846,7 @@ export interface ContractTermAction {
    * Reason or purpose for the action stipulated by this Contract
    * Provision.
    */
-  intent?: CodeableConcept;
+  intent: CodeableConcept;
 
   /**
    * Id [identifier??] of the clause or question text related to this
@@ -857,7 +857,7 @@ export interface ContractTermAction {
   /**
    * Current state of the term action.
    */
-  status?: CodeableConcept;
+  status: CodeableConcept;
 
   /**
    * Encounter or Episode with primary association to specified term
@@ -1005,7 +1005,7 @@ export interface ContractTermActionSubject {
   /**
    * The entity the action is performed or not performed on or for.
    */
-  reference?: Reference<Patient | RelatedPerson | Practitioner | PractitionerRole | Device | Group | Organization>[];
+  reference: Reference<Patient | RelatedPerson | Practitioner | PractitionerRole | Device | Group | Organization>[];
 
   /**
    * Role type of agent assigned roles in this Contract.
@@ -1603,12 +1603,12 @@ export interface ContractTermOfferParty {
   /**
    * Participant in the offer.
    */
-  reference?: Reference<Patient | RelatedPerson | Practitioner | PractitionerRole | Device | Group | Organization>[];
+  reference: Reference<Patient | RelatedPerson | Practitioner | PractitionerRole | Device | Group | Organization>[];
 
   /**
    * How the party participates in the offer.
    */
-  role?: CodeableConcept;
+  role: CodeableConcept;
 }
 
 /**
@@ -1662,7 +1662,7 @@ export interface ContractTermSecurityLabel {
    * Security label privacy tag that species the level of confidentiality
    * protection required for this term and/or term elements.
    */
-  classification?: Coding;
+  classification: Coding;
 
   /**
    * Security label privacy tag that species the applicable privacy and

--- a/packages/fhirtypes/dist/Contributor.d.ts
+++ b/packages/fhirtypes/dist/Contributor.d.ts
@@ -31,13 +31,13 @@ export interface Contributor {
   /**
    * The type of contributor.
    */
-  type?: 'author' | 'editor' | 'reviewer' | 'endorser';
+  type: 'author' | 'editor' | 'reviewer' | 'endorser';
 
   /**
    * The name of the individual or organization responsible for the
    * contribution.
    */
-  name?: string;
+  name: string;
 
   /**
    * Contact details to assist a user in finding and communicating with the

--- a/packages/fhirtypes/dist/Coverage.d.ts
+++ b/packages/fhirtypes/dist/Coverage.d.ts
@@ -108,7 +108,7 @@ export interface Coverage {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * The type of coverage: social program, medical plan, accident coverage
@@ -138,7 +138,7 @@ export interface Coverage {
    * The party who benefits from the insurance coverage; the patient when
    * products and/or services are provided.
    */
-  beneficiary?: Reference<Patient>;
+  beneficiary: Reference<Patient>;
 
   /**
    * A unique identifier for a dependent under the coverage.
@@ -161,7 +161,7 @@ export interface Coverage {
    * The program or plan underwriter or payor including both insurance and
    * non-insurance agreements, such as patient-pay agreements.
    */
-  payor?: Reference<Organization | Patient | RelatedPerson>[];
+  payor: Reference<Organization | Patient | RelatedPerson>[];
 
   /**
    * A suite of underwriter specific classifiers.
@@ -249,13 +249,13 @@ export interface CoverageClass {
    * or number and optional name is provided, for example may be used to
    * identify a class of coverage or employer group, Policy, Plan.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The alphanumeric string value associated with the insurer issued
    * label.
    */
-  value?: string;
+  value: string;
 
   /**
    * A short description for the class.
@@ -371,7 +371,7 @@ export interface CoverageCostToBeneficiaryException {
   /**
    * The code for the specific exception.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The timeframe during when the exception is in force.

--- a/packages/fhirtypes/dist/CoverageEligibilityRequest.d.ts
+++ b/packages/fhirtypes/dist/CoverageEligibilityRequest.d.ts
@@ -114,7 +114,7 @@ export interface CoverageEligibilityRequest {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * When the requestor expects the processor to complete processing.
@@ -128,13 +128,13 @@ export interface CoverageEligibilityRequest {
    * patient; and/or validation that the specified coverage is in-force at
    * the date/period specified or 'now' if not specified.
    */
-  purpose?: ('auth-requirements' | 'benefits' | 'discovery' | 'validation')[];
+  purpose: ('auth-requirements' | 'benefits' | 'discovery' | 'validation')[];
 
   /**
    * The party who is the beneficiary of the supplied coverage and for whom
    * eligibility is sought.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The date or dates when the enclosed suite of services were performed
@@ -151,7 +151,7 @@ export interface CoverageEligibilityRequest {
   /**
    * The date when this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * Person who created the request.
@@ -167,7 +167,7 @@ export interface CoverageEligibilityRequest {
    * The Insurer who issued the coverage in question and is the recipient
    * of the request.
    */
-  insurer?: Reference<Organization>;
+  insurer: Reference<Organization>;
 
   /**
    * Facility where the services are intended to be provided.
@@ -247,7 +247,7 @@ export interface CoverageEligibilityRequestInsurance {
    * to locate the patient's actual coverage within the insurer's
    * information system.
    */
-  coverage?: Reference<Coverage>;
+  coverage: Reference<Coverage>;
 
   /**
    * A business agreement number established between the provider and the
@@ -451,14 +451,14 @@ export interface CoverageEligibilityRequestSupportingInfo {
   /**
    * A number to uniquely identify supporting information entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * Additional data or information such as resources, documents, images
    * etc. including references to the data or the actual inclusion of the
    * data.
    */
-  information?: Reference<Resource>;
+  information: Reference<Resource>;
 
   /**
    * The supporting materials are applicable for all detail items,

--- a/packages/fhirtypes/dist/CoverageEligibilityResponse.d.ts
+++ b/packages/fhirtypes/dist/CoverageEligibilityResponse.d.ts
@@ -109,7 +109,7 @@ export interface CoverageEligibilityResponse {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * Code to specify whether requesting: prior authorization requirements
@@ -118,13 +118,13 @@ export interface CoverageEligibilityResponse {
    * patient; and/or validation that the specified coverage is in-force at
    * the date/period specified or 'now' if not specified.
    */
-  purpose?: ('auth-requirements' | 'benefits' | 'discovery' | 'validation')[];
+  purpose: ('auth-requirements' | 'benefits' | 'discovery' | 'validation')[];
 
   /**
    * The party who is the beneficiary of the supplied coverage and for whom
    * eligibility is sought.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The date or dates when the enclosed suite of services were performed
@@ -141,7 +141,7 @@ export interface CoverageEligibilityResponse {
   /**
    * The date this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * The provider which is responsible for the request.
@@ -151,12 +151,12 @@ export interface CoverageEligibilityResponse {
   /**
    * Reference to the original request resource.
    */
-  request?: Reference<CoverageEligibilityRequest>;
+  request: Reference<CoverageEligibilityRequest>;
 
   /**
    * The outcome of the request processing.
    */
-  outcome?: 'queued' | 'complete' | 'error' | 'partial';
+  outcome: 'queued' | 'complete' | 'error' | 'partial';
 
   /**
    * A human readable description of the status of the adjudication.
@@ -167,7 +167,7 @@ export interface CoverageEligibilityResponse {
    * The Insurer who issued the coverage in question and is the author of
    * the response.
    */
-  insurer?: Reference<Organization>;
+  insurer: Reference<Organization>;
 
   /**
    * Financial instruments for reimbursement for the health care products
@@ -236,7 +236,7 @@ export interface CoverageEligibilityResponseError {
    * An error code,from a specified code system, which details why the
    * eligibility check could not be performed.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 }
 
 /**
@@ -286,7 +286,7 @@ export interface CoverageEligibilityResponseInsurance {
    * to locate the patient's actual coverage within the insurer's
    * information system.
    */
-  coverage?: Reference<Coverage>;
+  coverage: Reference<Coverage>;
 
   /**
    * Flag indicating if the coverage provided is inforce currently if no
@@ -473,7 +473,7 @@ export interface CoverageEligibilityResponseInsuranceItemBenefit {
   /**
    * Classification of benefit being provided.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The quantity of the benefit which is permitted under the coverage.

--- a/packages/fhirtypes/dist/DataRequirement.d.ts
+++ b/packages/fhirtypes/dist/DataRequirement.d.ts
@@ -38,7 +38,7 @@ export interface DataRequirement {
    * resource. For profiles, this value is set to the type of the base
    * resource of the profile.
    */
-  type?: string;
+  type: string;
 
   /**
    * The profile of the required data, specified as the uri of the profile
@@ -266,10 +266,10 @@ export interface DataRequirementSort {
    * traverse multiple-cardinality sub-elements. Note that the index must
    * be an integer constant.
    */
-  path?: string;
+  path: string;
 
   /**
    * The direction of the sort, ascending or descending.
    */
-  direction?: 'ascending' | 'descending';
+  direction: 'ascending' | 'descending';
 }

--- a/packages/fhirtypes/dist/DetectedIssue.d.ts
+++ b/packages/fhirtypes/dist/DetectedIssue.d.ts
@@ -108,7 +108,7 @@ export interface DetectedIssue {
   /**
    * Indicates the status of the detected issue.
    */
-  status?: 'registered' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'registered' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * Identifies the general type of issue identified.
@@ -278,7 +278,7 @@ export interface DetectedIssueMitigation {
    * Describes the action that was taken or the observation that was made
    * that reduces/eliminates the risk associated with the identified issue.
    */
-  action?: CodeableConcept;
+  action: CodeableConcept;
 
   /**
    * Indicates when the mitigating action was documented.

--- a/packages/fhirtypes/dist/Device.d.ts
+++ b/packages/fhirtypes/dist/Device.d.ts
@@ -298,14 +298,14 @@ export interface DeviceDeviceName {
   /**
    * The name of the device.
    */
-  name?: string;
+  name: string;
 
   /**
    * The type of deviceName.
    * UDILabelName | UserFriendlyName | PatientReportedName |
    * ManufactureDeviceName | ModelName.
    */
-  type?: 'udi-label-name' | 'user-friendly-name' | 'patient-reported-name' | 'manufacturer-name' | 'model-name' | 'other';
+  type: 'udi-label-name' | 'user-friendly-name' | 'patient-reported-name' | 'manufacturer-name' | 'model-name' | 'other';
 }
 
 /**
@@ -353,7 +353,7 @@ export interface DeviceProperty {
    * Code that specifies the property DeviceDefinitionPropetyCode
    * (Extensible).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Property value as a quantity.
@@ -411,7 +411,7 @@ export interface DeviceSpecialization {
   /**
    * The standard that is used to operate and communicate.
    */
-  systemType?: CodeableConcept;
+  systemType: CodeableConcept;
 
   /**
    * The version of the standard that is used to operate and communicate.
@@ -566,5 +566,5 @@ export interface DeviceVersion {
   /**
    * The version text.
    */
-  value?: string;
+  value: string;
 }

--- a/packages/fhirtypes/dist/DeviceDefinition.d.ts
+++ b/packages/fhirtypes/dist/DeviceDefinition.d.ts
@@ -284,7 +284,7 @@ export interface DeviceDefinitionCapability {
   /**
    * Type of capability.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Description of capability.
@@ -335,7 +335,7 @@ export interface DeviceDefinitionClassification {
   /**
    * A classification or risk class of the device model.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Further information qualifying this classification of the device
@@ -387,14 +387,14 @@ export interface DeviceDefinitionDeviceName {
   /**
    * The name of the device.
    */
-  name?: string;
+  name: string;
 
   /**
    * The type of deviceName.
    * UDILabelName | UserFriendlyName | PatientReportedName |
    * ManufactureDeviceName | ModelName.
    */
-  type?: 'udi-label-name' | 'user-friendly-name' | 'patient-reported-name' | 'manufacturer-name' | 'model-name' | 'other';
+  type: 'udi-label-name' | 'user-friendly-name' | 'patient-reported-name' | 'manufacturer-name' | 'model-name' | 'other';
 }
 
 /**
@@ -441,7 +441,7 @@ export interface DeviceDefinitionMaterial {
   /**
    * The substance.
    */
-  substance?: CodeableConcept;
+  substance: CodeableConcept;
 
   /**
    * Indicates an alternative material of the device.
@@ -499,7 +499,7 @@ export interface DeviceDefinitionProperty {
    * Code that specifies the property DeviceDefinitionPropetyCode
    * (Extensible).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Property value as a quantity.
@@ -557,7 +557,7 @@ export interface DeviceDefinitionSpecialization {
   /**
    * The standard that is used to operate and communicate.
    */
-  systemType?: string;
+  systemType: string;
 
   /**
    * The version of the standard that is used to operate and communicate.
@@ -613,15 +613,15 @@ export interface DeviceDefinitionUdiDeviceIdentifier {
    * references this DeviceDefintiion for the issuer and jurisdication
    * porvided in the DeviceDefinition.udiDeviceIdentifier.
    */
-  deviceIdentifier?: string;
+  deviceIdentifier: string;
 
   /**
    * The organization that assigns the identifier algorithm.
    */
-  issuer?: string;
+  issuer: string;
 
   /**
    * The jurisdiction to which the deviceIdentifier applies.
    */
-  jurisdiction?: string;
+  jurisdiction: string;
 }

--- a/packages/fhirtypes/dist/DeviceMetric.d.ts
+++ b/packages/fhirtypes/dist/DeviceMetric.d.ts
@@ -106,7 +106,7 @@ export interface DeviceMetric {
    * Describes the type of the metric. For example: Heart Rate, PEEP
    * Setting, etc.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Describes the unit that an observed value determined for this metric
@@ -151,7 +151,7 @@ export interface DeviceMetric {
    * DeviceMetric can be for example a setting, measurement, or
    * calculation.
    */
-  category?: 'measurement' | 'setting' | 'calculation' | 'unspecified';
+  category: 'measurement' | 'setting' | 'calculation' | 'unspecified';
 
   /**
    * Describes the measurement repetition time. This is not necessarily the

--- a/packages/fhirtypes/dist/DeviceRequest.d.ts
+++ b/packages/fhirtypes/dist/DeviceRequest.d.ts
@@ -161,7 +161,7 @@ export interface DeviceRequest {
    * Whether the request is a proposal, plan, an original order or a reflex
    * order.
    */
-  intent?: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
+  intent: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
 
   /**
    * Indicates how quickly the {{title}} should be addressed with respect
@@ -188,7 +188,7 @@ export interface DeviceRequest {
   /**
    * The patient who will use the device.
    */
-  subject?: Reference<Patient | Group | Location | Device>;
+  subject: Reference<Patient | Group | Location | Device>;
 
   /**
    * An encounter that provides additional context in which this request is

--- a/packages/fhirtypes/dist/DeviceUseStatement.d.ts
+++ b/packages/fhirtypes/dist/DeviceUseStatement.d.ts
@@ -127,12 +127,12 @@ export interface DeviceUseStatement {
    * state of the device used that this statement is about.  Generally this
    * will be active or completed.
    */
-  status?: 'active' | 'completed' | 'entered-in-error' | 'intended' | 'stopped' | 'on-hold';
+  status: 'active' | 'completed' | 'entered-in-error' | 'intended' | 'stopped' | 'on-hold';
 
   /**
    * The patient who used the device.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * Allows linking the DeviceUseStatement to the underlying Request, or to
@@ -169,7 +169,7 @@ export interface DeviceUseStatement {
   /**
    * The details of the device used.
    */
-  device?: Reference<Device>;
+  device: Reference<Device>;
 
   /**
    * Reason or justification for the use of the device.

--- a/packages/fhirtypes/dist/DiagnosticReport.d.ts
+++ b/packages/fhirtypes/dist/DiagnosticReport.d.ts
@@ -130,7 +130,7 @@ export interface DiagnosticReport {
   /**
    * The status of the diagnostic report.
    */
-  status?: 'registered' | 'partial' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'appended' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'registered' | 'partial' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'appended' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * A code that classifies the clinical discipline, department or
@@ -143,7 +143,7 @@ export interface DiagnosticReport {
   /**
    * A code or name that describes this diagnostic report.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The subject of the report. Usually, but not always, this is a patient.
@@ -290,5 +290,5 @@ export interface DiagnosticReportMedia {
   /**
    * Reference to the image source.
    */
-  link?: Reference<Media>;
+  link: Reference<Media>;
 }

--- a/packages/fhirtypes/dist/DocumentManifest.d.ts
+++ b/packages/fhirtypes/dist/DocumentManifest.d.ts
@@ -115,7 +115,7 @@ export interface DocumentManifest {
   /**
    * The status of this document manifest.
    */
-  status?: 'current' | 'superseded' | 'entered-in-error';
+  status: 'current' | 'superseded' | 'entered-in-error';
 
   /**
    * The code specifying the type of clinical activity that resulted in
@@ -167,7 +167,7 @@ export interface DocumentManifest {
   /**
    * The list of Resources that consist of the parts of this manifest.
    */
-  content?: Reference<Resource>[];
+  content: Reference<Resource>[];
 
   /**
    * Related identifiers or resources associated with the DocumentManifest.

--- a/packages/fhirtypes/dist/DocumentReference.d.ts
+++ b/packages/fhirtypes/dist/DocumentReference.d.ts
@@ -126,7 +126,7 @@ export interface DocumentReference {
   /**
    * The status of this document reference.
    */
-  status?: 'current' | 'superseded' | 'entered-in-error';
+  status: 'current' | 'superseded' | 'entered-in-error';
 
   /**
    * The status of the underlying document.
@@ -202,7 +202,7 @@ export interface DocumentReference {
    * The document and format referenced. There may be multiple content
    * element repetitions, each with a different format.
    */
-  content?: DocumentReferenceContent[];
+  content: DocumentReferenceContent[];
 
   /**
    * The clinical context in which the document was prepared.
@@ -255,7 +255,7 @@ export interface DocumentReferenceContent {
    * The document or URL of the document along with critical metadata to
    * prove content has integrity.
    */
-  attachment?: Attachment;
+  attachment: Attachment;
 
   /**
    * An identifier of the document encoding, structure, and template that
@@ -394,10 +394,10 @@ export interface DocumentReferenceRelatesTo {
   /**
    * The type of relationship that this document has with anther document.
    */
-  code?: 'replaces' | 'transforms' | 'signs' | 'appends';
+  code: 'replaces' | 'transforms' | 'signs' | 'appends';
 
   /**
    * The target document of this relationship.
    */
-  target?: Reference<DocumentReference>;
+  target: Reference<DocumentReference>;
 }

--- a/packages/fhirtypes/dist/DomainConfiguration.d.ts
+++ b/packages/fhirtypes/dist/DomainConfiguration.d.ts
@@ -45,7 +45,7 @@ export interface DomainConfiguration {
   /**
    * Globally unique domain name for this configuration.
    */
-  domain?: string;
+  domain: string;
 
   /**
    * Optional external Identity Provider (IdP) for the domain name.

--- a/packages/fhirtypes/dist/EffectEvidenceSynthesis.d.ts
+++ b/packages/fhirtypes/dist/EffectEvidenceSynthesis.d.ts
@@ -148,7 +148,7 @@ export interface EffectEvidenceSynthesis {
    * The status of this effect evidence synthesis. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * The date  (and optionally time) when the effect evidence synthesis was
@@ -278,25 +278,25 @@ export interface EffectEvidenceSynthesis {
    * A reference to a EvidenceVariable resource that defines the population
    * for the research.
    */
-  population?: Reference<EvidenceVariable>;
+  population: Reference<EvidenceVariable>;
 
   /**
    * A reference to a EvidenceVariable resource that defines the exposure
    * for the research.
    */
-  exposure?: Reference<EvidenceVariable>;
+  exposure: Reference<EvidenceVariable>;
 
   /**
    * A reference to a EvidenceVariable resource that defines the comparison
    * exposure for the research.
    */
-  exposureAlternative?: Reference<EvidenceVariable>;
+  exposureAlternative: Reference<EvidenceVariable>;
 
   /**
    * A reference to a EvidenceVariable resomece that defines the outcome
    * for the research.
    */
-  outcome?: Reference<EvidenceVariable>;
+  outcome: Reference<EvidenceVariable>;
 
   /**
    * A description of the size of the sample involved in the synthesis.
@@ -626,7 +626,7 @@ export interface EffectEvidenceSynthesisResultsByExposure {
   /**
    * Reference to a RiskEvidenceSynthesis resource.
    */
-  riskEvidenceSynthesis?: Reference<RiskEvidenceSynthesis>;
+  riskEvidenceSynthesis: Reference<RiskEvidenceSynthesis>;
 }
 
 /**

--- a/packages/fhirtypes/dist/ElementDefinition.d.ts
+++ b/packages/fhirtypes/dist/ElementDefinition.d.ts
@@ -82,7 +82,7 @@ export interface ElementDefinition {
    * list of ancestor elements, beginning with the name of the resource or
    * extension.
    */
-  path?: string;
+  path: string;
 
   /**
    * Codes that define how this element is represented in instances, when
@@ -2351,17 +2351,17 @@ export interface ElementDefinitionBase {
    * a [StructureDefinition](structuredefinition.html#) without a
    * StructureDefinition.base.
    */
-  path?: string;
+  path: string;
 
   /**
    * Minimum cardinality of the base element identified by the path.
    */
-  min?: number;
+  min: number;
 
   /**
    * Maximum cardinality of the base element identified by the path.
    */
-  max?: string;
+  max: string;
 }
 
 /**
@@ -2391,7 +2391,7 @@ export interface ElementDefinitionBinding {
    * binding - that is, the degree to which the provided value set must be
    * adhered to in the instances.
    */
-  strength?: 'required' | 'extensible' | 'preferred' | 'example';
+  strength: 'required' | 'extensible' | 'preferred' | 'example';
 
   /**
    * Describes the intended use of this particular set of codes.
@@ -2432,7 +2432,7 @@ export interface ElementDefinitionConstraint {
    * impacted by the constraint.  Will not be referenced for constraints
    * that do not affect cardinality.
    */
-  key?: string;
+  key: string;
 
   /**
    * Description of why this constraint is necessary or appropriate.
@@ -2443,13 +2443,13 @@ export interface ElementDefinitionConstraint {
    * Identifies the impact constraint violation has on the conformance of
    * the instance.
    */
-  severity?: 'error' | 'warning';
+  severity: 'error' | 'warning';
 
   /**
    * Text that can be used to describe the constraint in messages
    * identifying that the constraint has been violated.
    */
-  human?: string;
+  human: string;
 
   /**
    * A [FHIRPath](fhirpath.html) expression of constraint that can be
@@ -2495,7 +2495,7 @@ export interface ElementDefinitionExample {
   /**
    * Describes the purpose of this example amoung the set of examples.
    */
-  label?: string;
+  label: string;
 
   /**
    * The actual value for the element, which must be one of the types
@@ -2823,7 +2823,7 @@ export interface ElementDefinitionMapping {
   /**
    * An internal reference to the definition of a mapping.
    */
-  identity?: string;
+  identity: string;
 
   /**
    * Identifies the computable language in which mapping.map is expressed.
@@ -2834,7 +2834,7 @@ export interface ElementDefinitionMapping {
    * Expresses what part of the target specification corresponds to this
    * element.
    */
-  map?: string;
+  map: string;
 
   /**
    * Comments that provide information about the mapping or its use.
@@ -2898,7 +2898,7 @@ export interface ElementDefinitionSlicing {
    * ordered, profile authors can also say that additional slices are only
    * allowed at the end.
    */
-  rules?: 'closed' | 'open' | 'openAtEnd';
+  rules: 'closed' | 'open' | 'openAtEnd';
 }
 
 /**
@@ -2929,14 +2929,14 @@ export interface ElementDefinitionSlicingDiscriminator {
   /**
    * How the element value is interpreted when discrimination is evaluated.
    */
-  type?: 'value' | 'exists' | 'pattern' | 'type' | 'profile';
+  type: 'value' | 'exists' | 'pattern' | 'type' | 'profile';
 
   /**
    * A FHIRPath expression, using [the simple subset of
    * FHIRPath](fhirpath.html#simple), that is used to identify the element
    * on which discrimination is based.
    */
-  path?: string;
+  path: string;
 }
 
 /**
@@ -2968,7 +2968,7 @@ export interface ElementDefinitionType {
    * to http://hl7.org/fhir/StructureDefinition/string. Absolute URLs are
    * only allowed in logical models.
    */
-  code?: string;
+  code: string;
 
   /**
    * Identifies a profile structure or implementation Guide that applies to

--- a/packages/fhirtypes/dist/Encounter.d.ts
+++ b/packages/fhirtypes/dist/Encounter.d.ts
@@ -121,7 +121,7 @@ export interface Encounter {
    * planned | arrived | triaged | in-progress | onleave | finished |
    * cancelled +.
    */
-  status?: 'planned' | 'arrived' | 'triaged' | 'in-progress' | 'onleave' | 'finished' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'planned' | 'arrived' | 'triaged' | 'in-progress' | 'onleave' | 'finished' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * The status history permits the encounter resource to contain the
@@ -135,7 +135,7 @@ export interface Encounter {
    * ambulatory (outpatient), inpatient, emergency, home health or others
    * due to local variations.
    */
-  class?: Coding;
+  class: Coding;
 
   /**
    * The class history permits the tracking of the encounters transitions
@@ -309,12 +309,12 @@ export interface EncounterClassHistory {
   /**
    * inpatient | outpatient | ambulatory | emergency +.
    */
-  class?: Coding;
+  class: Coding;
 
   /**
    * The time that the episode was in the specified class.
    */
-  period?: Period;
+  period: Period;
 }
 
 /**
@@ -363,7 +363,7 @@ export interface EncounterDiagnosis {
    * indication will typically be a Condition (with other resources
    * referenced in the evidence.detail), or a Procedure.
    */
-  condition?: Reference<Condition | Procedure>;
+  condition: Reference<Condition | Procedure>;
 
   /**
    * Role that this diagnosis has within the encounter (e.g. admission,
@@ -509,7 +509,7 @@ export interface EncounterLocation {
   /**
    * The location where the encounter takes place.
    */
-  location?: Reference<Location>;
+  location: Reference<Location>;
 
   /**
    * The status of the participants' presence at the specified location
@@ -634,10 +634,10 @@ export interface EncounterStatusHistory {
    * planned | arrived | triaged | in-progress | onleave | finished |
    * cancelled +.
    */
-  status?: 'planned' | 'arrived' | 'triaged' | 'in-progress' | 'onleave' | 'finished' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'planned' | 'arrived' | 'triaged' | 'in-progress' | 'onleave' | 'finished' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * The time that the episode was in the specified status.
    */
-  period?: Period;
+  period: Period;
 }

--- a/packages/fhirtypes/dist/Endpoint.d.ts
+++ b/packages/fhirtypes/dist/Endpoint.d.ts
@@ -108,14 +108,14 @@ export interface Endpoint {
   /**
    * active | suspended | error | off | test.
    */
-  status?: 'active' | 'suspended' | 'error' | 'off' | 'entered-in-error' | 'test';
+  status: 'active' | 'suspended' | 'error' | 'off' | 'entered-in-error' | 'test';
 
   /**
    * A coded value that represents the technical details of the usage of
    * this endpoint, such as what WSDLs should be used in what way. (e.g.
    * XDS.b/DICOM/cds-hook).
    */
-  connectionType?: Coding;
+  connectionType: Coding;
 
   /**
    * A friendly name that this endpoint can be referred to with.
@@ -144,7 +144,7 @@ export interface Endpoint {
    * The payload type describes the acceptable content that can be
    * communicated on the endpoint.
    */
-  payloadType?: CodeableConcept[];
+  payloadType: CodeableConcept[];
 
   /**
    * The mime type to send the payload in - e.g. application/fhir+xml,
@@ -157,7 +157,7 @@ export interface Endpoint {
   /**
    * The uri that describes the actual end-point to connect to.
    */
-  address?: string;
+  address: string;
 
   /**
    * Additional headers / information to send as part of the notification.

--- a/packages/fhirtypes/dist/EpisodeOfCare.d.ts
+++ b/packages/fhirtypes/dist/EpisodeOfCare.d.ts
@@ -114,7 +114,7 @@ export interface EpisodeOfCare {
   /**
    * planned | waitlist | active | onhold | finished | cancelled.
    */
-  status?: 'planned' | 'waitlist' | 'active' | 'onhold' | 'finished' | 'cancelled' | 'entered-in-error';
+  status: 'planned' | 'waitlist' | 'active' | 'onhold' | 'finished' | 'cancelled' | 'entered-in-error';
 
   /**
    * The history of statuses that the EpisodeOfCare has been through
@@ -136,7 +136,7 @@ export interface EpisodeOfCare {
   /**
    * The patient who is the focus of this episode of care.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The organization that has assumed the specific responsibilities for
@@ -219,7 +219,7 @@ export interface EpisodeOfCareDiagnosis {
    * A list of conditions/problems/diagnoses that this episode of care is
    * intended to be providing care for.
    */
-  condition?: Reference<Condition>;
+  condition: Reference<Condition>;
 
   /**
    * Role that this diagnosis has within the episode of care (e.g.
@@ -277,10 +277,10 @@ export interface EpisodeOfCareStatusHistory {
   /**
    * planned | waitlist | active | onhold | finished | cancelled.
    */
-  status?: 'planned' | 'waitlist' | 'active' | 'onhold' | 'finished' | 'cancelled' | 'entered-in-error';
+  status: 'planned' | 'waitlist' | 'active' | 'onhold' | 'finished' | 'cancelled' | 'entered-in-error';
 
   /**
    * The period during this EpisodeOfCare that the specific status applied.
    */
-  period?: Period;
+  period: Period;
 }

--- a/packages/fhirtypes/dist/EventDefinition.d.ts
+++ b/packages/fhirtypes/dist/EventDefinition.d.ts
@@ -150,7 +150,7 @@ export interface EventDefinition {
    * The status of this event definition. Enables tracking the life-cycle
    * of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this event definition is authored for
@@ -293,5 +293,5 @@ export interface EventDefinition {
    * trigger condition is specified, the event fires whenever any one of
    * the trigger conditions is met.
    */
-  trigger?: TriggerDefinition[];
+  trigger: TriggerDefinition[];
 }

--- a/packages/fhirtypes/dist/Evidence.d.ts
+++ b/packages/fhirtypes/dist/Evidence.d.ts
@@ -162,7 +162,7 @@ export interface Evidence {
    * The status of this evidence. Enables tracking the life-cycle of the
    * content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * The date  (and optionally time) when the evidence was published. The
@@ -279,7 +279,7 @@ export interface Evidence {
    * A reference to a EvidenceVariable resource that defines the population
    * for the research.
    */
-  exposureBackground?: Reference<EvidenceVariable>;
+  exposureBackground: Reference<EvidenceVariable>;
 
   /**
    * A reference to a EvidenceVariable resource that defines the exposure

--- a/packages/fhirtypes/dist/EvidenceVariable.d.ts
+++ b/packages/fhirtypes/dist/EvidenceVariable.d.ts
@@ -165,7 +165,7 @@ export interface EvidenceVariable {
    * The status of this evidence variable. Enables tracking the life-cycle
    * of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * The date  (and optionally time) when the evidence variable was
@@ -288,7 +288,7 @@ export interface EvidenceVariable {
    * A characteristic that defines the members of the evidence element.
    * Multiple characteristics are applied with &quot;and&quot; semantics.
    */
-  characteristic?: EvidenceVariableCharacteristic[];
+  characteristic: EvidenceVariableCharacteristic[];
 }
 
 /**

--- a/packages/fhirtypes/dist/ExampleScenario.d.ts
+++ b/packages/fhirtypes/dist/ExampleScenario.d.ts
@@ -134,7 +134,7 @@ export interface ExampleScenario {
    * The status of this example scenario. Enables tracking the life-cycle
    * of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this example scenario is authored for
@@ -257,12 +257,12 @@ export interface ExampleScenarioActor {
   /**
    * ID or acronym of actor.
    */
-  actorId?: string;
+  actorId: string;
 
   /**
    * The type of actor - person or system.
    */
-  type?: 'person' | 'entity';
+  type: 'person' | 'entity';
 
   /**
    * The name of the actor as shown in the page.
@@ -318,12 +318,12 @@ export interface ExampleScenarioInstance {
   /**
    * The id of the resource for referencing.
    */
-  resourceId?: string;
+  resourceId: string;
 
   /**
    * The type of the resource.
    */
-  resourceType?: ResourceType;
+  resourceType: ResourceType;
 
   /**
    * A short name for the resource instance.
@@ -391,7 +391,7 @@ export interface ExampleScenarioInstanceContainedInstance {
   /**
    * Each resource contained in the instance.
    */
-  resourceId?: string;
+  resourceId: string;
 
   /**
    * A specific version of a resource contained in the instance.
@@ -442,12 +442,12 @@ export interface ExampleScenarioInstanceVersion {
   /**
    * The identifier of a specific version of a resource.
    */
-  versionId?: string;
+  versionId: string;
 
   /**
    * The description of the resource version.
    */
-  description?: string;
+  description: string;
 }
 
 /**
@@ -493,7 +493,7 @@ export interface ExampleScenarioProcess {
   /**
    * The diagram title of the group of operations.
    */
-  title?: string;
+  title: string;
 
   /**
    * A longer description of the group of operations.
@@ -623,7 +623,7 @@ export interface ExampleScenarioProcessStepAlternative {
    * The label to display for the alternative that gives a sense of the
    * circumstance in which the alternative should be invoked.
    */
-  title?: string;
+  title: string;
 
   /**
    * A human-readable description of the alternative explaining when the
@@ -680,7 +680,7 @@ export interface ExampleScenarioProcessStepOperation {
   /**
    * The sequential number of the interaction, e.g. 1.2.5.
    */
-  number?: string;
+  number: string;
 
   /**
    * The type of operation - CRUD.

--- a/packages/fhirtypes/dist/ExplanationOfBenefit.d.ts
+++ b/packages/fhirtypes/dist/ExplanationOfBenefit.d.ts
@@ -124,13 +124,13 @@ export interface ExplanationOfBenefit {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * The category of claim, e.g. oral, pharmacy, vision, institutional,
    * professional.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * A finer grained suite of claim type codes which may convey additional
@@ -146,14 +146,14 @@ export interface ExplanationOfBenefit {
    * or requesting the non-binding adjudication of the listed products and
    * services which could be provided in the future.
    */
-  use?: 'claim' | 'preauthorization' | 'predetermination';
+  use: 'claim' | 'preauthorization' | 'predetermination';
 
   /**
    * The party to whom the professional services and/or products have been
    * supplied or are being considered and for whom actual for forecast
    * reimbursement is sought.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The period for which charges are being submitted.
@@ -163,7 +163,7 @@ export interface ExplanationOfBenefit {
   /**
    * The date this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * Individual who created the claim, predetermination or
@@ -175,13 +175,13 @@ export interface ExplanationOfBenefit {
    * The party responsible for authorization, adjudication and
    * reimbursement.
    */
-  insurer?: Reference<Organization>;
+  insurer: Reference<Organization>;
 
   /**
    * The provider which is responsible for the claim, predetermination or
    * preauthorization.
    */
-  provider?: Reference<Practitioner | PractitionerRole | Organization>;
+  provider: Reference<Practitioner | PractitionerRole | Organization>;
 
   /**
    * The provider-required urgency of processing the request. Typical
@@ -252,7 +252,7 @@ export interface ExplanationOfBenefit {
    * The outcome of the claim, predetermination, or preauthorization
    * processing.
    */
-  outcome?: 'queued' | 'complete' | 'error' | 'partial';
+  outcome: 'queued' | 'complete' | 'error' | 'partial';
 
   /**
    * A human readable description of the status of the adjudication.
@@ -303,7 +303,7 @@ export interface ExplanationOfBenefit {
    * Financial instruments for reimbursement for the health care products
    * and services specified on the claim.
    */
-  insurance?: ExplanationOfBenefitInsurance[];
+  insurance: ExplanationOfBenefitInsurance[];
 
   /**
    * Details of a accident which resulted in injuries which required the
@@ -501,7 +501,7 @@ export interface ExplanationOfBenefitAddItem {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -640,7 +640,7 @@ export interface ExplanationOfBenefitAddItemDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -736,7 +736,7 @@ export interface ExplanationOfBenefitAddItemDetailSubDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -826,7 +826,7 @@ export interface ExplanationOfBenefitBenefitBalance {
    * Code to identify the general type of benefits under which products and
    * services are provided.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * True if the indicated class of service is excluded from the plan,
@@ -911,7 +911,7 @@ export interface ExplanationOfBenefitBenefitBalanceFinancial {
   /**
    * Classification of benefit being provided.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The quantity of the benefit which is permitted under the coverage.
@@ -982,12 +982,12 @@ export interface ExplanationOfBenefitCareTeam {
   /**
    * A number to uniquely identify care team entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * Member of the team who provided the product or service.
    */
-  provider?: Reference<Practitioner | PractitionerRole | Organization>;
+  provider: Reference<Practitioner | PractitionerRole | Organization>;
 
   /**
    * The party who is billing and/or responsible for the claimed products
@@ -1051,7 +1051,7 @@ export interface ExplanationOfBenefitDiagnosis {
   /**
    * A number to uniquely identify diagnosis entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The nature of illness or problem in a coded form or as a reference to
@@ -1129,7 +1129,7 @@ export interface ExplanationOfBenefitInsurance {
    * A flag to indicate that this Coverage is to be used for adjudication
    * of this claim when set to true.
    */
-  focal?: boolean;
+  focal: boolean;
 
   /**
    * Reference to the insurance card level information contained in the
@@ -1137,7 +1137,7 @@ export interface ExplanationOfBenefitInsurance {
    * to locate the patient's actual coverage within the insurer's
    * information system.
    */
-  coverage?: Reference<Coverage>;
+  coverage: Reference<Coverage>;
 
   /**
    * Reference numbers previously provided by the insurer to the provider
@@ -1191,7 +1191,7 @@ export interface ExplanationOfBenefitItem {
   /**
    * A number to uniquely identify item entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * Care team members related to this service or product.
@@ -1231,7 +1231,7 @@ export interface ExplanationOfBenefitItem {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -1388,7 +1388,7 @@ export interface ExplanationOfBenefitItemAdjudication {
    * amounts paid by other coverages, and the benefit payable for this
    * item.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * A code supporting the understanding of the adjudication result and
@@ -1452,7 +1452,7 @@ export interface ExplanationOfBenefitItemDetail {
    * A claim detail line. Either a simple (a product or service) or a
    * 'group' of sub-details which are simple items.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The type of revenue or cost center providing the product and/or
@@ -1471,7 +1471,7 @@ export interface ExplanationOfBenefitItemDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -1576,7 +1576,7 @@ export interface ExplanationOfBenefitItemDetailSubDetail {
    * A claim detail line. Either a simple (a product or service) or a
    * 'group' of sub-details which are simple items.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The type of revenue or cost center providing the product and/or
@@ -1595,7 +1595,7 @@ export interface ExplanationOfBenefitItemDetailSubDetail {
    * related claim details, otherwise this contains the product, service,
    * drug or other billing code for the item.
    */
-  productOrService?: CodeableConcept;
+  productOrService: CodeableConcept;
 
   /**
    * Item typification or modifiers codes to convey additional context for
@@ -1822,7 +1822,7 @@ export interface ExplanationOfBenefitProcedure {
   /**
    * A number to uniquely identify procedure entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * When the condition was observed or the relative ranking.
@@ -2016,13 +2016,13 @@ export interface ExplanationOfBenefitSupportingInfo {
   /**
    * A number to uniquely identify supporting information entries.
    */
-  sequence?: number;
+  sequence: number;
 
   /**
    * The general class of the information supplied: information; exception;
    * accident, employment; onset, etc.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * System and code pertaining to the specific information regarding
@@ -2131,10 +2131,10 @@ export interface ExplanationOfBenefitTotal {
    * amounts paid by other coverages, and the benefit payable for this
    * item.
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * Monetary total amount associated with the category.
    */
-  amount?: Money;
+  amount: Money;
 }

--- a/packages/fhirtypes/dist/Expression.d.ts
+++ b/packages/fhirtypes/dist/Expression.d.ts
@@ -44,7 +44,7 @@ export interface Expression {
   /**
    * The media type of the language for the expression.
    */
-  language?: 'text/cql' | 'text/fhirpath' | 'application/x-fhir-query';
+  language: 'text/cql' | 'text/fhirpath' | 'application/x-fhir-query';
 
   /**
    * An expression in the specified language that returns a value.

--- a/packages/fhirtypes/dist/Extension.d.ts
+++ b/packages/fhirtypes/dist/Extension.d.ts
@@ -60,7 +60,7 @@ export interface Extension {
    * Source of the definition for the extension code - a logical name or a
    * URL.
    */
-  url?: string;
+  url: string;
 
   /**
    * Value of extension - must be one of a constrained set of the data

--- a/packages/fhirtypes/dist/FamilyMemberHistory.d.ts
+++ b/packages/fhirtypes/dist/FamilyMemberHistory.d.ts
@@ -129,7 +129,7 @@ export interface FamilyMemberHistory {
    * A code specifying the status of the record of the family history of a
    * specific family member.
    */
-  status?: 'partial' | 'completed' | 'entered-in-error' | 'health-unknown';
+  status: 'partial' | 'completed' | 'entered-in-error' | 'health-unknown';
 
   /**
    * Describes why the family member's history is not available.
@@ -139,7 +139,7 @@ export interface FamilyMemberHistory {
   /**
    * The person who this history concerns.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The date (and possibly time) when the family member history was
@@ -157,7 +157,7 @@ export interface FamilyMemberHistory {
    * The type of relationship this person has to the patient (father,
    * mother, brother etc.).
    */
-  relationship?: CodeableConcept;
+  relationship: CodeableConcept;
 
   /**
    * The birth sex of the family member.
@@ -309,7 +309,7 @@ export interface FamilyMemberHistoryCondition {
    * much is known about the condition and the capabilities of the creating
    * system.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * Indicates what happened following the condition.  If the condition

--- a/packages/fhirtypes/dist/Flag.d.ts
+++ b/packages/fhirtypes/dist/Flag.d.ts
@@ -115,7 +115,7 @@ export interface Flag {
   /**
    * Supports basic workflow.
    */
-  status?: 'active' | 'inactive' | 'entered-in-error';
+  status: 'active' | 'inactive' | 'entered-in-error';
 
   /**
    * Allows a flag to be divided into different categories like clinical,
@@ -128,13 +128,13 @@ export interface Flag {
    * The coded value or textual component of the flag to display to the
    * user.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The patient, location, group, organization, or practitioner etc. this
    * is about record this flag is associated with.
    */
-  subject?: Reference<Patient | Location | Group | Organization | Practitioner | PlanDefinition | Medication | Procedure>;
+  subject: Reference<Patient | Location | Group | Organization | Practitioner | PlanDefinition | Medication | Procedure>;
 
   /**
    * The period of time from the activation of the flag to inactivation of

--- a/packages/fhirtypes/dist/Goal.d.ts
+++ b/packages/fhirtypes/dist/Goal.d.ts
@@ -122,7 +122,7 @@ export interface Goal {
   /**
    * The state of the goal throughout its lifecycle.
    */
-  lifecycleStatus?: 'proposed' | 'planned' | 'accepted' | 'active' | 'on-hold' | 'completed' | 'cancelled' | 'entered-in-error' | 'rejected';
+  lifecycleStatus: 'proposed' | 'planned' | 'accepted' | 'active' | 'on-hold' | 'completed' | 'cancelled' | 'entered-in-error' | 'rejected';
 
   /**
    * Describes the progression, or lack thereof, towards the goal against
@@ -146,13 +146,13 @@ export interface Goal {
    * objective of care, such as &quot;control blood pressure&quot; or &quot;negotiate an
    * obstacle course&quot; or &quot;dance with child at wedding&quot;.
    */
-  description?: CodeableConcept;
+  description: CodeableConcept;
 
   /**
    * Identifies the patient, group or organization for whom the goal is
    * being established.
    */
-  subject?: Reference<Patient | Group | Organization>;
+  subject: Reference<Patient | Group | Organization>;
 
   /**
    * The date or event after which the goal should begin being pursued.

--- a/packages/fhirtypes/dist/GraphDefinition.d.ts
+++ b/packages/fhirtypes/dist/GraphDefinition.d.ts
@@ -123,13 +123,13 @@ export interface GraphDefinition {
    * should be usable as an identifier for the module by machine processing
    * applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * The status of this graph definition. Enables tracking the life-cycle
    * of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this graph definition is authored for
@@ -188,7 +188,7 @@ export interface GraphDefinition {
   /**
    * The type of FHIR resource at which instances of this graph start.
    */
-  start?: ResourceType;
+  start: ResourceType;
 
   /**
    * The profile that describes the use of the base resource.
@@ -317,7 +317,7 @@ export interface GraphDefinitionLinkTarget {
   /**
    * Type of resource this link refers to.
    */
-  type?: ResourceType;
+  type: ResourceType;
 
   /**
    * A set of parameters to look up.
@@ -385,17 +385,17 @@ export interface GraphDefinitionLinkTargetCompartment {
    * test whether resources are subject to the rule, or whether it is a
    * rule that must be followed.
    */
-  use?: 'condition' | 'requirement';
+  use: 'condition' | 'requirement';
 
   /**
    * Identifies the compartment.
    */
-  code?: 'Patient' | 'Encounter' | 'RelatedPerson' | 'Practitioner' | 'Device';
+  code: 'Patient' | 'Encounter' | 'RelatedPerson' | 'Practitioner' | 'Device';
 
   /**
    * identical | matching | different | no-rule | custom.
    */
-  rule?: 'identical' | 'matching' | 'different' | 'custom';
+  rule: 'identical' | 'matching' | 'different' | 'custom';
 
   /**
    * Custom rule, as a FHIRPath expression.

--- a/packages/fhirtypes/dist/Group.d.ts
+++ b/packages/fhirtypes/dist/Group.d.ts
@@ -121,14 +121,14 @@ export interface Group {
    * Identifies the broad classification of the kind of resources the group
    * includes.
    */
-  type?: 'person' | 'animal' | 'practitioner' | 'device' | 'medication' | 'substance';
+  type: 'person' | 'animal' | 'practitioner' | 'device' | 'medication' | 'substance';
 
   /**
    * If true, indicates that the resource refers to a specific group of
    * real individuals.  If false, the group defines a set of intended
    * individuals.
    */
-  actual?: boolean;
+  actual: boolean;
 
   /**
    * Provides a specific type of resource the group includes; e.g. &quot;cow&quot;,
@@ -210,7 +210,7 @@ export interface GroupCharacteristic {
   /**
    * A code that identifies the kind of trait being asserted.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The value of the trait that holds (or does not hold - see 'exclude')
@@ -246,7 +246,7 @@ export interface GroupCharacteristic {
    * If true, indicates the characteristic is one that is NOT held by
    * members of the group.
    */
-  exclude?: boolean;
+  exclude: boolean;
 
   /**
    * The period over which the characteristic is tested; e.g. the patient
@@ -300,7 +300,7 @@ export interface GroupMember {
    * consistent with Group.type. If the entity is another group, then the
    * type must be the same.
    */
-  entity?: Reference<Patient | Practitioner | PractitionerRole | Device | Medication | Substance | Group>;
+  entity: Reference<Patient | Practitioner | PractitionerRole | Device | Medication | Substance | Group>;
 
   /**
    * The period that the member was in the group, if known.

--- a/packages/fhirtypes/dist/GuidanceResponse.d.ts
+++ b/packages/fhirtypes/dist/GuidanceResponse.d.ts
@@ -151,7 +151,7 @@ export interface GuidanceResponse {
    * available, the status will be data-requested, and the response will
    * contain a description of the additional requested information.
    */
-  status?: 'success' | 'data-requested' | 'data-required' | 'in-progress' | 'failure' | 'entered-in-error';
+  status: 'success' | 'data-requested' | 'data-required' | 'in-progress' | 'failure' | 'entered-in-error';
 
   /**
    * The patient for which the request was processed.

--- a/packages/fhirtypes/dist/HealthcareService.d.ts
+++ b/packages/fhirtypes/dist/HealthcareService.d.ts
@@ -405,7 +405,7 @@ export interface HealthcareServiceNotAvailable {
    * The reason that can be presented to the user as to why this time is
    * not available.
    */
-  description?: string;
+  description: string;
 
   /**
    * Service is not available (seasonally or for a public holiday) from

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -11,12 +11,12 @@ export interface IdentityProvider {
   /**
    * Remote URL for the external Identity Provider authorize endpoint.
    */
-  authorizeUrl?: string;
+  authorizeUrl: string;
 
   /**
    * Remote URL for the external Identity Provider token endpoint.
    */
-  tokenUrl?: string;
+  tokenUrl: string;
 
   /**
    * Client Authentication method used by Clients to authenticate to the
@@ -28,17 +28,17 @@ export interface IdentityProvider {
   /**
    * Remote URL for the external Identity Provider userinfo endpoint.
    */
-  userInfoUrl?: string;
+  userInfoUrl: string;
 
   /**
    * External Identity Provider client ID.
    */
-  clientId?: string;
+  clientId: string;
 
   /**
    * External Identity Provider client secret.
    */
-  clientSecret?: string;
+  clientSecret: string;
 
   /**
    * Optional flag to use PKCE in the token request.

--- a/packages/fhirtypes/dist/ImagingStudy.d.ts
+++ b/packages/fhirtypes/dist/ImagingStudy.d.ts
@@ -131,7 +131,7 @@ export interface ImagingStudy {
   /**
    * The current state of the ImagingStudy.
    */
-  status?: 'registered' | 'available' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'registered' | 'available' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * A list of all the series.modality values that are actual acquisition
@@ -143,7 +143,7 @@ export interface ImagingStudy {
   /**
    * The subject, typically a patient, of the imaging study.
    */
-  subject?: Reference<Patient | Device | Group>;
+  subject: Reference<Patient | Device | Group>;
 
   /**
    * The healthcare event (e.g. a patient and healthcare provider
@@ -286,7 +286,7 @@ export interface ImagingStudySeries {
   /**
    * The DICOM Series Instance UID for the series.
    */
-  uid?: string;
+  uid: string;
 
   /**
    * The numeric identifier of this series in the study.
@@ -296,7 +296,7 @@ export interface ImagingStudySeries {
   /**
    * The modality of this series sequence.
    */
-  modality?: Coding;
+  modality: Coding;
 
   /**
    * A description of the series.
@@ -402,12 +402,12 @@ export interface ImagingStudySeriesInstance {
   /**
    * The DICOM SOP Instance UID for this image or other DICOM content.
    */
-  uid?: string;
+  uid: string;
 
   /**
    * DICOM instance  type.
    */
-  sopClass?: Coding;
+  sopClass: Coding;
 
   /**
    * The number of instance in the series.
@@ -468,5 +468,5 @@ export interface ImagingStudySeriesPerformer {
   /**
    * Indicates who or what performed the series.
    */
-  actor?: Reference<Practitioner | PractitionerRole | Organization | CareTeam | Patient | Device | RelatedPerson>;
+  actor: Reference<Practitioner | PractitionerRole | Organization | CareTeam | Patient | Device | RelatedPerson>;
 }

--- a/packages/fhirtypes/dist/Immunization.d.ts
+++ b/packages/fhirtypes/dist/Immunization.d.ts
@@ -113,7 +113,7 @@ export interface Immunization {
   /**
    * Indicates the current status of the immunization event.
    */
-  status?: 'completed' | 'entered-in-error' | 'not-done';
+  status: 'completed' | 'entered-in-error' | 'not-done';
 
   /**
    * Indicates the reason the immunization event was not performed.
@@ -123,12 +123,12 @@ export interface Immunization {
   /**
    * Vaccine that was administered or was to be administered.
    */
-  vaccineCode?: CodeableConcept;
+  vaccineCode: CodeableConcept;
 
   /**
    * The patient who either received or did not receive the immunization.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The visit or admission or other contact between patient and health
@@ -379,7 +379,7 @@ export interface ImmunizationPerformer {
   /**
    * The practitioner or organization who performed the action.
    */
-  actor?: Reference<Practitioner | PractitionerRole | Organization>;
+  actor: Reference<Practitioner | PractitionerRole | Organization>;
 }
 
 /**

--- a/packages/fhirtypes/dist/ImmunizationEvaluation.d.ts
+++ b/packages/fhirtypes/dist/ImmunizationEvaluation.d.ts
@@ -106,12 +106,12 @@ export interface ImmunizationEvaluation {
    * Indicates the current status of the evaluation of the vaccination
    * administration event.
    */
-  status?: 'completed' | 'entered-in-error';
+  status: 'completed' | 'entered-in-error';
 
   /**
    * The individual for whom the evaluation is being done.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The date the evaluation of the vaccine administration event was
@@ -127,18 +127,18 @@ export interface ImmunizationEvaluation {
   /**
    * The vaccine preventable disease the dose is being evaluated against.
    */
-  targetDisease?: CodeableConcept;
+  targetDisease: CodeableConcept;
 
   /**
    * The vaccine administration event being evaluated.
    */
-  immunizationEvent?: Reference<Immunization>;
+  immunizationEvent: Reference<Immunization>;
 
   /**
    * Indicates if the dose is valid or not valid with respect to the
    * published recommendations.
    */
-  doseStatus?: CodeableConcept;
+  doseStatus: CodeableConcept;
 
   /**
    * Provides an explanation as to why the vaccine administration event is

--- a/packages/fhirtypes/dist/ImmunizationRecommendation.d.ts
+++ b/packages/fhirtypes/dist/ImmunizationRecommendation.d.ts
@@ -106,12 +106,12 @@ export interface ImmunizationRecommendation {
   /**
    * The patient the recommendation(s) are for.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The date the immunization recommendation(s) were created.
    */
-  date?: string;
+  date: string;
 
   /**
    * Indicates the authority who published the protocol (e.g. ACIP).
@@ -121,7 +121,7 @@ export interface ImmunizationRecommendation {
   /**
    * Vaccine administration recommendations.
    */
-  recommendation?: ImmunizationRecommendationRecommendation[];
+  recommendation: ImmunizationRecommendationRecommendation[];
 }
 
 /**
@@ -183,7 +183,7 @@ export interface ImmunizationRecommendationRecommendation {
    * Indicates the patient status with respect to the path to immunity for
    * the target disease.
    */
-  forecastStatus?: CodeableConcept;
+  forecastStatus: CodeableConcept;
 
   /**
    * The reason for the assigned forecast status.
@@ -289,10 +289,10 @@ export interface ImmunizationRecommendationRecommendationDateCriterion {
    * Date classification of recommendation.  For example, earliest date to
    * give, latest date to give, etc.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The date whose meaning is specified by dateCriterion.code.
    */
-  value?: string;
+  value: string;
 }

--- a/packages/fhirtypes/dist/ImplementationGuide.d.ts
+++ b/packages/fhirtypes/dist/ImplementationGuide.d.ts
@@ -109,7 +109,7 @@ export interface ImplementationGuide {
    * SHALL remain the same when the implementation guide is stored on
    * different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * The identifier that is used to identify this version of the
@@ -127,7 +127,7 @@ export interface ImplementationGuide {
    * name should be usable as an identifier for the module by machine
    * processing applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * A short, descriptive, user-friendly title for the implementation
@@ -139,7 +139,7 @@ export interface ImplementationGuide {
    * The status of this implementation guide. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this implementation guide is authored
@@ -203,7 +203,7 @@ export interface ImplementationGuide {
    * based tooling manages IG dependencies. This value must be globally
    * unique, and should be assigned with care.
    */
-  packageId?: string;
+  packageId: string;
 
   /**
    * The license that applies to this Implementation Guide, using an SPDX
@@ -260,7 +260,7 @@ export interface ImplementationGuide {
    * formal version of the specification, without the revision number, e.g.
    * [publication].[major].[minor], which is 4.0.1. for this version.
    */
-  fhirVersion?: ('0.01' | '0.05' | '0.06' | '0.11' | '0.0.80' | '0.0.81' | '0.0.82' | '0.4.0' | '0.5.0' | '1.0.0' |
+  fhirVersion: ('0.01' | '0.05' | '0.06' | '0.11' | '0.0.80' | '0.0.81' | '0.0.82' | '0.4.0' | '0.5.0' | '1.0.0' |
       '1.0.1' | '1.0.2' | '1.1.0' | '1.4.0' | '1.6.0' | '1.8.0' | '3.0.0' | '3.0.1' | '3.3.0' | '3.5.0' | '4.0.0' |
       '4.0.1')[];
 
@@ -343,7 +343,7 @@ export interface ImplementationGuideDefinition {
    * etc.) are obvious candidates for inclusion, but any kind of resource
    * can be included as an example resource.
    */
-  resource?: ImplementationGuideDefinitionResource[];
+  resource: ImplementationGuideDefinitionResource[];
 
   /**
    * A page / section in the implementation guide. The root page is the
@@ -407,7 +407,7 @@ export interface ImplementationGuideDefinitionGrouping {
    * The human-readable title to display for the package of resources when
    * rendering the implementation guide.
    */
-  name?: string;
+  name: string;
 
   /**
    * Human readable text describing the package.
@@ -470,12 +470,12 @@ export interface ImplementationGuideDefinitionPage {
    * A short title used to represent this page in navigational structures
    * such as table of contents, bread crumbs, etc.
    */
-  title?: string;
+  title: string;
 
   /**
    * A code that indicates how the page is generated.
    */
-  generation?: 'html' | 'markdown' | 'xml' | 'generated';
+  generation: 'html' | 'markdown' | 'xml' | 'generated';
 
   /**
    * Nested Pages/Sections under this page.
@@ -528,13 +528,13 @@ export interface ImplementationGuideDefinitionParameter {
    * expansion-parameter | rule-broken-links | generate-xml | generate-json
    * | generate-turtle | html-template.
    */
-  code?: 'apply' | 'path-resource' | 'path-pages' | 'path-tx-cache' | 'expansion-parameter' | 'rule-broken-links' |
+  code: 'apply' | 'path-resource' | 'path-pages' | 'path-tx-cache' | 'expansion-parameter' | 'rule-broken-links' |
       'generate-xml' | 'generate-json' | 'generate-turtle' | 'html-template';
 
   /**
    * Value for named type.
    */
-  value?: string;
+  value: string;
 }
 
 /**
@@ -583,7 +583,7 @@ export interface ImplementationGuideDefinitionResource {
   /**
    * Where this resource is found.
    */
-  reference?: Reference<Resource>;
+  reference: Reference<Resource>;
 
   /**
    * Indicates the FHIR Version(s) this artifact is intended to apply to.
@@ -670,12 +670,12 @@ export interface ImplementationGuideDefinitionTemplate {
   /**
    * Type of template specified.
    */
-  code?: string;
+  code: string;
 
   /**
    * The source location for the template.
    */
-  source?: string;
+  source: string;
 
   /**
    * The scope in which the template applies.
@@ -728,7 +728,7 @@ export interface ImplementationGuideDependsOn {
   /**
    * A canonical reference to the Implementation guide for the dependency.
    */
-  uri?: string;
+  uri: string;
 
   /**
    * The NPM package name for the Implementation Guide that this IG depends
@@ -787,12 +787,12 @@ export interface ImplementationGuideGlobal {
   /**
    * The type of resource that all instances must conform to.
    */
-  type?: ResourceType;
+  type: ResourceType;
 
   /**
    * A reference to the profile that all instances must conform to.
    */
-  profile?: string;
+  profile: string;
 }
 
 /**
@@ -848,7 +848,7 @@ export interface ImplementationGuideManifest {
    * etc.) are obvious candidates for inclusion, but any kind of resource
    * can be included as an example resource.
    */
-  resource?: ImplementationGuideManifestResource[];
+  resource: ImplementationGuideManifestResource[];
 
   /**
    * Information about a page within the IG.
@@ -911,7 +911,7 @@ export interface ImplementationGuideManifestPage {
   /**
    * Relative path to the page.
    */
-  name?: string;
+  name: string;
 
   /**
    * Label for the page intended for human display.
@@ -970,7 +970,7 @@ export interface ImplementationGuideManifestResource {
   /**
    * Where this resource is found.
    */
-  reference?: Reference<Resource>;
+  reference: Reference<Resource>;
 
   /**
    * If true or a reference, indicates the resource is an example instance.

--- a/packages/fhirtypes/dist/InsurancePlan.d.ts
+++ b/packages/fhirtypes/dist/InsurancePlan.d.ts
@@ -290,7 +290,7 @@ export interface InsurancePlanCoverage {
    * Type of coverage  (Medical; Dental; Mental Health; Substance Abuse;
    * Vision; Drug; Short Term; Long Term Care; Hospice; Home Health).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Reference to the network that providing the type of coverage.
@@ -300,7 +300,7 @@ export interface InsurancePlanCoverage {
   /**
    * Specific benefits under this type of coverage.
    */
-  benefit?: InsurancePlanCoverageBenefit[];
+  benefit: InsurancePlanCoverageBenefit[];
 }
 
 /**
@@ -347,7 +347,7 @@ export interface InsurancePlanCoverageBenefit {
    * Type of benefit (primary care; speciality care; inpatient;
    * outpatient).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The referral requirements to have access/coverage for this benefit.
@@ -592,7 +592,7 @@ export interface InsurancePlanPlanSpecificCost {
    * General category of benefit (Medical; Dental; Vision; Drug; Mental
    * Health; Substance Abuse; Hospice, Home Health).
    */
-  category?: CodeableConcept;
+  category: CodeableConcept;
 
   /**
    * List of the specific benefits under this category of benefit.
@@ -645,7 +645,7 @@ export interface InsurancePlanPlanSpecificCostBenefit {
    * speciality office visit; hospitalization; emergency room; urgent
    * care).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * List of the costs associated with a specific benefit.
@@ -697,7 +697,7 @@ export interface InsurancePlanPlanSpecificCostBenefitCost {
    * Type of cost (copay; individual cap; family cap; coinsurance;
    * deductible).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Whether the cost applies to in-network or out-of-network providers

--- a/packages/fhirtypes/dist/Invoice.d.ts
+++ b/packages/fhirtypes/dist/Invoice.d.ts
@@ -113,7 +113,7 @@ export interface Invoice {
   /**
    * The current state of the Invoice.
    */
-  status?: 'draft' | 'issued' | 'balanced' | 'cancelled' | 'entered-in-error';
+  status: 'draft' | 'issued' | 'balanced' | 'cancelled' | 'entered-in-error';
 
   /**
    * In case of Invoice cancellation a reason must be given (entered in
@@ -323,7 +323,7 @@ export interface InvoiceLineItemPriceComponent {
   /**
    * This code identifies the type of the component.
    */
-  type?: 'base' | 'surcharge' | 'deduction' | 'discount' | 'tax' | 'informational';
+  type: 'base' | 'surcharge' | 'deduction' | 'discount' | 'tax' | 'informational';
 
   /**
    * A code that identifies the component. Codes may be used to
@@ -395,5 +395,5 @@ export interface InvoiceParticipant {
    * The device, practitioner, etc. who performed or participated in the
    * service.
    */
-  actor?: Reference<Practitioner | Organization | Patient | PractitionerRole | Device | RelatedPerson>;
+  actor: Reference<Practitioner | Organization | Patient | PractitionerRole | Device | RelatedPerson>;
 }

--- a/packages/fhirtypes/dist/Library.d.ts
+++ b/packages/fhirtypes/dist/Library.d.ts
@@ -160,7 +160,7 @@ export interface Library {
    * The status of this library. Enables tracking the life-cycle of the
    * content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this library is authored for testing
@@ -173,7 +173,7 @@ export interface Library {
    * Identifies the type of library such as a Logic Library, Model
    * Definition, Asset Collection, or Module Definition.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * A code or group definition that describes the intended subject of the

--- a/packages/fhirtypes/dist/Linkage.d.ts
+++ b/packages/fhirtypes/dist/Linkage.d.ts
@@ -112,7 +112,7 @@ export interface Linkage {
    * real-world occurrence as well as how the items should be evaluated
    * within the collection of linked items.
    */
-  item?: LinkageItem[];
+  item: LinkageItem[];
 }
 
 /**
@@ -161,10 +161,10 @@ export interface LinkageItem {
    * Distinguishes which item is &quot;source of truth&quot; (if any) and which items
    * are no longer considered to be current representations.
    */
-  type?: 'source' | 'alternate' | 'historical';
+  type: 'source' | 'alternate' | 'historical';
 
   /**
    * The resource instance being linked as part of the group.
    */
-  resource?: Reference<Resource>;
+  resource: Reference<Resource>;
 }

--- a/packages/fhirtypes/dist/List.d.ts
+++ b/packages/fhirtypes/dist/List.d.ts
@@ -109,7 +109,7 @@ export interface List {
   /**
    * Indicates the current state of this list.
    */
-  status?: 'current' | 'retired' | 'entered-in-error';
+  status: 'current' | 'retired' | 'entered-in-error';
 
   /**
    * How this list was prepared - whether it is a working list that is
@@ -117,7 +117,7 @@ export interface List {
    * a snapshot of a list of items from another source, or whether it is a
    * prepared list where items may be marked as added, modified or deleted.
    */
-  mode?: 'working' | 'snapshot' | 'changes';
+  mode: 'working' | 'snapshot' | 'changes';
 
   /**
    * A label for the list assigned by the author.
@@ -232,5 +232,5 @@ export interface ListEntry {
   /**
    * A reference to the actual resource from which data was derived.
    */
-  item?: Reference<Resource>;
+  item: Reference<Resource>;
 }

--- a/packages/fhirtypes/dist/Location.d.ts
+++ b/packages/fhirtypes/dist/Location.d.ts
@@ -308,13 +308,13 @@ export interface LocationPosition {
    * Longitude. The value domain and the interpretation are the same as for
    * the text of the longitude element in KML (see notes below).
    */
-  longitude?: number;
+  longitude: number;
 
   /**
    * Latitude. The value domain and the interpretation are the same as for
    * the text of the latitude element in KML (see notes below).
    */
-  latitude?: number;
+  latitude: number;
 
   /**
    * Altitude. The value domain and the interpretation are the same as for

--- a/packages/fhirtypes/dist/Login.d.ts
+++ b/packages/fhirtypes/dist/Login.d.ts
@@ -67,7 +67,7 @@ export interface Login {
   /**
    * The user requesting the code.
    */
-  user?: Reference<Bot | ClientApplication | User>;
+  user: Reference<Bot | ClientApplication | User>;
 
   /**
    * Reference to the project membership which includes FHIR identity
@@ -84,12 +84,12 @@ export interface Login {
    * The authentication method used to obtain the code (password or
    * google).
    */
-  authMethod?: 'client' | 'exchange' | 'execute' | 'external' | 'google' | 'password';
+  authMethod: 'client' | 'exchange' | 'execute' | 'external' | 'google' | 'password';
 
   /**
    * Time when the End-User authentication occurred.
    */
-  authTime?: string;
+  authTime: string;
 
   /**
    * The cookie value that can be used for session management.

--- a/packages/fhirtypes/dist/MarketingStatus.d.ts
+++ b/packages/fhirtypes/dist/MarketingStatus.d.ts
@@ -54,7 +54,7 @@ export interface MarketingStatus {
    * shall be specified It should be specified using the ISO 3166 ‑ 1
    * alpha-2 code elements.
    */
-  country?: CodeableConcept;
+  country: CodeableConcept;
 
   /**
    * Where a Medicines Regulatory Agency has granted a marketing
@@ -70,7 +70,7 @@ export interface MarketingStatus {
    * the medicinal product See ISO/TS 20443 for more information and
    * examples.
    */
-  status?: CodeableConcept;
+  status: CodeableConcept;
 
   /**
    * The date when the Medicinal Product is placed on the market by the
@@ -81,7 +81,7 @@ export interface MarketingStatus {
    * refers to the release of the Medicinal Product into the distribution
    * chain.
    */
-  dateRange?: Period;
+  dateRange: Period;
 
   /**
    * The date when the Medicinal Product is placed on the market by the

--- a/packages/fhirtypes/dist/Measure.d.ts
+++ b/packages/fhirtypes/dist/Measure.d.ts
@@ -153,7 +153,7 @@ export interface Measure {
    * The status of this measure. Enables tracking the life-cycle of the
    * content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this measure is authored for testing
@@ -503,7 +503,7 @@ export interface MeasureGroupPopulation {
    * An expression that specifies the criteria for the population,
    * typically the name of an expression in a library.
    */
-  criteria?: Expression;
+  criteria: Expression;
 }
 
 /**
@@ -637,7 +637,7 @@ export interface MeasureGroupStratifierComponent {
    * a referenced library, but it may also be a path to a stratifier
    * element.
    */
-  criteria?: Expression;
+  criteria: Expression;
 }
 
 /**
@@ -711,5 +711,5 @@ export interface MeasureSupplementalData {
    * also be a path to a specific data element. The criteria defines the
    * data to be returned for this element.
    */
-  criteria?: Expression;
+  criteria: Expression;
 }

--- a/packages/fhirtypes/dist/MeasureReport.d.ts
+++ b/packages/fhirtypes/dist/MeasureReport.d.ts
@@ -116,7 +116,7 @@ export interface MeasureReport {
    * The MeasureReport status. No data will be available until the
    * MeasureReport status is complete.
    */
-  status?: 'complete' | 'pending' | 'error';
+  status: 'complete' | 'pending' | 'error';
 
   /**
    * The type of measure report. This may be an individual report, which
@@ -127,12 +127,12 @@ export interface MeasureReport {
    * a data-collection, which enables the MeasureReport to be used to
    * exchange the data-of-interest for a quality measure.
    */
-  type?: 'individual' | 'subject-list' | 'summary' | 'data-collection';
+  type: 'individual' | 'subject-list' | 'summary' | 'data-collection';
 
   /**
    * A reference to the Measure that was calculated to produce this report.
    */
-  measure?: string;
+  measure: string;
 
   /**
    * Optional subject identifying the individual or individuals the report
@@ -153,7 +153,7 @@ export interface MeasureReport {
   /**
    * The reporting period for which the report was calculated.
    */
-  period?: Period;
+  period: Period;
 
   /**
    * Whether improvement in the measure is noted by an increase or decrease
@@ -464,12 +464,12 @@ export interface MeasureReportGroupStratifierStratumComponent {
   /**
    * The code for the stratum component value.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The stratum component value.
    */
-  value?: CodeableConcept;
+  value: CodeableConcept;
 }
 
 /**

--- a/packages/fhirtypes/dist/Media.d.ts
+++ b/packages/fhirtypes/dist/Media.d.ts
@@ -132,7 +132,7 @@ export interface Media {
   /**
    * The current state of the {{title}}.
    */
-  status?: 'preparation' | 'in-progress' | 'not-done' | 'on-hold' | 'stopped' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'preparation' | 'in-progress' | 'not-done' | 'on-hold' | 'stopped' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * A code that classifies whether the media is an image, video or audio
@@ -233,7 +233,7 @@ export interface Media {
    * The actual content of the media - inline or by direct reference to the
    * media source file.
    */
-  content?: Attachment;
+  content: Attachment;
 
   /**
    * Comments made about the media by the performer, subject or other

--- a/packages/fhirtypes/dist/MedicationAdministration.d.ts
+++ b/packages/fhirtypes/dist/MedicationAdministration.d.ts
@@ -142,7 +142,7 @@ export interface MedicationAdministration {
    * it is possible for an administration to be started but not completed
    * or it may be paused while some other process is under way.
    */
-  status?: 'in-progress' | 'not-done' | 'on-hold' | 'completed' | 'entered-in-error' | 'stopped' | 'unknown';
+  status: 'in-progress' | 'not-done' | 'on-hold' | 'completed' | 'entered-in-error' | 'stopped' | 'unknown';
 
   /**
    * A code indicating why the administration was not performed.
@@ -174,7 +174,7 @@ export interface MedicationAdministration {
   /**
    * The person or animal or group receiving the medication.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The visit, admission, or other contact between patient and health care
@@ -399,5 +399,5 @@ export interface MedicationAdministrationPerformer {
   /**
    * Indicates who or what performed the medication administration.
    */
-  actor?: Reference<Practitioner | PractitionerRole | Patient | RelatedPerson | Device>;
+  actor: Reference<Practitioner | PractitionerRole | Patient | RelatedPerson | Device>;
 }

--- a/packages/fhirtypes/dist/MedicationDispense.d.ts
+++ b/packages/fhirtypes/dist/MedicationDispense.d.ts
@@ -132,7 +132,7 @@ export interface MedicationDispense {
   /**
    * A code specifying the state of the set of dispense events.
    */
-  status?: 'preparation' | 'in-progress' | 'cancelled' | 'on-hold' | 'completed' | 'entered-in-error' | 'stopped' | 'declined' | 'unknown';
+  status: 'preparation' | 'in-progress' | 'cancelled' | 'on-hold' | 'completed' | 'entered-in-error' | 'stopped' | 'declined' | 'unknown';
 
   /**
    * Indicates the reason why a dispense was not performed.
@@ -325,7 +325,7 @@ export interface MedicationDispensePerformer {
    * The device, practitioner, etc. who performed the action.  It should be
    * assumed that the actor is the dispenser of the medication.
    */
-  actor?: Reference<Practitioner | PractitionerRole | Organization | Patient | Device | RelatedPerson>;
+  actor: Reference<Practitioner | PractitionerRole | Organization | Patient | Device | RelatedPerson>;
 }
 
 /**
@@ -376,7 +376,7 @@ export interface MedicationDispenseSubstitution {
    * True if the dispenser dispensed a different drug or product from what
    * was prescribed.
    */
-  wasSubstituted?: boolean;
+  wasSubstituted: boolean;
 
   /**
    * A code signifying whether a different drug was dispensed from what was

--- a/packages/fhirtypes/dist/MedicationKnowledge.d.ts
+++ b/packages/fhirtypes/dist/MedicationKnowledge.d.ts
@@ -345,12 +345,12 @@ export interface MedicationKnowledgeAdministrationGuidelinesDosage {
    * The type of dosage (for example, prophylaxis, maintenance,
    * therapeutic, etc.).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Dosage for the medication for the specific guidelines.
    */
-  dosage?: Dosage[];
+  dosage: Dosage[];
 }
 
 /**
@@ -456,7 +456,7 @@ export interface MedicationKnowledgeCost {
    * The category of the cost information.  For example, manufacturers'
    * cost, patient cost, claim reimbursement cost, actual acquisition cost.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The source or owner that assigns the price to the medication.
@@ -466,7 +466,7 @@ export interface MedicationKnowledgeCost {
   /**
    * The price of the medication.
    */
-  cost?: Money;
+  cost: Money;
 }
 
 /**
@@ -706,7 +706,7 @@ export interface MedicationKnowledgeMedicineClassification {
    * The type of category for the medication (for example, therapeutic
    * classification, therapeutic sub-classification).
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Specific category assigned to the medication (e.g. anti-infective,
@@ -913,7 +913,7 @@ export interface MedicationKnowledgeRegulatory {
   /**
    * The authority that is specifying the regulations.
    */
-  regulatoryAuthority?: Reference<Organization>;
+  regulatoryAuthority: Reference<Organization>;
 
   /**
    * Specifies if changes are allowed when dispensing a medication from a
@@ -977,7 +977,7 @@ export interface MedicationKnowledgeRegulatoryMaxDispense {
   /**
    * The maximum number of units of the medication that can be dispensed.
    */
-  quantity?: Quantity;
+  quantity: Quantity;
 
   /**
    * The period that applies to the maximum number of units.
@@ -1028,7 +1028,7 @@ export interface MedicationKnowledgeRegulatorySchedule {
   /**
    * Specifies the specific drug schedule.
    */
-  schedule?: CodeableConcept;
+  schedule: CodeableConcept;
 }
 
 /**
@@ -1075,13 +1075,13 @@ export interface MedicationKnowledgeRegulatorySubstitution {
   /**
    * Specifies the type of substitution allowed.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Specifies if regulation allows for changes in the medication when
    * dispensing.
    */
-  allowed?: boolean;
+  allowed: boolean;
 }
 
 /**
@@ -1127,10 +1127,10 @@ export interface MedicationKnowledgeRelatedMedicationKnowledge {
   /**
    * The category of the associated medication knowledge reference.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Associated documentation about the associated medication knowledge.
    */
-  reference?: Reference<MedicationKnowledge>[];
+  reference: Reference<MedicationKnowledge>[];
 }

--- a/packages/fhirtypes/dist/MedicationRequest.d.ts
+++ b/packages/fhirtypes/dist/MedicationRequest.d.ts
@@ -135,7 +135,7 @@ export interface MedicationRequest {
    * A code specifying the current state of the order.  Generally, this
    * will be active or completed state.
    */
-  status?: 'active' | 'on-hold' | 'cancelled' | 'completed' | 'entered-in-error' | 'stopped' | 'draft' | 'unknown';
+  status: 'active' | 'on-hold' | 'cancelled' | 'completed' | 'entered-in-error' | 'stopped' | 'draft' | 'unknown';
 
   /**
    * Captures the reason for the current state of the MedicationRequest.
@@ -145,7 +145,7 @@ export interface MedicationRequest {
   /**
    * Whether the request is a proposal, plan, or an original order.
    */
-  intent?: 'proposal' | 'plan' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
+  intent: 'proposal' | 'plan' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
 
   /**
    * Indicates the type of medication request (for example, where the
@@ -200,7 +200,7 @@ export interface MedicationRequest {
    * A link to a resource representing the person or set of individuals to
    * whom the medication will be given.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The Encounter during which this [x] was created or to which the

--- a/packages/fhirtypes/dist/MedicationStatement.d.ts
+++ b/packages/fhirtypes/dist/MedicationStatement.d.ts
@@ -163,7 +163,7 @@ export interface MedicationStatement {
    * state of the medication used that this statement is about.  Generally,
    * this will be active or completed.
    */
-  status?: 'active' | 'completed' | 'entered-in-error' | 'intended' | 'stopped' | 'on-hold' | 'unknown' | 'not-taken';
+  status: 'active' | 'completed' | 'entered-in-error' | 'intended' | 'stopped' | 'on-hold' | 'unknown' | 'not-taken';
 
   /**
    * Captures the reason for the current state of the MedicationStatement.
@@ -195,7 +195,7 @@ export interface MedicationStatement {
   /**
    * The person, animal or group who is/was taking the medication.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The encounter or episode of care that establishes the context for this

--- a/packages/fhirtypes/dist/MedicinalProduct.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProduct.d.ts
@@ -191,7 +191,7 @@ export interface MedicinalProduct {
   /**
    * The product's name, including full name and possibly coded parts.
    */
-  name?: MedicinalProductName[];
+  name: MedicinalProductName[];
 
   /**
    * Reference to another product, e.g. for linking authorised to
@@ -327,7 +327,7 @@ export interface MedicinalProductName {
   /**
    * The full product name.
    */
-  productName?: string;
+  productName: string;
 
   /**
    * Coding words or phrases of the name.
@@ -383,7 +383,7 @@ export interface MedicinalProductNameCountryLanguage {
   /**
    * Country code for where this name applies.
    */
-  country?: CodeableConcept;
+  country: CodeableConcept;
 
   /**
    * Jurisdiction code for where this name applies.
@@ -393,7 +393,7 @@ export interface MedicinalProductNameCountryLanguage {
   /**
    * Language code for this name.
    */
-  language?: CodeableConcept;
+  language: CodeableConcept;
 }
 
 /**
@@ -439,12 +439,12 @@ export interface MedicinalProductNameNamePart {
   /**
    * A fragment of a product name.
    */
-  part?: string;
+  part: string;
 
   /**
    * Idenifying type for this part of the name (e.g. strength part).
    */
-  type?: Coding;
+  type: Coding;
 }
 
 /**

--- a/packages/fhirtypes/dist/MedicinalProductAuthorization.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductAuthorization.d.ts
@@ -301,7 +301,7 @@ export interface MedicinalProductAuthorizationProcedure {
   /**
    * Type of procedure.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * Date of procedure.

--- a/packages/fhirtypes/dist/MedicinalProductContraindication.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductContraindication.d.ts
@@ -181,7 +181,7 @@ export interface MedicinalProductContraindicationOtherTherapy {
    * The type of relationship between the medicinal product indication or
    * contraindication and another therapy.
    */
-  therapyRelationshipType?: CodeableConcept;
+  therapyRelationshipType: CodeableConcept;
 
   /**
    * Reference to a specific medication (active substance, medicinal

--- a/packages/fhirtypes/dist/MedicinalProductIndication.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductIndication.d.ts
@@ -192,7 +192,7 @@ export interface MedicinalProductIndicationOtherTherapy {
    * The type of relationship between the medicinal product indication or
    * contraindication and another therapy.
    */
-  therapyRelationshipType?: CodeableConcept;
+  therapyRelationshipType: CodeableConcept;
 
   /**
    * Reference to a specific medication (active substance, medicinal

--- a/packages/fhirtypes/dist/MedicinalProductIngredient.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductIngredient.d.ts
@@ -104,7 +104,7 @@ export interface MedicinalProductIngredient {
   /**
    * Ingredient role e.g. Active ingredient, excipient.
    */
-  role?: CodeableConcept;
+  role: CodeableConcept;
 
   /**
    * If the ingredient is a known or suspected allergen.
@@ -170,12 +170,12 @@ export interface MedicinalProductIngredientSpecifiedSubstance {
   /**
    * The specified substance.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The group of specified substance, e.g. group 1 to 4.
    */
-  group?: CodeableConcept;
+  group: CodeableConcept;
 
   /**
    * Confidentiality level of the specified substance as the ingredient.
@@ -235,7 +235,7 @@ export interface MedicinalProductIngredientSpecifiedSubstanceStrength {
    * volume (or mass) of the single pharmaceutical product or manufactured
    * item.
    */
-  presentation?: Ratio;
+  presentation: Ratio;
 
   /**
    * A lower limit for the quantity of substance in the unit of
@@ -320,7 +320,7 @@ export interface MedicinalProductIngredientSpecifiedSubstanceStrengthReferenceSt
   /**
    * Strength expressed in terms of a reference substance.
    */
-  strength?: Ratio;
+  strength: Ratio;
 
   /**
    * Strength expressed in terms of a reference substance.
@@ -381,7 +381,7 @@ export interface MedicinalProductIngredientSubstance {
   /**
    * The ingredient substance.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * Quantity of the substance or specified substance present in the

--- a/packages/fhirtypes/dist/MedicinalProductManufactured.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductManufactured.d.ts
@@ -99,7 +99,7 @@ export interface MedicinalProductManufactured {
    * Dose form as manufactured and before any transformation into the
    * pharmaceutical product.
    */
-  manufacturedDoseForm?: CodeableConcept;
+  manufacturedDoseForm: CodeableConcept;
 
   /**
    * The &ldquo;real world&rdquo; units in which the quantity of the manufactured item
@@ -110,7 +110,7 @@ export interface MedicinalProductManufactured {
   /**
    * The quantity or &quot;count number&quot; of the manufactured item.
    */
-  quantity?: Quantity;
+  quantity: Quantity;
 
   /**
    * Manufacturer of the item (Note that this should be named

--- a/packages/fhirtypes/dist/MedicinalProductPackaged.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductPackaged.d.ts
@@ -146,7 +146,7 @@ export interface MedicinalProductPackaged {
    * A packaging item, as a contained for medicine, possibly with other
    * packaging items within.
    */
-  packageItem?: MedicinalProductPackagedPackageItem[];
+  packageItem: MedicinalProductPackagedPackageItem[];
 }
 
 /**
@@ -192,7 +192,7 @@ export interface MedicinalProductPackagedBatchIdentifier {
   /**
    * A number appearing on the outer packaging of a specific batch.
    */
-  outerPackaging?: Identifier;
+  outerPackaging: Identifier;
 
   /**
    * A number appearing on the immediate packaging (and not the outer
@@ -250,13 +250,13 @@ export interface MedicinalProductPackagedPackageItem {
   /**
    * The physical type of the container of the medicine.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The quantity of this package in the medicinal product, at the current
    * level of packaging. The outermost is always 1.
    */
-  quantity?: Quantity;
+  quantity: Quantity;
 
   /**
    * Material type of the package item.

--- a/packages/fhirtypes/dist/MedicinalProductPharmaceutical.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductPharmaceutical.d.ts
@@ -106,7 +106,7 @@ export interface MedicinalProductPharmaceutical {
   /**
    * The administrable dose form, after necessary reconstitution.
    */
-  administrableDoseForm?: CodeableConcept;
+  administrableDoseForm: CodeableConcept;
 
   /**
    * Todo.
@@ -132,7 +132,7 @@ export interface MedicinalProductPharmaceutical {
    * The path by which the pharmaceutical product is taken into or makes
    * contact with the body.
    */
-  routeOfAdministration?: MedicinalProductPharmaceuticalRouteOfAdministration[];
+  routeOfAdministration: MedicinalProductPharmaceuticalRouteOfAdministration[];
 }
 
 /**
@@ -178,7 +178,7 @@ export interface MedicinalProductPharmaceuticalCharacteristics {
   /**
    * A coded characteristic.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The status of characteristic e.g. assigned or pending.
@@ -230,7 +230,7 @@ export interface MedicinalProductPharmaceuticalRouteOfAdministration {
   /**
    * Coded expression for the route.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The first dose (dose quantity) administered in humans can be
@@ -315,7 +315,7 @@ export interface MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpecie
   /**
    * Coded expression for the species.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * A species specific time during which consumption of animal product is
@@ -369,12 +369,12 @@ export interface MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpecie
    * Coded expression for the type of tissue for which the withdrawal
    * period applues, e.g. meat, milk.
    */
-  tissue?: CodeableConcept;
+  tissue: CodeableConcept;
 
   /**
    * A value for the time.
    */
-  value?: Quantity;
+  value: Quantity;
 
   /**
    * Extra information about the withdrawal period.

--- a/packages/fhirtypes/dist/MessageDefinition.d.ts
+++ b/packages/fhirtypes/dist/MessageDefinition.d.ts
@@ -143,7 +143,7 @@ export interface MessageDefinition {
    * The status of this message definition. Enables tracking the life-cycle
    * of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this message definition is authored
@@ -158,7 +158,7 @@ export interface MessageDefinition {
    * it must change if the status code changes. In addition, it should
    * change when the substantive content of the message definition changes.
    */
-  date?: string;
+  date: string;
 
   /**
    * The name of the organization or individual that published the message
@@ -307,7 +307,7 @@ export interface MessageDefinitionAllowedResponse {
    * A reference to the message definition that must be adhered to by this
    * supported response.
    */
-  message?: string;
+  message: string;
 
   /**
    * Provides a description of the circumstances in which this response
@@ -361,7 +361,7 @@ export interface MessageDefinitionFocus {
   /**
    * The kind of resource that must be the focus for this message.
    */
-  code?: ResourceType;
+  code: ResourceType;
 
   /**
    * A profile that reflects constraints for the focal resource (and
@@ -374,7 +374,7 @@ export interface MessageDefinitionFocus {
    * pointed to by a message in order for it to be valid against this
    * MessageDefinition.
    */
-  min?: number;
+  min: number;
 
   /**
    * Identifies the maximum number of resources of this type that must be

--- a/packages/fhirtypes/dist/MessageHeader.d.ts
+++ b/packages/fhirtypes/dist/MessageHeader.d.ts
@@ -149,7 +149,7 @@ export interface MessageHeader {
   /**
    * The source application from which this message originated.
    */
-  source?: MessageHeaderSource;
+  source: MessageHeaderSource;
 
   /**
    * The person or organization that accepts overall responsibility for the
@@ -236,7 +236,7 @@ export interface MessageHeaderDestination {
   /**
    * Indicates where the message should be routed to.
    */
-  endpoint?: string;
+  endpoint: string;
 
   /**
    * Allows data conveyed by a message to be addressed to a particular
@@ -291,13 +291,13 @@ export interface MessageHeaderResponse {
    * The MessageHeader.id of the message to which this message is a
    * response.
    */
-  identifier?: string;
+  identifier: string;
 
   /**
    * Code that identifies the type of response to the message - whether it
    * was successful or not, and whether it should be resent or not.
    */
-  code?: 'ok' | 'transient-error' | 'fatal-error';
+  code: 'ok' | 'transient-error' | 'fatal-error';
 
   /**
    * Full details of any issues found in the message.
@@ -370,5 +370,5 @@ export interface MessageHeaderSource {
   /**
    * Identifies the routing target to send acknowledgements to.
    */
-  endpoint?: string;
+  endpoint: string;
 }

--- a/packages/fhirtypes/dist/MolecularSequence.d.ts
+++ b/packages/fhirtypes/dist/MolecularSequence.d.ts
@@ -114,7 +114,7 @@ export interface MolecularSequence {
    * coordinates, inclusive start, exclusive end) or starting at 1 (1-based
    * numbering, inclusive start and inclusive end).
    */
-  coordinateSystem?: number;
+  coordinateSystem: number;
 
   /**
    * The patient whose sequencing results are described by this resource.
@@ -238,7 +238,7 @@ export interface MolecularSequenceQuality {
   /**
    * INDEL / SNP / Undefined variant.
    */
-  type?: 'indel' | 'snp' | 'unknown';
+  type: 'indel' | 'snp' | 'unknown';
 
   /**
    * Gold standard sequence used for comparing against.
@@ -569,7 +569,7 @@ export interface MolecularSequenceRepository {
    * Click and see / RESTful API / Need login to see / RESTful API with
    * authentication / Other ways to see resource.
    */
-  type?: 'directlink' | 'openapi' | 'login' | 'oauth' | 'other';
+  type: 'directlink' | 'openapi' | 'login' | 'oauth' | 'other';
 
   /**
    * URI of an external repository which contains further details about the

--- a/packages/fhirtypes/dist/NamingSystem.d.ts
+++ b/packages/fhirtypes/dist/NamingSystem.d.ts
@@ -100,19 +100,19 @@ export interface NamingSystem {
    * should be usable as an identifier for the module by machine processing
    * applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * The status of this naming system. Enables tracking the life-cycle of
    * the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * Indicates the purpose for the naming system - what kinds of things
    * does it make unique?
    */
-  kind?: 'codesystem' | 'identifier' | 'root';
+  kind: 'codesystem' | 'identifier' | 'root';
 
   /**
    * The date  (and optionally time) when the naming system was published.
@@ -120,7 +120,7 @@ export interface NamingSystem {
    * change if the status code changes. In addition, it should change when
    * the substantive content of the naming system changes.
    */
-  date?: string;
+  date: string;
 
   /**
    * The name of the organization or individual that published the naming
@@ -179,7 +179,7 @@ export interface NamingSystem {
    * Indicates how the system may be identified when referenced in
    * electronic exchange.
    */
-  uniqueId?: NamingSystemUniqueId[];
+  uniqueId: NamingSystemUniqueId[];
 }
 
 /**
@@ -227,13 +227,13 @@ export interface NamingSystemUniqueId {
    * Identifies the unique identifier scheme used for this particular
    * identifier.
    */
-  type?: 'oid' | 'uuid' | 'uri' | 'other';
+  type: 'oid' | 'uuid' | 'uri' | 'other';
 
   /**
    * The string that should be sent over the wire to identify the code
    * system or identifier system.
    */
-  value?: string;
+  value: string;
 
   /**
    * Indicates whether this identifier is the &quot;preferred&quot; identifier of

--- a/packages/fhirtypes/dist/Narrative.d.ts
+++ b/packages/fhirtypes/dist/Narrative.d.ts
@@ -32,10 +32,10 @@ export interface Narrative {
    * just the defined data or the extensions too), or whether a human
    * authored it and it may contain additional data.
    */
-  status?: 'generated' | 'extensions' | 'additional' | 'empty';
+  status: 'generated' | 'extensions' | 'additional' | 'empty';
 
   /**
    * The actual narrative content, a stripped down version of XHTML.
    */
-  div?: string;
+  div: string;
 }

--- a/packages/fhirtypes/dist/NutritionOrder.d.ts
+++ b/packages/fhirtypes/dist/NutritionOrder.d.ts
@@ -132,19 +132,19 @@ export interface NutritionOrder {
   /**
    * The workflow status of the nutrition order/request.
    */
-  status?: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Indicates the level of authority/intentionality associated with the
    * NutrionOrder and where the request fits into the workflow chain.
    */
-  intent?: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
+  intent: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
 
   /**
    * The person (patient) who needs the nutrition order for an oral diet,
    * nutritional supplement and/or enteral or formula feeding.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * An encounter that provides additional information about the healthcare
@@ -155,7 +155,7 @@ export interface NutritionOrder {
   /**
    * The date and time that this nutrition order was requested.
    */
-  dateTime?: string;
+  dateTime: string;
 
   /**
    * The practitioner that holds legal responsibility for ordering the

--- a/packages/fhirtypes/dist/Observation.d.ts
+++ b/packages/fhirtypes/dist/Observation.d.ts
@@ -149,7 +149,7 @@ export interface Observation {
   /**
    * The status of the result value.
    */
-  status?: 'registered' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'registered' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * A code that classifies the general type of observation being made.
@@ -160,7 +160,7 @@ export interface Observation {
    * Describes what was observed. Sometimes this is called the observation
    * &quot;name&quot;.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The patient, or group of patients, location, or device this
@@ -423,7 +423,7 @@ export interface ObservationComponent {
    * Describes what was observed. Sometimes this is called the observation
    * &quot;code&quot;.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * The information determined as a result of making the observation, if

--- a/packages/fhirtypes/dist/ObservationDefinition.d.ts
+++ b/packages/fhirtypes/dist/ObservationDefinition.d.ts
@@ -113,7 +113,7 @@ export interface ObservationDefinition {
    * Describes what will be observed. Sometimes this is called the
    * observation &quot;name&quot;.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * A unique identifier assigned to this ObservationDefinition artifact.

--- a/packages/fhirtypes/dist/OperationDefinition.d.ts
+++ b/packages/fhirtypes/dist/OperationDefinition.d.ts
@@ -122,7 +122,7 @@ export interface OperationDefinition {
    * name should be usable as an identifier for the module by machine
    * processing applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * A short, descriptive, user-friendly title for the operation
@@ -134,12 +134,12 @@ export interface OperationDefinition {
    * The status of this operation definition. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * Whether this is an operation or a named query.
    */
-  kind?: 'operation' | 'query';
+  kind: 'operation' | 'query';
 
   /**
    * A Boolean value to indicate that this operation definition is authored
@@ -205,7 +205,7 @@ export interface OperationDefinition {
   /**
    * The name used to invoke the operation.
    */
-  code?: string;
+  code: string;
 
   /**
    * Additional information about how to use this operation or named query.
@@ -228,20 +228,20 @@ export interface OperationDefinition {
    * system level (e.g. without needing to choose a resource type for the
    * context).
    */
-  system?: boolean;
+  system: boolean;
 
   /**
    * Indicates whether this operation or named query can be invoked at the
    * resource type level for any given resource type level (e.g. without
    * needing to choose a specific resource id for the context).
    */
-  type?: boolean;
+  type: boolean;
 
   /**
    * Indicates whether this operation can be invoked on a particular
    * instance of one of the given types.
    */
-  instance?: boolean;
+  instance: boolean;
 
   /**
    * Additional validation information for the in parameters - a single
@@ -366,24 +366,24 @@ export interface OperationDefinitionParameter {
   /**
    * The name of used to identify the parameter.
    */
-  name?: string;
+  name: string;
 
   /**
    * Whether this is an input or an output parameter.
    */
-  use?: 'in' | 'out';
+  use: 'in' | 'out';
 
   /**
    * The minimum number of times this parameter SHALL appear in the request
    * or response.
    */
-  min?: number;
+  min: number;
 
   /**
    * The maximum number of times this element is permitted to appear in the
    * request or response.
    */
-  max?: string;
+  max: string;
 
   /**
    * Describes the meaning or use of this parameter.
@@ -478,13 +478,13 @@ export interface OperationDefinitionParameterBinding {
    * binding - that is, the degree to which the provided value set must be
    * adhered to in the instances.
    */
-  strength?: 'required' | 'extensible' | 'preferred' | 'example';
+  strength: 'required' | 'extensible' | 'preferred' | 'example';
 
   /**
    * Points to the value set or external definition (e.g. implicit value
    * set) that identifies the set of codes to be used.
    */
-  valueSet?: string;
+  valueSet: string;
 }
 
 /**
@@ -533,7 +533,7 @@ export interface OperationDefinitionParameterReferencedFrom {
    * pointing to the resource parameter that is expected to contain a
    * reference to this resource.
    */
-  source?: string;
+  source: string;
 
   /**
    * The id of the element in the referencing resource that is expected to

--- a/packages/fhirtypes/dist/OperationOutcome.d.ts
+++ b/packages/fhirtypes/dist/OperationOutcome.d.ts
@@ -95,7 +95,7 @@ export interface OperationOutcome {
    * An error, warning, or information message that results from a system
    * action.
    */
-  issue?: OperationOutcomeIssue[];
+  issue: OperationOutcomeIssue[];
 }
 
 /**
@@ -143,7 +143,7 @@ export interface OperationOutcomeIssue {
    * Indicates whether the issue indicates a variation from successful
    * processing.
    */
-  severity?: 'fatal' | 'error' | 'warning' | 'information';
+  severity: 'fatal' | 'error' | 'warning' | 'information';
 
   /**
    * Describes the type of the issue. The system that creates an
@@ -151,7 +151,7 @@ export interface OperationOutcomeIssue {
    * IssueType value set, and may additional provide its own code for the
    * error in the details element.
    */
-  code?: 'invalid' | 'structure' | 'required' | 'value' | 'invariant' | 'security' | 'login' | 'unknown' | 'expired' |
+  code: 'invalid' | 'structure' | 'required' | 'value' | 'invariant' | 'security' | 'login' | 'unknown' | 'expired' |
       'forbidden' | 'suppressed' | 'processing' | 'not-supported' | 'duplicate' | 'multiple-matches' | 'not-found' |
       'deleted' | 'too-long' | 'code-invalid' | 'extension' | 'too-costly' | 'business-rule' | 'conflict' | 'transient' |
       'lock-error' | 'no-store' | 'exception' | 'timeout' | 'incomplete' | 'throttled' | 'informational';

--- a/packages/fhirtypes/dist/ParameterDefinition.d.ts
+++ b/packages/fhirtypes/dist/ParameterDefinition.d.ts
@@ -38,7 +38,7 @@ export interface ParameterDefinition {
   /**
    * Whether the parameter is input or output for the module.
    */
-  use?: 'in' | 'out';
+  use: 'in' | 'out';
 
   /**
    * The minimum number of times this parameter SHALL appear in the request
@@ -61,7 +61,7 @@ export interface ParameterDefinition {
   /**
    * The type of the parameter.
    */
-  type?: string;
+  type: string;
 
   /**
    * If specified, this indicates a profile that the input data must

--- a/packages/fhirtypes/dist/Parameters.d.ts
+++ b/packages/fhirtypes/dist/Parameters.d.ts
@@ -124,7 +124,7 @@ export interface ParametersParameter {
   /**
    * The name of the parameter (reference to the operation definition).
    */
-  name?: string;
+  name: string;
 
   /**
    * If the parameter is a data type.

--- a/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
+++ b/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
@@ -51,12 +51,12 @@ export interface PasswordChangeRequest {
   /**
    * The user requesting the password change.
    */
-  user?: Reference<User>;
+  user: Reference<User>;
 
   /**
    * Secret string used to verify the identity of the user.
    */
-  secret?: string;
+  secret: string;
 
   /**
    * Whether this request has been used, and is therefore no longer valid.

--- a/packages/fhirtypes/dist/Patient.d.ts
+++ b/packages/fhirtypes/dist/Patient.d.ts
@@ -254,7 +254,7 @@ export interface PatientCommunication {
    * upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English
    * versus &quot;en-EN&quot; for England English.
    */
-  language?: CodeableConcept;
+  language: CodeableConcept;
 
   /**
    * Indicates whether or not the patient prefers this language (over other
@@ -388,11 +388,11 @@ export interface PatientLink {
   /**
    * The other patient resource that the link refers to.
    */
-  other?: Reference<Patient | RelatedPerson>;
+  other: Reference<Patient | RelatedPerson>;
 
   /**
    * The type of link between this patient resource and another patient
    * resource.
    */
-  type?: 'replaced-by' | 'replaces' | 'refer' | 'seealso';
+  type: 'replaced-by' | 'replaces' | 'refer' | 'seealso';
 }

--- a/packages/fhirtypes/dist/PaymentNotice.d.ts
+++ b/packages/fhirtypes/dist/PaymentNotice.d.ts
@@ -106,7 +106,7 @@ export interface PaymentNotice {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * Reference of resource for which payment is being made.
@@ -121,7 +121,7 @@ export interface PaymentNotice {
   /**
    * The date when this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * The practitioner who is responsible for the services rendered to the
@@ -132,7 +132,7 @@ export interface PaymentNotice {
   /**
    * A reference to the payment which is the subject of this notice.
    */
-  payment?: Reference<PaymentReconciliation>;
+  payment: Reference<PaymentReconciliation>;
 
   /**
    * The date when the above payment action occurred.
@@ -148,12 +148,12 @@ export interface PaymentNotice {
   /**
    * The party who is notified of the payment status.
    */
-  recipient?: Reference<Organization>;
+  recipient: Reference<Organization>;
 
   /**
    * The amount sent to the payee.
    */
-  amount?: Money;
+  amount: Money;
 
   /**
    * A code indicating whether payment has been sent or cleared.

--- a/packages/fhirtypes/dist/PaymentReconciliation.d.ts
+++ b/packages/fhirtypes/dist/PaymentReconciliation.d.ts
@@ -107,7 +107,7 @@ export interface PaymentReconciliation {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * The period of time for which payments have been gathered into this
@@ -118,7 +118,7 @@ export interface PaymentReconciliation {
   /**
    * The date when the resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * The party who generated the payment.
@@ -150,12 +150,12 @@ export interface PaymentReconciliation {
   /**
    * The date of payment as indicated on the financial instrument.
    */
-  paymentDate?: string;
+  paymentDate: string;
 
   /**
    * Total payment amount as indicated on the financial instrument.
    */
-  paymentAmount?: Money;
+  paymentAmount: Money;
 
   /**
    * Issuer's unique identifier for the payment instrument.
@@ -236,7 +236,7 @@ export interface PaymentReconciliationDetail {
   /**
    * Code to indicate the nature of the payment.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * A resource, such as a Claim, the evaluation of which could lead to

--- a/packages/fhirtypes/dist/Person.d.ts
+++ b/packages/fhirtypes/dist/Person.d.ts
@@ -196,7 +196,7 @@ export interface PersonLink {
   /**
    * The resource to which this actual person is associated.
    */
-  target?: Reference<Patient | Practitioner | RelatedPerson | Person>;
+  target: Reference<Patient | Practitioner | RelatedPerson | Person>;
 
   /**
    * Level of assurance that this link is associated with the target

--- a/packages/fhirtypes/dist/PlanDefinition.d.ts
+++ b/packages/fhirtypes/dist/PlanDefinition.d.ts
@@ -170,7 +170,7 @@ export interface PlanDefinition {
    * The status of this plan definition. Enables tracking the life-cycle of
    * the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this plan definition is authored for
@@ -610,7 +610,7 @@ export interface PlanDefinitionActionCondition {
   /**
    * The kind of condition.
    */
-  kind?: 'applicability' | 'start' | 'stop';
+  kind: 'applicability' | 'start' | 'stop';
 
   /**
    * An expression that returns true or false, indicating whether the
@@ -725,7 +725,7 @@ export interface PlanDefinitionActionParticipant {
   /**
    * The type of participant in the action.
    */
-  type?: 'patient' | 'practitioner' | 'related-person' | 'device';
+  type: 'patient' | 'practitioner' | 'related-person' | 'device';
 
   /**
    * The role the participant should play in performing the described
@@ -778,12 +778,12 @@ export interface PlanDefinitionActionRelatedAction {
   /**
    * The element id of the related action.
    */
-  actionId?: string;
+  actionId: string;
 
   /**
    * The relationship of this action to the related action.
    */
-  relationship?: 'before-start' | 'before' | 'before-end' | 'concurrent-with-start' | 'concurrent' |
+  relationship: 'before-start' | 'before' | 'before-end' | 'concurrent-with-start' | 'concurrent' |
       'concurrent-with-end' | 'after-start' | 'after' | 'after-end';
 
   /**
@@ -852,7 +852,7 @@ export interface PlanDefinitionGoal {
    * objective of care, such as &quot;control blood pressure&quot; or &quot;negotiate an
    * obstacle course&quot; or &quot;dance with child at wedding&quot;.
    */
-  description?: CodeableConcept;
+  description: CodeableConcept;
 
   /**
    * Identifies the expected level of importance associated with

--- a/packages/fhirtypes/dist/Practitioner.d.ts
+++ b/packages/fhirtypes/dist/Practitioner.d.ts
@@ -209,7 +209,7 @@ export interface PractitionerQualification {
   /**
    * Coded representation of the qualification.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * Period during which the qualification is valid.

--- a/packages/fhirtypes/dist/PractitionerRole.d.ts
+++ b/packages/fhirtypes/dist/PractitionerRole.d.ts
@@ -292,7 +292,7 @@ export interface PractitionerRoleNotAvailable {
    * The reason that can be presented to the user as to why this time is
    * not available.
    */
-  description?: string;
+  description: string;
 
   /**
    * Service is not available (seasonally or for a public holiday) from

--- a/packages/fhirtypes/dist/Procedure.d.ts
+++ b/packages/fhirtypes/dist/Procedure.d.ts
@@ -154,7 +154,7 @@ export interface Procedure {
    * A code specifying the state of the procedure. Generally, this will be
    * the in-progress or completed state.
    */
-  status?: 'preparation' | 'in-progress' | 'not-done' | 'on-hold' | 'stopped' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'preparation' | 'in-progress' | 'not-done' | 'on-hold' | 'stopped' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Captures the reason for the current state of the procedure.
@@ -176,7 +176,7 @@ export interface Procedure {
   /**
    * The person, animal or group on which the procedure was performed.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The Encounter during which this Procedure was created or performed or
@@ -371,7 +371,7 @@ export interface ProcedureFocalDevice {
   /**
    * The device that was manipulated (changed) during the procedure.
    */
-  manipulated?: Reference<Device>;
+  manipulated: Reference<Device>;
 }
 
 /**
@@ -423,7 +423,7 @@ export interface ProcedurePerformer {
   /**
    * The practitioner who was involved in the procedure.
    */
-  actor?: Reference<Practitioner | PractitionerRole | Organization | Patient | RelatedPerson | Device>;
+  actor: Reference<Practitioner | PractitionerRole | Organization | Patient | RelatedPerson | Device>;
 
   /**
    * The organization the device or practitioner was acting on behalf of.

--- a/packages/fhirtypes/dist/ProductShelfLife.d.ts
+++ b/packages/fhirtypes/dist/ProductShelfLife.d.ts
@@ -62,7 +62,7 @@ export interface ProductShelfLife {
    * using an appropriate controlled vocabulary The controlled term and the
    * controlled term identifier shall be specified.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The shelf life time period can be specified using a numerical value
@@ -71,7 +71,7 @@ export interface ProductShelfLife {
    * resulting terminology The symbol and the symbol identifier shall be
    * used.
    */
-  period?: Quantity;
+  period: Quantity;
 
   /**
    * Special precautions for storage, if any, can be specified using an

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -108,7 +108,7 @@ export interface ProjectSecret {
   /**
    * The secret name.
    */
-  name?: string;
+  name: string;
 
   /**
    * The secret value.
@@ -140,7 +140,7 @@ export interface ProjectSite {
    * Friendly name that will make it easy for you to identify the site in
    * the future.
    */
-  name?: string;
+  name: string;
 
   /**
    * The list of domain names associated with the site. User authentication
@@ -149,7 +149,7 @@ export interface ProjectSite {
    * subdomain.example.com. A valid domain requires a host and must not
    * include any path, port, query or fragment.
    */
-  domain?: string[];
+  domain: string[];
 
   /**
    * The publicly visible Google Client ID for the site. This is used to

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -55,7 +55,7 @@ export interface ProjectMembership {
   /**
    * Project where the memberships are available.
    */
-  project?: Reference<Project>;
+  project: Reference<Project>;
 
   /**
    * The project administrator who invited the user to the project.
@@ -65,13 +65,13 @@ export interface ProjectMembership {
   /**
    * User that is granted access to the project.
    */
-  user?: Reference<Bot | ClientApplication | User>;
+  user: Reference<Bot | ClientApplication | User>;
 
   /**
    * Reference to the resource that represents the user profile within the
    * project.
    */
-  profile?: Reference<Bot | ClientApplication | Patient | Practitioner | RelatedPerson>;
+  profile: Reference<Bot | ClientApplication | Patient | Practitioner | RelatedPerson>;
 
   /**
    * A String that is an identifier for the resource as defined by the
@@ -120,7 +120,7 @@ export interface ProjectMembershipAccess {
    * The base access policy used as a template.  Variables in the template
    * access policy are replaced by the values in the parameter.
    */
-  policy?: Reference<AccessPolicy>;
+  policy: Reference<AccessPolicy>;
 
   /**
    * User options that control the display of the application.
@@ -136,7 +136,7 @@ export interface ProjectMembershipAccessParameter {
   /**
    * The unique name of the parameter.
    */
-  name?: string;
+  name: string;
 
   /**
    * Value of the parameter - must be one of a constrained set of the data

--- a/packages/fhirtypes/dist/Provenance.d.ts
+++ b/packages/fhirtypes/dist/Provenance.d.ts
@@ -116,7 +116,7 @@ export interface Provenance {
    * target if multiple resources were created/updated by the same
    * activity.
    */
-  target?: Reference<Resource>[];
+  target: Reference<Resource>[];
 
   /**
    * The period during which the activity occurred.
@@ -131,7 +131,7 @@ export interface Provenance {
   /**
    * The instant of time at which the activity was recorded.
    */
-  recorded?: string;
+  recorded: string;
 
   /**
    * Policy or plan the activity was defined by. Typically, a single
@@ -161,7 +161,7 @@ export interface Provenance {
    * An actor taking a role in an activity  for which it can be assigned
    * some degree of responsibility for the activity taking place.
    */
-  agent?: ProvenanceAgent[];
+  agent: ProvenanceAgent[];
 
   /**
    * An entity used in this activity.
@@ -230,7 +230,7 @@ export interface ProvenanceAgent {
   /**
    * The individual, device or organization that participated in the event.
    */
-  who?: Reference<Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization>;
+  who: Reference<Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization>;
 
   /**
    * The individual, device, or organization for whom the change was made.
@@ -281,13 +281,13 @@ export interface ProvenanceEntity {
   /**
    * How the entity was used during the activity.
    */
-  role?: 'derivation' | 'revision' | 'quotation' | 'source' | 'removal';
+  role: 'derivation' | 'revision' | 'quotation' | 'source' | 'removal';
 
   /**
    * Identity of the  Entity used. May be a logical or physical uri and
    * maybe absolute or relative.
    */
-  what?: Reference<Resource>;
+  what: Reference<Resource>;
 
   /**
    * The entity is attributed to an agent to express the agent's

--- a/packages/fhirtypes/dist/Questionnaire.d.ts
+++ b/packages/fhirtypes/dist/Questionnaire.d.ts
@@ -152,7 +152,7 @@ export interface Questionnaire {
    * The status of this questionnaire. Enables tracking the life-cycle of
    * the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this questionnaire is authored for
@@ -299,7 +299,7 @@ export interface QuestionnaireItem {
    * An identifier that is unique within the Questionnaire allowing linkage
    * to the equivalent item in a QuestionnaireResponse resource.
    */
-  linkId?: string;
+  linkId: string;
 
   /**
    * This element is a URI that refers to an
@@ -345,8 +345,8 @@ export interface QuestionnaireItem {
    * grouping of other items or a particular type of data to be captured
    * (string, integer, coded choice, etc.).
    */
-  type?: 'group' | 'display' | 'question' | 'boolean' | 'decimal' | 'integer' | 'date' | 'dateTime' | 'time' |
-      'string' | 'text' | 'url' | 'choice' | 'open-choice' | 'attachment' | 'reference' | 'quantity';
+  type: 'group' | 'display' | 'question' | 'boolean' | 'decimal' | 'integer' | 'date' | 'dateTime' | 'time' | 'string'
+      | 'text' | 'url' | 'choice' | 'open-choice' | 'attachment' | 'reference' | 'quantity';
 
   /**
    * A constraint indicating that this item should only be enabled
@@ -534,12 +534,12 @@ export interface QuestionnaireItemEnableWhen {
    * The linkId for the question whose answer (or lack of answer) governs
    * whether this item is enabled.
    */
-  question?: string;
+  question: string;
 
   /**
    * Specifies the criteria by which the question is enabled.
    */
-  operator?: 'exists' | '=' | '!=' | '>' | '<' | '>=' | '<=';
+  operator: 'exists' | '=' | '!=' | '>' | '<' | '>=' | '<=';
 
   /**
    * A value that the referenced question is tested using the specified

--- a/packages/fhirtypes/dist/QuestionnaireResponse.d.ts
+++ b/packages/fhirtypes/dist/QuestionnaireResponse.d.ts
@@ -138,7 +138,7 @@ export interface QuestionnaireResponse {
    * The position of the questionnaire response within its overall
    * lifecycle.
    */
-  status?: 'in-progress' | 'completed' | 'amended' | 'entered-in-error' | 'stopped';
+  status: 'in-progress' | 'completed' | 'amended' | 'entered-in-error' | 'stopped';
 
   /**
    * The subject of the questionnaire response.  This could be a patient,
@@ -221,7 +221,7 @@ export interface QuestionnaireResponseItem {
    * The item from the Questionnaire that corresponds to this item in the
    * QuestionnaireResponse resource.
    */
-  linkId?: string;
+  linkId: string;
 
   /**
    * A reference to an [ElementDefinition](elementdefinition.html) that

--- a/packages/fhirtypes/dist/RelatedArtifact.d.ts
+++ b/packages/fhirtypes/dist/RelatedArtifact.d.ts
@@ -31,7 +31,7 @@ export interface RelatedArtifact {
   /**
    * The type of relationship to the related artifact.
    */
-  type?: 'documentation' | 'justification' | 'citation' | 'predecessor' | 'successor' | 'derived-from' | 'depends-on' | 'composed-of';
+  type: 'documentation' | 'justification' | 'citation' | 'predecessor' | 'successor' | 'derived-from' | 'depends-on' | 'composed-of';
 
   /**
    * A short label that can be used to reference the citation from

--- a/packages/fhirtypes/dist/RelatedPerson.d.ts
+++ b/packages/fhirtypes/dist/RelatedPerson.d.ts
@@ -113,7 +113,7 @@ export interface RelatedPerson {
   /**
    * The patient this person is related to.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * The nature of the relationship between a patient and the related
@@ -213,7 +213,7 @@ export interface RelatedPersonCommunication {
    * upper case; e.g. &quot;en&quot; for English, or &quot;en-US&quot; for American English
    * versus &quot;en-EN&quot; for England English.
    */
-  language?: CodeableConcept;
+  language: CodeableConcept;
 
   /**
    * Indicates whether or not the patient prefers this language (over other

--- a/packages/fhirtypes/dist/RequestGroup.d.ts
+++ b/packages/fhirtypes/dist/RequestGroup.d.ts
@@ -156,13 +156,13 @@ export interface RequestGroup {
    * The current state of the request. For request groups, the status
    * reflects the status of all the requests in the group.
    */
-  status?: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Indicates the level of authority/intentionality associated with the
    * request and where the request fits into the workflow chain.
    */
-  intent?: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
+  intent: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
 
   /**
    * Indicates how quickly the request should be addressed with respect to
@@ -435,7 +435,7 @@ export interface RequestGroupActionCondition {
   /**
    * The kind of condition.
    */
-  kind?: 'applicability' | 'start' | 'stop';
+  kind: 'applicability' | 'start' | 'stop';
 
   /**
    * An expression that returns true or false, indicating whether or not
@@ -488,12 +488,12 @@ export interface RequestGroupActionRelatedAction {
   /**
    * The element id of the action this is related to.
    */
-  actionId?: string;
+  actionId: string;
 
   /**
    * The relationship of this action to the related action.
    */
-  relationship?: 'before-start' | 'before' | 'before-end' | 'concurrent-with-start' | 'concurrent' |
+  relationship: 'before-start' | 'before' | 'before-end' | 'concurrent-with-start' | 'concurrent' |
       'concurrent-with-end' | 'after-start' | 'after' | 'after-end';
 
   /**

--- a/packages/fhirtypes/dist/ResearchDefinition.d.ts
+++ b/packages/fhirtypes/dist/ResearchDefinition.d.ts
@@ -162,7 +162,7 @@ export interface ResearchDefinition {
    * The status of this research definition. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this research definition is authored
@@ -319,7 +319,7 @@ export interface ResearchDefinition {
    * A reference to a ResearchElementDefinition resource that defines the
    * population for the research.
    */
-  population?: Reference<ResearchElementDefinition>;
+  population: Reference<ResearchElementDefinition>;
 
   /**
    * A reference to a ResearchElementDefinition resource that defines the

--- a/packages/fhirtypes/dist/ResearchElementDefinition.d.ts
+++ b/packages/fhirtypes/dist/ResearchElementDefinition.d.ts
@@ -166,7 +166,7 @@ export interface ResearchElementDefinition {
    * The status of this research element definition. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this research element definition is
@@ -326,7 +326,7 @@ export interface ResearchElementDefinition {
    * The type of research element, a population, an exposure, or an
    * outcome.
    */
-  type?: 'population' | 'exposure' | 'outcome';
+  type: 'population' | 'exposure' | 'outcome';
 
   /**
    * The type of the outcome (e.g. Dichotomous, Continuous, or
@@ -338,7 +338,7 @@ export interface ResearchElementDefinition {
    * A characteristic that defines the members of the research element.
    * Multiple characteristics are applied with &quot;and&quot; semantics.
    */
-  characteristic?: ResearchElementDefinitionCharacteristic[];
+  characteristic: ResearchElementDefinitionCharacteristic[];
 }
 
 /**

--- a/packages/fhirtypes/dist/ResearchStudy.d.ts
+++ b/packages/fhirtypes/dist/ResearchStudy.d.ts
@@ -134,7 +134,7 @@ export interface ResearchStudy {
   /**
    * The current state of the study.
    */
-  status?: 'active' | 'administratively-completed' | 'approved' | 'closed-to-accrual' |
+  status: 'active' | 'administratively-completed' | 'approved' | 'closed-to-accrual' |
       'closed-to-accrual-and-intervention' | 'completed' | 'disapproved' | 'in-review' | 'temporarily-closed-to-accrual' |
       'temporarily-closed-to-accrual-and-intervention' | 'withdrawn';
 
@@ -303,7 +303,7 @@ export interface ResearchStudyArm {
   /**
    * Unique, human-readable label for this arm of the study.
    */
-  name?: string;
+  name: string;
 
   /**
    * Categorization of study arm, e.g. experimental, active comparator,

--- a/packages/fhirtypes/dist/ResearchSubject.d.ts
+++ b/packages/fhirtypes/dist/ResearchSubject.d.ts
@@ -104,7 +104,7 @@ export interface ResearchSubject {
   /**
    * The current state of the subject.
    */
-  status?: 'candidate' | 'eligible' | 'follow-up' | 'ineligible' | 'not-registered' | 'off-study' | 'on-study' |
+  status: 'candidate' | 'eligible' | 'follow-up' | 'ineligible' | 'not-registered' | 'off-study' | 'on-study' |
       'on-study-intervention' | 'on-study-observation' | 'pending-on-study' | 'potential-candidate' | 'screening' |
       'withdrawn';
 
@@ -117,12 +117,12 @@ export interface ResearchSubject {
   /**
    * Reference to the study the subject is participating in.
    */
-  study?: Reference<ResearchStudy>;
+  study: Reference<ResearchStudy>;
 
   /**
    * The record of the person or animal who is involved in the study.
    */
-  individual?: Reference<Patient>;
+  individual: Reference<Patient>;
 
   /**
    * The name of the arm in the study the subject is expected to follow as

--- a/packages/fhirtypes/dist/RiskAssessment.d.ts
+++ b/packages/fhirtypes/dist/RiskAssessment.d.ts
@@ -126,7 +126,7 @@ export interface RiskAssessment {
    * The status of the RiskAssessment, using the same statuses as an
    * Observation.
    */
-  status?: 'registered' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'cancelled' | 'entered-in-error' | 'unknown';
+  status: 'registered' | 'preliminary' | 'final' | 'amended' | 'corrected' | 'cancelled' | 'entered-in-error' | 'unknown';
 
   /**
    * The algorithm, process or mechanism used to evaluate the risk.
@@ -141,7 +141,7 @@ export interface RiskAssessment {
   /**
    * The patient or group the risk assessment applies to.
    */
-  subject?: Reference<Patient | Group>;
+  subject: Reference<Patient | Group>;
 
   /**
    * The encounter where the assessment was performed.

--- a/packages/fhirtypes/dist/RiskEvidenceSynthesis.d.ts
+++ b/packages/fhirtypes/dist/RiskEvidenceSynthesis.d.ts
@@ -147,7 +147,7 @@ export interface RiskEvidenceSynthesis {
    * The status of this risk evidence synthesis. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * The date  (and optionally time) when the risk evidence synthesis was
@@ -277,7 +277,7 @@ export interface RiskEvidenceSynthesis {
    * A reference to a EvidenceVariable resource that defines the population
    * for the research.
    */
-  population?: Reference<EvidenceVariable>;
+  population: Reference<EvidenceVariable>;
 
   /**
    * A reference to a EvidenceVariable resource that defines the exposure
@@ -289,7 +289,7 @@ export interface RiskEvidenceSynthesis {
    * A reference to a EvidenceVariable resomece that defines the outcome
    * for the research.
    */
-  outcome?: Reference<EvidenceVariable>;
+  outcome: Reference<EvidenceVariable>;
 
   /**
    * A description of the size of the sample involved in the synthesis.

--- a/packages/fhirtypes/dist/SampledData.d.ts
+++ b/packages/fhirtypes/dist/SampledData.d.ts
@@ -32,12 +32,12 @@ export interface SampledData {
    * The base quantity that a measured value of zero represents. In
    * addition, this provides the units of the entire measurement series.
    */
-  origin?: Quantity;
+  origin: Quantity;
 
   /**
    * The length of time between sampling times, measured in milliseconds.
    */
-  period?: number;
+  period: number;
 
   /**
    * A correction factor that is applied to the sampled data points before
@@ -64,7 +64,7 @@ export interface SampledData {
    * greater than one, then the dimensions will be interlaced - all the
    * sample points for a point in time will be recorded at once.
    */
-  dimensions?: number;
+  dimensions: number;
 
   /**
    * A series of data points which are decimal values separated by a single

--- a/packages/fhirtypes/dist/Schedule.d.ts
+++ b/packages/fhirtypes/dist/Schedule.d.ts
@@ -133,7 +133,7 @@ export interface Schedule {
    * Slots that reference this schedule resource provide the availability
    * details to these referenced resource(s).
    */
-  actor?: Reference<Patient | Practitioner | PractitionerRole | RelatedPerson | Device | HealthcareService | Location>[];
+  actor: Reference<Patient | Practitioner | PractitionerRole | RelatedPerson | Device | HealthcareService | Location>[];
 
   /**
    * The period of time that the slots that reference this Schedule

--- a/packages/fhirtypes/dist/SearchParameter.d.ts
+++ b/packages/fhirtypes/dist/SearchParameter.d.ts
@@ -103,7 +103,7 @@ export interface SearchParameter {
    * can be the target of a canonical reference. It SHALL remain the same
    * when the search parameter is stored on different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * The identifier that is used to identify this version of the search
@@ -121,7 +121,7 @@ export interface SearchParameter {
    * should be usable as an identifier for the module by machine processing
    * applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * Where this search parameter is originally defined. If a derivedFrom is
@@ -136,7 +136,7 @@ export interface SearchParameter {
    * The status of this search parameter. Enables tracking the life-cycle
    * of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this search parameter is authored for
@@ -168,7 +168,7 @@ export interface SearchParameter {
   /**
    * And how it used.
    */
-  description?: string;
+  description: string;
 
   /**
    * The content was developed with a focus and intent of supporting the
@@ -195,19 +195,19 @@ export interface SearchParameter {
    * The code used in the URL or the parameter name in a parameters
    * resource for this search parameter.
    */
-  code?: string;
+  code: string;
 
   /**
    * The base resource type(s) that this search parameter can be used
    * against.
    */
-  base?: ResourceType[];
+  base: ResourceType[];
 
   /**
    * The type of value that a search parameter may contain, and how the
    * content is interpreted.
    */
-  type?: 'number' | 'date' | 'string' | 'token' | 'reference' | 'composite' | 'quantity' | 'uri' | 'special';
+  type: 'number' | 'date' | 'string' | 'token' | 'reference' | 'composite' | 'quantity' | 'uri' | 'special';
 
   /**
    * A FHIRPath expression that returns a set of elements for the search
@@ -315,11 +315,11 @@ export interface SearchParameterComponent {
   /**
    * The definition of the search parameter that describes this part.
    */
-  definition?: string;
+  definition: string;
 
   /**
    * A sub-expression that defines how to extract values for this component
    * from the output of the main SearchParameter.expression.
    */
-  expression?: string;
+  expression: string;
 }

--- a/packages/fhirtypes/dist/ServiceRequest.d.ts
+++ b/packages/fhirtypes/dist/ServiceRequest.d.ts
@@ -161,13 +161,13 @@ export interface ServiceRequest {
   /**
    * The status of the order.
    */
-  status?: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
+  status: 'draft' | 'active' | 'on-hold' | 'revoked' | 'completed' | 'entered-in-error' | 'unknown';
 
   /**
    * Whether the request is a proposal, plan, an original order or a reflex
    * order.
    */
-  intent?: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
+  intent: 'proposal' | 'plan' | 'directive' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
 
   /**
    * A code that classifies the service for searching, sorting and display
@@ -230,7 +230,7 @@ export interface ServiceRequest {
    * or animals, devices such as dialysis machines, or even locations
    * (typically for environmental scans).
    */
-  subject?: Reference<Patient | Group | Location | Device>;
+  subject: Reference<Patient | Group | Location | Device>;
 
   /**
    * An encounter that provides additional information about the healthcare

--- a/packages/fhirtypes/dist/Signature.d.ts
+++ b/packages/fhirtypes/dist/Signature.d.ts
@@ -45,18 +45,18 @@ export interface Signature {
    * can be used when determining accountability for various actions
    * concerning the document.
    */
-  type?: Coding[];
+  type: Coding[];
 
   /**
    * When the digital signature was signed.
    */
-  when?: string;
+  when: string;
 
   /**
    * A reference to an application-usable description of the identity that
    * signed  (e.g. the signature used their private key).
    */
-  who?: Reference<Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization>;
+  who: Reference<Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization>;
 
   /**
    * A reference to an application-usable description of the identity that

--- a/packages/fhirtypes/dist/Slot.d.ts
+++ b/packages/fhirtypes/dist/Slot.d.ts
@@ -129,22 +129,22 @@ export interface Slot {
    * The schedule resource that this slot defines an interval of status
    * information.
    */
-  schedule?: Reference<Schedule>;
+  schedule: Reference<Schedule>;
 
   /**
    * busy | free | busy-unavailable | busy-tentative | entered-in-error.
    */
-  status?: 'busy' | 'free' | 'busy-unavailable' | 'busy-tentative' | 'entered-in-error';
+  status: 'busy' | 'free' | 'busy-unavailable' | 'busy-tentative' | 'entered-in-error';
 
   /**
    * Date/Time that the slot is to begin.
    */
-  start?: string;
+  start: string;
 
   /**
    * Date/Time that the slot is to conclude.
    */
-  end?: string;
+  end: string;
 
   /**
    * This slot has already been overbooked, appointments are unlikely to be

--- a/packages/fhirtypes/dist/SpecimenDefinition.d.ts
+++ b/packages/fhirtypes/dist/SpecimenDefinition.d.ts
@@ -182,7 +182,7 @@ export interface SpecimenDefinitionTypeTested {
   /**
    * The preference for this type of conditioned specimen.
    */
-  preference?: 'preferred' | 'alternate';
+  preference: 'preferred' | 'alternate';
 
   /**
    * The specimen's container.

--- a/packages/fhirtypes/dist/StructureDefinition.d.ts
+++ b/packages/fhirtypes/dist/StructureDefinition.d.ts
@@ -107,7 +107,7 @@ export interface StructureDefinition {
    * SHALL remain the same when the structure definition is stored on
    * different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * A formal identifier that is used to identify this structure definition
@@ -132,7 +132,7 @@ export interface StructureDefinition {
    * name should be usable as an identifier for the module by machine
    * processing applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * A short, descriptive, user-friendly title for the structure
@@ -144,7 +144,7 @@ export interface StructureDefinition {
    * The status of this structure definition. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this structure definition is authored
@@ -232,7 +232,7 @@ export interface StructureDefinition {
   /**
    * Defines the kind of structure that this definition is describing.
    */
-  kind?: 'primitive-type' | 'complex-type' | 'resource' | 'logical';
+  kind: 'primitive-type' | 'complex-type' | 'resource' | 'logical';
 
   /**
    * Whether structure this definition describes is abstract or not  - that
@@ -240,7 +240,7 @@ export interface StructureDefinition {
    * Resources and Data types, abstract types will never be exchanged
    * between systems.
    */
-  abstract?: boolean;
+  abstract: boolean;
 
   /**
    * Identifies the types of resource or data type elements to which the
@@ -266,7 +266,7 @@ export interface StructureDefinition {
    * to http://hl7.org/fhir/StructureDefinition/string. Absolute URLs are
    * only allowed in logical models.
    */
-  type?: string;
+  type: string;
 
   /**
    * An absolute URI that is the base structure from which this type is
@@ -337,13 +337,13 @@ export interface StructureDefinitionContext {
    * Defines how to interpret the expression that defines what the context
    * of the extension is.
    */
-  type?: 'fhirpath' | 'element' | 'extension';
+  type: 'fhirpath' | 'element' | 'extension';
 
   /**
    * An expression that defines where an extension can be used in
    * resources.
    */
-  expression?: string;
+  expression: string;
 }
 
 /**
@@ -390,7 +390,7 @@ export interface StructureDefinitionDifferential {
   /**
    * Captures constraints on each element within the resource.
    */
-  element?: ElementDefinition[];
+  element: ElementDefinition[];
 }
 
 /**
@@ -437,7 +437,7 @@ export interface StructureDefinitionMapping {
    * An Internal id that is used to identify this mapping set when specific
    * mappings are made.
    */
-  identity?: string;
+  identity: string;
 
   /**
    * An absolute URI that identifies the specification that this mapping is
@@ -501,5 +501,5 @@ export interface StructureDefinitionSnapshot {
   /**
    * Captures constraints on each element within the resource.
    */
-  element?: ElementDefinition[];
+  element: ElementDefinition[];
 }

--- a/packages/fhirtypes/dist/StructureMap.d.ts
+++ b/packages/fhirtypes/dist/StructureMap.d.ts
@@ -129,7 +129,7 @@ export interface StructureMap {
    * be the target of a canonical reference. It SHALL remain the same when
    * the structure map is stored on different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * A formal identifier that is used to identify this structure map when
@@ -154,7 +154,7 @@ export interface StructureMap {
    * should be usable as an identifier for the module by machine processing
    * applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * A short, descriptive, user-friendly title for the structure map.
@@ -165,7 +165,7 @@ export interface StructureMap {
    * The status of this structure map. Enables tracking the life-cycle of
    * the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this structure map is authored for
@@ -244,7 +244,7 @@ export interface StructureMap {
    * Organizes the mapping into manageable chunks for human review/ease of
    * maintenance.
    */
-  group?: StructureMapGroup[];
+  group: StructureMapGroup[];
 }
 
 /**
@@ -291,7 +291,7 @@ export interface StructureMapGroup {
   /**
    * A unique name for the group for the convenience of human readers.
    */
-  name?: string;
+  name: string;
 
   /**
    * Another group that this group adds rules to.
@@ -302,7 +302,7 @@ export interface StructureMapGroup {
    * If this is the default rule set to apply for the source type or this
    * combination of types.
    */
-  typeMode?: 'none' | 'types' | 'type-and-types';
+  typeMode: 'none' | 'types' | 'type-and-types';
 
   /**
    * Additional supporting documentation that explains the purpose of the
@@ -314,12 +314,12 @@ export interface StructureMapGroup {
    * A name assigned to an instance of data. The instance must be provided
    * when the mapping is invoked.
    */
-  input?: StructureMapGroupInput[];
+  input: StructureMapGroupInput[];
 
   /**
    * Transform Rule from source to target.
    */
-  rule?: StructureMapGroupRule[];
+  rule: StructureMapGroupRule[];
 }
 
 /**
@@ -366,7 +366,7 @@ export interface StructureMapGroupInput {
   /**
    * Name for this instance of data.
    */
-  name?: string;
+  name: string;
 
   /**
    * Type for this instance of data.
@@ -376,7 +376,7 @@ export interface StructureMapGroupInput {
   /**
    * Mode for this instance of data.
    */
-  mode?: 'source' | 'target';
+  mode: 'source' | 'target';
 
   /**
    * Documentation for this instance of data.
@@ -427,12 +427,12 @@ export interface StructureMapGroupRule {
   /**
    * Name of the rule for internal references.
    */
-  name?: string;
+  name: string;
 
   /**
    * Source inputs to the mapping.
    */
-  source?: StructureMapGroupRuleSource[];
+  source: StructureMapGroupRuleSource[];
 
   /**
    * Content to create because of this mapping rule.
@@ -498,12 +498,12 @@ export interface StructureMapGroupRuleDependent {
   /**
    * Name of a rule or group to apply.
    */
-  name?: string;
+  name: string;
 
   /**
    * Variable to pass to the rule or group.
    */
-  variable?: string[];
+  variable: string[];
 }
 
 /**
@@ -549,7 +549,7 @@ export interface StructureMapGroupRuleSource {
   /**
    * Type or variable this rule applies to.
    */
-  context?: string;
+  context: string;
 
   /**
    * Specified minimum cardinality for the element. This is optional; if
@@ -1046,12 +1046,12 @@ export interface StructureMapStructure {
   /**
    * The canonical reference to the structure.
    */
-  url?: string;
+  url: string;
 
   /**
    * How the referenced structure is used in this mapping.
    */
-  mode?: 'source' | 'queried' | 'target' | 'produced';
+  mode: 'source' | 'queried' | 'target' | 'produced';
 
   /**
    * The name used for this type in the map.

--- a/packages/fhirtypes/dist/Subscription.d.ts
+++ b/packages/fhirtypes/dist/Subscription.d.ts
@@ -99,7 +99,7 @@ export interface Subscription {
    * The status of the subscription, which marks the server state for
    * managing the subscription.
    */
-  status?: 'requested' | 'active' | 'error' | 'off';
+  status: 'requested' | 'active' | 'error' | 'off';
 
   /**
    * Contact details for a human to contact about the subscription. The
@@ -115,13 +115,13 @@ export interface Subscription {
   /**
    * A description of why this subscription is defined.
    */
-  reason?: string;
+  reason: string;
 
   /**
    * The rules that the server should use to determine when to generate
    * notifications for this subscription.
    */
-  criteria?: string;
+  criteria: string;
 
   /**
    * A record of the last error that occurred when the server processed a
@@ -133,7 +133,7 @@ export interface Subscription {
    * Details where to send notifications when resources are received that
    * meet the criteria.
    */
-  channel?: SubscriptionChannel;
+  channel: SubscriptionChannel;
 }
 
 /**
@@ -180,7 +180,7 @@ export interface SubscriptionChannel {
   /**
    * The type of channel to send notifications on.
    */
-  type?: 'rest-hook' | 'websocket' | 'email' | 'sms' | 'message';
+  type: 'rest-hook' | 'websocket' | 'email' | 'sms' | 'message';
 
   /**
    * The url that describes the actual end-point to send messages to.

--- a/packages/fhirtypes/dist/SubscriptionStatus.d.ts
+++ b/packages/fhirtypes/dist/SubscriptionStatus.d.ts
@@ -102,7 +102,7 @@ export interface SubscriptionStatus {
   /**
    * The type of event being conveyed with this notificaiton.
    */
-  type?: string;
+  type: string;
 
   /**
    * The total number of actual events which have been generated since the
@@ -121,7 +121,7 @@ export interface SubscriptionStatus {
   /**
    * The reference to the Subscription which generated this notification.
    */
-  subscription?: Reference<Subscription>;
+  subscription: Reference<Subscription>;
 
   /**
    * The reference to the SubscriptionTopic for the Subscription which
@@ -181,7 +181,7 @@ export interface SubscriptionStatusNotificationEvent {
    * The sequential number of this event in this subscription context. Note
    * that this value is a 64-bit integer value, encoded as a string.
    */
-  eventNumber?: string;
+  eventNumber: string;
 
   /**
    * The actual time this event occured on the server.

--- a/packages/fhirtypes/dist/Substance.d.ts
+++ b/packages/fhirtypes/dist/Substance.d.ts
@@ -113,7 +113,7 @@ export interface Substance {
   /**
    * A code (or set of codes) that identify this substance.
    */
-  code?: CodeableConcept;
+  code: CodeableConcept;
 
   /**
    * A description of the substance - its appearance, handling

--- a/packages/fhirtypes/dist/SubstanceSpecification.d.ts
+++ b/packages/fhirtypes/dist/SubstanceSpecification.d.ts
@@ -394,7 +394,7 @@ export interface SubstanceSpecificationName {
   /**
    * The actual name.
    */
-  name?: string;
+  name: string;
 
   /**
    * Name type.

--- a/packages/fhirtypes/dist/SupplyRequest.d.ts
+++ b/packages/fhirtypes/dist/SupplyRequest.d.ts
@@ -152,7 +152,7 @@ export interface SupplyRequest {
   /**
    * The amount that is being ordered of the indicated item.
    */
-  quantity?: Quantity;
+  quantity: Quantity;
 
   /**
    * Specific parameters for the ordered item.  For example, the size of

--- a/packages/fhirtypes/dist/Task.d.ts
+++ b/packages/fhirtypes/dist/Task.d.ts
@@ -176,7 +176,7 @@ export interface Task {
   /**
    * The current status of the task.
    */
-  status?: 'draft' | 'requested' | 'received' | 'accepted' | 'rejected' | 'ready' | 'cancelled' | 'in-progress' |
+  status: 'draft' | 'requested' | 'received' | 'accepted' | 'rejected' | 'ready' | 'cancelled' | 'in-progress' |
       'on-hold' | 'failed' | 'completed' | 'entered-in-error';
 
   /**
@@ -194,7 +194,7 @@ export interface Task {
    * i+R[9]Cs this a proposed task, a planned task, an actionable task,
    * etc.
    */
-  intent?: 'unknown' | 'proposal' | 'plan' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
+  intent: 'unknown' | 'proposal' | 'plan' | 'order' | 'original-order' | 'reflex-order' | 'filler-order' | 'instance-order' | 'option';
 
   /**
    * Indicates how quickly the Task should be addressed with respect to
@@ -361,7 +361,7 @@ export interface TaskInput {
    * A code or description indicating how the input is intended to be used
    * as part of the task execution.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The value of the input parameter as a basic type.
@@ -657,7 +657,7 @@ export interface TaskOutput {
   /**
    * The name of the Output parameter.
    */
-  type?: CodeableConcept;
+  type: CodeableConcept;
 
   /**
    * The value of the Output parameter as a basic type.

--- a/packages/fhirtypes/dist/TerminologyCapabilities.d.ts
+++ b/packages/fhirtypes/dist/TerminologyCapabilities.d.ts
@@ -135,7 +135,7 @@ export interface TerminologyCapabilities {
    * The status of this terminology capabilities. Enables tracking the
    * life-cycle of the content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this terminology capabilities is
@@ -151,7 +151,7 @@ export interface TerminologyCapabilities {
    * change when the substantive content of the terminology capabilities
    * changes.
    */
-  date?: string;
+  date: string;
 
   /**
    * The name of the organization or individual that published the
@@ -209,7 +209,7 @@ export interface TerminologyCapabilities {
    * instance of software) or a class of implementation (e.g. a desired
    * purchase).
    */
-  kind?: 'instance' | 'capability' | 'requirements';
+  kind: 'instance' | 'capability' | 'requirements';
 
   /**
    * Software that is covered by this terminology capability statement.  It
@@ -490,12 +490,12 @@ export interface TerminologyCapabilitiesCodeSystemVersionFilter {
   /**
    * Code of the property supported.
    */
-  code?: string;
+  code: string;
 
   /**
    * Operations supported for the property.
    */
-  op?: string[];
+  op: string[];
 }
 
 /**
@@ -608,7 +608,7 @@ export interface TerminologyCapabilitiesExpansionParameter {
   /**
    * Expansion Parameter name.
    */
-  name?: string;
+  name: string;
 
   /**
    * Description of support for parameter.
@@ -662,7 +662,7 @@ export interface TerminologyCapabilitiesImplementation {
    * Information about the specific installation that this terminology
    * capability statement relates to.
    */
-  description?: string;
+  description: string;
 
   /**
    * An absolute base URL for the implementation.
@@ -715,7 +715,7 @@ export interface TerminologyCapabilitiesSoftware {
   /**
    * Name the software is known by.
    */
-  name?: string;
+  name: string;
 
   /**
    * The version identifier for the software covered by this statement.
@@ -768,7 +768,7 @@ export interface TerminologyCapabilitiesTranslation {
   /**
    * Whether the client must identify the map.
    */
-  needsMap?: boolean;
+  needsMap: boolean;
 }
 
 /**
@@ -816,5 +816,5 @@ export interface TerminologyCapabilitiesValidateCode {
   /**
    * Whether translations are validated.
    */
-  translations?: boolean;
+  translations: boolean;
 }

--- a/packages/fhirtypes/dist/TestReport.d.ts
+++ b/packages/fhirtypes/dist/TestReport.d.ts
@@ -107,19 +107,19 @@ export interface TestReport {
   /**
    * The current state of this test report.
    */
-  status?: 'completed' | 'in-progress' | 'waiting' | 'stopped' | 'entered-in-error';
+  status: 'completed' | 'in-progress' | 'waiting' | 'stopped' | 'entered-in-error';
 
   /**
    * Ideally this is an absolute URL that is used to identify the
    * version-specific TestScript that was executed, matching the
    * `TestScript.url`.
    */
-  testScript?: Reference<TestScript>;
+  testScript: Reference<TestScript>;
 
   /**
    * The overall result from the execution of the TestScript.
    */
-  result?: 'pass' | 'fail' | 'pending';
+  result: 'pass' | 'fail' | 'pending';
 
   /**
    * The final score (percentage of tests passed) resulting from the
@@ -205,12 +205,12 @@ export interface TestReportParticipant {
   /**
    * The type of participant.
    */
-  type?: 'test-engine' | 'client' | 'server';
+  type: 'test-engine' | 'client' | 'server';
 
   /**
    * The uri of the participant. An absolute URL is preferred.
    */
-  uri?: string;
+  uri: string;
 
   /**
    * The display name of the participant.
@@ -262,7 +262,7 @@ export interface TestReportSetup {
   /**
    * Action would contain either an operation or an assertion.
    */
-  action?: TestReportSetupAction[];
+  action: TestReportSetupAction[];
 }
 
 /**
@@ -359,7 +359,7 @@ export interface TestReportSetupActionAssert {
   /**
    * The result of this assertion.
    */
-  result?: 'pass' | 'skip' | 'fail' | 'warning' | 'error';
+  result: 'pass' | 'skip' | 'fail' | 'warning' | 'error';
 
   /**
    * An explanatory message associated with the result.
@@ -415,7 +415,7 @@ export interface TestReportSetupActionOperation {
   /**
    * The result of this operation.
    */
-  result?: 'pass' | 'skip' | 'fail' | 'warning' | 'error';
+  result: 'pass' | 'skip' | 'fail' | 'warning' | 'error';
 
   /**
    * An explanatory message associated with the result.
@@ -472,7 +472,7 @@ export interface TestReportTeardown {
   /**
    * The teardown action will only contain an operation.
    */
-  action?: TestReportTeardownAction[];
+  action: TestReportTeardownAction[];
 }
 
 /**
@@ -518,7 +518,7 @@ export interface TestReportTeardownAction {
   /**
    * An operation would involve a REST request to a server.
    */
-  operation?: TestReportSetupActionOperation;
+  operation: TestReportSetupActionOperation;
 }
 
 /**
@@ -576,7 +576,7 @@ export interface TestReportTest {
   /**
    * Action would contain either an operation or an assertion.
    */
-  action?: TestReportTestAction[];
+  action: TestReportTestAction[];
 }
 
 /**

--- a/packages/fhirtypes/dist/TestScript.d.ts
+++ b/packages/fhirtypes/dist/TestScript.d.ts
@@ -105,7 +105,7 @@ export interface TestScript {
    * be the target of a canonical reference. It SHALL remain the same when
    * the test script is stored on different servers.
    */
-  url?: string;
+  url: string;
 
   /**
    * A formal identifier that is used to identify this test script when it
@@ -130,7 +130,7 @@ export interface TestScript {
    * be usable as an identifier for the module by machine processing
    * applications such as code generation.
    */
-  name?: string;
+  name: string;
 
   /**
    * A short, descriptive, user-friendly title for the test script.
@@ -141,7 +141,7 @@ export interface TestScript {
    * The status of this test script. Enables tracking the life-cycle of the
    * content.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this test script is authored for
@@ -301,12 +301,12 @@ export interface TestScriptDestination {
    * Abstract name given to a destination server in this test script.  The
    * name is provided as a number starting at 1.
    */
-  index?: number;
+  index: number;
 
   /**
    * The type of destination profile the test system supports.
    */
-  profile?: Coding;
+  profile: Coding;
 }
 
 /**
@@ -356,7 +356,7 @@ export interface TestScriptFixture {
    * during setup, therefore no create operation is required for this
    * fixture in the TestScript.setup section.
    */
-  autocreate?: boolean;
+  autocreate: boolean;
 
   /**
    * Whether or not to implicitly delete the fixture during teardown. If
@@ -364,7 +364,7 @@ export interface TestScriptFixture {
    * during teardown, therefore no delete operation is required for this
    * fixture in the TestScript.teardown section.
    */
-  autodelete?: boolean;
+  autodelete: boolean;
 
   /**
    * Reference to the resource (containing the contents of the resource
@@ -423,7 +423,7 @@ export interface TestScriptMetadata {
    * Capabilities that must exist and are assumed to function correctly on
    * the FHIR server being tested.
    */
-  capability?: TestScriptMetadataCapability[];
+  capability: TestScriptMetadataCapability[];
 }
 
 /**
@@ -471,13 +471,13 @@ export interface TestScriptMetadataCapability {
    * Whether or not the test execution will require the given capabilities
    * of the server in order for this test script to execute.
    */
-  required?: boolean;
+  required: boolean;
 
   /**
    * Whether or not the test execution will validate the given capabilities
    * of the server in order for this test script to execute.
    */
-  validated?: boolean;
+  validated: boolean;
 
   /**
    * Description of the capabilities that this test script is requiring the
@@ -506,7 +506,7 @@ export interface TestScriptMetadataCapability {
    * successfully.   If server does not meet at a minimum the referenced
    * capability statement, then all tests in this script are skipped.
    */
-  capabilities?: string;
+  capabilities: string;
 }
 
 /**
@@ -553,7 +553,7 @@ export interface TestScriptMetadataLink {
    * URL to a particular requirement or feature within the FHIR
    * specification.
    */
-  url?: string;
+  url: string;
 
   /**
    * Short description of the link.
@@ -606,12 +606,12 @@ export interface TestScriptOrigin {
    * Abstract name given to an origin server in this test script.  The name
    * is provided as a number starting at 1.
    */
-  index?: number;
+  index: number;
 
   /**
    * The type of origin profile the test system supports.
    */
-  profile?: Coding;
+  profile: Coding;
 }
 
 /**
@@ -657,7 +657,7 @@ export interface TestScriptSetup {
   /**
    * Action would contain either an operation or an assertion.
    */
-  action?: TestScriptSetupAction[];
+  action: TestScriptSetupAction[];
 }
 
 /**
@@ -880,7 +880,7 @@ export interface TestScriptSetupActionAssert {
    * Whether or not the test execution will produce a warning only on error
    * for this assert.
    */
-  warningOnly?: boolean;
+  warningOnly: boolean;
 }
 
 /**
@@ -968,7 +968,7 @@ export interface TestScriptSetupActionOperation {
    * to false when communicating with a server that does not support
    * encoded url paths.
    */
-  encodeRequestUrl?: boolean;
+  encodeRequestUrl: boolean;
 
   /**
    * The HTTP method the test engine MUST use for this operation regardless
@@ -1063,12 +1063,12 @@ export interface TestScriptSetupActionOperationRequestHeader {
   /**
    * The HTTP header field e.g. &quot;Accept&quot;.
    */
-  field?: string;
+  field: string;
 
   /**
    * The value of the header e.g. &quot;application/fhir+xml&quot;.
    */
-  value?: string;
+  value: string;
 }
 
 /**
@@ -1115,7 +1115,7 @@ export interface TestScriptTeardown {
   /**
    * The teardown action will only contain an operation.
    */
-  action?: TestScriptTeardownAction[];
+  action: TestScriptTeardownAction[];
 }
 
 /**
@@ -1161,7 +1161,7 @@ export interface TestScriptTeardownAction {
   /**
    * An operation would involve a REST request to a server.
    */
-  operation?: TestScriptSetupActionOperation;
+  operation: TestScriptSetupActionOperation;
 }
 
 /**
@@ -1219,7 +1219,7 @@ export interface TestScriptTest {
   /**
    * Action would contain either an operation or an assertion.
    */
-  action?: TestScriptTestAction[];
+  action: TestScriptTestAction[];
 }
 
 /**
@@ -1318,7 +1318,7 @@ export interface TestScriptVariable {
   /**
    * Descriptive name for this variable.
    */
-  name?: string;
+  name: string;
 
   /**
    * A default, hard-coded, or user-defined value for this variable.

--- a/packages/fhirtypes/dist/TriggerDefinition.d.ts
+++ b/packages/fhirtypes/dist/TriggerDefinition.d.ts
@@ -35,7 +35,7 @@ export interface TriggerDefinition {
   /**
    * The type of triggering event.
    */
-  type?: 'named-event' | 'periodic' | 'data-changed' | 'data-added' | 'data-modified' | 'data-removed' | 'data-accessed' | 'data-access-ended';
+  type: 'named-event' | 'periodic' | 'data-changed' | 'data-added' | 'data-modified' | 'data-removed' | 'data-accessed' | 'data-access-ended';
 
   /**
    * A formal name for the event. This may be an absolute URI that

--- a/packages/fhirtypes/dist/UsageContext.d.ts
+++ b/packages/fhirtypes/dist/UsageContext.d.ts
@@ -46,7 +46,7 @@ export interface UsageContext {
    * A code that identifies the type of context being specified by this
    * usage context.
    */
-  code?: Coding;
+  code: Coding;
 
   /**
    * A value that defines the context specified in this context of use. The

--- a/packages/fhirtypes/dist/User.d.ts
+++ b/packages/fhirtypes/dist/User.d.ts
@@ -47,13 +47,13 @@ export interface User {
    * The first name or given name of the user. This is the value as entered
    * when the user is created. It is used to populate the profile resource.
    */
-  firstName?: string;
+  firstName: string;
 
   /**
    * The last name or family name of the user. This is the value as entered
    * when the user is created. It is used to populate the profile resource.
    */
-  lastName?: string;
+  lastName: string;
 
   /**
    * DEPRECATED Replaced by ProjectMembership.externalId.

--- a/packages/fhirtypes/dist/UserConfiguration.d.ts
+++ b/packages/fhirtypes/dist/UserConfiguration.d.ts
@@ -70,7 +70,7 @@ export interface UserConfigurationMenu {
   /**
    * Title of the menu.
    */
-  title?: string;
+  title: string;
 
   /**
    * Shortcut links to URLs.
@@ -86,12 +86,12 @@ export interface UserConfigurationMenuLink {
   /**
    * The human friendly name of the link.
    */
-  name?: string;
+  name: string;
 
   /**
    * The URL target of the link.
    */
-  target?: string;
+  target: string;
 }
 
 /**
@@ -102,7 +102,7 @@ export interface UserConfigurationOption {
   /**
    * The unique identifier of the option.
    */
-  id?: string;
+  id: string;
 
   /**
    * Value of option - must be one of a constrained set of the data types
@@ -143,11 +143,11 @@ export interface UserConfigurationSearch {
   /**
    * The human friendly name of the link.
    */
-  name?: string;
+  name: string;
 
   /**
    * The rules that the server should use to determine which resources to
    * return.
    */
-  criteria?: string;
+  criteria: string;
 }

--- a/packages/fhirtypes/dist/ValueSet.d.ts
+++ b/packages/fhirtypes/dist/ValueSet.d.ts
@@ -144,7 +144,7 @@ export interface ValueSet {
    * definition (ValueSet.compose) and the associated ValueSet metadata.
    * Expansions do not have a state.
    */
-  status?: 'draft' | 'active' | 'retired' | 'unknown';
+  status: 'draft' | 'active' | 'retired' | 'unknown';
 
   /**
    * A Boolean value to indicate that this value set is authored for
@@ -295,7 +295,7 @@ export interface ValueSetCompose {
   /**
    * Include one or more codes from a code system or other value set(s).
    */
-  include?: ValueSetComposeInclude[];
+  include: ValueSetComposeInclude[];
 
   /**
    * Exclude one or more codes from the value set based on code system
@@ -421,7 +421,7 @@ export interface ValueSetComposeIncludeConcept {
   /**
    * Specifies a code for the concept to be included or excluded.
    */
-  code?: string;
+  code: string;
 
   /**
    * The text to display to the user for this concept in the context of
@@ -493,7 +493,7 @@ export interface ValueSetComposeIncludeConceptDesignation {
   /**
    * The text value for this designation.
    */
-  value?: string;
+  value: string;
 }
 
 /**
@@ -543,12 +543,12 @@ export interface ValueSetComposeIncludeFilter {
    * A code that identifies a property or a filter defined in the code
    * system.
    */
-  property?: string;
+  property: string;
 
   /**
    * The kind of operation to perform as a part of the filter criteria.
    */
-  op?: '=' | 'is-a' | 'descendent-of' | 'is-not-a' | 'regex' | 'in' | 'not-in' | 'generalizes' | 'exists';
+  op: '=' | 'is-a' | 'descendent-of' | 'is-not-a' | 'regex' | 'in' | 'not-in' | 'generalizes' | 'exists';
 
   /**
    * The match value may be either a code defined by the system, or a
@@ -558,7 +558,7 @@ export interface ValueSetComposeIncludeFilter {
    * filter defined in CodeSystem) when the operation is 'regex', or one of
    * the values (true and false), when the operation is 'exists'.
    */
-  value?: string;
+  value: string;
 }
 
 /**
@@ -616,7 +616,7 @@ export interface ValueSetExpansion {
   /**
    * The time at which the expansion was produced by the expanding system.
    */
-  timestamp?: string;
+  timestamp: string;
 
   /**
    * The total number of concepts in the expansion. If the number of
@@ -791,7 +791,7 @@ export interface ValueSetExpansionParameter {
    * server-assigned name for additional default or other server-supplied
    * parameters used to control the expansion process.
    */
-  name?: string;
+  name: string;
 
   /**
    * The value of the parameter.

--- a/packages/fhirtypes/dist/VerificationResult.d.ts
+++ b/packages/fhirtypes/dist/VerificationResult.d.ts
@@ -117,7 +117,7 @@ export interface VerificationResult {
    * The validation status of the target (attested; validated; in process;
    * requires revalidation; validation failed; revalidation failed).
    */
-  status?: 'attested' | 'validated' | 'in-process' | 'req-revalid' | 'val-fail' | 'reval-fail';
+  status: 'attested' | 'validated' | 'in-process' | 'req-revalid' | 'val-fail' | 'reval-fail';
 
   /**
    * When the validation status was updated.
@@ -384,7 +384,7 @@ export interface VerificationResultValidator {
   /**
    * Reference to the organization validating information.
    */
-  organization?: Reference<Organization>;
+  organization: Reference<Organization>;
 
   /**
    * A digital identity certificate associated with the validator.

--- a/packages/fhirtypes/dist/VisionPrescription.d.ts
+++ b/packages/fhirtypes/dist/VisionPrescription.d.ts
@@ -107,18 +107,18 @@ export interface VisionPrescription {
   /**
    * The status of the resource instance.
    */
-  status?: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
+  status: 'active' | 'cancelled' | 'draft' | 'entered-in-error';
 
   /**
    * The date this resource was created.
    */
-  created?: string;
+  created: string;
 
   /**
    * A resource reference to the person to whom the vision prescription
    * applies.
    */
-  patient?: Reference<Patient>;
+  patient: Reference<Patient>;
 
   /**
    * A reference to a resource that identifies the particular occurrence of
@@ -130,19 +130,19 @@ export interface VisionPrescription {
   /**
    * The date (and perhaps time) when the prescription was written.
    */
-  dateWritten?: string;
+  dateWritten: string;
 
   /**
    * The healthcare professional responsible for authorizing the
    * prescription.
    */
-  prescriber?: Reference<Practitioner | PractitionerRole>;
+  prescriber: Reference<Practitioner | PractitionerRole>;
 
   /**
    * Contain the details of  the individual lens specifications and serves
    * as the authorization for the fullfillment by certified professionals.
    */
-  lensSpecification?: VisionPrescriptionLensSpecification[];
+  lensSpecification: VisionPrescriptionLensSpecification[];
 }
 
 /**
@@ -190,12 +190,12 @@ export interface VisionPrescriptionLensSpecification {
    * Identifies the type of vision correction product which is required for
    * the patient.
    */
-  product?: CodeableConcept;
+  product: CodeableConcept;
 
   /**
    * The eye for which the lens specification applies.
    */
-  eye?: 'right' | 'left';
+  eye: 'right' | 'left';
 
   /**
    * Lens power measured in dioptres (0.25 units).
@@ -302,10 +302,10 @@ export interface VisionPrescriptionLensSpecificationPrism {
   /**
    * Amount of prism to compensate for eye alignment in fractional units.
    */
-  amount?: number;
+  amount: number;
 
   /**
    * The relative base, or reference lens edge, for the prism.
    */
-  base?: 'up' | 'down' | 'in' | 'out';
+  base: 'up' | 'down' | 'in' | 'out';
 }

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -155,7 +155,9 @@ function writeInterfaceProperty(
   for (const typeScriptProperty of getTypeScriptProperties(property, path, fhirType.name)) {
     b.newLine();
     generateJavadoc(b, property.description);
-    b.append(typeScriptProperty.name + '?: ' + typeScriptProperty.typeName + ';');
+    b.append(
+      typeScriptProperty.name + (typeScriptProperty.required ? '' : '?') + ': ' + typeScriptProperty.typeName + ';'
+    );
   }
 }
 
@@ -208,11 +210,13 @@ function getTypeScriptProperties(
   property: InternalSchemaElement,
   path: string,
   typeName: string
-): { name: string; typeName: string }[] {
+): { name: string; typeName: string; required?: boolean }[] {
+  const required = property.min > 0;
+
   if ((typeName === 'BundleEntry' && path === 'resource') || (typeName === 'Reference' && path === 'resource')) {
-    return [{ name: 'resource', typeName: 'T' }];
+    return [{ name: 'resource', typeName: 'T', required }];
   } else if (typeName === 'Bundle' && path === 'entry') {
-    return [{ name: 'entry', typeName: 'BundleEntry<T>[]' }];
+    return [{ name: 'entry', typeName: 'BundleEntry<T>[]', required }];
   }
 
   const name = path.split('.').pop() as string;
@@ -231,6 +235,7 @@ function getTypeScriptProperties(
     result.push({
       name,
       typeName: getTypeScriptTypeForProperty(property, property.type?.[0] as ElementDefinitionType, path),
+      required,
     });
   }
 

--- a/packages/health-gorilla/src/requestgroupbuilder.ts
+++ b/packages/health-gorilla/src/requestgroupbuilder.ts
@@ -176,7 +176,7 @@ export class HealthGorillaRequestGroupBuilder {
       ...medplumCoverage,
       id: 'coverage' + this.coverages.length,
       beneficiary: createReference(this.patient),
-      payor: undefined,
+      payor: [],
       subscriber: undefined,
     };
 

--- a/packages/health-gorilla/src/utils.test.ts
+++ b/packages/health-gorilla/src/utils.test.ts
@@ -102,7 +102,9 @@ describe('Health Gorilla utils', () => {
   test('checkAbn', async () => {
     const medplum = new MockClient();
     const healthGorilla = new MockClient();
-    const requestGroup = await healthGorilla.createResource<RequestGroup>({ resourceType: 'RequestGroup' });
+    const requestGroup = await healthGorilla.createResource<RequestGroup>({
+      resourceType: 'RequestGroup',
+    } as RequestGroup);
 
     healthGorilla.router.router.add('GET', 'RequestGroup/:id/$abn', async () => {
       return [allOk, { resourceType: 'Parameters', parameter: [{ name: 'url', valueString: 'https://example.com' }] }];

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -1,16 +1,16 @@
 import {
-  allOk,
   ClientStorage,
   ContentType,
-  getReferenceString,
-  indexSearchParameterBundle,
-  indexStructureDefinitionBundle,
   LoginState,
+  MockAsyncClientStorage,
   NewPatientRequest,
   NewProjectRequest,
   NewUserRequest,
   OperationOutcomeError,
-  MockAsyncClientStorage,
+  allOk,
+  getReferenceString,
+  indexSearchParameterBundle,
+  indexStructureDefinitionBundle,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, CodeableConcept, Patient, SearchParameter, ServiceRequest } from '@medplum/fhirtypes';
@@ -473,7 +473,7 @@ describe('MockClient', () => {
     const resource1 = await client.createResource<ServiceRequest>({
       resourceType: 'ServiceRequest',
       orderDetail: [{ text: 'foo' }],
-    });
+    } as ServiceRequest);
     expect(resource1).toBeDefined();
 
     // Explicitly edit the resource in place

--- a/packages/mock/src/mocks/accesspolicy.ts
+++ b/packages/mock/src/mocks/accesspolicy.ts
@@ -9,6 +9,7 @@ export const ExampleAccessPolicy: AccessPolicy = {
 export const ExampleStatusValueSet: ValueSet = {
   resourceType: 'ValueSet',
   id: 'example-statuses',
+  status: 'active',
   compose: {
     include: [
       {

--- a/packages/mock/src/mocks/alice.ts
+++ b/packages/mock/src/mocks/alice.ts
@@ -77,7 +77,9 @@ export const makeDrAliceSmithSlots = lazy((): Slot[] => {
       result.push({
         resourceType: 'Slot',
         id: `slot-${day}-${hour}`,
+        status: 'free',
         start: slotDate.toISOString(),
+        end: new Date(slotDate.getTime() + 60 * 60 * 1000).toISOString(),
         schedule,
       });
     }

--- a/packages/mock/src/mocks/project.ts
+++ b/packages/mock/src/mocks/project.ts
@@ -11,6 +11,7 @@ export const TestProject: Project = {
 export const TestProjectMembersihp: ProjectMembership = {
   resourceType: 'ProjectMembership',
   id: '456',
+  user: { reference: 'User/123' },
   project: createReference(TestProject),
   profile: createReference(DrAliceSmith),
 };

--- a/packages/mock/src/mocks/questionnaire.ts
+++ b/packages/mock/src/mocks/questionnaire.ts
@@ -3,6 +3,7 @@ import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 export const ExampleQuestionnaire: Questionnaire = {
   resourceType: 'Questionnaire',
   id: '123',
+  status: 'active',
   name: 'Vitals',
   title: 'Vitals',
   subjectType: ['Patient'],
@@ -18,6 +19,7 @@ export const ExampleQuestionnaire: Questionnaire = {
 export const ExampleQuestionnaireResponse: QuestionnaireResponse = {
   resourceType: 'QuestionnaireResponse',
   id: '123',
+  status: 'completed',
   questionnaire: 'Questionnaire/123',
   subject: {
     reference: 'Patient/123',

--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -311,6 +311,8 @@ export const HomerEncounter: Encounter = {
       reference: 'Practitioner/123',
     },
   },
+  status: 'finished',
+  class: { code: 'AMB', display: 'ambulatory' },
 };
 
 export const HomerCommunication: Communication = {
@@ -322,6 +324,7 @@ export const HomerCommunication: Communication = {
       reference: 'Practitioner/123',
     },
   },
+  status: 'completed',
   encounter: createReference(HomerEncounter),
   payload: [
     {
@@ -339,6 +342,7 @@ export const HomerMedia: Media = {
       reference: 'Practitioner/123',
     },
   },
+  status: 'completed',
   encounter: createReference(HomerEncounter),
   content: {
     contentType: ContentType.TEXT,
@@ -475,6 +479,7 @@ export const HomerObservation6: Observation = {
   },
   component: [
     {
+      code: { text: 'Systolic' },
       valueQuantity: {
         value: 110,
         unit: 'mmHg',
@@ -482,6 +487,7 @@ export const HomerObservation6: Observation = {
       },
     },
     {
+      code: { text: 'Diastolic' },
       valueQuantity: {
         value: 75,
         unit: 'mmHg',
@@ -504,6 +510,7 @@ export const HomerObservation7: Observation = {
   },
   component: [
     {
+      code: { text: 'Glucose' },
       valueQuantity: {
         value: 1000,
         unit: 'mg/dL',
@@ -537,6 +544,7 @@ export const HomerObservation8: Observation = {
   },
   component: [
     {
+      code: { text: 'HIV' },
       valueString: 'REACTIVE',
     },
   ],
@@ -600,6 +608,7 @@ export const HomerServiceRequest: ServiceRequest = {
     display: 'Homer Simpson',
   },
   status: 'active',
+  intent: 'order',
   orderDetail: [
     {
       text: 'ORDERED',
@@ -619,6 +628,8 @@ export const HomerDiagnosticReport: DiagnosticReport = {
       reference: 'Practitioner/123',
     },
   },
+  status: 'final',
+  code: { text: 'Test Report' },
   subject: createReference(HomerSimpson),
   basedOn: [createReference(HomerServiceRequest)],
   specimen: [createReference(HomerSimpsonSpecimen)],

--- a/packages/mock/src/mocks/subscription.ts
+++ b/packages/mock/src/mocks/subscription.ts
@@ -6,6 +6,13 @@ export const ExampleSubscription: Subscription = {
   meta: {
     versionId: '456',
   },
+  status: 'active',
+  reason: 'Reason',
+  criteria: 'Criteria',
+  channel: {
+    type: 'rest-hook',
+    endpoint: 'https://example.com',
+  },
 };
 
 export const ExampleAuditEvent: AuditEvent = {
@@ -16,6 +23,24 @@ export const ExampleAuditEvent: AuditEvent = {
     versionId: '456',
     author: {
       reference: 'Practitioner/123',
+    },
+  },
+  type: {
+    system: 'http://terminology.hl7.org/CodeSystem/audit-event-type',
+    code: 'rest-hook',
+  },
+  recorded: new Date().toISOString(),
+  agent: [
+    {
+      requestor: true,
+      who: {
+        reference: 'Practitioner/123',
+      },
+    },
+  ],
+  source: {
+    observer: {
+      reference: 'Device/123',
     },
   },
 };

--- a/packages/mock/src/mocks/valueset.ts
+++ b/packages/mock/src/mocks/valueset.ts
@@ -2,7 +2,9 @@ import { ValueSet } from '@medplum/fhirtypes';
 
 export const exampleValueSet: ValueSet = {
   resourceType: 'ValueSet',
+  status: 'active',
   expansion: {
+    timestamp: '2021-01-01T00:00:00.000Z',
     contains: [
       {
         system: 'x',

--- a/packages/mock/src/mocks/workflow.ts
+++ b/packages/mock/src/mocks/workflow.ts
@@ -6,6 +6,7 @@ import { HomerSimpson } from './simpsons';
 export const ExampleWorkflowQuestionnaire1: Questionnaire = {
   resourceType: 'Questionnaire',
   id: 'workflow-questionnaire-1',
+  status: 'active',
   name: 'Patient Registration',
   title: 'Patient Registration',
   subjectType: ['Patient'],
@@ -21,6 +22,7 @@ export const ExampleWorkflowQuestionnaire1: Questionnaire = {
 export const ExampleWorkflowQuestionnaire2: Questionnaire = {
   resourceType: 'Questionnaire',
   id: 'workflow-questionnaire-2',
+  status: 'active',
   name: 'Surgery History',
   title: 'Surgery History',
   subjectType: ['Patient'],
@@ -36,6 +38,7 @@ export const ExampleWorkflowQuestionnaire2: Questionnaire = {
 export const ExampleWorkflowQuestionnaire3: Questionnaire = {
   resourceType: 'Questionnaire',
   id: 'workflow-questionnaire-3',
+  status: 'active',
   name: 'Family Health History',
   title: 'Family Health History',
   subjectType: ['Patient'],
@@ -51,6 +54,7 @@ export const ExampleWorkflowQuestionnaire3: Questionnaire = {
 export const ExampleWorkflowPlanDefinition: PlanDefinition = {
   resourceType: 'PlanDefinition',
   id: 'workflow-plan-definition-1',
+  status: 'active',
   title: 'Example Plan Definition',
   action: [
     {
@@ -71,6 +75,7 @@ export const ExampleWorkflowPlanDefinition: PlanDefinition = {
 export const ExampleWorkflowQuestionnaireResponse1: QuestionnaireResponse = {
   resourceType: 'QuestionnaireResponse',
   id: 'workflow-questionnaire-response-1',
+  status: 'completed',
   questionnaire: getReferenceString(ExampleWorkflowQuestionnaire1),
   subject: createReference(HomerSimpson),
   source: createReference(HomerSimpson),
@@ -81,28 +86,51 @@ export const ExampleWorkflowTask1: Task = {
   resourceType: 'Task',
   id: 'workflow-task-1',
   status: 'completed',
+  intent: 'order',
   meta: { author: createReference(HomerSimpson) },
   requester: createReference(DrAliceSmith),
-  input: [{ valueReference: createReference(ExampleWorkflowQuestionnaire1) }],
-  output: [{ valueReference: createReference(ExampleWorkflowQuestionnaireResponse1) }],
+  input: [
+    {
+      type: { text: 'Questionnaire' },
+      valueReference: createReference(ExampleWorkflowQuestionnaire1),
+    },
+  ],
+  output: [
+    {
+      type: { text: 'QuestionnaireResponse' },
+      valueReference: createReference(ExampleWorkflowQuestionnaireResponse1),
+    },
+  ],
 };
 
 export const ExampleWorkflowTask2: Task = {
   resourceType: 'Task',
   id: 'workflow-task-2',
   status: 'requested',
+  intent: 'order',
   meta: { author: createReference(DrAliceSmith) },
   requester: createReference(DrAliceSmith),
-  input: [{ valueReference: createReference(ExampleWorkflowQuestionnaire2) }],
+  input: [
+    {
+      type: { text: 'Questionnaire' },
+      valueReference: createReference(ExampleWorkflowQuestionnaire2),
+    },
+  ],
 };
 
 export const ExampleWorkflowTask3: Task = {
   resourceType: 'Task',
   id: 'workflow-task-3',
   status: 'requested',
+  intent: 'order',
   meta: { author: createReference(DrAliceSmith) },
   requester: createReference(DrAliceSmith),
-  input: [{ valueReference: createReference(ExampleWorkflowQuestionnaire3) }],
+  input: [
+    {
+      type: { text: 'Questionnaire' },
+      valueReference: createReference(ExampleWorkflowQuestionnaire3),
+    },
+  ],
 };
 
 export const ExampleWorkflowRequestGroup: RequestGroup = {
@@ -110,6 +138,7 @@ export const ExampleWorkflowRequestGroup: RequestGroup = {
   id: 'workflow-request-group-1',
   instantiatesCanonical: [getReferenceString(ExampleWorkflowPlanDefinition)],
   status: 'active',
+  intent: 'order',
   action: [
     {
       title: ExampleWorkflowQuestionnaire1.title,

--- a/packages/react-hooks/src/useResource/useResource.test.tsx
+++ b/packages/react-hooks/src/useResource/useResource.test.tsx
@@ -118,8 +118,11 @@ describe('useResource', () => {
     function TestComponentWrapper(): JSX.Element {
       const [resource, setResource] = useState<ServiceRequest>({
         resourceType: 'ServiceRequest',
-        status: 'draft',
         id: '123',
+        status: 'draft',
+        intent: 'order',
+        code: { text: 'test' },
+        subject: { reference: 'Patient/123' },
       });
       return (
         <>
@@ -154,8 +157,11 @@ describe('useResource', () => {
       useResource({ reference: 'ServiceRequest/123' });
       const [resource, setResource] = useState<ServiceRequest>({
         resourceType: 'ServiceRequest',
-        status: 'draft',
         id: '123',
+        status: 'draft',
+        intent: 'order',
+        code: { text: 'test' },
+        subject: { reference: 'Patient/123' },
       });
 
       return (

--- a/packages/react-hooks/src/useResource/useResource.ts
+++ b/packages/react-hooks/src/useResource/useResource.ts
@@ -11,7 +11,7 @@ import { useMedplum } from '../MedplumProvider/MedplumProvider.context';
  * @returns The resolved resource.
  */
 export function useResource<T extends Resource>(
-  value: Reference<T> | T | undefined,
+  value: Reference<T> | Partial<T> | undefined,
   setOutcome?: (outcome: OperationOutcome) => void
 ): T | undefined {
   const medplum = useMedplum();
@@ -68,11 +68,11 @@ export function useResource<T extends Resource>(
  */
 function getInitialResource<T extends Resource>(
   medplum: MedplumClient,
-  value: Reference<T> | T | undefined
+  value: Reference<T> | Partial<T> | undefined
 ): T | undefined {
   if (value) {
     if (isResource(value)) {
-      return value;
+      return value as T;
     }
 
     if (isReference(value)) {

--- a/packages/react/src/AnnotationInput/AnnotationInput.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.tsx
@@ -2,7 +2,7 @@ import { TextInput } from '@mantine/core';
 import { createReference } from '@medplum/core';
 import { Annotation } from '@medplum/fhirtypes';
 import { useMedplumProfile } from '@medplum/react-hooks';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 export interface AnnotationInputProps {
   name: string;
@@ -12,10 +12,7 @@ export interface AnnotationInputProps {
 
 export function AnnotationInput(props: AnnotationInputProps): JSX.Element {
   const author = useMedplumProfile();
-  const [value, setValue] = useState<Annotation>(props.defaultValue || {});
-
-  const valueRef = useRef<Annotation>();
-  valueRef.current = value;
+  const [value, setValue] = useState<Annotation>(props.defaultValue || ({} as Annotation));
 
   function setText(text: string): void {
     const newValue: Annotation = text
@@ -24,7 +21,7 @@ export function AnnotationInput(props: AnnotationInputProps): JSX.Element {
           authorReference: author && createReference(author),
           time: new Date().toISOString(),
         }
-      : {};
+      : ({} as Annotation);
 
     setValue(newValue);
     if (props.onChange) {

--- a/packages/react/src/CalendarInput/CalendarInput.test.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.test.tsx
@@ -54,7 +54,7 @@ describe('CalendarInput', () => {
         resourceType: 'Slot',
         start: startTime.toISOString(),
       },
-    ];
+    ] as Slot[];
 
     const onClick = jest.fn();
     render(<CalendarInput slots={slots} onChangeMonth={jest.fn()} onClick={onClick} />);

--- a/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
@@ -1,3 +1,4 @@
+import { badRequest } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { DateTimeInput } from './DateTimeInput';
@@ -16,18 +17,7 @@ describe('DateTimeInput', () => {
   });
 
   test('Renders aria invalid', () => {
-    const outcome: OperationOutcome = {
-      resourceType: 'OperationOutcome',
-      issue: [
-        {
-          details: {
-            text: 'Bad',
-          },
-          expression: ['test'],
-        },
-      ],
-    };
-
+    const outcome: OperationOutcome = badRequest('Bad', 'test');
     render(<DateTimeInput name="test" placeholder="Placeholder" outcome={outcome} />);
     const input = screen.getByPlaceholderText('Placeholder');
     expect(input).toBeDefined();

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { createReference } from '@medplum/core';
-import { DiagnosticReport } from '@medplum/fhirtypes';
+import { DiagnosticReport, Observation } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '../test-utils/render';
@@ -209,7 +209,7 @@ describe('DiagnosticReportDisplay', () => {
 
   test('No specimen header if no specimen', async () => {
     await act(async () => {
-      setup({ value: { resourceType: 'DiagnosticReport' } });
+      setup({ value: { resourceType: 'DiagnosticReport' } as DiagnosticReport });
     });
 
     expect(screen.getByText('Diagnostic Report')).toBeInTheDocument();
@@ -220,12 +220,13 @@ describe('DiagnosticReportDisplay', () => {
     // This is a technically valid Observation resource,
     // although it doesn't really make sense.
     // It uses "Observation Grouping" to create a cycle.
-    let obs = await medplum.createResource({ resourceType: 'Observation', valueString: 'XYZ' });
-    obs = await medplum.updateResource({ ...obs, hasMember: [createReference(obs)] });
+    let obs = await medplum.createResource({ resourceType: 'Observation', valueString: 'XYZ' } as Observation);
+    obs = await medplum.updateResource({ ...obs, hasMember: [createReference(obs)] } as Observation);
 
     const report: DiagnosticReport = {
       resourceType: 'DiagnosticReport',
       status: 'final',
+      code: { text: 'test' },
       subject: createReference(HomerSimpson),
       result: [createReference(obs)],
     };

--- a/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.stories.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.stories.tsx
@@ -13,6 +13,7 @@ export default {
 function createMeasure(title: string, url: string, subtitle?: string): Measure {
   return {
     resourceType: 'Measure',
+    status: 'active',
     url,
     title,
     subtitle,
@@ -46,7 +47,10 @@ export const Basic = (): JSX.Element => {
         measureReport={{
           resourceType: 'MeasureReport',
           id: 'basic-example',
-          measure: measure?.url,
+          measure: measure?.url as string,
+          status: 'complete',
+          type: 'individual',
+          period: { start: '2021-01-01', end: '2021-12-31' },
           group: [
             {
               id: 'group-1',
@@ -93,7 +97,10 @@ export const Multiple = (): JSX.Element => {
         measureReport={{
           resourceType: 'MeasureReport',
           id: 'basic-example',
-          measure: measure?.url,
+          measure: measure?.url as string,
+          status: 'complete',
+          type: 'individual',
+          period: { start: '2021-01-01', end: '2021-12-31' },
           group: [
             {
               id: 'group-1',
@@ -147,7 +154,10 @@ export const WithPopulation = (): JSX.Element => {
         measureReport={{
           resourceType: 'MeasureReport',
           id: 'basic-example',
-          measure: measure?.url,
+          measure: measure?.url as string,
+          status: 'complete',
+          type: 'individual',
+          period: { start: '2021-01-01', end: '2021-12-31' },
           group: [
             {
               id: 'group-1',

--- a/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.test.tsx
+++ b/packages/react/src/MeasureReportDisplay/MeasureReportDisplay.test.tsx
@@ -1,8 +1,8 @@
 import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
 import { act, render, screen } from '../test-utils/render';
 import { MeasureReportDisplay, MeasureReportDisplayProps } from './MeasureReportDisplay';
-import { MemoryRouter } from 'react-router-dom';
-import { MedplumProvider } from '@medplum/react-hooks';
 
 const medplum = new MockClient();
 
@@ -26,6 +26,7 @@ describe('MeasureReportDisplay', () => {
       title: 'Test Measure',
       subtitle: 'Test Subtitle',
       url: 'http://example.com',
+      status: 'active',
     });
   });
 
@@ -33,6 +34,10 @@ describe('MeasureReportDisplay', () => {
     await setup({
       measureReport: {
         resourceType: 'MeasureReport',
+        measure: 'http://example.com',
+        status: 'complete',
+        type: 'individual',
+        period: { start: '2021-01-01', end: '2021-12-31' },
         group: [
           {
             id: 'group-1',
@@ -52,6 +57,10 @@ describe('MeasureReportDisplay', () => {
     await setup({
       measureReport: {
         resourceType: 'MeasureReport',
+        measure: 'http://example.com',
+        status: 'complete',
+        type: 'individual',
+        period: { start: '2021-01-01', end: '2021-12-31' },
         group: [
           {
             id: 'group-1',
@@ -80,6 +89,9 @@ describe('MeasureReportDisplay', () => {
       measureReport: {
         resourceType: 'MeasureReport',
         measure: 'http://example.com',
+        status: 'complete',
+        type: 'individual',
+        period: { start: '2021-01-01', end: '2021-12-31' },
         group: [
           {
             id: 'group-1',
@@ -102,6 +114,10 @@ describe('MeasureReportDisplay', () => {
       measureReport: {
         resourceType: 'MeasureReport',
         id: 'basic-example',
+        measure: 'http://example.com',
+        status: 'complete',
+        type: 'individual',
+        period: { start: '2021-01-01', end: '2021-12-31' },
         group: [
           {
             id: 'group-1',
@@ -148,6 +164,10 @@ describe('MeasureReportDisplay', () => {
       measureReport: {
         resourceType: 'MeasureReport',
         id: 'insufficient-example',
+        measure: 'http://example.com',
+        status: 'complete',
+        type: 'individual',
+        period: { start: '2021-01-01', end: '2021-12-31' },
         group: [
           {
             id: 'group-1',
@@ -183,6 +203,10 @@ describe('MeasureReportDisplay', () => {
       measureReport: {
         resourceType: 'MeasureReport',
         id: 'insufficient-example',
+        measure: 'http://example.com',
+        status: 'complete',
+        type: 'individual',
+        period: { start: '2021-01-01', end: '2021-12-31' },
         group: [
           {
             id: 'group-1',

--- a/packages/react/src/PatientSummary/Allergies.test.tsx
+++ b/packages/react/src/PatientSummary/Allergies.test.tsx
@@ -38,7 +38,14 @@ describe('PatientSummary - Allergies', () => {
     await setup(
       <Allergies
         patient={HomerSimpson}
-        allergies={[{ resourceType: 'AllergyIntolerance', id: 'peanut', code: { text: 'Peanut' } }]}
+        allergies={[
+          {
+            resourceType: 'AllergyIntolerance',
+            id: 'peanut',
+            patient: { reference: 'Patient/123' },
+            code: { text: 'Peanut' },
+          },
+        ]}
       />
     );
     expect(screen.getByText('Allergies')).toBeInTheDocument();

--- a/packages/react/src/PatientSummary/Medications.test.tsx
+++ b/packages/react/src/PatientSummary/Medications.test.tsx
@@ -39,7 +39,14 @@ describe('PatientSummary - Medications', () => {
       <Medications
         patient={HomerSimpson}
         medicationRequests={[
-          { resourceType: 'MedicationRequest', id: 'peanut', medicationCodeableConcept: { text: 'Tylenol' } },
+          {
+            resourceType: 'MedicationRequest',
+            id: 'peanut',
+            status: 'active',
+            intent: 'order',
+            subject: { reference: 'Patient/123' },
+            medicationCodeableConcept: { text: 'Tylenol' },
+          },
         ]}
       />
     );

--- a/packages/react/src/PatientSummary/ProblemList.test.tsx
+++ b/packages/react/src/PatientSummary/ProblemList.test.tsx
@@ -38,7 +38,14 @@ describe('PatientSummary - ProblemList', () => {
     await setup(
       <ProblemList
         patient={HomerSimpson}
-        problems={[{ resourceType: 'Condition', id: 'peanut', code: { text: 'Peanut' } }]}
+        problems={[
+          {
+            resourceType: 'Condition',
+            id: 'peanut',
+            subject: { reference: 'Patient/123' },
+            code: { text: 'Peanut' },
+          },
+        ]}
       />
     );
     expect(screen.getByText('Problem List')).toBeInTheDocument();

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
@@ -16,7 +16,7 @@ import { killEvent } from '../utils/dom';
 import classes from './PlanDefinitionBuilder.module.css';
 
 export interface PlanDefinitionBuilderProps {
-  value: PlanDefinition | Reference<PlanDefinition>;
+  value: Partial<PlanDefinition> | Reference<PlanDefinition>;
   onSubmit: (result: PlanDefinition) => void;
 }
 
@@ -47,7 +47,7 @@ export function PlanDefinitionBuilder(props: PlanDefinitionBuilderProps): JSX.El
   }, [medplum]);
 
   useEffect(() => {
-    setValue(ensurePlanDefinitionKeys(defaultValue ?? { resourceType: 'PlanDefinition' }));
+    setValue(ensurePlanDefinitionKeys(defaultValue ?? { resourceType: 'PlanDefinition', status: 'active' }));
     document.addEventListener('mouseover', handleDocumentMouseOver);
     document.addEventListener('click', handleDocumentClick);
     return () => {

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -27,7 +27,7 @@ import {
 import classes from './QuestionnaireBuilder.module.css';
 
 export interface QuestionnaireBuilderProps {
-  questionnaire: Questionnaire | Reference<Questionnaire>;
+  questionnaire: Partial<Questionnaire> | Reference<Questionnaire>;
   onSubmit: (result: Questionnaire) => void;
   autoSave?: boolean;
 }
@@ -56,7 +56,7 @@ export function QuestionnaireBuilder(props: QuestionnaireBuilderProps): JSX.Elem
   }, [medplum]);
 
   useEffect(() => {
-    setValue(ensureQuestionnaireKeys(defaultValue ?? { resourceType: 'Questionnaire' }));
+    setValue(ensureQuestionnaireKeys(defaultValue ?? { resourceType: 'Questionnaire', status: 'active' }));
     document.addEventListener('mouseover', handleDocumentMouseOver);
     document.addEventListener('click', handleDocumentClick);
     return () => {
@@ -217,7 +217,14 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
           <>
             {resource.title && <Title>{resource.title}</Title>}
             {item.text && <div>{item.text}</div>}
-            {!isContainer && <QuestionnaireFormItem item={item} index={0} onChange={() => undefined} response={{}} />}
+            {!isContainer && (
+              <QuestionnaireFormItem
+                item={item}
+                index={0}
+                onChange={() => undefined}
+                response={{ linkId: item.linkId }}
+              />
+            )}
           </>
         )}
       </div>
@@ -530,7 +537,7 @@ function ReferenceProfiles(props: ReferenceTypeProps): JSX.Element {
               name="resourceType"
               placeholder="Resource Type"
               defaultValue={targetType}
-              onChange={(newValue: ResourceType | undefined) => {
+              onChange={(newValue) => {
                 props.onChange(
                   setQuestionnaireItemReferenceTargetTypes(
                     props.item,

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -53,6 +53,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
       },
       onSubmit: jest.fn(),
     });
@@ -63,6 +64,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'display',
@@ -82,6 +84,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'group1',
@@ -181,6 +184,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -275,6 +279,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
       },
       onSubmit,
     });
@@ -308,6 +313,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -337,6 +343,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -364,6 +371,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -418,6 +426,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -469,6 +478,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -518,6 +528,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -545,6 +556,7 @@ describe('QuestionnaireForm', () => {
   test('Attachment input', async () => {
     const questionnaire: Questionnaire = {
       resourceType: 'Questionnaire',
+      status: 'active',
       id: randomUUID(),
       item: [
         {
@@ -557,6 +569,7 @@ describe('QuestionnaireForm', () => {
 
     const expectedResponse: QuestionnaireResponse = {
       resourceType: 'QuestionnaireResponse',
+      status: 'completed',
       questionnaire: 'Questionnaire/' + questionnaire.id,
       source: {
         display: 'Alice Smith',
@@ -612,6 +625,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -639,6 +653,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -722,6 +737,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -764,6 +780,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -789,6 +806,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -842,6 +860,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -902,6 +921,7 @@ describe('QuestionnaireForm', () => {
       questionnaire: {
         id: 'groups-example',
         resourceType: 'Questionnaire',
+        status: 'active',
         title: 'Groups Example',
         item: [
           {
@@ -994,6 +1014,7 @@ describe('QuestionnaireForm', () => {
       questionnaire: {
         id: 'groups-example',
         resourceType: 'Questionnaire',
+        status: 'active',
         title: 'Groups Example',
         item: [
           {
@@ -1072,6 +1093,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'value-set-example',
         title: 'Valueset',
         item: [
@@ -1126,6 +1148,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'default-values',
         title: 'Default Values Example',
         item: [
@@ -1183,6 +1206,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'enable-when',
         title: 'Enable When Example',
         item: [
@@ -1243,6 +1267,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'multi-select',
         title: 'Multi Select Example',
         item: [
@@ -1327,6 +1352,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         item: [
           {
             linkId: 'q1',
@@ -1367,6 +1393,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'pages-example',
         title: 'Pages Example',
         item: [
@@ -1432,6 +1459,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'repeatable-when',
         title: 'repeatable Questionnaire',
         item: [
@@ -1476,6 +1504,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'no-answers',
         title: 'No Answers Example',
         item: [
@@ -1511,6 +1540,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'empty-answers',
         title: 'Empty Answers Example',
         item: [
@@ -1547,6 +1577,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'empty-radio',
         title: 'Empty Radio Example',
         item: [
@@ -1568,6 +1599,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        status: 'active',
         id: 'reference-filter',
         item: [
           {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -12,8 +12,8 @@ import { useMedplum, useResource } from '@medplum/react-hooks';
 import { useEffect, useState } from 'react';
 import { Form } from '../Form/Form';
 import { buildInitialResponse, getNumberOfPages, isQuestionEnabled } from '../utils/questionnaire';
-import { QuestionnairePageSequence } from './QuestionnaireFormComponents/QuestionnaireFormPageSequence';
 import { QuestionnaireFormContext } from './QuestionnaireForm.context';
+import { QuestionnairePageSequence } from './QuestionnaireFormComponents/QuestionnaireFormPageSequence';
 
 export interface QuestionnaireFormProps {
   questionnaire: Questionnaire | Reference<Questionnaire>;
@@ -52,6 +52,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
 
     const newResponse: QuestionnaireResponse = {
       resourceType: 'QuestionnaireResponse',
+      status: 'in-progress',
       item: mergedItems,
     };
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormComponents/QuestionnaireFormGroup.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormComponents/QuestionnaireFormGroup.tsx
@@ -58,10 +58,10 @@ export function QuestionnaireGroup(props: QuestionnaireGroupProps): JSX.Element 
     const newResponse = response.item?.map((current) => {
       const matchingItem = newResponseItem.find((newResponse) => newResponse.id === current.id);
       return matchingItem ?? current;
-    }) as QuestionnaireResponseItem[];
+    });
     // This checks to see if there were any nested repeated groups that we need to add
-    const mergedResponse = newResponse?.concat(newResponseItem.slice(1)) as QuestionnaireResponseItem;
-    const groupResponse = { ...response, item: mergedResponse } as QuestionnaireResponseItem;
+    const mergedResponse = newResponse?.concat(newResponseItem.slice(1));
+    const groupResponse = { ...response, item: mergedResponse };
     onChange([groupResponse]);
   }
 
@@ -92,7 +92,7 @@ export function QuestionnaireGroup(props: QuestionnaireGroupProps): JSX.Element 
                 key={item.linkId}
                 item={item}
                 checkForQuestionEnabled={checkForQuestionEnabled}
-                response={response.item?.find((i) => i.linkId === item.linkId) ?? {}}
+                response={response.item?.find((i) => i.linkId === item.linkId) ?? { linkId: item.linkId }}
                 onChange={onSetGroup}
               />
             );

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireRepeatableItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireRepeatableItem.tsx
@@ -14,7 +14,7 @@ interface QuestionnaireRepeatableItemProps {
 
 export function QuestionnaireRepeatableItem(props: QuestionnaireRepeatableItemProps): JSX.Element | null {
   const { item, response, onChange } = props;
-  const [number, setNumber] = useState(getNumberOfRepeats(item, response ?? {}));
+  const [number, setNumber] = useState(getNumberOfRepeats(item, response ?? { linkId: item.linkId }));
   if (!props.checkForQuestionEnabled(item)) {
     return null;
   }

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -86,7 +86,7 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
             console.error(`StructureDefinition.type missing for ${tt.value}`);
             newTargetType.error = 'StructureDefinition.type missing';
           } else {
-            newTargetType.resourceType = profile.type satisfies string;
+            newTargetType.resourceType = profile.type;
             newTargetType.name = profile.name;
             newTargetType.title = profile.title;
           }
@@ -246,18 +246,16 @@ function getInitialTargetType(
   return undefined;
 }
 
-type PartialStructureDefinition = Pick<StructureDefinition, 'type' | 'name' | 'title'>;
-
 interface ResourceTypeGraphQLResponse {
   readonly data: {
-    readonly StructureDefinitionList: PartialStructureDefinition[];
+    readonly StructureDefinitionList: Partial<StructureDefinition>[];
   };
 }
 
 async function fetchResourceTypeOfProfile(
   medplum: MedplumClient,
   profileUrl: string
-): Promise<PartialStructureDefinition | undefined> {
+): Promise<Partial<StructureDefinition> | undefined> {
   const profile = tryGetProfile(profileUrl);
   if (profile) {
     return { type: profile.type, name: profile.name, title: profile.title };

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.stories.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.stories.tsx
@@ -1,8 +1,9 @@
+import { ObservationDefinition } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
-import { ReferenceRangeEditor } from './ReferenceRangeEditor';
 import { HDLDefinition, KidneyLabDefinition, TestosteroneDefinition } from '../stories/referenceLab';
+import { ReferenceRangeEditor } from './ReferenceRangeEditor';
 
 export default {
   title: 'Medplum/ReferenceRangeEditor',
@@ -14,7 +15,7 @@ export const Empty = (): JSX.Element => {
     <Document>
       <ErrorBoundary>
         <ReferenceRangeEditor
-          definition={{ resourceType: 'ObservationDefinition' }}
+          definition={{ resourceType: 'ObservationDefinition' } as ObservationDefinition}
           onSubmit={(definition) => console.dir(definition, { depth: null })}
         />
       </ErrorBoundary>

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.test.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.test.tsx
@@ -32,7 +32,7 @@ describe('ReferenceRangeEditor', () => {
     await setup({
       definition: {
         resourceType: 'ObservationDefinition',
-      },
+      } as ObservationDefinition,
       onSubmit: jest.fn(),
     });
     const checkAddButton = screen.getByTitle('Add Group');
@@ -49,7 +49,7 @@ describe('ReferenceRangeEditor', () => {
     await setup({
       definition: {
         resourceType: 'ObservationDefinition',
-      },
+      } as ObservationDefinition,
       onSubmit,
     });
 
@@ -72,7 +72,7 @@ describe('ReferenceRangeEditor', () => {
     await setup({
       definition: {
         resourceType: 'ObservationDefinition',
-      },
+      } as ObservationDefinition,
       onSubmit,
     });
 
@@ -105,7 +105,7 @@ describe('ReferenceRangeEditor', () => {
     await setup({
       definition: {
         resourceType: 'ObservationDefinition',
-      },
+      } as ObservationDefinition,
       onSubmit,
     });
 

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
@@ -25,7 +25,10 @@ export type IntervalGroup = {
 };
 
 const defaultProps: ReferenceRangeEditorProps = {
-  definition: { resourceType: 'ObservationDefinition' },
+  definition: {
+    resourceType: 'ObservationDefinition',
+    code: { text: '' },
+  },
   onSubmit: () => {
     return undefined;
   },

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -1,6 +1,6 @@
 import { Table } from '@mantine/core';
 import { capitalize, evalFhirPathTyped, getSearchParameterDetails, toTypedValue } from '@medplum/core';
-import { Resource } from '@medplum/fhirtypes';
+import { Resource, SearchParameter } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { useEffect, useState } from 'react';
 import { createPatch } from 'rfc6902';
@@ -53,7 +53,7 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
             base: [props.original.resourceType],
             code: props.original.resourceType + '.' + fhirPath,
             expression: props.original.resourceType + '.' + fhirPath,
-          });
+          } as SearchParameter);
           const property = details?.elementDefinitions?.[0];
           const isArray = !!property?.isArray;
           const originalValue = op.op === 'add' ? undefined : evalFhirPathTyped(fhirPath, typedOriginal)?.[0];

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -1,9 +1,9 @@
 import { createReference } from '@medplum/core';
-import { Patient, Specimen } from '@medplum/fhirtypes';
+import { Observation, Patient, Specimen } from '@medplum/fhirtypes';
 import { HomerObservation1, MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
-import { convertIsoToLocal, convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { convertIsoToLocal, convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
+import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { ResourceForm, ResourceFormProps } from './ResourceForm';
 
 const medplum = new MockClient();
@@ -85,7 +85,7 @@ describe('ResourceForm', () => {
     await setup({
       defaultValue: {
         resourceType: 'Observation',
-      },
+      } as Observation,
       onSubmit,
     });
 
@@ -121,7 +121,7 @@ describe('ResourceForm', () => {
           value: 1,
           unit: 'kg',
         },
-      },
+      } as Observation,
       onSubmit,
     });
 

--- a/packages/react/src/ResourceForm/ResourceForm.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.tsx
@@ -7,7 +7,7 @@ import { BackboneElementInput } from '../BackboneElementInput/BackboneElementInp
 import { FormSection } from '../FormSection/FormSection';
 
 export interface ResourceFormProps {
-  defaultValue: Resource | Reference;
+  defaultValue: Partial<Resource> | Reference;
   outcome?: OperationOutcome;
   onSubmit: (resource: Resource) => void;
   onDelete?: (resource: Resource) => void;

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.stories.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.stories.tsx
@@ -54,6 +54,7 @@ export const WithComments = (): JSX.Element => (
       })}
       createMedia={(resource: Encounter, operator: ProfileResource, content: Attachment) => ({
         resourceType: 'Media',
+        status: 'completed',
         encounter: createReference(resource),
         subject: (resource as Encounter).subject,
         operator: createReference(operator),

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
@@ -102,6 +102,7 @@ describe('ResourceTimeline', () => {
       createCommunication: jest.fn(),
       createMedia: (resource: Encounter, operator: ProfileResource, content: Attachment) => ({
         resourceType: 'Media',
+        status: 'completed',
         encounter: createReference(resource),
         subject: (resource as Encounter).subject,
         operator: createReference(operator),

--- a/packages/react/src/SearchControl/SearchControlField.ts
+++ b/packages/react/src/SearchControl/SearchControlField.ts
@@ -75,7 +75,7 @@ function getFieldDefinition(resourceType: string, name: string): SearchControlFi
           name: '_lastUpdated',
           type: 'date',
           expression: 'Resource.meta.lastUpdated',
-        },
+        } as SearchParameter,
       ],
     };
   }
@@ -91,7 +91,7 @@ function getFieldDefinition(resourceType: string, name: string): SearchControlFi
           name: '_versionId',
           type: 'token',
           expression: 'Resource.meta.versionId',
-        },
+        } as SearchParameter,
       ],
     };
   }

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -1,11 +1,11 @@
 import { Button, Menu } from '@mantine/core';
-import { Filter, globalSchema, Operator, SearchRequest } from '@medplum/core';
+import { Filter, Operator, SearchRequest, globalSchema } from '@medplum/core';
 import { ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen } from '../test-utils/render';
-import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
 import { getFieldDefinitions } from '../SearchControl/SearchControlField';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { SearchPopupMenu, SearchPopupMenuProps } from './SearchPopupMenu';
 
 const medplum = new MockClient();
@@ -678,7 +678,7 @@ describe('SearchPopupMenu', () => {
         code: 'patient',
         type: 'reference',
         expression: 'Observation.patient',
-      },
+      } as SearchParameter,
     };
 
     const search: SearchRequest = {

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
@@ -92,6 +92,7 @@ describe('ServiceRequestTimeline', () => {
     // Create a comment
     const comment = await medplum.createResource<Communication>({
       resourceType: 'Communication',
+      status: 'completed',
       basedOn: [createReference(HomerServiceRequest)],
       subject: createReference(HomerSimpson),
       payload: [{ contentString: randomUUID() }],
@@ -127,6 +128,7 @@ describe('ServiceRequestTimeline', () => {
     // Create a comment
     const comment = await medplum.createResource<Communication>({
       resourceType: 'Communication',
+      status: 'completed',
       basedOn: [createReference(HomerServiceRequest)],
       subject: createReference(HomerSimpson),
       payload: [{ contentString: randomUUID() }],
@@ -152,6 +154,7 @@ describe('ServiceRequestTimeline', () => {
     // Create a comment
     const comment = await medplum.createResource<Communication>({
       resourceType: 'Communication',
+      status: 'completed',
       basedOn: [createReference(HomerServiceRequest)],
       subject: createReference(HomerSimpson),
       payload: [{ contentString: randomUUID() }],
@@ -177,6 +180,7 @@ describe('ServiceRequestTimeline', () => {
     // Create a comment
     const comment = await medplum.createResource<Communication>({
       resourceType: 'Communication',
+      status: 'completed',
       basedOn: [createReference(HomerServiceRequest)],
       subject: createReference(HomerSimpson),
       payload: [{ contentString: randomUUID() }],

--- a/packages/react/src/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/Timeline/Timeline.stories.tsx
@@ -18,6 +18,7 @@ export const Basic = (): JSX.Element => (
         resourceType: 'Communication',
         id: '123',
         meta: { lastUpdated: '2021-01-01T12:00:00Z' },
+        status: 'completed',
       }}
     >
       <div style={{ padding: '2px 16px' }}>
@@ -30,6 +31,8 @@ export const Basic = (): JSX.Element => (
         resourceType: 'Media',
         id: '123',
         meta: { lastUpdated: '2021-01-01T12:00:00Z' },
+        status: 'completed',
+        content: { url: 'https://www.medplum.com/img/wikimedia-papercut.jpg' },
       }}
     >
       <img src="https://www.medplum.com/img/wikimedia-papercut.jpg" alt="Papercut" title="Papercut" />
@@ -40,6 +43,8 @@ export const Basic = (): JSX.Element => (
         resourceType: 'Media',
         id: '123',
         meta: { lastUpdated: '2021-01-01T12:00:00Z' },
+        status: 'completed',
+        content: { url: 'https://www.medplum.com/img/beat-boxing-mri.mp4' },
       }}
     >
       <video src="https://www.medplum.com/img/beat-boxing-mri.mp4" controls autoPlay muted></video>

--- a/packages/react/src/Timeline/Timeline.test.tsx
+++ b/packages/react/src/Timeline/Timeline.test.tsx
@@ -1,8 +1,8 @@
 import { Communication } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { render, screen } from '../test-utils/render';
-import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '../test-utils/render';
 import { Timeline, TimelineItem } from './Timeline';
 
 const medplum = new MockClient();
@@ -11,7 +11,7 @@ describe('Timeline', () => {
   test('Renders', async () => {
     const resource: Communication = {
       resourceType: 'Communication',
-    };
+    } as Communication;
 
     render(
       <MemoryRouter>

--- a/packages/react/src/stories/healthgorilla.ts
+++ b/packages/react/src/stories/healthgorilla.ts
@@ -166,6 +166,7 @@ export const HealthGorillaDiagnosticReport: DiagnosticReport = {
   resourceType: 'DiagnosticReport',
   id: 'hg-report-1',
   status: 'final',
+  code: { text: 'Example Panel' },
   category: [
     {
       coding: [

--- a/packages/react/src/utils/blame.test.ts
+++ b/packages/react/src/utils/blame.test.ts
@@ -6,6 +6,7 @@ describe('Blame', () => {
   test('blame oldest to newest', () => {
     const history: Bundle = {
       resourceType: 'Bundle',
+      type: 'history',
       entry: [
         {
           resource: {
@@ -61,6 +62,7 @@ describe('Blame', () => {
   test('blame newest to oldest', () => {
     const history: Bundle = {
       resourceType: 'Bundle',
+      type: 'history',
       entry: [
         {
           resource: {
@@ -116,6 +118,7 @@ describe('Blame', () => {
   test('Handle deleted resource', () => {
     const history: Bundle = {
       resourceType: 'Bundle',
+      type: 'history',
       entry: [
         {
           resource: {
@@ -131,6 +134,7 @@ describe('Blame', () => {
         },
         {
           response: {
+            status: '410',
             outcome: gone,
           },
         },

--- a/packages/react/src/utils/date.test.ts
+++ b/packages/react/src/utils/date.test.ts
@@ -12,7 +12,7 @@ describe('Date utils', () => {
       { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
       { resourceType: 'DiagnosticReport', issued: '2005-05-05T00:00:00.000Z' },
       { resourceType: 'Communication', sent: '2004-04-04T00:00:00.000Z' },
-    ];
+    ] as Resource[];
     const expected: Resource[] = [
       { resourceType: 'Patient', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
       { resourceType: 'Patient', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
@@ -22,7 +22,7 @@ describe('Date utils', () => {
       { resourceType: 'Media', issued: '2006-06-06T00:00:00.000Z' },
       { resourceType: 'Observation', issued: '2007-07-07T00:00:00.000Z' },
       { resourceType: 'DocumentReference', date: '2008-08-08T00:00:00.000Z' },
-    ];
+    ] as Resource[];
     sortByDateAndPriority(input);
     expect(input).toMatchObject(expected);
   });
@@ -34,14 +34,14 @@ describe('Date utils', () => {
       { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
       { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
       { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
-    ];
+    ] as Communication[];
     const expected: Communication[] = [
       { resourceType: 'Communication', meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
       { resourceType: 'Communication', meta: { lastUpdated: '2002-02-02T00:00:00.000Z' } },
       { resourceType: 'Communication', meta: { lastUpdated: '2003-03-03T00:00:00.000Z' } },
       { resourceType: 'Communication', meta: { lastUpdated: '2005-05-05T00:00:00.000Z' }, priority: 'routine' },
       { resourceType: 'Communication', meta: { lastUpdated: '2004-04-04T00:00:00.000Z' }, priority: 'stat' },
-    ];
+    ] as Communication[];
     sortByDateAndPriority(input);
     expect(input).toMatchObject(expected);
   });
@@ -57,14 +57,14 @@ describe('Date utils', () => {
       { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
       { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
       { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
-    ];
+    ] as Communication[];
     const expected: Communication[] = [
       { resourceType, id, meta: { lastUpdated: '2001-01-01T00:00:00.000Z' } },
       { resourceType, id, meta: { lastUpdated: '2001-01-02T00:00:00.000Z' }, sent: '2000-01-01T00:00:00.000Z' },
       { resourceType, id, meta: { lastUpdated: '2001-01-03T00:00:00.000Z' } },
       { resourceType, id, meta: { lastUpdated: '2001-01-04T00:00:00.000Z' }, priority: 'stat' },
       { resourceType, id, meta: { lastUpdated: '2001-01-05T00:00:00.000Z' }, priority: 'routine' },
-    ];
+    ] as Communication[];
     sortByDateAndPriority(input, input[0]);
     expect(input).toMatchObject(expected);
   });

--- a/packages/react/src/utils/questionnaire.test.ts
+++ b/packages/react/src/utils/questionnaire.test.ts
@@ -1,11 +1,11 @@
-import { QuestionnaireItemEnableWhen } from '@medplum/fhirtypes';
-import { isChoiceQuestion, isQuestionEnabled, getNewMultiSelectValues, formatReferenceString } from './questionnaire';
+import { QuestionnaireItem, QuestionnaireItemEnableWhen } from '@medplum/fhirtypes';
+import { formatReferenceString, getNewMultiSelectValues, isChoiceQuestion, isQuestionEnabled } from './questionnaire';
 
 describe('QuestionnaireUtils', () => {
   test('isChoiceQuestion', () => {
-    expect(isChoiceQuestion({ type: 'string' })).toBe(false);
-    expect(isChoiceQuestion({ type: 'choice' })).toBe(true);
-    expect(isChoiceQuestion({ type: 'open-choice' })).toBe(true);
+    expect(isChoiceQuestion({ linkId: 'q3', type: 'string' })).toBe(false);
+    expect(isChoiceQuestion({ linkId: 'q3', type: 'choice' })).toBe(true);
+    expect(isChoiceQuestion({ linkId: 'q3', type: 'open-choice' })).toBe(true);
   });
 });
 
@@ -13,14 +13,18 @@ test('isQuestionEnabled', () => {
   expect(
     isQuestionEnabled(
       {
+        linkId: 'q3',
+        type: 'string',
         enableBehavior: 'any',
         enableWhen: [
           {
             question: 'q1',
+            operator: '=',
             answerString: 'Yes',
           },
           {
             question: 'q2',
+            operator: '=',
             answerString: 'Yes',
           },
         ],
@@ -44,17 +48,19 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'any',
           enableWhen: [
             {
               question: 'q1',
-              answerString: 'Yes',
               operator: '=',
+              answerString: 'Yes',
             },
             {
               question: 'q2',
-              answerString: 'Yes',
               operator: '=',
+              answerString: 'Yes',
             },
           ],
         },
@@ -76,6 +82,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'any',
           enableWhen: [
             {
@@ -108,6 +116,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'all',
           enableWhen: [
             {
@@ -140,6 +150,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'all',
           enableWhen: [
             {
@@ -172,6 +184,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'any',
           enableWhen: [
             {
@@ -205,6 +219,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'all',
           enableWhen: [
             {
@@ -237,6 +253,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'any',
           enableWhen: [
             {
@@ -269,6 +287,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'all',
           enableWhen: [
             {
@@ -301,6 +321,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableBehavior: 'all',
           enableWhen: [
             {
@@ -333,6 +355,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -359,6 +383,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -385,6 +411,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -407,6 +435,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -429,6 +459,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -451,6 +483,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -473,6 +507,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -499,6 +535,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q1',
@@ -525,6 +563,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q3',
@@ -551,6 +591,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen: [
             {
               question: 'q3',
@@ -585,6 +627,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -599,6 +643,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -623,6 +669,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -637,6 +685,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -661,6 +711,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -675,6 +727,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -699,6 +753,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -713,6 +769,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -737,6 +795,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -751,6 +811,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -765,6 +827,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -785,6 +849,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -799,6 +865,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -807,15 +875,14 @@ describe('isQuestionEnabled', () => {
             answer: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
           },
         ]
-        // {
-        //   q1: [{ valueCoding: { code: 'MEDPLUM123', display: 'Medplum123' } }],
-        // }
       )
     ).toBe(true);
 
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -836,6 +903,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -850,6 +919,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -864,6 +935,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -878,6 +951,8 @@ describe('isQuestionEnabled', () => {
     expect(
       isQuestionEnabled(
         {
+          linkId: 'q3',
+          type: 'string',
           enableWhen,
         },
         [
@@ -893,7 +968,9 @@ describe('isQuestionEnabled', () => {
   test('multi-select map selected values', () => {
     const selected = ['value1', 'value2'];
     const propertyName = 'valueString';
-    const item = {
+    const item: QuestionnaireItem = {
+      linkId: 'q3',
+      type: 'string',
       answerOption: [
         {
           valueString: 'value1',
@@ -912,7 +989,9 @@ describe('isQuestionEnabled', () => {
   test('multi-select non selected values', () => {
     const selected = ['nonMatchingValue'];
     const propertyName = 'valueString';
-    const item = {
+    const item: QuestionnaireItem = {
+      linkId: 'q3',
+      type: 'string',
       answerOption: [
         {
           valueString: 'value1',
@@ -931,7 +1010,9 @@ describe('isQuestionEnabled', () => {
   test('multi-select empty array', () => {
     const selected: string[] = [];
     const propertyName = 'valueString';
-    const item = {
+    const item: QuestionnaireItem = {
+      linkId: 'q3',
+      type: 'string',
       answerOption: [{ valueString: 'value1' }, { valueString: 'value2' }],
     };
 
@@ -943,7 +1024,9 @@ describe('isQuestionEnabled', () => {
   test('multi-select with value coding', () => {
     const selected = ['code1'];
     const propertyName = 'valueCoding';
-    const item = {
+    const item: QuestionnaireItem = {
+      linkId: 'q3',
+      type: 'string',
       answerOption: [
         {
           valueCoding: { code: 'code1' },
@@ -961,7 +1044,9 @@ describe('isQuestionEnabled', () => {
   test('multi-select with non existing values', () => {
     const selected = ['value1'];
     const propertyName = 'nonExistingProperty';
-    const item = {
+    const item: QuestionnaireItem = {
+      linkId: 'q3',
+      type: 'string',
       answerOption: [{ valueString: 'value1' }],
     };
 

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -268,6 +268,7 @@ export function buildInitialResponse(questionnaire: Questionnaire): Questionnair
     resourceType: 'QuestionnaireResponse',
     questionnaire: getReferenceString(questionnaire),
     item: buildInitialResponseItems(questionnaire.item),
+    status: 'in-progress',
   };
 
   return response;

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -12,10 +12,10 @@ import { Handler, NextFunction, Request, Response } from 'express';
 import fetch from 'node-fetch';
 import { getConfig } from '../config';
 import { getRequestContext } from '../context';
+import { sendOutcome } from '../fhir/outcomes';
 import { systemRepo } from '../fhir/repo';
 import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 import { getClient, getMembershipsForLogin } from '../oauth/utils';
-import { sendOutcome } from '../fhir/outcomes';
 
 export async function createProfile(
   project: Project,
@@ -42,7 +42,7 @@ export async function createProfile(
       },
     ],
     telecom,
-  });
+  } as ProfileResource);
   ctx.logger.info('Created profile', { id: result.id });
   return result;
 }

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -696,6 +696,9 @@ describe('AccessPolicy', () => {
       const clientRepo = await getRepoForLogin(
         {
           resourceType: 'Login',
+          user: createReference(clientApplication),
+          authMethod: 'client',
+          authTime: new Date().toISOString(),
         },
         {
           resourceType: 'ProjectMembership',
@@ -704,6 +707,7 @@ describe('AccessPolicy', () => {
           },
           profile: createReference(clientApplication as ClientApplication),
           accessPolicy: createReference(accessPolicy),
+          user: createReference(clientApplication),
         }
       );
 
@@ -798,6 +802,9 @@ describe('AccessPolicy', () => {
       const clientRepo = await getRepoForLogin(
         {
           resourceType: 'Login',
+          user: createReference(clientApplication),
+          authMethod: 'client',
+          authTime: new Date().toISOString(),
         },
         {
           resourceType: 'ProjectMembership',
@@ -806,6 +813,7 @@ describe('AccessPolicy', () => {
           },
           profile: createReference(clientApplication as ClientApplication),
           accessPolicy: createReference(accessPolicy),
+          user: createReference(clientApplication),
         }
       );
 

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -4,11 +4,11 @@ import { Request, Response, Router } from 'express';
 import internal from 'stream';
 import zlib from 'zlib';
 import { asyncWrap } from '../async';
+import { getAuthenticatedContext } from '../context';
+import { authenticateRequest } from '../oauth/middleware';
 import { sendOutcome } from './outcomes';
 import { getPresignedUrl } from './signer';
 import { getBinaryStorage } from './storage';
-import { authenticateRequest } from '../oauth/middleware';
-import { getAuthenticatedContext } from '../context';
 
 export const binaryRouter = Router().use(authenticateRequest);
 
@@ -18,7 +18,7 @@ binaryRouter.post(
   asyncWrap(async (req: Request, res: Response) => {
     const ctx = getAuthenticatedContext();
     const filename = req.query['_filename'] as string | undefined;
-    const contentType = req.get('Content-Type');
+    const contentType = req.get('Content-Type') as string;
     const resource = await ctx.repo.createResource<Binary>({
       resourceType: 'Binary',
       contentType,
@@ -52,7 +52,7 @@ binaryRouter.put(
     const ctx = getAuthenticatedContext();
     const { id } = req.params;
     const filename = req.query['_filename'] as string | undefined;
-    const contentType = req.get('Content-Type');
+    const contentType = req.get('Content-Type') as string;
     const resource = await ctx.repo.updateResource<Binary>({
       resourceType: 'Binary',
       id,

--- a/packages/server/src/fhir/jsonschema.test.ts
+++ b/packages/server/src/fhir/jsonschema.test.ts
@@ -1,5 +1,5 @@
 import { OperationOutcomeError } from '@medplum/core';
-import { Patient, Questionnaire, Resource } from '@medplum/fhirtypes';
+import { DiagnosticReport, Patient, Questionnaire, Resource } from '@medplum/fhirtypes';
 import { validateResourceWithJsonSchema } from './jsonschema';
 
 describe('FHIR JSONSchema', () => {
@@ -42,7 +42,7 @@ describe('FHIR JSONSchema', () => {
 
   test('Required properties', () => {
     try {
-      validateResourceWithJsonSchema({ resourceType: 'DiagnosticReport' });
+      validateResourceWithJsonSchema({ resourceType: 'DiagnosticReport' } as DiagnosticReport);
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -41,5 +41,5 @@ export function deriveIdentifierSearchParameter(inputParam: SearchParameter): Se
     base: inputParam.base,
     type: 'token',
     expression: `(${inputParam.expression}).identifier`,
-  };
+  } as SearchParameter;
 }

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -1,12 +1,12 @@
+import { OperationOutcomeError, Operator, allOk, badRequest, normalizeOperationOutcome } from '@medplum/core';
 import { CodeSystem, Coding, OperationDefinition } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import { getAuthenticatedContext } from '../../context';
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
-import { OperationOutcomeError, Operator, allOk, badRequest, normalizeOperationOutcome } from '@medplum/core';
-import { getClient } from '../../database';
-import { InsertQuery, SelectQuery } from '../sql';
-import { sendOutcome } from '../outcomes';
 import { Pool } from 'pg';
+import { getAuthenticatedContext } from '../../context';
+import { getClient } from '../../database';
+import { sendOutcome } from '../outcomes';
+import { InsertQuery, SelectQuery } from '../sql';
+import { parseInputParameters, sendOutputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
   resourceType: 'OperationDefinition',
@@ -28,9 +28,9 @@ const operation: OperationDefinition = {
       min: 0,
       max: '*',
       part: [
-        { name: 'code', type: 'code', min: 1, max: '1' },
-        { name: 'property', type: 'code', min: 1, max: '1' },
-        { name: 'value', type: 'string', min: 1, max: '1' },
+        { use: 'in', name: 'code', type: 'code', min: 1, max: '1' },
+        { use: 'in', name: 'property', type: 'code', min: 1, max: '1' },
+        { use: 'in', name: 'value', type: 'string', min: 1, max: '1' },
       ],
     },
     { use: 'out', name: 'return', type: 'CodeSystem', min: 1, max: '1' },

--- a/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.test.ts
@@ -1,10 +1,10 @@
-import express from 'express';
-import { loadTestConfig } from '../../config';
-import { initApp, shutdownApp } from '../../app';
-import { initTestAuth } from '../../test.setup';
-import request from 'supertest';
 import { ContentType } from '@medplum/core';
 import { ConceptMap, OperationOutcome, Parameters, ParametersParameter } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config';
+import { initTestAuth } from '../../test.setup';
 
 const app = express();
 
@@ -304,7 +304,7 @@ describe('ConceptMap $translate', () => {
       });
     expect(res.status).toBe(400);
 
-    expect(res.body).toMatchObject<OperationOutcome>({
+    expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
         {
@@ -325,7 +325,7 @@ describe('ConceptMap $translate', () => {
       });
     expect(res.status).toBe(400);
 
-    expect(res.body).toMatchObject<OperationOutcome>({
+    expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
         {
@@ -372,7 +372,7 @@ describe('ConceptMap $translate', () => {
       });
     expect(res.status).toBe(400);
 
-    expect(res.body).toMatchObject<OperationOutcome>({
+    expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
         {
@@ -398,7 +398,7 @@ describe('ConceptMap $translate', () => {
       });
     expect(res.status).toBe(404);
 
-    expect(res.body).toMatchObject<OperationOutcome>({
+    expect(res.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
         {
@@ -610,7 +610,7 @@ describe('ConceptMap $translate', () => {
         parameter: [{ name: 'coding', valueCoding: { system, code } }],
       });
     expect(res2.status).toBe(400);
-    expect(res2.body).toMatchObject<OperationOutcome>({
+    expect(res2.body).toMatchObject({
       resourceType: 'OperationOutcome',
       issue: [
         {

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -9,10 +9,10 @@ import {
   Resource,
 } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
+import { getAuthenticatedContext } from '../../context';
 import { sendOutcome } from '../outcomes';
 import { Repository } from '../repo';
 import { isFhirJsonContentType, sendResponse } from '../routes';
-import { getAuthenticatedContext } from '../../context';
 
 interface EvaluateMeasureParameters {
   readonly periodStart: string;
@@ -106,7 +106,7 @@ async function evaluateMeasure(
     resourceType: 'MeasureReport',
     status: 'complete',
     type: 'summary',
-    measure: measure.url,
+    measure: measure.url as string,
     date: new Date().toISOString(),
     period: {
       start: params.periodStart,

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -21,6 +21,7 @@ import {
   Organization,
   Project,
   ProjectMembership,
+  ProjectSecret,
   Reference,
   Subscription,
 } from '@medplum/fhirtypes';
@@ -490,7 +491,7 @@ async function getBotAccessToken(runAs: ProjectMembership): Promise<string> {
   return accessToken;
 }
 
-async function getBotSecrets(bot: Bot): Promise<Record<string, string>> {
+async function getBotSecrets(bot: Bot): Promise<Record<string, ProjectSecret>> {
   const project = await systemRepo.readResource<Project>('Project', bot.meta?.project as string);
   const secrets = Object.fromEntries(project.secret?.map((secret) => [secret.name, secret]) || []);
   return secrets;

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -42,7 +42,7 @@ describe('GraphQL', () => {
       });
 
       // Create a profile picture
-      binary = await aliceRepo.createResource<Binary>({ resourceType: 'Binary' });
+      binary = await aliceRepo.createResource<Binary>({ resourceType: 'Binary' } as Binary);
 
       // Creat a simple patient
       patient = await aliceRepo.createResource<Patient>({

--- a/packages/server/src/fhir/operations/resourcegraph.test.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.test.ts
@@ -4,6 +4,7 @@ import {
   Bundle,
   DiagnosticReport,
   GraphDefinition,
+  GraphDefinitionLink,
   Observation,
   ObservationDefinition,
   Organization,
@@ -107,7 +108,7 @@ describe('Resource $graph', () => {
         link: [{ path: 'PlanDefinition.action.definition', target: [{ type: 'Questionnaire' }] }],
       });
 
-      await getResourceGraph({ resourceType: 'PlanDefinition', id: randomUUID() }, graphName, 404);
+      await getResourceGraph({ resourceType: 'PlanDefinition', id: randomUUID() } as PlanDefinition, graphName, 404);
     });
 
     test('Missing Target', async () => {
@@ -149,7 +150,7 @@ describe('Resource $graph', () => {
         link: [
           {
             target: [{ id: 'foo' }],
-          },
+          } as GraphDefinitionLink,
         ],
       });
 
@@ -174,7 +175,7 @@ describe('Resource $graph', () => {
             target: [{ type: 'Practitioner' }],
           },
         ],
-      });
+      } as GraphDefinition);
 
       const outcome = await getResourceGraph(patient, graphName, 400);
       expect(normalizeErrorString(outcome)).toContain('Missing or incorrect `start` type');

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -1,3 +1,5 @@
+import { allOk, created, indexStructureDefinitionBundle } from '@medplum/core';
+import { readJson } from '@medplum/definitions';
 import {
   Observation,
   OperationDefinition,
@@ -7,11 +9,9 @@ import {
   Patient,
   Reference,
 } from '@medplum/fhirtypes';
-import { parseInputParameters, parseParameters, sendOutputParameters } from './parameters';
 import { Request, Response } from 'express';
-import { allOk, created, indexStructureDefinitionBundle } from '@medplum/core';
 import { withTestContext } from '../../../test.setup';
-import { readJson } from '@medplum/definitions';
+import { parseInputParameters, parseParameters, sendOutputParameters } from './parameters';
 
 describe('FHIR Parameters parsing', () => {
   test('Read Parameters', () => {
@@ -59,8 +59,8 @@ const opDef: OperationDefinition = {
       min: 0,
       max: '*',
       part: [
-        { name: 'foo', min: 1, max: '1', type: 'string' },
-        { name: 'bar', min: 0, max: '1', type: 'boolean' },
+        { use: 'in', name: 'foo', min: 1, max: '1', type: 'string' },
+        { use: 'in', name: 'bar', min: 0, max: '1', type: 'boolean' },
       ],
     },
     { name: 'singleOut', use: 'out', min: 1, max: '1', type: 'Quantity' },

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -16,14 +16,14 @@ import {
   ParametersParameter,
 } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import { sendResponse } from '../../routes';
 import { sendOutcome } from '../../outcomes';
+import { sendResponse } from '../../routes';
 
 export function parseParameters<T>(input: T | Parameters): T {
   if (input && typeof input === 'object' && 'resourceType' in input && input.resourceType === 'Parameters') {
     // Convert the parameters to input
     const parameters = (input as Parameters).parameter ?? [];
-    return Object.fromEntries(parameters.map((p) => [p.name, p.valueString]));
+    return Object.fromEntries(parameters.map((p) => [p.name, p.valueString])) as T;
   } else {
     return input as T;
   }

--- a/packages/server/src/fhir/patient.test.ts
+++ b/packages/server/src/fhir/patient.test.ts
@@ -60,6 +60,8 @@ describe('FHIR Patient utils', () => {
     expect(
       getPatients({
         resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'abc' },
         subject: 'bad',
       } as Observation)
     ).toEqual([]);
@@ -86,6 +88,9 @@ describe('FHIR Patient utils', () => {
     expect(
       getPatients({
         resourceType: 'ServiceRequest',
+        status: 'active',
+        intent: 'order',
+        code: { text: 'abc' },
         subject: { reference: 'Patient/123' },
       })
     ).toMatchObject([{ reference: 'Patient/123' }]);
@@ -93,6 +98,8 @@ describe('FHIR Patient utils', () => {
     expect(
       getPatients({
         resourceType: 'DiagnosticReport',
+        status: 'final',
+        code: { text: 'abc' },
         subject: { reference: 'Patient/123' },
       })
     ).toMatchObject([{ reference: 'Patient/123' }]);
@@ -108,6 +115,7 @@ describe('FHIR Patient utils', () => {
   test('Multiple patients', () => {
     const communication: Communication = {
       resourceType: 'Communication',
+      status: 'completed',
       subject: { reference: 'Patient/123' },
       sender: { reference: 'Patient/456' },
       recipient: [{ reference: 'Patient/789' }],
@@ -122,6 +130,7 @@ describe('FHIR Patient utils', () => {
   test('Duplicate patients', () => {
     const communication: Communication = {
       resourceType: 'Communication',
+      status: 'completed',
       subject: { reference: 'Patient/123' },
       sender: { reference: 'Patient/123' },
       recipient: [{ reference: 'Patient/789' }],
@@ -132,6 +141,8 @@ describe('FHIR Patient utils', () => {
   test('Follow search params', () => {
     const carePlan: CarePlan = {
       resourceType: 'CarePlan',
+      status: 'active',
+      intent: 'order',
       subject: { reference: 'Patient/123' },
     };
 

--- a/packages/server/src/fhir/references.test.ts
+++ b/packages/server/src/fhir/references.test.ts
@@ -1,11 +1,11 @@
 import { createReference, normalizeErrorString } from '@medplum/core';
-import { Patient, ServiceRequest } from '@medplum/fhirtypes';
+import { Login, Patient, ServiceRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { getRepoForLogin } from './accesspolicy';
 import { withTestContext } from '../test.setup';
+import { getRepoForLogin } from './accesspolicy';
 
 describe('Reference checks', () => {
   beforeAll(async () => {
@@ -27,7 +27,7 @@ describe('Reference checks', () => {
         password: randomUUID(),
       });
 
-      const repo = await getRepoForLogin({ resourceType: 'Login' }, membership, true, true, true);
+      const repo = await getRepoForLogin({ resourceType: 'Login' } as Login, membership, true, true, true);
 
       const patient = await repo.createResource<Patient>({
         resourceType: 'Patient',

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -5,11 +5,14 @@ import {
   Observation,
   OperationOutcome,
   Patient,
+  ProjectMembership,
   Questionnaire,
   ResourceType,
   StructureDefinition,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew, RegisterRequest } from '../auth/register';
 import { loadTestConfig } from '../config';
@@ -17,8 +20,6 @@ import { getClient } from '../database';
 import { bundleContains, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { Repository, systemRepo } from './repo';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 
 jest.mock('hibp');
 jest.mock('ioredis');
@@ -35,7 +36,7 @@ describe('FHIR Repo', () => {
 
   test('getRepoForLogin', async () => {
     await expect(() =>
-      getRepoForLogin({ resourceType: 'Login' }, { resourceType: 'ProjectMembership' })
+      getRepoForLogin({ resourceType: 'Login' } as Login, { resourceType: 'ProjectMembership' } as ProjectMembership)
     ).rejects.toThrow('Invalid author reference');
   });
 
@@ -445,7 +446,7 @@ describe('FHIR Repo', () => {
       const result1 = await registerNew(registration1);
       expect(result1.profile).toBeDefined();
 
-      const repo1 = await getRepoForLogin({ resourceType: 'Login' }, result1.membership);
+      const repo1 = await getRepoForLogin({ resourceType: 'Login' } as Login, result1.membership);
       const patient1 = await repo1.createResource<Patient>({
         resourceType: 'Patient',
       });
@@ -468,7 +469,7 @@ describe('FHIR Repo', () => {
       const result2 = await registerNew(registration2);
       expect(result2.profile).toBeDefined();
 
-      const repo2 = await getRepoForLogin({ resourceType: 'Login' }, result2.membership);
+      const repo2 = await getRepoForLogin({ resourceType: 'Login' } as Login, result2.membership);
       try {
         await repo2.readResource('Patient', patient1.id as string);
         fail('Should have thrown');

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -3,10 +3,10 @@ import { Binary, Bundle, Practitioner } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { URL } from 'url';
 import { initAppServices, shutdownApp } from '../app';
-import { loadTestConfig, MedplumServerConfig } from '../config';
-import { systemRepo } from './repo';
-import { rewriteAttachments, RewriteMode } from './rewrite';
+import { MedplumServerConfig, loadTestConfig } from '../config';
 import { withTestContext } from '../test.setup';
+import { systemRepo } from './repo';
+import { RewriteMode, rewriteAttachments } from './rewrite';
 
 describe('URL rewrite', () => {
   let config: MedplumServerConfig;
@@ -227,6 +227,7 @@ describe('URL rewrite', () => {
 
     const bundle: Bundle = deepClone({
       resourceType: 'Bundle',
+      type: 'searchset',
       entry: [{ resource: practitioner }, { resource: practitioner }],
     });
 

--- a/packages/server/src/fhir/signer.test.ts
+++ b/packages/server/src/fhir/signer.test.ts
@@ -16,13 +16,13 @@ describe('Signer', () => {
   test('Presign URL', () => {
     jest.setSystemTime(new Date('2023-02-10T00:00:00.000Z'));
 
-    const binary: Binary = {
+    const binary = {
       resourceType: 'Binary',
       id: randomUUID(),
       meta: {
         versionId: randomUUID(),
       },
-    };
+    } as Binary;
 
     expect(getPresignedUrl(binary)).toMatch(/\?Expires=1675990800&Key-Pair-Id=/);
   });

--- a/packages/server/src/fhir/storage.test.ts
+++ b/packages/server/src/fhir/storage.test.ts
@@ -37,13 +37,13 @@ describe('Storage', () => {
     expect(storage).toBeDefined();
 
     // Write a file
-    const binary: Binary = {
+    const binary = {
       resourceType: 'Binary',
       id: '123',
       meta: {
         versionId: '456',
       },
-    };
+    } as Binary;
 
     // Create a request
     const req = new Readable();
@@ -73,13 +73,13 @@ describe('Storage', () => {
     expect(storage).toBeDefined();
 
     // Write a file
-    const binary: Binary = {
+    const binary = {
       resourceType: 'Binary',
       id: '123',
       meta: {
         versionId: '456',
       },
-    };
+    } as Binary;
     const req = new Readable();
     req.push('foo');
     req.push(null);
@@ -110,13 +110,13 @@ describe('Storage', () => {
     expect(storage).toBeDefined();
 
     // Write a file
-    const binary: Binary = {
+    const binary = {
       resourceType: 'Binary',
       id: '123',
       meta: {
         versionId: '456',
       },
-    };
+    } as Binary;
     const req = new Readable();
     req.push('foo');
     req.push(null);
@@ -180,13 +180,13 @@ describe('Storage', () => {
     expect(storage).toBeDefined();
 
     // Write a file
-    const binary: Binary = {
+    const binary = {
       resourceType: 'Binary',
       id: '123',
       meta: {
         versionId: '456',
       },
-    };
+    } as Binary;
 
     jest.spyOn(fs, 'existsSync').mockReturnValue(false);
 
@@ -205,13 +205,13 @@ describe('Storage', () => {
     expect(storage).toBeDefined();
 
     // Write a file
-    const binary: Binary = {
+    const binary = {
       resourceType: 'Binary',
       id: '123',
       meta: {
         versionId: '456',
       },
-    };
+    } as Binary;
     const req = new Readable();
     req.push('foo');
     req.push(null);
@@ -231,13 +231,13 @@ describe('Storage', () => {
     mockS3Client.reset();
 
     // Copy the object
-    const destinationBinary: Binary = {
+    const destinationBinary = {
       resourceType: 'Binary',
       id: '789',
       meta: {
         versionId: '012',
       },
-    };
+    } as Binary;
     await storage.copyBinary(binary, destinationBinary);
 
     expect(mockS3Client.send.callCount).toBe(1);

--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -168,7 +168,10 @@ describe('FHIRCast routes', () => {
     let contextRes;
 
     const payload = createFhircastMessagePayload('my-topic', 'DiagnosticReport-open', [
-      { key: 'report', resource: { id: 'def-456', resourceType: 'DiagnosticReport' } },
+      {
+        key: 'report',
+        resource: { id: 'def-456', resourceType: 'DiagnosticReport', status: 'final', code: { text: 'test' } },
+      },
       { key: 'patient', resource: { id: 'xyz-789', resourceType: 'Patient' } },
     ]);
     const publishRes = await request(app)
@@ -200,7 +203,10 @@ describe('FHIRCast routes', () => {
     let afterContextRes;
 
     const context = [
-      { key: 'report', resource: { id: 'def-456', resourceType: 'DiagnosticReport' } },
+      {
+        key: 'report',
+        resource: { id: 'def-456', resourceType: 'DiagnosticReport', status: 'final', code: { text: 'test' } },
+      },
       { key: 'patient', resource: { id: 'xyz-789', resourceType: 'Patient' } },
     ] satisfies FhircastEventContext<'DiagnosticReport-open'>[];
 
@@ -248,8 +254,11 @@ describe('FHIRCast routes', () => {
 
   test('Check for `context.versionId` on `DiagnosticReport-open`', async () => {
     const context = [
-      { key: 'report', resource: { id: 'abc-123', resourceType: 'DiagnosticReport' } },
-      { key: 'study', resource: { id: 'def-456', resourceType: 'ImagingStudy' } },
+      {
+        key: 'report',
+        resource: { id: 'abc-123', resourceType: 'DiagnosticReport', status: 'final', code: { text: 'test' } },
+      },
+      { key: 'study', resource: { id: 'def-456', resourceType: 'ImagingStudy', status: 'available', subject: {} } },
       { key: 'patient', resource: { id: 'xyz-789', resourceType: 'Patient' } },
     ] satisfies FhircastEventContext<'DiagnosticReport-open'>[];
 
@@ -273,8 +282,11 @@ describe('FHIRCast routes', () => {
 
   test('`DiagnosticReport-update`: `context.priorVersionId` matches prior `context.versionId`', async () => {
     const context = [
-      { key: 'report', resource: { id: 'abc-123', resourceType: 'DiagnosticReport' } },
-      { key: 'updates', resource: { id: 'bundle-123', resourceType: 'Bundle' } },
+      {
+        key: 'report',
+        resource: { id: 'abc-123', resourceType: 'DiagnosticReport', status: 'final', code: { text: 'test' } },
+      },
+      { key: 'updates', resource: { id: 'bundle-123', resourceType: 'Bundle', type: 'searchset' } },
     ] satisfies FhircastEventContext<'DiagnosticReport-update'>[];
 
     const versionId = randomUUID();

--- a/packages/server/src/logger.test.ts
+++ b/packages/server/src/logger.test.ts
@@ -4,15 +4,16 @@ import {
   CreateLogStreamCommand,
   PutLogEventsCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
-import fs from 'fs';
-import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';
+import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
+import fs from 'fs';
 
+import { AuditEvent } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import { PassThrough } from 'stream';
 import { loadConfig } from './config';
 import { LogLevel, Logger, globalLogger, parseLogLevel } from './logger';
 import { waitFor } from './test.setup';
-import { PassThrough } from 'stream';
-import { randomUUID } from 'crypto';
 
 describe('Global Logger', () => {
   let mockCloudWatchLogsClient: AwsClientStub<CloudWatchLogsClient>;
@@ -96,7 +97,7 @@ describe('Global Logger', () => {
 
     await loadConfig('file:test.json');
 
-    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' });
+    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);
 
     expect(console.info).not.toHaveBeenCalled();
     expect(console.log).not.toHaveBeenCalled();
@@ -109,7 +110,7 @@ describe('Global Logger', () => {
     await loadConfig('file:test.json');
 
     // Log an AuditEvent
-    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' });
+    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);
 
     // It should have been logged
     expect(console.log).toHaveBeenCalledWith('{"resourceType":"AuditEvent"}');
@@ -131,8 +132,8 @@ describe('Global Logger', () => {
     await loadConfig('file:test.json');
 
     // Log an AuditEvent
-    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' });
-    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' });
+    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);
+    globalLogger.logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);
 
     await waitFor(async () => expect(mockCloudWatchLogsClient).toHaveReceivedCommand(PutLogEventsCommand));
 

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -1,4 +1,4 @@
-import { OperationOutcomeError, unauthorized } from '@medplum/core';
+import { OperationOutcomeError, createReference, unauthorized } from '@medplum/core';
 import { ClientApplication, Login, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response } from 'express';
 import { IncomingMessage } from 'http';
@@ -83,7 +83,9 @@ async function authenticateBasicAuth(req: IncomingMessage, token: string): Promi
   const project = await systemRepo.readReference<Project>(membership.project as Reference<Project>);
   const login: Login = {
     resourceType: 'Login',
+    user: createReference(client),
     authMethod: 'client',
+    authTime: new Date().toISOString(),
     superAdmin: project.superAdmin,
   };
 

--- a/packages/server/src/oauth/utils.test.ts
+++ b/packages/server/src/oauth/utils.test.ts
@@ -1,5 +1,5 @@
 import { OperationOutcomeError } from '@medplum/core';
-import { ClientApplication } from '@medplum/fhirtypes';
+import { ClientApplication, Login } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
@@ -373,7 +373,7 @@ describe('OAuth utils', () => {
 
   test('verifyMfaToken login revoked', async () => {
     try {
-      await verifyMfaToken({ resourceType: 'Login', revoked: true }, 'token');
+      await verifyMfaToken({ resourceType: 'Login', revoked: true } as Login, 'token');
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -383,7 +383,7 @@ describe('OAuth utils', () => {
 
   test('verifyMfaToken login granted', async () => {
     try {
-      await verifyMfaToken({ resourceType: 'Login', granted: true }, 'token');
+      await verifyMfaToken({ resourceType: 'Login', granted: true } as Login, 'token');
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -393,7 +393,7 @@ describe('OAuth utils', () => {
 
   test('verifyMfaToken login already verified', async () => {
     try {
-      await verifyMfaToken({ resourceType: 'Login', mfaVerified: true }, 'token');
+      await verifyMfaToken({ resourceType: 'Login', mfaVerified: true } as Login, 'token');
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -403,7 +403,7 @@ describe('OAuth utils', () => {
 
   test('getMembershipsForLogin missing user reference', async () => {
     try {
-      await getMembershipsForLogin({ resourceType: 'Login', user: {} });
+      await getMembershipsForLogin({ resourceType: 'Login', user: {} } as Login);
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -413,7 +413,7 @@ describe('OAuth utils', () => {
 
   test('getAuthTokens missing user', async () => {
     try {
-      await getAuthTokens({ resourceType: 'Login', user: {} }, { reference: 'Patient/123' });
+      await getAuthTokens({ resourceType: 'Login', user: {} } as Login, { reference: 'Patient/123' });
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;
@@ -423,7 +423,9 @@ describe('OAuth utils', () => {
 
   test('getAuthTokens Login missing profile', async () => {
     try {
-      await getAuthTokens({ resourceType: 'Login', user: { reference: 'User/123' } }, { reference: 'Patient/123' });
+      await getAuthTokens({ resourceType: 'Login', user: { reference: 'User/123' } } as Login, {
+        reference: 'Patient/123',
+      });
       fail('Expected error');
     } catch (err) {
       const outcome = (err as OperationOutcomeError).outcome;

--- a/packages/server/src/subscriptions/websockets.ts
+++ b/packages/server/src/subscriptions/websockets.ts
@@ -110,7 +110,7 @@ export function createSubEventNotification<ResourceType extends Resource = Resou
           resourceType: 'SubscriptionStatus',
           status,
           type: 'event-notification',
-          subscription: createReference({ resourceType: 'Subscription', id: subscriptionId }),
+          subscription: { reference: `Subscription/${subscriptionId}` },
           notificationEvent: [{ eventNumber: '0', timestamp, focus: createReference(resource) }],
         },
       },

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -181,7 +181,7 @@ export async function execDownloadJob(job: Job<DownloadJobData>): Promise<void> 
     }
 
     const contentDisposition = response.headers.get('content-disposition') as string | undefined;
-    const contentType = response.headers.get('content-type') as string | undefined;
+    const contentType = response.headers.get('content-type') as string;
     const binary = await systemRepo.createResource<Binary>({
       resourceType: 'Binary',
       contentType,

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -519,7 +519,7 @@ describe('Subscription Worker', () => {
           type: 'rest-hook',
           endpoint: 'https://example.com/subscription',
         },
-      });
+      } as Subscription);
       expect(subscription).toBeDefined();
 
       const queue = getSubscriptionQueue() as any;

--- a/packages/server/src/workers/utils.test.ts
+++ b/packages/server/src/workers/utils.test.ts
@@ -6,6 +6,7 @@ describe('Job Success Checker', () => {
   test('Successful job with no custom codes', () => {
     const subscription: Subscription = {
       resourceType: 'Subscription',
+      status: 'active',
       reason: 'test',
       criteria: 'Patient',
       channel: {
@@ -19,6 +20,7 @@ describe('Job Success Checker', () => {
   test('Successful job with invalid custom codes', () => {
     const subscription: Subscription = {
       resourceType: 'Subscription',
+      status: 'active',
       reason: 'test',
       criteria: 'Patient',
       channel: {
@@ -38,6 +40,7 @@ describe('Job Success Checker', () => {
   test('Unsuccessful job with invalid custom codes', () => {
     const subscription: Subscription = {
       resourceType: 'Subscription',
+      status: 'active',
       reason: 'test',
       criteria: 'Patient',
       channel: {
@@ -57,6 +60,7 @@ describe('Job Success Checker', () => {
   test('Successful job with valid custom codes', () => {
     const subscription: Subscription = {
       resourceType: 'Subscription',
+      status: 'active',
       reason: 'test',
       criteria: 'Patient',
       channel: {
@@ -76,6 +80,7 @@ describe('Job Success Checker', () => {
   test('Unsuccessful job with valid custom codes', () => {
     const subscription: Subscription = {
       resourceType: 'Subscription',
+      status: 'active',
       reason: 'test',
       criteria: 'Patient',
       channel: {
@@ -95,6 +100,7 @@ describe('Job Success Checker', () => {
   test('Successful job with valid custom codes comma separated', () => {
     const subscription: Subscription = {
       resourceType: 'Subscription',
+      status: 'active',
       reason: 'test',
       criteria: 'Patient',
       channel: {


### PR DESCRIPTION
> [!CAUTION]
> This PR includes breaking changes. It is part of [Medplum 3.0](https://github.com/medplum/medplum/issues/3124)

Updates FHIR type definitions in `@medplum/fhirtypes` to mark all required fields as required.

Despite being a breaking API change, this should be low risk.  It only applies at build time.  At runtime, most projects are in "strict mode", and are subject to these same constraints.  If anything, this catches quite a few bugs in client side code.