### PR TITLE
fix-3803 add prefix to client storage

### DIFF
--- a/packages/core/src/storage.test.ts
+++ b/packages/core/src/storage.test.ts
@@ -1,6 +1,20 @@
 import { ClientStorage, MemoryStorage } from './storage';
 
 describe('Storage', () => {
+  test('clearing should keep non-medplum intact', () => {
+    const store = new MemoryStorage();
+    const storage = new ClientStorage(store);
+
+    store.setItem('foo', 'bar');
+    storage.setString('baz', 'qux');
+
+    expect(store.length).toEqual(2);
+
+    storage.clear();
+    expect(store.length).toEqual(1);
+    expect(store.getItem('foo')).toEqual('bar');
+  });
+
   test('Using localStorage', () => {
     const storage = new ClientStorage();
 


### PR DESCRIPTION
Fixes #3803

> [!WARNING]
> This is a breaking change for any client that depends on the local storage key names `activeLogin` & `logins` and as such should be highly visible in release notes, assuming there is alignment on proceeding with this change.