### PR TITLE
Fix invalid mermaid graph in diagnostic catalog docs

### DIFF
--- a/packages/docs/docs/careplans/diagnostic-catalog/diagnostic-catalog.mdx
+++ b/packages/docs/docs/careplans/diagnostic-catalog/diagnostic-catalog.mdx
@@ -347,18 +347,18 @@ graph TD
 		C --> H(Chloride Level)
 		C --> J(Total CO2 Level)
 
-		subgraph <code>PlanDefinition</code>
+		subgraph PlanDefinition
       A
       Z
     end
 
-    subgraph <code>ActivityDefinition</code>
+    subgraph ActivityDefinition
       B
       C
       Y
     end
 
-    subgraph <code>ObservationDefinition</code>
+    subgraph ObservationDefinition
       E
       F
       G


### PR DESCRIPTION
The mermaid chart on the ["Defining your Diagnostic Catalog" page](https://www.medplum.com/docs/careplans/diagnostic-catalog) is currently broken:

<img width="1392" alt="Screenshot 2024-01-29 at 5 41 42 pm" src="https://github.com/medplum/medplum/assets/712727/357a6398-cf09-4188-8796-068276265ac3">

<details>
<summary>the following error is thrown:</summary>


	[Error] Error: Parse error on line 14:
	... Level)		subgraph <code>PlanDefinition
	---------------------^
	Expecting 'SPACE', 'GRAPH', 'DIR', 'subgraph', 'end', 'AMP', 'COLON', 'START_LINK', 'STR', 'MD_STR', 'STYLE', 'LINKSTYLE', 'CLASSDEF', 'CLASS', 'CLICK', 'DOWN', 'UP', 'NUM', 'NODE_STRING', 'BRKT', 'MINUS', 'MULT', 'UNICODE_TEXT', got 'TAGSTART'
	parseError — 62893.aafab8ed.js:1:19751
	parse — 62893.aafab8ed.js:1:20895
	parse — 31348.fea3b48b.js:2:266514
	tr — 31348.fea3b48b.js:2:266249
	(anonymous function) — 31348.fea3b48b.js:2:266831
	er — 31348.fea3b48b.js:2:266837
	(anonymous function) — 31348.fea3b48b.js:2:300178
	render — 31348.fea3b48b.js:2:302054
	(anonymous function) — 31348.fea3b48b.js:2:304905
	Promise
	(anonymous function) — 31348.fea3b48b.js:2:304886
	(anonymous function) — 31348.fea3b48b.js:2:304772
	eo — 31348.fea3b48b.js:2:304828
	(anonymous function) — 31348.fea3b48b.js:2:305032
	Promise
	io — 31348.fea3b48b.js:2:304852
	(anonymous function) — 31348.fea3b48b.js:2:8686
	(anonymous function) — 31348.fea3b48b.js:2:8753
	(anonymous function) — 31348.fea3b48b.js:2:8754
	si — main.4b8d0ce0.js:2:699947
	wd — main.4b8d0ce0.js:2:720078
	(anonymous function) — main.4b8d0ce0.js:2:718820
	vd — main.4b8d0ce0.js:2:718883
	dd — main.4b8d0ce0.js:2:712641
	$s — main.4b8d0ce0.js:2:653340
	(anonymous function) — main.4b8d0ce0.js:2:710042

		ua (main.4b8d0ce0.js:2:678148)
		(anonymous function) (main.4b8d0ce0.js:2:678662)
		Mn (main.4b8d0ce0.js:2:659935)
		_i (main.4b8d0ce0.js:2:707482)
		yi (main.4b8d0ce0.js:2:707052)
		xi (main.4b8d0ce0.js:2:706590)
		(anonymous function) (main.4b8d0ce0.js:2:718374)
		vd (main.4b8d0ce0.js:2:718883)
		dd (main.4b8d0ce0.js:2:712641)
		$s (main.4b8d0ce0.js:2:653340)
		(anonymous function) (main.4b8d0ce0.js:2:710042)


</details>


This PR removes the `<code>` attributes from the graph which appears to resolve the error (based on my local testing).