### PR TITLE
Fix Sonar code smells: mark React props readonly

### DIFF
--- a/examples/foomedical/src/components/InfoButton.tsx
+++ b/examples/foomedical/src/components/InfoButton.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 import classes from './InfoButton.module.css';
 
 export interface InfoButtonProps {
-  onClick?: () => void;
-  children: ReactNode;
+  readonly onClick?: () => void;
+  readonly children: ReactNode;
 }
 
 export function InfoButton(props: InfoButtonProps): JSX.Element {

--- a/examples/foomedical/src/components/InfoSection.tsx
+++ b/examples/foomedical/src/components/InfoSection.tsx
@@ -3,11 +3,11 @@ import { ReactNode } from 'react';
 import classes from './InfoSection.module.css';
 
 interface InfoSectionProps {
-  title?: string | JSX.Element;
-  children: ReactNode;
-  onButtonClick?: (id: string) => void;
-  resourceType?: string;
-  id?: string;
+  readonly title?: string | JSX.Element;
+  readonly children: ReactNode;
+  readonly onButtonClick?: (id: string) => void;
+  readonly resourceType?: string;
+  readonly id?: string;
 }
 
 export function InfoSection({ title, children, onButtonClick, id = '' }: InfoSectionProps): JSX.Element {

--- a/examples/foomedical/src/components/LineChart.tsx
+++ b/examples/foomedical/src/components/LineChart.tsx
@@ -16,7 +16,7 @@ const lineChartOptions = {
 };
 
 interface LineChartProps {
-  chartData: ChartData<'line', number[]>;
+  readonly chartData: ChartData<'line', number[]>;
 }
 
 const AsyncLine = lazy(async () => {

--- a/examples/foomedical/src/components/Logo.tsx
+++ b/examples/foomedical/src/components/Logo.tsx
@@ -1,7 +1,7 @@
 import { useMantineTheme } from '@mantine/core';
 
 export interface LogoProps {
-  width: number;
+  readonly width: number;
 }
 
 export function Logo(props: LogoProps): JSX.Element {

--- a/examples/foomedical/src/components/SideMenu.tsx
+++ b/examples/foomedical/src/components/SideMenu.tsx
@@ -5,13 +5,13 @@ import { NavLink } from 'react-router-dom';
 import classes from './SideMenu.module.css';
 
 export interface SubMenuProps {
-  name: string;
-  href: string;
+  readonly name: string;
+  readonly href: string;
 }
 
 export interface SideMenuProps {
-  title: string;
-  menu: { name: string; href: string; subMenu?: SubMenuProps[] }[];
+  readonly title: string;
+  readonly menu: { name: string; href: string; subMenu?: SubMenuProps[] }[];
 }
 
 export function SideMenu(props: SideMenuProps): JSX.Element {

--- a/examples/foomedical/src/pages/health-record/Medication.tsx
+++ b/examples/foomedical/src/pages/health-record/Medication.tsx
@@ -33,9 +33,9 @@ function RenewalModal({
   opened,
   setOpened,
 }: {
-  prev: MedicationRequest;
-  opened: boolean;
-  setOpened: (o: boolean) => void;
+  readonly prev: MedicationRequest;
+  readonly opened: boolean;
+  readonly setOpened: (o: boolean) => void;
 }): JSX.Element {
   const medplum = useMedplum();
   const patient = medplum.getProfile();

--- a/examples/medplum-chart-demo/src/components/tasks/QuestionnaireTask.tsx
+++ b/examples/medplum-chart-demo/src/components/tasks/QuestionnaireTask.tsx
@@ -39,10 +39,10 @@ export function QuestionnaireTask(props: TaskCellProps): JSX.Element {
 }
 
 function QuestionnaireModal(props: {
-  task: Task;
-  questionnaire: Questionnaire;
-  setSubmitted: (submit: boolean) => void;
-  handleSubmit: (questionnaireResponse: QuestionnaireResponse) => Promise<void>;
+  readonly task: Task;
+  readonly questionnaire: Questionnaire;
+  readonly setSubmitted: (submit: boolean) => void;
+  readonly handleSubmit: (questionnaireResponse: QuestionnaireResponse) => Promise<void>;
 }): JSX.Element {
   const [open, setOpen] = useState(false);
 
@@ -64,10 +64,10 @@ function QuestionnaireModal(props: {
 }
 
 function QuestionnaireQuickAction(props: {
-  task: Task;
-  questionnaire: Questionnaire;
-  setSubmitted: (submit: boolean) => void;
-  handleSubmit: (questionnaireResponse: QuestionnaireResponse) => Promise<void>;
+  readonly task: Task;
+  readonly questionnaire: Questionnaire;
+  readonly setSubmitted: (submit: boolean) => void;
+  readonly handleSubmit: (questionnaireResponse: QuestionnaireResponse) => Promise<void>;
 }): JSX.Element {
   return <QuestionnaireForm questionnaire={props.questionnaire} onSubmit={props.handleSubmit} />;
 }

--- a/examples/medplum-chart-demo/src/components/tasks/TaskList.tsx
+++ b/examples/medplum-chart-demo/src/components/tasks/TaskList.tsx
@@ -24,15 +24,15 @@ const focusIcons: Record<string, JSX.Element> = {
 };
 
 export interface TaskCellProps {
-  task: Task;
-  resource: Resource;
+  readonly task: Task;
+  readonly resource: Resource;
 }
 
 interface TaskItemProps {
-  task: Task;
-  resource: Resource;
-  profile?: Reference;
-  children?: ReactNode;
+  readonly task: Task;
+  readonly resource: Resource;
+  readonly profile?: Reference;
+  readonly children?: ReactNode;
 }
 
 export function TaskList(): JSX.Element | null {

--- a/examples/medplum-chart-demo/src/pages/SearchPage.tsx
+++ b/examples/medplum-chart-demo/src/pages/SearchPage.tsx
@@ -44,7 +44,6 @@ export function SearchPage(): JSX.Element {
       <MemoizedSearchControl
         checkboxesEnabled={true}
         search={search}
-        userConfig={medplum.getUserConfiguration()}
         onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
         onAuxClick={(e) => window.open(`/${e.resource.resourceType}/${e.resource.id}`, '_blank')}
         onChange={(e) => {

--- a/examples/medplum-fhircast-demo/src/components/ConnectionHandler.tsx
+++ b/examples/medplum-fhircast-demo/src/components/ConnectionHandler.tsx
@@ -5,10 +5,10 @@ import { useEffect, useRef, useState } from 'react';
 type ConnectionStatus = 'IDLE' | 'CONNECTING' | 'CONNECTED' | 'DISCONNECTING' | 'DISCONNECTED' | 'UNSUBSCRIBED';
 
 type WebSocketHandlerProps = {
-  clientId: string;
-  onMessage: (message: FhircastMessagePayload) => void;
-  subRequest?: SubscriptionRequest;
-  onStatusChange?: (status: ConnectionStatus) => void;
+  readonly clientId: string;
+  readonly onMessage: (message: FhircastMessagePayload) => void;
+  readonly subRequest?: SubscriptionRequest;
+  readonly onStatusChange?: (status: ConnectionStatus) => void;
 };
 
 export default function ConnectionHandler(props: WebSocketHandlerProps): null {

--- a/examples/medplum-fhircast-demo/src/components/Redirect.tsx
+++ b/examples/medplum-fhircast-demo/src/components/Redirect.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 type RedirectProps = {
-  path: string;
+  readonly path: string;
 };
 
 export default function Redirect(props: RedirectProps): null {

--- a/examples/medplum-fhircast-demo/src/components/Subscriber.tsx
+++ b/examples/medplum-fhircast-demo/src/components/Subscriber.tsx
@@ -8,8 +8,8 @@ import ConnectionHandler from './ConnectionHandler';
 import TopicLoader from './TopicLoader';
 
 type FhircastMessageDisplayProps = {
-  eventNo: number;
-  message: FhircastMessagePayload<'Patient-open'>;
+  readonly eventNo: number;
+  readonly message: FhircastMessagePayload<'Patient-open'>;
 };
 
 function FhircastMessageLabel(props: FhircastMessageDisplayProps): JSX.Element {

--- a/examples/medplum-fhircast-demo/src/components/TopicGenerator.tsx
+++ b/examples/medplum-fhircast-demo/src/components/TopicGenerator.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { usePrevious } from '../hooks';
 
 interface TopicGeneratorProps {
-  onTopicChange?: (topic: string | undefined) => void;
+  readonly onTopicChange?: (topic: string | undefined) => void;
 }
 
 export default function TopicGenerator(props: TopicGeneratorProps): JSX.Element {

--- a/examples/medplum-fhircast-demo/src/components/TopicLoader.tsx
+++ b/examples/medplum-fhircast-demo/src/components/TopicLoader.tsx
@@ -2,7 +2,7 @@ import { Button, Input, Stack } from '@mantine/core';
 import { useEffect, useState } from 'react';
 
 interface TopicLoaderProps {
-  onSetTopic: (topic: string | undefined) => void;
+  readonly onSetTopic: (topic: string | undefined) => void;
 }
 export default function TopicLoader(props: TopicLoaderProps): JSX.Element {
   const [topicInput, setTopicInput] = useState<string>('');

--- a/examples/medplum-hello-world/src/pages/PatientHeader.tsx
+++ b/examples/medplum-hello-world/src/pages/PatientHeader.tsx
@@ -4,7 +4,7 @@ import { HumanNameDisplay, MedplumLink, ResourceAvatar, useResource } from '@med
 import classes from './PatientHeader.module.css';
 
 export interface PatientHeaderProps {
-  patient: Patient | Reference<Patient>;
+  readonly patient: Patient | Reference<Patient>;
 }
 
 export function PatientHeader(props: PatientHeaderProps): JSX.Element | null {

--- a/examples/medplum-react-native-example/src/CustomButton.tsx
+++ b/examples/medplum-react-native-example/src/CustomButton.tsx
@@ -1,8 +1,8 @@
 import { GestureResponderEvent, Pressable, StyleSheet, Text } from 'react-native';
 
 interface CustomButtonProps {
-  onPress: ((event: GestureResponderEvent) => void) | undefined;
-  title: string;
+  readonly onPress: ((event: GestureResponderEvent) => void) | undefined;
+  readonly title: string;
 }
 
 export default function CustomButton(props: CustomButtonProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/AddDueDate.tsx
+++ b/examples/medplum-task-demo/src/components/actions/AddDueDate.tsx
@@ -7,8 +7,8 @@ import { QuestionnaireForm, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface AddDueDateProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function AddDueDate(props: AddDueDateProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/AddNote.tsx
+++ b/examples/medplum-task-demo/src/components/actions/AddNote.tsx
@@ -13,8 +13,8 @@ import { QuestionnaireForm, useMedplum, useMedplumProfile } from '@medplum/react
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface AddCommentProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function AddNote(props: AddCommentProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/AssignRole.tsx
+++ b/examples/medplum-task-demo/src/components/actions/AssignRole.tsx
@@ -7,8 +7,8 @@ import { QuestionnaireForm, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface AssignTaskProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function AssignRole(props: AssignTaskProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/AssignTask.tsx
+++ b/examples/medplum-task-demo/src/components/actions/AssignTask.tsx
@@ -7,8 +7,8 @@ import { QuestionnaireForm, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface AssignTaskProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function AssignTask(props: AssignTaskProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/ClaimTask.tsx
+++ b/examples/medplum-task-demo/src/components/actions/ClaimTask.tsx
@@ -7,8 +7,8 @@ import { useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface ClaimTaskProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function ClaimTask(props: ClaimTaskProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/CompleteTask.tsx
+++ b/examples/medplum-task-demo/src/components/actions/CompleteTask.tsx
@@ -6,8 +6,8 @@ import { useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface CompleteTaskProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function CompleteTask({ task, onChange }: CompleteTaskProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/CreateTaskModal.tsx
+++ b/examples/medplum-task-demo/src/components/actions/CreateTaskModal.tsx
@@ -5,8 +5,8 @@ import { ResourceForm, useMedplum } from '@medplum/react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 interface CreateTaskModalProps {
-  opened: boolean;
-  onClose: () => void;
+  readonly opened: boolean;
+  readonly onClose: () => void;
 }
 
 export function CreateTaskModal(props: CreateTaskModalProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/DeleteTask.tsx
+++ b/examples/medplum-task-demo/src/components/actions/DeleteTask.tsx
@@ -8,8 +8,8 @@ import { IconAlertCircle, IconCircleCheck, IconCircleOff } from '@tabler/icons-r
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 
 interface DeleteTaskProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function DeleteTask(props: DeleteTaskProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/PauseResumeTask.tsx
+++ b/examples/medplum-task-demo/src/components/actions/PauseResumeTask.tsx
@@ -6,8 +6,8 @@ import { useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface PauseResumeTaskProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function PauseResumeTask({ task, onChange }: PauseResumeTaskProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/TaskActions.tsx
+++ b/examples/medplum-task-demo/src/components/actions/TaskActions.tsx
@@ -12,8 +12,8 @@ import { PauseResumeTask } from './PauseResumeTask';
 import { CompleteTask } from './CompleteTask';
 
 interface TaskActionsProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function TaskActions(props: TaskActionsProps): JSX.Element {

--- a/examples/medplum-task-demo/src/components/actions/UpdateBusinessStatus.tsx
+++ b/examples/medplum-task-demo/src/components/actions/UpdateBusinessStatus.tsx
@@ -7,8 +7,8 @@ import { QuestionnaireForm, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
 interface UpdateBusinessStatusProps {
-  task: Task;
-  onChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
 }
 
 export function UpdateBusinessStatus(props: UpdateBusinessStatusProps): JSX.Element {

--- a/examples/medplum-task-demo/src/pages/NotesPage.tsx
+++ b/examples/medplum-task-demo/src/pages/NotesPage.tsx
@@ -3,7 +3,7 @@ import { Annotation, Task } from '@medplum/fhirtypes';
 import { Document } from '@medplum/react';
 
 export interface NotesPageProps {
-  task: Task;
+  readonly task: Task;
 }
 
 export function NotesPage(props: NotesPageProps): JSX.Element {

--- a/examples/medplum-task-demo/src/pages/TaskPage.tsx
+++ b/examples/medplum-task-demo/src/pages/TaskPage.tsx
@@ -87,7 +87,7 @@ export function TaskPage(): JSX.Element {
 }
 
 interface PatientProfileProps {
-  patient?: Patient;
+  readonly patient?: Patient;
 }
 
 function PatientProfile({ patient }: PatientProfileProps): JSX.Element {
@@ -106,10 +106,10 @@ function PatientProfile({ patient }: PatientProfileProps): JSX.Element {
 }
 
 interface TaskDetailsProps {
-  task: Task;
-  tabs: string[];
-  currentTab: string;
-  handleTabChange: (newTab: string | null) => void;
+  readonly task: Task;
+  readonly tabs: string[];
+  readonly currentTab: string;
+  readonly handleTabChange: (newTab: string | null) => void;
 }
 
 function TaskDetails({ task, tabs, currentTab, handleTabChange }: TaskDetailsProps): JSX.Element {
@@ -139,8 +139,8 @@ function TaskDetails({ task, tabs, currentTab, handleTabChange }: TaskDetailsPro
 }
 
 interface ActionsProps {
-  task: Task;
-  onTaskChange: (updatedTask: Task) => void;
+  readonly task: Task;
+  readonly onTaskChange: (updatedTask: Task) => void;
 }
 
 function Actions({ task, onTaskChange }: ActionsProps): JSX.Element {

--- a/examples/medplum-websocket-subscriptions-demo/src/pages/HomePage.tsx
+++ b/examples/medplum-websocket-subscriptions-demo/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ import { IconArrowNarrowRight } from '@tabler/icons-react';
 import { useState } from 'react';
 
 interface BundleDisplayProps {
-  bundle: Bundle;
+  readonly bundle: Bundle;
 }
 
 function BundleDisplay(props: BundleDisplayProps): JSX.Element {

--- a/packages/app/src/BatchPage.tsx
+++ b/packages/app/src/BatchPage.tsx
@@ -10,14 +10,14 @@ import { useCallback, useState } from 'react';
 const DEFAULT_VALUE = `{"resourceType": "Bundle"}`;
 
 interface ShowNotificationProps {
-  id: string;
-  title: string;
-  message: string;
-  color?: string;
-  icon?: JSX.Element | null;
-  withCloseButton?: boolean;
-  method?: 'show' | 'update';
-  loading?: boolean;
+  readonly id: string;
+  readonly title: string;
+  readonly message: string;
+  readonly color?: string;
+  readonly icon?: JSX.Element | null;
+  readonly withCloseButton?: boolean;
+  readonly method?: 'show' | 'update';
+  readonly loading?: boolean;
 }
 
 function showNotification({

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -44,7 +44,6 @@ export function HomePage(): JSX.Element {
       <MemoizedSearchControl
         checkboxesEnabled={true}
         search={search}
-        userConfig={medplum.getUserConfiguration()}
         onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
         onAuxClick={(e) => window.open(`/${e.resource.resourceType}/${e.resource.id}`, '_blank')}
         onChange={(e) => {

--- a/packages/app/src/SecurityPage.tsx
+++ b/packages/app/src/SecurityPage.tsx
@@ -13,18 +13,18 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface UserSession {
-  id: string;
-  lastUpdated: string;
-  authMethod: string;
-  remoteAddress: string;
-  browser?: string;
-  os?: string;
+  readonly id: string;
+  readonly lastUpdated: string;
+  readonly authMethod: string;
+  readonly remoteAddress: string;
+  readonly browser?: string;
+  readonly os?: string;
 }
 
 interface SecurityDetails {
-  profile: ProfileResource;
-  config: UserConfiguration;
-  security: {
+  readonly profile: ProfileResource;
+  readonly config: UserConfiguration;
+  readonly security: {
     mfaEnrolled: boolean;
     sessions: UserSession[];
   };

--- a/packages/app/src/admin/MembersTable.tsx
+++ b/packages/app/src/admin/MembersTable.tsx
@@ -6,8 +6,8 @@ import { useNavigate } from 'react-router-dom';
 import { getProjectId } from '../utils';
 
 export interface MemberTableProps {
-  resourceType: ResourceType;
-  fields: string[];
+  readonly resourceType: ResourceType;
+  readonly fields: string[];
 }
 
 export function MemberTable(props: MemberTableProps): JSX.Element {

--- a/packages/app/src/components/InfoBar.tsx
+++ b/packages/app/src/components/InfoBar.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 import classes from './InfoBar.module.css';
 
 export interface InfoBarProps {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 export function InfoBar(props: InfoBarProps): JSX.Element {
@@ -15,7 +15,7 @@ export function InfoBar(props: InfoBarProps): JSX.Element {
 }
 
 export interface InfoBarEntryProps {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 InfoBar.Entry = function InfoBarEntry(props: InfoBarEntryProps): JSX.Element {
@@ -23,7 +23,7 @@ InfoBar.Entry = function InfoBarEntry(props: InfoBarEntryProps): JSX.Element {
 };
 
 export interface InfoBarKeyProps {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 InfoBar.Key = function InfoBarEntry(props: InfoBarKeyProps): JSX.Element {
@@ -31,7 +31,7 @@ InfoBar.Key = function InfoBarEntry(props: InfoBarKeyProps): JSX.Element {
 };
 
 export interface InfoBarValueProps {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 InfoBar.Value = function InfoBarEntry(props: InfoBarValueProps): JSX.Element {

--- a/packages/app/src/components/PatientHeader.tsx
+++ b/packages/app/src/components/PatientHeader.tsx
@@ -5,7 +5,7 @@ import { InfoBar } from './InfoBar';
 import { getDefaultColor } from './PatientHeader.utils';
 
 export interface PatientHeaderProps {
-  patient: Patient | Reference<Patient>;
+  readonly patient: Patient | Reference<Patient>;
 }
 
 export function PatientHeader(props: PatientHeaderProps): JSX.Element | null {

--- a/packages/app/src/components/QuickServiceRequests.tsx
+++ b/packages/app/src/components/QuickServiceRequests.tsx
@@ -8,7 +8,7 @@ import { getPatient } from '../utils';
 import classes from './QuickServiceRequests.module.css';
 
 export interface QuickServiceRequestsProps {
-  value: Resource | Reference;
+  readonly value: Resource | Reference;
 }
 
 export function QuickServiceRequests(props: QuickServiceRequestsProps): JSX.Element | null {

--- a/packages/app/src/components/QuickStatus.tsx
+++ b/packages/app/src/components/QuickStatus.tsx
@@ -4,9 +4,9 @@ import { useResource } from '@medplum/react';
 import classes from './QuickStatus.module.css';
 
 export interface QuickStatusProps {
-  valueSet: Reference<ValueSet> | ValueSet;
-  defaultValue?: string;
-  onChange: (newStatus: string) => void;
+  readonly valueSet: Reference<ValueSet> | ValueSet;
+  readonly defaultValue?: string;
+  readonly onChange: (newStatus: string) => void;
 }
 
 export function QuickStatus(props: QuickStatusProps): JSX.Element | null {

--- a/packages/app/src/components/ResourceHeader.tsx
+++ b/packages/app/src/components/ResourceHeader.tsx
@@ -5,7 +5,7 @@ import { ReactNode } from 'react';
 import { InfoBar } from './InfoBar';
 
 export interface ResourceHeaderProps {
-  resource: Resource | Reference;
+  readonly resource: Resource | Reference;
 }
 
 export function ResourceHeader(props: ResourceHeaderProps): JSX.Element | null {

--- a/packages/app/src/components/SpecimenHeader.tsx
+++ b/packages/app/src/components/SpecimenHeader.tsx
@@ -4,7 +4,7 @@ import { useResource } from '@medplum/react';
 import { InfoBar } from './InfoBar';
 
 export interface SpecimenHeaderProps {
-  specimen: Specimen | Reference<Specimen>;
+  readonly specimen: Specimen | Reference<Specimen>;
 }
 
 export function SpecimenHeader(props: SpecimenHeaderProps): JSX.Element | null {

--- a/packages/app/src/lab/AssaysPage.tsx
+++ b/packages/app/src/lab/AssaysPage.tsx
@@ -48,7 +48,7 @@ export function AssaysPage(): JSX.Element {
 }
 
 interface IntervalsDisplayProps {
-  ranges: ObservationDefinitionQualifiedInterval[] | undefined;
+  readonly ranges: ObservationDefinitionQualifiedInterval[] | undefined;
 }
 
 function IntervalsDisplay(props: IntervalsDisplayProps): JSX.Element | null {

--- a/packages/app/src/resource/BotRunner.tsx
+++ b/packages/app/src/resource/BotRunner.tsx
@@ -1,11 +1,11 @@
 import { RefObject } from 'react';
 
 export interface BotRunnerProps {
-  className?: string;
-  iframeRef?: RefObject<HTMLIFrameElement>;
-  testId?: string;
-  minHeight?: string;
-  onChange?: (value: string) => void;
+  readonly className?: string;
+  readonly iframeRef?: RefObject<HTMLIFrameElement>;
+  readonly testId?: string;
+  readonly minHeight?: string;
+  readonly onChange?: (value: string) => void;
 }
 
 export function BotRunner(props: BotRunnerProps): JSX.Element {

--- a/packages/app/src/resource/BotRunner.tsx
+++ b/packages/app/src/resource/BotRunner.tsx
@@ -5,7 +5,6 @@ export interface BotRunnerProps {
   readonly iframeRef?: RefObject<HTMLIFrameElement>;
   readonly testId?: string;
   readonly minHeight?: string;
-  readonly onChange?: (value: string) => void;
 }
 
 export function BotRunner(props: BotRunnerProps): JSX.Element {

--- a/packages/app/src/resource/CodeEditor.tsx
+++ b/packages/app/src/resource/CodeEditor.tsx
@@ -2,12 +2,12 @@ import { RefObject } from 'react';
 import { sendCommand } from '../utils';
 
 export interface CodeEditorProps {
-  language: 'typescript' | 'json';
-  module?: 'commonjs' | 'esnext';
-  defaultValue?: string;
-  iframeRef: RefObject<HTMLIFrameElement>;
-  testId?: string;
-  minHeight?: string;
+  readonly language: 'typescript' | 'json';
+  readonly module?: 'commonjs' | 'esnext';
+  readonly defaultValue?: string;
+  readonly iframeRef: RefObject<HTMLIFrameElement>;
+  readonly testId?: string;
+  readonly minHeight?: string;
 }
 
 export function CodeEditor(props: CodeEditorProps): JSX.Element {

--- a/packages/app/src/resource/ProfilesPage.tsx
+++ b/packages/app/src/resource/ProfilesPage.tsx
@@ -100,9 +100,9 @@ export function ProfilesPage(): JSX.Element | null {
 }
 
 type ProfileDetailProps = {
-  profile: SupportedProfileStructureDefinition;
-  resource: Resource;
-  onResourceUpdated: (newResource: Resource) => void;
+  readonly profile: SupportedProfileStructureDefinition;
+  readonly resource: Resource;
+  readonly onResourceUpdated: (newResource: Resource) => void;
 };
 
 const ProfileDetail: React.FC<ProfileDetailProps> = ({ profile, resource, onResourceUpdated }) => {

--- a/packages/docs/src/components/Card.tsx
+++ b/packages/docs/src/components/Card.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from './Card.module.css';
 
 export interface CardProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function Card(props: CardProps): JSX.Element {

--- a/packages/docs/src/components/CardButton.tsx
+++ b/packages/docs/src/components/CardButton.tsx
@@ -2,10 +2,10 @@ import { ReactNode } from 'react';
 import styles from './CardButton.module.css';
 
 export interface CardButtonProps {
-  href: string;
-  alt: string;
-  target?: string;
-  children?: ReactNode;
+  readonly href: string;
+  readonly alt: string;
+  readonly target?: string;
+  readonly children?: ReactNode;
 }
 
 export function CardButton(props: CardButtonProps): JSX.Element {

--- a/packages/docs/src/components/CardContainer.tsx
+++ b/packages/docs/src/components/CardContainer.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from './CardContainer.module.css';
 
 export interface CardContainerProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function CardContainer(props: CardContainerProps): JSX.Element {

--- a/packages/docs/src/components/Container.tsx
+++ b/packages/docs/src/components/Container.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 
 export interface ContainerProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function Container(props: ContainerProps): JSX.Element {

--- a/packages/docs/src/components/HomepageCallout.tsx
+++ b/packages/docs/src/components/HomepageCallout.tsx
@@ -1,10 +1,10 @@
 import styles from './HomepageCallout.module.css';
 
 type HomepageCalloutProps = {
-  title: string;
-  body: string;
-  linkText: string;
-  linkRef: string;
+  readonly title: string;
+  readonly body: string;
+  readonly linkText: string;
+  readonly linkRef: string;
 };
 export default function HomepageCallout(props: HomepageCalloutProps): JSX.Element {
   return (

--- a/packages/docs/src/components/MedplumCodeBlock.tsx
+++ b/packages/docs/src/components/MedplumCodeBlock.tsx
@@ -5,8 +5,8 @@ const BLOCK_START_PATTERN = /^\s*\/\/\s*start-block\s+([A-Za-z_-]*)/;
 const BLOCK_END_PATTERN = /^\s*\/\/\s*end-block\s+([A-Za-z_-]*)/;
 
 interface MedplumCodeBlockProps extends Props {
-  selectLines?: number[][];
-  selectBlocks?: string;
+  readonly selectLines?: number[][];
+  readonly selectBlocks?: string;
 }
 
 export default function MedplumCodeBlock({

--- a/packages/docs/src/components/ProfileCard.tsx
+++ b/packages/docs/src/components/ProfileCard.tsx
@@ -5,13 +5,13 @@ import YouTubeSvg from './youtube.svg';
 import styles from './ProfileCard.module.css';
 
 export interface ProfileCardProps {
-  name: string;
-  title: string;
-  imgUrl: string;
-  linkedInUrl?: string;
-  githubUrl?: string;
-  webUrl?: string;
-  youtubeUrl?: string;
+  readonly name: string;
+  readonly title: string;
+  readonly imgUrl: string;
+  readonly linkedInUrl?: string;
+  readonly githubUrl?: string;
+  readonly webUrl?: string;
+  readonly youtubeUrl?: string;
 }
 
 export function ProfileCard(props: ProfileCardProps): JSX.Element {

--- a/packages/docs/src/components/landing/AnimatedCircle.tsx
+++ b/packages/docs/src/components/landing/AnimatedCircle.tsx
@@ -3,8 +3,8 @@ import { useInView } from 'react-intersection-observer';
 import './animations.css';
 
 export interface AnimatedCircleProps {
-  value: number;
-  suffix?: string;
+  readonly value: number;
+  readonly suffix?: string;
 }
 
 export function AnimatedCircle(props: AnimatedCircleProps): JSX.Element {

--- a/packages/docs/src/components/landing/FeatureGrid.tsx
+++ b/packages/docs/src/components/landing/FeatureGrid.tsx
@@ -2,8 +2,8 @@ import { CSSProperties, ReactNode } from 'react';
 import styles from './FeatureGrid.module.css';
 
 export interface FeatureGridProps {
-  columns: number;
-  children?: ReactNode;
+  readonly columns: number;
+  readonly children?: ReactNode;
 }
 
 export function FeatureGrid(props: FeatureGridProps): JSX.Element {
@@ -15,9 +15,9 @@ export function FeatureGrid(props: FeatureGridProps): JSX.Element {
 }
 
 export interface FeatureProps {
-  imgSrc: string;
-  title: string;
-  children: ReactNode;
+  readonly imgSrc: string;
+  readonly title: string;
+  readonly children: ReactNode;
 }
 
 export function Feature(props: FeatureProps): JSX.Element {

--- a/packages/docs/src/components/landing/Jumbotron.tsx
+++ b/packages/docs/src/components/landing/Jumbotron.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from './Jumbotron.module.css';
 
 export interface JumbotronProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function Jumbotron(props: JumbotronProps): JSX.Element {

--- a/packages/docs/src/components/landing/Section.tsx
+++ b/packages/docs/src/components/landing/Section.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from './Section.module.css';
 
 export interface SectionProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function Section(props: SectionProps): JSX.Element {

--- a/packages/docs/src/components/landing/SectionHeader.tsx
+++ b/packages/docs/src/components/landing/SectionHeader.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import styles from './SectionHeader.module.css';
 
 export interface SectionHeaderProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function SectionHeader(props: SectionHeaderProps): JSX.Element {

--- a/packages/docs/src/components/landing/TestimonialHeader.tsx
+++ b/packages/docs/src/components/landing/TestimonialHeader.tsx
@@ -1,10 +1,10 @@
 import styles from './TestimonialHeader.module.css';
 
 export interface TestimonialHeaderProps {
-  imgSrc: string;
-  name: string;
-  title?: string;
-  twitter?: string;
+  readonly imgSrc: string;
+  readonly name: string;
+  readonly title?: string;
+  readonly twitter?: string;
 }
 
 export function TestimonialHeader(props: TestimonialHeaderProps): JSX.Element {

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
@@ -3,9 +3,9 @@ import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { MepdlumNavigateFunction, reactContext } from './MedplumProvider.context';
 
 export interface MedplumProviderProps {
-  medplum: MedplumClient;
-  navigate?: MepdlumNavigateFunction;
-  children: ReactNode;
+  readonly medplum: MedplumClient;
+  readonly navigate?: MepdlumNavigateFunction;
+  readonly children: ReactNode;
 }
 
 /**

--- a/packages/react/src/AddressDisplay/AddressDisplay.tsx
+++ b/packages/react/src/AddressDisplay/AddressDisplay.tsx
@@ -2,7 +2,7 @@ import { formatAddress } from '@medplum/core';
 import { Address } from '@medplum/fhirtypes';
 
 export interface AddressDisplayProps {
-  value?: Address;
+  readonly value?: Address;
 }
 
 export function AddressDisplay(props: AddressDisplayProps): JSX.Element | null {

--- a/packages/react/src/AnnotationInput/AnnotationInput.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.tsx
@@ -5,9 +5,9 @@ import { useMedplumProfile } from '@medplum/react-hooks';
 import { useState } from 'react';
 
 export interface AnnotationInputProps {
-  name: string;
-  defaultValue?: Annotation;
-  onChange?: (value: Annotation) => void;
+  readonly name: string;
+  readonly defaultValue?: Annotation;
+  readonly onChange?: (value: Annotation) => void;
 }
 
 export function AnnotationInput(props: AnnotationInputProps): JSX.Element {

--- a/packages/react/src/AppShell/AppShell.tsx
+++ b/packages/react/src/AppShell/AppShell.tsx
@@ -9,15 +9,15 @@ import { Header } from './Header';
 import { Navbar, NavbarMenu } from './Navbar';
 
 export interface AppShellProps {
-  logo: ReactNode;
-  pathname?: string;
-  searchParams?: URLSearchParams;
-  headerSearchDisabled?: boolean;
-  version?: string;
-  menus?: NavbarMenu[];
-  children: ReactNode;
-  displayAddBookmark?: boolean;
-  resourceTypeSearchDisabled?: boolean;
+  readonly logo: ReactNode;
+  readonly pathname?: string;
+  readonly searchParams?: URLSearchParams;
+  readonly headerSearchDisabled?: boolean;
+  readonly version?: string;
+  readonly menus?: NavbarMenu[];
+  readonly children: ReactNode;
+  readonly displayAddBookmark?: boolean;
+  readonly resourceTypeSearchDisabled?: boolean;
 }
 
 export function AppShell(props: AppShellProps): JSX.Element {

--- a/packages/react/src/AppShell/Header.tsx
+++ b/packages/react/src/AppShell/Header.tsx
@@ -22,12 +22,12 @@ import classes from './Header.module.css';
 import { HeaderSearchInput } from './HeaderSearchInput';
 
 export interface HeaderProps {
-  pathname?: string;
-  searchParams?: URLSearchParams;
-  headerSearchDisabled?: boolean;
-  logo: ReactNode;
-  version?: string;
-  navbarToggle: () => void;
+  readonly pathname?: string;
+  readonly searchParams?: URLSearchParams;
+  readonly headerSearchDisabled?: boolean;
+  readonly logo: ReactNode;
+  readonly version?: string;
+  readonly navbarToggle: () => void;
 }
 
 export function Header(props: HeaderProps): JSX.Element {

--- a/packages/react/src/AppShell/HeaderSearchInput.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.tsx
@@ -27,8 +27,8 @@ function toOption(resource: HeaderSearchTypes): AsyncAutocompleteOption<HeaderSe
 }
 
 export interface HeaderSearchInputProps {
-  pathname?: string;
-  searchParams?: URLSearchParams;
+  readonly pathname?: string;
+  readonly searchParams?: URLSearchParams;
 }
 
 export function HeaderSearchInput(props: HeaderSearchInputProps): JSX.Element {

--- a/packages/react/src/AppShell/Navbar.tsx
+++ b/packages/react/src/AppShell/Navbar.tsx
@@ -9,23 +9,23 @@ import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
 import classes from './Navbar.module.css';
 
 export interface NavbarLink {
-  icon?: JSX.Element;
-  label?: string;
-  href: string;
+  readonly icon?: JSX.Element;
+  readonly label?: string;
+  readonly href: string;
 }
 
 export interface NavbarMenu {
-  title?: string;
-  links?: NavbarLink[];
+  readonly title?: string;
+  readonly links?: NavbarLink[];
 }
 
 export interface NavbarProps {
-  pathname?: string;
-  searchParams?: URLSearchParams;
-  menus?: NavbarMenu[];
-  closeNavbar: () => void;
-  displayAddBookmark?: boolean;
-  resourceTypeSearchDisabled?: boolean;
+  readonly pathname?: string;
+  readonly searchParams?: URLSearchParams;
+  readonly menus?: NavbarMenu[];
+  readonly closeNavbar: () => void;
+  readonly displayAddBookmark?: boolean;
+  readonly resourceTypeSearchDisabled?: boolean;
 }
 
 export function Navbar(props: NavbarProps): JSX.Element {
@@ -107,10 +107,10 @@ export function Navbar(props: NavbarProps): JSX.Element {
 }
 
 interface NavbarLinkProps {
-  to: string;
-  active: boolean;
-  onClick: MouseEventHandler;
-  children: ReactNode;
+  readonly to: string;
+  readonly active: boolean;
+  readonly onClick: MouseEventHandler;
+  readonly children: ReactNode;
 }
 
 function NavbarLink(props: NavbarLinkProps): JSX.Element {
@@ -126,8 +126,8 @@ function NavbarLink(props: NavbarLinkProps): JSX.Element {
 }
 
 interface NavLinkIconProps {
-  to: string;
-  icon?: JSX.Element;
+  readonly to: string;
+  readonly icon?: JSX.Element;
 }
 
 function NavLinkIcon(props: NavLinkIconProps): JSX.Element {

--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -5,7 +5,7 @@ import { KeyboardEvent, ReactNode, useCallback, useEffect, useRef, useState } fr
 import { killEvent } from '../utils/dom';
 
 export interface AsyncAutocompleteOption<T> extends ComboboxItem {
-  resource: T;
+  readonly resource: T;
 }
 
 export interface AsyncAutocompleteProps<T>

--- a/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
+++ b/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
@@ -2,8 +2,8 @@ import { Attachment } from '@medplum/fhirtypes';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 
 export interface AttachmentArrayDisplayProps {
-  values?: Attachment[];
-  maxWidth?: number;
+  readonly values?: Attachment[];
+  readonly maxWidth?: number;
 }
 
 export function AttachmentArrayDisplay(props: AttachmentArrayDisplayProps): JSX.Element {

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
@@ -7,10 +7,10 @@ import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { killEvent } from '../utils/dom';
 
 export interface AttachmentArrayInputProps {
-  name: string;
-  defaultValue?: Attachment[];
-  arrayElement?: boolean;
-  onChange?: (value: Attachment[]) => void;
+  readonly name: string;
+  readonly defaultValue?: Attachment[];
+  readonly arrayElement?: boolean;
+  readonly onChange?: (value: Attachment[]) => void;
 }
 
 export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Element {

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -5,10 +5,10 @@ import { ChangeEvent, MouseEvent, ReactNode, useRef } from 'react';
 import { killEvent } from '../utils/dom';
 
 export interface AttachmentButtonProps {
-  onUpload: (attachment: Attachment) => void;
-  onUploadStart?: () => void;
-  onUploadProgress?: (e: ProgressEvent) => void;
-  onUploadError?: (outcome: OperationOutcome) => void;
+  readonly onUpload: (attachment: Attachment) => void;
+  readonly onUploadStart?: () => void;
+  readonly onUploadProgress?: (e: ProgressEvent) => void;
+  readonly onUploadError?: (outcome: OperationOutcome) => void;
   children(props: { onClick(e: MouseEvent): void }): ReactNode;
 }
 

--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.tsx
@@ -2,8 +2,8 @@ import { Anchor } from '@mantine/core';
 import { Attachment } from '@medplum/fhirtypes';
 
 export interface AttachmentDisplayProps {
-  value?: Attachment;
-  maxWidth?: number;
+  readonly value?: Attachment;
+  readonly maxWidth?: number;
 }
 
 export function AttachmentDisplay(props: AttachmentDisplayProps): JSX.Element | null {

--- a/packages/react/src/AttachmentInput/AttachmentInput.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.tsx
@@ -6,10 +6,10 @@ import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { killEvent } from '../utils/dom';
 
 export interface AttachmentInputProps {
-  name: string;
-  defaultValue?: Attachment;
-  arrayElement?: boolean;
-  onChange?: (value: Attachment | undefined) => void;
+  readonly name: string;
+  readonly defaultValue?: Attachment;
+  readonly arrayElement?: boolean;
+  readonly onChange?: (value: Attachment | undefined) => void;
 }
 
 export function AttachmentInput(props: AttachmentInputProps): JSX.Element {

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -5,10 +5,10 @@ import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourceProp
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 
 export interface BackboneElementDisplayProps {
-  value: TypedValue;
-  compact?: boolean;
-  ignoreMissingValues?: boolean;
-  link?: boolean;
+  readonly value: TypedValue;
+  readonly compact?: boolean;
+  readonly ignoreMissingValues?: boolean;
+  readonly link?: boolean;
 }
 
 export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.Element | null {

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -6,15 +6,15 @@ import { BackboneElementContext, buildBackboneElementContext } from './BackboneE
 
 export interface BackboneElementInputProps {
   /** Type name the backbone element represents */
-  typeName: string;
+  readonly typeName: string;
   /** (optional) The contents of the resource represented by the backbone element */
-  defaultValue?: any;
+  readonly defaultValue?: any;
   /** (optional) OperationOutcome from the last attempted system action*/
-  outcome?: OperationOutcome;
+  readonly outcome?: OperationOutcome;
   /** (optional) callback function that is called when the value of the backbone element changes */
-  onChange?: (value: any) => void;
+  readonly onChange?: (value: any) => void;
   /** (optional) Profile URL of the structure definition represented by the backbone element */
-  profileUrl?: string;
+  readonly profileUrl?: string;
 }
 
 export function BackboneElementInput(props: BackboneElementInputProps): JSX.Element {

--- a/packages/react/src/BookmarkDialog/BookmarkDialog.tsx
+++ b/packages/react/src/BookmarkDialog/BookmarkDialog.tsx
@@ -6,12 +6,12 @@ import { useMedplum } from '@medplum/react-hooks';
 import { Form } from '../Form/Form';
 
 interface BookmarkDialogProps {
-  pathname: string;
-  searchParams: URLSearchParams;
-  visible: boolean;
-  onOk: () => void;
-  onCancel: () => void;
-  defaultValue?: string;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+  readonly visible: boolean;
+  readonly onOk: () => void;
+  readonly onCancel: () => void;
+  readonly defaultValue?: string;
 }
 export function BookmarkDialog(props: BookmarkDialogProps): JSX.Element | null {
   const medplum = useMedplum();
@@ -61,7 +61,7 @@ export function BookmarkDialog(props: BookmarkDialogProps): JSX.Element | null {
 }
 
 interface SelectMenuProps {
-  config: UserConfiguration | undefined;
+  readonly config: UserConfiguration | undefined;
 }
 
 function SelectMenu(props: SelectMenuProps): JSX.Element {

--- a/packages/react/src/CalendarInput/CalendarInput.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.tsx
@@ -5,14 +5,14 @@ import classes from './CalendarInput.module.css';
 import { getMonthString, getStartMonth } from './CalendarInput.utils';
 
 export interface CalendarInputProps {
-  slots: Slot[];
-  onChangeMonth: (date: Date) => void;
-  onClick: (date: Date) => void;
+  readonly slots: Slot[];
+  readonly onChangeMonth: (date: Date) => void;
+  readonly onClick: (date: Date) => void;
 }
 
 interface CalendarCell {
-  date: Date;
-  available: boolean;
+  readonly date: Date;
+  readonly available: boolean;
 }
 
 type OptionalCalendarCell = CalendarCell | undefined;

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -3,13 +3,13 @@ import { ReactNode, useContext } from 'react';
 import { BackboneElementContext } from '../BackboneElementInput/BackboneElementInput.utils';
 
 export interface CheckboxFormSectionProps {
-  htmlFor?: string;
-  title?: string;
-  description?: string;
-  withAsterisk?: boolean;
-  children?: ReactNode;
-  testId?: string;
-  fhirPath?: string;
+  readonly htmlFor?: string;
+  readonly title?: string;
+  readonly description?: string;
+  readonly withAsterisk?: boolean;
+  readonly children?: ReactNode;
+  readonly testId?: string;
+  readonly fhirPath?: string;
 }
 
 export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Element {

--- a/packages/react/src/CodeInput/CodeInput.tsx
+++ b/packages/react/src/CodeInput/CodeInput.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodeInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
-  defaultValue?: string;
-  onChange?: (value: string | undefined) => void;
+  readonly defaultValue?: string;
+  readonly onChange?: (value: string | undefined) => void;
 }
 
 export function CodeInput(props: CodeInputProps): JSX.Element {

--- a/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.tsx
+++ b/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.tsx
@@ -2,7 +2,7 @@ import { formatCodeableConcept } from '@medplum/core';
 import { CodeableConcept } from '@medplum/fhirtypes';
 
 export interface CodeableConceptDisplayProps {
-  value?: CodeableConcept;
+  readonly value?: CodeableConcept;
 }
 
 export function CodeableConceptDisplay(props: CodeableConceptDisplayProps): JSX.Element {

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodeableConceptInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
-  defaultValue?: CodeableConcept;
-  onChange?: (value: CodeableConcept | undefined) => void;
+  readonly defaultValue?: CodeableConcept;
+  readonly onChange?: (value: CodeableConcept | undefined) => void;
 }
 
 export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Element {

--- a/packages/react/src/CodingDisplay/CodingDisplay.tsx
+++ b/packages/react/src/CodingDisplay/CodingDisplay.tsx
@@ -2,7 +2,7 @@ import { formatCoding } from '@medplum/core';
 import { Coding } from '@medplum/fhirtypes';
 
 export interface CodingDisplayProps {
-  value?: Coding;
+  readonly value?: Coding;
 }
 
 export function CodingDisplay(props: CodingDisplayProps): JSX.Element {

--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodingInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
-  defaultValue?: Coding;
-  onChange?: (value: Coding | undefined) => void;
+  readonly defaultValue?: Coding;
+  readonly onChange?: (value: Coding | undefined) => void;
 }
 
 export function CodingInput(props: CodingInputProps): JSX.Element {

--- a/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.tsx
+++ b/packages/react/src/ContactDetailDisplay/ContactDetailDisplay.tsx
@@ -2,7 +2,7 @@ import { ContactDetail } from '@medplum/fhirtypes';
 import { ContactPointDisplay } from '../ContactPointDisplay/ContactPointDisplay';
 
 export interface ContactDetailDisplayProps {
-  value?: ContactDetail;
+  readonly value?: ContactDetail;
 }
 
 export function ContactDetailDisplay(props: ContactDetailDisplayProps): JSX.Element | null {

--- a/packages/react/src/ContactPointDisplay/ContactPointDisplay.tsx
+++ b/packages/react/src/ContactPointDisplay/ContactPointDisplay.tsx
@@ -1,7 +1,7 @@
 import { ContactPoint } from '@medplum/fhirtypes';
 
 export interface ContactPointDisplayProps {
-  value?: ContactPoint;
+  readonly value?: ContactPoint;
 }
 
 export function ContactPointDisplay(props: ContactPointDisplayProps): JSX.Element | null {

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -6,7 +6,7 @@ import { BackboneElementContext } from '../BackboneElementInput/BackboneElementI
 import { getErrorsForInput } from '../utils/outcomes';
 
 export type ContactPointInputProps = ComplexTypeInputProps<ContactPoint> & {
-  onChange: ((value: ContactPoint | undefined) => void) | undefined;
+  readonly onChange: ((value: ContactPoint | undefined) => void) | undefined;
 };
 
 export function ContactPointInput(props: ContactPointInputProps): JSX.Element {

--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -5,13 +5,13 @@ import { getErrorsForInput } from '../utils/outcomes';
 import { convertIsoToLocal, convertLocalToIso } from './DateTimeInput.utils';
 
 export interface DateTimeInputProps {
-  name?: string;
-  placeholder?: string;
-  defaultValue?: string;
-  autoFocus?: boolean;
-  required?: boolean;
-  outcome?: OperationOutcome;
-  onChange?: (value: string) => void;
+  readonly name?: string;
+  readonly placeholder?: string;
+  readonly defaultValue?: string;
+  readonly autoFocus?: boolean;
+  readonly required?: boolean;
+  readonly outcome?: OperationOutcome;
+  readonly onChange?: (value: string) => void;
 }
 
 /**

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.tsx
@@ -3,7 +3,7 @@ import { Reference, Resource, ResourceType } from '@medplum/fhirtypes';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface DefaultResourceTimelineProps {
-  resource: Resource | Reference;
+  readonly resource: Resource | Reference;
 }
 
 export function DefaultResourceTimeline(props: DefaultResourceTimelineProps): JSX.Element {

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 import classes from './DescriptionList.module.css';
 
 export interface DescriptionListProps {
-  children: ReactNode;
-  compact?: boolean;
+  readonly children: ReactNode;
+  readonly compact?: boolean;
 }
 
 export function DescriptionList(props: DescriptionListProps): JSX.Element {
@@ -13,8 +13,8 @@ export function DescriptionList(props: DescriptionListProps): JSX.Element {
 }
 
 export interface DescriptionListEntryProps {
-  term: string;
-  children: ReactNode;
+  readonly term: string;
+  readonly children: ReactNode;
 }
 
 export function DescriptionListEntry(props: DescriptionListEntryProps): JSX.Element {

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.tsx
@@ -22,9 +22,9 @@ import { StatusBadge } from '../StatusBadge/StatusBadge';
 import classes from './DiagnosticReportDisplay.module.css';
 
 export interface DiagnosticReportDisplayProps {
-  value?: DiagnosticReport | Reference<DiagnosticReport>;
-  hideObservationNotes?: boolean;
-  hideSpecimenInfo?: boolean;
+  readonly value?: DiagnosticReport | Reference<DiagnosticReport>;
+  readonly hideObservationNotes?: boolean;
+  readonly hideSpecimenInfo?: boolean;
 }
 
 DiagnosticReportDisplay.defaultProps = {
@@ -77,7 +77,7 @@ export function DiagnosticReportDisplay(props: DiagnosticReportDisplayProps): JS
 }
 
 interface DiagnosticReportHeaderProps {
-  value: DiagnosticReport;
+  readonly value: DiagnosticReport;
 }
 
 function DiagnosticReportHeader({ value }: DiagnosticReportHeaderProps): JSX.Element {
@@ -153,9 +153,9 @@ function SpecimenInfo(specimens: Specimen[] | undefined): JSX.Element {
 }
 
 export interface ObservationTableProps {
-  value?: Observation[] | Reference<Observation>[];
-  ancestorIds?: string[];
-  hideObservationNotes?: boolean;
+  readonly value?: Observation[] | Reference<Observation>[];
+  readonly ancestorIds?: string[];
+  readonly hideObservationNotes?: boolean;
 }
 
 export function ObservationTable(props: ObservationTableProps): JSX.Element {
@@ -184,9 +184,9 @@ export function ObservationTable(props: ObservationTableProps): JSX.Element {
 }
 
 interface ObservationRowGroupProps {
-  value?: Observation[] | Reference<Observation>[];
-  ancestorIds?: string[];
-  hideObservationNotes?: boolean;
+  readonly value?: Observation[] | Reference<Observation>[];
+  readonly ancestorIds?: string[];
+  readonly hideObservationNotes?: boolean;
 }
 
 function ObservationRowGroup(props: ObservationRowGroupProps): JSX.Element {
@@ -205,9 +205,9 @@ function ObservationRowGroup(props: ObservationRowGroupProps): JSX.Element {
 }
 
 interface ObservationRowProps {
-  value: Observation | Reference<Observation>;
-  ancestorIds?: string[];
-  hideObservationNotes?: boolean;
+  readonly value: Observation | Reference<Observation>;
+  readonly ancestorIds?: string[];
+  readonly hideObservationNotes?: boolean;
 }
 
 function ObservationRow(props: ObservationRowProps): JSX.Element | null {
@@ -277,7 +277,7 @@ function ObservationRow(props: ObservationRowProps): JSX.Element | null {
 }
 
 interface ObservationValueDisplayProps {
-  value?: Observation | ObservationComponent;
+  readonly value?: Observation | ObservationComponent;
 }
 
 function ObservationValueDisplay(props: ObservationValueDisplayProps): JSX.Element | null {
@@ -286,7 +286,7 @@ function ObservationValueDisplay(props: ObservationValueDisplayProps): JSX.Eleme
 }
 
 interface ReferenceRangeProps {
-  value?: ObservationReferenceRange[];
+  readonly value?: ObservationReferenceRange[];
 }
 
 function ReferenceRangeDisplay(props: ReferenceRangeProps): JSX.Element | null {

--- a/packages/react/src/ElementsInput/ElementsInput.tsx
+++ b/packages/react/src/ElementsInput/ElementsInput.tsx
@@ -13,12 +13,12 @@ const EXTENSION_KEYS = new Set(['extension', 'modifierExtension']);
 const IGNORED_PROPERTIES = new Set(['id', ...DEFAULT_IGNORED_PROPERTIES].filter((prop) => !EXTENSION_KEYS.has(prop)));
 
 export interface ElementsInputProps {
-  type: string | undefined;
-  elements: { [key: string]: InternalSchemaElement };
-  defaultValue: any;
-  outcome: OperationOutcome | undefined;
-  onChange: ((value: any) => void) | undefined;
-  testId?: string;
+  readonly type: string | undefined;
+  readonly elements: { [key: string]: InternalSchemaElement };
+  readonly defaultValue: any;
+  readonly outcome: OperationOutcome | undefined;
+  readonly onChange: ((value: any) => void) | undefined;
+  readonly testId?: string;
 }
 
 export function ElementsInput(props: ElementsInputProps): JSX.Element {

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.tsx
@@ -3,7 +3,7 @@ import { Attachment, Encounter, Reference, ResourceType } from '@medplum/fhirtyp
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface EncounterTimelineProps {
-  encounter: Encounter | Reference<Encounter>;
+  readonly encounter: Encounter | Reference<Encounter>;
 }
 
 export function EncounterTimeline(props: EncounterTimelineProps): JSX.Element {

--- a/packages/react/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorBoundary.tsx
@@ -4,12 +4,12 @@ import { IconAlertCircle } from '@tabler/icons-react';
 import { Component, ErrorInfo, ReactNode } from 'react';
 
 export interface ErrorBoundaryProps {
-  children: ReactNode;
+  readonly children: ReactNode;
 }
 
 export interface ErrorBoundaryState {
-  error?: Error;
-  lastLocation: string;
+  readonly error?: Error;
+  readonly lastLocation: string;
 }
 
 /**
@@ -17,7 +17,7 @@ export interface ErrorBoundaryState {
  * See: https://reactjs.org/docs/error-boundaries.html
  */
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState;
+  readonly state: ErrorBoundaryState;
 
   constructor(props: ErrorBoundaryProps) {
     super(props);
@@ -28,7 +28,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { error, lastLocation: window.location.toString() };
   }
 
-  componentDidUpdate(_prevProps: Readonly<ErrorBoundaryProps>, _prevState: Readonly<ErrorBoundaryState>): void {
+  componentDidUpdate(_prevProps: ErrorBoundaryProps, _prevState: ErrorBoundaryState): void {
     if (window.location.toString() !== this.state.lastLocation) {
       this.setState({
         lastLocation: window.location.toString(),
@@ -37,7 +37,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     }
   }
 
-  shouldComponentUpdate(nextProps: Readonly<ErrorBoundaryProps>, nextState: Readonly<ErrorBoundaryState>): boolean {
+  shouldComponentUpdate(nextProps: ErrorBoundaryProps, nextState: ErrorBoundaryState): boolean {
     if (this.props.children !== nextProps.children) {
       return true;
     }

--- a/packages/react/src/ExtensionInput/ExtensionInput.tsx
+++ b/packages/react/src/ExtensionInput/ExtensionInput.tsx
@@ -7,7 +7,7 @@ import { BackboneElementInput } from '../BackboneElementInput/BackboneElementInp
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export type ExtensionInputProps = ComplexTypeInputProps<Extension> & {
-  propertyType: ElementDefinitionType;
+  readonly propertyType: ElementDefinitionType;
 };
 
 export function ExtensionInput(props: ExtensionInputProps): JSX.Element | null {

--- a/packages/react/src/FhirPathDisplay/FhirPathDisplay.tsx
+++ b/packages/react/src/FhirPathDisplay/FhirPathDisplay.tsx
@@ -3,9 +3,9 @@ import { Resource } from '@medplum/fhirtypes';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 
 export interface FhirPathDisplayProps {
-  resource: Resource;
-  path: string;
-  propertyType: string;
+  readonly resource: Resource;
+  readonly path: string;
+  readonly propertyType: string;
 }
 
 export function FhirPathDisplay(props: FhirPathDisplayProps): JSX.Element | null {

--- a/packages/react/src/FhirPathTable/FhirPathTable.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.tsx
@@ -14,17 +14,17 @@ export interface FhirPathTableField {
 }
 
 export interface FhirPathTableProps {
-  resourceType: string;
-  query: string;
-  fields: FhirPathTableField[];
-  checkboxesEnabled?: boolean;
-  onClick?: (e: SearchClickEvent) => void;
-  onAuxClick?: (e: SearchClickEvent) => void;
-  onBulk?: (ids: string[]) => void;
+  readonly resourceType: string;
+  readonly query: string;
+  readonly fields: FhirPathTableField[];
+  readonly checkboxesEnabled?: boolean;
+  readonly onClick?: (e: SearchClickEvent) => void;
+  readonly onAuxClick?: (e: SearchClickEvent) => void;
+  readonly onBulk?: (ids: string[]) => void;
 }
 
 export interface SmartSearchResponse {
-  data: {
+  readonly data: {
     ResourceList: Resource[];
   };
 }

--- a/packages/react/src/Form/Form.tsx
+++ b/packages/react/src/Form/Form.tsx
@@ -2,10 +2,10 @@ import { CSSProperties, ReactNode, SyntheticEvent } from 'react';
 import { parseForm } from './FormUtils';
 
 export interface FormProps {
-  onSubmit?: (formData: Record<string, string>) => void;
-  style?: CSSProperties;
-  children?: ReactNode;
-  testid?: string;
+  readonly onSubmit?: (formData: Record<string, string>) => void;
+  readonly style?: CSSProperties;
+  readonly children?: ReactNode;
+  readonly testid?: string;
 }
 
 export function Form(props: FormProps): JSX.Element {

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -5,14 +5,14 @@ import { getErrorsForInput } from '../utils/outcomes';
 import { BackboneElementContext } from '../BackboneElementInput/BackboneElementInput.utils';
 
 export interface FormSectionProps {
-  title?: string;
-  htmlFor?: string;
-  description?: string;
-  withAsterisk?: boolean;
-  outcome?: OperationOutcome;
-  children?: ReactNode;
-  testId?: string;
-  fhirPath?: string;
+  readonly title?: string;
+  readonly htmlFor?: string;
+  readonly description?: string;
+  readonly withAsterisk?: boolean;
+  readonly outcome?: OperationOutcome;
+  readonly children?: ReactNode;
+  readonly testId?: string;
+  readonly fhirPath?: string;
 }
 
 export function FormSection(props: FormSectionProps): JSX.Element {

--- a/packages/react/src/GoogleButton/GoogleButton.tsx
+++ b/packages/react/src/GoogleButton/GoogleButton.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createScriptTag } from '../utils/script';
 
 interface GoogleApi {
-  accounts: {
+  readonly accounts: {
     id: {
       initialize: (args: any) => void;
       renderButton: (parent: HTMLElement, args: any) => void;

--- a/packages/react/src/HumanNameDisplay/HumanNameDisplay.tsx
+++ b/packages/react/src/HumanNameDisplay/HumanNameDisplay.tsx
@@ -2,8 +2,8 @@ import { formatHumanName, HumanNameFormatOptions } from '@medplum/core';
 import { HumanName } from '@medplum/fhirtypes';
 
 export interface HumanNameDisplayProps {
-  value?: HumanName;
-  options?: HumanNameFormatOptions;
+  readonly value?: HumanName;
+  readonly options?: HumanNameFormatOptions;
 }
 
 export function HumanNameDisplay(props: HumanNameDisplayProps): JSX.Element | null {

--- a/packages/react/src/IdentifierDisplay/IdentifierDisplay.tsx
+++ b/packages/react/src/IdentifierDisplay/IdentifierDisplay.tsx
@@ -1,7 +1,7 @@
 import { Identifier } from '@medplum/fhirtypes';
 
 export interface IdentifierDisplayProps {
-  value?: Identifier;
+  readonly value?: Identifier;
 }
 
 export function IdentifierDisplay(props: IdentifierDisplayProps): JSX.Element {

--- a/packages/react/src/Logo/Logo.tsx
+++ b/packages/react/src/Logo/Logo.tsx
@@ -1,6 +1,6 @@
 export interface LogoProps {
-  size: number;
-  fill?: string;
+  readonly size: number;
+  readonly fill?: string;
 }
 
 export function Logo(props: LogoProps): JSX.Element {

--- a/packages/react/src/MedplumLink/MedplumLink.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.tsx
@@ -6,11 +6,11 @@ import { MouseEvent, MouseEventHandler, ReactNode } from 'react';
 import { killEvent } from '../utils/dom';
 
 export interface MedplumLinkProps extends TextProps {
-  to?: Resource | Reference | string;
-  suffix?: string;
-  label?: string;
-  onClick?: MouseEventHandler;
-  children: ReactNode;
+  readonly to?: Resource | Reference | string;
+  readonly suffix?: string;
+  readonly label?: string;
+  readonly onClick?: MouseEventHandler;
+  readonly children: ReactNode;
 }
 
 export function MedplumLink(props: MedplumLinkProps): JSX.Element {

--- a/packages/react/src/MoneyDisplay/MoneyDisplay.tsx
+++ b/packages/react/src/MoneyDisplay/MoneyDisplay.tsx
@@ -2,7 +2,7 @@ import { formatMoney } from '@medplum/core';
 import { Money } from '@medplum/fhirtypes';
 
 export interface MoneyDisplayProps {
-  value?: Money;
+  readonly value?: Money;
 }
 
 export function MoneyDisplay(props: MoneyDisplayProps): JSX.Element | null {

--- a/packages/react/src/MoneyInput/MoneyInput.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.tsx
@@ -81,6 +81,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
   return (
     <TextInput
       type="number"
+      name={props.name}
       label={props.label}
       placeholder={props.placeholder ?? 'Value'}
       defaultValue={value?.value?.toString() ?? 'USD'}

--- a/packages/react/src/MoneyInput/MoneyInput.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.tsx
@@ -21,11 +21,11 @@ import { ChangeEvent, useCallback, useState } from 'react';
 const data = ['USD', 'EUR', 'CAD', 'GBP', 'AUD'];
 
 export interface MoneyInputProps {
-  name: string;
-  label?: string;
-  placeholder?: string;
-  defaultValue?: Money;
-  onChange?: (value: Money) => void;
+  readonly name: string;
+  readonly label?: string;
+  readonly placeholder?: string;
+  readonly defaultValue?: Money;
+  readonly onChange?: (value: Money) => void;
 }
 
 export function MoneyInput(props: MoneyInputProps): JSX.Element {

--- a/packages/react/src/NoteDisplay/NoteDisplay.tsx
+++ b/packages/react/src/NoteDisplay/NoteDisplay.tsx
@@ -3,7 +3,7 @@ import { Annotation } from '@medplum/fhirtypes';
 import classes from './NoteDisplay.module.css';
 
 export interface NoteDisplayProps {
-  value?: Annotation[];
+  readonly value?: Annotation[];
 }
 
 export function NoteDisplay({ value }: NoteDisplayProps): JSX.Element | null {

--- a/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
+++ b/packages/react/src/OperationOutcomeAlert/OperationOutcomeAlert.tsx
@@ -4,8 +4,8 @@ import { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { IconAlertCircle } from '@tabler/icons-react';
 
 export interface OperationOutcomeAlertProps {
-  outcome?: OperationOutcome;
-  issues?: OperationOutcomeIssue[];
+  readonly outcome?: OperationOutcome;
+  readonly issues?: OperationOutcomeIssue[];
 }
 
 export function OperationOutcomeAlert(props: OperationOutcomeAlertProps): JSX.Element | null {

--- a/packages/react/src/Panel/Panel.tsx
+++ b/packages/react/src/Panel/Panel.tsx
@@ -3,14 +3,14 @@ import cx from 'clsx';
 import classes from './Panel.module.css';
 
 export interface PanelStylesParams {
-  width?: number;
-  fill?: boolean;
+  readonly width?: number;
+  readonly fill?: boolean;
 }
 
 export interface PanelProps extends PaperProps {
-  width?: number;
-  fill?: boolean;
-  children?: React.ReactNode;
+  readonly width?: number;
+  readonly fill?: boolean;
+  readonly children?: React.ReactNode;
 }
 
 export function Panel(props: PanelProps): JSX.Element {

--- a/packages/react/src/PatientTimeline/PatientTimeline.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface PatientTimelineProps {
-  patient: Patient | Reference<Patient>;
+  readonly patient: Patient | Reference<Patient>;
 }
 
 export function PatientTimeline(props: PatientTimelineProps): JSX.Element {

--- a/packages/react/src/PeriodInput/PeriodInput.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 
 export interface PeriodInputProps {
-  name: string;
-  defaultValue?: Period;
-  onChange?: (value: Period) => void;
+  readonly name: string;
+  readonly defaultValue?: Period;
+  readonly onChange?: (value: Period) => void;
 }
 
 export function PeriodInput(props: PeriodInputProps): JSX.Element {

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.tsx
@@ -16,8 +16,8 @@ import { killEvent } from '../utils/dom';
 import classes from './PlanDefinitionBuilder.module.css';
 
 export interface PlanDefinitionBuilderProps {
-  value: Partial<PlanDefinition> | Reference<PlanDefinition>;
-  onSubmit: (result: PlanDefinition) => void;
+  readonly value: Partial<PlanDefinition> | Reference<PlanDefinition>;
+  readonly onSubmit: (result: PlanDefinition) => void;
 }
 
 export function PlanDefinitionBuilder(props: PlanDefinitionBuilderProps): JSX.Element | null {
@@ -90,12 +90,12 @@ export function PlanDefinitionBuilder(props: PlanDefinitionBuilderProps): JSX.El
 }
 
 interface ActionArrayBuilderProps {
-  actions: PlanDefinitionAction[];
-  selectedKey: string | undefined;
-  setSelectedKey: (key: string | undefined) => void;
-  hoverKey: string | undefined;
-  setHoverKey: (key: string | undefined) => void;
-  onChange: (actions: PlanDefinitionAction[]) => void;
+  readonly actions: PlanDefinitionAction[];
+  readonly selectedKey: string | undefined;
+  readonly setSelectedKey: (key: string | undefined) => void;
+  readonly hoverKey: string | undefined;
+  readonly setHoverKey: (key: string | undefined) => void;
+  readonly onChange: (actions: PlanDefinitionAction[]) => void;
 }
 
 function ActionArrayBuilder(props: ActionArrayBuilderProps): JSX.Element {
@@ -148,13 +148,13 @@ function ActionArrayBuilder(props: ActionArrayBuilderProps): JSX.Element {
 }
 
 interface ActionBuilderProps {
-  action: PlanDefinitionAction;
-  selectedKey: string | undefined;
-  setSelectedKey: (key: string | undefined) => void;
-  hoverKey: string | undefined;
-  setHoverKey: (key: string | undefined) => void;
-  onChange: (action: PlanDefinitionAction) => void;
-  onRemove: () => void;
+  readonly action: PlanDefinitionAction;
+  readonly selectedKey: string | undefined;
+  readonly setSelectedKey: (key: string | undefined) => void;
+  readonly hoverKey: string | undefined;
+  readonly setHoverKey: (key: string | undefined) => void;
+  readonly onChange: (action: PlanDefinitionAction) => void;
+  readonly onRemove: () => void;
 }
 
 function ActionBuilder(props: ActionBuilderProps): JSX.Element {
@@ -220,8 +220,8 @@ const timingProperty: InternalSchemaElement = {
 };
 
 interface ActionDisplayProps {
-  action: PlanDefinitionAction;
-  actionType: string | undefined;
+  readonly action: PlanDefinitionAction;
+  readonly actionType: string | undefined;
 }
 
 function ActionDisplay(props: ActionDisplayProps): JSX.Element {
@@ -247,14 +247,14 @@ function ActionDisplay(props: ActionDisplayProps): JSX.Element {
 }
 
 interface ActionEditorProps {
-  action: PlanDefinitionAction;
-  actionType: string | undefined;
-  selectedKey: string | undefined;
-  setSelectedKey: (key: string | undefined) => void;
-  hoverKey: string | undefined;
-  setHoverKey: (key: string | undefined) => void;
-  onChange: (action: PlanDefinitionAction) => void;
-  onRemove: () => void;
+  readonly action: PlanDefinitionAction;
+  readonly actionType: string | undefined;
+  readonly selectedKey: string | undefined;
+  readonly setSelectedKey: (key: string | undefined) => void;
+  readonly hoverKey: string | undefined;
+  readonly setHoverKey: (key: string | undefined) => void;
+  readonly onChange: (action: PlanDefinitionAction) => void;
+  readonly onRemove: () => void;
 }
 
 function ActionEditor(props: ActionEditorProps): JSX.Element {
@@ -354,11 +354,11 @@ function ActionEditor(props: ActionEditorProps): JSX.Element {
 }
 
 interface ActionResourceTypeBuilderProps {
-  action: PlanDefinitionAction;
-  title: string;
-  description: string;
-  resourceType: ResourceType;
-  onChange: (action: PlanDefinitionAction) => void;
+  readonly action: PlanDefinitionAction;
+  readonly title: string;
+  readonly description: string;
+  readonly resourceType: ResourceType;
+  readonly onChange: (action: PlanDefinitionAction) => void;
 }
 
 function ActionResourceTypeBuilder(props: ActionResourceTypeBuilderProps): JSX.Element {
@@ -384,9 +384,9 @@ function ActionResourceTypeBuilder(props: ActionResourceTypeBuilderProps): JSX.E
 }
 
 interface ActionTimingInputProps {
-  name: string;
-  action: PlanDefinitionAction;
-  onChange: (action: PlanDefinitionAction) => void;
+  readonly name: string;
+  readonly action: PlanDefinitionAction;
+  readonly onChange: (action: PlanDefinitionAction) => void;
 }
 
 function ActionTimingInput(props: ActionTimingInputProps): JSX.Element {

--- a/packages/react/src/QuantityDisplay/QuantityDisplay.tsx
+++ b/packages/react/src/QuantityDisplay/QuantityDisplay.tsx
@@ -2,7 +2,7 @@ import { formatQuantity } from '@medplum/core';
 import { Quantity } from '@medplum/fhirtypes';
 
 export interface QuantityDisplayProps {
-  value?: Quantity;
+  readonly value?: Quantity;
 }
 
 export function QuantityDisplay(props: QuantityDisplayProps): JSX.Element | null {

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -3,12 +3,12 @@ import { Quantity } from '@medplum/fhirtypes';
 import { useState, WheelEvent } from 'react';
 
 export interface QuantityInputProps {
-  name: string;
-  defaultValue?: Quantity;
-  autoFocus?: boolean;
-  required?: boolean;
-  onChange?: (value: Quantity) => void;
-  disableWheel?: boolean;
+  readonly name: string;
+  readonly defaultValue?: Quantity;
+  readonly autoFocus?: boolean;
+  readonly required?: boolean;
+  readonly onChange?: (value: Quantity) => void;
+  readonly disableWheel?: boolean;
 }
 
 export function QuantityInput(props: QuantityInputProps): JSX.Element {

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -27,9 +27,9 @@ import {
 import classes from './QuestionnaireBuilder.module.css';
 
 export interface QuestionnaireBuilderProps {
-  questionnaire: Partial<Questionnaire> | Reference<Questionnaire>;
-  onSubmit: (result: Questionnaire) => void;
-  autoSave?: boolean;
+  readonly questionnaire: Partial<Questionnaire> | Reference<Questionnaire>;
+  readonly onSubmit: (result: Questionnaire) => void;
+  readonly autoSave?: boolean;
 }
 
 export function QuestionnaireBuilder(props: QuestionnaireBuilderProps): JSX.Element | null {
@@ -94,16 +94,16 @@ export function QuestionnaireBuilder(props: QuestionnaireBuilderProps): JSX.Elem
 }
 
 interface ItemBuilderProps<T extends Questionnaire | QuestionnaireItem> {
-  item: T;
-  selectedKey: string | undefined;
-  setSelectedKey: (key: string | undefined) => void;
-  hoverKey: string | undefined;
-  isFirst?: boolean;
-  isLast?: boolean;
-  setHoverKey: (key: string | undefined) => void;
-  onChange: (item: T, disableSubmit?: boolean) => void;
-  onRemove?: () => void;
-  onRepeatable?: (item: QuestionnaireItem) => void;
+  readonly item: T;
+  readonly selectedKey: string | undefined;
+  readonly setSelectedKey: (key: string | undefined) => void;
+  readonly hoverKey: string | undefined;
+  readonly isFirst?: boolean;
+  readonly isLast?: boolean;
+  readonly setHoverKey: (key: string | undefined) => void;
+  readonly onChange: (item: T, disableSubmit?: boolean) => void;
+  readonly onRemove?: () => void;
+  readonly onRepeatable?: (item: QuestionnaireItem) => void;
   onMoveUp?(): void;
   onMoveDown?(): void;
 }
@@ -398,8 +398,8 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
 }
 
 interface AnswerBuilderProps {
-  item: QuestionnaireItem;
-  onChange: (item: QuestionnaireItem) => void;
+  readonly item: QuestionnaireItem;
+  readonly onChange: (item: QuestionnaireItem) => void;
 }
 
 function AnswerBuilder(props: AnswerBuilderProps): JSX.Element {
@@ -455,10 +455,10 @@ function AnswerBuilder(props: AnswerBuilderProps): JSX.Element {
 }
 
 interface AnswerOptionsInputProps {
-  options: QuestionnaireItemAnswerOption[];
-  property: any;
-  item: QuestionnaireItem;
-  onChange: (item: QuestionnaireItem) => void;
+  readonly options: QuestionnaireItemAnswerOption[];
+  readonly property: any;
+  readonly item: QuestionnaireItem;
+  readonly onChange: (item: QuestionnaireItem) => void;
 }
 
 function AnswerOptionsInput(props: AnswerOptionsInputProps): JSX.Element {
@@ -522,8 +522,8 @@ function AnswerOptionsInput(props: AnswerOptionsInputProps): JSX.Element {
 }
 
 interface ReferenceTypeProps {
-  item: QuestionnaireItem;
-  onChange: (updatedItem: QuestionnaireItem) => void;
+  readonly item: QuestionnaireItem;
+  readonly onChange: (updatedItem: QuestionnaireItem) => void;
 }
 
 function ReferenceProfiles(props: ReferenceTypeProps): JSX.Element {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -16,11 +16,11 @@ import { QuestionnaireFormContext } from './QuestionnaireForm.context';
 import { QuestionnairePageSequence } from './QuestionnaireFormComponents/QuestionnaireFormPageSequence';
 
 export interface QuestionnaireFormProps {
-  questionnaire: Questionnaire | Reference<Questionnaire>;
-  subject?: Reference;
-  encounter?: Reference<Encounter>;
-  submitButtonText?: string;
-  onSubmit: (response: QuestionnaireResponse) => void;
+  readonly questionnaire: Questionnaire | Reference<Questionnaire>;
+  readonly subject?: Reference;
+  readonly encounter?: Reference<Encounter>;
+  readonly submitButtonText?: string;
+  readonly onSubmit: (response: QuestionnaireResponse) => void;
 }
 
 export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | null {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -34,10 +34,10 @@ import {
 import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
 
 export interface QuestionnaireFormItemProps {
-  item: QuestionnaireItem;
-  index: number;
-  response: QuestionnaireResponseItem;
-  onChange: (newResponseItem: QuestionnaireResponseItem) => void;
+  readonly item: QuestionnaireItem;
+  readonly index: number;
+  readonly response: QuestionnaireResponseItem;
+  readonly onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }
 
 export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.Element | null {
@@ -235,11 +235,13 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
 }
 
 interface QuestionnaireChoiceInputProps {
-  name: string;
-  item: QuestionnaireItem;
-  initial: QuestionnaireItemInitial | undefined;
-  response: QuestionnaireResponseItem;
-  onChangeAnswer: (newResponseAnswer: QuestionnaireResponseItemAnswer | QuestionnaireResponseItemAnswer[]) => void;
+  readonly name: string;
+  readonly item: QuestionnaireItem;
+  readonly initial: QuestionnaireItemInitial | undefined;
+  readonly response: QuestionnaireResponseItem;
+  readonly onChangeAnswer: (
+    newResponseAnswer: QuestionnaireResponseItemAnswer | QuestionnaireResponseItemAnswer[]
+  ) => void;
 }
 
 function QuestionnaireChoiceDropDownInput(props: QuestionnaireChoiceInputProps): JSX.Element {
@@ -450,13 +452,13 @@ function isDropDownChoice(item: QuestionnaireItem): boolean {
 }
 
 interface MultiSelect {
-  value: any;
-  label: any;
+  readonly value: any;
+  readonly label: any;
 }
 
 interface FormattedData {
-  propertyName: string;
-  data: MultiSelect[];
+  readonly propertyName: string;
+  readonly data: MultiSelect[];
 }
 
 function formatSelectData(item: QuestionnaireItem): FormattedData {

--- a/packages/react/src/RangeDisplay/RangeDisplay.tsx
+++ b/packages/react/src/RangeDisplay/RangeDisplay.tsx
@@ -2,7 +2,7 @@ import { formatRange } from '@medplum/core';
 import { Range } from '@medplum/fhirtypes';
 
 export interface RangeDisplayProps {
-  value?: Range;
+  readonly value?: Range;
 }
 
 export function RangeDisplay(props: RangeDisplayProps): JSX.Element | null {

--- a/packages/react/src/RangeInput/RangeInput.tsx
+++ b/packages/react/src/RangeInput/RangeInput.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
 
 export interface RangeInputProps {
-  name: string;
-  defaultValue?: Range;
-  onChange?: (value: Range) => void;
+  readonly name: string;
+  readonly defaultValue?: Range;
+  readonly onChange?: (value: Range) => void;
 }
 
 /**

--- a/packages/react/src/RatioDisplay/RatioDisplay.tsx
+++ b/packages/react/src/RatioDisplay/RatioDisplay.tsx
@@ -2,7 +2,7 @@ import { Ratio } from '@medplum/fhirtypes';
 import { QuantityDisplay } from '../QuantityDisplay/QuantityDisplay';
 
 export interface RatioDisplayProps {
-  value?: Ratio;
+  readonly value?: Ratio;
 }
 
 export function RatioDisplay(props: RatioDisplayProps): JSX.Element | null {

--- a/packages/react/src/RatioInput/RatioInput.tsx
+++ b/packages/react/src/RatioInput/RatioInput.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
 
 export interface RatioInputProps {
-  name: string;
-  defaultValue?: Ratio;
-  onChange?: (value: Ratio) => void;
+  readonly name: string;
+  readonly defaultValue?: Ratio;
+  readonly onChange?: (value: Ratio) => void;
 }
 
 /**

--- a/packages/react/src/ReferenceDisplay/ReferenceDisplay.tsx
+++ b/packages/react/src/ReferenceDisplay/ReferenceDisplay.tsx
@@ -3,8 +3,8 @@ import { Reference } from '@medplum/fhirtypes';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface ReferenceDisplayProps {
-  value?: Reference;
-  link?: boolean;
+  readonly value?: Reference;
+  readonly link?: boolean;
 }
 
 export function ReferenceDisplay(props: ReferenceDisplayProps): JSX.Element | null {

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -15,31 +15,31 @@ import { ResourceInput } from '../ResourceInput/ResourceInput';
 import { ResourceTypeInput } from '../ResourceTypeInput/ResourceTypeInput';
 
 export interface ReferenceInputProps {
-  name: string;
-  placeholder?: string;
-  defaultValue?: Reference;
-  targetTypes?: string[];
-  searchCriteria?: Record<string, string>;
-  autoFocus?: boolean;
-  required?: boolean;
-  onChange?: (value: Reference | undefined) => void;
+  readonly name: string;
+  readonly placeholder?: string;
+  readonly defaultValue?: Reference;
+  readonly targetTypes?: string[];
+  readonly searchCriteria?: Record<string, string>;
+  readonly autoFocus?: boolean;
+  readonly required?: boolean;
+  readonly onChange?: (value: Reference | undefined) => void;
 }
 
 interface BaseTargetType {
-  value: string;
+  readonly value: string;
 }
 
 type ProfileTargetType = BaseTargetType & {
-  type: 'profile';
-  name?: string;
-  title?: string;
-  resourceType?: string;
-  error?: any;
+  readonly type: 'profile';
+  readonly name?: string;
+  readonly title?: string;
+  readonly resourceType?: string;
+  readonly error?: any;
 };
 
 type ResourceTypeTargetType = BaseTargetType & {
-  type: 'resourceType';
-  resourceType: string;
+  readonly type: 'resourceType';
+  readonly resourceType: string;
 };
 type TargetType = ResourceTypeTargetType | ProfileTargetType;
 

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
@@ -13,8 +13,8 @@ import classes from './ReferenceRangeEditor.module.css';
 const intervalFilters = ['gender', 'age', 'gestationalAge', 'context', 'appliesTo', 'category'] as const;
 
 export interface ReferenceRangeEditorProps {
-  definition: ObservationDefinition;
-  onSubmit: (result: ObservationDefinition) => void;
+  readonly definition: ObservationDefinition;
+  readonly onSubmit: (result: ObservationDefinition) => void;
 }
 
 // Helper type that groups of qualified intervals by equal filter criteria
@@ -159,12 +159,12 @@ export function ReferenceRangeEditor(props: ReferenceRangeEditorProps): JSX.Elem
  * that have the same filter values
  */
 export interface ReferenceRangeGroupEditorProps {
-  intervalGroup: IntervalGroup;
-  unit: string | undefined;
-  onChange: (groupId: string, changed: ObservationDefinitionQualifiedInterval) => void;
-  onAdd: (groupId: string, added: ObservationDefinitionQualifiedInterval) => void;
-  onRemove: (groupId: string, removed: ObservationDefinitionQualifiedInterval) => void;
-  onRemoveGroup: (removedGroup: IntervalGroup) => void;
+  readonly intervalGroup: IntervalGroup;
+  readonly unit: string | undefined;
+  readonly onChange: (groupId: string, changed: ObservationDefinitionQualifiedInterval) => void;
+  readonly onAdd: (groupId: string, added: ObservationDefinitionQualifiedInterval) => void;
+  readonly onRemove: (groupId: string, removed: ObservationDefinitionQualifiedInterval) => void;
+  readonly onRemoveGroup: (removedGroup: IntervalGroup) => void;
 }
 
 export function ReferenceRangeGroupEditor(props: ReferenceRangeGroupEditorProps): JSX.Element {
@@ -250,8 +250,8 @@ export function ReferenceRangeGroupEditor(props: ReferenceRangeGroupEditorProps)
 }
 
 interface ReferenceRangeGroupFiltersProps {
-  intervalGroup: IntervalGroup;
-  onChange: ReferenceRangeGroupEditorProps['onChange'];
+  readonly intervalGroup: IntervalGroup;
+  readonly onChange: ReferenceRangeGroupEditorProps['onChange'];
 }
 
 /**

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.tsx
@@ -8,9 +8,9 @@ import { ResourceName } from '../ResourceName/ResourceName';
 import { StatusBadge } from '../StatusBadge/StatusBadge';
 
 export interface RequestGroupDisplayProps {
-  value?: RequestGroup | Reference<RequestGroup>;
-  onStart: (task: Task, input: Reference) => void;
-  onEdit: (task: Task, input: Reference, output: Reference) => void;
+  readonly value?: RequestGroup | Reference<RequestGroup>;
+  readonly onStart: (task: Task, input: Reference) => void;
+  readonly onEdit: (task: Task, input: Reference, output: Reference) => void;
 }
 
 export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Element | null {

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -2,11 +2,11 @@ import { InternalSchemaElement } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 
 export interface ResourceArrayDisplayProps {
-  property: InternalSchemaElement;
-  values: any[];
-  arrayElement?: boolean;
-  ignoreMissingValues?: boolean;
-  link?: boolean;
+  readonly property: InternalSchemaElement;
+  readonly values: any[];
+  readonly arrayElement?: boolean;
+  readonly ignoreMissingValues?: boolean;
+  readonly link?: boolean;
 }
 
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element {

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -26,7 +26,6 @@ export interface ResourceArrayInputProps {
   readonly name: string;
   readonly defaultValue?: any[];
   readonly indent?: boolean;
-  readonly arrayElement?: boolean;
   readonly outcome: OperationOutcome | undefined;
   readonly onChange?: (value: any[]) => void;
   readonly hideNonSliceValues?: boolean;

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -22,17 +22,17 @@ import {
 } from './ResourceArrayInput.utils';
 
 export interface ResourceArrayInputProps {
-  property: InternalSchemaElement;
-  name: string;
-  defaultValue?: any[];
-  indent?: boolean;
-  arrayElement?: boolean;
-  outcome: OperationOutcome | undefined;
-  onChange?: (value: any[]) => void;
-  hideNonSliceValues?: boolean;
+  readonly property: InternalSchemaElement;
+  readonly name: string;
+  readonly defaultValue?: any[];
+  readonly indent?: boolean;
+  readonly arrayElement?: boolean;
+  readonly outcome: OperationOutcome | undefined;
+  readonly onChange?: (value: any[]) => void;
+  readonly hideNonSliceValues?: boolean;
 }
 
-export function ResourceArrayInput(props: Readonly<ResourceArrayInputProps>): JSX.Element {
+export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element {
   const { property } = props;
   const medplum = useMedplum();
   const [loading, setLoading] = useState(true);
@@ -186,14 +186,14 @@ export function ResourceArrayInput(props: Readonly<ResourceArrayInputProps>): JS
   );
 }
 
-type SliceInputProps = Readonly<{
-  slice: SupportedSliceDefinition;
-  property: InternalSchemaElement;
-  defaultValue: any[];
-  onChange: (newValue: any[]) => void;
-  outcome?: OperationOutcome;
-  testId?: string;
-}>;
+interface SliceInputProps {
+  readonly slice: SupportedSliceDefinition;
+  readonly property: InternalSchemaElement;
+  readonly defaultValue: any[];
+  readonly onChange: (newValue: any[]) => void;
+  readonly outcome?: OperationOutcome;
+  readonly testId?: string;
+}
 
 function SliceInput(props: SliceInputProps): JSX.Element | null {
   const { slice, property } = props;
@@ -293,11 +293,11 @@ function SliceInput(props: SliceInputProps): JSX.Element | null {
   );
 }
 
-type ButtonProps = Readonly<{
-  propertyDisplayName?: string;
-  onClick: React.MouseEventHandler;
-  testId?: string;
-}>;
+interface ButtonProps {
+  readonly propertyDisplayName?: string;
+  readonly onClick: React.MouseEventHandler;
+  readonly testId?: string;
+}
 
 function AddButton({ propertyDisplayName, onClick, testId }: ButtonProps): JSX.Element {
   const text = propertyDisplayName ? `Add ${propertyDisplayName}` : 'Add';

--- a/packages/react/src/ResourceAvatar/ResourceAvatar.tsx
+++ b/packages/react/src/ResourceAvatar/ResourceAvatar.tsx
@@ -5,8 +5,8 @@ import { useResource } from '@medplum/react-hooks';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface ResourceAvatarProps extends AvatarProps {
-  value?: Reference | Resource;
-  link?: boolean;
+  readonly value?: Reference | Resource;
+  readonly link?: boolean;
 }
 
 export function ResourceAvatar(props: ResourceAvatarProps): JSX.Element {

--- a/packages/react/src/ResourceBadge/ResourceBadge.tsx
+++ b/packages/react/src/ResourceBadge/ResourceBadge.tsx
@@ -4,8 +4,8 @@ import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceName } from '../ResourceName/ResourceName';
 
 export interface ResourceBadgeProps {
-  value?: Reference | Resource;
-  link?: boolean;
+  readonly value?: Reference | Resource;
+  readonly link?: boolean;
 }
 
 export function ResourceBadge(props: ResourceBadgeProps): JSX.Element {

--- a/packages/react/src/ResourceBlame/ResourceBlame.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.tsx
@@ -8,9 +8,9 @@ import classes from './ResourceBlame.module.css';
 import { getTimeString, getVersionUrl } from './ResourceBlame.utils';
 
 export interface ResourceBlameProps {
-  history?: Bundle;
-  resourceType?: ResourceType;
-  id?: string;
+  readonly history?: Bundle;
+  readonly resourceType?: ResourceType;
+  readonly id?: string;
 }
 
 export function ResourceBlame(props: ResourceBlameProps): JSX.Element | null {

--- a/packages/react/src/ResourceDiff/ResourceDiff.tsx
+++ b/packages/react/src/ResourceDiff/ResourceDiff.tsx
@@ -4,9 +4,9 @@ import { Delta, diff } from '../utils/diff';
 import classes from './ResourceDiff.module.css';
 
 export interface ResourceDiffProps {
-  original: Resource;
-  revised: Resource;
-  ignoreMeta?: boolean;
+  readonly original: Resource;
+  readonly revised: Resource;
+  readonly ignoreMeta?: boolean;
 }
 
 export function ResourceDiff(props: ResourceDiffProps): JSX.Element {

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -8,8 +8,8 @@ import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourceProp
 import classes from './ResourceDiffTable.module.css';
 
 export interface ResourceDiffTableProps {
-  original: Resource;
-  revised: Resource;
+  readonly original: Resource;
+  readonly revised: Resource;
 }
 
 export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | null {

--- a/packages/react/src/ResourceForm/ResourceForm.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.tsx
@@ -7,13 +7,13 @@ import { BackboneElementInput } from '../BackboneElementInput/BackboneElementInp
 import { FormSection } from '../FormSection/FormSection';
 
 export interface ResourceFormProps {
-  defaultValue: Partial<Resource> | Reference;
-  outcome?: OperationOutcome;
-  onSubmit: (resource: Resource) => void;
-  onDelete?: (resource: Resource) => void;
-  schemaName?: string;
+  readonly defaultValue: Partial<Resource> | Reference;
+  readonly outcome?: OperationOutcome;
+  readonly onSubmit: (resource: Resource) => void;
+  readonly onDelete?: (resource: Resource) => void;
+  readonly schemaName?: string;
   /** (optional) URL of the resource profile used to display the form. Takes priority over schemaName. */
-  profileUrl?: string;
+  readonly profileUrl?: string;
 }
 
 export function ResourceForm(props: ResourceFormProps): JSX.Element {

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.tsx
@@ -7,9 +7,9 @@ import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceBadge } from '../ResourceBadge/ResourceBadge';
 
 export interface ResourceHistoryTableProps {
-  history?: Bundle;
-  resourceType?: string;
-  id?: string;
+  readonly history?: Bundle;
+  readonly resourceType?: string;
+  readonly id?: string;
 }
 
 export function ResourceHistoryTable(props: ResourceHistoryTableProps): JSX.Element {
@@ -46,7 +46,7 @@ export function ResourceHistoryTable(props: ResourceHistoryTableProps): JSX.Elem
 }
 
 interface HistoryRowProps {
-  entry: BundleEntry;
+  readonly entry: BundleEntry;
 }
 
 function HistoryRow(props: HistoryRowProps): JSX.Element {

--- a/packages/react/src/ResourceName/ResourceName.tsx
+++ b/packages/react/src/ResourceName/ResourceName.tsx
@@ -6,8 +6,8 @@ import { useState } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface ResourceNameProps extends TextProps {
-  value?: Reference | Resource;
-  link?: boolean;
+  readonly value?: Reference | Resource;
+  readonly link?: boolean;
 }
 
 export function ResourceName(props: ResourceNameProps): JSX.Element | null {

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -26,13 +26,13 @@ import { ReferenceDisplay } from '../ReferenceDisplay/ReferenceDisplay';
 import { ResourceArrayDisplay } from '../ResourceArrayDisplay/ResourceArrayDisplay';
 
 export interface ResourcePropertyDisplayProps {
-  property?: InternalSchemaElement;
-  propertyType: string;
-  value: any;
-  arrayElement?: boolean;
-  maxWidth?: number;
-  ignoreMissingValues?: boolean;
-  link?: boolean;
+  readonly property?: InternalSchemaElement;
+  readonly propertyType: string;
+  readonly value: any;
+  readonly arrayElement?: boolean;
+  readonly maxWidth?: number;
+  readonly ignoreMissingValues?: boolean;
+  readonly link?: boolean;
 }
 
 /**

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -29,13 +29,13 @@ import { getErrorsForInput } from '../utils/outcomes';
 import { ComplexTypeInputProps } from './ResourcePropertyInput.utils';
 
 export interface ResourcePropertyInputProps {
-  property: InternalSchemaElement;
-  name: string;
-  defaultPropertyType?: string | undefined;
-  defaultValue: any;
-  arrayElement?: boolean | undefined;
-  onChange: ((value: any, propName?: string) => void) | undefined;
-  outcome: OperationOutcome | undefined;
+  readonly property: InternalSchemaElement;
+  readonly name: string;
+  readonly defaultPropertyType?: string | undefined;
+  readonly defaultValue: any;
+  readonly arrayElement?: boolean | undefined;
+  readonly onChange: ((value: any, propName?: string) => void) | undefined;
+  readonly outcome: OperationOutcome | undefined;
 }
 
 export function ResourcePropertyInput(props: ResourcePropertyInputProps): JSX.Element {
@@ -91,7 +91,7 @@ export function ResourcePropertyInput(props: ResourcePropertyInputProps): JSX.El
 }
 
 export interface ElementDefinitionSelectorProps extends ResourcePropertyInputProps {
-  elementDefinitionTypes: ElementDefinitionType[];
+  readonly elementDefinitionTypes: ElementDefinitionType[];
 }
 
 export function ElementDefinitionInputSelector(props: ElementDefinitionSelectorProps): JSX.Element {
@@ -142,15 +142,15 @@ export function ElementDefinitionInputSelector(props: ElementDefinitionSelectorP
 
 // Avoiding optional props on lower-level components like to make it more difficult to misuse
 export type ElementDefinitionTypeInputProps = {
-  name: ResourcePropertyInputProps['name'];
-  path: string;
-  defaultValue: ResourcePropertyInputProps['defaultValue'];
-  onChange: ResourcePropertyInputProps['onChange'];
-  outcome: ResourcePropertyInputProps['outcome'];
-  elementDefinitionType: ElementDefinitionType;
-  min: number;
-  max: number;
-  binding: ElementDefinitionBinding | undefined;
+  readonly name: ResourcePropertyInputProps['name'];
+  readonly path: string;
+  readonly defaultValue: ResourcePropertyInputProps['defaultValue'];
+  readonly onChange: ResourcePropertyInputProps['onChange'];
+  readonly outcome: ResourcePropertyInputProps['outcome'];
+  readonly elementDefinitionType: ElementDefinitionType;
+  readonly min: number;
+  readonly max: number;
+  readonly binding: ElementDefinitionBinding | undefined;
 };
 
 export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProps): JSX.Element {

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -7,20 +7,20 @@ export interface ResourceTableProps {
   /**
    * The input value either as a resource or a reference.
    */
-  value: Resource | Reference;
+  readonly value: Resource | Reference;
 
   /**
    * Optional flag to ignore missing values.
    * By default, missing values are displayed as empty strings.
    */
-  ignoreMissingValues?: boolean;
+  readonly ignoreMissingValues?: boolean;
 
   /**
    * Optional flag to force use the input value.
    * This is useful when you want to display a specific version of the resource,
    * and not use the latest version.
    */
-  forceUseInput?: boolean;
+  readonly forceUseInput?: boolean;
 }
 
 export function ResourceTable(props: ResourceTableProps): JSX.Element | null {

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -40,14 +40,14 @@ import { sortByDateAndPriority } from '../utils/date';
 import classes from './ResourceTimeline.module.css';
 
 export interface ResourceTimelineProps<T extends Resource> {
-  value: T | Reference<T>;
-  loadTimelineResources: (
+  readonly value: T | Reference<T>;
+  readonly loadTimelineResources: (
     medplum: MedplumClient,
     resourceType: ResourceType,
     id: string
   ) => Promise<PromiseSettledResult<Bundle>[]>;
-  createCommunication?: (resource: T, sender: ProfileResource, text: string) => Communication;
-  createMedia?: (resource: T, operator: ProfileResource, attachment: Attachment) => Media;
+  readonly createCommunication?: (resource: T, sender: ProfileResource, text: string) => Communication;
+  readonly createMedia?: (resource: T, operator: ProfileResource, attachment: Attachment) => Media;
 }
 
 export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProps<T>): JSX.Element {
@@ -361,12 +361,12 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
 }
 
 interface BaseTimelineItemProps<T extends Resource> {
-  resource: T;
-  onPin?: (resource: T) => void;
-  onUnpin?: (resource: T) => void;
-  onDetails?: (resource: T) => void;
-  onEdit?: (resource: T) => void;
-  onDelete?: (resource: T) => void;
+  readonly resource: T;
+  readonly onPin?: (resource: T) => void;
+  readonly onUnpin?: (resource: T) => void;
+  readonly onDetails?: (resource: T) => void;
+  readonly onEdit?: (resource: T) => void;
+  readonly onDelete?: (resource: T) => void;
 }
 
 function TimelineItemPopupMenu<T extends Resource>(props: BaseTimelineItemProps<T>): JSX.Element {
@@ -428,7 +428,7 @@ function TimelineItemPopupMenu<T extends Resource>(props: BaseTimelineItemProps<
 }
 
 interface HistoryTimelineItemProps extends BaseTimelineItemProps<Resource> {
-  history: Bundle;
+  readonly history: Bundle;
 }
 
 function HistoryTimelineItem(props: HistoryTimelineItemProps): JSX.Element {

--- a/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
+++ b/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
@@ -3,13 +3,13 @@ import { useCallback, useState } from 'react';
 import { CodeInput } from '../CodeInput/CodeInput';
 
 export interface ResourceTypeInputProps {
-  name: string;
-  placeholder?: string;
-  defaultValue?: ResourceType;
-  targetTypes?: string[];
-  autoFocus?: boolean;
-  testId?: string;
-  onChange?: (value: ResourceType | undefined) => void;
+  readonly name: string;
+  readonly placeholder?: string;
+  readonly defaultValue?: ResourceType;
+  readonly targetTypes?: string[];
+  readonly autoFocus?: boolean;
+  readonly testId?: string;
+  readonly onChange?: (value: ResourceType | undefined) => void;
 }
 
 export function ResourceTypeInput(props: ResourceTypeInputProps): JSX.Element {

--- a/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
+++ b/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
@@ -6,7 +6,6 @@ export interface ResourceTypeInputProps {
   readonly name: string;
   readonly placeholder?: string;
   readonly defaultValue?: ResourceType;
-  readonly targetTypes?: string[];
   readonly autoFocus?: boolean;
   readonly testId?: string;
   readonly onChange?: (value: ResourceType | undefined) => void;

--- a/packages/react/src/Scheduler/Scheduler.tsx
+++ b/packages/react/src/Scheduler/Scheduler.tsx
@@ -11,8 +11,8 @@ import { ResourceName } from '../ResourceName/ResourceName';
 import classes from './Scheduler.module.css';
 
 export interface SchedulerProps {
-  schedule: Schedule | Reference<Schedule>;
-  questionnaire: Questionnaire | Reference<Questionnaire>;
+  readonly schedule: Schedule | Reference<Schedule>;
+  readonly questionnaire: Questionnaire | Reference<Questionnaire>;
 }
 
 export function Scheduler(props: SchedulerProps): JSX.Element | null {

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -11,14 +11,7 @@ import {
   UnstyledButton,
 } from '@mantine/core';
 import { DEFAULT_SEARCH_COUNT, Filter, SearchRequest, formatSearchQuery, isDataTypeLoaded } from '@medplum/core';
-import {
-  Bundle,
-  OperationOutcome,
-  Resource,
-  ResourceType,
-  SearchParameter,
-  UserConfiguration,
-} from '@medplum/fhirtypes';
+import { Bundle, OperationOutcome, Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import {
   IconAdjustmentsHorizontal,
@@ -74,7 +67,6 @@ export class SearchClickEvent extends Event {
 
 export interface SearchControlProps {
   readonly search: SearchRequest;
-  readonly userConfig?: UserConfiguration;
   readonly checkboxesEnabled?: boolean;
   readonly hideToolbar?: boolean;
   readonly hideFilters?: boolean;
@@ -87,7 +79,6 @@ export interface SearchControlProps {
   readonly onExportCsv?: () => void;
   readonly onExportTransactionBundle?: () => void;
   readonly onDelete?: (ids: string[]) => void;
-  readonly onPatch?: (ids: string[]) => void;
   readonly onBulk?: (ids: string[]) => void;
 }
 

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -73,33 +73,33 @@ export class SearchClickEvent extends Event {
 }
 
 export interface SearchControlProps {
-  search: SearchRequest;
-  userConfig?: UserConfiguration;
-  checkboxesEnabled?: boolean;
-  hideToolbar?: boolean;
-  hideFilters?: boolean;
-  onLoad?: (e: SearchLoadEvent) => void;
-  onChange?: (e: SearchChangeEvent) => void;
-  onClick?: (e: SearchClickEvent) => void;
-  onAuxClick?: (e: SearchClickEvent) => void;
-  onNew?: () => void;
-  onExport?: () => void;
-  onExportCsv?: () => void;
-  onExportTransactionBundle?: () => void;
-  onDelete?: (ids: string[]) => void;
-  onPatch?: (ids: string[]) => void;
-  onBulk?: (ids: string[]) => void;
+  readonly search: SearchRequest;
+  readonly userConfig?: UserConfiguration;
+  readonly checkboxesEnabled?: boolean;
+  readonly hideToolbar?: boolean;
+  readonly hideFilters?: boolean;
+  readonly onLoad?: (e: SearchLoadEvent) => void;
+  readonly onChange?: (e: SearchChangeEvent) => void;
+  readonly onClick?: (e: SearchClickEvent) => void;
+  readonly onAuxClick?: (e: SearchClickEvent) => void;
+  readonly onNew?: () => void;
+  readonly onExport?: () => void;
+  readonly onExportCsv?: () => void;
+  readonly onExportTransactionBundle?: () => void;
+  readonly onDelete?: (ids: string[]) => void;
+  readonly onPatch?: (ids: string[]) => void;
+  readonly onBulk?: (ids: string[]) => void;
 }
 
 interface SearchControlState {
-  searchResponse?: Bundle;
-  selected: { [id: string]: boolean };
-  fieldEditorVisible: boolean;
-  filterEditorVisible: boolean;
-  filterDialogVisible: boolean;
-  exportDialogVisible: boolean;
-  filterDialogFilter?: Filter;
-  filterDialogSearchParam?: SearchParameter;
+  readonly searchResponse?: Bundle;
+  readonly selected: { [id: string]: boolean };
+  readonly fieldEditorVisible: boolean;
+  readonly filterEditorVisible: boolean;
+  readonly filterDialogVisible: boolean;
+  readonly exportDialogVisible: boolean;
+  readonly filterDialogFilter?: Filter;
+  readonly filterDialogSearchParam?: SearchParameter;
 }
 
 /**

--- a/packages/react/src/SearchExportDialog/SearchExportDialog.tsx
+++ b/packages/react/src/SearchExportDialog/SearchExportDialog.tsx
@@ -1,10 +1,10 @@
 import { Box, Button, Modal, Text } from '@mantine/core';
 
 interface SearchExportDialogProps {
-  visible: boolean;
-  exportCsv?: () => void;
-  exportTransactionBundle?: () => void;
-  onCancel: () => void;
+  readonly visible: boolean;
+  readonly exportCsv?: () => void;
+  readonly exportTransactionBundle?: () => void;
+  readonly onCancel: () => void;
 }
 
 export function SearchExportDialog(props: SearchExportDialogProps): JSX.Element | null {
@@ -26,9 +26,9 @@ export function SearchExportDialog(props: SearchExportDialogProps): JSX.Element 
 }
 
 interface ExportButtonProps {
-  text: string;
-  exportLogic: () => void;
-  onCancel: () => void;
+  readonly text: string;
+  readonly exportLogic: () => void;
+  readonly onCancel: () => void;
 }
 
 export function ExportButton(props: ExportButtonProps): JSX.Element {

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -5,10 +5,10 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { buildFieldNameString } from '../SearchControl/SearchUtils';
 
 export interface SearchFieldEditorProps {
-  visible: boolean;
-  search: SearchRequest;
-  onOk: (search: SearchRequest) => void;
-  onCancel: () => void;
+  readonly visible: boolean;
+  readonly search: SearchRequest;
+  readonly onOk: (search: SearchRequest) => void;
+  readonly onCancel: () => void;
 }
 
 export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | null {

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -14,10 +14,10 @@ import { SearchFilterValueDisplay } from '../SearchFilterValueDisplay/SearchFilt
 import { SearchFilterValueInput } from '../SearchFilterValueInput/SearchFilterValueInput';
 
 export interface SearchFilterEditorProps {
-  visible: boolean;
-  search: SearchRequest;
-  onOk: (search: SearchRequest) => void;
-  onCancel: () => void;
+  readonly visible: boolean;
+  readonly search: SearchRequest;
+  readonly onOk: (search: SearchRequest) => void;
+  readonly onCancel: () => void;
 }
 
 export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element | null {
@@ -140,12 +140,12 @@ function FilterRowDisplay(props: FilterRowDisplayProps): JSX.Element | null {
 }
 
 interface FilterRowInputProps {
-  resourceType: string;
-  searchParams: Record<string, SearchParameter>;
-  defaultValue?: Filter;
-  okText: string;
-  onOk: (value: Filter) => void;
-  onCancel?: () => void;
+  readonly resourceType: string;
+  readonly searchParams: Record<string, SearchParameter>;
+  readonly defaultValue?: Filter;
+  readonly okText: string;
+  readonly onOk: (value: Filter) => void;
+  readonly onCancel?: () => void;
 }
 
 function FilterRowInput(props: FilterRowInputProps): JSX.Element {

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -1,5 +1,5 @@
 import { Button, Group, Modal, NativeSelect } from '@mantine/core';
-import { Filter, getSearchParameters, Operator, SearchRequest, stringify } from '@medplum/core';
+import { Filter, Operator, SearchRequest, getSearchParameters, stringify } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
 import { useEffect, useRef, useState } from 'react';
 import {
@@ -91,7 +91,6 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
                   <FilterRowDisplay
                     key={`filter-${filter.code}-${filter.operator}-${filter.value}-display`}
                     resourceType={resourceType}
-                    searchParams={searchParams}
                     filter={filter}
                     onEdit={() => setEditingIndex(index)}
                     onDelete={() => setSearch(deleteFilter(searchRef.current, index))}
@@ -111,7 +110,6 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
 }
 
 interface FilterRowDisplayProps {
-  readonly searchParams: Record<string, SearchParameter>;
   readonly resourceType: string;
   readonly filter: Filter;
   readonly onEdit: () => void;

--- a/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
+++ b/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
@@ -6,14 +6,14 @@ import { Form } from '../Form/Form';
 import { SearchFilterValueInput } from '../SearchFilterValueInput/SearchFilterValueInput';
 
 export interface SearchFilterValueDialogProps {
-  title: string;
-  visible: boolean;
-  resourceType: string;
-  searchParam?: SearchParameter;
-  filter?: Filter;
-  defaultValue?: string;
-  onOk: (filter: Filter) => void;
-  onCancel: () => void;
+  readonly title: string;
+  readonly visible: boolean;
+  readonly resourceType: string;
+  readonly searchParam?: SearchParameter;
+  readonly filter?: Filter;
+  readonly defaultValue?: string;
+  readonly onOk: (filter: Filter) => void;
+  readonly onCancel: () => void;
 }
 
 export function SearchFilterValueDialog(props: SearchFilterValueDialogProps): JSX.Element | null {

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
@@ -6,11 +6,11 @@ import { QuantityInput } from '../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../ReferenceInput/ReferenceInput';
 
 export interface SearchFilterValueInputProps {
-  resourceType: string;
-  searchParam: SearchParameter;
-  defaultValue?: string;
-  autoFocus?: boolean;
-  onChange: (value: string) => void;
+  readonly resourceType: string;
+  readonly searchParam: SearchParameter;
+  readonly defaultValue?: string;
+  readonly autoFocus?: boolean;
+  readonly onChange: (value: string) => void;
 }
 
 export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.Element | null {

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
@@ -32,10 +32,10 @@ import {
 } from '../SearchControl/SearchUtils';
 
 export interface SearchPopupMenuProps {
-  search: SearchRequest;
-  searchParams?: SearchParameter[];
-  onPrompt: (searchParam: SearchParameter, filter: Filter) => void;
-  onChange: (definition: SearchRequest) => void;
+  readonly search: SearchRequest;
+  readonly searchParams?: SearchParameter[];
+  readonly onPrompt: (searchParam: SearchParameter, filter: Filter) => void;
+  readonly onChange: (definition: SearchRequest) => void;
 }
 
 export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null {
@@ -84,12 +84,12 @@ export function SearchPopupMenu(props: SearchPopupMenuProps): JSX.Element | null
 }
 
 interface SearchPopupSubMenuProps {
-  search: SearchRequest;
-  searchParam: SearchParameter;
-  onSort: (searchParam: SearchParameter, descending: boolean) => void;
-  onPrompt: (searchParam: SearchParameter, operator: Operator) => void;
-  onChange: (search: SearchRequest) => void;
-  onClear: (searchParam: SearchParameter) => void;
+  readonly search: SearchRequest;
+  readonly searchParam: SearchParameter;
+  readonly onSort: (searchParam: SearchParameter, descending: boolean) => void;
+  readonly onPrompt: (searchParam: SearchParameter, operator: Operator) => void;
+  readonly onChange: (search: SearchRequest) => void;
+  readonly onClear: (searchParam: SearchParameter) => void;
 }
 
 function SearchParameterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.tsx
@@ -3,7 +3,7 @@ import { Attachment, Group, Patient, Reference, ResourceType, ServiceRequest } f
 import { ResourceTimeline } from '../ResourceTimeline/ResourceTimeline';
 
 export interface ServiceRequestTimelineProps {
-  serviceRequest: ServiceRequest | Reference<ServiceRequest>;
+  readonly serviceRequest: ServiceRequest | Reference<ServiceRequest>;
 }
 
 export function ServiceRequestTimeline(props: ServiceRequestTimelineProps): JSX.Element {

--- a/packages/react/src/Timeline/Timeline.tsx
+++ b/packages/react/src/Timeline/Timeline.tsx
@@ -11,7 +11,7 @@ import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { ResourceName } from '../ResourceName/ResourceName';
 
 export interface TimelineProps {
-  children?: ReactNode;
+  readonly children?: ReactNode;
 }
 
 export function Timeline(props: TimelineProps): JSX.Element {
@@ -19,11 +19,11 @@ export function Timeline(props: TimelineProps): JSX.Element {
 }
 
 export interface TimelineItemProps extends PanelProps {
-  resource: Resource;
-  profile?: Reference;
-  dateTime?: string;
-  padding?: boolean;
-  popupMenuItems?: ReactNode;
+  readonly resource: Resource;
+  readonly profile?: Reference;
+  readonly dateTime?: string;
+  readonly padding?: boolean;
+  readonly popupMenuItems?: ReactNode;
 }
 
 export function TimelineItem(props: TimelineItemProps): JSX.Element {

--- a/packages/react/src/TimingInput/TimingInput.tsx
+++ b/packages/react/src/TimingInput/TimingInput.tsx
@@ -12,9 +12,9 @@ type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
 type PeriodUnit = 'a' | 's' | 'min' | 'h' | 'd' | 'wk' | 'mo';
 
 export interface TimingInputProps {
-  name: string;
-  defaultValue?: Timing;
-  onChange?: (newValue: Timing) => void;
+  readonly name: string;
+  readonly defaultValue?: Timing;
+  readonly onChange?: (newValue: Timing) => void;
 }
 
 export function TimingInput(props: TimingInputProps): JSX.Element {
@@ -47,10 +47,10 @@ export function TimingInput(props: TimingInputProps): JSX.Element {
 }
 
 interface TimingEditorDialogProps {
-  visible: boolean;
-  defaultValue?: Timing;
-  onOk: (newValue: Timing) => void;
-  onCancel: () => void;
+  readonly visible: boolean;
+  readonly defaultValue?: Timing;
+  readonly onOk: (newValue: Timing) => void;
+  readonly onCancel: () => void;
 }
 
 const defaultValue: Timing = {

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -10,10 +10,10 @@ import {
 
 export interface ValueSetAutocompleteProps
   extends Omit<AsyncAutocompleteProps<ValueSetExpansionContains>, 'loadOptions' | 'toKey' | 'toOption'> {
-  binding: string | undefined;
-  creatable?: boolean;
-  clearable?: boolean;
-  expandParams?: Partial<ValueSetExpandParams>;
+  readonly binding: string | undefined;
+  readonly creatable?: boolean;
+  readonly clearable?: boolean;
+  readonly expandParams?: Partial<ValueSetExpandParams>;
 }
 
 function toKey(element: ValueSetExpansionContains): string {

--- a/packages/react/src/auth/ChooseProfileForm.tsx
+++ b/packages/react/src/auth/ChooseProfileForm.tsx
@@ -7,9 +7,9 @@ import { useMedplum } from '@medplum/react-hooks';
 import { OperationOutcomeAlert } from '../OperationOutcomeAlert/OperationOutcomeAlert';
 
 export interface ChooseProfileFormProps {
-  login: string;
-  memberships: ProjectMembership[];
-  handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly login: string;
+  readonly memberships: ProjectMembership[];
+  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
 }
 
 export function ChooseProfileForm(props: ChooseProfileFormProps): JSX.Element {

--- a/packages/react/src/auth/ChooseScopeForm.tsx
+++ b/packages/react/src/auth/ChooseScopeForm.tsx
@@ -5,9 +5,9 @@ import { Logo } from '../Logo/Logo';
 import { useMedplum } from '@medplum/react-hooks';
 
 export interface ChooseScopeFormProps {
-  login: string;
-  scope: string | undefined;
-  handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly login: string;
+  readonly scope: string | undefined;
+  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
 }
 
 export function ChooseScopeForm(props: ChooseScopeFormProps): JSX.Element {

--- a/packages/react/src/auth/MfaForm.tsx
+++ b/packages/react/src/auth/MfaForm.tsx
@@ -7,8 +7,8 @@ import { Logo } from '../Logo/Logo';
 import { useMedplum } from '@medplum/react-hooks';
 
 export interface MfaFormProps {
-  login: string;
-  handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly login: string;
+  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
 }
 
 export function MfaForm(props: MfaFormProps): JSX.Element {

--- a/packages/react/src/auth/NewProjectForm.tsx
+++ b/packages/react/src/auth/NewProjectForm.tsx
@@ -8,8 +8,8 @@ import { useMedplum } from '@medplum/react-hooks';
 import { getErrorsForInput } from '../utils/outcomes';
 
 export interface NewProjectFormProps {
-  login: string;
-  handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly login: string;
+  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
 }
 
 export function NewProjectForm(props: NewProjectFormProps): JSX.Element {


### PR DESCRIPTION
Fixed Sonar code smells: "Mark the props of the component as read-only."

<img width="1068" alt="image" src="https://github.com/medplum/medplum/assets/749094/10e8b858-299a-4d8e-9adc-788c3dd8c6b8">
