### PR TITLE
Github Actions cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,9 @@ name: Build
 # Limit a single job to run at a time for a given branch/PR to save resources and speed up CI
 # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ci-build-${{ github.ref_name == 'main' && github.sha || github.ref }}
+  group: ci-build-${{ github.ref }}
   cancel-in-progress: true
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -59,12 +57,6 @@ jobs:
             ${{ runner.os }}-
       - name: Build Project
         run: ./scripts/build.sh
-        env:
-          MEDPLUM_BASE_URL: '__MEDPLUM_BASE_URL__'
-          MEDPLUM_CLIENT_ID: '__MEDPLUM_CLIENT_ID__'
-          MEDPLUM_REGISTER_ENABLED: '__MEDPLUM_REGISTER_ENABLED__'
-          GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
-          RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
       - name: Test
         run: ./scripts/test.sh
         env:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,8 @@
 name: 'Chromatic'
 
-on: push
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   chromatic:


### PR DESCRIPTION
Our recent commits to `main` appear in "pending" status rather than "success" status:

<img width="647" alt="image" src="https://github.com/medplum/medplum/assets/749094/f43ec7db-5c30-4fa7-9ca9-e44640a862da">

The main cause is pending Chromatic "UI Tests":

<img width="494" alt="image" src="https://github.com/medplum/medplum/assets/749094/a56b7991-04ca-47ab-b58c-d93ee1aaf053">

This PR disables Chromatic on pushes to `main`.

It also disables all of the extra "Build" actions, because they are superfluous.  Once upon a time, the "Build" action was also responsible for deploying, but that is now handled by the "Deploy" action (see https://github.com/medplum/medplum/pull/3026)