### PR TITLE
fix: duplicate headers warning on $expunge

### DIFF
--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -34,8 +34,8 @@ export async function expungeHandler(req: Request, res: Response): Promise<void>
     sendOutcome(res, accepted(exec.getContentLocation(baseUrl)));
   } else {
     await ctx.repo.expungeResource(resourceType, id);
+    sendOutcome(res, allOk);
   }
-  sendOutcome(res, allOk);
 }
 
 export class Expunger {


### PR DESCRIPTION
In our testing it looks like we're getting an error from the server because we are `$expunge`ing with the `everything` param set to true.

```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
at new NodeError (node:internal/errors:405:5)
at ServerResponse.setHeader (node:_http_outgoing:648:11)
at ServerResponse.header (/usr/src/medplum/node_modules/express/lib/response.js:794:10)
at ServerResponse.send (/usr/src/medplum/node_modules/express/lib/response.js:174:12)
at ServerResponse.json (/usr/src/medplum/node_modules/express/lib/response.js:278:15)
at sendOutcome (/usr/src/medplum/packages/server/dist/fhir/outcomes.js:32:55)
at expungeHandler (/usr/src/medplum/packages/server/dist/fhir/operations/expunge.js:37:32)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This change is what we expected the code to look like, but, I'm curious if there's a reason we're not aware of. Thanks!