### PR TITLE
Fixes #3669 - preemptive token refresh

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -59,6 +59,9 @@ describe('App', () => {
       await sleep(100);
     }
 
+    // Send an error message
+    wsClient.send(Buffer.from(JSON.stringify({ type: 'agent:error', body: 'details' })));
+
     // Send an unknown message type
     wsClient.send(Buffer.from(JSON.stringify({ type: 'unknown' })));
 

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -96,6 +96,9 @@ export class App {
           case 'agent:transmit:request':
             this.pushMessage(command);
             break;
+          case 'agent:error':
+            this.log.error(command.body);
+            break;
           default:
             this.log.error(`Unknown message type: ${command.type}`);
         }
@@ -142,6 +145,11 @@ export class App {
       this.webSocket = undefined;
     }
     this.log.info('Medplum service stopped successfully');
+  }
+
+  async getAccessToken(): Promise<string> {
+    await this.medplum.refreshIfExpired();
+    return this.medplum.getAccessToken() as string;
   }
 
   addToWebSocketQueue(message: AgentMessage): void {

--- a/packages/agent/src/hl7.ts
+++ b/packages/agent/src/hl7.ts
@@ -63,7 +63,7 @@ export class AgentHl7ChannelConnection {
       this.channel.app.log.info(event.message.toString().replaceAll('\r', '\n'));
       this.channel.app.addToWebSocketQueue({
         type: 'agent:transmit:request',
-        accessToken: this.channel.app.medplum.getAccessToken() as string,
+        accessToken: await this.channel.app.getAccessToken(),
         channel: this.channel.definition.name as string,
         remote: this.remote,
         contentType: ContentType.HL7_V2,

--- a/packages/core/src/jwt.test.ts
+++ b/packages/core/src/jwt.test.ts
@@ -1,0 +1,25 @@
+import { isJwt, isMedplumAccessToken, tryGetJwtExpiration } from './jwt';
+
+describe('JWT utils', () => {
+  test('isJwt', () => {
+    expect(isJwt('')).toBe(false);
+    expect(isJwt('header.payload')).toBe(false);
+    expect(isJwt(createFakeJwt({ exp: 0 }))).toBe(true);
+  });
+
+  test('isMedplumAccessToken', () => {
+    expect(isMedplumAccessToken('')).toBe(false);
+    expect(isMedplumAccessToken(createFakeJwt({}))).toBe(false);
+    expect(isMedplumAccessToken(createFakeJwt({ login_id: '123' }))).toBe(true);
+  });
+
+  test('tryGetJwtExpiration', () => {
+    expect(tryGetJwtExpiration('')).toBe(undefined);
+    expect(tryGetJwtExpiration(createFakeJwt({}))).toBe(undefined);
+    expect(tryGetJwtExpiration(createFakeJwt({ exp: 0 }))).toBe(0);
+  });
+});
+
+function createFakeJwt(claims: Record<string, string | number>): string {
+  return 'header.' + window.btoa(JSON.stringify(claims)) + '.signature';
+}

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -49,3 +49,21 @@ export function isMedplumAccessToken(accessToken: string): boolean {
     return false;
   }
 }
+
+/**
+ * Returns the JWT expiration time in number of milliseconds elapsed since the epoch.
+ * @param token - The JWT token.
+ * @returns The JWT expiration time in number of milliseconds elapsed since the epoch if available, undefined if unknown.
+ */
+export function tryGetJwtExpiration(token: string): number | undefined {
+  try {
+    const payload = parseJWTPayload(token);
+    const exp = payload.exp;
+    if (typeof exp === 'number') {
+      return exp * 1000;
+    }
+    return undefined;
+  } catch (err) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Before: `MedplumClient` waited for token expiration error before refreshing.

After: `MedplumClient` attempts to preemptively refresh an expired token before using it.

I modified my localhost server to issue access tokens with a 10sec expiration (rather than default 1 hour).  That seemed to be a good way to build confidence that the app was working as expected.