### PR TITLE
Remove tsconfig.build.json files

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -3,7 +3,7 @@
   "mainEntryPointFilePath": "<projectFolder>/dist/types/index.d.ts",
   "bundledPackages": ["@medplum/react-hooks"],
   "compiler": {
-    "tsconfigFilePath": "<projectFolder>/tsconfig.build.json",
+    "tsconfigFilePath": "<projectFolder>/tsconfig.json",
     "skipLibCheck": true
   },
   "apiReport": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs",
+    "build": "npm run clean && tsc && node esbuild.mjs",
     "clean": "rimraf dist",
     "medplum": "ts-node src/index.ts",
     "test": "jest"

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts"]
-}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "api-documenter": "api-documenter markdown --input-folder ./dist/api/ --output-folder ./dist/docs/",
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor && npm run api-documenter",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor && npm run api-documenter",
     "clean": "rimraf dist",
     "test": "jest"
   },

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -10,6 +10,7 @@ import {
   FetchLike,
   InviteRequest,
   MedplumClient,
+  MedplumClientOptions,
   NewPatientRequest,
   NewProjectRequest,
   NewUserRequest,
@@ -2694,7 +2695,7 @@ describe('Passed in async-backed `ClientStorage`', () => {
   test('MedplumClient resolves initialized after storage is initialized', async () => {
     const fetch = mockFetch(200, { success: true });
     const storage = new MockAsyncClientStorage();
-    const medplum = new MedplumClient({ fetch, storage });
+    const medplum = new MedplumClient({ fetch, storage } as unknown as MedplumClientOptions);
     expect(storage.isInitialized).toEqual(false);
     expect(medplum.isInitialized).toEqual(false);
     storage.setInitialized();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1,5 +1,4 @@
 import { Bot, Bundle, Identifier, Patient, SearchParameter, StructureDefinition } from '@medplum/fhirtypes';
-import { MockAsyncClientStorage } from '@medplum/mock';
 import { randomUUID, webcrypto } from 'crypto';
 import PdfPrinter from 'pdfmake';
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
@@ -10,7 +9,6 @@ import {
   FetchLike,
   InviteRequest,
   MedplumClient,
-  MedplumClientOptions,
   NewPatientRequest,
   NewProjectRequest,
   NewUserRequest,
@@ -18,6 +16,7 @@ import {
 import { mockFetch } from './client-test-utils';
 import { ContentType } from './contenttype';
 import { OperationOutcomeError, notFound, unauthorized } from './outcomes';
+import { MockAsyncClientStorage } from './storage';
 import { getDataType, isDataTypeLoaded, isProfileLoaded } from './typeschema/types';
 import { ProfileResource, createReference } from './utils';
 
@@ -2695,7 +2694,7 @@ describe('Passed in async-backed `ClientStorage`', () => {
   test('MedplumClient resolves initialized after storage is initialized', async () => {
     const fetch = mockFetch(200, { success: true });
     const storage = new MockAsyncClientStorage();
-    const medplum = new MedplumClient({ fetch, storage } as unknown as MedplumClientOptions);
+    const medplum = new MedplumClient({ fetch, storage });
     expect(storage.isInitialized).toEqual(false);
     expect(medplum.isInitialized).toEqual(false);
     storage.setInitialized();

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -113,3 +113,36 @@ export class MemoryStorage implements Storage {
     return Array.from(this.data.keys())[index];
   }
 }
+
+/**
+ * The MockAsyncClientStorage class is a mock implementation of the ClientStorage class.
+ * This can be used for testing async initialization of the MedplumClient.
+ */
+export class MockAsyncClientStorage extends ClientStorage implements IClientStorage {
+  private initialized: boolean;
+  private initPromise: Promise<void>;
+  private initResolve: () => void = () => undefined;
+
+  constructor() {
+    super();
+    this.initialized = false;
+    this.initPromise = new Promise((resolve) => {
+      this.initResolve = resolve;
+    });
+  }
+
+  setInitialized(): void {
+    if (!this.initialized) {
+      this.initResolve();
+      this.initialized = true;
+    }
+  }
+
+  getInitPromise(): Promise<void> {
+    return this.initPromise;
+  }
+
+  get isInitialized(): boolean {
+    return this.initialized;
+  }
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts"]
-}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "module": "es2020",
     "types": ["jest", "vite/client"],
-    "lib": ["esnext", "dom"]
+    "lib": ["esnext", "dom"],
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/expo-polyfills/package.json
+++ b/packages/expo-polyfills/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf ./build",
     "test": "jest --runInBand"
   },

--- a/packages/expo-polyfills/tsconfig.build.json
+++ b/packages/expo-polyfills/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts"]
-}

--- a/packages/expo-polyfills/tsconfig.json
+++ b/packages/expo-polyfills/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["esnext", "dom"]
+    "lib": ["esnext", "dom"],
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
     "test": "jest"
   },

--- a/packages/fhir-router/tsconfig.build.json
+++ b/packages/fhir-router/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts"]
-}

--- a/packages/fhir-router/tsconfig.json
+++ b/packages/fhir-router/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "es2020",
+    "types": ["jest", "vite/client"],
+    "lib": ["esnext", "dom"],
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/hl7/package.json
+++ b/packages/hl7/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
     "test": "jest"
   },

--- a/packages/hl7/tsconfig.build.json
+++ b/packages/hl7/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts"]
-}

--- a/packages/hl7/tsconfig.json
+++ b/packages/hl7/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "es2020",
+    "types": ["jest", "vite/client"],
+    "lib": ["esnext", "dom"],
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -48,7 +48,7 @@
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
     "test": "jest"
   },

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -10,12 +10,13 @@ import {
   NewProjectRequest,
   NewUserRequest,
   OperationOutcomeError,
+  MockAsyncClientStorage,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, CodeableConcept, Patient, SearchParameter, ServiceRequest } from '@medplum/fhirtypes';
 import { randomUUID, webcrypto } from 'crypto';
 import { TextEncoder } from 'util';
-import { MockAsyncClientStorage, MockClient } from './client';
+import { MockClient } from './client';
 import { DrAliceSmith, DrAliceSmithSchedule, HomerSimpson } from './mocks';
 
 describe('MockClient', () => {

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -1,10 +1,8 @@
 import {
   allOk,
   badRequest,
-  ClientStorage,
   ContentType,
   getStatus,
-  IClientStorage,
   indexSearchParameter,
   loadDataType,
   LoginState,
@@ -567,31 +565,6 @@ export class MockFetchClient {
     } else {
       return result[1];
     }
-  }
-}
-
-export class MockAsyncClientStorage extends ClientStorage implements IClientStorage {
-  #initialized: boolean;
-  #initPromise: Promise<void>;
-  #initResolve: () => void = () => undefined;
-  constructor() {
-    super();
-    this.#initialized = false;
-    this.#initPromise = new Promise((resolve) => {
-      this.#initResolve = resolve;
-    });
-  }
-  setInitialized(): void {
-    if (!this.#initialized) {
-      this.#initResolve();
-      this.#initialized = true;
-    }
-  }
-  getInitPromise(): Promise<void> {
-    return this.#initPromise;
-  }
-  get isInitialized(): boolean {
-    return this.#initialized;
   }
 }
 

--- a/packages/mock/tsconfig.build.json
+++ b/packages/mock/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts"]
-}

--- a/packages/mock/tsconfig.json
+++ b/packages/mock/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "es2020",
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -52,7 +52,7 @@
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
     "test": "jest"
   },

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
@@ -1,5 +1,5 @@
-import { getDisplayString, MedplumClient, ProfileResource } from '@medplum/core';
-import { MockAsyncClientStorage, MockClient } from '@medplum/mock';
+import { MedplumClient, MockAsyncClientStorage, ProfileResource, getDisplayString } from '@medplum/core';
+import { MockClient } from '@medplum/mock';
 import { act, render, screen } from '@testing-library/react';
 import { MedplumProvider } from './MedplumProvider';
 import { useMedplum, useMedplumContext, useMedplumNavigate, useMedplumProfile } from './MedplumProvider.context';

--- a/packages/react-hooks/tsconfig.build.json
+++ b/packages/react-hooks/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
-}

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["esnext", "dom", "dom.iterable"]
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,7 @@
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
-    "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs && npm run api-extractor",
+    "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist storybook-static",
     "dev": "storybook dev -p 6006",
     "storybook": "storybook build",

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/types",
-    "noEmit": false,
-    "emitDeclarationOnly": true
-  },
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
-}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "module": "es2020",
     "types": ["vite/client"],
-    "lib": ["esnext", "dom", "dom.iterable"]
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "outDir": "dist/types",
+    "noEmit": false,
+    "emitDeclarationOnly": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/3571

For many of our TypeScript packages, the `"build"` step does the following:

1. `npm run clean` - clean the `dist` directory
2. `tsc --project tsconfig.build.json` - type check and produce `.d.ts` files
3. `node esbuild.mjs` - build `.cjs` and `.mjs` output files
4. `npm run api-extractor` - build consolidated `.d.ts` output file

Note that we don't run bare `tsc`, we run `tsc --project tsconfig.build.json`.  The reason is that `tsc` actually does 2 related but separate things:

1. Type checks
2. Generates `.d.ts` output

We want to type check the entire project

But we only want to generate `.d.ts` output for `.tsx` files, not `.test.tsx` files.

And hence it is possible to get type errors in `.test.tsx`

This PR removes `tsconfig.build.json` files, and always emits `.d.ts`, even for unwanted files like `.test.ts`.  The `api-extractor` tool is smart enough to ignore them when generating the consolidated `.d.ts` that we publish to NPM.