### PR TITLE
Fixed lookup tables in migration generator

### DIFF
--- a/packages/generator/src/migrate.ts
+++ b/packages/generator/src/migrate.ts
@@ -374,12 +374,12 @@ function buildLookupTable(result: SchemaDefinition, tableName: string, columns: 
   const tableDefinition: TableDefinition = {
     name: tableName,
     columns: [
-      { name: 'id', type: 'UUID NOT NULL PRIMARY KEY' },
+      { name: 'id', type: 'UUID NOT NULL PRIMARY KEY' }, // Deprecated - to be removed
       { name: 'resourceId', type: 'UUID NOT NULL' },
       { name: 'index', type: 'INTEGER NOT NULL' },
       { name: 'content', type: 'TEXT NOT NULL' },
     ],
-    indexes: [],
+    indexes: [{ columns: ['resourceId'], indexType: 'btree' }],
   };
 
   for (const column of columns) {
@@ -394,7 +394,8 @@ function buildValueSetElementTable(result: SchemaDefinition): void {
   result.tables.push({
     name: 'ValueSetElement',
     columns: [
-      { name: 'id', type: 'UUID NOT NULL PRIMARY KEY' },
+      { name: 'id', type: 'UUID NOT NULL PRIMARY KEY' }, // Deprecated - to be removed
+      { name: 'resourceId', type: 'UUID NOT NULL' },
       { name: 'system', type: 'TEXT' },
       { name: 'code', type: 'TEXT' },
       { name: 'display', type: 'TEXT' },

--- a/packages/server/src/fhir/lookups/reference.ts
+++ b/packages/server/src/fhir/lookups/reference.ts
@@ -106,6 +106,7 @@ function isIndexed(searchParam: SearchParameter): boolean {
  */
 async function getExistingValues(client: PoolClient, tableName: string, resourceId: string): Promise<ReferenceRow[]> {
   return new SelectQuery(tableName)
+    .column('content')
     .where('resourceId', '=', resourceId)
     .execute(client)
     .then((result) =>

--- a/packages/server/src/fhir/lookups/reference.ts
+++ b/packages/server/src/fhir/lookups/reference.ts
@@ -1,8 +1,8 @@
+import { PropertyType, evalFhirPathTyped, getSearchParameters, isUUID, toTypedValue } from '@medplum/core';
 import { Reference, Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { PoolClient } from 'pg';
-import { LookupTable } from './lookuptable';
-import { PropertyType, evalFhirPathTyped, getSearchParameters, isUUID, toTypedValue } from '@medplum/core';
 import { SelectQuery } from '../sql';
+import { LookupTable } from './lookuptable';
 import { compareArrays } from './util';
 
 /**
@@ -15,7 +15,7 @@ export class ReferenceTable extends LookupTable<Reference> {
   }
 
   getColumnName(): string {
-    return '';
+    throw new Error('ReferenceTable.getColumnName not implemented');
   }
 
   /**
@@ -106,14 +106,9 @@ function isIndexed(searchParam: SearchParameter): boolean {
  */
 async function getExistingValues(client: PoolClient, tableName: string, resourceId: string): Promise<ReferenceRow[]> {
   return new SelectQuery(tableName)
-    .column('content')
+    .column('code')
+    .column('resourceId')
+    .column('targetId')
     .where('resourceId', '=', resourceId)
-    .execute(client)
-    .then((result) =>
-      result.map((row) => ({
-        code: row.code,
-        resourceId: row.resourceId,
-        targetId: row.targetId,
-      }))
-    );
+    .execute(client);
 }

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -138,6 +138,11 @@ describe('SqlBuilder', () => {
     expect(sql.toString()).toBe('SELECT "MyTable"."id" FROM "MyTable" WHERE LOWER("MyTable"."name") NOT LIKE $1');
   });
 
+  test('Select missing columns', () => {
+    const sql = new SqlBuilder();
+    expect(() => new SelectQuery('MyTable').buildSql(sql)).toThrow('No columns selected');
+  });
+
   test('Debug mode', async () => {
     console.log = jest.fn();
 

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -499,6 +499,9 @@ export class SelectQuery extends BaseQuery {
   }
 
   private buildColumns(sql: SqlBuilder): void {
+    if (this.columns.length === 0) {
+      throw new Error('No columns selected');
+    }
     let first = true;
     for (const column of this.columns) {
       if (!first) {


### PR DESCRIPTION
Context:  
* In the early days, we used more adhoc scripts to generate database migrations.
* In https://github.com/medplum/medplum/pull/3015 we adopted a new migration generator that works by diffing the current schema with a "target" schema
* So far, it has only been used for adding new resource type tables and new search parameter columns

Today I was playing with CockroachDB, and experimented with generating a single "migration" from scratch, for a clean schema deployment.  In that process, I found a few issues with the schema generator for lookup tables

1. `resourceId` was missing from `ValueSetElement`
2. `resourceId` index was missing from all lookup 
3. `SELECT` queries with no columns - valid in Postgres but not in CockroachDB