### PR TITLE
Run chromatic on every push

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,6 @@
 name: 'Chromatic'
 
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+on: push
 
 jobs:
   chromatic:
@@ -26,3 +24,4 @@ jobs:
           workingDir: packages/react
           buildScriptName: storybook
           exitZeroOnChanges: true
+          onlyChanged: true


### PR DESCRIPTION
Now that all stories are stable, this should establish a green baseline on `main`. If it doesn't, next step will be explicitly specifying `autoAcceptChanges: "main"`