### PR TITLE
Update hibp server dependency and include in future dependency upgrades

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,7 +50,7 @@
     "express-rate-limit": "7.1.5",
     "express-validator": "7.0.1",
     "graphql": "16.8.1",
-    "hibp": "13.0.0",
+    "hibp": "14.0.2",
     "http-graceful-shutdown": "^3.1.13",
     "ioredis": "5.3.2",
     "jose": "5.1.3",

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -16,9 +16,8 @@ git checkout -b "$BRANCH_NAME"
 
 # Exclude known problem packages
 # @mantine/* - holding back until the Mantine 7 migration is complete
-# hibp - version 14+ requires ESM, holding back until server supports ESM
 # node-fetch - version 3+ requires ESM, holding back until server supports ESM
-EXCLUDE="@mantine/* hibp node-fetch"
+EXCLUDE="@mantine/* node-fetch"
 
 npx npm-check-updates -u -x "$EXCLUDE" --packageFile package.json
 


### PR DESCRIPTION
Hi, all 👋  - author of the `hibp` library here. I noticed your `server` workspace depends on `hibp` and that it was pinned to an older version, citing that the current major version (v14) requires ESM. This wasn't supposed to be the case, but it happened due to a publishing mistake on my part (so sorry about that!). I've since corrected the issue and published v14.0.2 which supports CommonJS again, so `hibp` is safe to include in your future dependency upgrades. Thanks!