### PR TITLE
Updated otel instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ WORKDIR /usr/src/medplum
 ADD ./medplum-server.tar.gz ./
 RUN npm ci --maxsockets 1
 EXPOSE 5000 8103
-ENTRYPOINT [ "node", "packages/server/dist/index.js" ]
+ENTRYPOINT [ "node", "--require", "./packages/server/dist/instrumentation.js", "packages/server/dist/index.js" ]

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -203,7 +203,14 @@ export class BackEnd extends Construct {
         // CloudWatch Logs: Create streams and put events
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+          actions: [
+            'logs:PutLogEvents',
+            'logs:CreateLogGroup',
+            'logs:CreateLogStream',
+            'logs:DescribeLogStreams',
+            'logs:DescribeLogGroups',
+            'logs:PutRetentionPolicy',
+          ],
           resources: ['arn:aws:logs:*'],
         }),
 
@@ -274,7 +281,13 @@ export class BackEnd extends Construct {
         // https://docs.aws.amazon.com/xray/latest/devguide/xray-api-permissions-ref.html
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ['xray:PutTraceSegments', 'xray:PutTelemetryRecords'],
+          actions: [
+            'xray:PutTraceSegments',
+            'xray:PutTelemetryRecords',
+            'xray:GetSamplingRules',
+            'xray:GetSamplingTargets',
+            'xray:GetSamplingStatisticSummaries',
+          ],
           resources: ['*'],
         }),
       ],
@@ -312,6 +325,7 @@ export class BackEnd extends Construct {
       image: this.getContainerImage(config, config.serverImage),
       command: [config.region === 'us-east-1' ? `aws:/medplum/${name}/` : `aws:${config.region}:/medplum/${name}/`],
       logging: this.logDriver,
+      environment: config.environment,
     });
 
     this.serviceContainer.addPortMappings({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -13,6 +13,7 @@ export type ExternalSecret<T extends ExternalSecretPrimitive = ExternalSecretPri
   type: TypeName<T>;
 };
 export type ValueOrExternalSecret<T extends ExternalSecretPrimitive> = T | ExternalSecret<T>;
+export type StringMap = { [key: string]: string };
 
 export interface MedplumSourceInfraConfig {
   name: ValueOrExternalSecret<string>;
@@ -72,6 +73,7 @@ export interface MedplumSourceInfraConfig {
     snsTopicArn?: ValueOrExternalSecret<string>;
     snsTopicName?: ValueOrExternalSecret<string>;
   };
+  environment?: StringMap;
 }
 
 export interface MedplumInfraConfig {
@@ -132,4 +134,5 @@ export interface MedplumInfraConfig {
     snsTopicArn?: string;
     snsTopicName?: string;
   };
+  environment?: StringMap;
 }

--- a/packages/docs/docs/self-hosting/opentelemetry.md
+++ b/packages/docs/docs/self-hosting/opentelemetry.md
@@ -30,7 +30,11 @@ This page describes Medplum's optional OpenTelemetry support, and how to integra
 
 When running on localhost, OpenTelemetry is disabled by default. To enable OpenTelemetry, follow these steps:
 
-#### 1. Start the OpenTelemetry Collector
+#### 1. Start an OpenTelemetry Collector
+
+If you already have a running OpenTelemetry Collector, you can skip this step.
+
+Start the default OpenTelemetry Collector using Docker:
 
 On Mac/Linux:
 
@@ -46,13 +50,13 @@ docker run -p 4317:4317 -p 4318:4318 --rm -v %cd%\collector-config.yaml:/etc/ote
 
 #### 2. Add the OpenTelemetry config settings
 
-Update the `medplum.config.json` file or your custom config JSON file with the following values:
+OpenTelemetry cannot be configured through the normal `medplum.config.json` file, because it instruments Node.js and dependencies.
 
-```js
-  // HTTP endpoint of the OpenTelemetry trace collector
-  otlpTraceEndpoint: "http://localhost:4318/v1/traces",
-  // HTTP endpoint of the OpenTelemetry metrics collector
-  otlpMetricsEndpoint: "http://localhost:4318/v1/metrics",
+Instead, you must add the following environment variables:
+
+```bash
+export OTLP_TRACES_ENDPOINT="http://localhost:4318/v1/traces"
+export OTLP_METRICS_ENDPOINT="http://localhost:4318/v1/metrics"
 ```
 
 #### 3. Restart the Medplum server
@@ -65,11 +69,21 @@ First, make sure you go through all steps in [Install on AWS](/docs/self-hosting
 
 Use the Medplum "additional containers" feature to add the AWS CloudWatch Agent as an OpenTelemetry collector.
 
+Next, add the following to your Medplum CDK JSON config file:
+
+1. Environment variables as described above
+2. "Additional containers" for the AWS OpenTelemetry collector ("ADOT Collector")
+
 ```js
 {
   "name": "staging",
   "region": "us-east-1",
   "stackName": "MedplumStagingStack",
+  // ...
+  "environment": {
+    "OTLP_TRACES_ENDPOINT": "http://localhost:4318/v1/traces",
+    "OTLP_METRICS_ENDPOINT": "http://localhost:4318/v1/metrics"
+  },
   // ...
   "additionalContainers": [
     {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,9 +16,8 @@
   "scripts": {
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "clean": "rimraf dist",
-    "dev": "ts-node-dev --poll --respawn --transpile-only src/index.ts",
-    "prestart": "tsc",
-    "start": "node dist/index.js",
+    "dev": "ts-node-dev --poll --respawn --transpile-only --require ./src/instrumentation.ts src/index.ts",
+    "start": "node --require ./dist/instrumentation.js dist/index.js",
     "test": "jest --runInBand"
   },
   "dependencies": {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -25,7 +25,6 @@ import { fhircastSTU2Router, fhircastSTU3Router } from './fhircast/routes';
 import { healthcheckHandler } from './healthcheck';
 import { cleanupHeartbeat, initHeartbeat } from './heartbeat';
 import { hl7BodyParser } from './hl7/parser';
-import { initOpenTelemetry, shutdownOpenTelemetry } from './instrumentation';
 import { globalLogger } from './logger';
 import { initKeys } from './oauth/keys';
 import { oauthRouter } from './oauth/routes';
@@ -190,7 +189,6 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
 
 export function initAppServices(config: MedplumServerConfig): Promise<void> {
   return requestContextStore.run(AuthenticatedRequestContext.system(), async () => {
-    initOpenTelemetry(config);
     loadStructureDefinitions();
     initRedis(config.redis);
     await initDatabase(config.database);
@@ -209,7 +207,6 @@ export async function shutdownApp(): Promise<void> {
   await closeWebSockets();
   closeRedis();
   closeRateLimiter();
-  await shutdownOpenTelemetry();
 
   if (server) {
     server.close();

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -49,8 +49,6 @@ export interface MedplumServerConfig {
   keepAliveTimeout?: number;
   vmContextBotsEnabled?: boolean;
   shutdownTimeoutMilliseconds?: number;
-  otlpTraceEndpoint?: string;
-  otlpMetricsEndpoint?: string;
 }
 
 /**

--- a/packages/server/src/instrumentation.test.ts
+++ b/packages/server/src/instrumentation.test.ts
@@ -1,41 +1,44 @@
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { MedplumServerConfig } from './config';
 import { initOpenTelemetry, shutdownOpenTelemetry } from './instrumentation';
 
 describe('Instrumentation', () => {
+  const OLD_ENV = process.env;
   let sdkSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
     sdkSpy = jest.spyOn(NodeSDK.prototype, 'start').mockImplementation(() => jest.fn());
   });
 
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
   test('None', async () => {
-    initOpenTelemetry({} as MedplumServerConfig);
+    initOpenTelemetry();
     await shutdownOpenTelemetry();
     expect(sdkSpy).not.toHaveBeenCalled();
   });
 
   test('Both metrics and traces', async () => {
-    initOpenTelemetry({
-      otlpMetricsEndpoint: 'http://localhost:4318/v1/metrics',
-      otlpTraceEndpoint: 'http://localhost:4318/v1/traces',
-    } as MedplumServerConfig);
+    process.env.OTLP_METRICS_ENDPOINT = 'http://localhost:4318/v1/metrics';
+    process.env.OTLP_TRACE_ENDPOINT = 'http://localhost:4318/v1/traces';
+    initOpenTelemetry();
     await shutdownOpenTelemetry();
     expect(sdkSpy).toHaveBeenCalled();
   });
 
   test('Only metrics', async () => {
-    initOpenTelemetry({
-      otlpMetricsEndpoint: 'http://localhost:4318/v1/metrics',
-    } as MedplumServerConfig);
+    process.env.OTLP_METRICS_ENDPOINT = 'http://localhost:4318/v1/metrics';
+    initOpenTelemetry();
     await shutdownOpenTelemetry();
     expect(sdkSpy).toHaveBeenCalled();
   });
 
   test('Only traces', async () => {
-    initOpenTelemetry({
-      otlpTraceEndpoint: 'http://localhost:4318/v1/traces',
-    } as MedplumServerConfig);
+    process.env.OTLP_TRACE_ENDPOINT = 'http://localhost:4318/v1/traces';
+    initOpenTelemetry();
     await shutdownOpenTelemetry();
     expect(sdkSpy).toHaveBeenCalled();
   });

--- a/packages/server/src/instrumentation.ts
+++ b/packages/server/src/instrumentation.ts
@@ -1,31 +1,54 @@
+import { MEDPLUM_VERSION } from '@medplum/core';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { Resource } from '@opentelemetry/resources';
+import { MetricReader, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { MedplumServerConfig } from './config';
+import { SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 // Configures OpenTelemetry for Node.js
 // https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/
 // https://opentelemetry.io/docs/instrumentation/js/exporters/
 
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+
 let sdk: NodeSDK | undefined = undefined;
 
-export function initOpenTelemetry(config: MedplumServerConfig): void {
-  if (!config.otlpMetricsEndpoint && !config.otlpTraceEndpoint) {
+export function initOpenTelemetry(): void {
+  const OTLP_METRICS_ENDPOINT = process.env.OTLP_METRICS_ENDPOINT;
+  const OTLP_TRACES_ENDPOINT = process.env.OTLP_TRACE_ENDPOINT;
+  if (!OTLP_METRICS_ENDPOINT && !OTLP_TRACES_ENDPOINT) {
     return;
   }
 
+  const resource = Resource.default().merge(
+    new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: 'medplum',
+      [SemanticResourceAttributes.SERVICE_VERSION]: MEDPLUM_VERSION,
+    })
+  );
+
+  let metricReader: MetricReader | undefined = undefined;
+  if (OTLP_METRICS_ENDPOINT) {
+    const exporter = new OTLPMetricExporter({ url: OTLP_METRICS_ENDPOINT });
+    metricReader = new PeriodicExportingMetricReader({ exporter });
+  }
+
+  let traceExporter: SpanExporter | undefined = undefined;
+  if (OTLP_TRACES_ENDPOINT) {
+    traceExporter = new OTLPTraceExporter({ url: OTLP_TRACES_ENDPOINT });
+  }
+
+  const instrumentations = [getNodeAutoInstrumentations()];
+
   sdk = new NodeSDK({
-    traceExporter: config.otlpTraceEndpoint ? new OTLPTraceExporter({ url: config.otlpTraceEndpoint }) : undefined,
-    metricReader: config.otlpMetricsEndpoint
-      ? new PeriodicExportingMetricReader({
-          exporter: new OTLPMetricExporter({
-            url: config.otlpMetricsEndpoint,
-          }),
-        })
-      : undefined,
-    instrumentations: [getNodeAutoInstrumentations()],
+    resource,
+    instrumentations,
+    metricReader,
+    traceExporter,
   });
 
   sdk.start();
@@ -36,4 +59,12 @@ export async function shutdownOpenTelemetry(): Promise<void> {
     await sdk.shutdown();
     sdk = undefined;
   }
+}
+
+if (require.main === undefined) {
+  // There are 2 ways that this file can be loaded:
+  // 1. As a "require" from the command line when starting the server
+  // 2. As an "import" from the unit tests
+  // We want to initialize OpenTelemetry only when starting the server
+  initOpenTelemetry();
 }


### PR DESCRIPTION
While adding a custom OTel metric, I realized that the first draft implementation was missing out on a lot of the automatic instrumentation included in our various dependencies.

When setting OTel to use verbose logger, you get all kinds of useful information.

For better or worse, you cannot load `instrumentation.ts` as a normal `import`.  Instead, you need to load it directly from the command line using the `--require` switch (see `packages/server/package.json` changes).

-----

Example of automatic metrics in CloudWatch:

<img width="683" alt="image" src="https://github.com/medplum/medplum/assets/749094/58b11cf8-c4cc-436d-a389-ee98e3e65bbc">


-----

Example custom metric:

```ts
import opentelemetry from '@opentelemetry/api';

  const myMeter = opentelemetry.metrics.getMeter('my-service-meter');
  const myGuage = myMeter.createObservableGauge('cody.random');
  myGuage.addCallback((result) => {
    result.observe(Math.random());
  });
```