### PR TITLE
Document using medplum client to integrate with external FHIR servers

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -604,7 +604,7 @@ export interface ValueSetExpandParams {
  *   6. Searching
  *   7. Making GraphQL queries
  *
- * The client can also be used to integrate with other FHIR servers. For an example, see the Epic Connection Demo Bot here: https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/epic
+ * The client can also be used to integrate with other FHIR servers. For an example, see the Epic Connection Demo Bot [here](https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/epic).
  *
  * @example
  * Here is a quick example of how to use the client:

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -604,6 +604,8 @@ export interface ValueSetExpandParams {
  *   6. Searching
  *   7. Making GraphQL queries
  *
+ * The client can also be used to integrate with other FHIR servers. For an example, see the Epic Connection Demo Bot here: https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/epic
+ *
  * @example
  * Here is a quick example of how to use the client:
  *


### PR DESCRIPTION
This will add a single line to the Medplum client page that links to a bot showing how to integrate with external FHIR servers