### PR TITLE
Support Redis TLS config from Env

### DIFF
--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -81,11 +81,13 @@ describe('Config', () => {
     process.env.MEDPLUM_BASE_URL = 'http://localhost:3000';
     process.env.MEDPLUM_PORT = '3000';
     process.env.MEDPLUM_DATABASE_PORT = '5432';
+    process.env.MEDPLUM_REDIS_TLS = '{}';
     const config = await loadConfig('env');
     expect(config).toBeDefined();
     expect(config.baseUrl).toEqual('http://localhost:3000');
     expect(config.port).toEqual(3000);
     expect(config.database.port).toEqual(5432);
+    expect(config.redis.tls).toEqual({});
     expect(getConfig()).toBe(config);
   });
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -85,6 +85,7 @@ export interface MedplumRedisConfig {
   host?: string;
   port?: number;
   password?: string;
+  tls?: Record<string, unknown>;
 }
 
 export interface MedplumSmtpConfig {
@@ -190,6 +191,8 @@ function loadEnvConfig(): MedplumServerConfig {
       currConfig.port = parseInt(value ?? '', 10);
     } else if (isBooleanConfig(key)) {
       currConfig[key] = value === 'true';
+    } else if (isObjectConfig(key)) {
+      currConfig[key] = JSON.parse(value ?? '');
     } else {
       currConfig[key] = value;
     }
@@ -306,4 +309,8 @@ function isBooleanConfig(key: string): boolean {
     key === 'require' ||
     key === 'rejectUnauthorized'
   );
+}
+
+function isObjectConfig(key: string): boolean {
+  return key === 'tls';
 }


### PR DESCRIPTION
## Why
Loading config from environment does not (nicely) support enabling TLS on Redis due to the fact that `ioredis` expects an object.

It turns out that setting `MEDPLUM_REDIS_TLS` to a string (any string - including `'{}'`) _does_ work, but it violates the type signature that `ioredis` expects and if the implementation changes that could break.

Yes, we could use SSM / SecretsManager and not need this - but the secretops platform we use doesn't support case sensitive keys (fail, I know...), so Medplum's config loader won't quite work for us as intended. That itself is kind of funny, because we are actually using SSM to load the config into ENV. Nonetheless...

## What
* Improves the typing of `MedplumRedisConfig` by adding a `tls` field typed as `Record<string, unknown>`. This isn't quite as strict as possible, but `ioredis` doesn't export the `ConnectionOptions` type that `tls` is expected to be. Nonetheless, this is at least better than the current state where `tls` is hidden from the type completely and `Record<string, unknown>` is at least compatible with `ConnectionOptions`. 
* Adds an `isObjectConfig` helper which returns `true` for the `tls` key
* Use `JSON.parse` on the value when `isObjectConfig` is true
* Adds an expectation to the existing env loading test in `config.test.ts`