### PR TITLE
Fixed socket.dev dependency warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29198,17 +29198,13 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "hasInstallScript": true,
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       }
     },
     "node_modules/es6-error": {
@@ -43343,9 +43339,9 @@
       }
     },
     "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha512-mc/caHeUcdjnC/boPWJefDr4KUIWQNv+tlnFnJd38QMou86QtxQzBJfxgGRzvx8jazYRqrVlaHarfO72uNxPOg=="
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
@@ -52040,10 +52036,10 @@
       }
     },
     "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+      "name": "@jridgewell/sourcemap-codec",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -65,10 +65,12 @@
     "node": ">=18.0.0"
   },
   "overrides": {
+    "es5-ext": "0.10.53",
     "esbuild": "0.20.0",
     "got": "11.8.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@1.4.15",
     "trim": "0.0.3"
   }
 }


### PR DESCRIPTION
Socket.dev package analysis: https://socket.dev/npm/package/@medplum/core

There are 2 "high" alerts, both in transitive dependencies.

`sourcemap-codec` marked as deprecated, so overriding to use `@jridgewell/sourcemap-codec@1.4.15`, which is already in our dependency tree.

`es5-ext` marked as "Protestware or potentially unwanted behavior".  See: https://github.com/medikoo/es5-ext/issues/186  Pinning to last known good version.