### PR TITLE
Disambiguate getClient

### DIFF
--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -13,7 +13,7 @@ import { asyncWrap } from '../async';
 import { setPassword } from '../auth/setpassword';
 import { getConfig } from '../config';
 import { AuthenticatedRequestContext, getAuthenticatedContext } from '../context';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { systemRepo } from '../fhir/repo';
@@ -184,7 +184,7 @@ superAdminRouter.post(
     await sendAsyncResponse(req, res, async () => {
       const resourceTypes = getResourceTypes();
       for (const resourceType of resourceTypes) {
-        await getDatabaseClient().query(
+        await getDatabasePool().query(
           `UPDATE "${resourceType}" SET "projectId"="compartments"[1] WHERE "compartments" IS NOT NULL AND cardinality("compartments")>0`
         );
       }
@@ -203,7 +203,7 @@ superAdminRouter.post(
     requireAsync(req);
 
     await sendAsyncResponse(req, res, async () => {
-      const client = getDatabaseClient();
+      const client = getDatabasePool();
       const result = await client.query('SELECT "dataVersion" FROM "DatabaseMigration"');
       const version = result.rows[0]?.dataVersion as number;
       const migrationKeys = Object.keys(dataMigrations);

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -12,18 +12,18 @@ import { body, validationResult } from 'express-validator';
 import { asyncWrap } from '../async';
 import { setPassword } from '../auth/setpassword';
 import { getConfig } from '../config';
-import { getClient } from '../database';
+import { AuthenticatedRequestContext, getAuthenticatedContext } from '../context';
+import { getDatabaseClient } from '../database';
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
-import { authenticateRequest } from '../oauth/middleware';
 import { systemRepo } from '../fhir/repo';
 import * as dataMigrations from '../migrations/data';
+import { authenticateRequest } from '../oauth/middleware';
 import { getUserByEmail } from '../oauth/utils';
 import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { removeBullMQJobByKey } from '../workers/cron';
-import { AuthenticatedRequestContext, getAuthenticatedContext } from '../context';
 
 export const superAdminRouter = Router();
 superAdminRouter.use(authenticateRequest);
@@ -184,7 +184,7 @@ superAdminRouter.post(
     await sendAsyncResponse(req, res, async () => {
       const resourceTypes = getResourceTypes();
       for (const resourceType of resourceTypes) {
-        await getClient().query(
+        await getDatabaseClient().query(
           `UPDATE "${resourceType}" SET "projectId"="compartments"[1] WHERE "compartments" IS NOT NULL AND cardinality("compartments")>0`
         );
       }
@@ -203,7 +203,7 @@ superAdminRouter.post(
     requireAsync(req);
 
     await sendAsyncResponse(req, res, async () => {
-      const client = getClient();
+      const client = getDatabaseClient();
       const result = await client.query('SELECT "dataVersion" FROM "DatabaseMigration"');
       const version = result.rows[0]?.dataVersion as number;
       const migrationKeys = Object.keys(dataMigrations);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config';
-import { getDatabaseClient } from './database';
+import { getDatabasePool } from './database';
 import { globalLogger } from './logger';
 
 describe('App', () => {
@@ -87,7 +87,7 @@ describe('App', () => {
     console.log = jest.fn();
     const loggerError = jest.spyOn(globalLogger, 'error').mockReturnValueOnce();
     const error = new Error('Mock database disconnect');
-    getDatabaseClient().emit('error', error);
+    getDatabasePool().emit('error', error);
     expect(loggerError).toHaveBeenCalledWith('Database connection error', error);
 
     await shutdownApp();

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config';
-import { getClient } from './database';
+import { getDatabaseClient } from './database';
 import { globalLogger } from './logger';
 
 describe('App', () => {
@@ -87,7 +87,7 @@ describe('App', () => {
     console.log = jest.fn();
     const loggerError = jest.spyOn(globalLogger, 'error').mockReturnValueOnce();
     const error = new Error('Mock database disconnect');
-    getClient().emit('error', error);
+    getDatabaseClient().emit('error', error);
     expect(loggerError).toHaveBeenCalledWith('Database connection error', error);
 
     await shutdownApp();

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -15,7 +15,7 @@ import { getRequestContext } from '../context';
 import { sendOutcome } from '../fhir/outcomes';
 import { systemRepo } from '../fhir/repo';
 import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
-import { getClient, getMembershipsForLogin } from '../oauth/utils';
+import { getClientApplication, getMembershipsForLogin } from '../oauth/utils';
 
 export async function createProfile(
   project: Project,
@@ -162,7 +162,7 @@ export async function getProjectIdByClientId(
 ): Promise<string | undefined> {
   // For OAuth2 flow, check the clientId
   if (clientId) {
-    const client = await getClient(clientId);
+    const client = await getClientApplication(clientId);
     const clientProjectId = client.meta?.project as string;
     if (projectId !== undefined && projectId !== clientProjectId) {
       throw new OperationOutcomeError(badRequest('Invalid projectId'));

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -5,7 +5,7 @@ import * as migrations from './migrations/schema';
 
 let pool: Pool | undefined;
 
-export function getClient(): Pool {
+export function getDatabaseClient(): Pool {
   if (!pool) {
     throw new Error('Database not setup');
   }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -5,7 +5,7 @@ import * as migrations from './migrations/schema';
 
 let pool: Pool | undefined;
 
-export function getDatabaseClient(): Pool {
+export function getDatabasePool(): Pool {
   if (!pool) {
     throw new Error('Database not setup');
   }

--- a/packages/server/src/fhir/lookups/coding.test.ts
+++ b/packages/server/src/fhir/lookups/coding.test.ts
@@ -1,7 +1,7 @@
 import { CodeSystem } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getDatabaseClient } from '../../database';
+import { getDatabasePool } from '../../database';
 import { withTestContext } from '../../test.setup';
 import { systemRepo } from '../repo';
 
@@ -31,7 +31,7 @@ describe('Coding lookup table', () => {
 
       const systemResource = await systemRepo.createResource(codeSystem);
 
-      const db = getDatabaseClient();
+      const db = getDatabasePool();
       const results = await db.query('SELECT id, code, display FROM "Coding" WHERE system = $1', [systemResource.id]);
       expect(results.rows.map((r) => `${r.code} (${r.display})`).sort()).toEqual([
         'AB (Ambulance)',
@@ -66,7 +66,7 @@ describe('Coding lookup table', () => {
 
       const systemResource = await systemRepo.createResource(codeSystem);
 
-      const db = getDatabaseClient();
+      const db = getDatabasePool();
       const results = await db.query('SELECT code, display FROM "Coding" WHERE system = $1', [systemResource.id]);
       expect(results.rowCount).toEqual(0);
     }));

--- a/packages/server/src/fhir/lookups/coding.test.ts
+++ b/packages/server/src/fhir/lookups/coding.test.ts
@@ -1,9 +1,9 @@
 import { CodeSystem } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { systemRepo } from '../repo';
-import { getClient } from '../../database';
+import { getDatabaseClient } from '../../database';
 import { withTestContext } from '../../test.setup';
+import { systemRepo } from '../repo';
 
 describe('Coding lookup table', () => {
   beforeAll(async () => {
@@ -31,7 +31,7 @@ describe('Coding lookup table', () => {
 
       const systemResource = await systemRepo.createResource(codeSystem);
 
-      const db = getClient();
+      const db = getDatabaseClient();
       const results = await db.query('SELECT id, code, display FROM "Coding" WHERE system = $1', [systemResource.id]);
       expect(results.rows.map((r) => `${r.code} (${r.display})`).sort()).toEqual([
         'AB (Ambulance)',
@@ -66,7 +66,7 @@ describe('Coding lookup table', () => {
 
       const systemResource = await systemRepo.createResource(codeSystem);
 
-      const db = getClient();
+      const db = getDatabaseClient();
       const results = await db.query('SELECT code, display FROM "Coding" WHERE system = $1', [systemResource.id]);
       expect(results.rowCount).toEqual(0);
     }));

--- a/packages/server/src/fhir/operations/codesystemimport.test.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.test.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getDatabaseClient } from '../../database';
+import { getDatabasePool } from '../../database';
 import { initTestAuth } from '../../test.setup';
 import { Column, Condition, SelectQuery } from '../sql';
 
@@ -265,7 +265,7 @@ describe('CodeSystem $import', () => {
 });
 
 async function assertCodeExists(system: string | undefined, code: string): Promise<any> {
-  const db = getDatabaseClient();
+  const db = getDatabasePool();
   const coding = await new SelectQuery('Coding')
     .column('id')
     .where('system', '=', system)
@@ -281,7 +281,7 @@ async function assertPropertyExists(
   property: string,
   value: string
 ): Promise<any> {
-  const db = getDatabaseClient();
+  const db = getDatabasePool();
   const query = await new SelectQuery('Coding_Property');
   const codingTable = query.getNextJoinAlias();
   query.innerJoin(

--- a/packages/server/src/fhir/operations/codesystemimport.test.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.test.ts
@@ -1,11 +1,11 @@
-import express from 'express';
-import { loadTestConfig } from '../../config';
-import { initApp, shutdownApp } from '../../app';
-import { initTestAuth } from '../../test.setup';
-import request from 'supertest';
-import { CodeSystem, Parameters } from '@medplum/fhirtypes';
 import { ContentType } from '@medplum/core';
-import { getClient } from '../../database';
+import { CodeSystem, Parameters } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config';
+import { getDatabaseClient } from '../../database';
+import { initTestAuth } from '../../test.setup';
 import { Column, Condition, SelectQuery } from '../sql';
 
 const app = express();
@@ -265,7 +265,7 @@ describe('CodeSystem $import', () => {
 });
 
 async function assertCodeExists(system: string | undefined, code: string): Promise<any> {
-  const db = getClient();
+  const db = getDatabaseClient();
   const coding = await new SelectQuery('Coding')
     .column('id')
     .where('system', '=', system)
@@ -281,7 +281,7 @@ async function assertPropertyExists(
   property: string,
   value: string
 ): Promise<any> {
-  const db = getClient();
+  const db = getDatabaseClient();
   const query = await new SelectQuery('Coding_Property');
   const codingTable = query.getNextJoinAlias();
   query.innerJoin(

--- a/packages/server/src/fhir/operations/codesystemlookup.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.ts
@@ -2,7 +2,7 @@ import { Operator, TypedValue, allOk, badRequest, notFound } from '@medplum/core
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../../context';
-import { getDatabaseClient } from '../../database';
+import { getDatabasePool } from '../../database';
 import { sendOutcome } from '../outcomes';
 import { Column, Condition, SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
@@ -69,7 +69,7 @@ export async function codeSystemLookupHandler(req: Request, res: Response): Prom
     .where(new Column(codeSystemTable, 'id'), '=', codeSystem.id)
     .where(new Column('Coding', 'code'), '=', coding.code);
 
-  const db = getDatabaseClient();
+  const db = getDatabasePool();
   const result = await lookup.execute(db);
 
   if (result.length < 1) {

--- a/packages/server/src/fhir/operations/codesystemlookup.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.ts
@@ -1,12 +1,12 @@
+import { Operator, TypedValue, allOk, badRequest, notFound } from '@medplum/core';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import { getAuthenticatedContext } from '../../context';
+import { getDatabaseClient } from '../../database';
+import { sendOutcome } from '../outcomes';
+import { Column, Condition, SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
 import { parseInputParameters, sendOutputParameters } from './utils/parameters';
-import { Request, Response } from 'express';
-import { Operator, TypedValue, allOk, badRequest, notFound } from '@medplum/core';
-import { Column, Condition, SelectQuery } from '../sql';
-import { sendOutcome } from '../outcomes';
-import { getClient } from '../../database';
-import { getAuthenticatedContext } from '../../context';
 
 const operation = getOperationDefinition('CodeSystem', 'lookup');
 
@@ -69,7 +69,7 @@ export async function codeSystemLookupHandler(req: Request, res: Response): Prom
     .where(new Column(codeSystemTable, 'id'), '=', codeSystem.id)
     .where(new Column('Coding', 'code'), '=', coding.code);
 
-  const db = getClient();
+  const db = getDatabaseClient();
   const result = await lookup.execute(db);
 
   if (result.length < 1) {

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.ts
@@ -1,12 +1,12 @@
+import { Operator, allOk, badRequest } from '@medplum/core';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
-import { allOk, badRequest, Operator } from '@medplum/core';
-import { getClient } from '../../database';
-import { Column, Condition, SelectQuery } from '../sql';
-import { sendOutcome } from '../outcomes';
-import { getOperationDefinition } from './definitions';
 import { getAuthenticatedContext } from '../../context';
+import { getDatabaseClient } from '../../database';
+import { sendOutcome } from '../outcomes';
+import { Column, Condition, SelectQuery } from '../sql';
+import { getOperationDefinition } from './definitions';
+import { parseInputParameters, sendOutputParameters } from './utils/parameters';
 
 const operation = getOperationDefinition('CodeSystem', 'validate-code');
 
@@ -57,7 +57,7 @@ export async function codeSystemValidateCodeHandler(req: Request, res: Response)
   );
   query.column('display').where(new Column(codeSystemTable, 'id'), '=', codeSystem.id).where('code', '=', coding.code);
 
-  const db = getClient();
+  const db = getDatabaseClient();
   const result = await query.execute(db);
   const output: Record<string, any> = Object.create(null);
   if (result.length) {

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.ts
@@ -2,7 +2,7 @@ import { Operator, allOk, badRequest } from '@medplum/core';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../../context';
-import { getDatabaseClient } from '../../database';
+import { getDatabasePool } from '../../database';
 import { sendOutcome } from '../outcomes';
 import { Column, Condition, SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
@@ -57,7 +57,7 @@ export async function codeSystemValidateCodeHandler(req: Request, res: Response)
   );
   query.column('display').where(new Column(codeSystemTable, 'id'), '=', codeSystem.id).where('code', '=', coding.code);
 
-  const db = getDatabaseClient();
+  const db = getDatabasePool();
   const result = await query.execute(db);
   const output: Record<string, any> = Object.create(null);
   if (result.length) {

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -2,7 +2,7 @@ import { badRequest, Operator as SearchOperator } from '@medplum/core';
 import { ValueSet, ValueSetComposeInclude } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { asyncWrap } from '../../async';
-import { getClient } from '../../database';
+import { getDatabaseClient } from '../../database';
 import { sendOutcome } from '../outcomes';
 import { systemRepo } from '../repo';
 import { Condition, Conjunction, Disjunction, Expression, SelectQuery } from '../sql';
@@ -58,7 +58,7 @@ export const expandOperator = asyncWrap(async (req: Request, res: Response) => {
     count = Math.max(1, Math.min(20, parseInt(req.query.count as string, 10)));
   }
 
-  const client = getClient();
+  const client = getDatabaseClient();
   const query = new SelectQuery('ValueSetElement')
     .distinctOn('system')
     .distinctOn('code')

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -2,7 +2,7 @@ import { badRequest, Operator as SearchOperator } from '@medplum/core';
 import { ValueSet, ValueSetComposeInclude } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { asyncWrap } from '../../async';
-import { getDatabaseClient } from '../../database';
+import { getDatabasePool } from '../../database';
 import { sendOutcome } from '../outcomes';
 import { systemRepo } from '../repo';
 import { Condition, Conjunction, Disjunction, Expression, SelectQuery } from '../sql';
@@ -58,7 +58,7 @@ export const expandOperator = asyncWrap(async (req: Request, res: Response) => {
     count = Math.max(1, Math.min(20, parseInt(req.query.count as string, 10)));
   }
 
-  const client = getDatabaseClient();
+  const client = getDatabasePool();
   const query = new SelectQuery('ValueSetElement')
     .distinctOn('system')
     .distinctOn('code')

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -5,7 +5,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getDatabaseClient } from '../../database';
+import { getDatabasePool } from '../../database';
 import { getRedis } from '../../redis';
 import { createTestProject, initTestAuth, waitForAsyncJob, withTestContext } from '../../test.setup';
 import { systemRepo } from '../repo';
@@ -184,6 +184,6 @@ async function existsInCache(resourceType: string, id: string | undefined): Prom
 }
 
 async function existsInDatabase(tableName: string, id: string | undefined): Promise<boolean> {
-  const rows = await new SelectQuery(tableName).column('id').where('id', '=', id).execute(getDatabaseClient());
+  const rows = await new SelectQuery(tableName).column('id').where('id', '=', id).execute(getDatabasePool());
   return rows.length > 0;
 }

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -5,7 +5,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getClient } from '../../database';
+import { getDatabaseClient } from '../../database';
 import { getRedis } from '../../redis';
 import { createTestProject, initTestAuth, waitForAsyncJob, withTestContext } from '../../test.setup';
 import { systemRepo } from '../repo';
@@ -184,6 +184,6 @@ async function existsInCache(resourceType: string, id: string | undefined): Prom
 }
 
 async function existsInDatabase(tableName: string, id: string | undefined): Promise<boolean> {
-  const rows = await new SelectQuery(tableName).column('id').where('id', '=', id).execute(getClient());
+  const rows = await new SelectQuery(tableName).column('id').where('id', '=', id).execute(getDatabaseClient());
   return rows.length > 0;
 }

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -17,7 +17,7 @@ import { resolve } from 'path';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew, RegisterRequest } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { getClient } from '../database';
+import { getDatabaseClient } from '../database';
 import { bundleContains, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { Repository, systemRepo } from './repo';
@@ -833,7 +833,7 @@ describe('FHIR Repo', () => {
         subject: createReference(patient),
       });
 
-      const result = await getClient().query(
+      const result = await getDatabaseClient().query(
         'SELECT "code", "system", "value" FROM "Observation_Token" WHERE "resourceId"=$1',
         [obs1.id]
       );

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -17,7 +17,7 @@ import { resolve } from 'path';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew, RegisterRequest } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { bundleContains, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { Repository, systemRepo } from './repo';
@@ -833,7 +833,7 @@ describe('FHIR Repo', () => {
         subject: createReference(patient),
       });
 
-      const result = await getDatabaseClient().query(
+      const result = await getDatabasePool().query(
         'SELECT "code", "system", "value" FROM "Observation_Token" WHERE "resourceId"=$1',
         [obs1.id]
       );

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -54,7 +54,7 @@ import { Operation, applyPatch } from 'rfc6902';
 import validator from 'validator';
 import { getConfig } from '../config';
 import { getRequestContext } from '../context';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { getRedis } from '../redis';
 import { r4ProjectId } from '../seed';
 import {
@@ -732,8 +732,8 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
 
     // Do not use this.getDatabaseClient() for the cursor!
     // That would cause a deadlock.
-    // Instead, use getDatabaseClient() directly over a separate connection.
-    const client = getDatabaseClient();
+    // Instead, use getDatabasePool() directly over a separate connection.
+    const client = getDatabasePool();
     const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.addDeletedFilter(builder);
 
@@ -763,8 +763,8 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
 
     // Do not use this.getDatabaseClient() for the cursor!
     // That would cause a deadlock.
-    // Instead, use getDatabaseClient() directly over a separate connection.
-    const client = getDatabaseClient();
+    // Instead, use getDatabasePool() directly over a separate connection.
+    const client = getDatabasePool();
     const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.addDeletedFilter(builder);
 
@@ -1754,12 +1754,12 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
   getDatabaseClient(): Pool | PoolClient {
     // If in a transaction, then use the transaction client.
     // Otherwise, use the pool client.
-    return this.conn ?? getDatabaseClient();
+    return this.conn ?? getDatabasePool();
   }
 
   private async getConnection(): Promise<PoolClient> {
     if (!this.conn) {
-      this.conn = await getDatabaseClient().connect();
+      this.conn = await getDatabasePool().connect();
     }
     return this.conn;
   }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -54,7 +54,7 @@ import { Operation, applyPatch } from 'rfc6902';
 import validator from 'validator';
 import { getConfig } from '../config';
 import { getRequestContext } from '../context';
-import { getClient } from '../database';
+import { getDatabaseClient } from '../database';
 import { getRedis } from '../redis';
 import { r4ProjectId } from '../seed';
 import {
@@ -252,7 +252,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
 
     this.addSecurityFilters(builder, resourceType);
 
-    const rows = await builder.execute(this.getClient());
+    const rows = await builder.execute(this.getDatabaseClient());
     if (rows.length === 0) {
       throw new OperationOutcomeError(notFound);
     }
@@ -363,7 +363,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
         .where('id', '=', id)
         .orderBy('lastUpdated', true)
         .limit(100)
-        .execute(this.getClient());
+        .execute(this.getDatabaseClient());
 
       const entries: BundleEntry<T>[] = [];
 
@@ -428,7 +428,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
         .column('content')
         .where('id', '=', id)
         .where('versionId', '=', vid)
-        .execute(this.getClient());
+        .execute(this.getDatabaseClient());
 
       if (rows.length === 0) {
         throw new OperationOutcomeError(notFound);
@@ -698,7 +698,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
       .raw(`COUNT (DISTINCT "versionId")::int AS "count"`)
       .where('id', '=', id)
       .where('lastUpdated', '>', new Date(Date.now() - 1000 * seconds))
-      .execute(this.getClient());
+      .execute(this.getDatabaseClient());
     return rows[0].count >= maxVersions;
   }
 
@@ -730,10 +730,10 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
       throw new OperationOutcomeError(forbidden);
     }
 
-    // Do not use this.getClient() for the cursor!
+    // Do not use this.getDatabaseClient() for the cursor!
     // That would cause a deadlock.
-    // Instead, use getClient() directly over a separate connection.
-    const client = getClient();
+    // Instead, use getDatabaseClient() directly over a separate connection.
+    const client = getDatabaseClient();
     const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.addDeletedFilter(builder);
 
@@ -761,10 +761,10 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
       throw new OperationOutcomeError(forbidden);
     }
 
-    // Do not use this.getClient() for the cursor!
+    // Do not use this.getDatabaseClient() for the cursor!
     // That would cause a deadlock.
-    // Instead, use getClient() directly over a separate connection.
-    const client = getClient();
+    // Instead, use getDatabaseClient() directly over a separate connection.
+    const client = getDatabaseClient();
     const builder = new SelectQuery(resourceType).column({ tableName: resourceType, columnName: 'content' });
     this.addDeletedFilter(builder);
 
@@ -911,8 +911,8 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     if (!this.isSuperAdmin()) {
       throw new OperationOutcomeError(forbidden);
     }
-    await new DeleteQuery(resourceType).where('id', '=', id).execute(this.getClient());
-    await new DeleteQuery(resourceType + '_History').where('id', '=', id).execute(this.getClient());
+    await new DeleteQuery(resourceType).where('id', '=', id).execute(this.getDatabaseClient());
+    await new DeleteQuery(resourceType + '_History').where('id', '=', id).execute(this.getDatabaseClient());
     await deleteCacheEntry(resourceType, id);
   }
 
@@ -926,8 +926,8 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     if (!this.isSuperAdmin()) {
       throw new OperationOutcomeError(forbidden);
     }
-    await new DeleteQuery(resourceType).where('id', 'IN', ids).execute(this.getClient());
-    await new DeleteQuery(resourceType + '_History').where('id', 'IN', ids).execute(this.getClient());
+    await new DeleteQuery(resourceType).where('id', 'IN', ids).execute(this.getDatabaseClient());
+    await new DeleteQuery(resourceType + '_History').where('id', 'IN', ids).execute(this.getDatabaseClient());
     await deleteCacheEntries(resourceType, ids);
   }
 
@@ -941,8 +941,10 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     if (!this.isSuperAdmin()) {
       throw new OperationOutcomeError(forbidden);
     }
-    await new DeleteQuery(resourceType).where('lastUpdated', '<=', before).execute(this.getClient());
-    await new DeleteQuery(resourceType + '_History').where('lastUpdated', '<=', before).execute(this.getClient());
+    await new DeleteQuery(resourceType).where('lastUpdated', '<=', before).execute(this.getDatabaseClient());
+    await new DeleteQuery(resourceType + '_History')
+      .where('lastUpdated', '<=', before)
+      .execute(this.getDatabaseClient());
   }
 
   async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>> {
@@ -1749,15 +1751,15 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
    * Otherwise, returns the pool (Pool).
    * @returns The database client.
    */
-  getClient(): Pool | PoolClient {
+  getDatabaseClient(): Pool | PoolClient {
     // If in a transaction, then use the transaction client.
     // Otherwise, use the pool client.
-    return this.conn ?? getClient();
+    return this.conn ?? getDatabaseClient();
   }
 
   private async getConnection(): Promise<PoolClient> {
     if (!this.conn) {
-      this.conn = await getClient().connect();
+      this.conn = await getDatabaseClient().connect();
     }
     return this.conn;
   }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -138,7 +138,7 @@ async function getSearchEntries<T extends Resource>(
   builder.limit(count + 1); // Request one extra to test if there are more results
   builder.offset(searchRequest.offset || 0);
 
-  const rows = await builder.execute(repo.getClient());
+  const rows = await builder.execute(repo.getDatabaseClient());
   const rowCount = rows.length;
   const resources = rows.slice(0, count).map((row) => JSON.parse(row.content as string)) as T[];
   const entries = resources.map(
@@ -408,7 +408,7 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
     builder.raw('COUNT("id")::int AS "count"');
   }
 
-  const rows = await builder.execute(repo.getClient());
+  const rows = await builder.execute(repo.getDatabaseClient());
   return rows[0].count as number;
 }
 
@@ -435,7 +435,7 @@ async function getEstimateCount(
 
   // See: https://wiki.postgresql.org/wiki/Count_estimate
   // This parses the query plan to find the estimated number of rows.
-  const rows = await builder.execute(repo.getClient());
+  const rows = await builder.execute(repo.getDatabaseClient());
   let result = 0;
   for (const row of rows) {
     const queryPlan = row['QUERY PLAN'];

--- a/packages/server/src/healthcheck.ts
+++ b/packages/server/src/healthcheck.ts
@@ -1,6 +1,6 @@
 import { MEDPLUM_VERSION } from '@medplum/core';
 import { Request, Response } from 'express';
-import { getClient } from './database';
+import { getDatabaseClient } from './database';
 import { getRedis } from './redis';
 
 export async function healthcheckHandler(_req: Request, res: Response): Promise<void> {
@@ -15,7 +15,7 @@ export async function healthcheckHandler(_req: Request, res: Response): Promise<
 }
 
 async function testPostgres(): Promise<boolean> {
-  return (await getClient().query(`SELECT 1 AS "status"`)).rows[0].status === 1;
+  return (await getDatabaseClient().query(`SELECT 1 AS "status"`)).rows[0].status === 1;
 }
 
 async function testRedis(): Promise<boolean> {

--- a/packages/server/src/healthcheck.ts
+++ b/packages/server/src/healthcheck.ts
@@ -1,6 +1,6 @@
 import { MEDPLUM_VERSION } from '@medplum/core';
 import { Request, Response } from 'express';
-import { getDatabaseClient } from './database';
+import { getDatabasePool } from './database';
 import { getRedis } from './redis';
 
 export async function healthcheckHandler(_req: Request, res: Response): Promise<void> {
@@ -15,7 +15,7 @@ export async function healthcheckHandler(_req: Request, res: Response): Promise<
 }
 
 async function testPostgres(): Promise<boolean> {
-  return (await getDatabaseClient().query(`SELECT 1 AS "status"`)).rows[0].status === 1;
+  return (await getDatabasePool().query(`SELECT 1 AS "status"`)).rows[0].status === 1;
 }
 
 async function testRedis(): Promise<boolean> {

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -4,10 +4,10 @@ import { Request, Response } from 'express';
 import { URL } from 'url';
 import { asyncWrap } from '../async';
 import { getConfig } from '../config';
+import { getRequestContext } from '../context';
 import { systemRepo } from '../fhir/repo';
 import { MedplumIdTokenClaims, verifyJwt } from './keys';
-import { getClient } from './utils';
-import { getRequestContext } from '../context';
+import { getClientApplication } from './utils';
 
 /*
  * Handles the OAuth/OpenID Authorization Endpoint.
@@ -53,7 +53,7 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
   // If these are invalid, then show an error page.
   let client = undefined;
   try {
-    client = await getClient(params.client_id as string);
+    client = await getClientApplication(params.client_id as string);
   } catch (err) {
     res.status(400).send('Client not found');
     return false;

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -2,7 +2,8 @@ import { randomUUID } from 'crypto';
 import { generateKeyPair, SignJWT } from 'jose';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig, MedplumServerConfig } from '../config';
-import { getClient } from '../database';
+import { getDatabaseClient } from '../database';
+import { withTestContext } from '../test.setup';
 import {
   generateAccessToken,
   generateIdToken,
@@ -13,7 +14,6 @@ import {
   initKeys,
   verifyJwt,
 } from './keys';
-import { withTestContext } from '../test.setup';
 
 describe('Keys', () => {
   beforeAll(async () => {
@@ -30,7 +30,7 @@ describe('Keys', () => {
       const config = await loadTestConfig();
 
       // First, delete all existing keys
-      await getClient().query('DELETE FROM "JsonWebKey"');
+      await getDatabaseClient().query('DELETE FROM "JsonWebKey"');
 
       // Init once
       await initKeys(config);

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { generateKeyPair, SignJWT } from 'jose';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig, MedplumServerConfig } from '../config';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { withTestContext } from '../test.setup';
 import {
   generateAccessToken,
@@ -30,7 +30,7 @@ describe('Keys', () => {
       const config = await loadTestConfig();
 
       // First, delete all existing keys
-      await getDatabaseClient().query('DELETE FROM "JsonWebKey"');
+      await getDatabasePool().query('DELETE FROM "JsonWebKey"');
 
       // Init once
       await initKeys(config);

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -25,7 +25,7 @@ import { getTopicForUser } from '../fhircast/utils';
 import { MedplumRefreshTokenClaims, generateSecret, verifyJwt } from './keys';
 import {
   getAuthTokens,
-  getClient,
+  getClientApplication,
   getClientApplicationMembership,
   getExternalUserInfo,
   revokeLogin,
@@ -202,7 +202,7 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<voi
   let client: ClientApplication | undefined;
   if (clientId) {
     try {
-      client = await getClient(clientId);
+      client = await getClientApplication(clientId);
     } catch (err) {
       sendTokenError(res, 'invalid_request', 'Invalid client');
       return;

--- a/packages/server/src/oauth/utils.test.ts
+++ b/packages/server/src/oauth/utils.test.ts
@@ -6,7 +6,7 @@ import { loadTestConfig } from '../config';
 import { createTestClient, withTestContext } from '../test.setup';
 import {
   getAuthTokens,
-  getClient,
+  getClientApplication,
   getMembershipsForLogin,
   tryLogin,
   validateLoginRequest,
@@ -434,7 +434,7 @@ describe('OAuth utils', () => {
   });
 
   test('CLI client', async () => {
-    const client = await getClient('medplum-cli');
+    const client = await getClientApplication('medplum-cli');
     expect(client).toBeDefined();
     expect(client.id).toEqual('medplum-cli');
   });

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -110,7 +110,7 @@ export interface GoogleCredentialClaims extends JWTPayload {
  * @param clientId - The client ID.
  * @returns The client application.
  */
-export async function getClient(clientId: string): Promise<ClientApplication> {
+export async function getClientApplication(clientId: string): Promise<ClientApplication> {
   if (clientId === 'medplum-cli') {
     return {
       resourceType: 'ClientApplication',
@@ -127,7 +127,7 @@ export async function tryLogin(request: LoginRequest): Promise<Login> {
 
   let client: ClientApplication | undefined;
   if (request.clientId) {
-    client = await getClient(request.clientId);
+    client = await getClientApplication(request.clientId);
   }
 
   validatePkce(request, client);

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -1,7 +1,7 @@
 import { Project } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from './app';
 import { loadTestConfig } from './config';
-import { getClient } from './database';
+import { getDatabaseClient } from './database';
 import { SelectQuery } from './fhir/sql';
 import { seedDatabase } from './seed';
 import { withTestContext } from './test.setup';
@@ -26,7 +26,7 @@ describe('Seed', () => {
     const rows = await new SelectQuery('Project')
       .column('content')
       .where('name', '=', 'Super Admin')
-      .execute(getClient());
+      .execute(getDatabaseClient());
     expect(rows.length).toBe(1);
 
     const project = JSON.parse(rows[0].content) as Project;

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -1,7 +1,7 @@
 import { Project } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from './app';
 import { loadTestConfig } from './config';
-import { getDatabaseClient } from './database';
+import { getDatabasePool } from './database';
 import { SelectQuery } from './fhir/sql';
 import { seedDatabase } from './seed';
 import { withTestContext } from './test.setup';
@@ -26,7 +26,7 @@ describe('Seed', () => {
     const rows = await new SelectQuery('Project')
       .column('content')
       .where('name', '=', 'Super Admin')
-      .execute(getDatabaseClient());
+      .execute(getDatabasePool());
     expect(rows.length).toBe(1);
 
     const project = JSON.parse(rows[0].content) as Project;

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,6 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { BundleEntry, SearchParameter } from '@medplum/fhirtypes';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { systemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { r4ProjectId } from '../seed';
@@ -9,7 +9,7 @@ import { r4ProjectId } from '../seed';
  * Creates all SearchParameter resources.
  */
 export async function rebuildR4SearchParameters(): Promise<void> {
-  const client = getDatabaseClient();
+  const client = getDatabasePool();
   await client.query('DELETE FROM "SearchParameter" WHERE "projectId" = $1', [r4ProjectId]);
 
   for (const entry of readJson('fhir/r4/search-parameters.json').entry as BundleEntry[]) {

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,6 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { BundleEntry, SearchParameter } from '@medplum/fhirtypes';
-import { getClient } from '../database';
+import { getDatabaseClient } from '../database';
 import { systemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { r4ProjectId } from '../seed';
@@ -9,7 +9,7 @@ import { r4ProjectId } from '../seed';
  * Creates all SearchParameter resources.
  */
 export async function rebuildR4SearchParameters(): Promise<void> {
-  const client = getClient();
+  const client = getDatabaseClient();
   await client.query('DELETE FROM "SearchParameter" WHERE "projectId" = $1', [r4ProjectId]);
 
   for (const entry of readJson('fhir/r4/search-parameters.json').entry as BundleEntry[]) {

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,6 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
-import { getClient } from '../database';
+import { getDatabaseClient } from '../database';
 import { systemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { r4ProjectId } from '../seed';
@@ -9,7 +9,7 @@ import { r4ProjectId } from '../seed';
  * Creates all StructureDefinition resources.
  */
 export async function rebuildR4StructureDefinitions(): Promise<void> {
-  const client = getClient();
+  const client = getDatabaseClient();
   await client.query(`DELETE FROM "StructureDefinition" WHERE "projectId" = $1`, [r4ProjectId]);
   await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
   await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,6 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { systemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { r4ProjectId } from '../seed';
@@ -9,7 +9,7 @@ import { r4ProjectId } from '../seed';
  * Creates all StructureDefinition resources.
  */
 export async function rebuildR4StructureDefinitions(): Promise<void> {
-  const client = getDatabaseClient();
+  const client = getDatabasePool();
   await client.query(`DELETE FROM "StructureDefinition" WHERE "projectId" = $1`, [r4ProjectId]);
   await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
   await createStructureDefinitionsForBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -7,7 +7,7 @@ import { createHmac, randomUUID } from 'crypto';
 import fetch from 'node-fetch';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
-import { getDatabaseClient } from '../database';
+import { getDatabasePool } from '../database';
 import { Repository, systemRepo } from '../fhir/repo';
 import { getRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
@@ -80,7 +80,7 @@ describe('Subscription Worker', () => {
   });
 
   beforeEach(async () => {
-    await getDatabaseClient().query('DELETE FROM "Subscription"');
+    await getDatabasePool().query('DELETE FROM "Subscription"');
     (fetch as unknown as jest.Mock).mockClear();
   });
 

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -5,12 +5,11 @@ import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import { Job } from 'bullmq';
 import { createHmac, randomUUID } from 'crypto';
 import fetch from 'node-fetch';
-import { getRedis } from '../redis';
-
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
-import { getClient } from '../database';
+import { getDatabaseClient } from '../database';
 import { Repository, systemRepo } from '../fhir/repo';
+import { getRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 import { AuditEventOutcome } from '../util/auditevent';
 import { closeSubscriptionWorker, execSubscriptionJob, getSubscriptionQueue } from './subscription';
@@ -81,7 +80,7 @@ describe('Subscription Worker', () => {
   });
 
   beforeEach(async () => {
-    await getClient().query('DELETE FROM "Subscription"');
+    await getDatabaseClient().query('DELETE FROM "Subscription"');
     (fetch as unknown as jest.Mock).mockClear();
   });
 


### PR DESCRIPTION
This is a pure cleanup PR, no functional changes.

We had 2 global methods in `server` named `getClient()`

1. Get a database client
    a. Global `getClient()` renamed to `getDatabasePool()`
    b. Repo `getClient()` renamed to `repo.getDatabaseClient()`
2. Get a `ClientApplication` by ID, renamed to `getClientApplicaiton()`