### PR TITLE
⚠️ Fixes #3724 - change MedplumClient default cache time

### DIFF
--- a/examples/medplum-nextjs-demo/app/root.tsx
+++ b/examples/medplum-nextjs-demo/app/root.tsx
@@ -16,6 +16,9 @@ const medplum = new MedplumClient({
 
   // Use Next.js fetch
   fetch: (url: string, options?: any) => fetch(url, options),
+
+  // Recommend using cache for React performance
+  cacheTime: 10000,
 });
 
 export default function Root(props: { children: ReactNode }): JSX.Element {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -83,7 +83,8 @@ export const DEFAULT_ACCEPT = ContentType.FHIR_JSON + ', */*; q=0.1';
 
 const DEFAULT_BASE_URL = 'https://api.medplum.com/';
 const DEFAULT_RESOURCE_CACHE_SIZE = 1000;
-const DEFAULT_CACHE_TIME = 60000; // 60 seconds
+const DEFAULT_BROWSER_CACHE_TIME = 60000; // 60 seconds
+const DEFAULT_NODE_CACHE_TIME = 0;
 const BINARY_URL_PREFIX = 'Binary/';
 
 const system: Device = { resourceType: 'Device', id: 'system', deviceName: [{ name: 'System' }] };
@@ -691,7 +692,8 @@ export class MedplumClient extends EventTarget {
     this.clientSecret = options?.clientSecret ?? '';
     this.onUnauthenticated = options?.onUnauthenticated;
 
-    this.cacheTime = options?.cacheTime ?? DEFAULT_CACHE_TIME;
+    this.cacheTime =
+      options?.cacheTime ?? (typeof window === 'undefined' ? DEFAULT_NODE_CACHE_TIME : DEFAULT_BROWSER_CACHE_TIME);
     if (this.cacheTime > 0) {
       this.requestCache = new LRUCache(options?.resourceCacheSize ?? DEFAULT_RESOURCE_CACHE_SIZE);
     } else {


### PR DESCRIPTION
> [!CAUTION]
> This PR includes breaking changes. It is part of [Medplum 3.0](https://github.com/medplum/medplum/issues/3124)

Changes the default `MedplumClient.cacheTime` behavior in Node.js environments.

Before: `MedplumClient` always used default `cacheTime` of 60 seconds, in all environments

After: `MedplumClient` uses default `cacheTime` depending on the environment:

- In browser environments (`typeof window !== 'undefined'`), continue using existing default of 60 seconds
- In Node.js environments (`typeof window === 'undefined'`), use new default value of 0
