### PR TITLE
Fixes #3751 - restore AsyncAutocomplete props

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -5,11 +5,13 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { App } from './App';
 
+const navigateMock = jest.fn();
+
 async function setup(url = '/'): Promise<void> {
   await act(async () => {
     render(
       <MemoryRouter initialEntries={[url]} initialIndex={0}>
-        <MedplumProvider medplum={new MockClient()} navigate={jest.fn()}>
+        <MedplumProvider medplum={new MockClient()} navigate={navigateMock}>
           <MantineProvider>
             <App />
           </MantineProvider>
@@ -120,6 +122,6 @@ describe('App', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(screen.getByText('Test Display')).toBeDefined();
+    expect(navigateMock).toHaveBeenCalledWith('/test-code');
   });
 });

--- a/packages/react/src/AppShell/AppShell.test.tsx
+++ b/packages/react/src/AppShell/AppShell.test.tsx
@@ -116,6 +116,6 @@ describe('AppShell', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(screen.getByText('Test Display')).toBeDefined();
+    expect(navigateMock).toHaveBeenCalledWith('/test-code');
   });
 });

--- a/packages/react/src/CodingInput/CodingInput.stories.tsx
+++ b/packages/react/src/CodingInput/CodingInput.stories.tsx
@@ -14,3 +14,21 @@ export const Basic = (): JSX.Element => (
     <CodingInput binding={valueSet} name="code" />
   </Document>
 );
+
+export const WithWrapperText = (): JSX.Element => (
+  <Document>
+    <CodingInput binding={valueSet} name="code" label="My Label" description="My help text" />
+  </Document>
+);
+
+export const WithError = (): JSX.Element => (
+  <Document>
+    <CodingInput binding={valueSet} name="code" label="My Label" description="My help text" error="My error" />
+  </Document>
+);
+
+export const MultipleValues = (): JSX.Element => (
+  <Document>
+    <CodingInput binding={valueSet} name="code" label="Max Values 2" maxValues={2} />
+  </Document>
+);


### PR DESCRIPTION
See https://github.com/medplum/medplum/issues/3751

Thanks @dillonstreator for being an early adopter of Medplum 3.0 🙏 

In Medplum 2.x / Mantine 6, we were heavy users of the Mantine `<MultiSelect>` component.  In Mantine 6, `<MultiSelect>` was highly customizable, and we used it to the fullest extent.

In Mantine 7, the philosophy of `<MultiSelect>` changed significantly.  It is no longer customizable.  Instead, it is quite opinionated, and no longer servers our needs.

Instead, the Mantine 7 recommendation is to use the lower level `<ComboBox>` component, which exposes all of the low level guts of a combobox / autocomplete system.

As part of that migration, a few features were lost that we didn't even know people were using.

The main bug here was that `AsyncAutocompleteProps` still extended `MultiSelectProps`, when it should have extended `ComboBoxProps`.  That gave a false sense of confidence that we still supported all of the `MultiSelect` features.