### PR TITLE
Fix attachment diff display

### DIFF
--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -205,4 +205,29 @@ describe('ResourceDiffTable', () => {
     const operations = screen.getAllByText('Replace identifier');
     expect(operations).toHaveLength(1);
   });
+
+  test('Change attachment URL', async () => {
+    const original: Patient = {
+      resourceType: 'Patient',
+      id: '123',
+      meta: { versionId: '456' },
+      name: [{ family: 'Smith', given: ['John'] }],
+      photo: [{ url: 'http://example.com/foo.jpg' }],
+    };
+
+    const revised: Patient = {
+      ...original,
+      meta: { versionId: '457' },
+      photo: [{ url: 'http://example.com/bar.jpg' }],
+    };
+
+    await act(async () => {
+      setup({ original, revised });
+    });
+
+    await waitFor(() => screen.getByText('Replace photo[0]'));
+
+    // There should be 2 download links
+    expect(screen.getAllByText('Download')).toHaveLength(2);
+  });
 });

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -148,6 +148,15 @@ function jsonPathToFhirPath(path: string): string {
       result += part;
     }
   }
+
+  // For attachments, remove the .url suffix
+  // Note that not all ".url" properties are attachments, but it is the common case.
+  // If the property is not an attachment, the diff will simply render the parent element,
+  // which is still fine.
+  if (result.endsWith('.url')) {
+    result = result.replace(/\.url$/, '');
+  }
+
   return result;
 }
 


### PR DESCRIPTION
The new `<ResourceDiffTable>` logic had a regression when changing `Attachment` values.

This shows up most commonly when:
1. Changing profile pictures
2. Saving/deploying bots

Rather than using the `<AttachmentDisplay>` component, it would diff the URL. 

Given that these are normally Medplum storage URL's, which are long and ugly presigned URLs, this was not a particularly helpful display.  The URLs were too long to read, and they often had bad spacing and overflow.

After this PR, the `<ResourceDiffTable>` will correctly use the `<AttachmentDisplay>` component.