### PR TITLE
Update FHIR Basics

### DIFF
--- a/packages/docs/docs/fhir-basics.md
+++ b/packages/docs/docs/fhir-basics.md
@@ -2,9 +2,30 @@
 id: fhir-basics
 toc_max_heading_level: 2
 sidebar_position: 2.1
+keywords:
+  - getting started
+  - fhir
+  - resource
+  - codeableconcept
+  - reference
+  - identifier
 ---
 
 # FHIR Basics
+
+import MedicationExample from '!!raw-loader!@site/..//examples/src/medications/medication-codes.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+
+[patient]: /docs/api/fhir/resources/patient
+[practitioner]: /docs/api/fhir/resources/practitioner
+[medicationrequest]: /docs/api/fhir/resources/medicationrequest
+[medication]: /docs/api/fhir/resources/medication
+[device]: /docs/api/fhir/resources/device
+[procedure]: /docs/api/fhir/resources/procedure
+[careplan]: /docs/api/fhir/resources/careplan
+[encounter]: /docs/api/fhir/resources/encounter
+[reference]: /docs/api/fhir/datatypes/reference
+[codeableconcept]: /docs/api/fhir/datatypes/codeableconcept
 
 ## Why FHIR?
 
@@ -15,25 +36,28 @@ Medplum stores healthcare data using the FHIR standard. Storing data according t
 
 While FHIR is quite powerful, it can have a bit of a learning curve. The page will go over the basic concepts for understanding FHIR data in Medplum. For more information, you can check out the [official FHIR documentation](http://hl7.org/fhir/).
 
-## Resources
+## Storing Data: Resources
 
-A core data object in FHIR is called a [**Resource**](https://www.hl7.org/fhir/resource.html). You can think of Resources as **objects** in object oriented languages. The FHIR standard defines a set of [**Resource Types**](./api/fhir/resources), similar to **classes**, that have been built for healthcare applications.
+A core data object in FHIR is called a [**Resource**](https://www.hl7.org/fhir/resource.html). You can think of Resources as **objects** in object oriented languages.
 
-Resources can represent a broad range of healthcare ideas, from very **concrete healthcare items** (e.g. [Patient](./api/fhir/resources/patient), [Medication](./api/fhir/resources/medication), [Device](./api/fhir/resources/device)) or more **abstract concepts** (e.g. [Procedure](./api/fhir/resources/procedure), [Care Plan](./api/fhir/resources/careplan), [Encounter](./api/fhir/resources/encounter)).
+The FHIR standard defines over 150 [**Resource Types**](./api/fhir/resources) that model broad range of healthcare-specific concepts. These include **concrete entities** ([`Patient`][patient], [`Medication`][medication], [`Device`][device]) as well as **abstract concepts** ([`Procedure`][procedure], [`CarePlan`][careplan], [`Encounter`][encounter]).
 
-A `Resource` is composed of multiple fields, called `Elements`, each of which can be a **primitive type** (e.g. strings, numbers, dates) or a **complex type** (e.g. JSON objects).
+Each field in a resource is called an [**Element**](https://hl7.org/fhir/R4/element.html), each of which can be a **primitive type** (e.g. `string`, `number`, `date`) or a **complex type** (e.g. [`HumanName`](/docs/api/fhir/datatypes/humanname)).
 
-### Example
+Lastly, all resources have an `id` element, which is a server-assigned identifier that serves as their **primary key**.
 
-The example below shows an example **[Patient](./api/fhir/resources/patient) resource**, represented as JSON. Here we can see that the `Patient` contains multiple `Elements`, including: `name`, `telecom`, and `address`.
-
+<details>
+<summary>
+Example [`Patient`][patient]
+</summary>
+The example below shows an example [`Patient`][patient] resource. Here we can see that the [`Patient`][patient] contains multiple elements, including `name`, `telecom`, and `address`.
 ```javascript
 {
   // Resource Type (i.e. "class name")
   "resourceType": "Patient",
   // Unique id for this resource
   "id": "j_chalmers",
-  // Paitient Name (could have multiple)
+  // Patient Name (could have multiple)
   "name": [
     {
       "use": "official",
@@ -69,29 +93,32 @@ The example below shows an example **[Patient](./api/fhir/resources/patient) res
   ]
 }
 ```
+</details>
 
-<br/>
+## Linking Data: References
 
-## References: Linking Resources
+When working with FHIR, clinical data is often split across multiple resources. For example a prescription is related to the receiving patient, and a diagnostic report may consist of multiple observations.
 
-Often times, multiple resources contain related data. For example a **prescription is related to the receiving patient**, and a **diagnostic report may consist of multiple observations**.
+To create link between objects, we use [`Reference`][reference] elements. A FHIR [`Reference`][reference] an element element that functions like a **foreign key** in traditional relational databases to create 1-to-1 or many-to-many relationships between resources.
 
-**To create pointers between objects, we use** `Reference` **elements**. A FHIR `Reference` is not a `Resource`, but a data type for a resource `Element`. The full FHIR `Reference` object has the follow structure:
+[`Reference`][reference] elements have the following structure:
 
 ```ts
 {
-  "reference" : string,     // Unique id of the referenced Resource
+  "reference" : ":resourceType/:id",     // Resource type + unique id of the referenced Resource
   "display" : string,       // Display string for the reference
   "type" : uri,             // Resource type (if using a "logical reference")
   "identifier" : Identifier
 }
 ```
 
-In Medplum, we will typically only use the `reference` and `display` fields.
+In Medplum, we will typically only use the `reference` and `display` elements.
 
-### Example
-
-The example below shows a [MedicationRequest](./api/fhir/resources/medicationrequest) resource two references: **`subject` (i.e. the patient)** and **`requester` (i.e. physician)**.
+<details>
+<summary>
+Example: Linking a [`MedicationRequest`][medicationrequest] to a [`Patient`][patient] and [`Practitioner`][practitioner]
+</summary>
+The example below shows a resource modeling a prescription (i.e. [`MedicationRequest`][medicationrequest]) with two references: **`subject` (i.e. the patient)** and **`requester` (i.e. the requesting physician)**.
 
 ```javascript
 {
@@ -115,25 +142,72 @@ The example below shows a [MedicationRequest](./api/fhir/resources/medicationreq
 }
 ```
 
-<br/>
+</details>
 
-## Identifiers: Naming Resources
+## Querying Data: Search
 
-One issue in healthcare applications is that **the same resource can have many different identifiers**, depending on the context. For example, a patient might be identified simulataneously by their:
+FHIR offers both a [REST API](/docs/search) and [GraphQL API](/docs/graphql) to query, search, sort, and filter resources by specific criteria (see [this blog post](/blog/2023/09/06/graphql-vs-rest) for tradeoffs between REST and GraphQL).
+
+**FHIR resources cannot be searched by arbitrary fields**. Instead, the specification defines specific [search parameters](/docs/search/basic-search#search-parameters) for each resource that can be used for queries.
+
+Refer to the [Medplum search documentation](/docs/search/basic-search) for a more in-depth tutorial on FHIR search.
+
+## Standardizing Data: Codeable Concepts
+
+The healthcare system commonly uses standardized coding systems to describe healthcare share information between organizations about **diagnoses**, **procedures**, **clinical outcomes**, **billing**.
+
+Some of the most commonly used code systems in the U.S. are:
+
+- [ICD-10](https://www.cms.gov/Medicare/Coding/ICD10) - Diagnoses.
+- [LOINC](/docs/careplans/loinc) - Clinical measurements and lab results.
+- [RXNorm](/docs/medications/medication-codes#rxnorm) or [NDC](/docs/medications/medication-codes#ndc) - [Medication](/docs/medications/medication-codes#ndc).
+- [SNOMED](https://www.snomed.org/) - [Workforce administration](/docs/careplans/tasks#task-assignment), clinical findings.
+
+Because there are multiple code systems for many domains, the same _concept_ can be defined in _multiple code systems_. To handle this mapping from concept to system, the FHIR defines the [`CodeableConcept`][codeableconcept] element type.
+
+A [`CodeableConcept`][codeableconcept] consists of two parts:
+
+- A `text` element the describes the concept in plain language
+- A `coding` element - an array of `(system, code)` pairs that provide the standard code for the concept within each code system.
+
+FHIR [`CodeableConcepts`][codeableconcept] use the `system` element to identify each code system within the `coding` array. By convention, FHIR uses absolute URLs to enforce that these systems are a globally unique namespace. _However, these URLs do not always point to hosted web sites._
+
+Refer to [this blog post](/blog/demystifying-fhir-systems) for a longer discussion of `system` strings.
+
+Refer to the [FHIR official documentation](https://hl7.org/fhir/R4/terminologies-systems.html) for a list of `systems` for common healthcare code systems.
+
+<details>
+Example: Tylenol
+<summary>
+Below is an example [`CodeableConcept`][codeableconcept], that defines the medication Tylenol, in both the [RXNorm](/docs/medications/medication-codes#rxnorm) or [NDC](/docs/medications/medication-codes#ndc) systems.
+
+<MedplumCodeBlock language="ts" selectBlocks="tylenol-example">
+  {MedicationExample}
+</MedplumCodeBlock>
+</summary>
+</details>
+
+## Naming Data: Identifiers
+
+One issue in healthcare applications is that the same entity can have many different identifiers in different systems. For example, a patient might be identified simultaneously by their:
 
 - Social Security Number (SSN)
 - Medical Record Number (MRN)
 - Medicare Beneficiary Identifier
 - Driver's License Number
 
-FHIR anticipates this complexity by allowing each resource to have multiple identfiers.
+FHIR anticipates this complexity by allowing each resource to have multiple identifiers.
 
-**Each identifier is defined by a** `(system, value)` **pair.** The `system` acts as _namespace_ for the identifier, and _must be specified as an absolute URL_ to ensure that it is globally unique.
+Each identifier is defined by a `(system, value)` pair. As with [`CodeableConcepts`][codeableconcept], the `system` acts as namespace for the identifier, and _must be specified as an absolute URL_ to ensure that it is globally unique.
 
-**Using the identifier system allows you to simplify your healthcare applications** by consolidating data in a single resource, while allowing different systems to access the data by different ID schemes.
+Refer to [this blog post](/blog/demystifying-fhir-systems#identifiers-1) for best practices on using identifier `system` strings.
 
-### Example
+Using the identifier system allows you to simplify your healthcare applications by consolidating data in a single resource, while allowing different systems to access the data by different ID schemes.
 
+<details>
+<summary>
+Example: [`Patient`][patient] with two medical record numbers (MRNs)
+</summary>
 The example `Patient` below has three identifiers: **an SSN and two MRN identifiers** from different hospital systems.
 
 ```javascript
@@ -170,31 +244,9 @@ The example `Patient` below has three identifiers: **an SSN and two MRN identifi
 }
 ```
 
-<br/>
+</details>
 
-## Search Parameters: Querying Resources
-
-There are many cases in which a client would like to query resources by a certain field value. **FHIR resources cannot be searched by arbitrary fields**. Instead, the specification **defines specific search parameters for each resource** that can be used for queries.
-
-You can find the search parameters on the [reference page](./api/fhir/resources) for each resource. **Refer to the [FHIR Search](https://www.hl7.org/fhir/search.html) documentation** for how construct search queries using these parameters.
-
-### Example
-
-For example the [Medication resource](./api/fhir/resources/medication#search-parameters) defines the following search parameters:
-
-- Identifier
-- Code
-- Expiration Date
-- Form
-- Ingredient
-- Ingredient Code
-- Lot Number
-- Manufacturer
-- Status
-
-<br/>
-
-## Subscriptions: Listening for changes
+## Listening for changes: Subscriptions
 
 **FHIR has a built-in [Subscription](./api/fhir/resources/subscription) resource** that is used to define a push-based subscription to resources in the system, analogous to web-hooks. A `Subscription` has two primary elements:
 
@@ -204,32 +256,3 @@ For example the [Medication resource](./api/fhir/resources/medication#search-par
 In Medplum, a powerful feature is to to **use a [Medplum Bot](./bots)** as the endpoint of the `rest-hook` channel. This allows you to run an arbitrary piece of code in response to data changes and automate your medical workflows. See our [Bot-Subscription tutorial](./bots/bot-for-questionnaire-response) for more information.
 
 <br/>
-
-## Codeable Concepts: Standarding Data
-
-The healthcare system commonly uses standardized coding systems to describe healthcare concepts such as **diagnoses**, **procedures**, **medical equipment**, and **billing information**. These coding systems are crucial for sharing data between systems because they provide standardized values that organizations know how to process. Some common coding systems include [LOINC](https://loinc.org/), [SNOMED](https://www.snomed.org/), [CPT](https://www.ama-assn.org/amaone/cpt-current-procedural-terminology), [ICD](https://www.cms.gov/Medicare/Coding/ICD10), and [HCPCS](https://www.cms.gov/medicare/coding/medhcpcsgeninfo).
-
-The same concept being defined in mulitple coding systems. To handle this mapping from concept to system, the FHIR standard defines a data structure called a `CodeableConcept`. A `CodeableConcept` contains an array of `(system, code)` pairs, along with a text field to describe the overall concept.
-
-Below is an example `CodeableConcept`, that defines a negative test result outcome in the **SNOMED** and **ACME Lab** systems.
-
-```javascript
-{
-  // Text description of the concept
-  "text": "Negative for Chlamydia Trachomatis rRNA",
-  "coding": [
-    // Encoding of the value in SNOMED system
-    {
-      "system": "http://snomed.info/sct",
-      "code": "260385009",
-      "display": "Negative"
-    },
-    // Encoding of the value in ACME LAB system
-    {
-      "system": "https://acme.lab/resultcodes",
-      "code": "NEG",
-      "display": "Negative"
-    }
-  ]
-}
-```

--- a/packages/docs/docs/medications/medication-codes.md
+++ b/packages/docs/docs/medications/medication-codes.md
@@ -10,6 +10,9 @@ tags:
   - rxnorm
 ---
 
+import ExampleCode from '!!raw-loader!@site/..//examples/src/medications/medication-codes.ts';
+import MedplumCodeBlock from '@site/src/components/MedplumCodeBlock';
+
 # Medication Code Systems
 
 ## Introduction
@@ -66,21 +69,9 @@ Unlike RXNorm, NDC operates as a flat code system and only refers to the "leaf n
 
 However, there are connections between the two code systems, as a drug product can have both NDC and RXNorm codes. Below is an example of the a [CodeableConcept](/docs/fhir-basics#codeable-concepts-standarding-data) for Tylenol, with both NDC and RxNorm codes
 
-```ts
-{
-  text: 'Tylenol 325 MG Oral Tablet'
-  coding: [
-    {
-      system: 'http://hl7.org/fhir/sid/ndc',
-      code: '50580045850'
-    }
-    {
-      system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
-      code: '209387'
-    }
-  ]
-}
-```
+<MedplumCodeBlock language="ts" selectBlocks="tylenol-example">
+  {ExampleCode}
+</MedplumCodeBlock>
 
 ## Other Drug databases
 

--- a/packages/examples/src/medications/medication-codes.ts
+++ b/packages/examples/src/medications/medication-codes.ts
@@ -1,0 +1,21 @@
+import { CodeableConcept} from '@medplum/fhirtypes';
+
+const tylenol: CodeableConcept =
+// start-block tylenol-example
+{
+  text: 'Tylenol 325 MG Oral Tablet',
+  coding: [
+    {
+      system: 'http://hl7.org/fhir/sid/ndc',
+      code: '50580045850'
+    },
+    {
+      system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+      code: '209387'
+    }
+  ]
+}
+// end-block tylenol-example
+
+
+console.log(tylenol);

--- a/packages/examples/src/medications/medication-codes.ts
+++ b/packages/examples/src/medications/medication-codes.ts
@@ -1,21 +1,20 @@
-import { CodeableConcept} from '@medplum/fhirtypes';
+import { CodeableConcept } from '@medplum/fhirtypes';
 
 const tylenol: CodeableConcept =
-// start-block tylenol-example
-{
-  text: 'Tylenol 325 MG Oral Tablet',
-  coding: [
-    {
-      system: 'http://hl7.org/fhir/sid/ndc',
-      code: '50580045850'
-    },
-    {
-      system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
-      code: '209387'
-    }
-  ]
-}
+  // start-block tylenol-example
+  {
+    text: 'Tylenol 325 MG Oral Tablet',
+    coding: [
+      {
+        system: 'http://hl7.org/fhir/sid/ndc',
+        code: '50580045850',
+      },
+      {
+        system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+        code: '209387',
+      },
+    ],
+  };
 // end-block tylenol-example
-
 
 console.log(tylenol);


### PR DESCRIPTION
This page was written a long time ago. After explaining FHIR to many customers, I've made to following changes to make the explanations more beginner friendly: 

- Better example of CodeableConcepts
- Aligning with our stylec conventions around examples
- Added links from basics page to more in-depth material
- Added clarification around `system` strings