### PR TITLE
Fixed constraint validation on primitive extensions

### DIFF
--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -4,7 +4,9 @@ import {
   Appointment,
   Binary,
   Bundle,
+  CodeSystem,
   Condition,
+  Extension,
   HumanName,
   ImplementationGuide,
   Media,
@@ -1240,6 +1242,54 @@ describe('Legacy tests for parity checking', () => {
     expect(() =>
       validateResource({ resourceType: 'Patient', name: { family: 'foo' } as unknown as HumanName[] })
     ).toThrow('Expected array of values for property (Patient.name)');
+  });
+
+  test('Primitive and extension', () => {
+    const resource: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'active',
+      content: 'complete',
+      concept: [
+        {
+          extension: [
+            {
+              url: 'http://hl7.org/fhir/StructureDefinition/codesystem-concept-comments',
+              _valueString: {
+                extension: [
+                  {
+                    extension: [
+                      {
+                        url: 'lang',
+                        valueCode: 'nl',
+                      },
+                      {
+                        url: 'content',
+                        valueString: 'Zo spoedig mogelijk',
+                      },
+                    ],
+                    url: 'http://hl7.org/fhir/StructureDefinition/translation',
+                  },
+                ],
+              },
+            } as unknown as Extension,
+          ],
+          code: 'A',
+          display: 'ASAP',
+          designation: [
+            {
+              language: 'nl',
+              use: {
+                system: 'http://terminology.hl7.org/CodeSystem/designation-usage',
+                code: 'display',
+              },
+              value: 'ZSM',
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(() => validateResource(resource)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Fixes the constraint error here: https://github.com/medplum/medplum/pull/3595

```
  FAIL src/seed.test.ts (45.508 s)
    ● Seed › Seeder completes successfully
  
      Constraint ext-1 not met: Must have either extensions or value[x], not both ({"fhirpath":"extension.exists() != value.exists()"}) (CodeSystem.concept.extension); Invalid additional property "_valueString" (CodeSystem.concept.extension._valueString)
  
        119 |     this.issues = []; // Reset issues to allow re-using the validator for other resources
        120 |     if (issues.length > 0) {
      > 121 |       throw new OperationOutcomeError({
            |             ^
        122 |         resourceType: 'OperationOutcome',
        123 |         issue: issues,
        124 |       });
  
        at Lr.validate (../core/src/typeschema/validation.ts:121:13)
        at Sa (../core/src/typeschema/validation.ts:88:67)
        at Repository.validateResource (src/fhir/repo.ts:526:23)
        at Repository.validateResource [as updateResourceImpl] (src/fhir/repo.ts:462:16)
        at Repository.updateResourceImpl [as createResource] (src/fhir/repo.ts:189:33)
        at createResource (src/seeds/valuesets.ts:17:24)
        at seedDatabase (src/seed.ts:72:3)
        at src/app.ts:195:5
```

The constraint was valid.  Our handling of primitive extensions was not.