### PR TITLE
feat(agent): add `ping` via `Agent/$push`

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -13,7 +13,7 @@ import {
 import { Endpoint, Reference } from '@medplum/fhirtypes';
 import { Hl7Client } from '@medplum/hl7';
 import { exec as _exec } from 'node:child_process';
-import { isIP } from 'node:net';
+import { isIPv4, isIPv6 } from 'node:net';
 import { promisify } from 'node:util';
 import { platform } from 'os';
 import WebSocket from 'ws';
@@ -271,8 +271,11 @@ export class App {
         const warnMsg = 'Message body present but unused. Body should be empty for a ping request.';
         this.log.warn(warnMsg);
       }
-      if (!isIP(message.remote)) {
-        const errMsg = `Attempted to ping invalid IP: ${message.remote}`;
+      if (!isIPv4(message.remote)) {
+        let errMsg = `Attempted to ping invalid IP: ${message.remote}`;
+        if (isIPv6(message.remote)) {
+          errMsg = `Attempted to ping an IPv6 address: ${message.remote}\n\nIPv6 is currently unsupported.`;
+        }
         this.log.error(errMsg);
         throw new Error(errMsg);
       }

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -1,6 +1,8 @@
 import {
+  AgentError,
   AgentMessage,
   AgentTransmitRequest,
+  AgentTransmitResponse,
   ContentType,
   Hl7Message,
   LogLevel,
@@ -10,10 +12,16 @@ import {
 } from '@medplum/core';
 import { Endpoint, Reference } from '@medplum/fhirtypes';
 import { Hl7Client } from '@medplum/hl7';
+import { exec as _exec } from 'node:child_process';
+import { isIP } from 'node:net';
+import { promisify } from 'node:util';
+import { platform } from 'os';
 import WebSocket from 'ws';
 import { Channel } from './channel';
 import { AgentDicomChannel } from './dicom';
 import { AgentHl7Channel } from './hl7';
+
+const exec = promisify(_exec);
 
 export class App {
   static instance: App;
@@ -137,7 +145,11 @@ export class App {
           // @ts-expect-error - Deprecated message type
           case 'push':
           case 'agent:transmit:request':
-            this.pushMessage(command);
+            if (command.contentType === ContentType.PING) {
+              await this.tryPingIp(command);
+            } else {
+              this.pushMessage(command);
+            }
             break;
           case 'agent:error':
             this.log.error(command.body);
@@ -250,6 +262,50 @@ export class App {
           channel.sendToRemote(msg);
         }
       }
+    }
+  }
+
+  // Send ping
+  // TODO: Handle error
+  // What should return to user?
+  // Should we validate IP?
+  // What about linux vs windows? How to test?
+
+  private async tryPingIp(message: AgentTransmitRequest): Promise<void> {
+    try {
+      if (message.body && message.body !== 'PING') {
+        const warnMsg = 'Message body present but unused. Body should be empty for a ping request.';
+        this.log.warn(warnMsg);
+      }
+      if (!isIP(message.remote)) {
+        const errMsg = `Attempted to ping invalid IP: ${message.remote}`;
+        this.log.error(errMsg);
+        throw new Error(errMsg);
+      }
+      // This covers Windows, Linux, and Mac
+      const { stderr, stdout } = await exec(
+        platform() === 'win32' ? `ping ${message.remote}` : `ping -c 4 ${message.remote}`
+      );
+      if (stderr) {
+        throw new Error(`Received on stderr:\n\n${stderr}`);
+      }
+      // TODO: parse stdout
+      // Unix: 12.245/13.927/16.017/1.567 ms (second is avg)
+      this.log.info(`Ping result for ${message.remote}:\n\n${stdout}`);
+      this.addToWebSocketQueue({
+        type: 'agent:transmit:response',
+        channel: message.channel,
+        contentType: ContentType.PING,
+        remote: message.remote,
+        callback: message.callback,
+        body: stdout,
+      } satisfies AgentTransmitResponse);
+    } catch (err) {
+      this.log.error(`Error during ping attempt to ${message.remote ?? 'NO_IP_GIVEN'}: ${normalizeErrorString(err)}`);
+      this.addToWebSocketQueue({
+        type: 'agent:error',
+        body: (err as Error).message,
+      } satisfies AgentError);
     }
   }
 

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -265,12 +265,6 @@ export class App {
     }
   }
 
-  // Send ping
-  // TODO: Handle error
-  // What should return to user?
-  // Should we validate IP?
-  // What about linux vs windows? How to test?
-
   private async tryPingIp(message: AgentTransmitRequest): Promise<void> {
     try {
       if (message.body && message.body !== 'PING') {
@@ -289,8 +283,6 @@ export class App {
       if (stderr) {
         throw new Error(`Received on stderr:\n\n${stderr}`);
       }
-      // TODO: parse stdout
-      // Unix: 12.245/13.927/16.017/1.567 ms (second is avg)
       this.log.info(`Ping result for ${message.remote}:\n\n${stdout}`);
       this.addToWebSocketQueue({
         type: 'agent:transmit:response',

--- a/packages/agent/src/net-utils.test.ts
+++ b/packages/agent/src/net-utils.test.ts
@@ -1,0 +1,109 @@
+import { AgentMessage, allOk, ContentType, createReference, LogLevel, sleep } from '@medplum/core';
+import { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { Client, Server } from 'mock-socket';
+import { App } from './app';
+
+jest.mock('node-windows');
+
+const medplum = new MockClient();
+let bot: Bot;
+let endpoint: Endpoint;
+
+describe('Agent Net Utils', () => {
+  beforeAll(async () => {
+    console.log = jest.fn();
+
+    medplum.router.router.add('POST', ':resourceType/:id/$execute', async () => {
+      return [allOk, {} as Resource];
+    });
+
+    bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
+    endpoint = await medplum.createResource<Endpoint>({
+      resourceType: 'Endpoint',
+      status: 'active',
+      address: 'mllp://0.0.0.0:57000',
+      connectionType: { code: ContentType.HL7_V2 },
+      payloadType: [{ coding: [{ code: ContentType.HL7_V2 }] }],
+    });
+  });
+
+  test('Ping', async () => {
+    const mockServer = new Server('wss://example.com/ws/agent');
+    let mySocket: Client | undefined = undefined;
+
+    let resolve: (value: AgentMessage) => void;
+    let reject: (error: Error) => void;
+    const deferredPromise = new Promise<AgentMessage>((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+
+    mockServer.on('connection', (socket) => {
+      mySocket = socket;
+      socket.on('message', (data) => {
+        const command = JSON.parse((data as Buffer).toString('utf8'));
+        console.log(command);
+        if (command.type === 'agent:connect:request') {
+          socket.send(
+            Buffer.from(
+              JSON.stringify({
+                type: 'agent:connect:response',
+              })
+            )
+          );
+        } else if (command.type === 'agent:transmit:response' && command.contentType === ContentType.PING) {
+          resolve(command);
+        }
+      });
+    });
+
+    const agent = await medplum.createResource<Agent>({
+      resourceType: 'Agent',
+      channel: [
+        {
+          name: 'test',
+          endpoint: createReference(endpoint),
+          targetReference: createReference(bot),
+        },
+      ],
+    } as Agent);
+
+    // Start the app
+    const app = new App(medplum, agent.id as string, LogLevel.INFO);
+    await app.start();
+
+    // Wait for the WebSocket to connect
+    // eslint-disable-next-line no-unmodified-loop-condition
+    while (!mySocket) {
+      await sleep(100);
+    }
+
+    // At this point, we expect the websocket to be connected
+    expect(mySocket).toBeDefined();
+
+    // Send a push message
+    const wsClient = mySocket as unknown as Client;
+    wsClient.send(
+      Buffer.from(
+        JSON.stringify({
+          type: 'agent:transmit:request',
+          contentType: ContentType.PING,
+          remote: '127.0.0.1',
+          body: 'PING',
+        })
+      )
+    );
+
+    try {
+      const timer = setTimeout(() => {
+        reject(new Error('Timeout'));
+      }, 3500);
+      await deferredPromise;
+      clearTimeout(timer);
+    } finally {
+      app.stop();
+      mockServer.stop();
+    }
+  });
+});

--- a/packages/agent/src/net-utils.test.ts
+++ b/packages/agent/src/net-utils.test.ts
@@ -1,5 +1,5 @@
-import { AgentMessage, allOk, ContentType, createReference, LogLevel, sleep } from '@medplum/core';
-import { Agent, Bot, Endpoint, Resource } from '@medplum/fhirtypes';
+import { AgentMessage, allOk, ContentType, LogLevel, sleep } from '@medplum/core';
+import { Agent, Resource } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { Client, Server } from 'mock-socket';
 import { App } from './app';
@@ -7,8 +7,6 @@ import { App } from './app';
 jest.mock('node-windows');
 
 const medplum = new MockClient();
-let bot: Bot;
-let endpoint: Endpoint;
 
 describe('Agent Net Utils', () => {
   beforeAll(async () => {
@@ -16,15 +14,6 @@ describe('Agent Net Utils', () => {
 
     medplum.router.router.add('POST', ':resourceType/:id/$execute', async () => {
       return [allOk, {} as Resource];
-    });
-
-    bot = await medplum.createResource<Bot>({ resourceType: 'Bot' });
-    endpoint = await medplum.createResource<Endpoint>({
-      resourceType: 'Endpoint',
-      status: 'active',
-      address: 'mllp://0.0.0.0:57000',
-      connectionType: { code: ContentType.HL7_V2 },
-      payloadType: [{ coding: [{ code: ContentType.HL7_V2 }] }],
     });
   });
 
@@ -60,13 +49,6 @@ describe('Agent Net Utils', () => {
 
     const agent = await medplum.createResource<Agent>({
       resourceType: 'Agent',
-      channel: [
-        {
-          name: 'test',
-          endpoint: createReference(endpoint),
-          targetReference: createReference(bot),
-        },
-      ],
     } as Agent);
 
     // Start the app

--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -21,12 +21,12 @@ import { CreateClientPage } from './admin/CreateClientPage';
 import { EditMembershipPage } from './admin/EditMembershipPage';
 import { InvitePage } from './admin/InvitePage';
 import { PatientsPage } from './admin/PatientsPage';
+import { ProjectAdminConfigPage } from './admin/ProjectAdminConfigPage';
 import { ProjectDetailsPage } from './admin/ProjectDetailsPage';
 import { ProjectPage } from './admin/ProjectPage';
 import { SecretsPage } from './admin/SecretsPage';
 import { SitesPage } from './admin/SitesPage';
 import { SuperAdminPage } from './admin/SuperAdminPage';
-import { ProjectAdminConfigPage } from './admin/ProjectAdminConfigPage';
 import { UsersPage } from './admin/UsersPage';
 import { AssaysPage } from './lab/AssaysPage';
 import { PanelsPage } from './lab/PanelsPage';
@@ -40,9 +40,12 @@ import { ChecklistPage } from './resource/ChecklistPage';
 import { DeletePage } from './resource/DeletePage';
 import { DetailsPage } from './resource/DetailsPage';
 import { EditPage } from './resource/EditPage';
+import { FormCreatePage } from './resource/FormCreatePage';
 import { HistoryPage } from './resource/HistoryPage';
+import { JsonCreatePage } from './resource/JsonCreatePage';
 import { JsonPage } from './resource/JsonPage';
 import { PreviewPage } from './resource/PreviewPage';
+import { ProfilesPage } from './resource/ProfilesPage';
 import { QuestionnaireBotsPage } from './resource/QuestionnaireBotsPage';
 import { QuestionnaireResponsePage } from './resource/QuestionnaireResponsePage';
 import { ReferenceRangesPage } from './resource/ReferenceRangesPage';
@@ -51,9 +54,7 @@ import { ResourcePage } from './resource/ResourcePage';
 import { ResourceVersionPage } from './resource/ResourceVersionPage';
 import { SubscriptionsPage } from './resource/SubscriptionsPage';
 import { TimelinePage } from './resource/TimelinePage';
-import { FormCreatePage } from './resource/FormCreatePage';
-import { JsonCreatePage } from './resource/JsonCreatePage';
-import { ProfilesPage } from './resource/ProfilesPage';
+import { ToolsPage } from './resource/ToolsPage';
 
 export function AppRoutes(): JSX.Element {
   return (
@@ -96,6 +97,7 @@ export function AppRoutes(): JSX.Element {
           <Route path="form" element={<FormCreatePage />} />
           <Route path="json" element={<JsonCreatePage />} />
         </Route>
+        <Route path="/Agent/:id/tools" element={<ToolsPage />} />
         <Route path="/:resourceType/:id" element={<ResourcePage />}>
           <Route index element={<TimelinePage />} />
           <Route path="apply" element={<ApplyPage />} />

--- a/packages/app/src/resource/ResourcePage.tsx
+++ b/packages/app/src/resource/ResourcePage.tsx
@@ -40,6 +40,10 @@ function getTabs(resourceType: string): string[] {
     result.push('Ranges');
   }
 
+  if (resourceType === 'Agent') {
+    result.push('Tools');
+  }
+
   result.push('Details', 'Edit', 'Event', 'History', 'Blame', 'JSON', 'Apps', 'Profiles');
   return result;
 }

--- a/packages/app/src/resource/ToolsPage.test.tsx
+++ b/packages/app/src/resource/ToolsPage.test.tsx
@@ -1,0 +1,73 @@
+import { getReferenceString } from '@medplum/core';
+import { Agent } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AppRoutes } from '../AppRoutes';
+import { act, fireEvent, render, screen, userEvent } from '../test-utils/render';
+
+const medplum = new MockClient();
+
+describe('ToolsPage', () => {
+  let agent: Agent;
+
+  function setup(url: string): void {
+    render(
+      <MedplumProvider medplum={medplum}>
+        <MemoryRouter initialEntries={[url]} initialIndex={0}>
+          <AppRoutes />
+        </MemoryRouter>
+      </MedplumProvider>
+    );
+  }
+
+  beforeAll(async () => {
+    agent = await medplum.createResource<Agent>({
+      resourceType: 'Agent',
+      name: 'Agente',
+    } as Agent);
+  });
+
+  test('Renders last ping', async () => {
+    // load agent page
+    await act(async () => {
+      setup(`/${getReferenceString(agent)}`);
+    });
+
+    const toolsTab = screen.getByRole('tab', { name: 'Tools' });
+
+    // click on Tools tab
+    await act(async () => {
+      fireEvent.click(toolsTab);
+    });
+
+    expect(screen.getByText(agent.name)).toBeInTheDocument();
+    expect(screen.getByLabelText('IP')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('IP'), { target: { value: '8.8.8.8' } });
+      await userEvent.keyboard('8.8.8.8');
+      fireEvent.click(screen.getByText('Ping'));
+    });
+
+    await expect(screen.findByText('statistics', { exact: false })).resolves.toBeInTheDocument();
+  });
+
+  test('Displays error toast whenever invalid IP entered', async () => {
+    // load agent tools page
+    await act(async () => {
+      setup(`/${getReferenceString(agent)}/tools`);
+    });
+
+    expect(screen.getByText(agent.name)).toBeInTheDocument();
+    expect(screen.getByLabelText('IP')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('IP'), { target: { value: '8.8.8.8' } });
+      await userEvent.keyboard('abc123');
+      fireEvent.click(screen.getByText('Ping'));
+    });
+
+    await expect(screen.findByText('Error: Invalid IP entered'));
+  });
+});

--- a/packages/app/src/resource/ToolsPage.tsx
+++ b/packages/app/src/resource/ToolsPage.tsx
@@ -1,0 +1,70 @@
+import { Button, Input, Title } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { ContentType } from '@medplum/core';
+import { Agent, Reference } from '@medplum/fhirtypes';
+import { Document, Form, useMedplum } from '@medplum/react';
+import { IconRouter } from '@tabler/icons-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+export function ToolsPage(): JSX.Element | null {
+  const medplum = useMedplum();
+  const { id } = useParams() as { id: string };
+  const reference = useMemo(() => ({ reference: 'Agent/' + id }) as Reference<Agent>, [id]);
+  const [ip, setIp] = useState('');
+  const [lastPing, setLastPing] = useState<string | undefined>();
+  const [pinging, setPinging] = useState(false);
+
+  const ipRef = useRef(ip);
+  ipRef.current = ip;
+
+  const onSubmit = useCallback(() => {
+    if (ipRef.current === '') {
+      return;
+    }
+    setPinging(true);
+    medplum
+      .pushToAgent(reference, ipRef.current, 'PING', ContentType.PING, true)
+      .then((pingResult: string) => {
+        setLastPing(pingResult);
+        setPinging(false);
+      })
+      .catch((err) => {
+        setPinging(false);
+        if ((err as Error).message === 'Destination device not found') {
+          // Report error
+          showNotification({
+            color: 'red',
+            message: 'Error: Destination device not found or IP invalid',
+          });
+        }
+      });
+  }, [medplum, reference]);
+
+  return (
+    <Document>
+      <Title>Ping from Agent</Title>
+      <Form onSubmit={onSubmit}>
+        <Input.Wrapper label="IP">
+          <Input name="ip" onChange={(e) => setIp(e.target.value)} value={ip} />
+        </Input.Wrapper>
+      </Form>
+      <Button
+        mt={10}
+        mb={20}
+        type="button"
+        onClick={onSubmit}
+        loading={pinging}
+        leftSection={<IconRouter size="1rem" />}
+      >
+        Ping
+      </Button>
+      {!pinging && lastPing && (
+        <>
+          <Title order={5}>Last Ping</Title>
+          <pre>{lastPing}</pre>
+        </>
+      )}
+    </Document>
+  );
+}

--- a/packages/app/src/resource/ToolsPage.tsx
+++ b/packages/app/src/resource/ToolsPage.tsx
@@ -2,7 +2,7 @@ import { Button, Input, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { ContentType } from '@medplum/core';
 import { Agent, Reference } from '@medplum/fhirtypes';
-import { Document, Form, useMedplum } from '@medplum/react';
+import { Document, Form, ResourceName, useMedplum } from '@medplum/react';
 import { IconRouter } from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -29,13 +29,13 @@ export function ToolsPage(): JSX.Element | null {
         setLastPing(pingResult);
         setPinging(false);
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         setPinging(false);
         if ((err as Error).message === 'Destination device not found') {
           // Report error
           showNotification({
             color: 'red',
-            message: 'Error: Destination device not found or IP invalid',
+            message: 'Error: Invalid IP entered',
           });
         }
       });
@@ -44,6 +44,9 @@ export function ToolsPage(): JSX.Element | null {
   return (
     <Document>
       <Title>Ping from Agent</Title>
+      <div style={{ marginBottom: 10 }}>
+        Agent: <ResourceName value={reference} link />
+      </div>
       <Form onSubmit={onSubmit}>
         <Input.Wrapper label="IP">
           <Input name="ip" onChange={(e) => setIp(e.target.value)} value={ip} />

--- a/packages/app/src/resource/ToolsPage.tsx
+++ b/packages/app/src/resource/ToolsPage.tsx
@@ -35,7 +35,16 @@ export function ToolsPage(): JSX.Element | null {
           // Report error
           showNotification({
             color: 'red',
-            message: 'Error: Invalid IP entered',
+            title: 'Error',
+            message: 'Invalid IP entered',
+            autoClose: false,
+          });
+        } else if ((err as Error).message === 'Timeout') {
+          showNotification({
+            color: 'red',
+            title: 'Error',
+            message: '"$push" operation timed out. Agent may be unreachable',
+            autoClose: false,
           });
         }
       });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2397,7 +2397,7 @@ export class MedplumClient extends EventTarget {
    */
   pushToAgent(
     agent: Agent | Reference<Agent>,
-    destination: Device | Reference<Device>,
+    destination: Device | Reference<Device> | string,
     body: any,
     contentType?: string,
     waitForResponse?: boolean,
@@ -2406,7 +2406,7 @@ export class MedplumClient extends EventTarget {
     return this.post(
       this.fhirUrl('Agent', resolveId(agent) as string, '$push'),
       {
-        destination: getReferenceString(destination),
+        destination: typeof destination === 'string' ? destination : getReferenceString(destination),
         body,
         contentType,
         waitForResponse,

--- a/packages/core/src/contenttype.ts
+++ b/packages/core/src/contenttype.ts
@@ -16,4 +16,5 @@ export const ContentType = {
   SVG: 'image/svg+xml',
   TEXT: 'text/plain',
   TYPESCRIPT: 'text/typescript',
+  PING: 'x-application/ping',
 } as const;

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -8,6 +8,7 @@ import {
   LoginState,
   MedplumClient,
   MedplumClientOptions,
+  OperationOutcomeError,
   ProfileResource,
 } from '@medplum/core';
 import { FhirRequest, FhirRouter, HttpMethod, MemoryRepository } from '@medplum/fhir-router';
@@ -23,7 +24,6 @@ import {
 } from '@medplum/fhirtypes';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 /** @ts-ignore */
-import { OperationOutcomeError } from '@medplum/core';
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
 import {
   BartSimpson,

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -11,9 +11,19 @@ import {
   ProfileResource,
 } from '@medplum/core';
 import { FhirRequest, FhirRouter, HttpMethod, MemoryRepository } from '@medplum/fhir-router';
-import { Binary, Resource, SearchParameter, StructureDefinition, UserConfiguration } from '@medplum/fhirtypes';
+import {
+  Agent,
+  Binary,
+  Device,
+  Reference,
+  Resource,
+  SearchParameter,
+  StructureDefinition,
+  UserConfiguration,
+} from '@medplum/fhirtypes';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 /** @ts-ignore */
+import { OperationOutcomeError } from '@medplum/core';
 import type { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
 import {
   BartSimpson,
@@ -21,7 +31,6 @@ import {
   DrAliceSmith,
   DrAliceSmithPreviousVersion,
   DrAliceSmithSchedule,
-  makeDrAliceSmithSlots,
   ExampleBot,
   ExampleClient,
   ExampleQuestionnaire,
@@ -44,6 +53,7 @@ import {
   HomerSimpson,
   HomerSimpsonPreviousVersion,
   HomerSimpsonSpecimen,
+  makeDrAliceSmithSlots,
   TestOrganization,
 } from './mocks';
 import { ExampleAccessPolicy, ExampleStatusValueSet, ExampleUserConfiguration } from './mocks/accesspolicy';
@@ -178,6 +188,33 @@ export class MockClient extends MedplumClient {
       contentType,
       url: 'https://example.com/binary/123',
     };
+  }
+
+  async pushToAgent(
+    agent: Agent | Reference<Agent>,
+    destination: Device | Reference<Device> | string,
+    body: any,
+    contentType?: string | undefined,
+    _waitForResponse?: boolean | undefined,
+    _options?: RequestInit | undefined
+  ): Promise<any> {
+    if (contentType === ContentType.PING) {
+      if (typeof destination === 'string' && destination !== '8.8.8.8') {
+        console.warn('IPs other than 8.8.8.8 will always throw an error in MockClient');
+        throw new OperationOutcomeError(badRequest('Destination device not found'));
+      }
+      return `PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: icmp_seq=0 ttl=115 time=10.977 ms
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=115 time=13.037 ms
+64 bytes from 8.8.8.8: icmp_seq=2 ttl=115 time=23.159 ms
+64 bytes from 8.8.8.8: icmp_seq=3 ttl=115 time=12.725 ms
+
+--- 8.8.8.8 ping statistics ---
+4 packets transmitted, 4 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 10.977/14.975/23.159/4.790 ms
+`;
+    }
+    return undefined;
   }
 }
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -88,6 +88,7 @@ export class MockClient extends MedplumClient {
   readonly client: MockFetchClient;
   readonly debug: boolean;
   activeLoginOverride?: LoginState;
+  private agentAvailable: boolean = true;
   private readonly profile: ReturnType<MedplumClient['getProfile']>;
 
   constructor(clientOptions?: MockClientOptions) {
@@ -199,8 +200,14 @@ export class MockClient extends MedplumClient {
     _options?: RequestInit | undefined
   ): Promise<any> {
     if (contentType === ContentType.PING) {
+      if (!this.agentAvailable) {
+        throw new OperationOutcomeError(badRequest('Timeout'));
+      }
       if (typeof destination === 'string' && destination !== '8.8.8.8') {
-        console.warn('IPs other than 8.8.8.8 will always throw an error in MockClient');
+        // Exception for test case
+        if (destination !== 'abc123') {
+          console.warn('IPs other than 8.8.8.8 will always throw an error in MockClient');
+        }
         throw new OperationOutcomeError(badRequest('Destination device not found'));
       }
       return `PING 8.8.8.8 (8.8.8.8): 56 data bytes
@@ -215,6 +222,10 @@ round-trip min/avg/max/stddev = 10.977/14.975/23.159/4.790 ms
 `;
     }
     return undefined;
+  }
+
+  setAgentAvailable(value: boolean): void {
+    this.agentAvailable = value;
   }
 }
 

--- a/packages/server/src/fhir/operations/agentpush.ts
+++ b/packages/server/src/fhir/operations/agentpush.ts
@@ -10,7 +10,7 @@ import {
 import { Agent, Device } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
-import { isIP } from 'node:net';
+import { isIPv4 } from 'node:net';
 import { asyncWrap } from '../../async';
 import { getAuthenticatedContext } from '../../context';
 import { getRedis } from '../../redis';
@@ -145,14 +145,14 @@ async function getDevice(repo: Repository, destination: string): Promise<Device 
   if (destination.startsWith('Device/')) {
     try {
       return await repo.readReference<Device>({ reference: destination });
-    } catch (err) {
+    } catch (_err) {
       return undefined;
     }
   }
   if (destination.startsWith('Device?')) {
     return repo.searchOne<Device>(parseSearchDefinition(destination));
   }
-  if (isIP(destination)) {
+  if (isIPv4(destination)) {
     return { resourceType: 'Device', url: destination };
   }
   return undefined;

--- a/packages/server/src/fhir/operations/agentpush.ts
+++ b/packages/server/src/fhir/operations/agentpush.ts
@@ -10,6 +10,7 @@ import {
 import { Agent, Device } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
+import { isIP } from 'node:net';
 import { asyncWrap } from '../../async';
 import { getAuthenticatedContext } from '../../context';
 import { getRedis } from '../../redis';
@@ -113,8 +114,8 @@ export const agentPushHandler = asyncWrap(async (req: Request, res: Response) =>
 
 /**
  * Returns the Agent for the execute request.
- * If using "/Agent/:id/$execute", then the agent ID is read from the path parameter.
- * If using "/Agent/$execute?identifier=...", then the agent is searched by identifier.
+ * If using "/Agent/:id/$push", then the agent ID is read from the path parameter.
+ * If using "/Agent/$push?identifier=...", then the agent is searched by identifier.
  * Otherwise, returns undefined.
  * @param req - The HTTP request.
  * @param repo - The repository.
@@ -150,6 +151,9 @@ async function getDevice(repo: Repository, destination: string): Promise<Device 
   }
   if (destination.startsWith('Device?')) {
     return repo.searchOne<Device>(parseSearchDefinition(destination));
+  }
+  if (isIP(destination)) {
+    return { resourceType: 'Device', url: destination };
   }
   return undefined;
 }


### PR DESCRIPTION
This PR adds the `ping` functionality via `Agent/$push` with Content-Type of `ContentType.PING`.

It also adds the `Tools` tab for the `Agent` resource in Medplum app where you can issue pings from the selected agent as seen below:

<img width="1723" alt="Screenshot 2024-01-30 at 7 07 26 PM" src="https://github.com/medplum/medplum/assets/1592008/98a80e54-71e1-43fe-8201-8f5db6be13a5">

