### PR TITLE
FHIR Mapper - nested objects and dependent rules

### DIFF
--- a/packages/core/src/fhirmapper/parse.cda.test.ts
+++ b/packages/core/src/fhirmapper/parse.cda.test.ts
@@ -1,0 +1,33 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+
+describe('FHIR Mapping Language parser - C-CDA maps', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('Simplest possible transform', () => {
+    // https://build.fhir.org/mapping-tutorial.html#step1
+
+    const map = `
+    group CdaToBundle(source cda : ClinicalDocument, target bundle : Bundle) {
+      cda ->  bundle.entry as e, 
+        e.resource = create('Composition') as composition, 
+        composition.id = uuid() as uuid,
+        e.fullUrl = append('urn:uuid:',uuid),
+        bundle.entry as e2, 
+        e2.resource = create('Patient') as patient,
+        patient.id = uuid() as uuid2,
+        e2.fullUrl = append('urn:uuid:',uuid2)
+        then {
+          cda then ClinicalDocumentToBundle(cda, patient, composition, bundle) "cdatobundle";
+        } "ClinicalDocumentToBody";
+    }
+    `;
+
+    expect(parseMappingLanguage(map)).toBeDefined();
+  });
+});

--- a/packages/core/src/fhirmapper/parse.ts
+++ b/packages/core/src/fhirmapper/parse.ts
@@ -202,7 +202,6 @@ class StructureMapParser {
 
     if (this.parser.hasMore() && this.parser.peek()?.value === 'default') {
       this.parser.consume('Symbol', 'default');
-      // this.parser.consumeAndParse();
       result.defaultValueString = this.parser.consume('String').value;
     }
 

--- a/packages/core/src/fhirmapper/transform.copy.test.ts
+++ b/packages/core/src/fhirmapper/transform.copy.test.ts
@@ -1,0 +1,120 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+// Based on: https://github.com/Vermonster/fhir-kit-mapping-language/blob/master/test/engine/copy-concrete.test.js
+// MIT License
+
+describe('FHIR Mapper transform - copy', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('single rule, single source, new target', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v -> tgt.name = v;
+    }`;
+
+    const input = [{ name: 'bob' }];
+    const expected = [{ name: 'bob' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('single rule, single source, existing target', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v -> tgt.name = v;
+    }`;
+
+    const input = [{ name: 'bob' }, { size: 'average' }];
+    const expected = [{ name: 'bob', size: 'average' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('single rule, multiple source contexts, multiple target transforms', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v, src.size as s -> tgt.firstName = v, tgt.size = s;
+    }`;
+
+    const input = [{ name: 'bob', size: 'small' }];
+    const expected = [{ firstName: 'bob', size: 'small' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('single rule, single source, multiple target transforms', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v -> tgt.name = v, tgt.oldName = v;
+    }`;
+
+    const input = [{ name: 'bob' }];
+    const expected = [{ name: 'bob', oldName: 'bob' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('multiple rules, single source, new target', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v -> tgt.name = v;
+      src.size as v -> tgt.size = v;
+      src.active as sa -> tgt.activeStatus = sa;
+    }`;
+
+    const input = [{ name: 'bob', size: 'small', active: true }];
+    const expected = [{ name: 'bob', size: 'small', activeStatus: true }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('multiple rules, multiple sources, new target', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, source src2, target tgt) {
+      src.name as v -> tgt.name = v;
+      src2.size as v -> tgt.size = v;
+    }`;
+
+    const input = [{ name: 'bob' }, { size: 'small' }];
+    const expected = [{ name: 'bob', size: 'small' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('multiple rules, single source, multiple new actual', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt, target tgt2) {
+      src.name as v -> tgt.name = v;
+      src.size as v -> tgt2.size = v;
+    }`;
+
+    const input = [{ name: 'bob', size: 'small' }];
+    const expected = [{ name: 'bob' }, { size: 'small' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('multiple rules, multiple single sources, multiple exiting actual', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, source src2, target tgt, target tgt2) {
+      src.name as v -> tgt.name = v;
+      src.name as v -> tgt2.name = v;
+      src2.size as ss -> tgt2.size = ss;
+    }`;
+
+    const input = [{ name: 'bob' }, { size: 'small' }, { active: true }, { active: true }];
+    const expected = [
+      { name: 'bob', active: true },
+      { name: 'bob', size: 'small', active: true },
+    ];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/core/src/fhirmapper/transform.dependent.test.ts
+++ b/packages/core/src/fhirmapper/transform.dependent.test.ts
@@ -1,0 +1,63 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+// Based on: https://github.com/Vermonster/fhir-kit-mapping-language/blob/master/test/engine/copy-concrete.test.js
+// MIT License
+
+describe('FHIR Mapper transform - dependent', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('rule', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as vn -> tgt.name as tn then {
+        vn.firstName as g -> tn.firstName = g;
+        vn.lastName as ln -> tn.familyName = ln;
+      };
+    }`;
+
+    const input = [{ name: { firstName: 'bob', lastName: 'smith' } }];
+    const expected = [{ name: { firstName: 'bob', familyName: 'smith' } }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toMatchObject(expected);
+  });
+
+  test('invocation', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.status as ss -> tgt.statusCode = ss;
+      src.name as vn -> tgt.name as tn then name(vn, tn);
+    }
+
+    group name(source src, target tgt) {
+      src.firstName as ss -> tgt.firstName = ss;
+      src.lastName as ln -> tgt.familyName = ln;
+    }`;
+
+    const input = [{ status: 'active', name: { firstName: 'bob', lastName: 'smith' } }];
+    const expected = [{ statusCode: 'active', name: { firstName: 'bob', familyName: 'smith' } }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toMatchObject(expected);
+  });
+
+  test('Group not found', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.status as ss -> tgt.statusCode = ss;
+      src.name as vn -> tgt.name as tn then doesNotExist(vn, tn);
+    }`;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), [{}]);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toBe('Dependent group not found: doesNotExist');
+    }
+  });
+});

--- a/packages/core/src/fhirmapper/transform.errors.test.ts
+++ b/packages/core/src/fhirmapper/transform.errors.test.ts
@@ -70,7 +70,7 @@ describe('FHIR Mapper transform - errors', () => {
     const map = `
       uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
       uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
-      
+
       group tutorial(source src : TLeft, target tgt : TRight) {
         src.a as a -> notFound.a = a "rule_a";
       }
@@ -81,6 +81,24 @@ describe('FHIR Mapper transform - errors', () => {
       throw new Error('Expected error');
     } catch (err: any) {
       expect(err.message).toEqual('Target not found: notFound');
+    }
+  });
+
+  test('Invalid property', () => {
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a as a -> tgt.prototype = a "rule_a";
+      }
+    `;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), [{}]);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toEqual('Invalid key: prototype');
     }
   });
 });

--- a/packages/core/src/fhirmapper/transform.errors.test.ts
+++ b/packages/core/src/fhirmapper/transform.errors.test.ts
@@ -1,0 +1,86 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+describe('FHIR Mapper transform - errors', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('No source parameters', () => {
+    const map = `map "http://test.com" = test
+    group example(target tgt) {
+      src.name as v -> tgt.name = v;
+    }`;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), []);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toEqual('Missing source definitions');
+    }
+  });
+
+  test('No target parameters', () => {
+    const map = `map "http://test.com" = test
+    group example(source src) {
+      src.name as v -> tgt.name = v;
+    }`;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), []);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toEqual('Missing target definitions');
+    }
+  });
+
+  test('Not enough arguments', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v -> tgt.name = v;
+    }`;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), []);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toEqual('Not enough arguments (got 0, min 1)');
+    }
+  });
+
+  test('Too many arguments', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.name as v -> tgt.name = v;
+    }`;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), [{}, {}, {}]);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toEqual('Too many arguments (got 3, max 2)');
+    }
+  });
+
+  test('Target not found', () => {
+    const map = `
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
+      uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
+      
+      group tutorial(source src : TLeft, target tgt : TRight) {
+        src.a as a -> notFound.a = a "rule_a";
+      }
+    `;
+
+    try {
+      structureMapTransform(parseMappingLanguage(map), [{}]);
+      throw new Error('Expected error');
+    } catch (err: any) {
+      expect(err.message).toEqual('Target not found: notFound');
+    }
+  });
+});

--- a/packages/core/src/fhirmapper/transform.test.ts
+++ b/packages/core/src/fhirmapper/transform.test.ts
@@ -22,8 +22,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = { a: 'a' };
-    const expected = { a: 'a' };
+    const input = [{ a: 'a' }];
+    const expected = [{ a: 'a' }];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -40,8 +40,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = { a1: 'a' };
-    const expected = { a2: 'a' };
+    const input = [{ a1: 'a' }];
+    const expected = [{ a2: 'a' }];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -58,8 +58,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = { a2: 'abcdef' };
-    const expected = { a2: 'abc' };
+    const input = [{ a2: 'abcdef' }];
+    const expected = [{ a2: 'abc' }];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -76,13 +76,13 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input1 = { a2: 'abcdef' };
-    const expected1 = { a2: undefined };
+    const input1 = [{ a2: 'abcdef' }];
+    const expected1 = [{ a2: undefined }];
     const actual1 = structureMapTransform(parseMappingLanguage(map), input1);
     expect(actual1).toMatchObject(expected1);
 
-    const input2 = { a2: 'abc' };
-    const expected2 = { a2: 'abc' };
+    const input2 = [{ a2: 'abc' }];
+    const expected2 = [{ a2: 'abc' }];
     const actual2 = structureMapTransform(parseMappingLanguage(map), input2);
     expect(actual2).toMatchObject(expected2);
   });
@@ -99,7 +99,7 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input1 = { a2: 'abcdef' };
+    const input1 = [{ a2: 'abcdef' }];
     try {
       structureMapTransform(parseMappingLanguage(map), input1);
       throw new Error('Expected error');
@@ -107,8 +107,8 @@ describe('FHIR Mapper transform', () => {
       expect(err.message).toBe('Check failed: a2.length() <= 3');
     }
 
-    const input2 = { a2: 'abc' };
-    const expected2 = { a2: 'abc' };
+    const input2 = [{ a2: 'abc' }];
+    const expected2 = [{ a2: 'abc' }];
     const actual2 = structureMapTransform(parseMappingLanguage(map), input2);
     expect(actual2).toMatchObject(expected2);
   });
@@ -125,8 +125,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = { a3: 1 };
-    const expected = { a3: 123 };
+    const input = [{ a3: 1 }];
+    const expected = [{ a3: 123 }];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });

--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -3,129 +3,177 @@ import {
   StructureMapGroup,
   StructureMapGroupInput,
   StructureMapGroupRule,
+  StructureMapGroupRuleDependent,
   StructureMapGroupRuleSource,
   StructureMapGroupRuleTarget,
 } from '@medplum/fhirtypes';
 import { evalFhirPathTyped } from '../fhirpath/parse';
 import { getTypedPropertyValue, toJsBoolean, toTypedValue } from '../fhirpath/utils';
+import { TypedValue } from '../types';
 
 interface TransformContext {
   parent?: TransformContext;
   variables?: Record<string, any>;
 }
 
-export function structureMapTransform(structureMap: StructureMap, input: any): any {
+export function structureMapTransform(structureMap: StructureMap, input: any[]): any[] {
   return evalStructureMap({}, structureMap, input);
 }
 
-function evalStructureMap(ctx: TransformContext, structureMap: StructureMap, input: any): any {
+function evalStructureMap(ctx: TransformContext, structureMap: StructureMap, input: any[]): any[] {
   const groups = structureMap.group as StructureMapGroup[];
+
+  // Hoist groups by name
   for (const group of groups) {
-    input = evalGroup(ctx, group, input);
+    setVariable(ctx, group.name as string, group);
   }
-  return input;
+
+  // Only execute the first group - other groups can be called by name
+  return evalGroup(ctx, groups[0], input);
 }
 
-function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: any): any {
-  let sourceInput = undefined;
-  let targetInput = undefined;
+function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: any[]): any[] {
+  const sourceDefinitions: StructureMapGroupInput[] = [];
+  const targetDefinitions: StructureMapGroupInput[] = [];
 
-  for (const input of group.input as StructureMapGroupInput[]) {
-    if (input.mode === 'source') {
-      sourceInput = input;
+  for (const inputDefinition of group.input as StructureMapGroupInput[]) {
+    if (inputDefinition.mode === 'source') {
+      sourceDefinitions.push(inputDefinition);
     }
-    if (input.mode === 'target') {
-      targetInput = input;
+    if (inputDefinition.mode === 'target') {
+      targetDefinitions.push(inputDefinition);
     }
   }
 
-  if (!sourceInput) {
-    throw new Error('Missing source input');
+  if (sourceDefinitions.length === 0) {
+    throw new Error('Missing source definitions');
   }
 
-  if (!targetInput) {
-    throw new Error('Missing target input');
+  if (targetDefinitions.length === 0) {
+    throw new Error('Missing target definitions');
+  }
+
+  if (input.length < sourceDefinitions.length) {
+    throw new Error(`Not enough arguments (got ${input.length}, min ${sourceDefinitions.length})`);
+  }
+
+  if (input.length > sourceDefinitions.length + targetDefinitions.length) {
+    throw new Error(
+      `Too many arguments (got ${input.length}, max ${sourceDefinitions.length + targetDefinitions.length})`
+    );
   }
 
   const variables: Record<string, any> = {};
-  const result = {};
+  const outputs = [];
+  let inputIndex = 0;
 
-  if (sourceInput) {
-    variables[sourceInput.name as string] = input;
+  for (const sourceDefinition of sourceDefinitions) {
+    variables[sourceDefinition.name as string] = input[inputIndex++];
   }
 
-  if (targetInput) {
-    variables[targetInput.name as string] = result;
+  for (const targetDefinition of targetDefinitions) {
+    const output = input[inputIndex++] ?? {};
+    variables[targetDefinition.name as string] = output;
+    outputs.push(output);
   }
 
   const newContext: TransformContext = { parent: ctx, variables };
 
-  for (const rule of group.rule as StructureMapGroupRule[]) {
-    evalRule(newContext, rule);
+  if (group.rule) {
+    for (const rule of group.rule) {
+      evalRule(newContext, rule);
+    }
   }
 
-  return result;
+  return outputs;
 }
 
 function evalRule(ctx: TransformContext, rule: StructureMapGroupRule): void {
-  for (const source of rule.source as StructureMapGroupRuleSource[]) {
-    evalSource(ctx, source);
+  if (rule.source) {
+    for (const source of rule.source) {
+      evalSource(ctx, source);
+    }
   }
-  for (const target of rule.target as StructureMapGroupRuleTarget[]) {
-    evalTarget(ctx, target);
+  if (rule.target) {
+    for (const target of rule.target) {
+      evalTarget(ctx, target);
+    }
+  }
+  if (rule.rule) {
+    for (const childRule of rule.rule) {
+      evalRule(ctx, childRule);
+    }
+  }
+  if (rule.dependent) {
+    for (const dependent of rule.dependent) {
+      evalDependent(ctx, dependent);
+    }
   }
 }
 
 function evalSource(ctx: TransformContext, source: StructureMapGroupRuleSource): void {
   const sourceContext = getVariable(ctx, source.context as string);
-  const sourceElement = source.element as string;
+  const sourceElement = source.element;
+  if (!sourceElement) {
+    return;
+  }
+
   const sourceValue = evalFhirPathTyped(sourceElement, [toTypedValue(sourceContext)]);
   if (!sourceValue || sourceValue.length === 0) {
     return;
   }
 
   if (source.condition) {
-    const conditionExpression = source.condition as string;
-    const conditionInput = [toTypedValue(sourceContext)];
-    const conditionVariables = { [source.variable as string]: sourceValue[0] };
-    const conditionResult = evalFhirPathTyped(conditionExpression, conditionInput, conditionVariables);
-    if (!toJsBoolean(conditionResult)) {
+    if (!evalCondition(sourceContext, { [source.variable as string]: sourceValue[0] }, source.condition)) {
       return;
     }
   }
 
   if (source.check) {
-    const checkExpression = source.check as string;
-    const checkInput = [toTypedValue(sourceContext)];
-    const checkVariables = { [source.variable as string]: sourceValue[0] };
-    const checkResult = evalFhirPathTyped(checkExpression, checkInput, checkVariables);
-    if (!toJsBoolean(checkResult)) {
-      throw new Error('Check failed: ' + checkExpression);
+    if (!evalCondition(sourceContext, { [source.variable as string]: sourceValue[0] }, source.check)) {
+      throw new Error('Check failed: ' + source.check);
     }
   }
 
-  if (!ctx.variables) {
-    ctx.variables = {};
+  if (source.variable) {
+    setVariable(ctx, source.variable, sourceValue[0].value);
   }
+}
 
-  ctx.variables[source.variable as string] = sourceValue[0].value;
+function evalCondition(input: any, variables: Record<string, TypedValue>, condition: string): boolean {
+  return toJsBoolean(evalFhirPathTyped(condition, [toTypedValue(input)], variables));
 }
 
 function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
-  switch (target.transform as string) {
-    case 'copy':
-      evalCopy(ctx, target);
-      break;
-    case 'truncate':
-      evalTruncate(ctx, target);
-      break;
-    default:
-      throw new Error('Unsupported transform: ' + target.transform);
+  const targetContext = getVariable(ctx, target.context as string);
+  if (!targetContext) {
+    throw new Error('Target not found: ' + target.context);
+  }
+
+  let targetValue;
+
+  if (!target.transform) {
+    targetValue = {};
+    targetContext[target.element as string] = targetValue;
+  } else {
+    switch (target.transform) {
+      case 'copy':
+        targetValue = evalCopy(ctx, target, targetContext);
+        break;
+      case 'truncate':
+        targetValue = evalTruncate(ctx, target, targetContext);
+        break;
+      default:
+        console.warn('Unsupported transform: ' + target.transform);
+    }
+  }
+
+  if (target.variable) {
+    setVariable(ctx, target.variable, targetValue);
   }
 }
 
-function evalCopy(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
-  const targetContext = getVariable(ctx, target.context as string);
+function evalCopy(ctx: TransformContext, target: StructureMapGroupRuleTarget, targetContext: any): any {
   const targetElement = target.element as string;
   let targetParameter = getTypedPropertyValue(
     { type: 'StructureMapGroupRuleTargetParameter', value: target.parameter?.[0] },
@@ -135,17 +183,17 @@ function evalCopy(ctx: TransformContext, target: StructureMapGroupRuleTarget): v
     targetParameter = targetParameter[0];
   }
   if (!targetParameter) {
-    return;
+    throw new Error('Missing target parameter: ' + targetElement);
   }
   let targetValue = targetParameter.value;
   if (targetParameter.type === 'id') {
     targetValue = getVariable(ctx, targetParameter.value as string);
   }
   targetContext[targetElement] = targetValue;
+  return targetValue;
 }
 
-function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
-  const targetContext = getVariable(ctx, target.context as string);
+function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget, targetContext: any): any {
   const targetElement = target.element as string;
   let targetValue = getVariable(ctx, target.parameter?.[0]?.valueId as string);
   const targetLength = target.parameter?.[1]?.valueInteger as number;
@@ -153,6 +201,22 @@ function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget
     targetValue = targetValue.substring(0, targetLength);
   }
   targetContext[targetElement] = targetValue;
+  return targetValue;
+}
+
+function evalDependent(ctx: TransformContext, dependent: StructureMapGroupRuleDependent): void {
+  const dependentGroup = getVariable(ctx, dependent.name as string);
+  if (!dependentGroup) {
+    throw new Error('Dependent group not found: ' + dependent.name);
+  }
+
+  const variables = dependent.variable as string[];
+  const args = [];
+  for (const variable of variables) {
+    args.push(getVariable(ctx, variable));
+  }
+
+  evalGroup(ctx, dependentGroup as StructureMapGroup, args);
 }
 
 function getVariable(ctx: TransformContext, name: string): any {
@@ -164,4 +228,11 @@ function getVariable(ctx: TransformContext, name: string): any {
     return getVariable(ctx.parent, name);
   }
   return undefined;
+}
+
+function setVariable(ctx: TransformContext, name: string, value: any): void {
+  if (!ctx.variables) {
+    ctx.variables = {};
+  }
+  ctx.variables[name] = value;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './fhircast';
 export * from './fhirlexer/parse';
 export * from './fhirlexer/tokenize';
 export * from './fhirmapper/parse';
+export * from './fhirmapper/transform';
 export * from './fhirpath/atoms';
 export * from './fhirpath/parse';
 export * from './fhirpath/utils';


### PR DESCRIPTION
Incorporating tests from https://github.com/Vermonster/fhir-kit-mapping-language (MIT license)

Example of what this enables:

```ts
  test('invocation', () => {
    const map = `map "http://test.com" = test
    group example(source src, target tgt) {
      src.status as ss -> tgt.statusCode = ss;
      src.name as vn -> tgt.name as tn then name(vn, tn);
    }
    group name(source src, target tgt) {
      src.firstName as ss -> tgt.firstName = ss;
      src.lastName as ln -> tgt.familyName = ln;
    }`;

    const input = [{ status: 'active', name: { firstName: 'bob', lastName: 'smith' } }];
    const expected = [{ statusCode: 'active', name: { firstName: 'bob', familyName: 'smith' } }];
    const actual = structureMapTransform(parseMappingLanguage(map), input);
    expect(actual).toMatchObject(expected);
  });
```

We are not using FHIR Mapper in prod servers at this time, so this is a low risk change.