### PR TITLE
Proof of concept storybook GQL mocking

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1576,14 +1576,17 @@ export class MedplumClient extends EventTarget {
    * @returns Promise to a schema with the requested resource type.
    */
   requestSchema(resourceType: string): Promise<void> {
+    // Disable caching so that GQL path will be hit
     if (isDataTypeLoaded(resourceType)) {
-      return Promise.resolve();
+      console.log('Not resolving early to demonstrate GQL mocking');
+      //   return Promise.resolve();
     }
 
     const cacheKey = resourceType + '-requestSchema';
     const cached = this.getCacheEntry(cacheKey, undefined);
     if (cached) {
-      return cached.value;
+      console.log('Not returning cached value to demonstrate GQL mocking');
+      //   return cached.value;
     }
 
     const promise = new ReadablePromise<void>(
@@ -1630,6 +1633,7 @@ export class MedplumClient extends EventTarget {
     }`.replace(/\s+/g, ' ');
 
         const response = (await this.graphql(query)) as SchemaGraphQLResponse;
+        console.log('MedplumClient.requestSchema received GQL response', response);
 
         indexStructureDefinitionBundle(response.data.StructureDefinitionList);
 

--- a/packages/react/src/ResourceForm/ResourceForm.stories.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.stories.tsx
@@ -6,29 +6,673 @@ import {
   TestOrganization,
   USCoreStructureDefinitionList,
 } from '@medplum/mock';
-import { Meta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { ResourceForm } from './ResourceForm';
 import { useMedplum } from '@medplum/react-hooks';
 import { useEffect, useMemo, useState } from 'react';
 import { MedplumClient, deepClone, loadDataType } from '@medplum/core';
 import { StructureDefinition } from '@medplum/fhirtypes';
+import { withMockedGQL } from '../stories/decorators';
 
 export default {
   title: 'Medplum/ResourceForm',
   component: ResourceForm,
 } as Meta;
 
-export const Patient = (): JSX.Element => (
-  <Document>
-    <ResourceForm
-      defaultValue={HomerSimpson}
-      onSubmit={(formData: any) => {
-        console.log('submit', formData);
-      }}
-    />
-  </Document>
-);
+type Story = StoryObj<typeof ResourceForm>;
+
+export const Patient: Story = {
+  decorators: [
+    withMockedGQL([
+      {
+        query:
+          '{ StructureDefinitionList(name: "Patient") { resourceType, name, kind, description, type, snapshot { element { id, path, definition, min, max, base { path, min, max }, contentReference, type { code, profile, targetProfile }, binding { strength, valueSet } } } } SearchParameterList(base: "Patient", _count: 100) { base, code, type, expression, target } }',
+        response: {
+          data: {
+            SearchParameterList: [],
+            StructureDefinitionList: [
+              {
+                name: 'Patient',
+                type: 'Patient',
+                kind: 'resource',
+                elements: {
+                  id: {
+                    description: '',
+                    path: 'Patient.id',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'http://hl7.org/fhirpath/System.String',
+                      },
+                    ],
+                  },
+                  meta: {
+                    description: '',
+                    path: 'Patient.meta',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Meta',
+                      },
+                    ],
+                  },
+                  implicitRules: {
+                    description: '',
+                    path: 'Patient.implicitRules',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'uri',
+                      },
+                    ],
+                  },
+                  language: {
+                    description: '',
+                    path: 'Patient.language',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'code',
+                      },
+                    ],
+                  },
+                  text: {
+                    description: '',
+                    path: 'Patient.text',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Narrative',
+                      },
+                    ],
+                  },
+                  contained: {
+                    description: '',
+                    path: 'Patient.contained',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Resource',
+                      },
+                    ],
+                  },
+                  extension: {
+                    description: '',
+                    path: 'Patient.extension',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Extension',
+                      },
+                    ],
+                  },
+                  modifierExtension: {
+                    description: '',
+                    path: 'Patient.modifierExtension',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Extension',
+                      },
+                    ],
+                  },
+                  identifier: {
+                    description: '',
+                    path: 'Patient.identifier',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Identifier',
+                      },
+                    ],
+                  },
+                  active: {
+                    description: '',
+                    path: 'Patient.active',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'boolean',
+                      },
+                    ],
+                  },
+                  name: {
+                    description: '',
+                    path: 'Patient.name',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'HumanName',
+                      },
+                    ],
+                  },
+                  telecom: {
+                    description: '',
+                    path: 'Patient.telecom',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'ContactPoint',
+                      },
+                    ],
+                  },
+                  gender: {
+                    description: '',
+                    path: 'Patient.gender',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'code',
+                      },
+                    ],
+                  },
+                  birthDate: {
+                    description: '',
+                    path: 'Patient.birthDate',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'date',
+                      },
+                    ],
+                  },
+                  'deceased[x]': {
+                    description: '',
+                    path: 'Patient.deceased[x]',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'boolean',
+                      },
+                      {
+                        code: 'dateTime',
+                      },
+                    ],
+                  },
+                  address: {
+                    description: '',
+                    path: 'Patient.address',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Address',
+                      },
+                    ],
+                  },
+                  maritalStatus: {
+                    description: '',
+                    path: 'Patient.maritalStatus',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'CodeableConcept',
+                      },
+                    ],
+                  },
+                  'multipleBirth[x]': {
+                    description: '',
+                    path: 'Patient.multipleBirth[x]',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'boolean',
+                      },
+                      {
+                        code: 'integer',
+                      },
+                    ],
+                  },
+                  photo: {
+                    description: '',
+                    path: 'Patient.photo',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Attachment',
+                      },
+                    ],
+                  },
+                  contact: {
+                    description: '',
+                    path: 'Patient.contact',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'PatientContact',
+                      },
+                    ],
+                  },
+                  communication: {
+                    description: '',
+                    path: 'Patient.communication',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'PatientCommunication',
+                      },
+                    ],
+                  },
+                  generalPractitioner: {
+                    description: '',
+                    path: 'Patient.generalPractitioner',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Reference',
+                        targetProfile: [
+                          'http://hl7.org/fhir/StructureDefinition/Organization',
+                          'http://hl7.org/fhir/StructureDefinition/Practitioner',
+                          'http://hl7.org/fhir/StructureDefinition/PractitionerRole',
+                        ],
+                      },
+                    ],
+                  },
+                  managingOrganization: {
+                    description: '',
+                    path: 'Patient.managingOrganization',
+                    min: 0,
+                    max: 1,
+                    isArray: false,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'Reference',
+                        targetProfile: ['http://hl7.org/fhir/StructureDefinition/Organization'],
+                      },
+                    ],
+                  },
+                  link: {
+                    description: '',
+                    path: 'Patient.link',
+                    min: 0,
+                    max: null,
+                    isArray: true,
+                    constraints: [],
+                    type: [
+                      {
+                        code: 'PatientLink',
+                      },
+                    ],
+                  },
+                },
+                constraints: [],
+                innerTypes: [
+                  {
+                    name: 'PatientContact',
+                    elements: {
+                      id: {
+                        description: '',
+                        path: 'Patient.contact.id',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'http://hl7.org/fhirpath/System.String',
+                          },
+                        ],
+                      },
+                      extension: {
+                        description: '',
+                        path: 'Patient.contact.extension',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Extension',
+                          },
+                        ],
+                      },
+                      modifierExtension: {
+                        description: '',
+                        path: 'Patient.contact.modifierExtension',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Extension',
+                          },
+                        ],
+                      },
+                      relationship: {
+                        description: '',
+                        path: 'Patient.contact.relationship',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'CodeableConcept',
+                          },
+                        ],
+                      },
+                      name: {
+                        description: '',
+                        path: 'Patient.contact.name',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'HumanName',
+                          },
+                        ],
+                      },
+                      telecom: {
+                        description: '',
+                        path: 'Patient.contact.telecom',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'ContactPoint',
+                          },
+                        ],
+                      },
+                      address: {
+                        description: '',
+                        path: 'Patient.contact.address',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Address',
+                          },
+                        ],
+                      },
+                      gender: {
+                        description: '',
+                        path: 'Patient.contact.gender',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'code',
+                          },
+                        ],
+                      },
+                      organization: {
+                        description: '',
+                        path: 'Patient.contact.organization',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Reference',
+                            targetProfile: ['http://hl7.org/fhir/StructureDefinition/Organization'],
+                          },
+                        ],
+                      },
+                      period: {
+                        description: '',
+                        path: 'Patient.contact.period',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Period',
+                          },
+                        ],
+                      },
+                    },
+                    constraints: [],
+                    innerTypes: [],
+                  },
+                  {
+                    name: 'PatientCommunication',
+                    elements: {
+                      id: {
+                        description: '',
+                        path: 'Patient.communication.id',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'http://hl7.org/fhirpath/System.String',
+                          },
+                        ],
+                      },
+                      extension: {
+                        description: '',
+                        path: 'Patient.communication.extension',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Extension',
+                          },
+                        ],
+                      },
+                      modifierExtension: {
+                        description: '',
+                        path: 'Patient.communication.modifierExtension',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Extension',
+                          },
+                        ],
+                      },
+                      language: {
+                        description: '',
+                        path: 'Patient.communication.language',
+                        min: 1,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'CodeableConcept',
+                          },
+                        ],
+                      },
+                      preferred: {
+                        description: '',
+                        path: 'Patient.communication.preferred',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'boolean',
+                          },
+                        ],
+                      },
+                    },
+                    constraints: [],
+                    innerTypes: [],
+                  },
+                  {
+                    name: 'PatientLink',
+                    elements: {
+                      id: {
+                        description: '',
+                        path: 'Patient.link.id',
+                        min: 0,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'http://hl7.org/fhirpath/System.String',
+                          },
+                        ],
+                      },
+                      extension: {
+                        description: '',
+                        path: 'Patient.link.extension',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Extension',
+                          },
+                        ],
+                      },
+                      modifierExtension: {
+                        description: '',
+                        path: 'Patient.link.modifierExtension',
+                        min: 0,
+                        max: null,
+                        isArray: true,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Extension',
+                          },
+                        ],
+                      },
+                      other: {
+                        description: '',
+                        path: 'Patient.link.other',
+                        min: 1,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'Reference',
+                            targetProfile: [
+                              'http://hl7.org/fhir/StructureDefinition/Patient',
+                              'http://hl7.org/fhir/StructureDefinition/RelatedPerson',
+                            ],
+                          },
+                        ],
+                      },
+                      type: {
+                        description: '',
+                        path: 'Patient.link.type',
+                        min: 1,
+                        max: 1,
+                        isArray: false,
+                        constraints: [],
+                        type: [
+                          {
+                            code: 'code',
+                          },
+                        ],
+                      },
+                    },
+                    constraints: [],
+                    innerTypes: [],
+                  },
+                ],
+                summaryProperties: {},
+                mandatoryProperties: {},
+              },
+            ],
+          },
+        },
+      },
+    ]),
+  ],
+  render() {
+    return (
+      <Document>
+        <ResourceForm
+          defaultValue={HomerSimpson}
+          onSubmit={(formData: any) => {
+            console.log('submit', formData);
+          }}
+        />
+      </Document>
+    );
+  },
+};
 
 export const Organization = (): JSX.Element => (
   <Document>

--- a/packages/react/src/ResourceForm/ResourceForm.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.tsx
@@ -41,6 +41,7 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
           .catch(console.log);
       } else {
         const schemaName = props.schemaName ?? defaultValue?.resourceType;
+        console.log(`Calling requestSchema('${schemaName}')...`);
         medplum
           .requestSchema(schemaName)
           .then(() => setSchemaLoaded(schemaName))

--- a/packages/react/src/stories/MockGQLWrapper.tsx
+++ b/packages/react/src/stories/MockGQLWrapper.tsx
@@ -1,0 +1,39 @@
+import { useLayoutEffect } from 'react';
+import { useMedplum } from '@medplum/react-hooks';
+
+export type MockGQLWrapperProps = {
+  queryMocks: { query: string; response: any }[];
+  children: JSX.Element;
+};
+
+export function MockGQLWrapper({ queryMocks, children }: MockGQLWrapperProps): JSX.Element | null {
+  const medplum = useMedplum();
+
+  // useLayoutEffect instead of useEffect so that this happens before the first render and we don't need to deal
+  // with a ready state for demonstration purposes
+  useLayoutEffect(() => {
+    const realGQL = medplum.graphql;
+
+    async function fakeGraphql(
+      query: string,
+      _operationName?: string | null,
+      _variables?: any,
+      _options?: RequestInit
+    ): Promise<any> {
+      const mock = queryMocks.find((qm) => qm.query === query);
+      if (!mock) {
+        throw new Error(`Unexpected GQL query: ${query}`);
+      }
+
+      console.log(`Returning mocked response for query ${query}`, mock.response);
+      return Promise.resolve(mock.response);
+    }
+    medplum.graphql = fakeGraphql;
+
+    return () => {
+      medplum.graphql = realGQL;
+    };
+  }, [medplum, queryMocks]);
+
+  return children;
+}

--- a/packages/react/src/stories/decorators.tsx
+++ b/packages/react/src/stories/decorators.tsx
@@ -1,5 +1,6 @@
 import { Decorator } from '@storybook/react';
 import { MockDateWrapper } from './MockDateWrapper';
+import { MockGQLWrapper, MockGQLWrapperProps } from './MockGQLWrapper';
 
 export const withMockedDate: Decorator = (Story) => {
   return (
@@ -7,4 +8,13 @@ export const withMockedDate: Decorator = (Story) => {
       <Story />
     </MockDateWrapper>
   );
+};
+export const withMockedGQL = (queryMocks: MockGQLWrapperProps['queryMocks']): Decorator => {
+  return (Story) => {
+    return (
+      <MockGQLWrapper queryMocks={queryMocks}>
+        <Story />
+      </MockGQLWrapper>
+    );
+  };
 };


### PR DESCRIPTION
The interface is still a bit unwieldy since you have to obtain the exact GQL query string that is generated. It'd probably be sufficient to instead just provide an array of responses that you want to returned each time the `MedplumClient.graphql` is invoked and ignore the query string altogether.