### PR TITLE
FHIR Mapper - translate

### DIFF
--- a/packages/core/src/fhirmapper/conceptmaptranslate.test.ts
+++ b/packages/core/src/fhirmapper/conceptmaptranslate.test.ts
@@ -1,0 +1,225 @@
+import { ConceptMap } from '@medplum/fhirtypes';
+import { ConceptMapTranslateMatch, ConceptMapTranslateParameters, conceptMapTranslate } from './conceptmaptranslate';
+
+const system = 'http://example.com/private-codes';
+const code = 'FSH';
+const conceptMap: ConceptMap = {
+  resourceType: 'ConceptMap',
+  url: 'http://example.com/concept-map',
+  status: 'active',
+  sourceCanonical: 'http://example.com/labs',
+  group: [
+    {
+      source: system,
+      target: 'http://loinc.org',
+      element: [
+        {
+          code,
+          target: [
+            {
+              code: '15067-2',
+              display: 'Follitropin Qn',
+              equivalence: 'equivalent',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      source: system,
+      target: 'http://www.ama-assn.org/go/cpt',
+      element: [
+        {
+          code,
+          target: [{ code: '83001', equivalence: 'equivalent' }],
+        },
+      ],
+    },
+  ],
+};
+
+describe('ConceptMap $translate', () => {
+  test.each<[string, ConceptMapTranslateParameters]>([
+    ['with system and code', { system, code }],
+    ['with coding', { coding: { system, code } }],
+    ['with CodeableConcept', { codeableConcept: { coding: [{ system, code }] } }],
+  ])('Success %s', async (_format, params) => {
+    const output = conceptMapTranslate(conceptMap, params);
+    expect(output.result).toEqual(true);
+
+    const matches = output.match;
+    expect(matches).toHaveLength(2);
+    expect(matches?.[0]).toMatchObject<ConceptMapTranslateMatch>({
+      equivalence: 'equivalent',
+      concept: {
+        system: 'http://loinc.org',
+        code: '15067-2',
+        display: 'Follitropin Qn',
+      },
+    });
+    expect(matches?.[1]).toMatchObject<ConceptMapTranslateMatch>({
+      equivalence: 'equivalent',
+      concept: {
+        system: 'http://www.ama-assn.org/go/cpt',
+        code: '83001',
+      },
+    });
+  });
+
+  test('Filter on target system', async () => {
+    const output = conceptMapTranslate(conceptMap, {
+      url: conceptMap.url,
+      targetsystem: 'http://loinc.org',
+      coding: { system, code },
+    });
+    expect(output.result).toEqual(true);
+
+    const matches = output.match;
+    expect(matches).toHaveLength(1);
+    expect(matches?.[0]).toMatchObject<ConceptMapTranslateMatch>({
+      equivalence: 'equivalent',
+      concept: {
+        system: 'http://loinc.org',
+        code: '15067-2',
+        display: 'Follitropin Qn',
+      },
+    });
+  });
+
+  test('No match', async () => {
+    const output = conceptMapTranslate(conceptMap, { coding: { system, code: 'BAD' } });
+    expect(output.result).toEqual(false);
+  });
+
+  test('Code without system', async () => {
+    expect(() => conceptMapTranslate(conceptMap, { code: 'BAD' })).toThrow(
+      `Missing required 'system' input parameter with 'code' parameter`
+    );
+  });
+
+  test('Ambiguous coding provided', async () => {
+    expect(() => conceptMapTranslate(conceptMap, { coding: { system, code }, system, code: 'BAD' })).toThrow(
+      `Ambiguous input: multiple source codings provided`
+    );
+  });
+
+  test('No source coding', async () => {
+    expect(() => conceptMapTranslate(conceptMap, {})).toThrow(
+      `No source provided: 'code'+'system', 'coding', or 'codeableConcept' input parameter is required`
+    );
+  });
+
+  test('Unmapped code handling', async () => {
+    const conceptMap: ConceptMap = {
+      resourceType: 'ConceptMap',
+      url: 'http://example.com/concept-map',
+      status: 'active',
+      sourceCanonical: 'http://example.com/labs',
+      group: [
+        {
+          source: system,
+          target: system + '/v2',
+          element: [
+            {
+              code: 'OTHER',
+              target: [{ code: 'DISTINCT', equivalence: 'equivalent' }],
+            },
+          ],
+          unmapped: {
+            mode: 'provided',
+          },
+        },
+        {
+          source: system,
+          target: 'http://example.com/other-system',
+          element: [
+            {
+              code: 'OTHER',
+              target: [{ code: '1', equivalence: 'equivalent' }],
+            },
+          ],
+          unmapped: {
+            mode: 'fixed',
+            code: 'UNK',
+            display: 'Unknown',
+          },
+        },
+      ],
+    };
+
+    const output = conceptMapTranslate(conceptMap, { coding: { system, code } });
+    expect(output.result).toEqual(true);
+
+    const matches = output.match;
+    expect(matches).toHaveLength(2);
+    expect(matches?.[0]).toMatchObject<ConceptMapTranslateMatch>({
+      equivalence: 'equal',
+      concept: { system: system + '/v2', code },
+    });
+    expect(matches?.[1]).toMatchObject<ConceptMapTranslateMatch>({
+      equivalence: 'equivalent',
+      concept: {
+        system: 'http://example.com/other-system',
+        code: 'UNK',
+        display: 'Unknown',
+      },
+    });
+  });
+
+  test('Handles empty CodeableConcept', async () => {
+    const output = conceptMapTranslate(conceptMap, { codeableConcept: { text: 'Nebulous concept' } });
+    expect(output.result).toEqual(false);
+  });
+
+  test('Handles implicit system', async () => {
+    const conceptMap: ConceptMap = {
+      resourceType: 'ConceptMap',
+      url: 'http://example.com/concept-map',
+      status: 'active',
+      sourceCanonical: 'http://example.com/labs',
+      group: [
+        {
+          target: 'http://loinc.org',
+          element: [
+            {
+              code,
+              target: [
+                {
+                  code: '15067-2',
+                  display: 'Follitropin Qn',
+                  equivalence: 'equivalent',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const output = conceptMapTranslate(conceptMap, { codeableConcept: { coding: [{ code }] } });
+    expect(output.result).toEqual(true);
+
+    const matches = output.match;
+    expect(matches).toHaveLength(1);
+    expect(matches?.[0]).toMatchObject<ConceptMapTranslateMatch>({
+      equivalence: 'equivalent',
+      concept: {
+        system: 'http://loinc.org',
+        code: '15067-2',
+        display: 'Follitropin Qn',
+      },
+    });
+  });
+
+  test('No mapping groups specified', async () => {
+    const conceptMap: ConceptMap = {
+      resourceType: 'ConceptMap',
+      url: 'http://example.com/concept-map',
+      status: 'active',
+      sourceCanonical: 'http://example.com/labs',
+      targetCanonical: 'http://example.com/loinc',
+    };
+
+    expect(() => conceptMapTranslate(conceptMap, {})).toThrow('ConceptMap does not specify a mapping group');
+  });
+});

--- a/packages/core/src/fhirmapper/conceptmaptranslate.ts
+++ b/packages/core/src/fhirmapper/conceptmaptranslate.ts
@@ -1,0 +1,133 @@
+import { CodeableConcept, Coding, ConceptMap, ConceptMapGroup, OperationOutcome } from '@medplum/fhirtypes';
+import { OperationOutcomeError, badRequest, isOperationOutcome } from '../outcomes';
+
+export interface ConceptMapTranslateParameters {
+  url?: string;
+  source?: string;
+  code?: string;
+  system?: string;
+  coding?: Coding;
+  codeableConcept?: CodeableConcept;
+  targetsystem?: string;
+}
+
+export interface ConceptMapTranslateMatch {
+  equivalence?: string;
+  concept?: Coding;
+}
+
+export interface ConceptMapTranslateOutput {
+  result: boolean;
+  message?: string;
+  match?: ConceptMapTranslateMatch[];
+}
+
+export function conceptMapTranslate(map: ConceptMap, params: ConceptMapTranslateParameters): ConceptMapTranslateOutput {
+  if (!map.group) {
+    throw new OperationOutcomeError(badRequest('ConceptMap does not specify a mapping group', 'ConceptMap.group'));
+  }
+
+  const sourceCodes = constructSourceSet(params);
+  if (isOperationOutcome(sourceCodes)) {
+    throw new OperationOutcomeError(sourceCodes);
+  }
+
+  const matches = translateCodes(
+    sourceCodes,
+    params.targetsystem ? map.group.filter((g) => g.target === params.targetsystem) : map.group
+  );
+
+  const result = matches.length > 0;
+
+  return {
+    result,
+    match: result ? matches : undefined,
+  };
+}
+
+function constructSourceSet(params: ConceptMapTranslateParameters): Record<string, string[]> | OperationOutcome {
+  if (params.code && !params.coding && !params.codeableConcept) {
+    if (params.system === undefined) {
+      return badRequest(`Missing required 'system' input parameter with 'code' parameter`);
+    }
+    return { [params.system]: [params.code] };
+  } else if (params.coding && !params.code && !params.codeableConcept) {
+    return { [params.coding.system ?? '']: [params.coding.code ?? ''] };
+  } else if (params.codeableConcept && !params.code && !params.coding) {
+    return indexCodes(params.codeableConcept);
+  } else if (params.code || params.coding || params.codeableConcept) {
+    return badRequest('Ambiguous input: multiple source codings provided');
+  } else {
+    return badRequest(
+      `No source provided: 'code'+'system', 'coding', or 'codeableConcept' input parameter is required`
+    );
+  }
+}
+
+function indexCodes(concept: CodeableConcept): Record<string, string[]> {
+  const result: Record<string, string[]> = Object.create(null);
+  if (!concept.coding?.length) {
+    return result;
+  }
+
+  for (const { system, code } of concept.coding) {
+    if (!code) {
+      continue;
+    }
+    const key = system ?? '';
+    result[key] = result[key] ? [...result[key], code] : [code];
+  }
+  return result;
+}
+
+function translateCodes(sourceCodes: Record<string, string[]>, groups: ConceptMapGroup[]): ConceptMapTranslateMatch[] {
+  const matches: ConceptMapTranslateMatch[] = [];
+  for (const [system, codes] of Object.entries(sourceCodes)) {
+    for (const group of groups.filter((g) => (g.source ?? '') === system)) {
+      let mappings: ConceptMapTranslateMatch[] | undefined = group.element
+        ?.filter((m) => codes.includes(m.code as string))
+        .flatMap(
+          (m) =>
+            m.target?.map((target) => ({
+              equivalence: target.equivalence,
+              concept: {
+                system: group.target,
+                code: target.code,
+                display: target.display,
+              },
+            })) ?? []
+        );
+
+      if (!mappings?.length) {
+        mappings = handleUnmappedCodes(codes, group);
+      }
+      if (mappings) {
+        matches.push(...mappings);
+      }
+    }
+  }
+  return matches;
+}
+
+function handleUnmappedCodes(codes: string[], group: ConceptMapGroup): ConceptMapTranslateMatch[] | undefined {
+  switch (group.unmapped?.mode) {
+    case 'provided':
+      return codes.map((code) => ({
+        equivalence: 'equal',
+        concept: { system: group.target, code },
+      }));
+    case 'fixed':
+      return [
+        {
+          equivalence: 'equivalent',
+          concept: {
+            system: group.target,
+            code: group.unmapped.code,
+            display: group.unmapped.display,
+          },
+        },
+      ];
+    default:
+      return undefined;
+  }
+}

--- a/packages/core/src/fhirmapper/tokenize.ts
+++ b/packages/core/src/fhirmapper/tokenize.ts
@@ -1,7 +1,7 @@
 import { Token, Tokenizer } from '../fhirlexer/tokenize';
 import { FHIRPATH_KEYWORDS, FHIRPATH_OPERATORS } from '../fhirpath/tokenize';
 
-const MAPPING_LANGUAGE_OPERATORS = [...FHIRPATH_OPERATORS, '->', '<<', '>>'];
+const MAPPING_LANGUAGE_OPERATORS = [...FHIRPATH_OPERATORS, '->', '<<', '>>', '=='];
 
 export function tokenize(str: string): Token[] {
   return new Tokenizer(str, FHIRPATH_KEYWORDS, MAPPING_LANGUAGE_OPERATORS).tokenize();

--- a/packages/core/src/fhirmapper/transform.test.ts
+++ b/packages/core/src/fhirmapper/transform.test.ts
@@ -303,13 +303,21 @@ describe('FHIR Mapper transform', () => {
       uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
       uses "http://hl7.org/fhir/StructureDefinition/tutorial-right" as target
 
+      conceptmap "uri-of-concept-map" {
+        prefix s = "http://terminology.hl7.org/ValueSet/v3-AdministrativeGender"
+        prefix t = "http://hl7.org/fhir/ValueSet/administrative-gender"
+
+        s:M == t:male
+        s:F == t:female
+      }
+
       group tutorial(source src : TLeft, target tgt : TRight) {
         src.d as d -> tgt.d = translate(d, 'uri-of-concept-map', 'code');
       }
     `;
 
-    const input = [toTypedValue({ aa: { ab: 'a' } })];
-    const expected = [toTypedValue({ aa: { ab: 'a' } })];
+    const input = [toTypedValue({ d: 'M' })];
+    const expected = [toTypedValue({ d: 'male' })];
     const actual = structureMapTransform(parseMappingLanguage(map), input);
     expect(actual).toMatchObject(expected);
   });

--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -261,6 +261,10 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
     }
   }
 
+  if (targetValue.length === 0) {
+    return;
+  }
+
   if (isArray) {
     if (!originalValue) {
       originalValue = [];
@@ -305,6 +309,9 @@ function evalCreate(ctx: TransformContext, target: StructureMapGroupRuleTarget):
 function evalEvaluate(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue[] {
   const typedExpr = resolveParameter(ctx, target.parameter?.[0]);
   const expr = typedExpr[0].value as string;
+  if (expr === 'v.other') {
+    console.log(JSON.stringify(buildFhirPathVariables(ctx), null, 2));
+  }
   return evalFhirPathTyped(expr, [], buildFhirPathVariables(ctx) as Record<string, TypedValue>);
 }
 
@@ -381,6 +388,7 @@ function buildFhirPathVariables(
   if (ctx.variables) {
     for (const [key, value] of Object.entries(ctx.variables)) {
       result[key] = value;
+      result['%' + key] = value;
     }
   }
   return result;

--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -1,4 +1,5 @@
 import {
+  ConceptMap,
   StructureMap,
   StructureMapGroup,
   StructureMapGroupInput,
@@ -13,8 +14,10 @@ import { evalFhirPathTyped } from '../fhirpath/parse';
 import { getTypedPropertyValue, toJsBoolean, toTypedValue } from '../fhirpath/utils';
 import { TypedValue } from '../types';
 import { tryGetDataType } from '../typeschema/types';
+import { conceptMapTranslate } from './conceptmaptranslate';
 
 interface TransformContext {
+  root: StructureMap;
   loader?: (url: string) => StructureMap[];
   parent?: TransformContext;
   variables?: Record<string, TypedValue[] | TypedValue>;
@@ -35,7 +38,7 @@ export function structureMapTransform(
   input: TypedValue[],
   loader?: (url: string) => StructureMap[]
 ): TypedValue[] {
-  return evalStructureMap({ loader }, structureMap, input);
+  return evalStructureMap({ root: structureMap, loader }, structureMap, input);
 }
 
 function evalStructureMap(ctx: TransformContext, structureMap: StructureMap, input: TypedValue[]): TypedValue[] {
@@ -108,7 +111,7 @@ function evalGroup(ctx: TransformContext, group: StructureMapGroup, input: Typed
     outputs.push(output);
   }
 
-  const newContext: TransformContext = { parent: ctx, variables };
+  const newContext: TransformContext = { root: ctx.root, parent: ctx, variables };
 
   if (group.rule) {
     for (const rule of group.rule) {
@@ -247,8 +250,7 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
         targetValue = evalEvaluate(ctx, target);
         break;
       case 'translate':
-        // TODO: Implement
-        targetValue = evalCopy(ctx, target);
+        targetValue = evalTranslate(ctx, target);
         break;
       case 'truncate':
         targetValue = evalTruncate(ctx, target);
@@ -309,10 +311,19 @@ function evalCreate(ctx: TransformContext, target: StructureMapGroupRuleTarget):
 function evalEvaluate(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue[] {
   const typedExpr = resolveParameter(ctx, target.parameter?.[0]);
   const expr = typedExpr[0].value as string;
-  if (expr === 'v.other') {
-    console.log(JSON.stringify(buildFhirPathVariables(ctx), null, 2));
-  }
   return evalFhirPathTyped(expr, [], buildFhirPathVariables(ctx) as Record<string, TypedValue>);
+}
+
+function evalTranslate(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue[] {
+  const args = (target.parameter as StructureMapGroupRuleTargetParameter[]).flatMap((p) => resolveParameter(ctx, p));
+  const sourceValue = args[0].value;
+  const mapUri = args[1].value;
+  const conceptMap = ctx.root.contained?.find((r) => r.resourceType === 'ConceptMap' && r.url === mapUri) as ConceptMap;
+  // TODO: Verify whether system is actually required
+  // The FHIR Mapping Language spec does not say whether it is required
+  // But our current implementation requires it
+  const result = conceptMapTranslate(conceptMap, { system: conceptMap.group?.[0]?.source, code: sourceValue });
+  return [toTypedValue(result.match?.[0]?.concept?.code)];
 }
 
 function evalTruncate(ctx: TransformContext, target: StructureMapGroupRuleTarget): TypedValue[] {
@@ -340,7 +351,7 @@ function evalDependent(ctx: TransformContext, dependent: StructureMapGroupRuleDe
     args.push(variableValue);
   }
 
-  const newContext: TransformContext = { parent: ctx, variables: {} };
+  const newContext: TransformContext = { root: ctx.root, parent: ctx, variables: {} };
   evalGroup(newContext, dependentGroup.value as StructureMapGroup, args);
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './eventtarget';
 export * from './fhircast';
 export * from './fhirlexer/parse';
 export * from './fhirlexer/tokenize';
+export * from './fhirmapper/conceptmaptranslate';
 export * from './fhirmapper/parse';
 export * from './fhirmapper/transform';
 export * from './fhirpath/atoms';

--- a/packages/server/src/fhir/operations/conceptmaptranslate.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.ts
@@ -1,61 +1,32 @@
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
-import { Operator, allOk, badRequest, notFound } from '@medplum/core';
+import {
+  ConceptMapTranslateParameters,
+  Operator,
+  allOk,
+  badRequest,
+  conceptMapTranslate,
+  isOperationOutcome,
+  notFound,
+} from '@medplum/core';
+import { ConceptMap, OperationOutcome } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import { getOperationDefinition } from './definitions';
-import { CodeableConcept, Coding, ConceptMap, ConceptMapGroup, OperationOutcome } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { sendOutcome } from '../outcomes';
+import { getOperationDefinition } from './definitions';
+import { parseInputParameters, sendOutputParameters } from './utils/parameters';
 
 const operation = getOperationDefinition('ConceptMap', 'translate');
-
-type ConceptMapTranslateParameters = {
-  url?: string;
-  source?: string;
-  code?: string;
-  system?: string;
-  coding?: Coding;
-  codeableConcept?: CodeableConcept;
-  targetsystem?: string;
-};
-
-type Match = {
-  equivalence?: string;
-  concept?: Coding;
-};
-
-type ConceptMapTranslateOutput = {
-  result: boolean;
-  message?: string;
-  match?: Match[];
-};
 
 export async function conceptMapTranslateHandler(req: Request, res: Response): Promise<void> {
   const params = parseInputParameters<ConceptMapTranslateParameters>(operation, req);
 
   const map = await lookupConceptMap(params, req.params.id);
-  if (isOutcome(map)) {
+  if (isOperationOutcome(map)) {
     sendOutcome(res, map);
     return;
-  } else if (!map.group) {
-    sendOutcome(res, badRequest('ConceptMap does not specify a mapping group', 'ConceptMap.group'));
-    return;
   }
 
-  const sourceCodes = constructSourceSet(params);
-  if (isOutcome(sourceCodes)) {
-    sendOutcome(res, sourceCodes);
-    return;
-  }
-
-  const matches = translateCodes(
-    sourceCodes,
-    params.targetsystem ? map.group.filter((g) => g.target === params.targetsystem) : map.group
-  );
-  const result = matches.length > 0;
-  await sendOutputParameters(operation, res, allOk, {
-    result,
-    match: result ? matches : undefined,
-  } as ConceptMapTranslateOutput);
+  const output = conceptMapTranslate(map, params);
+  await sendOutputParameters(operation, res, allOk, output);
 }
 
 async function lookupConceptMap(
@@ -87,96 +58,5 @@ async function lookupConceptMap(
     return result;
   } else {
     return badRequest('No ConceptMap specified');
-  }
-}
-
-function constructSourceSet(params: ConceptMapTranslateParameters): Record<string, string[]> | OperationOutcome {
-  if (params.code && !params.coding && !params.codeableConcept) {
-    if (params.system === undefined) {
-      return badRequest(`Missing required 'system' input parameter with 'code' parameter`);
-    }
-    return { [params.system]: [params.code] };
-  } else if (params.coding && !params.code && !params.codeableConcept) {
-    return { [params.coding.system ?? '']: [params.coding.code ?? ''] };
-  } else if (params.codeableConcept && !params.code && !params.coding) {
-    return indexCodes(params.codeableConcept);
-  } else if (params.code || params.coding || params.codeableConcept) {
-    return badRequest('Ambiguous input: multiple source codings provided');
-  } else {
-    return badRequest(
-      `No source provided: 'code'+'system', 'coding', or 'codeableConcept' input parameter is required`
-    );
-  }
-}
-
-function indexCodes(concept: CodeableConcept): Record<string, string[]> {
-  const result: Record<string, string[]> = Object.create(null);
-  if (!concept.coding?.length) {
-    return result;
-  }
-
-  for (const { system, code } of concept.coding) {
-    if (!code) {
-      continue;
-    }
-    const key = system ?? '';
-    result[key] = result[key] ? [...result[key], code] : [code];
-  }
-  return result;
-}
-
-function translateCodes(sourceCodes: Record<string, string[]>, groups: ConceptMapGroup[]): Match[] {
-  const matches: Match[] = [];
-  for (const [system, codes] of Object.entries(sourceCodes)) {
-    for (const group of groups.filter((g) => (g.source ?? '') === system)) {
-      let mappings: Match[] | undefined = group.element
-        ?.filter((m) => codes.includes(m.code as string))
-        .flatMap(
-          (m) =>
-            m.target?.map((target) => ({
-              equivalence: target.equivalence,
-              concept: {
-                system: group.target,
-                code: target.code,
-                display: target.display,
-              },
-            })) ?? []
-        );
-
-      if (!mappings?.length) {
-        mappings = handleUnmappedCodes(codes, group);
-      }
-      if (mappings) {
-        matches.push(...mappings);
-      }
-    }
-  }
-  return matches;
-}
-
-function isOutcome(obj: any): obj is OperationOutcome {
-  return obj.resourceType === 'OperationOutcome';
-}
-
-function handleUnmappedCodes(codes: string[], group: ConceptMapGroup): Match[] | undefined {
-  switch (group.unmapped?.mode) {
-    case 'provided':
-      return codes.map((code) => ({
-        equivalence: 'equal',
-        concept: { system: group.target, code },
-      }));
-    case 'fixed':
-      return [
-        {
-          equivalence: 'equivalent',
-          concept: {
-            system: group.target,
-            code: group.unmapped.code,
-            display: group.unmapped.display,
-          },
-        },
-      ];
-    default:
-      return undefined;
   }
 }


### PR DESCRIPTION
In service of https://github.com/medplum/medplum/issues/3005

Implements the `translate` transform, which is essentially `ConceptMap` `$translate`.  See: https://build.fhir.org/mapping-tutorial.html#step8

@mattwiller added `$translate` in https://github.com/medplum/medplum/pull/3488  The original implementation was in `server`.  In this PR, I'm refactoring out the core logic of `$translate` into `core`.  I kept all of the original `server` tests to ensure this does not affect the server endpoint.

