### PR TITLE
Fixes #3605 - SmartAppLaunchLink react component

### DIFF
--- a/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.stories.tsx
+++ b/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.stories.tsx
@@ -1,0 +1,21 @@
+import { createReference } from '@medplum/core';
+import { HomerSimpson } from '@medplum/mock';
+import { Meta } from '@storybook/react';
+import { Document } from '../Document/Document';
+import { SmartAppLaunchLink } from './SmartAppLaunchLink';
+
+export default {
+  title: 'Medplum/SmartAppLaunchLink',
+  component: SmartAppLaunchLink,
+} as Meta;
+
+export const Basic = (): JSX.Element => (
+  <Document>
+    <SmartAppLaunchLink
+      client={{ resourceType: 'ClientApplication', launchUri: 'https://example.com' }}
+      patient={createReference(HomerSimpson)}
+    >
+      Example SMART Launch
+    </SmartAppLaunchLink>
+  </Document>
+);

--- a/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.test.tsx
+++ b/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.test.tsx
@@ -1,0 +1,53 @@
+import { createReference } from '@medplum/core';
+import { HomerEncounter, HomerSimpson, MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+import { SmartAppLaunchLink } from './SmartAppLaunchLink';
+
+const medplum = new MockClient();
+
+describe('SmartAppLaunchLink', () => {
+  function setup(children: ReactNode): void {
+    render(
+      <MemoryRouter>
+        <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+      </MemoryRouter>
+    );
+  }
+
+  test('Happy path', async () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        assign: jest.fn(),
+      },
+      writable: true,
+    });
+
+    setup(
+      <SmartAppLaunchLink
+        client={{ resourceType: 'ClientApplication', launchUri: 'https://example.com' }}
+        patient={createReference(HomerSimpson)}
+        encounter={createReference(HomerEncounter)}
+      >
+        My SmartAppLaunchLink
+      </SmartAppLaunchLink>
+    );
+
+    expect(screen.getByText('My SmartAppLaunchLink')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('My SmartAppLaunchLink'));
+    });
+
+    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
+    expect(window.location.assign).toHaveBeenCalled();
+
+    const url = (window.location.assign as jest.Mock).mock.calls[0][0];
+    expect(url).toContain('https://example.com');
+    expect(url).toContain('launch=');
+    expect(url).toContain('iss=');
+  });
+});

--- a/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.tsx
+++ b/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.tsx
@@ -1,0 +1,40 @@
+import { Anchor, AnchorProps } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { normalizeErrorString } from '@medplum/core';
+import { ClientApplication, Encounter, Patient, Reference, SmartAppLaunch } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
+import { ReactNode } from 'react';
+
+export interface SmartAppLaunchLinkProps extends AnchorProps {
+  readonly client: ClientApplication;
+  readonly patient?: Reference<Patient>;
+  readonly encounter?: Reference<Encounter>;
+  readonly children?: ReactNode;
+}
+
+export function SmartAppLaunchLink(props: SmartAppLaunchLinkProps): JSX.Element | null {
+  const medplum = useMedplum();
+  const { client, patient, encounter, children, ...rest } = props;
+
+  function launchApp(): void {
+    medplum
+      .createResource<SmartAppLaunch>({
+        resourceType: 'SmartAppLaunch',
+        patient,
+        encounter,
+      })
+      .then((result) => {
+        const url = new URL(client.launchUri as string);
+        url.searchParams.set('iss', medplum.getBaseUrl() + 'fhir/R4');
+        url.searchParams.set('launch', result.id as string);
+        window.location.assign(url.toString());
+      })
+      .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
+  }
+
+  return (
+    <Anchor onClick={() => launchApp()} {...rest}>
+      {children}
+    </Anchor>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -87,6 +87,7 @@ export * from './SearchControl/SearchUtils';
 export * from './SearchFieldEditor/SearchFieldEditor';
 export * from './SearchFilterEditor/SearchFilterEditor';
 export * from './ServiceRequestTimeline/ServiceRequestTimeline';
+export * from './SmartAppLaunchLink/SmartAppLaunchLink';
 export * from './StatusBadge/StatusBadge';
 export * from './Timeline/Timeline';
 export * from './TimingInput/TimingInput';


### PR DESCRIPTION
Example story: https://medplum-storybook-git-cody-smart-app-launch-link-medplum.vercel.app/iframe.html?args=&id=medplum-smartapplaunchlink--basic&viewMode=story

Example usage:

```tsx
    <SmartAppLaunchLink
      client={{ resourceType: 'ClientApplication', launchUri: 'https://example.com' }}
      patient={createReference(HomerSimpson)}
    >
      Example SMART Launch
    </SmartAppLaunchLink>
```

The React props inherits from `AnchorProps`, so you can use any Mantine `<Anchor>` props for styling: https://mantine.dev/core/anchor/

Also updated `app` to use this component.
