### PR TITLE
FHIR Mapper - structure map imports

### DIFF
--- a/packages/core/src/fhirmapper/parse.ts
+++ b/packages/core/src/fhirmapper/parse.ts
@@ -354,6 +354,7 @@ function literalToParameter(literalAtom: LiteralAtom): StructureMapGroupRuleTarg
       return { valueDecimal: literalAtom.value.value as number };
     case 'integer':
       return { valueInteger: literalAtom.value.value as number };
+    case 'dateTime':
     case 'string':
       return { valueString: literalAtom.value.value as string };
     default:

--- a/packages/core/src/fhirmapper/transform.import.test.ts
+++ b/packages/core/src/fhirmapper/transform.import.test.ts
@@ -1,0 +1,80 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle, StructureMap } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+// Based on: https://github.com/Vermonster/fhir-kit-mapping-language/blob/master/test/engine/import.test.js
+// MIT License
+
+describe('FHIR Mapper transform - import', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('importing single known map', () => {
+    const map1 = parseMappingLanguage(`map "http://test.com/1" = test
+
+    imports "http://test.com/2"
+
+    group example1(source src, target tgt) {
+      src.name as sn -> tgt.name as tn then example2(sn, tn);
+    }`);
+
+    const map2 = parseMappingLanguage(`map "http://test.com/2" = test
+    group example2(source src, target tgt) {
+      src.firstName as ss -> tgt.firstName = ss;
+    }`);
+
+    const maps = new StructureMapCollection([map1, map2]);
+
+    const input = [{ name: { firstName: 'Bob' } }];
+    const actual = structureMapTransform(map1, input, (url) => maps.get(url));
+    const expected = input;
+    expect(actual).toMatchObject(expected);
+  });
+
+  test('importing using wildcard', () => {
+    const map1 = parseMappingLanguage(`map "http://test.com/1" = test
+
+    imports "http://test.com/2*"
+
+    group example1(source src, target tgt) {
+      src.name as sn -> tgt.name as tn then example2(sn, tn);
+      src.name as sn -> tgt.name as tn then example3(sn, tn);
+    }`);
+
+    const map2 = parseMappingLanguage(`map "http://test.com/2first" = test
+    group example2(source src, target tgt) {
+      src.firstName as ss -> tgt.firstName = ss;
+    }`);
+
+    const map3 = parseMappingLanguage(`map "http://test.com/2last" = test
+    group example3(source src, target tgt) {
+      src.lastName as ss -> tgt.lastName = ss;
+    }`);
+
+    const maps = new StructureMapCollection([map1, map2, map3]);
+
+    const input = [{ name: { firstName: 'Bob', lastName: 'Smith' } }];
+    const actual = structureMapTransform(map1, input, (url) => maps.get(url));
+    const expected = input;
+    expect(actual).toMatchObject(expected);
+  });
+});
+
+class StructureMapCollection {
+  constructor(readonly maps: StructureMap[]) {}
+
+  get(url: string): StructureMap[] {
+    return this.maps.filter((map) => {
+      if (url.includes('*')) {
+        const parts = url.split('*')[0];
+        return map.url?.startsWith(parts[0]) && map.url.endsWith(parts[1]);
+      } else {
+        return map.url === url;
+      }
+    });
+  }
+}

--- a/packages/core/src/fhirmapper/transform.literal.test.ts
+++ b/packages/core/src/fhirmapper/transform.literal.test.ts
@@ -1,0 +1,92 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+// Based on: https://github.com/Vermonster/fhir-kit-mapping-language/blob/master/test/engine/literal.test.js
+// MIT License
+
+describe('FHIR Mapper transform - literal', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('string', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = 'test';
+    }`;
+
+    const input = [{}];
+    const expected = [{ value: 'test' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+    expect(typeof actual[0].value).toBe('string');
+  });
+
+  test('integer', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = 121;
+    }`;
+
+    const input = [{}];
+    const expected = [{ value: 121 }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+    expect(typeof actual[0].value).toBe('number');
+  });
+
+  test('number', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = 1.21;
+    }`;
+
+    const input = [{}];
+    const expected = [{ value: 1.21 }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+    expect(typeof actual[0].value).toBe('number');
+  });
+
+  test('bool, true', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = true;
+    }`;
+
+    const input = [{}];
+    const expected = [{ value: true }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+    expect(typeof actual[0].value).toBe('boolean');
+  });
+
+  test('bool, false', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = false;
+    }`;
+
+    const input = [{}];
+    const expected = [{ value: false }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+    expect(typeof actual[0].value).toBe('boolean');
+  });
+
+  test('datetime', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = @2019-08-19T16:22:23.118Z;
+    }`;
+
+    const input = [{}];
+    const expected = [{ value: '2019-08-19T16:22:23.118Z' }];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
In service of https://github.com/medplum/medplum/issues/3005

Implements the `import` statement in FHIR Mapping Language and `StructureMap/$transform`.  This allows you to import other map files into the current context.

For example:

```ts
  test('importing using wildcard', () => {
    const map1 = parseMappingLanguage(`map "http://test.com/1" = test
    imports "http://test.com/2*"
    group example1(source src, target tgt) {
      src.name as sn -> tgt.name as tn then example2(sn, tn);
      src.name as sn -> tgt.name as tn then example3(sn, tn);
    }`);

    const map2 = parseMappingLanguage(`map "http://test.com/2first" = test
    group example2(source src, target tgt) {
      src.firstName as ss -> tgt.firstName = ss;
    }`);

    const map3 = parseMappingLanguage(`map "http://test.com/2last" = test
    group example3(source src, target tgt) {
      src.lastName as ss -> tgt.lastName = ss;
    }`);

    const maps = new StructureMapCollection([map1, map2, map3]);

    const input = [{ name: { firstName: 'Bob', lastName: 'Smith' } }];
    const actual = structureMapTransform(map1, input, (url) => maps.get(url));
    const expected = input;
    expect(actual).toMatchObject(expected);
  });
```

The diff is messy due to refactoring to support multiple `StructureMap` resources in a single `$transform`.

The spec is not totally explicit on scoping rules, so I'm using the JS concept of "hoisting" to make all top-level "groups" (functions) available.

Unlike how things were implemented in [Vermonster/fhir-kit-mapping-language](https://github.com/Vermonster/fhir-kit-mapping-language), this implementation does not require all `StructureMap` resources be preloaded.  Instead, you pass in an optional `loader`, which can evaluate `import` statements.  This should dovetail nicely when we connect it with the server `Repository`, and dynamically pull in the structure maps.