### PR TITLE
bug: Prevent isRegisterEnabled optimization

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -19,6 +19,10 @@ export function getConfig(): MedplumAppConfig {
 }
 
 export function isRegisterEnabled(): boolean {
-  // Default to true
-  return config.registerEnabled !== false && config.registerEnabled !== 'false';
+  // This try/catch exists to prevent Rollup optimization from removing this function
+  try {
+    return config.registerEnabled !== false && config.registerEnabled !== 'false';
+  } catch {
+    return true;
+  }
 }


### PR DESCRIPTION
## Why
* Closes #3722

## What
* Prevents Rollup from optimizing the registerEnabled check away by use of a try/catch:
* Correctly compiles the function now when running the build, example from my local build:

```
function LA(){try{return Wy.registerEnabled!==!1&&Wy.registerEnabled!=="false"}catch{return!0}}
```