### PR TITLE
Add Agent Dockerfile. Fixes #3912

### DIFF
--- a/packages/agent/.dockerignore
+++ b/packages/agent/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# But not these files...
+!.gitignore
+!Dockerfile
+
+# ...even if they are in subdirectories
+!*/

--- a/packages/agent/Dockerfile
+++ b/packages/agent/Dockerfile
@@ -1,0 +1,17 @@
+FROM --platform=linux/amd64 debian:bullseye-slim
+
+ARG GIT_SHA
+ARG MEDPLUM_VERSION
+
+ENV GIT_SHA ${GIT_SHA}
+ENV MEDPLUM_VERSION ${MEDPLUM_VERSION}
+
+RUN adduser -u 5678 --disabled-password --gecos "" app
+
+COPY bin/medplum-agent-${MEDPLUM_VERSION}-linux /srv/medplum-agent
+
+WORKDIR /srv
+
+USER app
+
+CMD ./medplum-agent $MEDPLUM_BASE_URL $MEDPLUM_CLIENT_ID $MEDPLUM_CLIENT_SECRET $MEDPLUM_AGENT_ID


### PR DESCRIPTION
This is the Dockerfile to build an Agent docker container. Feel free to modify the build and run commands as they are not assuming the Dockerhub organization as part of the namespace. As well tagging the image other than `latest`.

The command to build with the build-args
```bash
docker build -t medplum-agent:latest \
  --build-arg GIT_SHA=$(git log -1 --format=format:%H) \
  --build-arg MEDPLUM_VERSION=3.0.2 \
  -f packages/agent/Dockerfile .
```

The Dockerfile expects the `medplum-agent-${MEDPLUM_VERSION}-linux` is located in `packages/agent/bin/` to copy into the container. I did not add the `bin` directory if we need to use the `packages/agent` location instead, but should adjust the Dockerfile in that case.

To run the container manually
```bash
docker run --rm \
  -e MEDPLUM_BASE_URL="" \
  -e MEDPLUM_CLIENT_ID="" \
  -e MEDPLUM_CLIENT_SECRET="" \
  -e MEDPLUM_AGENT_ID="" \
  medplum-agent:latest
```