### PR TITLE
Update HG setup-subscriptions

### DIFF
--- a/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
@@ -54,6 +54,15 @@ interface HealthGorillaConfig {
 
 // Available labs Health Gorilla IDs
 // These come from the Health Gorilla Organization resources
+
+// Sandbox
+// const availableLabs: Record<string, string> = {
+//   Testing: 'f-4f0235627ac2d59b49e5575c',
+//   Labcorp: 'f-388554647b89801ea5e8320b',
+//   Quest: 'f-7c075564349e1a592e53147a',
+// };
+
+// Prod
 const availableLabs: Record<string, string> = {
   Testing: 'f-4f0235627ac2d59b49e5575c',
   Labcorp: 'f-a855594f43fe879c6570b92e',

--- a/examples/medplum-demo-bots/src/health-gorilla/setup-subscriptions.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/setup-subscriptions.ts
@@ -136,7 +136,9 @@ export async function ensureSubscription(
   existingSubscriptions: Subscription[],
   criteria: string
 ): Promise<void> {
-  const existingSubscription = existingSubscriptions.find((s) => s.criteria === criteria && s.status === 'active');
+  const existingSubscription = existingSubscriptions.find(
+    (s) => s.criteria === criteria && s.status === 'active' && s.channel?.endpoint?.includes(config.callbackBotId)
+  );
   if (existingSubscription) {
     console.log(`Subscription for "${criteria}" already exists: ${existingSubscription.id}`);
     return;


### PR DESCRIPTION
This PR updates the `setup-subscriptions` bot to prevent duplicate Subscriptions in HG for the same target endpoint