### PR TITLE
Handle Blobs and Uint8Array in vm context bots

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2999,9 +2999,9 @@ export class MedplumClient extends EventTarget {
   private setRequestBody(options: RequestInit, data: any): void {
     if (
       typeof data === 'string' ||
-      (typeof Blob !== 'undefined' && data instanceof Blob) ||
-      (typeof File !== 'undefined' && data instanceof File) ||
-      (typeof Uint8Array !== 'undefined' && data instanceof Uint8Array)
+      (typeof Blob !== 'undefined' && (data instanceof Blob || data.constructor.name === 'Blob')) ||
+      (typeof File !== 'undefined' && (data instanceof File || data.constructor.name === 'File')) ||
+      (typeof Uint8Array !== 'undefined' && (data instanceof Uint8Array || data.constructor.name === 'Uint8Array'))
     ) {
       options.body = data;
     } else if (data) {


### PR DESCRIPTION
We originally had this check for binary

```ts
(typeof Uint8Array !== 'undefined' && data instanceof Uint8Array)
```

Turns out, in certain cases `data instanceof Uint8Array` will always return false, even if `data` _is_ a `Uint8Array`

This PR adds additional checks on the type of `data` to set the request body correctly

Tested with this bot: 
```ts
import { BotEvent, MedplumClient } from '@medplum/core';


export async function handler(medplum: MedplumClient, event: BotEvent): Promise<any> {
  // Create the PDF
  const pdfBlob = await medplum.download(
    'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf', 
    { headers: { Accept: 'application/pdf' } }
  );  

  // Create a Medplum media resource
  const attachment = await medplum.createAttachment(pdfBlob,  'example.pdf', 'application/pdf');
  await medplum.createResource({
    resourceType: 'DocumentReference',
    status: 'current',
    docStatus: 'final',
    content: [{ attachment }],
  });
  
}
```
