### PR TITLE
Fixes #3651 - add ValueSet expand params to input components

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1912,6 +1912,23 @@ describe('Client', () => {
     );
   });
 
+  test('ValueSet $expand', async () => {
+    const fetch = mockFetch(200, { resourceType: 'ValueSet' });
+    const client = new MedplumClient({ fetch });
+    const result = await client.valueSetExpand({ url: 'system', filter: 'filter', count: 20 });
+    expect(result).toBeDefined();
+    expect(result.resourceType).toBe('ValueSet');
+    expect(fetch).toBeCalledWith(
+      expect.stringContaining('https://api.medplum.com/fhir/R4/ValueSet/$expand'),
+      expect.objectContaining({ method: 'GET' })
+    );
+
+    const url = new URL(fetch.mock.calls[0][0] as string);
+    expect(url.searchParams.get('url')).toBe('system');
+    expect(url.searchParams.get('filter')).toBe('filter');
+    expect(url.searchParams.get('count')).toBe('20');
+  });
+
   describe('Batch', () => {
     const bundle: Bundle = {
       resourceType: 'Bundle',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -574,6 +574,18 @@ interface SessionDetails {
 }
 
 /**
+ * ValueSet $expand operation parameters.
+ * See: https://hl7.org/fhir/r4/valueset-operation-expand.html
+ */
+export interface ValueSetExpandParams {
+  url?: string;
+  filter?: string;
+  date?: string;
+  offset?: number;
+  count?: number;
+}
+
+/**
  * The MedplumClient class provides a client for the Medplum FHIR server.
  *
  * The client can be used in the browser, in a Node.js application, or in a Medplum Bot.
@@ -1442,11 +1454,23 @@ export class MedplumClient extends EventTarget {
    * @param filter - The search string.
    * @param options - Optional fetch options.
    * @returns Promise to expanded ValueSet.
+   * @deprecated Use `valueSetExpand()` instead.
    */
   searchValueSet(system: string, filter: string, options?: RequestInit): ReadablePromise<ValueSet> {
+    return this.valueSetExpand({ url: system, filter }, options);
+  }
+
+  /**
+   * Searches a ValueSet resource using the "expand" operation.
+   * See: https://www.hl7.org/fhir/operation-valueset-expand.html
+   * @category Search
+   * @param params - The ValueSet expand parameters.
+   * @param options - Optional fetch options.
+   * @returns Promise to expanded ValueSet.
+   */
+  valueSetExpand(params: ValueSetExpandParams, options?: RequestInit): ReadablePromise<ValueSet> {
     const url = this.fhirUrl('ValueSet', '$expand');
-    url.searchParams.set('url', system);
-    url.searchParams.set('filter', filter);
+    url.search = new URLSearchParams(params as Record<string, string>).toString();
     return this.get(url.toString(), options);
   }
 

--- a/packages/react/src/CodeInput/CodeInput.tsx
+++ b/packages/react/src/CodeInput/CodeInput.tsx
@@ -1,44 +1,26 @@
 import { ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { useState } from 'react';
-import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
+import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
-export interface CodeInputProps {
-  binding: string | undefined;
-  name: string;
-  placeholder?: string;
+export interface CodeInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
   defaultValue?: string;
   onChange?: (value: string | undefined) => void;
-  creatable?: boolean;
-  maxSelectedValues?: number;
-  clearSearchOnChange?: boolean;
-  clearable?: boolean;
 }
 
 export function CodeInput(props: CodeInputProps): JSX.Element {
-  const [value, setValue] = useState<string | undefined>(props.defaultValue);
+  const { defaultValue, onChange, ...rest } = props;
+  const [value, setValue] = useState<string | undefined>(defaultValue);
 
   function handleChange(newValues: ValueSetExpansionContains[]): void {
     const newValue = newValues[0];
     const newCode = valueSetElementToCode(newValue);
     setValue(newCode);
-    if (props.onChange) {
-      props.onChange(newCode);
+    if (onChange) {
+      onChange(newCode);
     }
   }
 
-  return (
-    <ValueSetAutocomplete
-      binding={props.binding}
-      name={props.name}
-      placeholder={props.placeholder}
-      defaultValue={codeToValueSetElement(value)}
-      onChange={handleChange}
-      creatable={props.creatable}
-      maxSelectedValues={props.maxSelectedValues ?? 1}
-      clearSearchOnChange={props.clearSearchOnChange}
-      clearable={props.clearable}
-    />
-  );
+  return <ValueSetAutocomplete defaultValue={codeToValueSetElement(value)} onChange={handleChange} {...rest} />;
 }
 
 function codeToValueSetElement(code: string | undefined): ValueSetExpansionContains | undefined {

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
@@ -1,34 +1,29 @@
 import { CodeableConcept, ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { useState } from 'react';
-import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
+import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
-export interface CodeableConceptInputProps {
-  binding: string | undefined;
-  name: string;
-  placeholder?: string;
+export interface CodeableConceptInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
   defaultValue?: CodeableConcept;
   onChange?: (value: CodeableConcept | undefined) => void;
 }
 
 export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Element {
-  const [value, setValue] = useState<CodeableConcept | undefined>(props.defaultValue);
+  const { defaultValue, onChange, ...rest } = props;
+  const [value, setValue] = useState<CodeableConcept | undefined>(defaultValue);
 
   function handleChange(newValues: ValueSetExpansionContains[]): void {
     const newConcept = valueSetElementToCodeableConcept(newValues);
     setValue(newConcept);
-    if (props.onChange) {
-      props.onChange(newConcept);
+    if (onChange) {
+      onChange(newConcept);
     }
   }
 
   return (
     <ValueSetAutocomplete
-      binding={props.binding}
-      name={props.name}
-      placeholder={props.placeholder}
       defaultValue={value && codeableConceptToValueSetElement(value)}
-      maxSelectedValues={1}
       onChange={handleChange}
+      {...rest}
     />
   );
 }

--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -1,35 +1,31 @@
 import { Coding, ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { useState } from 'react';
-import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
+import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
-export interface CodingInputProps {
-  binding: string | undefined;
-  name: string;
-  placeholder?: string;
+export interface CodingInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
   defaultValue?: Coding;
   onChange?: (value: Coding | undefined) => void;
 }
 
 export function CodingInput(props: CodingInputProps): JSX.Element {
-  const [value, setValue] = useState<Coding | undefined>(props.defaultValue);
+  const { defaultValue, onChange, ...rest } = props;
+  const [value, setValue] = useState<Coding | undefined>(defaultValue);
 
   function handleChange(newValues: ValueSetExpansionContains[]): void {
     const newValue = newValues[0];
     const newConcept = newValue && valueSetElementToCoding(newValue);
     setValue(newConcept);
-    if (props.onChange) {
-      props.onChange(newConcept);
+    if (onChange) {
+      onChange(newConcept);
     }
   }
 
   return (
     <ValueSetAutocomplete
-      binding={props.binding}
-      name={props.name}
-      placeholder={props.placeholder}
       defaultValue={value && codingToValueSetElement(value)}
       maxSelectedValues={1}
       onChange={handleChange}
+      {...rest}
     />
   );
 }


### PR DESCRIPTION
See: https://github.com/medplum/medplum/issues/3651

Added `expandParams` prop, which is passed through to the `ValueSet/$expand` call.

Examples:

```tsx
    <CodeInput
      name="foo"
      binding={valueSet}
      defaultValue="male"
      onChange={console.log}
      expandParams={{ count: 20 }}
    />
```

```tsx
    <CodingInput
      name="foo"
      binding={valueSet}
      defaultValue={{ code: 'abc' }}
      onChange={console.log}
      expandParams={{ count: 20 }}
    />
```

```tsx
    <CodeableConceptInput
      name="foo"
      binding={valueSet}
      defaultValue={{ coding: [{ code: 'M', display: 'Married' }] }}
      onChange={console.log}
      expandParams={{ count: 20 }}
    />
```