### PR TITLE
Start using vite-plugin-turbosnap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56553,6 +56553,12 @@
         }
       }
     },
+    "node_modules/vite-plugin-turbosnap": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.3.tgz",
+      "integrity": "sha512-p4D8CFVhZS412SyQX125qxyzOgIFouwOcvjZWk6bQbNPR1wtaEzFT6jZxAjf1dejlGqa6fqHcuCvQea6EWUkUA==",
+      "dev": true
+    },
     "node_modules/vitest": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.2.2.tgz",
@@ -59065,7 +59071,8 @@
         "rimraf": "5.0.5",
         "sinon": "17.0.1",
         "storybook": "7.6.10",
-        "typescript": "5.3.3"
+        "typescript": "5.3.3",
+        "vite-plugin-turbosnap": "^1.0.3"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -1,4 +1,6 @@
+import turbosnap from 'vite-plugin-turbosnap';
 import type { StorybookConfig } from '@storybook/react-vite';
+import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
   stories: [
@@ -25,6 +27,17 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: 'tag',
+  },
+  viteFinal(config, { configType }) {
+    let finalConfig = config;
+
+    if (configType === 'PRODUCTION') {
+      finalConfig = mergeConfig(config, {
+        plugins: [turbosnap({ rootDir: config.root ?? process.cwd() })],
+      });
+    }
+
+    return finalConfig;
   },
 };
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -103,7 +103,8 @@
     "rimraf": "5.0.5",
     "sinon": "17.0.1",
     "storybook": "7.6.10",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vite-plugin-turbosnap": "^1.0.3"
   },
   "peerDependencies": {
     "@mantine/core": "^7.0.0",


### PR DESCRIPTION
This will allow turbosnap to actually start working for our Chromatic builds to reduce the number of snapshots used in builds.