### PR TITLE
Add array append helper

### DIFF
--- a/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
+++ b/examples/medplum-demo-bots/src/health-gorilla/send-to-health-gorilla.ts
@@ -8,6 +8,7 @@ import {
   MedplumClient,
   setIdentifier,
   SNOMED,
+  append,
 } from '@medplum/core';
 import {
   Account,
@@ -452,13 +453,6 @@ async function checkAbn(
     const media = await medplum.uploadMedia(abnUint8Array, 'application/pdf', 'RequestGroup-ABN.pdf');
     console.log('Uploaded ABN PDF as media: ' + media.id);
   }
-}
-
-function append<T>(array: T[] | undefined, value: T): T[] {
-  if (!array) {
-    return [value];
-  }
-  return [...array, value];
 }
 
 class HealthGorillaRequestGroupBuilder {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -963,3 +963,11 @@ export function lazy<T>(fn: () => T): () => T {
     return result;
   };
 }
+
+export function append<T>(array: T[] | undefined, value: T): T[] {
+  if (!array) {
+    return [value];
+  }
+  array.push(value);
+  return array;
+}

--- a/packages/health-gorilla/src/requestgroupbuilder.ts
+++ b/packages/health-gorilla/src/requestgroupbuilder.ts
@@ -1,4 +1,4 @@
-import { createReference, getIdentifier, MedplumClient, setIdentifier, SNOMED } from '@medplum/core';
+import { createReference, getIdentifier, MedplumClient, setIdentifier, SNOMED, append } from '@medplum/core';
 import {
   Account,
   AccountCoverage,
@@ -19,7 +19,7 @@ import {
   Specimen,
 } from '@medplum/fhirtypes';
 import { HEALTH_GORILLA_SYSTEM } from './constants';
-import { append, assertNotEmpty } from './utils';
+import { assertNotEmpty } from './utils';
 
 export class HealthGorillaRequestGroupBuilder {
   practitioner?: Practitioner;

--- a/packages/health-gorilla/src/utils.test.ts
+++ b/packages/health-gorilla/src/utils.test.ts
@@ -1,9 +1,8 @@
-import { ContentType, allOk } from '@medplum/core';
+import { ContentType, allOk, append } from '@medplum/core';
 import { RequestGroup } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import {
   HealthGorillaConfig,
-  append,
   assertNotEmpty,
   checkAbn,
   connectToHealthGorilla,

--- a/packages/health-gorilla/src/utils.ts
+++ b/packages/health-gorilla/src/utils.ts
@@ -182,10 +182,3 @@ export async function checkAbn(
     console.log('Uploaded ABN PDF as media: ' + media.id);
   }
 }
-
-export function append<T>(array: T[] | undefined, value: T): T[] {
-  if (!array) {
-    return [value];
-  }
-  return [...array, value];
-}

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -1,3 +1,4 @@
+import { append } from '@medplum/core';
 import { AsyncLocalStorage } from 'async_hooks';
 import { Client, Pool, PoolClient } from 'pg';
 import Cursor from 'pg-cursor';
@@ -584,14 +585,7 @@ export class InsertQuery extends BaseQuery {
   }
 
   returnColumn(column: Column | string): this {
-    if (column instanceof Column) {
-      column = column.columnName;
-    }
-    if (this.returnColumns) {
-      this.returnColumns.push(column);
-    } else {
-      this.returnColumns = [column];
-    }
+    this.returnColumns = append(this.returnColumns, column instanceof Column ? column.columnName : column);
     return this;
   }
 


### PR DESCRIPTION
This pattern (i.e. appending to a possibly-undefined array) was used in a couple places, but the existing helper function was [not very efficient](https://jsperf.app/keboda); this adds a new `append(array, element)` helper function to `@medplum/core` and attempts to standardize usage throughout the codebase