### PR TITLE
FHIR Mapper - use TypedValue

### DIFF
--- a/packages/core/src/fhirmapper/transform.cda.test.ts
+++ b/packages/core/src/fhirmapper/transform.cda.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -27,9 +28,10 @@ describe('FHIR Mapper transform - C-CDA', () => {
     }
     `;
 
-    const input = [{}, { entry: [] }];
+    const input = [toTypedValue({}), toTypedValue({ resourceType: 'Bundle', entry: [] })];
     const expected = [
-      {
+      toTypedValue({
+        resourceType: 'Bundle',
         entry: [
           {
             fullUrl: expect.stringMatching(/^urn:uuid:[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$/),
@@ -46,7 +48,7 @@ describe('FHIR Mapper transform - C-CDA', () => {
             },
           },
         ],
-      },
+      }),
     ];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);

--- a/packages/core/src/fhirmapper/transform.copy.test.ts
+++ b/packages/core/src/fhirmapper/transform.copy.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -19,8 +20,8 @@ describe('FHIR Mapper transform - copy', () => {
       src.name as v -> tgt.name = v;
     }`;
 
-    const input = [{ name: 'bob' }];
-    const expected = [{ name: 'bob' }];
+    const input = [toTypedValue({ name: 'bob' })];
+    const expected = [toTypedValue({ name: 'bob' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -31,8 +32,8 @@ describe('FHIR Mapper transform - copy', () => {
       src.name as v -> tgt.name = v;
     }`;
 
-    const input = [{ name: 'bob' }, { size: 'average' }];
-    const expected = [{ name: 'bob', size: 'average' }];
+    const input = [toTypedValue({ name: 'bob' }), toTypedValue({ size: 'average' })];
+    const expected = [toTypedValue({ name: 'bob', size: 'average' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -43,8 +44,8 @@ describe('FHIR Mapper transform - copy', () => {
       src.name as v, src.size as s -> tgt.firstName = v, tgt.size = s;
     }`;
 
-    const input = [{ name: 'bob', size: 'small' }];
-    const expected = [{ firstName: 'bob', size: 'small' }];
+    const input = [toTypedValue({ name: 'bob', size: 'small' })];
+    const expected = [toTypedValue({ firstName: 'bob', size: 'small' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -55,8 +56,8 @@ describe('FHIR Mapper transform - copy', () => {
       src.name as v -> tgt.name = v, tgt.oldName = v;
     }`;
 
-    const input = [{ name: 'bob' }];
-    const expected = [{ name: 'bob', oldName: 'bob' }];
+    const input = [toTypedValue({ name: 'bob' })];
+    const expected = [toTypedValue({ name: 'bob', oldName: 'bob' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -69,8 +70,8 @@ describe('FHIR Mapper transform - copy', () => {
       src.active as sa -> tgt.activeStatus = sa;
     }`;
 
-    const input = [{ name: 'bob', size: 'small', active: true }];
-    const expected = [{ name: 'bob', size: 'small', activeStatus: true }];
+    const input = [toTypedValue({ name: 'bob', size: 'small', active: true })];
+    const expected = [toTypedValue({ name: 'bob', size: 'small', activeStatus: true })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -82,8 +83,8 @@ describe('FHIR Mapper transform - copy', () => {
       src2.size as v -> tgt.size = v;
     }`;
 
-    const input = [{ name: 'bob' }, { size: 'small' }];
-    const expected = [{ name: 'bob', size: 'small' }];
+    const input = [toTypedValue({ name: 'bob' }), toTypedValue({ size: 'small' })];
+    const expected = [toTypedValue({ name: 'bob', size: 'small' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -95,8 +96,8 @@ describe('FHIR Mapper transform - copy', () => {
       src.size as v -> tgt2.size = v;
     }`;
 
-    const input = [{ name: 'bob', size: 'small' }];
-    const expected = [{ name: 'bob' }, { size: 'small' }];
+    const input = [toTypedValue({ name: 'bob', size: 'small' })];
+    const expected = [toTypedValue({ name: 'bob' }), toTypedValue({ size: 'small' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });
@@ -109,10 +110,15 @@ describe('FHIR Mapper transform - copy', () => {
       src2.size as ss -> tgt2.size = ss;
     }`;
 
-    const input = [{ name: 'bob' }, { size: 'small' }, { active: true }, { active: true }];
+    const input = [
+      toTypedValue({ name: 'bob' }),
+      toTypedValue({ size: 'small' }),
+      toTypedValue({ active: true }),
+      toTypedValue({ active: true }),
+    ];
     const expected = [
-      { name: 'bob', active: true },
-      { name: 'bob', size: 'small', active: true },
+      toTypedValue({ name: 'bob', active: true }),
+      toTypedValue({ name: 'bob', size: 'small', active: true }),
     ];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);

--- a/packages/core/src/fhirmapper/transform.dependent.test.ts
+++ b/packages/core/src/fhirmapper/transform.dependent.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -22,8 +23,8 @@ describe('FHIR Mapper transform - dependent', () => {
       };
     }`;
 
-    const input = [{ name: { firstName: 'bob', lastName: 'smith' } }];
-    const expected = [{ name: { firstName: 'bob', familyName: 'smith' } }];
+    const input = [toTypedValue({ name: { firstName: 'bob', lastName: 'smith' } })];
+    const expected = [toTypedValue({ name: { firstName: 'bob', familyName: 'smith' } })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -40,8 +41,8 @@ describe('FHIR Mapper transform - dependent', () => {
       src.lastName as ln -> tgt.familyName = ln;
     }`;
 
-    const input = [{ status: 'active', name: { firstName: 'bob', lastName: 'smith' } }];
-    const expected = [{ statusCode: 'active', name: { firstName: 'bob', familyName: 'smith' } }];
+    const input = [toTypedValue({ status: 'active', name: { firstName: 'bob', lastName: 'smith' } })];
+    const expected = [toTypedValue({ statusCode: 'active', name: { firstName: 'bob', familyName: 'smith' } })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -54,7 +55,7 @@ describe('FHIR Mapper transform - dependent', () => {
     }`;
 
     try {
-      structureMapTransform(parseMappingLanguage(map), [{ status: 'x', name: 'y' }]);
+      structureMapTransform(parseMappingLanguage(map), [toTypedValue({ status: 'x', name: 'y' })]);
       throw new Error('Expected error');
     } catch (err: any) {
       expect(err.message).toBe('Dependent group not found: doesNotExist');
@@ -72,8 +73,8 @@ describe('FHIR Mapper transform - dependent', () => {
       src.section as srcSection -> tgt.section as tgtSection then section(srcSection, tgtSection);
     }`;
 
-    const input = [{ section: { section: { name: 'foo' } } }];
-    const expected = [{ section: { section: { name: 'foo' } } }];
+    const input = [toTypedValue({ section: { section: { name: 'foo' } } })];
+    const expected = [toTypedValue({ section: { section: { name: 'foo' } } })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });

--- a/packages/core/src/fhirmapper/transform.errors.test.ts
+++ b/packages/core/src/fhirmapper/transform.errors.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -59,7 +60,7 @@ describe('FHIR Mapper transform - errors', () => {
     }`;
 
     try {
-      structureMapTransform(parseMappingLanguage(map), [{}, {}, {}]);
+      structureMapTransform(parseMappingLanguage(map), [toTypedValue({}), toTypedValue({}), toTypedValue({})]);
       throw new Error('Expected error');
     } catch (err: any) {
       expect(err.message).toEqual('Too many arguments (got 3, max 2)');
@@ -77,7 +78,7 @@ describe('FHIR Mapper transform - errors', () => {
     `;
 
     try {
-      structureMapTransform(parseMappingLanguage(map), [{ a: 'abc' }]);
+      structureMapTransform(parseMappingLanguage(map), [toTypedValue({ a: 'abc' })]);
       throw new Error('Expected error');
     } catch (err: any) {
       expect(err.message).toEqual('Target not found: notFound');
@@ -95,7 +96,7 @@ describe('FHIR Mapper transform - errors', () => {
     `;
 
     try {
-      structureMapTransform(parseMappingLanguage(map), [{ a: 'abc' }]);
+      structureMapTransform(parseMappingLanguage(map), [toTypedValue({ a: 'abc' })]);
       throw new Error('Expected error');
     } catch (err: any) {
       expect(err.message).toEqual('Invalid key: prototype');

--- a/packages/core/src/fhirmapper/transform.import.test.ts
+++ b/packages/core/src/fhirmapper/transform.import.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle, StructureMap } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -29,7 +30,7 @@ describe('FHIR Mapper transform - import', () => {
 
     const maps = new StructureMapCollection([map1, map2]);
 
-    const input = [{ name: { firstName: 'Bob' } }];
+    const input = [toTypedValue({ name: { firstName: 'Bob' } })];
     const actual = structureMapTransform(map1, input, (url) => maps.get(url));
     const expected = input;
     expect(actual).toMatchObject(expected);
@@ -57,7 +58,7 @@ describe('FHIR Mapper transform - import', () => {
 
     const maps = new StructureMapCollection([map1, map2, map3]);
 
-    const input = [{ name: { firstName: 'Bob', lastName: 'Smith' } }];
+    const input = [toTypedValue({ name: { firstName: 'Bob', lastName: 'Smith' } })];
     const actual = structureMapTransform(map1, input, (url) => maps.get(url));
     const expected = input;
     expect(actual).toMatchObject(expected);

--- a/packages/core/src/fhirmapper/transform.literal.test.ts
+++ b/packages/core/src/fhirmapper/transform.literal.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -19,11 +20,11 @@ describe('FHIR Mapper transform - literal', () => {
       src -> tgt.value = 'test';
     }`;
 
-    const input = [{}];
-    const expected = [{ value: 'test' }];
+    const input = [toTypedValue({})];
+    const expected = [toTypedValue({ value: 'test' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
-    expect(typeof actual[0].value).toBe('string');
+    expect(typeof actual[0].value.value).toBe('string');
   });
 
   test('integer', () => {
@@ -32,11 +33,11 @@ describe('FHIR Mapper transform - literal', () => {
       src -> tgt.value = 121;
     }`;
 
-    const input = [{}];
-    const expected = [{ value: 121 }];
+    const input = [toTypedValue({})];
+    const expected = [{ type: 'BackboneElement', value: { value: 121 } }];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
-    expect(typeof actual[0].value).toBe('number');
+    expect(typeof actual[0].value.value).toBe('number');
   });
 
   test('number', () => {
@@ -45,11 +46,11 @@ describe('FHIR Mapper transform - literal', () => {
       src -> tgt.value = 1.21;
     }`;
 
-    const input = [{}];
-    const expected = [{ value: 1.21 }];
+    const input = [toTypedValue({})];
+    const expected = [{ type: 'BackboneElement', value: { value: 1.21 } }];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
-    expect(typeof actual[0].value).toBe('number');
+    expect(typeof actual[0].value.value).toBe('number');
   });
 
   test('bool, true', () => {
@@ -58,11 +59,11 @@ describe('FHIR Mapper transform - literal', () => {
       src -> tgt.value = true;
     }`;
 
-    const input = [{}];
-    const expected = [{ value: true }];
+    const input = [toTypedValue({})];
+    const expected = [toTypedValue({ value: true })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
-    expect(typeof actual[0].value).toBe('boolean');
+    expect(typeof actual[0].value.value).toBe('boolean');
   });
 
   test('bool, false', () => {
@@ -71,11 +72,11 @@ describe('FHIR Mapper transform - literal', () => {
       src -> tgt.value = false;
     }`;
 
-    const input = [{}];
-    const expected = [{ value: false }];
+    const input = [toTypedValue({})];
+    const expected = [toTypedValue({ value: false })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
-    expect(typeof actual[0].value).toBe('boolean');
+    expect(typeof actual[0].value.value).toBe('boolean');
   });
 
   test('datetime', () => {
@@ -84,8 +85,8 @@ describe('FHIR Mapper transform - literal', () => {
       src -> tgt.value = @2019-08-19T16:22:23.118Z;
     }`;
 
-    const input = [{}];
-    const expected = [{ value: '2019-08-19T16:22:23.118Z' }];
+    const input = [toTypedValue({})];
+    const expected = [toTypedValue({ value: '2019-08-19T16:22:23.118Z' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toEqual(expected);
   });

--- a/packages/core/src/fhirmapper/transform.test.ts
+++ b/packages/core/src/fhirmapper/transform.test.ts
@@ -1,5 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
@@ -22,8 +23,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = [{ a: 'a' }];
-    const expected = [{ a: 'a' }];
+    const input = [toTypedValue({ a: 'a' })];
+    const expected = [toTypedValue({ a: 'a' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -40,8 +41,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = [{ a1: 'a' }];
-    const expected = [{ a2: 'a' }];
+    const input = [toTypedValue({ a1: 'a' })];
+    const expected = [toTypedValue({ a2: 'a' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -58,8 +59,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = [{ a2: 'abcdef' }];
-    const expected = [{ a2: 'abc' }];
+    const input = [toTypedValue({ a2: 'abcdef' })];
+    const expected = [toTypedValue({ a2: 'abc' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });
@@ -76,13 +77,13 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input1 = [{ a2: 'abcdef' }];
-    const expected1 = [{}];
+    const input1 = [toTypedValue({ a2: 'abcdef' })];
+    const expected1 = [toTypedValue({})];
     const actual1 = structureMapTransform(parseMappingLanguage(map), input1);
     expect(actual1).toMatchObject(expected1);
 
-    const input2 = [{ a2: 'abc' }];
-    const expected2 = [{ a2: 'abc' }];
+    const input2 = [toTypedValue({ a2: 'abc' })];
+    const expected2 = [toTypedValue({ a2: 'abc' })];
     const actual2 = structureMapTransform(parseMappingLanguage(map), input2);
     expect(actual2).toMatchObject(expected2);
   });
@@ -99,7 +100,7 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input1 = [{ a2: 'abcdef' }];
+    const input1 = [toTypedValue({ a2: 'abcdef' })];
     try {
       structureMapTransform(parseMappingLanguage(map), input1);
       throw new Error('Expected error');
@@ -107,8 +108,8 @@ describe('FHIR Mapper transform', () => {
       expect(err.message).toBe('Check failed: a2.length() <= 3');
     }
 
-    const input2 = [{ a2: 'abc' }];
-    const expected2 = [{ a2: 'abc' }];
+    const input2 = [toTypedValue({ a2: 'abc' })];
+    const expected2 = [toTypedValue({ a2: 'abc' })];
     const actual2 = structureMapTransform(parseMappingLanguage(map), input2);
     expect(actual2).toMatchObject(expected2);
   });
@@ -125,8 +126,8 @@ describe('FHIR Mapper transform', () => {
       }
     `;
 
-    const input = [{ a3: 1 }];
-    const expected = [{ a3: 123 }];
+    const input = [toTypedValue({ a3: 1 })];
+    const expected = [toTypedValue({ a3: 123 })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });

--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -145,10 +145,6 @@ function evalSource(ctx: TransformContext, source: StructureMapGroupRuleSource):
     return false;
   }
 
-  if (!sourceContext.type) {
-    throw new Error('Source context has no type: ' + source.context);
-  }
-
   const sourceElement = source.element;
   if (!sourceElement) {
     return true;
@@ -193,8 +189,7 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
 
   if (!target.transform) {
     // TODO: Need to determine whether "targetValue" should be an object or an array
-    // To do this, we'll need to look at the StructureDefinition for the target
-    // What is the "path" at this point?
+    // To do this, we'll need to look at the StructureDefinition for the target element
     if (Array.isArray(originalValue) || originalValue === undefined) {
       targetValue = toTypedValue({});
     } else {
@@ -222,14 +217,8 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
         targetValue = { type: 'string', value: generateId() };
         break;
       default:
-        throw new Error(
-          `Unsupported transform: ${target.transform} (context=${target.context} element=${target.element})`
-        );
+        throw new Error(`Unsupported transform: ${target.transform}`);
     }
-  }
-
-  if (!targetValue.type) {
-    throw new Error('Missing type: ' + JSON.stringify(targetValue));
   }
 
   if (Array.isArray(originalValue)) {
@@ -328,9 +317,6 @@ function getVariable(ctx: TransformContext, name: string): TypedValue | undefine
 }
 
 function setVariable(ctx: TransformContext, name: string, value: TypedValue): void {
-  if (!value.type) {
-    throw new Error('Missing type: ' + JSON.stringify(value));
-  }
   if (!ctx.variables) {
     ctx.variables = {};
   }

--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -16,18 +16,18 @@ import { TypedValue } from '../types';
 interface TransformContext {
   loader?: (url: string) => StructureMap[];
   parent?: TransformContext;
-  variables?: Record<string, any>;
+  variables?: Record<string, TypedValue>;
 }
 
 export function structureMapTransform(
   structureMap: StructureMap,
-  input: any[],
+  input: TypedValue[],
   loader?: (url: string) => StructureMap[]
-): any[] {
+): TypedValue[] {
   return evalStructureMap({ loader }, structureMap, input);
 }
 
-function evalStructureMap(ctx: TransformContext, structureMap: StructureMap, input: any[]): any[] {
+function evalStructureMap(ctx: TransformContext, structureMap: StructureMap, input: TypedValue[]): TypedValue[] {
   evalImports(ctx, structureMap);
   hoistGroups(ctx, structureMap);
   return evalGroup(ctx, (structureMap.group as StructureMapGroup[])[0], input);
@@ -47,12 +47,12 @@ function evalImports(ctx: TransformContext, structureMap: StructureMap): void {
 function hoistGroups(ctx: TransformContext, structureMap: StructureMap): void {
   if (structureMap.group) {
     for (const group of structureMap.group) {
-      setVariable(ctx, group.name as string, group);
+      setVariable(ctx, group.name as string, { type: 'StructureMapGroup', value: group });
     }
   }
 }
 
-function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: any[]): any[] {
+function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: TypedValue[]): TypedValue[] {
   const sourceDefinitions: StructureMapGroupInput[] = [];
   const targetDefinitions: StructureMapGroupInput[] = [];
 
@@ -83,7 +83,7 @@ function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: any[]
     );
   }
 
-  const variables: Record<string, any> = {};
+  const variables: Record<string, TypedValue> = {};
   const outputs = [];
   let inputIndex = 0;
 
@@ -92,7 +92,7 @@ function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: any[]
   }
 
   for (const targetDefinition of targetDefinitions) {
-    const output = input[inputIndex++] ?? {};
+    const output = input[inputIndex++] ?? toTypedValue({});
     safeAssign(variables, targetDefinition.name as string, output);
     outputs.push(output);
   }
@@ -141,12 +141,20 @@ function evalRule(ctx: TransformContext, rule: StructureMapGroupRule): void {
 
 function evalSource(ctx: TransformContext, source: StructureMapGroupRuleSource): boolean {
   const sourceContext = getVariable(ctx, source.context as string);
+  if (!sourceContext) {
+    return false;
+  }
+
+  if (!sourceContext.type) {
+    throw new Error('Source context has no type: ' + source.context);
+  }
+
   const sourceElement = source.element;
   if (!sourceElement) {
     return true;
   }
 
-  const sourceValue = evalFhirPathTyped(sourceElement, [toTypedValue(sourceContext)]);
+  const sourceValue = evalFhirPathTyped(sourceElement, [sourceContext]);
   if (!sourceValue || sourceValue.length === 0) {
     return false;
   }
@@ -164,14 +172,14 @@ function evalSource(ctx: TransformContext, source: StructureMapGroupRuleSource):
   }
 
   if (source.variable) {
-    setVariable(ctx, source.variable, sourceValue[0].value);
+    setVariable(ctx, source.variable, sourceValue[0]);
   }
 
   return true;
 }
 
-function evalCondition(input: any, variables: Record<string, TypedValue>, condition: string): boolean {
-  return toJsBoolean(evalFhirPathTyped(condition, [toTypedValue(input)], variables));
+function evalCondition(input: TypedValue, variables: Record<string, TypedValue>, condition: string): boolean {
+  return toJsBoolean(evalFhirPathTyped(condition, [input], variables));
 }
 
 function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget): void {
@@ -180,14 +188,17 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
     throw new Error('Target not found: ' + target.context);
   }
 
-  const originalValue = targetContext[target.element as string];
-  let targetValue;
+  const originalValue = targetContext.value[target.element as string];
+  let targetValue: TypedValue;
 
   if (!target.transform) {
+    // TODO: Need to determine whether "targetValue" should be an object or an array
+    // To do this, we'll need to look at the StructureDefinition for the target
+    // What is the "path" at this point?
     if (Array.isArray(originalValue) || originalValue === undefined) {
-      targetValue = {};
+      targetValue = toTypedValue({});
     } else {
-      targetValue = originalValue;
+      targetValue = toTypedValue(originalValue);
     }
   } else {
     switch (target.transform) {
@@ -208,19 +219,23 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
         targetValue = evalTruncate(ctx, target);
         break;
       case 'uuid':
-        targetValue = generateId();
+        targetValue = { type: 'string', value: generateId() };
         break;
       default:
-        console.warn(
+        throw new Error(
           `Unsupported transform: ${target.transform} (context=${target.context} element=${target.element})`
         );
     }
   }
 
+  if (!targetValue.type) {
+    throw new Error('Missing type: ' + JSON.stringify(targetValue));
+  }
+
   if (Array.isArray(originalValue)) {
-    originalValue.push(targetValue);
+    originalValue.push(targetValue.value);
   } else {
-    safeAssign(targetContext, target.element as string, targetValue);
+    safeAssign(targetContext.value, target.element as string, targetValue.value);
   }
 
   if (target.variable) {
@@ -228,29 +243,29 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
   }
 }
 
-function evalAppend(ctx: TransformContext, target: StructureMapGroupRuleTarget): any {
-  const arg1 = resolveParameter(ctx, target.parameter?.[0]) as string | undefined;
-  const arg2 = resolveParameter(ctx, target.parameter?.[1]) as string | undefined;
-  return (arg1 ?? '').toString() + (arg2 ?? '').toString();
+function evalAppend(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue {
+  const arg1 = resolveParameter(ctx, target.parameter?.[0])?.value;
+  const arg2 = resolveParameter(ctx, target.parameter?.[1])?.value;
+  return { type: 'string', value: (arg1 ?? '').toString() + (arg2 ?? '').toString() };
 }
 
-function evalCopy(ctx: TransformContext, target: StructureMapGroupRuleTarget): any {
+function evalCopy(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue {
   return resolveParameter(ctx, target.parameter?.[0]);
 }
 
-function evalCreate(ctx: TransformContext, target: StructureMapGroupRuleTarget): any {
-  const targetValue: Record<string, unknown> = {};
+function evalCreate(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue {
+  const result: Record<string, unknown> = {};
   if (target.parameter && target.parameter.length > 0) {
-    targetValue.resourceType = resolveParameter(ctx, target.parameter?.[0]);
+    result.resourceType = resolveParameter(ctx, target.parameter?.[0])?.value;
   }
-  return targetValue;
+  return toTypedValue(result);
 }
 
-function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget): any {
-  let targetValue = resolveParameter(ctx, target.parameter?.[0]) as string | undefined;
-  const targetLength = resolveParameter(ctx, target.parameter?.[1]) as number;
-  if (targetValue && typeof targetValue === 'string') {
-    targetValue = targetValue.substring(0, targetLength);
+function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue {
+  const targetValue = resolveParameter(ctx, target.parameter?.[0]);
+  const targetLength = resolveParameter(ctx, target.parameter?.[1])?.value as number;
+  if (targetValue.type === 'string') {
+    return { type: 'string', value: targetValue.value.substring(0, targetLength) };
   }
   return targetValue;
 }
@@ -262,16 +277,23 @@ function evalDependent(ctx: TransformContext, dependent: StructureMapGroupRuleDe
   }
 
   const variables = dependent.variable as string[];
-  const args = [];
+  const args: TypedValue[] = [];
   for (const variable of variables) {
-    args.push(getVariable(ctx, variable));
+    const variableValue = getVariable(ctx, variable);
+    if (!variableValue) {
+      throw new Error('Dependent variable not found: ' + variable);
+    }
+    args.push(variableValue);
   }
 
   const newContext: TransformContext = { parent: ctx, variables: {} };
-  evalGroup(newContext, dependentGroup as StructureMapGroup, args);
+  evalGroup(newContext, dependentGroup.value as StructureMapGroup, args);
 }
 
-function resolveParameter(ctx: TransformContext, parameter: StructureMapGroupRuleTargetParameter | undefined): any {
+function resolveParameter(
+  ctx: TransformContext,
+  parameter: StructureMapGroupRuleTargetParameter | undefined
+): TypedValue {
   const typedParameter = { type: 'StructureMapGroupRuleTargetParameter', value: parameter };
   let paramValue = getTypedPropertyValue(typedParameter, 'value');
 
@@ -283,15 +305,18 @@ function resolveParameter(ctx: TransformContext, parameter: StructureMapGroupRul
     throw new Error('Missing target parameter: ' + JSON.stringify(parameter));
   }
 
-  let targetValue = paramValue.value;
   if (paramValue.type === 'id') {
-    targetValue = getVariable(ctx, paramValue.value as string);
+    const variableValue = getVariable(ctx, paramValue.value as string);
+    if (!variableValue) {
+      throw new Error('Variable not found: ' + paramValue.value);
+    }
+    return variableValue;
   }
 
-  return targetValue;
+  return paramValue;
 }
 
-function getVariable(ctx: TransformContext, name: string): any {
+function getVariable(ctx: TransformContext, name: string): TypedValue | undefined {
   const value = ctx.variables?.[name];
   if (value) {
     return value;
@@ -302,7 +327,10 @@ function getVariable(ctx: TransformContext, name: string): any {
   return undefined;
 }
 
-function setVariable(ctx: TransformContext, name: string, value: any): void {
+function setVariable(ctx: TransformContext, name: string, value: TypedValue): void {
+  if (!value.type) {
+    throw new Error('Missing type: ' + JSON.stringify(value));
+  }
   if (!ctx.variables) {
     ctx.variables = {};
   }


### PR DESCRIPTION
In service of https://github.com/medplum/medplum/issues/3005

Converts a bunch of `any` to `TypedValue`.  Unfortunately a bunch of FHIR Mapping Language is context dependent, such as whether to create an object or an array.  This is a necessary refactor to enable that.

For example, here is current state of CDA->FHIR transform.  You can see that a bunch of the array fields currently have `{}` object values.  This is intermediate work to solve that issue.

```json
{
  "resourceType": "Bundle",
  "entry": [
    {
      "resource": {
        "resourceType": "Composition",
        "id": "1145e935-bbe8-405f-b8fd-411faa6d4d5c",
        "language": {},
        "identifier": {},
        "status": "final",
        "type": {},
        "title": "t.dataString",
        "subject": {
          "resourceType": "Reference",
          "reference": "'urn:uuid:' + %patientResource.id"
        },
        "encounter": {
          "resourceType": "Reference",
          "reference": "'urn:uuid:' + %encounter.id"
        },
        "date": {},
        "author": {
          "resourceType": "Reference",
          "reference": "'urn:uuid:' + %practitioner.id",
          "extension": {
            "url": "http://fhir.ch/ig/ch-core/StructureDefinition/ch-ext-epr-time",
            "value": {
              "resourceType": "dateTime"
            }
          }
        },
        "confidentiality": {},
        "attester": {
          "mode": "official",
          "time": {},
          "party": {
            "resourceType": "Reference",
            "reference": "'urn:uuid:' + %practitioner.id"
          }
        },
        "custodian": {
          "resourceType": "Reference",
          "reference": "'urn:uuid:' + %organization.id"
        },
        "event": {
          "code": {},
          "period": {}
        },
        "section": {
          "title": "t.dataString",
          "code": {},
          "text": {
            "status": "generated",
            "div": "t"
          }
        }
      },
      "fullUrl": "urn:uuid:uuid"
    },
    {
      "resource": {
        "resourceType": "Patient",
        "id": "c63f3c5a-9db1-44a3-ab78-e21b54ac9710",
```
