### PR TITLE
rate limit should return `OperationOutcome`

### DIFF
--- a/packages/server/src/ratelimit.ts
+++ b/packages/server/src/ratelimit.ts
@@ -1,4 +1,5 @@
 import rateLimit, { MemoryStore, RateLimitRequestHandler } from 'express-rate-limit';
+import { OperationOutcomeError, tooManyRequests } from '@medplum/core';
 
 /*
  * MemoryStore must be shutdown to cleanly stop the server.
@@ -15,6 +16,9 @@ export function getRateLimiter(): RateLimitRequestHandler {
       max: 600, // limit each IP to 600 requests per windowMs
       validate: false, // Ignore X-Forwarded-For warnings
       store,
+      handler: (req, res, next) => {
+        next(new OperationOutcomeError(tooManyRequests));
+      },
     });
   }
   return handler;

--- a/packages/server/src/ratelimit.ts
+++ b/packages/server/src/ratelimit.ts
@@ -16,7 +16,7 @@ export function getRateLimiter(): RateLimitRequestHandler {
       max: 600, // limit each IP to 600 requests per windowMs
       validate: false, // Ignore X-Forwarded-For warnings
       store,
-      handler: (req, res, next) => {
+      handler: (_, __, next) => {
         next(new OperationOutcomeError(tooManyRequests));
       },
     });


### PR DESCRIPTION
custom error handler for express-rate-limit to respond with an OperationOutcome-compliant response when rate limit is encountered https://express-rate-limit.mintlify.app/reference/configuration#handler