### PR TITLE
FHIR Mapper - parse 'evaluate' transforms

### DIFF
--- a/packages/core/src/fhirmapper/parse.test.ts
+++ b/packages/core/src/fhirmapper/parse.test.ts
@@ -1655,6 +1655,16 @@ describe('FHIR Mapping Language parser', () => {
     ]);
   });
 
+  test('Evaluate FHIRPath', () => {
+    const input = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = src.value + '_test';
+    }`;
+    const result = parseMappingLanguage(input);
+    expect(result.group?.[0]?.rule?.[0]?.target?.[0]?.transform).toBe('evaluate');
+    expect(result.group?.[0]?.rule?.[0]?.target?.[0]?.parameter?.[0]?.valueString).toBe("src.value + '_test'");
+  });
+
   test.skip('C-CDA mapping file', () => {
     const mapFileName = 'C:\\Users\\cody\\dev\\cda-fhir-maps\\input\\maps\\CdaToBundle.map';
     const mapFileContents = readFileSync(mapFileName, 'utf8');

--- a/packages/core/src/fhirmapper/parse.ts
+++ b/packages/core/src/fhirmapper/parse.ts
@@ -290,9 +290,12 @@ class StructureMapParser {
     if (transformAtom instanceof FunctionAtom) {
       result.transform = transformAtom.name as 'append' | 'truncate';
       result.parameter = transformAtom.args?.map(atomToParameter);
-    } else {
+    } else if (transformAtom instanceof LiteralAtom || transformAtom instanceof SymbolAtom) {
       result.transform = 'copy';
       result.parameter = [atomToParameter(transformAtom)];
+    } else {
+      result.transform = 'evaluate';
+      result.parameter = [{ valueString: transformAtom.toString() }];
     }
   }
 
@@ -330,13 +333,7 @@ function atomToParameter(atom: Atom): StructureMapGroupRuleTargetParameter {
   if (atom instanceof LiteralAtom) {
     return literalToParameter(atom);
   }
-
-  // Unclear how this should be represented in a StructureMap.
-  // The situation is that the target is a complex FHIRPath expression, such as a math operation.
-  // "value[x]" is choice-of-type, but the only options are:
-  // valueId, valueString, valueBoolean, valueInteger, valueDecimal
-  // Ideally there would be "valueExpression".
-  return { valueId: atom.toString() };
+  throw new Error(`Unknown parameter atom type: ${atom.constructor.name} (${atom.toString()})`);
 }
 
 function literalToParameter(literalAtom: LiteralAtom): StructureMapGroupRuleTargetParameter {

--- a/packages/core/src/fhirmapper/transform.evaluate.test.ts
+++ b/packages/core/src/fhirmapper/transform.evaluate.test.ts
@@ -1,0 +1,37 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+
+describe('FHIR Mapper transform - evaluate', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('string concatenation', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src -> tgt.value = src.value + '_test';
+    }`;
+
+    const input = [toTypedValue({ value: 'foo' })];
+    const expected = [toTypedValue({ value: 'foo_test' })];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+
+  test('variable concatenation', () => {
+    const map = `map "http://test.com" = test
+    group example(source src, target tgt) {
+      src.value as v -> tgt.value = v.foo + '_test';
+    }`;
+
+    const input = [toTypedValue({ value: { foo: 'bar' } })];
+    const expected = [toTypedValue({ value: 'bar_test' })];
+    const actual = structureMapTransform(parseMappingLanguage(map), input);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -58,15 +58,12 @@ export class SymbolAtom implements Atom {
     if (this.name === '$this') {
       return input;
     }
-    if (this.name.startsWith('%')) {
-      const symbol = context.variables[this.name.slice(1)];
-      if (!symbol) {
-        throw new Error(`Undefined variable ${this.name}`);
-      }
-      return [symbol];
+    const variableValue = context.variables[this.name];
+    if (variableValue) {
+      return [variableValue];
     }
-    if (this.name in context.variables) {
-      return [context.variables[this.name]];
+    if (this.name.startsWith('%')) {
+      throw new Error(`Undefined variable ${this.name}`);
     }
     return input.flatMap((e) => this.evalValue(e)).filter((e) => e?.value !== undefined) as TypedValue[];
   }

--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -1,5 +1,5 @@
 import { Atom, AtomContext, InfixOperatorAtom, PrefixOperatorAtom } from '../fhirlexer/parse';
-import { isResource, PropertyType, TypedValue } from '../types';
+import { PropertyType, TypedValue, isResource } from '../types';
 import { functions } from './functions';
 import {
   booleanToTypedValue,
@@ -64,6 +64,9 @@ export class SymbolAtom implements Atom {
         throw new Error(`Undefined variable ${this.name}`);
       }
       return [symbol];
+    }
+    if (this.name in context.variables) {
+      return [context.variables[this.name]];
     }
     return input.flatMap((e) => this.evalValue(e)).filter((e) => e?.value !== undefined) as TypedValue[];
   }

--- a/packages/core/src/fhirpath/parse.test.ts
+++ b/packages/core/src/fhirpath/parse.test.ts
@@ -478,7 +478,7 @@ describe('FHIRPath parser', () => {
         { system: 'email', value: 'alice@example.com' },
       ],
     };
-    const variables = { current: toTypedValue(patient2), previous: toTypedValue(patient) };
+    const variables = { '%current': toTypedValue(patient2), '%previous': toTypedValue(patient) };
     const result = evalFhirPathTyped('%current=%previous', [toTypedValue(patient)], variables);
 
     expect(result).toEqual([
@@ -505,7 +505,7 @@ describe('FHIRPath parser', () => {
         { system: 'email', value: 'alice@example.com' },
       ],
     };
-    const variables = { current: toTypedValue(patient2), previous: toTypedValue(patient) };
+    const variables = { '%current': toTypedValue(patient2), '%previous': toTypedValue(patient) };
     const result = evalFhirPathTyped('%current!=%previous', [toTypedValue(patient)], variables);
 
     expect(result).toEqual([
@@ -532,7 +532,7 @@ describe('FHIRPath parser', () => {
         { system: 'email', value: 'alice@example.com' },
       ],
     };
-    const variables = { current: toTypedValue(patient2) };
+    const variables = { '%current': toTypedValue(patient2) };
 
     expect(() => evalFhirPathTyped('%current=%previous', [toTypedValue(patient)], variables)).toThrowError(
       `Undefined variable %previous`

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -1,8 +1,8 @@
-import { Bundle, Patient, SearchParameter } from '@medplum/fhirtypes';
-import { formatSearchQuery, Operator, parseSearchDefinition, parseXFhirQuery, SearchRequest } from './search';
-import { indexSearchParameterBundle } from '../types';
 import { readJson } from '@medplum/definitions';
+import { Bundle, Patient, SearchParameter } from '@medplum/fhirtypes';
+import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { Operator, SearchRequest, formatSearchQuery, parseSearchDefinition, parseXFhirQuery } from './search';
 
 describe('Search Utils', () => {
   beforeAll(() => {
@@ -351,7 +351,7 @@ describe('Search Utils', () => {
       name: [{ given: ['Jan', 'Wyatt'], family: 'Smith' }, { text: 'Green Lantern' }],
       generalPractitioner: [{ reference: 'Practitioner/98765' }],
     };
-    const actual = parseXFhirQuery(query, { patient: { type: 'Patient', value: patient } });
+    const actual = parseXFhirQuery(query, { '%patient': { type: 'Patient', value: patient } });
     expect(actual).toEqual(expected);
   });
 });

--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -3,24 +3,24 @@ import { UCUM } from '../constants';
 import { evalFhirPathTyped } from '../fhirpath/parse';
 import { getTypedPropertyValue, toTypedValue } from '../fhirpath/utils';
 import {
+  OperationOutcomeError,
   createConstraintIssue,
   createProcessingIssue,
   createStructureIssue,
-  OperationOutcomeError,
   validationError,
 } from '../outcomes';
 import { PropertyType, TypedValue } from '../types';
 import { arrayify, deepEquals, deepIncludes, isEmpty, isLowerCase } from '../utils';
-import { crawlResource, getNestedProperty, ResourceVisitor } from './crawler';
+import { ResourceVisitor, crawlResource, getNestedProperty } from './crawler';
 import {
   Constraint,
-  getDataType,
   InternalSchemaElement,
   InternalTypeSchema,
-  parseStructureDefinition,
   SliceDefinition,
   SliceDiscriminator,
   SlicingRules,
+  getDataType,
+  parseStructureDefinition,
 } from './types';
 
 /*
@@ -287,10 +287,10 @@ class ResourceValidator implements ResourceVisitor {
   private isExpressionTrue(constraint: Constraint, value: TypedValue, path: string): boolean {
     try {
       const evalValues = evalFhirPathTyped(constraint.expression, [value], {
-        context: value,
-        resource: toTypedValue(this.currentResource[this.currentResource.length - 1]),
-        rootResource: toTypedValue(this.rootResource),
-        ucum: toTypedValue(UCUM),
+        '%context': value,
+        '%resource': toTypedValue(this.currentResource[this.currentResource.length - 1]),
+        '%rootResource': toTypedValue(this.rootResource),
+        '%ucum': toTypedValue(UCUM),
       });
 
       return evalValues.length === 1 && evalValues[0].value === true;

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -1,13 +1,13 @@
 import {
+  TypedValue,
   deepClone,
   evalFhirPathTyped,
   formatCoding,
   getExtension,
-  getTypedPropertyValue,
-  TypedValue,
   getReferenceString,
-  stringify,
+  getTypedPropertyValue,
   splitN,
+  stringify,
 } from '@medplum/core';
 import {
   Encounter,
@@ -131,8 +131,8 @@ function evaluateMatch(actualAnswer: TypedValue | undefined, expectedAnswer: Typ
     // All other operators should be unmodified
     const fhirPathOperator = operator === '=' || operator === '!=' ? operator?.replace('=', '~') : operator;
     const [{ value }] = evalFhirPathTyped(`%actualAnswer ${fhirPathOperator} %expectedAnswer`, [actualAnswer], {
-      actualAnswer,
-      expectedAnswer,
+      '%actualAnswer': actualAnswer,
+      '%expectedAnswer': expectedAnswer,
     });
     return value;
   }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1583,8 +1583,8 @@ export class Repository extends BaseRepository implements FhirRepository {
           constraint.expression as string,
           [{ type: current.resourceType, value: current }],
           {
-            before: { type: previous?.resourceType ?? 'undefined', value: previous },
-            after: { type: current.resourceType, value: current },
+            '%before': { type: previous?.resourceType ?? 'undefined', value: previous },
+            '%after': { type: current.resourceType, value: current },
           }
         );
         return invariant.length === 1 && invariant[0].value === true;

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -10,9 +10,9 @@ import {
   Resource,
   Subscription,
 } from '@medplum/fhirtypes';
+import { getRequestContext } from '../context';
 import { systemRepo } from '../fhir/repo';
 import { AuditEventOutcome } from '../util/auditevent';
-import { getRequestContext } from '../context';
 
 export function findProjectMembership(project: string, profile: Reference): Promise<ProjectMembership | undefined> {
   return systemRepo.searchOne<ProjectMembership>({
@@ -115,10 +115,13 @@ export async function isFhirCriteriaMet(subscription: Subscription, currentResou
     return true;
   }
   const history = await systemRepo.readHistory(currentResource.resourceType, currentResource?.id as string);
-  const evalInput = { current: toTypedValue(currentResource), previous: toTypedValue({}) };
+  const evalInput = {
+    '%current': toTypedValue(currentResource),
+    '%previous': toTypedValue({}),
+  };
   const previousResource = history.entry?.[1]?.resource as Resource;
   if (previousResource) {
-    evalInput.previous = toTypedValue(previousResource);
+    evalInput['%previous'] = toTypedValue(previousResource);
   }
   const evalValue = evalFhirPathTyped(criteria.valueString, [toTypedValue(currentResource)], evalInput);
   if (evalValue?.[0]?.value === true) {


### PR DESCRIPTION
In service of https://github.com/medplum/medplum/issues/3005

Correctly parses `evaluate` transforms

Before, we were incorrectly jamming the FHIRPath expression into an `id` parameter of a `copy` transform (because a common case is a single variable name, which is handled similarly).  Now actually using an `evaluate` transform with `string` parameter.