### PR TITLE
Gravatar photos

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ set -e
 set -x
 
 # Set node options
-export NODE_OPTIONS='--max-old-space-size=5120'
+export NODE_OPTIONS='--max-old-space-size=8192'
 
 # Diagnostics
 node --version


### PR DESCRIPTION
I've had this sitting in drafts for a long time.

For new user profiles, it adds a Gravatar image to the profile: https://docs.gravatar.com/general/images/

Shortly after creating the profile, the download service grabs the image, and converts it to a FHIR `Binary`, and updates the attachment.

This only applies to system generated "profile" resources.

"Profile" resources being `Patient`, `Practitioner`, and `RelatedPerson`

3 code paths use `createProfile`:

1. Project init (new user registration)
2. Patient registration
3. Admin invite

This does not affect creating `Patient` or `Practitioner` through normal FHIR CRUD interactions.