### PR TITLE
Fixed sonar on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: Build
 # Limit a single job to run at a time for a given branch/PR to save resources and speed up CI
 # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ci-build-${{ github.ref }}
+  group: ci-build-${{ github.ref_name == 'main' && github.sha || github.ref }}
   cancel-in-progress: true
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
@@ -57,6 +59,12 @@ jobs:
             ${{ runner.os }}-
       - name: Build Project
         run: ./scripts/build.sh
+        env:
+          MEDPLUM_BASE_URL: '__MEDPLUM_BASE_URL__'
+          MEDPLUM_CLIENT_ID: '__MEDPLUM_CLIENT_ID__'
+          MEDPLUM_REGISTER_ENABLED: '__MEDPLUM_REGISTER_ENABLED__'
+          GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
+          RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
       - name: Test
         run: ./scripts/test.sh
         env:


### PR DESCRIPTION
I got over eager in https://github.com/medplum/medplum/pull/3632

In that PR, I disabled the "Build" action when pushing to `main`, because the "Deploy" action also builds which made the "Build" action seem redundant.

But that broke Sonar on `main`, because only the "Build" action uploads code coverage artifacts and triggers the Sonar action.

This is still suboptimal, because we're overbuilding 4x on commits to `main`, but c’est la vie, that's a problem for another day.