### PR TITLE
No longer need to build core for @medplum/react npm run dev

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -1,6 +1,7 @@
 import turbosnap from 'vite-plugin-turbosnap';
 import type { StorybookConfig } from '@storybook/react-vite';
 import { mergeConfig } from 'vite';
+import path from 'path';
 
 const config: StorybookConfig = {
   stories: [
@@ -28,16 +29,24 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
-  viteFinal(config, { configType }) {
-    let finalConfig = config;
+  async viteFinal(inputConfig, { configType }) {
+    let config = inputConfig;
 
     if (configType === 'PRODUCTION') {
-      finalConfig = mergeConfig(config, {
+      config = mergeConfig(config, {
         plugins: [turbosnap({ rootDir: config.root ?? process.cwd() })],
+      });
+    } else if (configType === 'DEVELOPMENT') {
+      config = mergeConfig(config, {
+        resolve: {
+          alias: {
+            '@medplum/core': path.resolve(__dirname, '../../core/src'),
+          },
+        },
       });
     }
 
-    return finalConfig;
+    return config;
   },
 };
 


### PR DESCRIPTION
Title says it all; you can view the dev storybook, i.e. `npm run dev`, and see changes in core without having to rebuild core.