### PR TITLE
Project admin password reset cleanup

### DIFF
--- a/packages/app/src/admin/ProjectAdminConfigPage.tsx
+++ b/packages/app/src/admin/ProjectAdminConfigPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, PasswordInput, Stack, TextInput, Title } from '@mantine/core';
+import { Button, Divider, PasswordInput, Stack, Text, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { forbidden, normalizeErrorString } from '@medplum/core';
 import { Document, Form, OperationOutcomeAlert, useMedplum } from '@medplum/react';
@@ -22,10 +22,13 @@ export function ProjectAdminConfigPage(): JSX.Element {
       <Title order={1}>Project Admin</Title>
       <Divider my="lg" />
       <Title order={2}>Force Set Password</Title>
-      <p>
-        Note that this applies to all projects for the user. Therefore, this should only be used in extreme
-        circumstances. Always prefer to use the "Forgot Password" flow first.
-      </p>
+      <Text>
+        Sets the password for the specified user <Text w={500}>in this project</Text>.
+      </Text>
+      <Text>
+        This action can only be performed by project administrators. Passwords can only be set for users scoped in this
+        project.
+      </Text>
       <Form onSubmit={forceSetPassword}>
         <Stack>
           <TextInput name="email" label="Email" required />

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -656,32 +656,6 @@ export async function getUserByEmailWithoutProject(email: string): Promise<User 
 }
 
 /**
- * Check if a user is associated with a project.
- * @param userId - The user ID.
- * @param projectId - The project ID.
- * @returns True if the user is associated with the project; otherwise, false.
- */
-export async function isUserInProject(userId: string, projectId: string): Promise<boolean> {
-  const bundle = await systemRepo.searchOne({
-    resourceType: 'ProjectMembership',
-    filters: [
-      {
-        code: 'user',
-        operator: Operator.EQUALS,
-        value: 'User/' + userId,
-      },
-      {
-        code: 'project',
-        operator: Operator.EQUALS,
-        value: 'Project/' + projectId,
-      },
-    ],
-  });
-
-  return bundle !== undefined;
-}
-
-/**
  * Performs constant time comparison of two strings.
  * Returns true if a is equal to b, without leaking timing information
  * that would allow an attacker to guess one of the values.


### PR DESCRIPTION
1. Clarify help text that Project Admin password reset only applies to project-scoped users
2. Eliminate extra queries in the server side implementation