### PR TITLE
Update subscription worker concurrency and start time logic

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -89,6 +89,11 @@ export interface MedplumSmtpConfig {
 }
 
 export interface MedplumBullmqConfig {
+  /**
+   * Amount of jobs that a single worker is allowed to work on in parallel.
+   * @see {@link https://docs.bullmq.io/guide/workers/concurrency}
+   */
+  concurrency?: number;
   removeOnComplete: KeepJobs;
   removeOnFail: KeepJobs;
 }
@@ -277,7 +282,7 @@ function addDefaults(config: MedplumServerConfig): MedplumServerConfig {
   config.awsRegion = config.awsRegion || DEFAULT_AWS_REGION;
   config.botLambdaLayerName = config.botLambdaLayerName || 'medplum-bot-layer';
   config.bcryptHashSalt = config.bcryptHashSalt || 10;
-  config.bullmq = { removeOnComplete: { count: 1 }, removeOnFail: { count: 1 }, ...config.bullmq };
+  config.bullmq = { concurrency: 10, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 }, ...config.bullmq };
   config.shutdownTimeoutMilliseconds = config.shutdownTimeoutMilliseconds ?? 30000;
   return config;
 }

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -54,6 +54,7 @@ export interface BotExecutionRequest {
   readonly device?: Device;
   readonly remoteAddress?: string;
   readonly forwardedFor?: string;
+  readonly requestTime?: string;
 }
 
 export interface BotExecutionResult {
@@ -147,7 +148,7 @@ async function getBotForRequest(req: Request): Promise<Bot | undefined> {
  */
 export async function executeBot(request: BotExecutionRequest): Promise<BotExecutionResult> {
   const { bot } = request;
-  const startTime = new Date().toISOString();
+  const startTime = request.requestTime ?? new Date().toISOString();
 
   let result: BotExecutionResult;
 


### PR DESCRIPTION
1. Default BullMQ worker uses concurrency of "1".  Update Medplum default to "10".
2. We track the "start" time of a subscription job in `AuditEvent.period.start`.  Before, that value was "start of job execution".  Now it is "time that the subscription job was requested".  This should help with analyzing slow job starts.