### PR TITLE
Separate search popup menus for 'text' and 'token'

### DIFF
--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
@@ -102,9 +102,10 @@ function SearchParameterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
     case 'reference':
       return <ReferenceFilterSubMenu {...props} />;
     case 'string':
+      return <TextFilterSubMenu {...props} />;
     case 'token':
     case 'uri':
-      return <TextFilterSubMenu {...props} />;
+      return <TokenFilterSubMenu {...props} />;
     default:
       return <>Unknown search param type: {props.searchParam.type}</>;
   }
@@ -288,6 +289,21 @@ function TextFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
       </Menu.Item>
       <Menu.Item leftSection={<IconBucketOff size={14} />} onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>
         Does not contain...
+      </Menu.Item>
+      <CommonMenuItems {...props} />
+    </Menu.Dropdown>
+  );
+}
+
+function TokenFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
+  const { searchParam } = props;
+  return (
+    <Menu.Dropdown>
+      <Menu.Item leftSection={<IconEqual size={14} />} onClick={() => props.onPrompt(searchParam, Operator.EQUALS)}>
+        Equals...
+      </Menu.Item>
+      <Menu.Item leftSection={<IconEqualNot size={14} />} onClick={() => props.onPrompt(searchParam, Operator.NOT)}>
+        Does not equal...
       </Menu.Item>
       <CommonMenuItems {...props} />
     </Menu.Dropdown>


### PR DESCRIPTION
Removes "sort" and "contains" from `token` search parameters.

"Priority":

<img width="763" alt="image" src="https://github.com/medplum/medplum/assets/749094/2109012c-9f11-44ea-8889-570a45b397e6">


Confirmed that our "Priority Order" search params still work as expected:

<img width="757" alt="image" src="https://github.com/medplum/medplum/assets/749094/a7ed08dd-1af5-41a2-a5c2-e29dbc0cb7d7">
