### PR TITLE
Repo sql fixes for cockroachdb

### DIFF
--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -1,13 +1,13 @@
 import { AsyncJob } from '@medplum/fhirtypes';
-import { Repository, systemRepo } from '../../repo';
-import { getRequestContext } from '../../../context';
 import { AsyncLocalStorage } from 'async_hooks';
+import { getRequestContext } from '../../../context';
+import { Repository, systemRepo } from '../../repo';
 
 export class AsyncJobExecutor {
   readonly repo: Repository;
   private resource: AsyncJob | undefined;
   constructor(repo: Repository) {
-    this.repo = repo;
+    this.repo = repo.clone();
   }
 
   async init(url: string): Promise<AsyncJob> {
@@ -53,6 +53,8 @@ export class AsyncJobExecutor {
         transactionTime: new Date().toISOString(),
       });
       throw err;
+    } finally {
+      this.repo.close();
     }
   }
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -768,7 +768,7 @@ function buildReferenceSearchFilter(details: SearchParameterDetails, values: str
     !v.includes('/') && (details.columnName === 'subject' || details.columnName === 'patient') ? `Patient/${v}` : v
   );
   if (details.array) {
-    return new Condition(details.columnName, 'ARRAY_CONTAINS', values);
+    return new Condition(details.columnName, 'ARRAY_CONTAINS', values, 'TEXT[]');
   } else if (values.length === 1) {
     return new Condition(details.columnName, '=', values[0]);
   }

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -38,17 +38,24 @@ describe('SqlBuilder', () => {
 
   test('Select where array contains', () => {
     const sql = new SqlBuilder();
-    new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', 'x').buildSql(sql);
+    new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', 'x', 'TEXT[]').buildSql(sql);
     expect(sql.toString()).toBe(
-      'SELECT "MyTable"."id" FROM "MyTable" WHERE ("MyTable"."name" IS NOT NULL AND "MyTable"."name" && ARRAY[$1])'
+      'SELECT "MyTable"."id" FROM "MyTable" WHERE ("MyTable"."name" IS NOT NULL AND "MyTable"."name" && ARRAY[$1]::TEXT[])'
     );
   });
 
   test('Select where array contains array', () => {
     const sql = new SqlBuilder();
-    new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', ['x', 'y']).buildSql(sql);
+    new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', ['x', 'y'], 'TEXT[]').buildSql(sql);
     expect(sql.toString()).toBe(
-      'SELECT "MyTable"."id" FROM "MyTable" WHERE ("MyTable"."name" IS NOT NULL AND "MyTable"."name" && ARRAY[$1,$2])'
+      'SELECT "MyTable"."id" FROM "MyTable" WHERE ("MyTable"."name" IS NOT NULL AND "MyTable"."name" && ARRAY[$1,$2]::TEXT[])'
+    );
+  });
+
+  test('Select where array contains missing param type', () => {
+    const sql = new SqlBuilder();
+    expect(() => new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', 'x').buildSql(sql)).toThrow(
+      'ARRAY_CONTAINS requires paramType'
     );
   });
 

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -145,6 +145,10 @@ export class Condition implements Expression {
     readonly parameter: any,
     readonly parameterType?: string
   ) {
+    if (operator === 'ARRAY_CONTAINS' && !parameterType) {
+      throw new Error('ARRAY_CONTAINS requires paramType');
+    }
+
     this.column = getColumn(column);
   }
 


### PR DESCRIPTION
Assortment of SQL fixes found when running Medplum with CockroachDB backend

1. `AsyncJobExecutor` needs a clone of the `Repository` to ensure no shared state / shared connections (otherwise connections can get prematurely closed by the request, breaking the async job).
2. `addSubscriptionJobs` needs to be outside of the `deleteResource` transaction
3. The `&&` operator requires explicit typing (i.e., `"name" && ARRAY[$1]::TEXT[]`) in CockroachDB.