### PR TITLE
Fix return documentation for client read methods

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1534,7 +1534,7 @@ export class MedplumClient extends EventTarget {
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
    * @param options - Optional fetch options.
-   * @returns The resource if available; undefined otherwise.
+   * @returns The resource if available.
    */
   readResource<K extends ResourceType>(
     resourceType: K,
@@ -1562,7 +1562,7 @@ export class MedplumClient extends EventTarget {
    * @category Read
    * @param reference - The FHIR reference object.
    * @param options - Optional fetch options.
-   * @returns The resource if available; undefined otherwise.
+   * @returns The resource if available.
    */
   readReference<T extends Resource>(reference: Reference<T>, options?: RequestInit): ReadablePromise<T> {
     const refString = reference.reference;
@@ -1736,7 +1736,7 @@ export class MedplumClient extends EventTarget {
    * @param id - The resource ID.
    * @param vid - The version ID.
    * @param options - Optional fetch options.
-   * @returns The resource if available; undefined otherwise.
+   * @returns The resource if available.
    */
   readVersion<K extends ResourceType>(
     resourceType: K,


### PR DESCRIPTION
This PR fixes the `@returns` comment for several methods in the medplum client.

For example, `readResource` is typed as returning `ReadablePromise<ExtractResource<K>>` and it's promise will reject when a resource isn't available.

for example, the following will print `promise rejected` instead of fulling the promise and printing `undefined` (as the `@returns` comment currently implies)

```ts
medplum
  .readResource('Patient', 'invalid-id-here')
  .then((patient) => {
    console.log(patient);
  })
  .catch(() => {
    console.log('promise rejected');
  });
```