### PR TITLE
Fixes #3453 - custom metrics for bot executions

### DIFF
--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -167,8 +167,9 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
     }
   }
 
-  incrementCounter('bot.execute');
-  incrementCounter(result.success ? 'bot.execute.success' : 'bot.execute.failure');
+  const attributes = { project: bot.meta?.project, bot: bot.id };
+  incrementCounter('medplum.bot.execute', attributes);
+  incrementCounter(result.success ? 'medplum.bot.execute.success' : 'medplum.bot.execute.failure', attributes);
 
   await createAuditEvent(
     request,

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -35,6 +35,7 @@ import { getConfig } from '../../config';
 import { getAuthenticatedContext, getRequestContext } from '../../context';
 import { globalLogger } from '../../logger';
 import { generateAccessToken } from '../../oauth/keys';
+import { incrementCounter } from '../../otel';
 import { AuditEventOutcome } from '../../util/auditevent';
 import { MockConsole } from '../../util/console';
 import { createAuditEventEntities } from '../../workers/utils';
@@ -165,6 +166,9 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
       result = { success: false, logResult: 'Unsupported bot runtime' };
     }
   }
+
+  incrementCounter('bot.execute');
+  incrementCounter(result.success ? 'bot.execute.success' : 'bot.execute.failure');
 
   await createAuditEvent(
     request,

--- a/packages/server/src/instrumentation.ts
+++ b/packages/server/src/instrumentation.ts
@@ -9,7 +9,11 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
-// Configures OpenTelemetry for Node.js
+// This file includes OpenTelemetry instrumentation.
+// Note that this file is related but separate from the OpenTelemetry helpers in otel.ts.
+// This file is used to initialize OpenTelemetry, and must be loaded before any other code.
+//
+// References:
 // https://opentelemetry.io/docs/instrumentation/js/getting-started/nodejs/
 // https://opentelemetry.io/docs/instrumentation/js/exporters/
 

--- a/packages/server/src/otel.test.ts
+++ b/packages/server/src/otel.test.ts
@@ -1,0 +1,33 @@
+import { incrementCounter, recordHistogramValue } from './otel';
+
+describe('OpenTelemetry', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test('Increment counter, disabled', async () => {
+    expect(incrementCounter('test', {})).toBe(false);
+  });
+
+  test('Increment counter, enabled', async () => {
+    process.env.OTLP_METRICS_ENDPOINT = 'http://localhost:4318/v1/metrics';
+    expect(incrementCounter('test', {})).toBe(true);
+  });
+
+  test('Record histogram value, disabled', async () => {
+    expect(recordHistogramValue('test', 1, {})).toBe(false);
+  });
+
+  test('Record histogram value, enabled', async () => {
+    process.env.OTLP_METRICS_ENDPOINT = 'http://localhost:4318/v1/metrics';
+    expect(recordHistogramValue('test', 1, {})).toBe(true);
+  });
+});

--- a/packages/server/src/otel.ts
+++ b/packages/server/src/otel.ts
@@ -1,4 +1,4 @@
-import opentelemetry, { Counter, Histogram, Meter } from '@opentelemetry/api';
+import opentelemetry, { Attributes, Counter, Histogram, Meter } from '@opentelemetry/api';
 
 let meter: Meter | undefined = undefined;
 const counters = new Map<string, Counter>();
@@ -20,9 +20,9 @@ function getCounter(name: string): Counter {
   return result;
 }
 
-export function incrementCounter(name: string): void {
+export function incrementCounter(name: string, attributes: Attributes): void {
   if (isOtelMetricsEnabled()) {
-    getCounter(name).add(1);
+    getCounter(name).add(1, attributes);
   }
 }
 
@@ -35,9 +35,9 @@ function getHistogram(name: string): Histogram {
   return result;
 }
 
-export function recordHistogramValue(name: string, value: number): void {
+export function recordHistogramValue(name: string, value: number, attributes: Attributes): void {
   if (isOtelMetricsEnabled()) {
-    getHistogram(name).record(value);
+    getHistogram(name).record(value, attributes);
   }
 }
 

--- a/packages/server/src/otel.ts
+++ b/packages/server/src/otel.ts
@@ -1,5 +1,10 @@
 import opentelemetry, { Attributes, Counter, Histogram, Meter } from '@opentelemetry/api';
 
+// This file includes OpenTelemetry helpers.
+// Note that this file is related but separate from the OpenTelemetry initialization code in instrumentation.ts.
+// The instrumentation.ts code is used to initialize OpenTelemetry.
+// This file is used to record metrics.
+
 let meter: Meter | undefined = undefined;
 const counters = new Map<string, Counter>();
 const histograms = new Map<string, Histogram>();
@@ -20,10 +25,12 @@ function getCounter(name: string): Counter {
   return result;
 }
 
-export function incrementCounter(name: string, attributes: Attributes): void {
-  if (isOtelMetricsEnabled()) {
-    getCounter(name).add(1, attributes);
+export function incrementCounter(name: string, attributes: Attributes): boolean {
+  if (!isOtelMetricsEnabled()) {
+    return false;
   }
+  getCounter(name).add(1, attributes);
+  return true;
 }
 
 function getHistogram(name: string): Histogram {
@@ -35,10 +42,12 @@ function getHistogram(name: string): Histogram {
   return result;
 }
 
-export function recordHistogramValue(name: string, value: number, attributes: Attributes): void {
-  if (isOtelMetricsEnabled()) {
-    getHistogram(name).record(value, attributes);
+export function recordHistogramValue(name: string, value: number, attributes: Attributes): boolean {
+  if (!isOtelMetricsEnabled()) {
+    return false;
   }
+  getHistogram(name).record(value, attributes);
+  return true;
 }
 
 function isOtelMetricsEnabled(): boolean {

--- a/packages/server/src/otel.ts
+++ b/packages/server/src/otel.ts
@@ -1,0 +1,46 @@
+import opentelemetry, { Counter, Histogram, Meter } from '@opentelemetry/api';
+
+let meter: Meter | undefined = undefined;
+const counters = new Map<string, Counter>();
+const histograms = new Map<string, Histogram>();
+
+function getMeter(): Meter {
+  if (!meter) {
+    meter = opentelemetry.metrics.getMeter('medplum');
+  }
+  return meter;
+}
+
+function getCounter(name: string): Counter {
+  let result = counters.get(name);
+  if (!result) {
+    result = getMeter().createCounter(name);
+    counters.set(name, result);
+  }
+  return result;
+}
+
+export function incrementCounter(name: string): void {
+  if (isOtelMetricsEnabled()) {
+    getCounter(name).add(1);
+  }
+}
+
+function getHistogram(name: string): Histogram {
+  let result = histograms.get(name);
+  if (!result) {
+    result = getMeter().createHistogram(name);
+    histograms.set(name, result);
+  }
+  return result;
+}
+
+export function recordHistogramValue(name: string, value: number): void {
+  if (isOtelMetricsEnabled()) {
+    getHistogram(name).record(value);
+  }
+}
+
+function isOtelMetricsEnabled(): boolean {
+  return !!process.env.OTLP_METRICS_ENDPOINT;
+}


### PR DESCRIPTION
In AWS CloudWatch Metrics, note the following groups:

1. `OTelLib` - all metrics, regardless of attributes
2. `OTelLib, bot` - metrics with a `bot` attribute, grouped by `bot`
3. `OTelLib, project` - metrics with a `project` attribute, grouped by `project`
4. `OTelLib, bot, project` - metrics with `bot` and `project` attributes

<img width="957" alt="image" src="https://github.com/medplum/medplum/assets/749094/7667e872-fadb-49b0-a4f9-3b4184eaab98">

You can graph them individually:

* `medplum.bot.execute` - total count of executions
* `medplum.bot.execute.success` - count of successful executions
* `medplum.bot.execute.failure` - count of failed executions

<img width="962" alt="image" src="https://github.com/medplum/medplum/assets/749094/7b8ad931-d37f-42fd-9db6-d373c5fd12d4">

AWS CloudWatch Metrics includes a number of aggregation controls:

<img width="697" alt="image" src="https://github.com/medplum/medplum/assets/749094/25530a55-6884-492a-9797-35493d677e70">
