### PR TITLE
Add global var "module" to vm context bots

### DIFF
--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -416,6 +416,7 @@ async function runInVmContext(request: BotExecutionRequest): Promise<BotExecutio
   // Wrap code in an async block for top-level await support
   const wrappedCode = `
   const exports = {};
+  const module = {exports};
 
   // Start user code
   ${code}


### PR DESCRIPTION
This PR to help make Bot code compiled for AWS Lambda also compatible with VM context bots

Common JS expects both `exports` and `module` to exist [link](https://github.com/evanw/esbuild/issues/1964#issuecomment-1022823792). 

To mimic this behavior in VM context bots, we add a "module" variable in the wrapper code.



