### PR TITLE
fix-3914 add `traceId` to `AuditEvent`s as extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10585,6 +10585,79 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jenniferplusplus/opentelemetry-instrumentation-bullmq/-/opentelemetry-instrumentation-bullmq-0.5.0.tgz",
+      "integrity": "sha512-g0xaSIb9h18SV1xHlPuHW6eA4v3FGxeV5AWIoUFX2F9cVKZnobETB4OVrAVg0kOBgNLEdxWc21s2NULOkmuQYg==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0",
+        "flat": "^5.0.2"
+      },
+      "peerDependencies": {
+        "bullmq": "^2 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/@jest/console": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
@@ -31745,7 +31818,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -58749,6 +58821,7 @@
         "@aws-sdk/cloudfront-signer": "3.496.0",
         "@aws-sdk/lib-storage": "3.504.0",
         "@aws-sdk/types": "3.502.0",
+        "@jenniferplusplus/opentelemetry-instrumentation-bullmq": "^0.5.0",
         "@medplum/core": "*",
         "@medplum/definitions": "*",
         "@medplum/fhir-router": "*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "@aws-sdk/cloudfront-signer": "3.496.0",
     "@aws-sdk/lib-storage": "3.504.0",
     "@aws-sdk/types": "3.502.0",
+    "@jenniferplusplus/opentelemetry-instrumentation-bullmq": "^0.5.0",
     "@medplum/core": "*",
     "@medplum/definitions": "*",
     "@medplum/fhir-router": "*",

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -111,7 +111,7 @@ const traceIdHeaderMap: {
 } as const;
 const traceIdHeaders = Object.entries(traceIdHeaderMap);
 
-const getTraceId = (req: Request): string => {
+const getTraceId = (req: Request): string | undefined => {
   for (const [headerKey, isTraceId] of traceIdHeaders) {
     const value = req.header(headerKey);
     if (value && isTraceId(value)) {
@@ -119,12 +119,12 @@ const getTraceId = (req: Request): string => {
     }
   }
 
-  return traceparentFromSpan(trace.getActiveSpan())?.toString() ?? randomUUID();
+  return traceparentFromSpan(trace.getActiveSpan())?.toString();
 };
 
 function requestIds(req: Request): { requestId: string; traceId: string } {
   const requestId = randomUUID();
-  const traceId = getTraceId(req);
+  const traceId = getTraceId(req) ?? randomUUID();
 
   return { requestId, traceId };
 }

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -574,12 +574,12 @@ async function createAuditEvent(
     entity: createAuditEventEntities(bot, request.input, request.subscription, request.agent, request.device),
     outcome,
     outcomeDesc,
-    extension: ctx.traceId ? [
+    extension: [
       {
-        url: "https://medplum.com/fhir/StructureDefinition/trace-id",
+        url: 'https://medplum.com/fhir/StructureDefinition/trace-id',
         valueString: ctx.traceId,
-      }
-    ] : undefined,
+      },
+    ],
   };
 
   const destination = bot.auditEventDestination ?? ['resource'];

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -576,8 +576,11 @@ async function createAuditEvent(
     outcomeDesc,
     extension: [
       {
-        url: 'https://medplum.com/fhir/StructureDefinition/trace-id',
-        valueString: ctx.traceId,
+        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
+        extension: [
+          { url: 'requestId', valueUuid: ctx.requestId },
+          { url: 'traceId', valueUuid: ctx.traceId },
+        ],
       },
     ],
   };

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -530,6 +530,7 @@ async function createAuditEvent(
   outcome: AuditEventOutcome,
   outcomeDesc: string
 ): Promise<void> {
+  const ctx = getRequestContext();
   const { bot } = request;
   const trigger = bot.auditEventTrigger ?? 'always';
   if (
@@ -573,6 +574,12 @@ async function createAuditEvent(
     entity: createAuditEventEntities(bot, request.input, request.subscription, request.agent, request.device),
     outcome,
     outcomeDesc,
+    extension: [
+      {
+        url: "https://medplum.com/fhir/StructureDefinition/trace-id",
+        valueString: ctx.traceId,
+      }
+    ]
   };
 
   const destination = bot.auditEventDestination ?? ['resource'];

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -42,6 +42,7 @@ import { createAuditEventEntities } from '../../workers/utils';
 import { sendOutcome } from '../outcomes';
 import { getSystemRepo } from '../repo';
 import { getBinaryStorage } from '../storage';
+import { createTracingExtension } from '../../util/extensions';
 
 export const EXECUTE_CONTENT_TYPES = [ContentType.JSON, ContentType.FHIR_JSON, ContentType.TEXT, ContentType.HL7_V2];
 
@@ -575,13 +576,7 @@ async function createAuditEvent(
     outcome,
     outcomeDesc,
     extension: [
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
-        extension: [
-          { url: 'requestId', valueUuid: ctx.requestId },
-          { url: 'traceId', valueUuid: ctx.traceId },
-        ],
-      },
+      createTracingExtension(ctx),
     ],
   };
 

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -574,12 +574,12 @@ async function createAuditEvent(
     entity: createAuditEventEntities(bot, request.input, request.subscription, request.agent, request.device),
     outcome,
     outcomeDesc,
-    extension: [
+    extension: ctx.traceId ? [
       {
         url: "https://medplum.com/fhir/StructureDefinition/trace-id",
         valueString: ctx.traceId,
       }
-    ]
+    ] : undefined,
   };
 
   const destination = bot.auditEventDestination ?? ['resource'];

--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { Response } from 'express';
 import { Result, ValidationError } from 'express-validator';
 import { getRequestContext } from '../context';
+import { createTracingExtension } from '../util/extensions';
 
 export function invalidRequest(errors: Result<ValidationError>): OperationOutcome {
   return {
@@ -34,13 +35,7 @@ export function sendOutcome(res: Response, outcome: OperationOutcome): Response 
   return res.status(getStatus(outcome)).json({
     ...outcome,
     extension: [
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
-        extension: [
-          { url: 'requestId', valueUuid: ctx.requestId },
-          { url: 'traceId', valueUuid: ctx.traceId },
-        ],
-      },
+      createTracingExtension(ctx),
     ],
   } as OperationOutcome);
 }

--- a/packages/server/src/otel/instrumentation.ts
+++ b/packages/server/src/otel/instrumentation.ts
@@ -8,6 +8,7 @@ import { MetricReader, PeriodicExportingMetricReader } from '@opentelemetry/sdk-
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { BullMQInstrumentation } from '@jenniferplusplus/opentelemetry-instrumentation-bullmq';
 
 // This file includes OpenTelemetry instrumentation.
 // Note that this file is related but separate from the OpenTelemetry helpers in otel.ts.
@@ -46,7 +47,7 @@ export function initOpenTelemetry(): void {
     traceExporter = new OTLPTraceExporter({ url: OTLP_TRACES_ENDPOINT });
   }
 
-  const instrumentations = [getNodeAutoInstrumentations()];
+  const instrumentations = [getNodeAutoInstrumentations(), new BullMQInstrumentation()];
 
   sdk = new NodeSDK({
     resource,

--- a/packages/server/src/traceparent.ts
+++ b/packages/server/src/traceparent.ts
@@ -1,27 +1,75 @@
+import type { Span } from '@opentelemetry/api';
+
 // https://www.w3.org/TR/trace-context/#traceparent-header
 
 type hex = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f';
 type twohex = `${hex}${hex}`;
 
-export type Traceparent = {
+type TraceparentOpts = {
   version?: twohex;
   traceId: string;
   parentId: string;
   flags?: hex | twohex;
 };
+export class Traceparent {
+  version?: twohex;
+  traceId: string;
+  parentId: string;
+  flags?: hex | twohex;
+
+  constructor({
+    version,
+    traceId,
+    parentId,
+    flags,
+  }: TraceparentOpts) {
+    this.traceId = traceId;
+    this.parentId = parentId;
+    this.version = version;
+    this.flags = flags;
+  }
+
+  toString(): string {
+    return [
+      this.version,
+      this.traceId,
+      this.parentId,
+      this.flags,
+    ].filter(Boolean).join('-');
+  }
+}
 
 const traceparentRegex = /^([0-9a-f]{2})?-?([0-9a-f]{32})-([0-9a-f]{16})-?([0-9a-f]{1,2})?$/i;
 
-export function parseTraceparent(traceparent: string): Traceparent | null {
-  const match = traceparent.match(traceparentRegex);
+export function parseTraceparent(value: string): Traceparent | null {
+  const match = value.match(traceparentRegex);
   if (!match) {
     return null;
   }
 
-  return {
+  return new Traceparent({
     version: (match[1] ?? undefined) as Traceparent['version'],
     traceId: match[2],
     parentId: match[3],
     flags: (match[4] ?? undefined) as Traceparent['flags'],
-  };
+  });
+}
+
+export function traceparentFromSpan(span?: Span): Traceparent | undefined {
+  const spanCtx = span?.spanContext();
+  if (!spanCtx?.traceId || !spanCtx?.spanId) {
+    return undefined;
+  }
+
+  let flags = spanCtx.traceFlags.toString().slice(0, 2) || '00';
+  if (flags.length === 1) {
+    flags = `0${flags}`;
+  }
+
+  return new Traceparent({
+    version: '00',
+    traceId: spanCtx.traceId,
+    parentId: spanCtx.spanId,
+    flags: flags as twohex,
+  })
 }

--- a/packages/server/src/traceparent.ts
+++ b/packages/server/src/traceparent.ts
@@ -17,12 +17,7 @@ export class Traceparent {
   parentId: string;
   flags?: hex | twohex;
 
-  constructor({
-    version,
-    traceId,
-    parentId,
-    flags,
-  }: TraceparentOpts) {
+  constructor({ version, traceId, parentId, flags }: TraceparentOpts) {
     this.traceId = traceId;
     this.parentId = parentId;
     this.version = version;
@@ -30,12 +25,7 @@ export class Traceparent {
   }
 
   toString(): string {
-    return [
-      this.version,
-      this.traceId,
-      this.parentId,
-      this.flags,
-    ].filter(Boolean).join('-');
+    return [this.version, this.traceId, this.parentId, this.flags].filter(Boolean).join('-');
   }
 }
 
@@ -71,5 +61,5 @@ export function traceparentFromSpan(span?: Span): Traceparent | undefined {
     traceId: spanCtx.traceId,
     parentId: spanCtx.spanId,
     flags: flags as twohex,
-  })
+  });
 }

--- a/packages/server/src/traceparent.ts
+++ b/packages/server/src/traceparent.ts
@@ -11,6 +11,7 @@ type TraceparentOpts = {
   parentId: string;
   flags?: hex | twohex;
 };
+
 export class Traceparent {
   version?: twohex;
   traceId: string;

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -11,6 +11,7 @@ import {
 import { MedplumServerConfig, getConfig } from '../config';
 import { CloudWatchLogger } from './cloudwatch';
 import { getRequestContext } from '../context';
+import { createTracingExtension } from './extensions';
 
 /*
  * This file includes a collection of utility functions for working with AuditEvents.
@@ -242,13 +243,7 @@ function createAuditEvent(
     outcomeDesc,
     entity,
     extension: [
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
-        extension: [
-          { url: 'requestId', valueUuid: ctx.requestId },
-          { url: 'traceId', valueUuid: ctx.traceId },
-        ],
-      },
+      createTracingExtension(ctx),
     ],
   };
 

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -243,8 +243,11 @@ function createAuditEvent(
     entity,
     extension: [
       {
-        url: 'https://medplum.com/fhir/StructureDefinition/trace-id',
-        valueString: ctx.traceId,
+        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
+        extension: [
+          { url: 'requestId', valueUuid: ctx.requestId },
+          { url: 'traceId', valueUuid: ctx.traceId },
+        ],
       },
     ],
   };

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -243,10 +243,10 @@ function createAuditEvent(
     entity,
     extension: [
       {
-        url: "https://medplum.com/fhir/StructureDefinition/trace-id",
+        url: 'https://medplum.com/fhir/StructureDefinition/trace-id',
         valueString: ctx.traceId,
-      }
-    ]
+      },
+    ],
   };
 
   return auditEvent;

--- a/packages/server/src/util/auditevent.ts
+++ b/packages/server/src/util/auditevent.ts
@@ -10,6 +10,7 @@ import {
 } from '@medplum/fhirtypes';
 import { MedplumServerConfig, getConfig } from '../config';
 import { CloudWatchLogger } from './cloudwatch';
+import { getRequestContext } from '../context';
 
 /*
  * This file includes a collection of utility functions for working with AuditEvents.
@@ -204,6 +205,7 @@ function createAuditEvent(
   resource?: Resource,
   searchQuery?: string
 ): AuditEvent {
+  const ctx = getRequestContext();
   const config = getConfig();
 
   let entity: AuditEventEntity[] | undefined = undefined;
@@ -239,6 +241,12 @@ function createAuditEvent(
     outcome,
     outcomeDesc,
     entity,
+    extension: [
+      {
+        url: "https://medplum.com/fhir/StructureDefinition/trace-id",
+        valueString: ctx.traceId,
+      }
+    ]
   };
 
   return auditEvent;

--- a/packages/server/src/util/extensions.ts
+++ b/packages/server/src/util/extensions.ts
@@ -1,0 +1,10 @@
+import { Extension } from '@medplum/fhirtypes';
+import { RequestContext } from '../context';
+
+export const createTracingExtension = (ctx: RequestContext): Extension => ({
+  url: 'https://medplum.com/fhir/StructureDefinition/tracing',
+  extension: [
+    { url: 'requestId', valueUuid: ctx.requestId },
+    { url: 'traceId', valueUuid: ctx.traceId },
+  ],
+});

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -50,6 +50,7 @@ export async function createAuditEvent(
   subscription?: Subscription,
   bot?: Bot
 ): Promise<void> {
+  const ctx = getRequestContext();
   const systemRepo = getSystemRepo();
   const auditedEvent = subscription ?? resource;
 
@@ -83,6 +84,12 @@ export async function createAuditEvent(
     entity: createAuditEventEntities(resource, subscription, bot),
     outcome,
     outcomeDesc,
+    extension: [
+      {
+        url: "https://medplum.com/fhir/StructureDefinition/trace-id",
+        valueString: ctx.traceId,
+      }
+    ]
   });
 }
 

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -86,8 +86,11 @@ export async function createAuditEvent(
     outcomeDesc,
     extension: [
       {
-        url: 'https://medplum.com/fhir/StructureDefinition/trace-id',
-        valueString: ctx.traceId,
+        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
+        extension: [
+          { url: 'requestId', valueUuid: ctx.requestId },
+          { url: 'traceId', valueUuid: ctx.traceId },
+        ],
       },
     ],
   });

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -86,10 +86,10 @@ export async function createAuditEvent(
     outcomeDesc,
     extension: [
       {
-        url: "https://medplum.com/fhir/StructureDefinition/trace-id",
+        url: 'https://medplum.com/fhir/StructureDefinition/trace-id',
         valueString: ctx.traceId,
-      }
-    ]
+      },
+    ],
   });
 }
 

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -13,6 +13,7 @@ import {
 import { getRequestContext } from '../context';
 import { getSystemRepo } from '../fhir/repo';
 import { AuditEventOutcome } from '../util/auditevent';
+import { createTracingExtension } from '../util/extensions';
 
 export function findProjectMembership(project: string, profile: Reference): Promise<ProjectMembership | undefined> {
   const systemRepo = getSystemRepo();
@@ -85,13 +86,7 @@ export async function createAuditEvent(
     outcome,
     outcomeDesc,
     extension: [
-      {
-        url: 'https://medplum.com/fhir/StructureDefinition/tracing',
-        extension: [
-          { url: 'requestId', valueUuid: ctx.requestId },
-          { url: 'traceId', valueUuid: ctx.traceId },
-        ],
-      },
+      createTracingExtension(ctx),
     ],
   });
 }


### PR DESCRIPTION
Addresses #3914

Add an extension (`https://medplum.com/fhir/StructureDefinition/tracing`) on `AuditEvent` that persists the associated `traceId` value.

This PR also Initialize a _new_ `traceId` and `requestId` for cron bot executions with bullmq opentelemetry instrumentation.

Questions:
- [x] [`getNodeAutoInstrumentations`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) covers `redis` and `ioredis` but not sure if this also covers `bullmq`.
  - `bullmq` is not covered by the auto instrumentation. There are community-driven libraries that provide compatible instrumentation such as https://github.com/jenniferplusplus/opentelemetry-instrumentation-bullmq