### PR TITLE
Fix typos

### DIFF
--- a/packages/docs/docs/agent/push.md
+++ b/packages/docs/docs/agent/push.md
@@ -58,7 +58,7 @@ The Agent connects to the Server using secure WebSockets (WSS). Because WebSocke
 
 ![Medplum Agent Push 5](./medplum-agent-push-5.webp)
 
-We can emulate this step using the Medplum CLI. This time, instead of using HL7 over MLLP, we will send a JSON message over HTTPS. The Server forwards the message to the Agent. The Agent forwards the message to the insrument.
+We can emulate this step using the Medplum CLI. This time, instead of using HL7 over MLLP, we will send a JSON message over HTTPS. The Server forwards the message to the Agent. The Agent forwards the message to the instrument.
 
 ```bash
 medplum post 'Agent/1080ee82-e4fc-4312-946f-322fbecf9bb9/$push' $'{"destination":"Device/52c9a9de-1081-4fb2-a40a-e62efe1b73b2","contentType":"x-application/hl7-v2+er7","body":"MSH|^~\\\\&|ADTSYS|HOSPITAL|RECEIVER|DEST|20231023235305.516||ADT^A01|1698105185516|P|2.5|\\nEVN|A01|20231023235305.516||\\nPID|1|12345|12345^^^HOSP^MR|123456|DOE^JOHN^MIDDLE^SUFFIX|19800101|M|||123 STREET^APT 4B^CITY^ST^12345-6789||555-555-5555||S|\\nPV1|1|I|2000^2012^01||||12345^DOCTOR^DOC||||||||||1234567^DOCTOR^DOC||AMB|||||||||||||||||||||||||202309280900|"}'

--- a/packages/docs/docs/api/fhir/datatypes/population.mdx
+++ b/packages/docs/docs/api/fhir/datatypes/population.mdx
@@ -10,7 +10,7 @@ import { ResourcePropertiesTable, SearchParamsTable } from '@site/src/components
 
 # Population
 
-Base <a href="/docs/api/fhir/resources/structuredefinition">StructureDefinition</a> for <a href="/docs/api/fhir/datatypes/population">Population</a> Type: A populatioof people with some set of grouping criteria.
+Base <a href="/docs/api/fhir/resources/structuredefinition">StructureDefinition</a> for <a href="/docs/api/fhir/datatypes/population">Population</a> Type: A population of people with some set of grouping criteria.
 
 <Tabs queryString="section">
 <TabItem value="schema" label="Schema" default>

--- a/packages/docs/docs/auth/user-management-guide/user-management-guide.md
+++ b/packages/docs/docs/auth/user-management-guide/user-management-guide.md
@@ -280,7 +280,7 @@ Check the box under the `Admin` label, and then save the user. This user will no
 
 To _invite_ a user as an admin in the app, please see the [Invite a User docs](https://www.medplum.com/docs/app/invite).
 
-Promoting a user to admin can also be done programatically. To do so, you will need to update the user's `ProjectMembership`.
+Promoting a user to admin can also be done programmatically. To do so, you will need to update the user's `ProjectMembership`.
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">

--- a/packages/docs/docs/billing/insurance-eligibility-checks.md
+++ b/packages/docs/docs/billing/insurance-eligibility-checks.md
@@ -13,9 +13,9 @@ Insurance eligibility checks cover a variety of use cases, but generally they ar
 2. Does this insurance cover basic visits to a provider?
 3. Does this insurance cover a specific service type?
 
-The most basic use case for an eligibility check is simply seeing if the policy is active and inforce.
+The most basic use case for an eligibility check is simply seeing if the policy is active and in force.
 
-Adding a second layer is checking if the policy is active and also covers basic visits to a provider. These include appointments like phsyicals and check-ups and is the most common type of eligibility request.
+Adding a second layer is checking if the policy is active and also covers basic visits to a provider. These include appointments like physicals and check-ups and is the most common type of eligibility request.
 
 Because it is so common, these types of requests are defined by the [X12 Service Type Codes](https://x12.org/codes/service-type-codes) in **service code 30**. This service type is "Plan Coverage and General Benefits", and checks for active basic coverage.
 
@@ -91,7 +91,7 @@ The `item` field also provides additional data about the procedure, product, or 
 
 Once you have created your [`CoverageEligibilityRequest`](/docs/api/fhir/resources/coverageeligibilityrequest), you need to send it to the insurer.
 
-In addition to sending it directly to the insurer, there are services that simplify the process. Companies such as [Opkit](https://www.opkit.co/), [Availty](https://www.availity.com/), [Change Healthcare](https://www.changehealthcare.com/), [Waystar](https://www.waystar.com/) and [Candid Health](https://www.joincandidhealth.com/) allow you to send them eligibility checks directly.
+In addition to sending it directly to the insurer, there are services that simplify the process. Companies such as [Opkit](https://www.opkit.co/), [Availity](https://www.availity.com/), [Change Healthcare](https://www.changehealthcare.com/), [Waystar](https://www.waystar.com/) and [Candid Health](https://www.joincandidhealth.com/) allow you to send them eligibility checks directly.
 
 Unfortunately, these companies format their requests based on [X12 EDI Format](https://x12.org/examples/005010x279) rather than FHIR, so you will need to convert your [`CoverageEligibilityRequest`](/docs/api/fhir/resources/coverageeligibilityrequest) to the correct format. This is a good workflow to implement [Bots](/docs/bots/bot-basics) to convert your request, interface with the company's API, and send the request. Additionally, you can have a [Subscription](/docs/subscriptions) to listen for a response and have a bot handle that as well.
 
@@ -105,7 +105,7 @@ When you send your request, the insurer will review it and respond. This respons
 | `disposition`             | A human-readable description of the status of the request.                                                                              | The policy is currently in-force.                               |
 | `error`                   | Documents any errors that encountered during the eligibility check. Describes why a check may not have been able to be completed.       | Missing Identifier                                              |
 | `insurance.item`          | Details about the benefits, authorization requirements, and current benefits of the insurance.                                          | [See below](#the-item-element-on-a-coverageeligibilityresponse) |
-| `insurance.inforce`       | A boolean indicating if the coverage is inforce for the requested period.                                                               | true                                                            |
+| `insurance.inforce`       | A boolean indicating if the coverage is in force for the requested period.                                                               | true                                                            |
 | `insurance.benefitPeriod` | The term period of the benefits documented in the response.                                                                             | 2023-01-01 – 2023-12-31                                         |
 | `insurance.coverage`      | A reference to the patient's [`Coverage`](/docs/api/fhir/resources/coverage) resource.                                                  | Coverage/example-coverage                                       |
 | `request`                 | A reference to the original [`CoverageEligibilityRequest`](/docs/api/fhir/resources/coverageeligibilityrequest) this is in response to. | CoverageEligibilityRequest/check-for-vision-coverage            |

--- a/packages/docs/docs/bots/bots-in-production.md
+++ b/packages/docs/docs/bots/bots-in-production.md
@@ -296,7 +296,7 @@ You can choose to only log certain events using the `Bot.auditEventTrigger` fiel
 
 Logging can also be limited by setting the destination that your Bot logs to. This is done using the `Bot.auditEventDestination` field. This element can be set to either `resource` or `log`.
 
-By default, `auditEventDestination` is set to `resource`. This will create an `AuditEvent` resource in the main database, which can be accessed by Medplum's API and will be visibile in your app. However, the operation is slower and takes up more space. It is best practice to always start by using `resource` as it allows for easier testing and debugging of your Bot.
+By default, `auditEventDestination` is set to `resource`. This will create an `AuditEvent` resource in the main database, which can be accessed by Medplum's API and will be visible in your app. However, the operation is slower and takes up more space. It is best practice to always start by using `resource` as it allows for easier testing and debugging of your Bot.
 
 Setting `auditEventDestination` to `log` will only output an `AuditEvent` in your existing enterprise logging infrastructure, such as [AWS Athena](/docs/self-hosting/aws-athena-guide), [Datadog](/docs/self-hosting/datadog), or others. This can make testing and debugging more difficult, but is quicker and useful for high-volume operations as it will fill up or slow down your main database.
 

--- a/packages/docs/docs/bots/hl7-into-fhir.md
+++ b/packages/docs/docs/bots/hl7-into-fhir.md
@@ -93,7 +93,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
 }
 ```
 
-Functionally, the code above will create a new patient with the `mrnNumber` provided, assuming that patient isn't aready in this system.
+Functionally, the code above will create a new patient with the `mrnNumber` provided, assuming that patient isn't already in this system.
 
 ### Testing your Bot
 
@@ -111,7 +111,7 @@ PV1|1|N||||||||||||||||||||||||||||||||||||||||||||||||||||
 PV2||||||||||||||||||||||N|||||||||||||||||||||||||||'
 ```
 
-If all goes well, you should see the following HL7 acknowldgement message in the console.
+If all goes well, you should see the following HL7 acknowledgement message in the console.
 
 ```bash
 MSH|^~\\&|CL|PDMT|Primary||2022-05-10T16:19:50.244Z||ACK|1652199590244|P|2.5.1\rMSA|AA|203598|OK

--- a/packages/docs/docs/bots/insurance-eligibility-check.md
+++ b/packages/docs/docs/bots/insurance-eligibility-check.md
@@ -20,7 +20,7 @@ _This guide includes an example of a bot written in TypeScript, deployed using t
 
 ## Background: Insurance Eligibility Check Concepts
 
-The term _eligbility check_ implies a yes or no answer, but in practice this tends to be more complex. Medical billing is run off of an [X12](https://x12.org/products/by-industry) data standard, and claims are submitted and managed using that standard. Eligibility checks, though they do not submit a full claim, use some of the data outlined by the format. In this simple example, the request has the following inputs and outputs.
+The term _eligibility check_ implies a yes or no answer, but in practice this tends to be more complex. Medical billing is run off of an [X12](https://x12.org/products/by-industry) data standard, and claims are submitted and managed using that standard. Eligibility checks, though they do not submit a full claim, use some of the data outlined by the format. In this simple example, the request has the following inputs and outputs.
 
 - Data Inputs
   - Patient information like **name** and **date of birth**

--- a/packages/docs/docs/bots/unit-testing-bots.mdx
+++ b/packages/docs/docs/bots/unit-testing-bots.mdx
@@ -102,12 +102,12 @@ Once you have created your data, you can write your tests. The above example use
 
 #### Using the Medplum CLI
 
-If you have a dev project that already has rich data, you can use the Mepdlum CLI to easily convert this data into test data.
+If you have a dev project that already has rich data, you can use the Medplum CLI to easily convert this data into test data.
 
 The Medplum CLI offers the optional `--as-transaction` flag when using the `medplum get` command. A `GET` request returns a `Bundle` with `type=searchset`, but this flag will convert it to `type=transaction`.
 
 <details>
-  <summary>Example: Get a patient and all encounters that reference them as a transactioin</summary>
+  <summary>Example: Get a patient and all encounters that reference them as a transaction</summary>
   <MedplumCodeBlock language="ts" selectBlocks="cliAsTransaction">
     {ExampleCode3}
   </MedplumCodeBlock>
@@ -115,7 +115,7 @@ The Medplum CLI offers the optional `--as-transaction` flag when using the `medp
 
 This example searches for all `Patient` resources named 'Alex'. It also uses the [`_revinclude` parameter](/docs/search/includes) to search for all `Encounter` resources that reference those patients.
 
-A transaction `Bundle` can be used directly in a batch request, and can be passed as an argument to `executeBatch` on your `MockClient`. This allows you to easily create test resoures from already existing data.
+A transaction `Bundle` can be used directly in a batch request, and can be passed as an argument to `executeBatch` on your `MockClient`. This allows you to easily create test resources from already existing data.
 
 #### Cloning an Existing Projects
 
@@ -158,12 +158,12 @@ Many times, you'd like to make sure your Bot is [idempotent](https://en.wikipedi
 
 ### Using the Medplum CLI
 
-If you have a dev project that already has rich data, you can use the Mepdlum CLI to easily convert this data into test data.
+If you have a dev project that already has rich data, you can use the Medplum CLI to easily convert this data into test data.
 
 The Medplum CLI offers the optional `--as-transaction` flag when using the `medplum get` command. A `GET` request returns a `Bundle` with `type=searchset`, but this flag will convert it to `type=transaction`.
 
 <details>
-<summary>Example: Get a patient and all encounters that reference them as a transactioin</summary>
+<summary>Example: Get a patient and all encounters that reference them as a transaction</summary>
 
 ```cli
 
@@ -175,4 +175,4 @@ The Medplum CLI offers the optional `--as-transaction` flag when using the `medp
 
 This example searches for all `Patient` resources named 'Alex'. It also uses the [`_revinclude` parameter](/docs/search/includes) to search for all `Encounter` resources that reference those patients.
 
-A transaction `Bundle` can be used directly in a batch request, and can be passed as an argument to `executeBatch` on your `MockClient`. This allows you to easily create test resoures from already existing data.
+A transaction `Bundle` can be used directly in a batch request, and can be passed as an argument to `executeBatch` on your `MockClient`. This allows you to easily create test resources from already existing data.

--- a/packages/docs/docs/careplans/diagnostic-catalog/diagnostic-catalog.mdx
+++ b/packages/docs/docs/careplans/diagnostic-catalog/diagnostic-catalog.mdx
@@ -224,7 +224,7 @@ This allows you to reuse the data definition of your procedures, while allowing 
 <details>
   <summary>Example: Men's Health Panel</summary>
   <p>
-    This PlanDefintion reuses the Electrolyte Panel from the previous example, and but adds a free testosterone test.
+    This PlanDefinition reuses the Electrolyte Panel from the previous example, and but adds a free testosterone test.
   </p>
     <h5>
     Patient-facing service
@@ -240,7 +240,7 @@ This allows you to reuse the data definition of your procedures, while allowing 
     {ExampleCode}
   </MedplumCodeBlock>
 
-  <h6>Electolytes Procedure</h6>
+  <h6>Electrolytes Procedure</h6>
   <MedplumCodeBlock language="ts" selectBlocks="electrolytesPanel">
     {ExampleCode}
   </MedplumCodeBlock>

--- a/packages/docs/docs/careplans/reference-ranges.mdx
+++ b/packages/docs/docs/careplans/reference-ranges.mdx
@@ -35,7 +35,7 @@ In this guide, we'll take a closer look at how administrators can use the [`Obse
 
 ## Defining a Reference Range
 
-A reference range is defined using the `ObservationDefinition.qualifiedInterval` element. This is an array field, which allows administrators to define mulitple ranges of interest for a single [`Observation`](/docs/api/fhir/resources/observation).
+A reference range is defined using the `ObservationDefinition.qualifiedInterval` element. This is an array field, which allows administrators to define multiple ranges of interest for a single [`Observation`](/docs/api/fhir/resources/observation).
 
 A range is defined by the following properties:
 
@@ -54,7 +54,7 @@ A range is defined by the following properties:
 
 <details>
   <summary>Example: Less or equal to than 5 mg/dL </summary>
-  <MedplumCodeBlock la nguage="ts" selectBlocks="lowRange">
+  <MedplumCodeBlock language="ts" selectBlocks="lowRange">
     {ExampleCode}
   </MedplumCodeBlock>
 </details>

--- a/packages/docs/docs/charting/capturing-vital-signs.mdx
+++ b/packages/docs/docs/charting/capturing-vital-signs.mdx
@@ -55,7 +55,7 @@ To record the actual _value_ of a measurement, you can use one of the various `v
 </details>
 
 <details>
-  <summary>Example: an observation generated from a survey resposne</summary>
+  <summary>Example: an observation generated from a survey response</summary>
 
 ```js
 {

--- a/packages/docs/docs/cli/external-fhir-servers.md
+++ b/packages/docs/docs/cli/external-fhir-servers.md
@@ -243,6 +243,6 @@ The Medplum CLI uses Medplum [TypescriptSDK](/docs/sdk) to power the functionali
 ## Related Resources
 
 - [Epic FHIR Test Environment](https://fhir.epic.com/Developer/Apps)
-- [eCLinicalworks FHIR documentation](https://fhir.eclinicalworks.com/ecwopendev/documentation#)
+- [eClinicalworks FHIR documentation](https://fhir.eclinicalworks.com/ecwopendev/documentation#)
 - [Cerner FHIR Documentation](https://fhir.cerner.com/millennium/r4/#open-sandbox)
 - [Health Gorilla FHIR Documentation](https://developer.healthgorilla.com/docs/oauth20)

--- a/packages/docs/docs/cli/index.md
+++ b/packages/docs/docs/cli/index.md
@@ -188,7 +188,7 @@ medplum delete Patient/$id
 
 ### Project
 
-`project` will have administration commands for visibilty and management
+`project` will have administration commands for visibility and management
 
 #### `current`
 
@@ -267,7 +267,7 @@ medplum aws describe <name>
 
 #### update-app
 
-Updates the app S3 buckeet in a Medplum deployment to the latest version.
+Updates the app S3 bucket in a Medplum deployment to the latest version.
 
 ```bash
 medplum aws update-app <name>

--- a/packages/docs/docs/communications/organizing-communications.mdx
+++ b/packages/docs/docs/communications/organizing-communications.mdx
@@ -50,7 +50,7 @@ While FHIR standard doesn't offer specific guidance on representing this lifecyc
 
 :::note `category` vs. `reasonCode`
 
-The `category` and `reasonCode` elements are similar, but offer different use cases. The `category` field is used to broadly classifiy messages, while the `reasonCode` is used to provide more granular detail about why a message was sent. For example, a `category` may be a notification while the `reasonCode` could be an appointment reminder.
+The `category` and `reasonCode` elements are similar, but offer different use cases. The `category` field is used to broadly classify messages, while the `reasonCode` is used to provide more granular detail about why a message was sent. For example, a `category` may be a notification while the `reasonCode` could be an appointment reminder.
 
 :::
 

--- a/packages/docs/docs/contributing/upgrading-dependencies.md
+++ b/packages/docs/docs/contributing/upgrading-dependencies.md
@@ -22,7 +22,7 @@ As a convention, we pin all dependency versions in `package.json`.
 
 ## Steps
 
-First, run the `updgrade.sh` script in the project root directory:
+First, run the `upgrade.sh` script in the project root directory:
 
 ```bash
 ./scripts/upgrade.sh

--- a/packages/docs/docs/fhir-basics.md
+++ b/packages/docs/docs/fhir-basics.md
@@ -99,7 +99,7 @@ The example below shows an example [`Patient`][patient] resource. Here we can se
 
 When working with FHIR, clinical data is often split across multiple resources. For example a prescription is related to the receiving patient, and a diagnostic report may consist of multiple observations.
 
-To create link between objects, we use [`Reference`][reference] elements. A FHIR [`Reference`][reference] an element element that functions like a **foreign key** in traditional relational databases to create 1-to-1 or many-to-many relationships between resources.
+To create a link between objects, we use [`Reference`][reference] elements. A FHIR [`Reference`][reference] is an element that functions like a **foreign key** in traditional relational databases to create 1-to-1 or many-to-many relationships between resources.
 
 [`Reference`][reference] elements have the following structure:
 

--- a/packages/docs/docs/integration/index.md
+++ b/packages/docs/docs/integration/index.md
@@ -25,7 +25,7 @@ Medplum supports the following first party integrations.
 | [Recaptcha](https://www.google.com/recaptcha/about/)                   | Security        | Enable recaptcha on patient registration      | [Setup recaptcha](/docs/auth/custom-emails#setup-recaptcha)                                                 |
 | [Datadog](https://www.datadoghq.com/)                                  | Observability   | Application monitoring                        | [Datadog sidecar setup](/docs/self-hosting/datadog)                                                         |
 | [Sumo Logic](https://www.sumologic.com/)                               | Observability   | Application monitoring                        | Coming soon                                                                                                 |
-| [Snowflake](https://www.datadoghq.com/)                                | Data warehouse  | Synchonize data to datawarehouse              | Documentation coming soon                                                                                   |
+| [Snowflake](https://www.datadoghq.com/)                                | Data warehouse  | Synchronize data to datawarehouse              | Documentation coming soon                                                                                   |
 | [OpenAI](https://www.openai.com/)                                      | AI              | Large language models                         | Documentation coming soon                                                                                   |
 
 ## Common Medical Integrations
@@ -57,7 +57,7 @@ Medplum provides building blocks for custom integrations. Some examples are belo
 | [CMS 1500](https://www.cms.gov/medicare/cms-forms/cms-forms/downloads/cms1500.pdf) | Bot PDF       | Create PDF for CMS 1500         | [PDF Bot](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/create-pdf.ts)       |
 | Superbill                                                                          | Bot PDF       | Create PDF for Superbill        | [PDF Bot](https://github.com/medplum/medplum/blob/main/examples/medplum-demo-bots/src/create-pdf.ts)       |
 | Medications                                                                        | API           | Prescribe and check medications | [Medication related integration](https://drive.google.com/drive/folders/1tkkKREaeCj8UOZErTHm28_y7jPfYn4Tb) |
-| [Accuity Scheduling](https://www.acuityscheduling.com/)                            | Bot Webhooks  | Enable third party scheduling   | [Consuming webhooks](/docs/bots/consuming-webhooks)                                                        |
+| [Acuity Scheduling](https://www.acuityscheduling.com/)                            | Bot Webhooks  | Enable third party scheduling   | [Consuming webhooks](/docs/bots/consuming-webhooks)                                                        |
 | [Cal.com](https://cal.com/)                                                        | Bot Webhooks  | Enable third party scheduling   | [Consuming webhooks](/docs/bots/consuming-webhooks)                                                        |
 
 ## Integration Building Blocks and Testing

--- a/packages/docs/docs/integration/log-streaming.md
+++ b/packages/docs/docs/integration/log-streaming.md
@@ -9,7 +9,7 @@ These instructions primarily apply to self-hosted users. To set up log streaming
 
 :::
 
-Medplum can be configured to stream service logs to your existing log management tools, liek [SumoLogic](https://www.sumologic.com/), [DataDog](https://www.datadoghq.com/), or [Splunk](https://www.splunk.com/). Centralizing log management allows for better observability and auditability, and offers real-time analytics capabilities.
+Medplum can be configured to stream service logs to your existing log management tools, like [SumoLogic](https://www.sumologic.com/), [DataDog](https://www.datadoghq.com/), or [Splunk](https://www.splunk.com/). Centralizing log management allows for better observability and auditability, and offers real-time analytics capabilities.
 
 ## Medplum Logs
 

--- a/packages/docs/docs/medications/formulary/index.mdx
+++ b/packages/docs/docs/medications/formulary/index.mdx
@@ -71,7 +71,7 @@ RxNorm term types `SBD`, `BPCK`, and `SBDG` all refer to specific brand names fo
 
 In contrast, using generic term types (`SCD`, `GPCK`, `SCDG`) indicates that physicians may prescribe _any_ brand of the medication.
 
-:::tip Prescribeable vs. Dispensable Medications
+:::tip Prescribable vs. Dispensable Medications
 
 While most Medplum applications will include _either_ generic _or_ branded versions of a medication, some advanced implementations may include both. This is especially common with providers that own their own pharmacy.
 

--- a/packages/docs/docs/medications/representing-prescriptions-and-medication-orders.mdx
+++ b/packages/docs/docs/medications/representing-prescriptions-and-medication-orders.mdx
@@ -135,7 +135,7 @@ The instructions to the pharmacy on how the order should be dispensed should be 
 | `quantity`               | The amount of the medication that is to be dispensed for one fill after the initial fill.                                                                                                              |
 | `dispenseInterval`       | The minimum amount of time between refills of the medication.                                                                                                                                          |
 | `validityPeriod`         | The period over which the prescription or order remains valid.                                                                                                                                         |
-| `numberOfRepeatsAllowed` | The number of times that the order may be refilled. Note that this does not include the intial dispense. If the value here is 3, the order can be refilled 3 times in addition to the intial dispense. |
+| `numberOfRepeatsAllowed` | The number of times that the order may be refilled. Note that this does not include the initial dispense. If the value here is 3, the order can be refilled 3 times in addition to the initial dispense. |
 | `expectedSupplyDuration` | The time period over which the medication is supposed to be used or which the prescription should last.                                                                                                |
 | `performer`              | The organization (i.e. Pharmacy) that should dispense the medication.                                                                                                                                  |
 
@@ -161,7 +161,7 @@ The instructions for how the patient should take the medication should be includ
 | `patientInstruction`       | Readable instructions that the patient is able to understand.                                          |
 | `additionalInstruction`    | Any additional directions to the patient for taking the medicine (e.g. with a meal, or before eating). |
 | `maxDosePerAdministration` | The limit to the amount of medication that should be taken in a single administration.                 |
-| `maxDosePerPeriod`         | The limit to the amount of medication that should be administed over a given period.                   |
+| `maxDosePerPeriod`         | The limit to the amount of medication that should be administered over a given period.                   |
 | `maxDosePerLifetime`       | The limit to the amount of medication that should be taken by a patient in their lifetime.             |
 | `sequence`                 | The specific step in which this dosage should be taken. It should start at 1 and increment from there. |
 

--- a/packages/docs/docs/search/advanced-search-parameters.mdx
+++ b/packages/docs/docs/search/advanced-search-parameters.mdx
@@ -51,7 +51,7 @@ The `_id` parameter allows you to search for any resource based on its `id` elem
 
 The `_lastUpdated` parameter allows you to search for resources based on when they were most recently changed.
 
-This is especially useful when combined with [comparision operators](/docs/search/basic-search#searching-by-comparison), such as `gt` (greater than) or `lt` (less than) to find resources that have or have not been changed since a certain time or date.
+This is especially useful when combined with [comparison operators](/docs/search/basic-search#searching-by-comparison), such as `gt` (greater than) or `lt` (less than) to find resources that have or have not been changed since a certain time or date.
 
 <details>
   <summary>Example: Searching for only communications that have occurred since the beginning of October, 2023</summary>

--- a/packages/docs/docs/search/chained-search.md
+++ b/packages/docs/docs/search/chained-search.md
@@ -40,7 +40,7 @@ The target resource for every link in the chain must be unambiguous. If a search
 
 Just like the example above, the below example searches for all [`Observation`](/docs/api/fhir/resources/observation) resources linked to a [`Patient`](/docs/api/fhir/resources/patient) with a name of 'homer', this time using the syntax `subject:Patient.name=homer`. The way to read this is "search for all [`Observation`](/docs/api/fhir/resources/observation) resources whose `subject` parameter is of type [`Patient`](/docs/api/fhir/resources/patient) and has a name 'homer'".
 
-In the above example, the `patient` parameter can only search for [`Patient`](/docs/api/fhir/resources/patient) resources, so it was not necessary to explicityly state which resource type we were searching for.
+In the above example, the `patient` parameter can only search for [`Patient`](/docs/api/fhir/resources/patient) resources, so it was not necessary to explicitly state which resource type we were searching for.
 
 The general syntax for a forward chained search is `<reference searchParam>:<referenced resource type>.<referenced resource searchParam>=<value>`.
 

--- a/packages/docs/docs/search/filter-search-parameter.mdx
+++ b/packages/docs/docs/search/filter-search-parameter.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # The `_filter` Search Parameter
 
-The `_filter` parameter extends FHIR's search functionality by allowing you to narrow down your results using complex filter expressions. It is a useful way to filter resources in a way that may not be easily achieveable using standard parameters.
+The `_filter` parameter extends FHIR's search functionality by allowing you to narrow down your results using complex filter expressions. It is a useful way to filter resources in a way that may not be easily achievable using standard parameters.
 
 ## Filter Syntax
 
@@ -52,7 +52,7 @@ The `_filter` parameter has several operators that you can use to create your fi
 | ----------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | eq                | equals                                           | Filters for items that are equal to the value provided.                                                                                        | Patient: given eq "homer"                                               |
 | ne                | does not equal                                   | Filters for items that are not equal to the value provided.                                                                                    | Patient: given ne "marge"                                               |
-| co                | contains                                         | Filters for items that contain the value provided.                                                                                             | Pateint: name co "sim"                                                  |
+| co                | contains                                         | Filters for items that contain the value provided.                                                                                             | Patient: name co "sim"                                                  |
 | gt / lt / ge / le | greater/less than, greater/less than or equal to | Filters for items that are greater than (gt), less than (lt), greater than or equal to (ge), or less than or equal to (le) the value provided. | Patient: birthdate ge "1996-06-06" / Patient: birthdate le "1996-06-06" |
 | sa                | starts after                                     | Filters for items that start after the value provided. Most useful when filtering for dates or time periods.                                   | Observation: date sa "2023-01-01"                                       |
 | eb                | ends before                                      | Filters for items that end before the value provided. Most useful when filtering for dates or time periods.                                    | Observation: date eb "2023-08-01"                                       |
@@ -67,7 +67,7 @@ The `_filter` parameter allows you to apply multiple filters using logical opera
 This example will return all male patients that have the string "sim" somewhere in their name.
 
 <details>
-  <summary>Example: Filtering a serach based on both name and gender</summary>
+  <summary>Example: Filtering a search based on both name and gender</summary>
   <Tabs groupId="language">
     <TabItem value="ts" label="Typescript">
       <MedplumCodeBlock language="ts" selectBlocks="logicalAndTs">
@@ -90,7 +90,7 @@ This example will return all male patients that have the string "sim" somewhere 
 This example will return any patients that have an identifier of 12345 OR the phone number "555-6789". It is important to note that this is _impossible_ to do using standard search parameter syntax.
 
 <details>
-  <summary>Example: Filtering a serach based on either an identifier or phone number</summary>
+  <summary>Example: Filtering a search based on either an identifier or phone number</summary>
   <Tabs groupId="language">
     <TabItem value="ts" label="Typescript">
       <MedplumCodeBlock language="ts" selectBlocks="logicalOrTs">

--- a/packages/docs/docs/self-hosting/super-admin-guide.md
+++ b/packages/docs/docs/self-hosting/super-admin-guide.md
@@ -38,7 +38,7 @@ In the future, we hope that most of this maintenance will be 100% automatic and 
 In the "Super Admin" page, there are buttons and sections for:
 
 - Rebuild Structure Definitions
-- Rebuild Search Paramters
+- Rebuild Search Parameters
 - Rebuild Value Sets
 
 From time to time, Medplum will make changes to custom resources. The server runtime uses `StructureDefinition` and `SearchParameter` files directly from disk. However, the client requests `StructureDefinition` resources to dynamically generate client-side UI elements such as search filters, the "Details" page, and the "Edit" page. If a Medplum changes these resources, you may need to rebuild the index before you see the changes in the client.


### PR DESCRIPTION
While reading Medplum's documentation I have encountered a couple of typos. This pull request fixes the typos that I have detected.