### PR TITLE
Fixed deprecated jest matchers

### DIFF
--- a/examples/medplum-demo-bots/src/finalize-reports.test.ts
+++ b/examples/medplum-demo-bots/src/finalize-reports.test.ts
@@ -150,9 +150,9 @@ describe('Finalize Report', async () => {
     await handler(medplum, { input: updatedReport, contentType, secrets: {} });
 
     // Ensure that no modification methods were called
-    expect(updateResourceSpy).not.toBeCalled();
-    expect(createResourceSpy).not.toBeCalled();
-    expect(patchResourceSpy).not.toBeCalled();
+    expect(updateResourceSpy).not.toHaveBeenCalled();
+    expect(createResourceSpy).not.toHaveBeenCalled();
+    expect(patchResourceSpy).not.toHaveBeenCalled();
     // end-block test-idempotent
   });
 });

--- a/examples/medplum-demo-bots/src/patient-intake.test.ts
+++ b/examples/medplum-demo-bots/src/patient-intake.test.ts
@@ -33,7 +33,7 @@ test('Missing first name', async () => {
   };
   const result = await handler(medplum, { input, contentType, secrets: {} });
   expect(result).toBe(false);
-  expect(console.log).toBeCalledWith('Missing first name');
+  expect(console.log).toHaveBeenCalledWith('Missing first name');
 });
 
 test('Missing last name', async () => {
@@ -49,5 +49,5 @@ test('Missing last name', async () => {
   };
   const result = await handler(medplum, { input, contentType, secrets: {} });
   expect(result).toBe(false);
-  expect(console.log).toBeCalledWith('Missing last name');
+  expect(console.log).toHaveBeenCalledWith('Missing last name');
 });

--- a/packages/app/src/ResetPasswordPage.test.tsx
+++ b/packages/app/src/ResetPasswordPage.test.tsx
@@ -77,7 +77,7 @@ describe('ResetPasswordPage', () => {
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Reset password' }));
     });
-    expect(grecaptchaResolved).not.toBeCalled();
+    expect(grecaptchaResolved).not.toHaveBeenCalled();
     expect(screen.getByText('password reset email will be sent', { exact: false })).toBeInTheDocument();
   });
 });

--- a/packages/app/src/resource/AppsPage.test.tsx
+++ b/packages/app/src/resource/AppsPage.test.tsx
@@ -62,7 +62,7 @@ describe('AppsPage', () => {
       fireEvent.click(screen.getByText('Inferno Client'));
     });
 
-    expect(window.location.assign).toBeCalled();
+    expect(window.location.assign).toHaveBeenCalled();
   });
 
   test('Encounter Smart App Launch', async () => {
@@ -84,7 +84,7 @@ describe('AppsPage', () => {
       fireEvent.click(screen.getByText('Inferno Client'));
     });
 
-    expect(window.location.assign).toBeCalled();
+    expect(window.location.assign).toHaveBeenCalled();
   });
 
   test('Access denied to ClientApplications', async () => {

--- a/packages/app/src/utils.test.ts
+++ b/packages/app/src/utils.test.ts
@@ -33,7 +33,7 @@ describe('JSON File Download', () => {
 
     exportJsonFile(jsonFile.entry);
 
-    expect(URL.revokeObjectURL).toBeCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
 });
 

--- a/packages/cdk/src/config.test.ts
+++ b/packages/cdk/src/config.test.ts
@@ -293,9 +293,7 @@ describe('Config', () => {
     // Test [object, string] => throws
     test('Provided object, expected string => throws', () => {
       // @ts-expect-error rawValue must be a valid primitive, string | boolean | number
-      expect(() => normalizeFetchedValue('medplumString', { med: 'plum' }, 'string')).toThrowError(
-        OperationOutcomeError
-      );
+      expect(() => normalizeFetchedValue('medplumString', { med: 'plum' }, 'string')).toThrow(OperationOutcomeError);
     });
     // Test [string, string] => return raw
     test('Provided string, expected string => rawValue', () => {
@@ -311,7 +309,7 @@ describe('Config', () => {
     });
     // Test [invalidNumStr, number] => throws
     test('Provided non-numeric string, expected number => throws', () => {
-      expect(() => normalizeFetchedValue('medplumNumber', 'medplum', 'number')).toThrowError(OperationOutcomeError);
+      expect(() => normalizeFetchedValue('medplumNumber', 'medplum', 'number')).toThrow(OperationOutcomeError);
     });
     // Test [string, boolean] => boolean
     test('Provided string, expected boolean => parsedBoolean', () => {
@@ -322,18 +320,18 @@ describe('Config', () => {
     });
     // Test [invalidStr, boolean] => throws
     test('Provided string, expected boolean => parsedBoolean', () => {
-      expect(() => normalizeFetchedValue('medplumBool', 'TRUEE', 'boolean')).toThrowError(OperationOutcomeError);
-      expect(() => normalizeFetchedValue('medplumBool', '10', 'boolean')).toThrowError(OperationOutcomeError);
-      expect(() => normalizeFetchedValue('medplumBool', '0', 'boolean')).toThrowError(OperationOutcomeError);
+      expect(() => normalizeFetchedValue('medplumBool', 'TRUEE', 'boolean')).toThrow(OperationOutcomeError);
+      expect(() => normalizeFetchedValue('medplumBool', '10', 'boolean')).toThrow(OperationOutcomeError);
+      expect(() => normalizeFetchedValue('medplumBool', '0', 'boolean')).toThrow(OperationOutcomeError);
     });
     // Test [bool, number] => throws
     test('Provided boolean, expected number => throws', () => {
-      expect(() => normalizeFetchedValue('medplumNumber', true, 'number')).toThrowError(OperationOutcomeError);
+      expect(() => normalizeFetchedValue('medplumNumber', true, 'number')).toThrow(OperationOutcomeError);
     });
     // Test [string, invalid_type] => throws
     test('Provided string, expected {invalidType} => throws', () => {
       // @ts-expect-error Plum is not a valid expectedType
-      expect(() => normalizeFetchedValue('medplum???', 'medplum', 'plum')).toThrowError(OperationOutcomeError);
+      expect(() => normalizeFetchedValue('medplum???', 'medplum', 'plum')).toThrow(OperationOutcomeError);
     });
   });
 
@@ -440,7 +438,7 @@ describe('Config', () => {
           key: 'medplumString',
           type: 'plum',
         })
-      ).toThrowError(OperationOutcomeError);
+      ).toThrow(OperationOutcomeError);
     });
     // Test completely invalid secret
     test('Invalid ExternalSecret', () => {
@@ -449,7 +447,7 @@ describe('Config', () => {
           key: 10,
           type: true,
         })
-      ).toThrowError(OperationOutcomeError);
+      ).toThrow(OperationOutcomeError);
     });
   });
 

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -64,15 +64,15 @@ describe('CLI auth', () => {
     const req1 = { url: '/favicon.ico' };
     const res1 = { writeHead: jest.fn(), end: jest.fn() };
     await handler(req1, res1);
-    expect(res1.writeHead).toBeCalledWith(404, { 'Content-Type': ContentType.TEXT });
-    expect(res1.end).toBeCalledWith('Not found');
+    expect(res1.writeHead).toHaveBeenCalledWith(404, { 'Content-Type': ContentType.TEXT });
+    expect(res1.end).toHaveBeenCalledWith('Not found');
 
     // Simulate the redirect
     const req2 = { url: '/?code=123' };
     const res2 = { writeHead: jest.fn(), end: jest.fn() };
     await handler(req2, res2);
-    expect(res2.writeHead).toBeCalledWith(200, { 'Content-Type': ContentType.TEXT });
-    expect(res2.end).toBeCalledWith('Signed in as Alice Smith. You may close this window.');
+    expect(res2.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': ContentType.TEXT });
+    expect(res2.end).toHaveBeenCalledWith('Signed in as Alice Smith. You may close this window.');
     expect(medplum.getActiveLogin()).toBeDefined();
   });
 

--- a/packages/cli/src/aws/describe.test.ts
+++ b/packages/cli/src/aws/describe.test.ts
@@ -90,12 +90,12 @@ describe('describe command', () => {
   test('Describe command', async () => {
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'describe', 'dev']);
-    expect(console.log).toBeCalledWith('Stack ID:              123');
+    expect(console.log).toHaveBeenCalledWith('Stack ID:              123');
   });
 
   test('Describe not found', async () => {
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'describe', 'not-found']);
-    expect(console.log).toBeCalledWith('Stack not found: not-found');
+    expect(console.log).toHaveBeenCalledWith('Stack not found: not-found');
   });
 });

--- a/packages/cli/src/aws/list.test.ts
+++ b/packages/cli/src/aws/list.test.ts
@@ -108,6 +108,6 @@ describe('list command', () => {
   test('List command', async () => {
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'list']);
-    expect(console.log).toBeCalledWith('Stack ID:              123');
+    expect(console.log).toHaveBeenCalledWith('Stack ID:              123');
   });
 });

--- a/packages/cli/src/aws/update-app.test.ts
+++ b/packages/cli/src/aws/update-app.test.ts
@@ -209,7 +209,7 @@ describe('update-app command', () => {
 
     expect(fetch).toHaveBeenNthCalledWith(1, 'https://registry.npmjs.org/@medplum/app/latest');
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://example.com/tarball.tar.gz');
-    expect(console.log).toBeCalledWith('Done');
+    expect(console.log).toHaveBeenCalledWith('Done');
     expect(s3Mock.calls()).toHaveLength(1);
     expect(cloudFrontMock.calls()).toHaveLength(1);
   });
@@ -277,7 +277,7 @@ describe('update-app command', () => {
 
     expect(fetch).toHaveBeenNthCalledWith(1, 'https://registry.npmjs.org/@medplum/app/latest');
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://example.com/tarball.tar.gz');
-    expect(console.log).toBeCalledWith('Done');
+    expect(console.log).toHaveBeenCalledWith('Done');
     expect(s3Mock.calls()).toHaveLength(0);
     expect(cloudFrontMock.calls()).toHaveLength(0);
   });
@@ -336,7 +336,7 @@ describe('update-app command', () => {
 
     await main(['node', 'index.js', 'aws', 'update-app', 'dev']);
 
-    expect(console.log).toBeCalledWith('Done');
+    expect(console.log).toHaveBeenCalledWith('Done');
   });
 
   test('Update app config not found', async () => {
@@ -344,7 +344,7 @@ describe('update-app command', () => {
 
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'update-app', 'not-found']);
-    expect(console.log).toBeCalledWith('Config not found: not-found');
+    expect(console.log).toHaveBeenCalledWith('Config not found: not-found');
   });
 
   test('Update app stack not found', async () => {
@@ -354,7 +354,7 @@ describe('update-app command', () => {
 
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'update-app', 'not-found']);
-    expect(console.log).toBeCalledWith('Stack not found: not-found');
+    expect(console.log).toHaveBeenCalledWith('Stack not found: not-found');
   });
 
   test('Update app stack incomplete', async () => {
@@ -364,6 +364,6 @@ describe('update-app command', () => {
 
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'update-app', 'incomplete']);
-    expect(console.log).toBeCalledWith('App bucket not found');
+    expect(console.log).toHaveBeenCalledWith('App bucket not found');
   });
 });

--- a/packages/cli/src/aws/update-bucket-policies.test.ts
+++ b/packages/cli/src/aws/update-bucket-policies.test.ts
@@ -146,7 +146,7 @@ describe('update-bucket-policies command', () => {
     );
 
     await main(['node', 'index.js', 'aws', 'update-bucket-policies', 'dev']);
-    expect(console.log).toBeCalledWith('App bucket policy:');
+    expect(console.log).toHaveBeenCalledWith('App bucket policy:');
   });
 
   test('Config not found', async () => {
@@ -154,7 +154,7 @@ describe('update-bucket-policies command', () => {
 
     console.log = jest.fn();
     await main(['node', 'index.js', 'aws', 'update-bucket-policies', 'not-found']);
-    expect(console.log).toBeCalledWith('Config not found: not-found');
+    expect(console.log).toHaveBeenCalledWith('Config not found: not-found');
   });
 
   test('Stack not found', async () => {
@@ -165,20 +165,20 @@ describe('update-bucket-policies command', () => {
     (fs.readFileSync as jest.Mock).mockReturnValueOnce('{}');
 
     await main(['node', 'index.js', 'aws', 'update-bucket-policies', 'not-found']);
-    expect(console.log).toBeCalledWith('Stack not found: not-found');
+    expect(console.log).toHaveBeenCalledWith('Stack not found: not-found');
   });
 
   describe('updateBucketPolicy', () => {
     test('Bucket not found', async () => {
       console.log = jest.fn();
       await updateBucketPolicy('App', undefined, undefined, undefined, {});
-      expect(console.log).toBeCalledWith('App bucket not found');
+      expect(console.log).toHaveBeenCalledWith('App bucket not found');
     });
 
     test('Distribution not found', async () => {
       console.log = jest.fn();
       await updateBucketPolicy('App', { PhysicalResourceId: 'x' } as StackResource, undefined, undefined, {});
-      expect(console.log).toBeCalledWith('App distribution not found');
+      expect(console.log).toHaveBeenCalledWith('App distribution not found');
     });
 
     test('OAI not found', async () => {
@@ -190,7 +190,7 @@ describe('update-bucket-policies command', () => {
         undefined,
         {}
       );
-      expect(console.log).toBeCalledWith('App OAI not found');
+      expect(console.log).toHaveBeenCalledWith('App OAI not found');
     });
 
     test('Dry run', async () => {
@@ -202,7 +202,7 @@ describe('update-bucket-policies command', () => {
         { PhysicalResourceId: 'x' } as StackResource,
         { dryrun: true }
       );
-      expect(console.log).toBeCalledWith('Dry run - skipping updates');
+      expect(console.log).toHaveBeenCalledWith('Dry run - skipping updates');
     });
   });
 });

--- a/packages/cli/src/aws/update-server.test.ts
+++ b/packages/cli/src/aws/update-server.test.ts
@@ -110,7 +110,7 @@ describe('update-server command', () => {
 
   test('Update server command', async () => {
     await main(['node', 'index.js', 'aws', 'update-server', 'dev']);
-    expect(console.log).toBeCalledWith('Performing update to v2.5.0');
+    expect(console.log).toHaveBeenCalledWith('Performing update to v2.5.0');
     expect(spawnSync).toHaveBeenCalledTimes(2);
     expect(spawnSync).toHaveBeenCalledWith(`npx cdk deploy -c config=medplum.dev.config.json --all`, {
       stdio: 'inherit',
@@ -121,7 +121,7 @@ describe('update-server command', () => {
 
   test('Update config not found', async () => {
     await main(['node', 'index.js', 'aws', 'update-server', 'not-found']);
-    expect(console.log).toBeCalledWith('Configuration file medplum.not-found.config.json not found');
+    expect(console.log).toHaveBeenCalledWith('Configuration file medplum.not-found.config.json not found');
     expect(spawnSync).not.toHaveBeenCalled();
     expect(medplum.startAsyncRequest).not.toHaveBeenCalled();
   });
@@ -129,7 +129,7 @@ describe('update-server command', () => {
   test('Update server from latest', async () => {
     writeFileSync(configFile, JSON.stringify({ serverImage: `medplum-server:latest`, region: 'us-west-2' }));
     await main(['node', 'index.js', 'aws', 'update-server', 'dev']);
-    expect(console.log).toBeCalledWith('Performing update to v2.5.0');
+    expect(console.log).toHaveBeenCalledWith('Performing update to v2.5.0');
     expect(spawnSync).toHaveBeenCalledTimes(2);
     expect(spawnSync).toHaveBeenCalledWith(`npx cdk deploy -c config=medplum.dev.config.json --all`, {
       stdio: 'inherit',

--- a/packages/cli/src/bot.test.ts
+++ b/packages/cli/src/bot.test.ts
@@ -41,7 +41,7 @@ describe('CLI Bots', () => {
 
   test('Deploy bot missing name', async () => {
     await main(['node', 'index.js', 'bot', 'deploy']);
-    expect(processError).toBeCalledWith(expect.stringContaining(`error: missing required argument 'botName'`));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining(`error: missing required argument 'botName'`));
   });
 
   test('Deploy bot config not found', async () => {
@@ -62,7 +62,7 @@ describe('CLI Bots', () => {
       })
     );
     await main(['node', 'index.js', 'bot', 'deprecate', 'does-not-exist']);
-    expect(processError).toBeCalledWith(expect.stringContaining(`error: unknown command 'deprecate'`));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining(`error: unknown command 'deprecate'`));
   });
 
   test('Deploy bot not found', async () => {
@@ -84,7 +84,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'deploy', 'hello-world']);
-    expect(console.error).toBeCalledWith(expect.stringContaining('Error: Not found'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Error: Not found'));
   });
 
   test('Save bot success', async () => {
@@ -108,7 +108,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'save', 'hello-world']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeUndefined();
     expect(check.sourceCode).toBeDefined();
@@ -135,7 +135,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'deploy', 'hello-world']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeUndefined();
     expect(check.sourceCode).toBeDefined();
@@ -161,7 +161,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'deploy', 'hello-world']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeUndefined();
     expect(check.sourceCode).toBeDefined();
@@ -194,8 +194,8 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'deploy', 'he**llo*']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 2/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 2/));
   });
 
   test('Deploy bot multiple bot ending with bot name that has no match', async () => {
@@ -225,7 +225,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'deploy', '*-staging']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
   });
 
   test('Deploy bot multiple bot ending with bot name with no config', async () => {
@@ -234,7 +234,7 @@ describe('CLI Bots', () => {
     (fs.readFileSync as unknown as jest.Mock).mockReturnValue(undefined);
 
     await main(['node', 'index.js', 'bot', 'deploy', '*-staging']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
   });
 
   test('Create bot command success with existing config file', async () => {
@@ -247,7 +247,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'bot', 'create', 'test-bot', '1', 'src/hello-world.ts', 'dist/src/hello-world.ts']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Success! Bot created:'));
     expect(fs.existsSync).toHaveBeenCalled();
     expect(fs.readFileSync).toHaveBeenCalled();
   });
@@ -258,7 +258,7 @@ describe('CLI Bots', () => {
     (fs.readFileSync as unknown as jest.Mock).mockReturnValue('');
 
     await main(['node', 'index.js', 'bot', 'create', 'test-bot', '1', 'src/hello-world.ts', 'dist/src/hello-world.ts']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Success! Bot created:'));
     expect(fs.existsSync).toHaveBeenCalled();
     expect(fs.readFileSync).not.toHaveBeenCalled();
   });
@@ -284,14 +284,14 @@ describe('CLI Bots', () => {
       '--client-secret',
       'test-client-secret',
     ]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Success! Bot created:'));
     expect(fs.existsSync).toHaveBeenCalled();
     expect(fs.readFileSync).not.toHaveBeenCalled();
   });
 
   test('Create bot error with lack of commands', async () => {
     await main(['node', 'index.js', 'bot', 'create', 'test-bot']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Error while creating new bot'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Error while creating new bot'));
   });
 
   test('Create bot do not write to config', async () => {
@@ -311,7 +311,7 @@ describe('CLI Bots', () => {
       'dist/src/hello-world.ts',
       '--no-write-config',
     ]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Success! Bot created:'));
     expect(fs.existsSync).toHaveBeenCalled();
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
@@ -320,7 +320,7 @@ describe('CLI Bots', () => {
 
   test('Deprecate Deploy bot missing name', async () => {
     await main(['node', 'index.js', 'deploy-bot']);
-    expect(processError).toBeCalledWith(expect.stringContaining(`error: missing required argument 'botName'`));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining(`error: missing required argument 'botName'`));
   });
 
   test('Deprecate Deploy bot config not found', async () => {
@@ -342,7 +342,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'deploy-bot', 'does-not-exist']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
   });
 
   test('Deprecate Deploy bot not found', async () => {
@@ -363,7 +363,7 @@ describe('CLI Bots', () => {
       })
     );
     await main(['node', 'index.js', 'deploy-bot', 'hello-world']);
-    expect(console.error).toBeCalledWith(expect.stringMatching('Error: Not found'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching('Error: Not found'));
   });
 
   test('Deprecate Save bot success', async () => {
@@ -387,7 +387,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'save-bot', 'hello-world']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeUndefined();
     expect(check.sourceCode).toBeDefined();
@@ -414,7 +414,7 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'deploy-bot', 'hello-world']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
     const check = await medplum.readResource('Bot', bot.id as string);
     expect(check.code).toBeUndefined();
     expect(check.sourceCode).toBeDefined();
@@ -447,8 +447,8 @@ describe('CLI Bots', () => {
     );
 
     await main(['node', 'index.js', 'deploy-bot', 'he**llo*']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Success/));
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 2/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 2/));
   });
 
   test('Deprecate Deploy bot multiple bot ending with bot name that has no match', async () => {
@@ -479,7 +479,7 @@ describe('CLI Bots', () => {
 
     await main(['node', 'index.js', 'deploy-bot', '*-staging']);
 
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
   });
 
   test('Deprecate Deploy bot multiple bot ending with bot name with no config', async () => {
@@ -488,17 +488,17 @@ describe('CLI Bots', () => {
     (fs.readFileSync as unknown as jest.Mock).mockReturnValue(undefined);
 
     await main(['node', 'index.js', 'deploy-bot', '*-staging']);
-    expect(console.log).not.toBeCalledWith(expect.stringMatching(/Success/));
-    expect(console.log).toBeCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
+    expect(console.log).not.toHaveBeenCalledWith(expect.stringMatching(/Success/));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/Number of bots deployed: 0/));
   });
 
   test('Deprecate Create bot command success', async () => {
     await main(['node', 'index.js', 'create-bot', 'test-bot', '1', 'src/hello-world.ts', 'dist/src/hello-world.ts']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Success! Bot created:'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Success! Bot created:'));
   });
 
   test('Depreate Create bot error with lack of commands', async () => {
     await main(['node', 'index.js', 'create-bot', 'test-bot']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Error while creating new bot'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Error while creating new bot'));
   });
 });

--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -151,13 +151,13 @@ describe('CLI Bulk Commands', () => {
         };
       });
       await main(['node', 'index.js', 'bulk', 'export', '-t', 'Patient']);
-      expect(medplumDownloadSpy).toBeCalled();
-      expect(console.log).toBeCalledWith(
+      expect(medplumDownloadSpy).toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(
         expect.stringMatching(
           'ProjectMembership_storage_20fabdd3_e036_49fc_9260_8a30eaffefb1_498475fe_5eb0_46e5_b9f4_b46943c9719b.ndjson is created'
         )
       );
-      expect(console.log).toBeCalledWith(
+      expect(console.log).toHaveBeenCalledWith(
         expect.stringMatching('Project_data_55555_aaaaaa_bbbbb_ccc_ddddd_eeeeee_ndjson.ndjson is created')
       );
     });
@@ -170,8 +170,8 @@ describe('CLI Bulk Commands', () => {
       });
       const testDirectory = 'testtargetdirectory';
       await main(['node', 'index.js', 'bulk', 'export', '-t', 'Patient', '--target-directory', testDirectory]);
-      expect(medplumDownloadSpy).toBeCalled();
-      expect(console.log).toBeCalledWith(expect.stringMatching(`${testDirectory}`));
+      expect(medplumDownloadSpy).toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`${testDirectory}`));
     });
   });
 
@@ -213,7 +213,7 @@ describe('CLI Bulk Commands', () => {
 
       testLineOutput.forEach((line) => {
         const resource = JSON.parse(line);
-        expect(fetch).toBeCalledWith(
+        expect(fetch).toHaveBeenCalledWith(
           expect.stringMatching(`/fhir/R4`),
           expect.objectContaining({
             body: expect.stringContaining(
@@ -228,8 +228,8 @@ describe('CLI Bulk Commands', () => {
           })
         );
       });
-      expect(console.log).toBeCalledWith(expect.stringMatching(`"status": "201"`));
-      expect(console.log).toBeCalledWith(expect.stringMatching(`"text": "Created"`));
+      expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`"status": "201"`));
+      expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`"text": "Created"`));
     });
 
     test('success with option --num-resources-per-request', async () => {
@@ -237,7 +237,7 @@ describe('CLI Bulk Commands', () => {
 
       testLineOutput.forEach((line) => {
         const resource = JSON.parse(line);
-        expect(fetch).toBeCalledWith(
+        expect(fetch).toHaveBeenCalledWith(
           expect.stringMatching(`/fhir/R4`),
           expect.objectContaining({
             body: expect.stringContaining(
@@ -253,7 +253,7 @@ describe('CLI Bulk Commands', () => {
         );
       });
 
-      expect(fetch).toBeCalled();
+      expect(fetch).toHaveBeenCalled();
     });
 
     test('success with option --target-directory', async () => {
@@ -261,7 +261,7 @@ describe('CLI Bulk Commands', () => {
 
       testLineOutput.forEach((line) => {
         const resource = JSON.parse(line);
-        expect(fetch).toBeCalledWith(
+        expect(fetch).toHaveBeenCalledWith(
           expect.stringMatching(`/fhir/R4`),
           expect.objectContaining({
             body: expect.stringContaining(
@@ -277,32 +277,32 @@ describe('CLI Bulk Commands', () => {
         );
       });
 
-      expect(fetch).toBeCalled();
+      expect(fetch).toHaveBeenCalled();
     });
 
     test('success with option --add-extensions-for-missing-values', async () => {
       await main(['node', 'index.js', 'bulk', 'import', 'file.json', '--add-extensions-for-missing-values']);
 
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringMatching(`/fhir/R4`),
         expect.objectContaining({
           body: expect.stringContaining(`"resourceType":"ExplanationOfBenefit","id":"1111111"`),
         })
       );
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringMatching(`/fhir/R4`),
         expect.objectContaining({
           body: expect.stringContaining(`"provider":` + JSON.stringify(getUnsupportedExtension())),
         })
       );
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringMatching(`/fhir/R4`),
         expect.objectContaining({
           body: expect.stringContaining(`"productOrService":` + JSON.stringify(getUnsupportedExtension())),
         })
       );
 
-      expect(fetch).toBeCalled();
+      expect(fetch).toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -29,7 +29,7 @@ describe('CLI', () => {
 
   test('run', async () => {
     await run();
-    expect(process.exit).toBeCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   test('run with optional env set', async () => {
@@ -38,19 +38,19 @@ describe('CLI', () => {
     process.env.MEDPLUM_CLIENT_ACCESS_TOKEN = 'test_token';
     process.env.MEDPLUM_TOKEN_URL = 'http://example.com/oauth/token';
     await run();
-    expect(process.exit).toBeCalledWith(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   test('Missing command', async () => {
     await main(['node', 'index.js']);
     expect(process.exit).toHaveBeenCalledWith(1);
     // default command help displays
-    expect(processError).toBeCalledWith(expect.stringContaining('Usage: medplum [options] [command]'));
-    expect(processError).toBeCalledWith(expect.stringContaining('Command to access Medplum CLI'));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining('Usage: medplum [options] [command]'));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining('Command to access Medplum CLI'));
   });
 
   test('Unknown command', async () => {
     await main(['node', 'index.js', 'xyz']);
-    expect(processError).toBeCalledWith(expect.stringContaining(`error: unknown command 'xyz'`));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining(`error: unknown command 'xyz'`));
   });
 });

--- a/packages/cli/src/profiles.test.ts
+++ b/packages/cli/src/profiles.test.ts
@@ -154,9 +154,9 @@ describe('Profiles', () => {
 
     // Describe profile
     await main(['node', 'index.js', 'profile', 'describe', profileName]);
-    expect(console.log).toBeCalledWith(obj);
+    expect(console.log).toHaveBeenCalledWith(obj);
 
-    expect(console.log).toBeCalledWith(expect.stringMatching('testProfile profile create'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('testProfile profile create'));
 
     // Replace the previous values
     const obj2 = {
@@ -207,7 +207,7 @@ describe('Profiles', () => {
 
     // List the 2 profiles
     await main(['node', 'index.js', 'profile', 'list']);
-    expect(console.log).toBeCalledWith([
+    expect(console.log).toHaveBeenCalledWith([
       { profileName, profile: { ...obj2, name: profileName } },
       { profileName: profileName2, profile: { ...obj, name: profileName2 } },
     ]);
@@ -217,7 +217,7 @@ describe('Profiles', () => {
 
     // ProfileName should be undefined, but profileName2 should still exist
     await main(['node', 'index.js', 'profile', 'list']);
-    expect(console.log).toBeCalledWith([{ profileName: profileName2, profile: { ...obj, name: profileName2 } }]);
+    expect(console.log).toHaveBeenCalledWith([{ profileName: profileName2, profile: { ...obj, name: profileName2 } }]);
   });
 
   test('Basic Auth profile bulk export', async () => {
@@ -245,8 +245,8 @@ describe('Profiles', () => {
 
     await main(['node', 'index.js', 'bulk', 'export', '-e', 'Patient', '-p', profileName]);
 
-    expect(medplumDownloadSpy).toBeCalled();
-    expect(console.log).toBeCalledWith(
+    expect(medplumDownloadSpy).toHaveBeenCalled();
+    expect(console.log).toHaveBeenCalledWith(
       expect.stringMatching(
         'ProjectMembership_storage_20fabdd3_e036_49fc_9260_8a30eaffefb1_498475fe_5eb0_46e5_b9f4_b46943c9719b.ndjson is created'
       )

--- a/packages/cli/src/project.test.ts
+++ b/packages/cli/src/project.test.ts
@@ -57,7 +57,7 @@ describe('CLI Project', () => {
       })
     );
     await main(['node', 'index.js', 'project', 'list']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(`(Project/456)`));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`(Project/456)`));
   });
 
   test('Project Current', async () => {
@@ -79,7 +79,7 @@ describe('CLI Project', () => {
       })
     );
     await main(['node', 'index.js', 'project', 'current']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(`(Project/456)`));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`(Project/456)`));
   });
 
   test('Project Switch', async () => {
@@ -115,7 +115,7 @@ describe('CLI Project', () => {
       })
     );
     await main(['node', 'index.js', 'project', 'switch', '789']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(`Switched to project 789`));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`Switched to project 789`));
   });
 
   test('Project Switch invalid id', async () => {
@@ -151,14 +151,14 @@ describe('CLI Project', () => {
       })
     );
     await main(['node', 'index.js', 'project', 'switch', 'bad-projectId']);
-    expect(console.log).toBeCalledWith(expect.stringMatching(`Error: project bad-projectId not found.`));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`Error: project bad-projectId not found.`));
   });
 
   test('Project invite with no login', async () => {
     try {
       await main(['node', 'index.js', 'project', 'invite', 'homer', 'simpon', 'homer@simpson.com']);
     } catch (err) {
-      expect(console.error).toBeCalledWith('Unauthenticated: run `npx medplum login` to login');
+      expect(console.error).toHaveBeenCalledWith('Unauthenticated: run `npx medplum login` to login');
     }
   });
 
@@ -175,7 +175,7 @@ describe('CLI Project', () => {
     try {
       await main(['node', 'index.js', 'project', 'invite', 'homer', 'simpon', 'homer@simpson.com']);
     } catch (err) {
-      expect(console.error).toBeCalledWith('No current project to invite user to');
+      expect(console.error).toHaveBeenCalledWith('No current project to invite user to');
     }
   });
 
@@ -210,8 +210,10 @@ describe('CLI Project', () => {
       'simpon',
       'homer@simpson.com',
     ]);
-    expect(console.log).not.toBeCalledWith(expect.stringMatching(`Email sent`));
-    expect(console.log).toBeCalledWith(expect.stringMatching(`See your users at https://app.medplum.com/admin/users`));
+    expect(console.log).not.toHaveBeenCalledWith(expect.stringMatching(`Email sent`));
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringMatching(`See your users at https://app.medplum.com/admin/users`)
+    );
   });
 
   test('Project invite with all default role and all flags', async () => {
@@ -246,7 +248,9 @@ describe('CLI Project', () => {
       'simpon',
       'homer@simpson.com',
     ]);
-    expect(console.log).toBeCalledWith(expect.stringMatching(`Email sent`));
-    expect(console.log).toBeCalledWith(expect.stringMatching(`See your users at https://app.medplum.com/admin/users`));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(`Email sent`));
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringMatching(`See your users at https://app.medplum.com/admin/users`)
+    );
   });
 });

--- a/packages/cli/src/rest.test.ts
+++ b/packages/cli/src/rest.test.ts
@@ -48,7 +48,7 @@ describe('CLI rest', () => {
   test('Delete command', async () => {
     const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
     await main(['node', 'index.js', 'delete', `Patient/${patient.id}`]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('OK'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('OK'));
     try {
       await medplum.readReference(createReference(patient));
       throw new Error('Expected error');
@@ -61,30 +61,30 @@ describe('CLI rest', () => {
     const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
     await main(['node', 'index.js', 'get', `Patient/${patient.id}`]);
 
-    expect(console.log).toBeCalledWith(expect.stringMatching(patient.id as string));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching(patient.id as string));
   });
 
   test('Get not found', async () => {
     await main(['node', 'index.js', 'get', `Patient/${randomUUID()}`]);
-    expect(console.error).toBeCalledWith(expect.stringMatching('Error: Not found'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching('Error: Not found'));
   });
 
   test('Get admin urls', async () => {
     await main(['node', 'index.js', 'get', 'admin/projects/123']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Project 123'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Project 123'));
   });
 
   test('Get command with as-transaction flag', async () => {
     Object.defineProperty(globalThis, 'crypto', { value: webcrypto });
     await medplum.createResource<Patient>({ resourceType: 'Patient' });
     await main(['node', 'index.js', 'get', '--as-transaction', `Patient?_count=2`]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('urn:uuid'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('urn:uuid'));
   });
 
   test('Get command with fhir-url flag', async () => {
     await main(['node', 'index.js', 'get', `Patient`, '--fhir-url', 'fhirulrtest']);
 
-    expect(createMedplumClient).toBeCalledWith(
+    expect(createMedplumClient).toHaveBeenCalledWith(
       expect.objectContaining({
         fhirUrlPath: 'fhirulrtest',
       })
@@ -94,7 +94,7 @@ describe('CLI rest', () => {
   test('Get command with fhir-url-path flag', async () => {
     await main(['node', 'index.js', 'get', `Patient`, '--fhir-url-path', 'fhirpathtest']);
 
-    expect(createMedplumClient).toBeCalledWith(
+    expect(createMedplumClient).toHaveBeenCalledWith(
       expect.objectContaining({
         fhirUrlPath: 'fhirpathtest',
       })
@@ -105,12 +105,12 @@ describe('CLI rest', () => {
     await medplum.createResource<Patient>({ resourceType: 'Patient' });
 
     await main(['node', 'index.js', 'get', '--bad-flag', `Patient?_count=2`]);
-    expect(processError).toBeCalledWith(expect.stringContaining(`error: unknown option '--bad-flag'`));
+    expect(processError).toHaveBeenCalledWith(expect.stringContaining(`error: unknown option '--bad-flag'`));
   });
 
   test('Post command', async () => {
     await main(['node', 'index.js', 'post', 'Patient', '{ "resourceType": "Patient" }']);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Patient'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Patient'));
   });
 
   test('Basic Auth profile request', async () => {
@@ -127,26 +127,26 @@ describe('CLI rest', () => {
     storage.setObject('options', obj);
 
     await main(['node', 'index.js', 'post', 'Patient', '{ "resourceType": "Patient" }', '-p', profileName]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Patient'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Patient'));
 
     await main(['node', 'index.js', 'get', 'Patient', '-p', profileName]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('Patient'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Patient'));
   });
 
   test('Post command with empty body', async () => {
     await main(['node', 'index.js', 'post', 'Patient', '']);
-    expect(console.error).toBeCalledWith(expect.stringMatching(`Error: Cannot read properties of undefined`));
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(`Error: Cannot read properties of undefined`));
   });
 
   test('Post command with invalid json', async () => {
     await main(['node', 'index.js', 'post', 'Patient', '{ "resourceType" }']);
-    expect(console.error).toBeCalledWith(expect.stringMatching(`Error:`));
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(`Error:`));
   });
 
   test('Put command', async () => {
     const patient = await medplum.createResource<Patient>({ resourceType: 'Patient' });
     await main(['node', 'index.js', 'put', `Patient/${patient.id}`, JSON.stringify({ ...patient, gender: 'male' })]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('male'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('male'));
   });
 
   test('Patch command', async () => {
@@ -158,6 +158,6 @@ describe('CLI rest', () => {
       `Patient/${patient.id}`,
       '[{"op":"add","path":"/active","value":[true]}]',
     ]);
-    expect(console.log).toBeCalledWith(expect.stringMatching('active'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('active'));
   });
 });

--- a/packages/cli/src/util/client.test.ts
+++ b/packages/cli/src/util/client.test.ts
@@ -110,7 +110,7 @@ describe('createMedplumClient', () => {
       await medplumClient.post('Patient', {});
       throw new Error('testing');
     } catch {
-      expect(console.log).toBeCalledWith('Unauthenticated: run `npx medplum login` to sign in');
+      expect(console.log).toHaveBeenCalledWith('Unauthenticated: run `npx medplum login` to sign in');
     }
   });
 });

--- a/packages/core/src/client-fhircast.test.ts
+++ b/packages/core/src/client-fhircast.test.ts
@@ -31,7 +31,7 @@ describe('FHIRcast', () => {
       const serializedSubRequest = serializeFhircastSubscriptionRequest(expectedSubRequest);
 
       const subRequest = await client.fhircastSubscribe(topic, events);
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         'https://api.medplum.com/fhircast/STU3',
         expect.objectContaining<RequestInit>({
           method: 'POST',
@@ -158,7 +158,7 @@ describe('FHIRcast', () => {
           topic: 'abc123',
           events: ['Patient-open'],
         })
-      ).toThrowError(OperationOutcomeError);
+      ).toThrow(OperationOutcomeError);
     });
   });
 
@@ -173,7 +173,7 @@ describe('FHIRcast', () => {
           createFhircastMessageContext<'Patient-open'>('patient', 'Patient', 'patient-123')
         )
       ).resolves;
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         'https://api.medplum.com/fhircast/STU3/abc123',
         expect.objectContaining<RequestInit>({
           method: 'POST',
@@ -189,7 +189,7 @@ describe('FHIRcast', () => {
           createFhircastMessageContext<'ImagingStudy-open'>('study', 'ImagingStudy', 'imagingstudy-456'),
         ])
       ).resolves;
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         'https://api.medplum.com/fhircast/STU3/def456',
         expect.objectContaining<RequestInit>({
           method: 'POST',
@@ -205,7 +205,7 @@ describe('FHIRcast', () => {
           createFhircastMessageContext<'DiagnosticReport-open'>('patient', 'Patient', 'patient-123'),
         ])
       ).resolves;
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         'https://api.medplum.com/fhircast/STU3/xyz-789',
         expect.objectContaining<RequestInit>({
           method: 'POST',

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -361,7 +361,7 @@ describe('Client', () => {
     // First, test the initial reidrect
     const result1 = await client.signInWithRedirect();
     expect(result1).toBeUndefined();
-    expect(assign).toBeCalledWith(expect.stringMatching(/authorize\?.+scope=/));
+    expect(assign).toHaveBeenCalledWith(expect.stringMatching(/authorize\?.+scope=/));
 
     // Mock response code
     Object.defineProperty(window, 'location', {
@@ -390,7 +390,7 @@ describe('Client', () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
     client.signOutWithRedirect();
-    expect(window.location.assign).toBeCalled();
+    expect(window.location.assign).toHaveBeenCalled();
   });
 
   test('Sign in with external auth', async () => {
@@ -411,9 +411,9 @@ describe('Client', () => {
       }
     );
     expect(result).toBeUndefined();
-    expect(assign).toBeCalledWith(expect.stringMatching(/authorize\?.+scope=/));
-    expect(assign).toBeCalledWith(expect.stringContaining('code_challenge'));
-    expect(assign).toBeCalledWith(expect.stringContaining('code_challenge_method'));
+    expect(assign).toHaveBeenCalledWith(expect.stringMatching(/authorize\?.+scope=/));
+    expect(assign).toHaveBeenCalledWith(expect.stringContaining('code_challenge'));
+    expect(assign).toHaveBeenCalledWith(expect.stringContaining('code_challenge_method'));
   });
 
   test('Sign in with external auth -- disabled PKCE', async () => {
@@ -435,8 +435,8 @@ describe('Client', () => {
       false
     );
     expect(result).toBeUndefined();
-    expect(assign).not.toBeCalledWith(expect.stringContaining('code_challenge'));
-    expect(assign).not.toBeCalledWith(expect.stringContaining('code_challenge_method'));
+    expect(assign).not.toHaveBeenCalledWith(expect.stringContaining('code_challenge'));
+    expect(assign).not.toHaveBeenCalledWith(expect.stringContaining('code_challenge_method'));
   });
 
   test('External auth token exchange', async () => {
@@ -799,7 +799,7 @@ describe('Client', () => {
     const result2 = await client.readResource('Patient', '123');
     expect(result2).toBeDefined();
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({
         method: 'GET',
@@ -826,7 +826,7 @@ describe('Client', () => {
     const result2 = await client.readResource('Patient', '123');
     expect(result2).toBeDefined();
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({
         method: 'GET',
@@ -864,7 +864,7 @@ describe('Client', () => {
     const result2 = await client.readResource('Patient', patientId);
     expect(result2).toBeDefined();
     expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       `https://api.medplum.com/fhir/R4/Patient/${patientId}`,
       expect.objectContaining({
         method: 'GET',
@@ -875,7 +875,7 @@ describe('Client', () => {
         },
       })
     );
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       `https://api.medplum.com/oauth2/token`,
       expect.objectContaining({
         method: 'POST',
@@ -912,7 +912,7 @@ describe('Client', () => {
     const result2 = await client.readResource('Patient', patientId);
     expect(result2).toBeDefined();
     expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       `https://api.medplum.com/fhir/R4/Patient/${patientId}`,
       expect.objectContaining({
         method: 'GET',
@@ -923,7 +923,7 @@ describe('Client', () => {
         },
       })
     );
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       `https://api.medplum.com/oauth2/token`,
       expect.objectContaining({
         method: 'POST',
@@ -1102,7 +1102,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch, onUnauthenticated });
     const result = client.get('expired');
     await expect(result).rejects.toThrow('Unauthenticated');
-    expect(onUnauthenticated).toBeCalled();
+    expect(onUnauthenticated).toHaveBeenCalled();
   });
 
   test('fhirUrl', () => {
@@ -1118,7 +1118,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.readResource('Patient', '123');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1131,7 +1131,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.readReference({ reference: 'Patient/123' });
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1175,7 +1175,7 @@ describe('Client', () => {
     expect(client.getCached('Patient', '123')).toBeUndefined(); // Promise in the cache
     const result = await readPromise;
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1212,7 +1212,7 @@ describe('Client', () => {
     expect(client.getCachedReference(reference)).toBeUndefined(); // Promise in the cache
     const result = await readPromise;
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1259,7 +1259,7 @@ describe('Client', () => {
     expect(client.getCached('Patient', '123')).toBeUndefined(); // Cache is disabled
     const result = await readPromise;
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1273,7 +1273,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.readHistory('Patient', '123');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123/_history',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1284,7 +1284,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.readPatientEverything('123');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123/$everything',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1295,7 +1295,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.createResource({ resourceType: 'Patient' });
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient',
       expect.objectContaining({
         method: 'POST',
@@ -1350,7 +1350,7 @@ describe('Client', () => {
       'name:contains=bob'
     );
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledTimes(2);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   test('Update resource', async () => {
@@ -1358,7 +1358,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.updateResource({ resourceType: 'Patient', id: '123' });
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({
         method: 'PUT',
@@ -1413,7 +1413,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.createAttachment('Hello world', undefined, ContentType.TEXT);
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Binary',
       expect.objectContaining({
         method: 'POST',
@@ -1431,7 +1431,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.createBinary('Hello world', undefined, ContentType.TEXT);
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Binary',
       expect.objectContaining({
         method: 'POST',
@@ -1449,7 +1449,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.createBinary('Hello world', 'hello.txt', ContentType.TEXT);
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Binary?_filename=hello.txt',
       expect.objectContaining({
         method: 'POST',
@@ -1482,8 +1482,8 @@ describe('Client', () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
     const promise = client.createBinary('Hello world', undefined, ContentType.TEXT, onProgress);
-    expect(xhrMock.open).toBeCalled();
-    expect(xhrMock.setRequestHeader).toBeCalled();
+    expect(xhrMock.open).toHaveBeenCalled();
+    expect(xhrMock.setRequestHeader).toHaveBeenCalled();
 
     // Emulate xhr progress events
     (xhrMock.upload?.onprogress as EventListener)(new Event(''));
@@ -1523,7 +1523,7 @@ describe('Client', () => {
       fonts
     );
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Binary',
       expect.objectContaining({
         method: 'POST',
@@ -1547,7 +1547,7 @@ describe('Client', () => {
       fonts
     );
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Binary?_filename=report.pdf',
       expect.objectContaining({
         method: 'POST',
@@ -1570,7 +1570,7 @@ describe('Client', () => {
     expect(result).toBeDefined();
     expect(result.basedOn).toBeDefined();
     expect(result.encounter).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Communication',
       expect.objectContaining({
         method: 'POST',
@@ -1593,7 +1593,7 @@ describe('Client', () => {
     );
     expect(result).toBeDefined();
     expect(result.basedOn).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Communication',
       expect.objectContaining({
         method: 'POST',
@@ -1608,7 +1608,7 @@ describe('Client', () => {
     expect(result).toBeDefined();
     expect(result.basedOn).toBeDefined();
     expect(result.subject).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Communication',
       expect.objectContaining({
         method: 'POST',
@@ -1623,7 +1623,7 @@ describe('Client', () => {
       { op: 'replace', path: '/name/0/family', value: 'Doe' },
     ]);
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({
         method: 'PATCH',
@@ -1636,7 +1636,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.deleteResource('Patient', 'xyz');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/xyz',
       expect.objectContaining({
         method: 'DELETE',
@@ -1649,7 +1649,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.validateResource({ resourceType: 'Patient' });
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/$validate',
       expect.objectContaining({
         method: 'POST',
@@ -1670,7 +1670,7 @@ describe('Client', () => {
 
     const result1 = await client.executeBot(bot.id as string, {});
     expect(result1).toBeDefined();
-    expect(fetch).toBeCalledWith('https://api.medplum.com/fhir/R4/Bot/123/$execute', expect.objectContaining({}));
+    expect(fetch).toHaveBeenCalledWith('https://api.medplum.com/fhir/R4/Bot/123/$execute', expect.objectContaining({}));
   });
 
   test('Execute bot by Identifier', async () => {
@@ -1686,7 +1686,7 @@ describe('Client', () => {
 
     const result2 = await client.executeBot(bot.identifier?.[0] as Identifier, {});
     expect(result2).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Bot/$execute?identifier=https://example.com|123',
       expect.objectContaining({})
     );
@@ -1732,7 +1732,7 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.search('Patient', 'name:contains=alice');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient?name%3Acontains=alice',
       expect.objectContaining({ method: 'GET' })
     );
@@ -1746,7 +1746,10 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch });
     const result = await client.search('Patient');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith('https://api.medplum.com/fhir/R4/Patient', expect.objectContaining({ method: 'GET' }));
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/fhir/R4/Patient',
+      expect.objectContaining({ method: 'GET' })
+    );
   });
 
   test('Search one', async () => {
@@ -1942,7 +1945,7 @@ describe('Client', () => {
     const result = await client.searchValueSet('system', 'filter');
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('ValueSet');
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('https://api.medplum.com/fhir/R4/ValueSet/$expand'),
       expect.objectContaining({ method: 'GET' })
     );
@@ -1954,7 +1957,7 @@ describe('Client', () => {
     const result = await client.valueSetExpand({ url: 'system', filter: 'filter', count: 20 });
     expect(result).toBeDefined();
     expect(result.resourceType).toBe('ValueSet');
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('https://api.medplum.com/fhir/R4/ValueSet/$expand'),
       expect.objectContaining({ method: 'GET' })
     );
@@ -2008,7 +2011,7 @@ describe('Client', () => {
       const client = new MedplumClient({ fetch });
       const result = await client.executeBatch(bundle);
       expect(result).toBeDefined();
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         'https://api.medplum.com/fhir/R4',
         expect.objectContaining({
           method: 'POST',
@@ -2032,7 +2035,7 @@ describe('Client', () => {
       const client = new MedplumClient({ fetch });
       const result = await client.executeBatch(bundle, options);
       expect(result).toBeDefined();
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         'https://api.medplum.com/fhir/R4',
         expect.objectContaining({
           method: 'POST',
@@ -2056,7 +2059,7 @@ describe('Client', () => {
       text: 'Hello',
     });
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/email/v1/send',
       expect.objectContaining({
         method: 'POST',
@@ -2080,7 +2083,7 @@ describe('Client', () => {
       ContentType.HL7_V2
     );
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Agent/123/$push',
       expect.objectContaining({
         method: 'POST',
@@ -2189,7 +2192,7 @@ describe('Client', () => {
     }
   }`);
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/$graphql',
       expect.objectContaining({
         method: 'POST',
@@ -2221,7 +2224,7 @@ describe('Client', () => {
       { patientId: '123' }
     );
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/$graphql',
       expect.objectContaining({
         body: expect.stringContaining('GetPatientById'),
@@ -2474,7 +2477,7 @@ describe('Client', () => {
     test('System Level', async () => {
       const medplum = new MedplumClient({ fetch });
       const response = await medplum.bulkExport();
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/$export'),
         expect.objectContaining({
           headers: {
@@ -2484,20 +2487,20 @@ describe('Client', () => {
           },
         })
       );
-      expect(fetch).toBeCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
-      expect(fetch).toBeCalledTimes(3);
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
+      expect(fetch).toHaveBeenCalledTimes(3);
       expect(response.output?.length).toBe(1);
     });
 
     test('with optional params type, since, options', async () => {
       const medplum = new MedplumClient({ fetch });
       const response = await medplum.bulkExport('', 'Observation', 'testdate', { headers: { test: 'test' } });
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/$export?_type=Observation&_since=testdate'),
         expect.any(Object)
       );
-      expect(fetch).toBeCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
-      expect(fetch).toBeCalledTimes(3);
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
+      expect(fetch).toHaveBeenCalledTimes(3);
       expect(response.output?.length).toBe(1);
     });
 
@@ -2505,18 +2508,18 @@ describe('Client', () => {
       const medplum = new MedplumClient({ fetch });
       const groupId = randomUUID();
       const response = await medplum.bulkExport(`Group/${groupId}`);
-      expect(fetch).toBeCalledWith(expect.stringContaining(`/Group/${groupId}/$export`), expect.any(Object));
-      expect(fetch).toBeCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
-      expect(fetch).toBeCalledTimes(3);
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining(`/Group/${groupId}/$export`), expect.any(Object));
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
+      expect(fetch).toHaveBeenCalledTimes(3);
       expect(response.output?.length).toBe(1);
     });
 
     test('All Patient', async () => {
       const medplum = new MedplumClient({ fetch });
       const response = await medplum.bulkExport(`Patient`);
-      expect(fetch).toBeCalledWith(expect.stringContaining(`/Patient/$export`), expect.any(Object));
-      expect(fetch).toBeCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
-      expect(fetch).toBeCalledTimes(3);
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining(`/Patient/$export`), expect.any(Object));
+      expect(fetch).toHaveBeenCalledWith(expect.stringContaining('bulkdata/id/status'), expect.any(Object));
+      expect(fetch).toHaveBeenCalledTimes(3);
       expect(response.output?.length).toBe(1);
     });
 
@@ -2548,7 +2551,7 @@ describe('Client', () => {
       const response = await medplum.bulkExport();
 
       expect(response.output).not.toBeDefined();
-      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
 
     test('Failed Kickoff', async () => {
@@ -2587,7 +2590,7 @@ describe('Client', () => {
 
     test('Downloading resources via URL', async () => {
       const blob = await client.download(baseUrl);
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         baseUrl,
         expect.objectContaining({
           headers: {
@@ -2601,7 +2604,7 @@ describe('Client', () => {
 
     test('Downloading resources via `Binary/{id}` URL', async () => {
       const blob = await client.download('Binary/fake-id');
-      expect(fetch).toBeCalledWith(
+      expect(fetch).toHaveBeenCalledWith(
         `${baseUrl}${fhirUrlPath}Binary/fake-id`,
         expect.objectContaining({
           headers: {
@@ -2620,7 +2623,7 @@ describe('Client', () => {
       const client = new MedplumClient({ fetch });
       const media = await client.uploadMedia('Hello world', 'text/plain', 'hello.txt');
       expect(media).toBeDefined();
-      expect(fetch).toBeCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(2);
 
       const calls = fetch.mock.calls;
       expect(calls).toHaveLength(2);
@@ -2729,17 +2732,17 @@ describe('Client', () => {
     const client = new MedplumClient({ fetch, verbose: true });
     const result = await client.readResource('Patient', '123');
     expect(result).toBeDefined();
-    expect(fetch).toBeCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Patient/123',
       expect.objectContaining({ method: 'GET' })
     );
     expect(result.resourceType).toBe('Patient');
     expect(result.id).toBe('123');
-    expect(console.log).toBeCalledWith('> GET https://api.medplum.com/fhir/R4/Patient/123');
-    expect(console.log).toBeCalledWith('> Accept: application/fhir+json, */*; q=0.1');
-    expect(console.log).toBeCalledWith('> X-Medplum: extended');
-    expect(console.log).toBeCalledWith('< 200 OK');
-    expect(console.log).toBeCalledWith('< foo: bar');
+    expect(console.log).toHaveBeenCalledWith('> GET https://api.medplum.com/fhir/R4/Patient/123');
+    expect(console.log).toHaveBeenCalledWith('> Accept: application/fhir+json, */*; q=0.1');
+    expect(console.log).toHaveBeenCalledWith('> X-Medplum: extended');
+    expect(console.log).toHaveBeenCalledWith('< 200 OK');
+    expect(console.log).toHaveBeenCalledWith('< foo: bar');
   });
 });
 

--- a/packages/core/src/eventtarget.test.ts
+++ b/packages/core/src/eventtarget.test.ts
@@ -11,7 +11,7 @@ describe('EventTarget', () => {
     const target = new EventTarget();
     target.addEventListener('test', myCallback);
     target.dispatchEvent({ type: 'test' });
-    expect(myCallback).toBeCalled();
+    expect(myCallback).toHaveBeenCalled();
   });
 
   test('Add multiple event listeners', () => {
@@ -21,8 +21,8 @@ describe('EventTarget', () => {
     target.addEventListener('test', myCallback1);
     target.addEventListener('test', myCallback2);
     target.dispatchEvent({ type: 'test' });
-    expect(myCallback1).toBeCalled();
-    expect(myCallback2).toBeCalled();
+    expect(myCallback1).toHaveBeenCalled();
+    expect(myCallback2).toHaveBeenCalled();
   });
 
   test('Remove event listener', () => {
@@ -31,7 +31,7 @@ describe('EventTarget', () => {
     target.addEventListener('test', myCallback);
     target.removeEventListener('test', myCallback);
     target.dispatchEvent({ type: 'test' });
-    expect(myCallback).not.toBeCalled();
+    expect(myCallback).not.toHaveBeenCalled();
   });
 
   test('Remove event listener not found', () => {
@@ -41,6 +41,6 @@ describe('EventTarget', () => {
     target.addEventListener('test', myCallback);
     target.removeEventListener('test', jest.fn());
     expect(() => target.dispatchEvent({ type: 'test' })).not.toThrow();
-    expect(myCallback).toBeCalled();
+    expect(myCallback).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -286,7 +286,7 @@ describe('createFhircastMessagePayload', () => {
           createFhircastMessageContext<'ImagingStudy-open'>('study', 'ImagingStudy', 'imagingstudy-123'),
         ]
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 
   test('Invalid event name', () => {
@@ -300,7 +300,7 @@ describe('createFhircastMessagePayload', () => {
           createFhircastMessageContext<'ImagingStudy-open'>('study', 'ImagingStudy', 'imagingstudy-123'),
         ]
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 
   test('Invalid context', () => {
@@ -311,7 +311,7 @@ describe('createFhircastMessagePayload', () => {
         'ImagingStudy-open',
         { key: 'study', resource: { id: 'imagingstudy-123', resourceType: 'ImagingStudy' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -319,7 +319,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid context, must be an object
         42
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -327,7 +327,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid context, must be of type FhircastEventContext | FhircastEventContext[]
         { id: 'imagingstudy-123' }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -335,7 +335,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid context, resource must have an ID
         { key: 'patient', resource: { resourceType: 'Patient' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -343,7 +343,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid resource, resourceType required
         { key: 'patient', resource: { id: 'patient-123' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -351,7 +351,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid resourceType, must be a FHIRcast-related resource
         { key: 'patient', resource: { resourceType: 'Observation', id: 'observation-123' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -359,7 +359,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid context, must have a valid resource AND a key
         { resource: { resourceType: 'Patient', id: 'patient-123' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -367,7 +367,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid context, must have a valid resource AND a key
         { key: 'subject', resource: { resourceType: 'Patient', id: 'patient-123' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload(
         'abc-123',
@@ -375,7 +375,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Invalid context, must have a valid resource AND a key
         { key: 'imagingstudy', resource: { resourceType: 'ImagingStudy', id: 'patient-123' } }
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       // Should throw because keys must be unique
       createFhircastMessagePayload('abc-123', 'ImagingStudy-open', [
@@ -399,7 +399,7 @@ describe('createFhircastMessagePayload', () => {
           },
         },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       // Should throw because Patient-open has an optional 2nd context of `Encounter`
       createFhircastMessagePayload('abc-123', 'Patient-open', [
@@ -407,27 +407,27 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error 'study' is not a valid key on 'Patient-open' event
         { key: 'study', resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-456' } },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload('abc-123', 'Patient-open', [
         // @ts-expect-error Key 'patient' expects a 'Patient' resource
         { key: 'patient', resource: { resourceType: 'Bundle', id: 'patient-123' } },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload('abc-123', 'Patient-open', [
         { key: 'patient', resource: { resourceType: 'Patient', id: 'patient-123' } },
         // @ts-expect-error Need a key
         { resource: { resourceType: 'Encounter', id: 'encounter-456' } },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
     expect(() =>
       createFhircastMessagePayload('abc-123', 'Patient-open', [
         { key: 'patient', resource: { resourceType: 'Patient', id: 'patient-123' } },
         // @ts-expect-error Resource should be an object
         { key: 'encounter', resource: 42 },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 
   test('Valid `DiagnosticReport-open` event w/ multiple studies', () => {
@@ -475,7 +475,7 @@ describe('createFhircastMessagePayload', () => {
           resource: { resourceType: 'ImagingStudy', id: 'imagingstudy-123', status: 'available', subject: {} },
         },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 
   test('Valid `DiagnosticReport-select` event', () => {
@@ -510,7 +510,7 @@ describe('createFhircastMessagePayload', () => {
         // @ts-expect-error Should have an array of resources at 'resources'
         { key: 'select', resource: { resourceType: 'Bundle', id: 'bundle-123' } },
       ])
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 
   test('Valid `DiagnosticReport-update` event', () => {
@@ -553,7 +553,7 @@ describe('createFhircastMessagePayload', () => {
           { key: 'updates', resource: { resourceType: 'Bundle', id: 'bundle-123' } },
         ]
       )
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 });
 
@@ -678,7 +678,7 @@ describe('FhircastConnection', () => {
           events: ['Patient-open'],
           endpoint: 'ws://localhost:1234',
         })
-    ).toThrowError(OperationOutcomeError);
+    ).toThrow(OperationOutcomeError);
   });
 });
 
@@ -700,6 +700,6 @@ describe('assertContextVersionOptional', () => {
   });
   test('Version optional: false', () => {
     expect(FHIRCAST_EVENT_VERSION_REQUIRED.includes('DiagnosticReport-update')).toEqual(true);
-    expect(() => assertContextVersionOptional('DiagnosticReport-update')).toThrowError(OperationOutcomeError);
+    expect(() => assertContextVersionOptional('DiagnosticReport-update')).toThrow(OperationOutcomeError);
   });
 });

--- a/packages/core/src/fhircast/test-utils.test.ts
+++ b/packages/core/src/fhircast/test-utils.test.ts
@@ -29,17 +29,17 @@ describe('FHIRcast Test Utils', () => {
 
     test('Invalid inputs', () => {
       // @ts-expect-error Invalid resource type, must be one a FHIRcast resource type
-      expect(() => createFhircastMessageContext<'Patient-open'>('', 'patient-123')).toThrowError(OperationOutcomeError);
+      expect(() => createFhircastMessageContext<'Patient-open'>('', 'patient-123')).toThrow(OperationOutcomeError);
       // @ts-expect-error Invalid resource type, must be one a FHIRcast resource type, eg. Patient, ImagingStudy
-      expect(() => createFhircastMessageContext<'Patient-open'>('Observation', 'observation-123')).toThrowError(
+      expect(() => createFhircastMessageContext<'Patient-open'>('Observation', 'observation-123')).toThrow(
         OperationOutcomeError
       );
       // @ts-expect-error Resource ID needs to be a string
-      expect(() => createFhircastMessageContext<'Patient-open'>('patient', 'Patient', 123)).toThrowError(
+      expect(() => createFhircastMessageContext<'Patient-open'>('patient', 'Patient', 123)).toThrow(
         OperationOutcomeError
       );
       // Resource ID needs a length
-      expect(() => createFhircastMessageContext<'Patient-open'>('patient', 'Patient', '')).toThrowError(
+      expect(() => createFhircastMessageContext<'Patient-open'>('patient', 'Patient', '')).toThrow(
         OperationOutcomeError
       );
     });

--- a/packages/core/src/fhirmapper/parse.test.ts
+++ b/packages/core/src/fhirmapper/parse.test.ts
@@ -1637,7 +1637,7 @@ describe('FHIR Mapping Language parser', () => {
     foo
     `;
 
-    expect(() => parseMappingLanguage(input)).toThrowError('Unexpected token: foo');
+    expect(() => parseMappingLanguage(input)).toThrow('Unexpected token: foo');
   });
 
   test('Multiple imports', () => {

--- a/packages/core/src/fhirpath/functions.test.ts
+++ b/packages/core/src/fhirpath/functions.test.ts
@@ -143,7 +143,7 @@ describe('FHIRPath functions', () => {
   test('single', () => {
     expect(functions.single(context, [])).toEqual([]);
     expect(functions.single(context, [TYPED_1])).toEqual([TYPED_1]);
-    expect(() => functions.single(context, [TYPED_1, TYPED_2])).toThrowError('Expected input length one for single()');
+    expect(() => functions.single(context, [TYPED_1, TYPED_2])).toThrow('Expected input length one for single()');
   });
 
   test('first', () => {
@@ -172,7 +172,7 @@ describe('FHIRPath functions', () => {
 
   test('skip', () => {
     const nonNumber: Atom = { eval: () => [TYPED_XYZ] };
-    expect(() => functions.skip(context, [TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
+    expect(() => functions.skip(context, [TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrow(
       'Expected a number for skip(num)'
     );
 
@@ -197,7 +197,7 @@ describe('FHIRPath functions', () => {
 
   test('take', () => {
     const nonNumber: Atom = { eval: () => [TYPED_XYZ] };
-    expect(() => functions.take(context, [TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrowError(
+    expect(() => functions.take(context, [TYPED_1, TYPED_2, TYPED_3], nonNumber)).toThrow(
       'Expected a number for take(num)'
     );
 

--- a/packages/core/src/fhirpath/parse.test.ts
+++ b/packages/core/src/fhirpath/parse.test.ts
@@ -32,17 +32,15 @@ describe('FHIRPath parser', () => {
   });
 
   test('Parser throws on missing closing parentheses', () => {
-    expect(() => parseFhirPath('(2 + 1')).toThrowError('Parse error: expected `)`');
+    expect(() => parseFhirPath('(2 + 1')).toThrow('Parse error: expected `)`');
   });
 
   test('Parser throws on unexpected symbol', () => {
-    expect(() => parseFhirPath('*')).toThrowError(
-      'Parse error at "*" (line 1, column 0). No matching prefix parselet.'
-    );
+    expect(() => parseFhirPath('*')).toThrow('Parse error at "*" (line 1, column 0). No matching prefix parselet.');
   });
 
   test('Parser throws on missing tokens', () => {
-    expect(() => parseFhirPath('1 * ')).toThrowError('Cant consume unknown more tokens.');
+    expect(() => parseFhirPath('1 * ')).toThrow('Cant consume unknown more tokens.');
   });
 
   test('Function minus number', () => {
@@ -305,11 +303,11 @@ describe('FHIRPath parser', () => {
   });
 
   test('Evaluate fails on function parentheses after non-symbol', () => {
-    expect(() => evalFhirPath('1()', [])).toThrowError('Unexpected parentheses');
+    expect(() => evalFhirPath('1()', [])).toThrow('Unexpected parentheses');
   });
 
   test('Evaluate fails on unrecognized function', () => {
-    expect(() => evalFhirPath('asdf()', [])).toThrowError('Unrecognized function');
+    expect(() => evalFhirPath('asdf()', [])).toThrow('Unrecognized function');
   });
 
   test('Evaluate FHIRPath where function', () => {
@@ -526,7 +524,7 @@ describe('FHIRPath parser', () => {
     };
     const variables = { '%current': toTypedValue(patient2) };
 
-    expect(() => evalFhirPathTyped('%current=%previous', [toTypedValue(patient)], variables)).toThrowError(
+    expect(() => evalFhirPathTyped('%current=%previous', [toTypedValue(patient)], variables)).toThrow(
       `Undefined variable %previous`
     );
   });

--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -93,7 +93,7 @@ describe('Outcomes', () => {
 
   test('Assert OK', () => {
     expect(() => assertOk(allOk, { resourceType: 'Patient' })).not.toThrow();
-    expect(() => assertOk(notFound, undefined)).toThrowError('Not found');
+    expect(() => assertOk(notFound, undefined)).toThrow('Not found');
   });
 
   test('Normalize error', () => {

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -920,12 +920,10 @@ describe('FHIR resource validation', () => {
     const binary: Binary = { resourceType: 'Binary', contentType: ContentType.TEXT };
 
     binary.data = 123 as unknown as string;
-    expect(() => validateResource(binary)).toThrowError(
-      'Invalid JSON type: expected string, but got number (Binary.data)'
-    );
+    expect(() => validateResource(binary)).toThrow('Invalid JSON type: expected string, but got number (Binary.data)');
 
     binary.data = '===';
-    expect(() => validateResource(binary)).toThrowError('Invalid base64Binary format');
+    expect(() => validateResource(binary)).toThrow('Invalid base64Binary format');
 
     binary.data = 'aGVsbG8=';
     expect(() => validateResource(binary)).not.toThrow();
@@ -935,7 +933,7 @@ describe('FHIR resource validation', () => {
     const patient: Patient = { resourceType: 'Patient' };
 
     patient.active = 123 as unknown as boolean;
-    expect(() => validateResource(patient)).toThrowError(
+    expect(() => validateResource(patient)).toThrow(
       'Invalid JSON type: expected boolean, but got number (Patient.active)'
     );
 
@@ -950,12 +948,12 @@ describe('FHIR resource validation', () => {
     const patient: Patient = { resourceType: 'Patient' };
 
     patient.birthDate = 123 as unknown as string;
-    expect(() => validateResource(patient)).toThrowError(
+    expect(() => validateResource(patient)).toThrow(
       'Invalid JSON type: expected string, but got number (Patient.birthDate)'
     );
 
     patient.birthDate = 'x';
-    expect(() => validateResource(patient)).toThrowError('Invalid date format');
+    expect(() => validateResource(patient)).toThrow('Invalid date format');
 
     patient.birthDate = '2000-01-01';
     expect(() => validateResource(patient)).not.toThrow();
@@ -965,12 +963,12 @@ describe('FHIR resource validation', () => {
     const condition: Condition = { resourceType: 'Condition', subject: { reference: 'Patient/1' } };
 
     condition.recordedDate = 123 as unknown as string;
-    expect(() => validateResource(condition)).toThrowError(
+    expect(() => validateResource(condition)).toThrow(
       'Invalid JSON type: expected string, but got number (Condition.recordedDate)'
     );
 
     condition.recordedDate = 'x';
-    expect(() => validateResource(condition)).toThrowError('Invalid dateTime format');
+    expect(() => validateResource(condition)).toThrow('Invalid dateTime format');
 
     condition.recordedDate = '2022-02-02';
     expect(() => validateResource(condition)).not.toThrow();
@@ -986,15 +984,15 @@ describe('FHIR resource validation', () => {
     const media: Media = { resourceType: 'Media', status: 'completed', content: { title: 'x' } };
 
     media.duration = 'x' as unknown as number;
-    expect(() => validateResource(media)).toThrowError(
+    expect(() => validateResource(media)).toThrow(
       'Invalid JSON type: expected number, but got string (Media.duration)'
     );
 
     media.duration = NaN;
-    expect(() => validateResource(media)).toThrowError('Invalid numeric value (Media.duration)');
+    expect(() => validateResource(media)).toThrow('Invalid numeric value (Media.duration)');
 
     media.duration = Infinity;
-    expect(() => validateResource(media)).toThrowError('Invalid numeric value (Media.duration)');
+    expect(() => validateResource(media)).toThrow('Invalid numeric value (Media.duration)');
 
     media.duration = 123.5;
     expect(() => validateResource(media)).not.toThrow();
@@ -1010,12 +1008,12 @@ describe('FHIR resource validation', () => {
     } as ImplementationGuide;
 
     ig.packageId = 123 as unknown as string;
-    expect(() => validateResource(ig)).toThrowError(
+    expect(() => validateResource(ig)).toThrow(
       'Invalid JSON type: expected string, but got number (ImplementationGuide.packageId)'
     );
 
     ig.packageId = '$';
-    expect(() => validateResource(ig)).toThrowError('Invalid id format');
+    expect(() => validateResource(ig)).toThrow('Invalid id format');
 
     ig.packageId = 'foo';
     expect(() => validateResource(ig)).not.toThrow();
@@ -1025,15 +1023,15 @@ describe('FHIR resource validation', () => {
     const obs: Observation = { resourceType: 'Observation', status: 'final', code: { text: 'x' } };
 
     obs.issued = 123 as unknown as string;
-    expect(() => validateResource(obs)).toThrowError(
+    expect(() => validateResource(obs)).toThrow(
       'Invalid JSON type: expected string, but got number (Observation.issued)'
     );
 
     obs.issued = 'x';
-    expect(() => validateResource(obs)).toThrowError('Invalid instant format');
+    expect(() => validateResource(obs)).toThrow('Invalid instant format');
 
     obs.issued = '2022-02-02';
-    expect(() => validateResource(obs)).toThrowError('Invalid instant format');
+    expect(() => validateResource(obs)).toThrow('Invalid instant format');
 
     obs.issued = '2022-02-02T12:00:00-04:00';
     expect(() => validateResource(obs)).not.toThrow();
@@ -1046,20 +1044,18 @@ describe('FHIR resource validation', () => {
     const sp: SubstanceProtein = { resourceType: 'SubstanceProtein' };
 
     sp.numberOfSubunits = 'x' as unknown as number;
-    expect(() => validateResource(sp)).toThrowError(
+    expect(() => validateResource(sp)).toThrow(
       'Invalid JSON type: expected number, but got string (SubstanceProtein.numberOfSubunits)'
     );
 
     sp.numberOfSubunits = NaN;
-    expect(() => validateResource(sp)).toThrowError('Invalid numeric value (SubstanceProtein.numberOfSubunits)');
+    expect(() => validateResource(sp)).toThrow('Invalid numeric value (SubstanceProtein.numberOfSubunits)');
 
     sp.numberOfSubunits = Infinity;
-    expect(() => validateResource(sp)).toThrowError('Invalid numeric value (SubstanceProtein.numberOfSubunits)');
+    expect(() => validateResource(sp)).toThrow('Invalid numeric value (SubstanceProtein.numberOfSubunits)');
 
     sp.numberOfSubunits = 123.5;
-    expect(() => validateResource(sp)).toThrowError(
-      'Expected number to be an integer (SubstanceProtein.numberOfSubunits)'
-    );
+    expect(() => validateResource(sp)).toThrow('Expected number to be an integer (SubstanceProtein.numberOfSubunits)');
 
     sp.numberOfSubunits = 10;
     expect(() => validateResource(sp)).not.toThrow();
@@ -1069,12 +1065,10 @@ describe('FHIR resource validation', () => {
     const acct: Account = { resourceType: 'Account', status: 'active' };
 
     acct.name = 123 as unknown as string;
-    expect(() => validateResource(acct)).toThrowError(
-      'Invalid JSON type: expected string, but got number (Account.name)'
-    );
+    expect(() => validateResource(acct)).toThrow('Invalid JSON type: expected string, but got number (Account.name)');
 
     acct.name = '    ';
-    expect(() => validateResource(acct)).toThrowError('String must contain non-whitespace content (Account.name)');
+    expect(() => validateResource(acct)).toThrow('String must contain non-whitespace content (Account.name)');
 
     acct.name = 'test';
     expect(() => validateResource(acct)).not.toThrow();
@@ -1092,24 +1086,24 @@ describe('FHIR resource validation', () => {
     };
 
     appt.minutesDuration = 'x' as unknown as number;
-    expect(() => validateResource(appt)).toThrowError(
+    expect(() => validateResource(appt)).toThrow(
       'Invalid JSON type: expected number, but got string (Appointment.minutesDuration)'
     );
 
     appt.minutesDuration = NaN;
-    expect(() => validateResource(appt)).toThrowError('Invalid numeric value (Appointment.minutesDuration)');
+    expect(() => validateResource(appt)).toThrow('Invalid numeric value (Appointment.minutesDuration)');
 
     appt.minutesDuration = Infinity;
-    expect(() => validateResource(appt)).toThrowError('Invalid numeric value (Appointment.minutesDuration)');
+    expect(() => validateResource(appt)).toThrow('Invalid numeric value (Appointment.minutesDuration)');
 
     appt.minutesDuration = 123.5;
-    expect(() => validateResource(appt)).toThrowError('Expected number to be an integer (Appointment.minutesDuration)');
+    expect(() => validateResource(appt)).toThrow('Expected number to be an integer (Appointment.minutesDuration)');
 
     appt.minutesDuration = -1;
-    expect(() => validateResource(appt)).toThrowError('Expected number to be positive (Appointment.minutesDuration)');
+    expect(() => validateResource(appt)).toThrow('Expected number to be positive (Appointment.minutesDuration)');
 
     appt.minutesDuration = 0;
-    expect(() => validateResource(appt)).toThrowError('Expected number to be positive (Appointment.minutesDuration)');
+    expect(() => validateResource(appt)).toThrow('Expected number to be positive (Appointment.minutesDuration)');
 
     appt.minutesDuration = 10;
     expect(() => validateResource(appt)).not.toThrow();
@@ -1127,21 +1121,21 @@ describe('FHIR resource validation', () => {
     };
 
     appt.priority = 'x' as unknown as number;
-    expect(() => validateResource(appt)).toThrowError(
+    expect(() => validateResource(appt)).toThrow(
       'Invalid JSON type: expected number, but got string (Appointment.priority)'
     );
 
     appt.priority = NaN;
-    expect(() => validateResource(appt)).toThrowError('Invalid numeric value (Appointment.priority)');
+    expect(() => validateResource(appt)).toThrow('Invalid numeric value (Appointment.priority)');
 
     appt.priority = Infinity;
-    expect(() => validateResource(appt)).toThrowError('Invalid numeric value (Appointment.priority)');
+    expect(() => validateResource(appt)).toThrow('Invalid numeric value (Appointment.priority)');
 
     appt.priority = 123.5;
-    expect(() => validateResource(appt)).toThrowError('Expected number to be an integer (Appointment.priority)');
+    expect(() => validateResource(appt)).toThrow('Expected number to be an integer (Appointment.priority)');
 
     appt.priority = -1;
-    expect(() => validateResource(appt)).toThrowError('Expected number to be non-negative (Appointment.priority)');
+    expect(() => validateResource(appt)).toThrow('Expected number to be non-negative (Appointment.priority)');
 
     appt.priority = 0;
     expect(() => validateResource(appt)).not.toThrow();

--- a/packages/hl7/src/connection.test.ts
+++ b/packages/hl7/src/connection.test.ts
@@ -27,7 +27,7 @@ describe('HL7 Connection', () => {
 
     // Simulate an error
     handlers.error(new Error('test'));
-    expect(listener).toBeCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
 
     // Reset the listener
     listener.mockReset();
@@ -35,7 +35,7 @@ describe('HL7 Connection', () => {
     // Simulate an invalid data event
     // this.socket.write(VT + reply.toString() + FS + CR);
     handlers.data(VT + FS + CR);
-    expect(listener).toBeCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
 
     // Close multiple times to test idempotency
     connection.close();

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -132,7 +132,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('My Other Project'));
     });
 
-    expect(window.location.reload).toBeCalled();
+    expect(window.location.reload).toHaveBeenCalled();
   });
 
   test('Add another account', async () => {
@@ -149,7 +149,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('Add another account'));
     });
 
-    expect(navigateMock).toBeCalledWith('/signin');
+    expect(navigateMock).toHaveBeenCalledWith('/signin');
   });
 
   test('Account settings', async () => {
@@ -166,7 +166,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('Account settings'));
     });
 
-    expect(navigateMock).toBeCalledWith('/Practitioner/123');
+    expect(navigateMock).toHaveBeenCalledWith('/Practitioner/123');
   });
 
   test('Sign out', async () => {
@@ -183,7 +183,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('Sign out'));
     });
 
-    expect(navigateMock).toBeCalledWith('/signin');
+    expect(navigateMock).toHaveBeenCalledWith('/signin');
   });
 
   test('Dark mode', async () => {

--- a/packages/react/src/AppShell/HeaderSearchInput.test.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.test.tsx
@@ -133,7 +133,7 @@ describe('HeaderSearchInput', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(navigateMock).toBeCalledWith('/Patient/' + HomerSimpson.id);
+    expect(navigateMock).toHaveBeenCalledWith('/Patient/' + HomerSimpson.id);
   });
 
   test('Search by UUID', async () => {
@@ -163,7 +163,7 @@ describe('HeaderSearchInput', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(navigateMock).toBeCalledWith('/Patient/' + HomerSimpson.id);
+    expect(navigateMock).toHaveBeenCalledWith('/Patient/' + HomerSimpson.id);
   });
 
   test.each(['Simpson', 'hom sim', 'abc', '9001'])('onChange with %s', async (query) => {

--- a/packages/react/src/AppShell/Navbar.test.tsx
+++ b/packages/react/src/AppShell/Navbar.test.tsx
@@ -162,8 +162,8 @@ describe('Navbar', () => {
       fireEvent.click(screen.getByText('Link 1'));
     });
 
-    expect(navigateMock).toBeCalledWith('/link1');
-    expect(closeMock).not.toBeCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/link1');
+    expect(closeMock).not.toHaveBeenCalled();
   });
 
   test('Click link on mobile', async () => {
@@ -175,8 +175,8 @@ describe('Navbar', () => {
       fireEvent.click(screen.getByText('Link 1'));
     });
 
-    expect(navigateMock).toBeCalledWith('/link1');
-    expect(closeMock).toBeCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/link1');
+    expect(closeMock).toHaveBeenCalled();
   });
 
   test('Resource Type Search', async () => {
@@ -204,7 +204,7 @@ describe('Navbar', () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     });
 
-    expect(navigateMock).toBeCalledWith('/test-code');
+    expect(navigateMock).toHaveBeenCalledWith('/test-code');
   });
 
   test('Add Bookmark render and submit', async () => {

--- a/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
@@ -51,7 +51,7 @@ describe('DateTimeInput', () => {
       fireEvent.change(screen.getByPlaceholderText('Placeholder'), { target: { value: localString } });
     });
 
-    expect(onChange).toBeCalledWith(isoString);
+    expect(onChange).toHaveBeenCalledWith(isoString);
   });
 
   test('Invalid date/time strings', () => {

--- a/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
@@ -155,7 +155,7 @@ describe('FhirPathTable', () => {
       fireEvent.click(screen.getByText('Bulk...'));
     });
 
-    expect(onBulk).toBeCalled();
+    expect(onBulk).toHaveBeenCalled();
   });
 
   test('Click on row', async () => {
@@ -182,8 +182,8 @@ describe('FhirPathTable', () => {
       fireEvent.click(rows[0]);
     });
 
-    expect(props.onClick).toBeCalled();
-    expect(props.onAuxClick).not.toBeCalled();
+    expect(props.onClick).toHaveBeenCalled();
+    expect(props.onAuxClick).not.toHaveBeenCalled();
   });
 
   test('Aux click on row', async () => {
@@ -210,8 +210,8 @@ describe('FhirPathTable', () => {
       fireEvent.click(rows[0], { button: 1 });
     });
 
-    expect(props.onClick).not.toBeCalled();
-    expect(props.onAuxClick).toBeCalled();
+    expect(props.onClick).not.toHaveBeenCalled();
+    expect(props.onAuxClick).toHaveBeenCalled();
   });
 
   test('Click all checkbox', async () => {

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
@@ -82,7 +82,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Change plan title', async () => {
@@ -110,7 +110,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Change action title', async () => {
@@ -147,7 +147,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Add appointment action', async () => {
@@ -187,7 +187,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Add lab action', async () => {
@@ -227,7 +227,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Add questionnaire action', async () => {
@@ -267,7 +267,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Add task action', async () => {
@@ -307,7 +307,7 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Remove action', async () => {
@@ -339,6 +339,6 @@ describe('PlanDefinitionBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
@@ -119,7 +119,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Handles AutoSave', async () => {
@@ -144,7 +144,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Add item'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Question 1'));
@@ -154,14 +154,14 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getAllByText('Remove')[0]);
     });
 
-    expect(onSubmit).toBeCalledTimes(2);
+    expect(onSubmit).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       fireEvent.click(screen.getByText('Add group'));
     });
 
     // Shouldn't autosave when adding a group
-    expect(onSubmit).toBeCalledTimes(2);
+    expect(onSubmit).toHaveBeenCalledTimes(2);
   });
 
   test('Sets ids', async () => {
@@ -195,7 +195,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     const result = onSubmit.mock.calls[0][0];
     expect(result.item[0].id).toBeDefined();
     expect(result.item[0].answerOption[0].id).toBeDefined();
@@ -236,7 +236,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -276,13 +276,13 @@ describe('QuestionnaireBuilder', () => {
     });
 
     // Should not submit without autosave flag
-    expect(onSubmit).not.toBeCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -330,7 +330,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -385,7 +385,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -428,7 +428,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -477,7 +477,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       title: 'Renamed',
@@ -569,7 +569,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -658,7 +658,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -784,7 +784,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -842,7 +842,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -908,7 +908,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -982,7 +982,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [
@@ -1063,7 +1063,7 @@ describe('QuestionnaireBuilder', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     expect(onSubmit.mock.calls[0][0]).toMatchObject({
       resourceType: 'Questionnaire',
       item: [

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -158,7 +158,7 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const response = onSubmit.mock.calls[0][0];
     expect(response.resourceType).toBe('QuestionnaireResponse');
@@ -263,7 +263,7 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const response = onSubmit.mock.calls[0][0];
     const answers = getQuestionnaireAnswers(response);
@@ -290,7 +290,7 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const response = onSubmit.mock.calls[0][0];
     expect(response.resourceType).toBe('QuestionnaireResponse');
@@ -644,7 +644,7 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Drop down choice input', async () => {
@@ -1137,7 +1137,7 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
     const response = onSubmit.mock.calls[0][0];
 
     const answer = getQuestionnaireAnswers(response);
@@ -1449,7 +1449,7 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const response = onSubmit.mock.calls[0][0];
     expect(response.item[0].item[0].item[0].answer[0].valueString).toEqual('answer1');

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -76,7 +76,7 @@ describe('ResourceForm', () => {
       fireEvent.click(screen.getByText('OK'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
   });
 
   test('Renders empty Observation form', async () => {
@@ -144,7 +144,7 @@ describe('ResourceForm', () => {
       fireEvent.click(screen.getByText('OK'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const result = onSubmit.mock.calls[0][0];
     expect(result.resourceType).toBe('Observation');
@@ -171,8 +171,8 @@ describe('ResourceForm', () => {
       fireEvent.click(screen.getByText('Delete'));
     });
 
-    expect(onSubmit).not.toBeCalled();
-    expect(onDelete).toBeCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalled();
   });
 
   test('Change Specimen.collection.collectedDateTime', async () => {
@@ -194,7 +194,7 @@ describe('ResourceForm', () => {
       fireEvent.click(screen.getByText('OK'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const result = onSubmit.mock.calls[0][0] as Specimen;
     expect(result.resourceType).toBe('Specimen');
@@ -217,7 +217,7 @@ describe('ResourceForm', () => {
       fireEvent.click(screen.getByText('OK'));
     });
 
-    expect(onSubmit).toBeCalled();
+    expect(onSubmit).toHaveBeenCalled();
 
     const patient = onSubmit.mock.calls[0][0] as Patient;
     expect(patient.resourceType).toBe('Patient');

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -430,9 +430,9 @@ describe('ResourcePropertyDisplay', () => {
 
   test('Handles unknown property', () => {
     console.error = jest.fn();
-    expect(() =>
-      setup(<ResourcePropertyDisplay propertyType={PropertyType.BackboneElement} value={{}} />)
-    ).toThrowError(new Error('Displaying property of type BackboneElement requires element schema'));
-    expect(console.error).toBeCalled();
+    expect(() => setup(<ResourcePropertyDisplay propertyType={PropertyType.BackboneElement} value={{}} />)).toThrow(
+      new Error('Displaying property of type BackboneElement requires element schema')
+    );
+    expect(console.error).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/SearchControl/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl/SearchControl.test.tsx
@@ -49,7 +49,7 @@ describe('SearchControl', () => {
 
     await waitFor(() => screen.getByText('Homer Simpson'));
 
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
   });
 
@@ -97,7 +97,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByText('No results');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
   });
 
   test('Renders choice of type', async () => {
@@ -115,7 +115,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('30 x')).toBeInTheDocument();
   });
 
@@ -142,7 +142,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
   });
 
   test('Renders empty results with checkboxes', async () => {
@@ -167,7 +167,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByText('No results');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
   });
 
   test('Renders search parameter columns', async () => {
@@ -185,7 +185,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
 
     expect(screen.getByText('chunkylover53@aol.com [home email]')).toBeInTheDocument();
     expect(screen.getByText('555-7334 [home phone]')).toBeInTheDocument();
@@ -206,7 +206,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
 
     expect(screen.getByText('Springfield')).toBeInTheDocument();
     expect(screen.getByText('IL')).toBeInTheDocument();
@@ -234,7 +234,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
   });
 
   test('Next page button', async () => {
@@ -261,7 +261,7 @@ describe('SearchControl', () => {
       fireEvent.click(screen.getByLabelText('Next page'));
     });
 
-    expect(props.onChange).toBeCalled();
+    expect(props.onChange).toHaveBeenCalled();
   });
 
   test('Next page button without onChange listener', async () => {
@@ -313,7 +313,7 @@ describe('SearchControl', () => {
       fireEvent.click(screen.getByLabelText('Previous page'));
     });
 
-    expect(props.onChange).toBeCalled();
+    expect(props.onChange).toHaveBeenCalled();
   });
 
   test('New button', async () => {
@@ -332,7 +332,7 @@ describe('SearchControl', () => {
       fireEvent.click(screen.getByText('New...'));
     });
 
-    expect(onNew).toBeCalled();
+    expect(onNew).toHaveBeenCalled();
   });
 
   test('Export button', async () => {
@@ -374,7 +374,7 @@ describe('SearchControl', () => {
       fireEvent.click(screen.getByText('Delete...'));
     });
 
-    expect(onDelete).toBeCalled();
+    expect(onDelete).toHaveBeenCalled();
   });
 
   test('Bulk button', async () => {
@@ -393,7 +393,7 @@ describe('SearchControl', () => {
       fireEvent.click(screen.getByText('Bulk...'));
     });
 
-    expect(onBulk).toBeCalled();
+    expect(onBulk).toHaveBeenCalled();
   });
 
   test('Click on row', async () => {
@@ -423,8 +423,8 @@ describe('SearchControl', () => {
       fireEvent.click(rows[0]);
     });
 
-    expect(props.onClick).toBeCalled();
-    expect(props.onAuxClick).not.toBeCalled();
+    expect(props.onClick).toHaveBeenCalled();
+    expect(props.onAuxClick).not.toHaveBeenCalled();
   });
 
   test('Aux click on row', async () => {
@@ -455,8 +455,8 @@ describe('SearchControl', () => {
       fireEvent.click(rows[0], { button: 1 });
     });
 
-    expect(props.onClick).not.toBeCalled();
-    expect(props.onAuxClick).toBeCalled();
+    expect(props.onClick).not.toHaveBeenCalled();
+    expect(props.onAuxClick).toHaveBeenCalled();
 
     // Test response to CMD key (MacOS)
     await act(async () => {
@@ -464,8 +464,8 @@ describe('SearchControl', () => {
       fireEvent.click(rows[0], { metaKey: true });
     });
 
-    expect(props.onClick).not.toBeCalled();
-    expect(props.onAuxClick).toBeCalledTimes(2);
+    expect(props.onClick).not.toHaveBeenCalled();
+    expect(props.onAuxClick).toHaveBeenCalledTimes(2);
 
     // Test response to Ctrl key (Windows)
     await act(async () => {
@@ -473,8 +473,8 @@ describe('SearchControl', () => {
       fireEvent.click(rows[0], { ctrlKey: true });
     });
 
-    expect(props.onClick).not.toBeCalled();
-    expect(props.onAuxClick).toBeCalledTimes(3);
+    expect(props.onClick).not.toHaveBeenCalled();
+    expect(props.onAuxClick).toHaveBeenCalledTimes(3);
   });
 
   test('Field editor onOk', async () => {
@@ -658,7 +658,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('all-checkbox'));
@@ -697,7 +697,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
 
     await act(async () => {
       fireEvent.click(screen.getAllByTestId('row-checkbox')[0]);
@@ -741,7 +741,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
 
     // Click on the column header to activate the popup menu
     await act(async () => {
@@ -785,7 +785,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.queryByText('Patient')).not.toBeInTheDocument();
   });
@@ -813,7 +813,7 @@ describe('SearchControl', () => {
 
     const control = screen.getByTestId('search-control');
     expect(control).toBeDefined();
-    expect(props.onLoad).toBeCalled();
+    expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.queryByText('no filters')).not.toBeInTheDocument();
   });
@@ -861,7 +861,7 @@ describe('SearchControl', () => {
 
     await setup(props);
     await waitFor(() => screen.getByText('Homer Simpson'));
-    expect(onLoad).toBeCalled();
+    expect(onLoad).toHaveBeenCalled();
     onLoad.mockReset();
 
     const refreshButton = screen.getByTitle('Refresh');
@@ -872,6 +872,6 @@ describe('SearchControl', () => {
     });
 
     await waitFor(() => screen.getByText('Homer Simpson'));
-    expect(onLoad).toBeCalled();
+    expect(onLoad).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.test.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.test.tsx
@@ -40,7 +40,7 @@ describe('SearchFieldEditor', () => {
       fireEvent.click(screen.getByTestId('overlay-child'));
     });
 
-    expect(onCancel).not.toBeCalled();
+    expect(onCancel).not.toHaveBeenCalled();
   });
 
   test('Modal onClose called when overlay clicked while dropdown NOT open', async () => {
@@ -59,6 +59,6 @@ describe('SearchFieldEditor', () => {
       fireEvent.click(screen.getByTestId('overlay-child'));
     });
 
-    expect(onCancel).toBeCalled();
+    expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
@@ -40,7 +40,7 @@ describe('SearchFilterValueInput', () => {
       fireEvent.change(screen.getByTestId('filter-value'), { target: { value: 'foo' } });
     });
 
-    expect(onChange).toBeCalledWith('foo');
+    expect(onChange).toHaveBeenCalledWith('foo');
   });
 
   test('Boolean input', async () => {
@@ -58,14 +58,14 @@ describe('SearchFilterValueInput', () => {
       fireEvent.click(screen.getByTestId('filter-value'));
     });
 
-    expect(onChange).toBeCalledWith('true');
+    expect(onChange).toHaveBeenCalledWith('true');
     onChange.mockClear();
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('filter-value'));
     });
 
-    expect(onChange).toBeCalledWith('false');
+    expect(onChange).toHaveBeenCalledWith('false');
     onChange.mockClear();
   });
 
@@ -84,7 +84,7 @@ describe('SearchFilterValueInput', () => {
       fireEvent.change(screen.getByTestId('filter-value'), { target: { value: '1950-01-01' } });
     });
 
-    expect(onChange).toBeCalledWith('1950-01-01');
+    expect(onChange).toHaveBeenCalledWith('1950-01-01');
   });
 
   test('Date/Time input', async () => {
@@ -104,7 +104,7 @@ describe('SearchFilterValueInput', () => {
       fireEvent.change(screen.getByTestId('filter-value'), { target: { value: localString } });
     });
 
-    expect(onChange).toBeCalledWith(isoString);
+    expect(onChange).toHaveBeenCalledWith(isoString);
   });
 
   test('Quantity input', async () => {
@@ -122,7 +122,7 @@ describe('SearchFilterValueInput', () => {
       fireEvent.change(screen.getByPlaceholderText('Value'), { target: { value: '5' } });
     });
 
-    expect(onChange).toBeCalledWith('5');
+    expect(onChange).toHaveBeenCalledWith('5');
   });
 
   test('Reference input', async () => {

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -117,7 +117,7 @@ describe('SearchPopupMenu', () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(onPrompt).toBeCalledWith(searchParam, {
+      expect(onPrompt).toHaveBeenCalledWith(searchParam, {
         code: 'birthdate',
         operator: option.operator,
         value: '',
@@ -294,7 +294,7 @@ describe('SearchPopupMenu', () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(onPrompt).toBeCalledWith(searchParam, {
+      expect(onPrompt).toHaveBeenCalledWith(searchParam, {
         code: 'value-quantity',
         operator: option.operator,
         value: '',
@@ -424,7 +424,7 @@ describe('SearchPopupMenu', () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(onPrompt).toBeCalledWith(searchParam, {
+      expect(onPrompt).toHaveBeenCalledWith(searchParam, {
         code: 'organization',
         operator: option.operator,
         value: '',
@@ -563,7 +563,7 @@ describe('SearchPopupMenu', () => {
         fireEvent.click(screen.getByText(option.text));
       });
 
-      expect(onPrompt).toBeCalledWith(searchParam, {
+      expect(onPrompt).toHaveBeenCalledWith(searchParam, {
         code: 'name',
         operator: option.operator,
         value: '',

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -534,7 +534,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Forgot password'));
     });
 
-    expect(props.onForgotPassword).toBeCalled();
+    expect(props.onForgotPassword).toHaveBeenCalled();
   });
 
   test('Register', async () => {
@@ -549,7 +549,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Register'));
     });
 
-    expect(props.onRegister).toBeCalled();
+    expect(props.onRegister).toHaveBeenCalled();
   });
 
   test('Disable Email', async () => {
@@ -680,7 +680,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Next'));
     });
 
-    await waitFor(() => expect(window.location.assign).toBeCalled());
-    expect(window.location.assign).toBeCalled();
+    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
+    expect(window.location.assign).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/utils/dom.test.ts
+++ b/packages/react/src/utils/dom.test.ts
@@ -8,8 +8,8 @@ describe('DOM utils', () => {
     };
 
     killEvent(e as unknown as Event);
-    expect(e.preventDefault).toBeCalled();
-    expect(e.stopPropagation).toBeCalled();
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(e.stopPropagation).toHaveBeenCalled();
   });
 
   test('isCheckboxCell', () => {

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -14,7 +14,7 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(null, { origin: false });
+    expect(callback).toHaveBeenCalledWith(null, { origin: false });
   });
 
   test('No Origin', () => {
@@ -24,7 +24,7 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(null, { origin: false });
+    expect(callback).toHaveBeenCalledWith(null, { origin: false });
   });
 
   test('Allow appBaseUrl', () => {
@@ -34,7 +34,7 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(
+    expect(callback).toHaveBeenCalledWith(
       null,
       expect.objectContaining({ credentials: true, origin: 'http://localhost:3000' })
     );
@@ -48,7 +48,7 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(
+    expect(callback).toHaveBeenCalledWith(
       null,
       expect.objectContaining({ credentials: true, origin: 'https://example.com' })
     );
@@ -62,7 +62,7 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(null, { origin: false });
+    expect(callback).toHaveBeenCalledWith(null, { origin: false });
   });
 
   test('Allowed origins ', () => {
@@ -73,7 +73,7 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(
+    expect(callback).toHaveBeenCalledWith(
       null,
       expect.objectContaining({ credentials: true, origin: 'https://example.com' })
     );
@@ -87,6 +87,6 @@ describe('CORS', () => {
     } as unknown as Request;
     const callback = jest.fn();
     corsOptions(req, callback);
-    expect(callback).toBeCalledWith(null, { origin: false });
+    expect(callback).toHaveBeenCalledWith(null, { origin: false });
   });
 });

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -264,8 +264,8 @@ describe('Email', () => {
       text: 'Hello Alice',
     });
 
-    expect(createTransportSpy).toBeCalledTimes(1);
-    expect(sendMail).toBeCalledTimes(1);
+    expect(createTransportSpy).toHaveBeenCalledTimes(1);
+    expect(sendMail).toHaveBeenCalledTimes(1);
     expect(mockSESv2Client.send.callCount).toBe(0);
 
     config.smtp = undefined;

--- a/packages/server/src/fhir/job.test.ts
+++ b/packages/server/src/fhir/job.test.ts
@@ -54,7 +54,7 @@ describe('Job status', () => {
         callback();
       });
 
-      expect(callback).toBeCalled();
+      expect(callback).toHaveBeenCalled();
 
       const resCompleted = await request(app)
         .get(`/fhir/R4/job/${job.id}/status`)

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -127,7 +127,7 @@ describe('Execute', () => {
       .send(text);
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toBe('x-application/hl7-v2+er7; charset=utf-8');
-    expect(writeFileSpy).toBeCalledTimes(1);
+    expect(writeFileSpy).toHaveBeenCalledTimes(1);
 
     const args = writeFileSpy.mock.calls[0];
     expect(args.length).toBe(3);

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -329,7 +329,7 @@ describe('Group Export', () => {
     await groupExportResources(exporter, project, group, systemRepo);
     const bulkDataExport = await exporter.close(project);
     expect(bulkDataExport.status).toBe('completed');
-    expect(exportWriteResourceSpy).toBeCalledTimes(0);
+    expect(exportWriteResourceSpy).toHaveBeenCalledTimes(0);
   });
 
   test('groupExportResources members without reference', async () => {

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.test.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.test.ts
@@ -38,7 +38,7 @@ describe('AsyncJobExecutor', () => {
       });
 
       expect(resource.status).toBe('accepted');
-      expect(callback).toBeCalled();
+      expect(callback).toHaveBeenCalled();
     }));
 
   test('start with error', () =>
@@ -55,7 +55,7 @@ describe('AsyncJobExecutor', () => {
         expect((err as Error).message).toBe('AsyncJob missing');
       }
 
-      expect(callback).not.toBeCalled();
+      expect(callback).not.toHaveBeenCalled();
     }));
 
   test('run', () =>
@@ -70,7 +70,7 @@ describe('AsyncJobExecutor', () => {
       });
 
       expect(resource.status).toBe('accepted');
-      expect(callback).toBeCalled();
+      expect(callback).toHaveBeenCalled();
     }));
 
   test('run with error', async () => {
@@ -86,7 +86,7 @@ describe('AsyncJobExecutor', () => {
       expect((err as Error).message).toBe('AsyncJob missing');
     }
 
-    expect(callback).not.toBeCalled();
+    expect(callback).not.toHaveBeenCalled();
   });
 
   test('getContentLocation', () =>
@@ -114,6 +114,6 @@ describe('AsyncJobExecutor', () => {
       expect((err as Error).message).toBe('AsyncJob missing');
     }
 
-    expect(callback).not.toBeCalled();
+    expect(callback).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -1382,7 +1382,7 @@ describe('OAuth2 Token', () => {
       client_assertion: jwt,
     });
     expect(res.status).toBe(200);
-    expect(jwtVerify).toBeCalledTimes(3);
+    expect(jwtVerify).toHaveBeenCalledTimes(3);
   });
 
   test('Client assertion multiple inner error', async () => {
@@ -1413,7 +1413,7 @@ describe('OAuth2 Token', () => {
       client_assertion: jwt,
     });
     expect(res.status).toBe(400);
-    expect(jwtVerify).toBeCalledTimes(2);
+    expect(jwtVerify).toHaveBeenCalledTimes(2);
   });
 
   test('Client assertion invalid assertion type', async () => {

--- a/packages/server/src/workers/cron.test.ts
+++ b/packages/server/src/workers/cron.test.ts
@@ -125,8 +125,8 @@ describe('Cron Worker', () => {
       });
 
       expect(bot).toBeDefined();
-      expect(queue.getRepeatableJobs).toBeCalled();
-      expect(queue.add).toBeCalledTimes(2);
+      expect(queue.getRepeatableJobs).toHaveBeenCalled();
+      expect(queue.add).toHaveBeenCalledTimes(2);
     }));
 
   test('Find a previous job to remove after updating bot', () =>
@@ -139,8 +139,8 @@ describe('Cron Worker', () => {
       });
 
       expect(bot).toBeDefined();
-      expect(queue.getRepeatableJobs).toBeCalled();
-      expect(queue.add).toBeCalled();
+      expect(queue.getRepeatableJobs).toHaveBeenCalled();
+      expect(queue.add).toHaveBeenCalled();
 
       queue.getRepeatableJobs.mockImplementation(() => [
         {
@@ -159,7 +159,7 @@ describe('Cron Worker', () => {
         },
       });
 
-      expect(queue.removeRepeatableByKey).toBeCalled();
+      expect(queue.removeRepeatableByKey).toHaveBeenCalled();
     }));
 
   test('Job should not be in queue if cron is not enabled', () =>
@@ -196,7 +196,7 @@ describe('Cron Worker', () => {
         },
       });
       expect(bot).toBeDefined();
-      expect(queue.add).not.toBeCalled();
+      expect(queue.add).not.toHaveBeenCalled();
     }));
 
   test('Bot should execute successfully', () =>


### PR DESCRIPTION
See: https://github.com/jestjs/jest/issues/13164

- `toBeCalled` deprecated in favor of `toHaveBeenCalled`
- `toBeCalledTimes` deprecated in favor of `toHaveBeenCalledTimes`
- `toBeCalledWith` deprecated in favor of `toHaveBeenCalledWith`
- `toThrowError` deprecated in favor of `toThrow`