### PR TITLE
Fixes #3786 - startAsyncRequest and token refresh

### DIFF
--- a/packages/core/src/client-test-utils.ts
+++ b/packages/core/src/client-test-utils.ts
@@ -12,12 +12,24 @@ export function mockFetch(
   return jest.fn((url: string, options?: any) => {
     const response = bodyFn(url, options);
     const responseStatus = isOperationOutcome(response) ? getStatus(response) : status;
-    return Promise.resolve({
-      ok: responseStatus < 400,
-      status: responseStatus,
-      headers: { get: () => contentType },
-      blob: () => Promise.resolve(response),
-      json: () => Promise.resolve(response),
-    });
+    return Promise.resolve(mockFetchResponse(responseStatus, response, { 'content-type': contentType }));
   });
+}
+
+export function mockFetchResponse(status: number, body: any, headers?: Record<string, string>): Response {
+  const headersMap = new Map<string, string>();
+  if (headers) {
+    for (const [key, value] of Object.entries(headers)) {
+      headersMap.set(key, value);
+    }
+  } else {
+    headersMap.set('content-type', ContentType.FHIR_JSON);
+  }
+  return {
+    ok: status < 400,
+    status,
+    headers: headersMap,
+    blob: () => Promise.resolve(body),
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
 }

--- a/packages/core/src/client-test-utils.ts
+++ b/packages/core/src/client-test-utils.ts
@@ -22,7 +22,8 @@ export function mockFetchResponse(status: number, body: any, headers?: Record<st
     for (const [key, value] of Object.entries(headers)) {
       headersMap.set(key, value);
     }
-  } else {
+  }
+  if (!headersMap.has('content-type')) {
     headersMap.set('content-type', ContentType.FHIR_JSON);
   }
   return {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2440,17 +2440,11 @@ describe('Client', () => {
       let count = 0;
       fetch = jest.fn(async (url) => {
         if (url.includes('/$export?_since=200')) {
-          return mockFetchResponse(200, accepted('bulkdata/id/status'), {
-            'content-type': ContentType.FHIR_JSON,
-            'content-location': 'bulkdata/id/status',
-          });
+          return mockFetchResponse(200, accepted('bulkdata/id/status'), { 'content-location': 'bulkdata/id/status' });
         }
 
         if (url.includes('/$export')) {
-          return mockFetchResponse(202, accepted('bulkdata/id/status'), {
-            'content-type': ContentType.FHIR_JSON,
-            'content-location': 'bulkdata/id/status',
-          });
+          return mockFetchResponse(202, accepted('bulkdata/id/status'), { 'content-location': 'bulkdata/id/status' });
         }
 
         if (url.includes('bulkdata/id/status')) {
@@ -2635,7 +2629,7 @@ describe('Client', () => {
             // Report status complete, and send the location of the bulk export
             expect(options.method).toBeUndefined();
             expect(url).toBe('https://api.medplum.com/' + statusUrl);
-            return mockFetchResponse(201, {}, { 'content-type': 'application/json', location: locationUrl });
+            return mockFetchResponse(201, {}, { location: locationUrl });
           case 8:
             // What a journey! Finally, we can get the contents of the bulk export
             expect(options.method).toBeUndefined();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -13,9 +13,9 @@ import {
   NewProjectRequest,
   NewUserRequest,
 } from './client';
-import { mockFetch } from './client-test-utils';
+import { mockFetch, mockFetchResponse } from './client-test-utils';
 import { ContentType } from './contenttype';
-import { OperationOutcomeError, notFound, unauthorized } from './outcomes';
+import { OperationOutcomeError, accepted, forbidden, notFound, unauthorized } from './outcomes';
 import { MockAsyncClientStorage } from './storage';
 import { getDataType, isDataTypeLoaded, isProfileLoaded } from './typeschema/types';
 import { ProfileResource, createReference } from './utils';
@@ -2619,6 +2619,82 @@ describe('Client', () => {
       } catch (err) {
         expect((err as Error).message).toBe('Not found');
       }
+    });
+
+    test('Poll after token refresh', async () => {
+      const clientId = randomUUID();
+      const clientSecret = randomUUID();
+      const statusUrl = 'status-' + randomUUID();
+      const locationUrl = 'location-' + randomUUID();
+
+      const mockTokens = {
+        access_token: createFakeJwt({ client_id: clientId, login_id: '123' }),
+        refresh_token: createFakeJwt({ client_id: clientId }),
+        profile: { reference: 'Patient/123' },
+      };
+
+      const mockMe = {
+        project: { resourceType: 'Project', id: '123' },
+        membership: { resourceType: 'ProjectMembership', id: '123' },
+        profile: { resouceType: 'Practitioner', id: '123' },
+        config: { resourceType: 'UserConfiguration', id: '123' },
+        accessPolicy: { resourceType: 'AccessPolicy', id: '123' },
+      };
+
+      let count = 0;
+
+      const mockFetch = async (url: string, options: any): Promise<any> => {
+        count++;
+        switch (count) {
+          case 1:
+            // First, handle the initial startClientLogin client credentials flow
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/oauth2/token');
+            return mockFetchResponse(200, mockTokens);
+          case 2:
+            // MedplumClient will automatically fetch the user profile after token refresh
+            expect(options.method).toBe('GET');
+            expect(url).toBe('https://api.medplum.com/auth/me');
+            return mockFetchResponse(200, mockMe);
+          case 3:
+            // Next, handle the initial bulk export - mock an expired token response
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/fhir/R4/$export');
+            return mockFetchResponse(401, forbidden);
+          case 4:
+            // Now MedplumClient will try to automatically refresh the token
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/oauth2/token');
+            return mockFetchResponse(200, mockTokens);
+          case 5:
+            // And then MedplumClient will automatically fetch the user profile again
+            expect(options.method).toBe('GET');
+            expect(url).toBe('https://api.medplum.com/auth/me');
+            return mockFetchResponse(200, mockMe);
+          case 6:
+            // Ok, whew, we are refreshed, so we can finally get the bulk export
+            // However, the bulk export isn't "done", so return "Accepted"
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/fhir/R4/$export');
+            return mockFetchResponse(202, accepted(statusUrl));
+          case 7:
+            // Report status complete, and send the location of the bulk export
+            expect(options.method).toBeUndefined();
+            expect(url).toBe('https://api.medplum.com/' + statusUrl);
+            return mockFetchResponse(201, {}, { 'content-type': 'application/json', location: locationUrl });
+          case 8:
+            // What a journey! Finally, we can get the contents of the bulk export
+            expect(options.method).toBeUndefined();
+            expect(url).toBe('https://api.medplum.com/' + locationUrl);
+            return mockFetchResponse(200, { resourceType: 'Bundle' });
+        }
+        throw new Error('Unexpected fetch call: ' + url);
+      };
+
+      const medplum = new MedplumClient({ fetch: mockFetch });
+      await medplum.startClientLogin(clientId, clientSecret);
+      const result = await medplum.bulkExport();
+      expect(result).toMatchObject({ resourceType: 'Bundle' });
     });
   });
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2440,84 +2440,38 @@ describe('Client', () => {
       let count = 0;
       fetch = jest.fn(async (url) => {
         if (url.includes('/$export?_since=200')) {
-          return {
-            status: 200,
-            headers: { get: () => ContentType.FHIR_JSON },
-            json: jest.fn(async () => {
-              return {
-                resourceType: 'OperationOutcome',
-                id: 'accepted',
-                issue: [
-                  {
-                    severity: 'information',
-                    code: 'informational',
-                    details: {
-                      text: 'Accepted',
-                    },
-                  },
-                ],
-              };
-            }),
-          };
+          return mockFetchResponse(200, accepted('bulkdata/id/status'), {
+            'content-type': ContentType.FHIR_JSON,
+            'content-location': 'bulkdata/id/status',
+          });
         }
 
         if (url.includes('/$export')) {
-          return {
-            status: 202,
-            json: jest.fn(async () => {
-              return {
-                resourceType: 'OperationOutcome',
-                id: 'accepted',
-                issue: [
-                  {
-                    severity: 'information',
-                    code: 'informational',
-                    details: {
-                      text: 'Accepted',
-                    },
-                  },
-                ],
-              };
-            }),
-            headers: {
-              get(name: string): string | undefined {
-                return {
-                  'content-type': ContentType.FHIR_JSON,
-                  'content-location': 'bulkdata/id/status',
-                }[name];
-              },
-            },
-          };
+          return mockFetchResponse(202, accepted('bulkdata/id/status'), {
+            'content-type': ContentType.FHIR_JSON,
+            'content-location': 'bulkdata/id/status',
+          });
         }
 
         if (url.includes('bulkdata/id/status')) {
           if (count < 1) {
             count++;
-            return {
-              status: 202,
-              json: jest.fn(async () => {
-                return {};
-              }),
-            };
+            return mockFetchResponse(202, {});
           }
         }
 
-        return {
-          status: 200,
-          headers: { get: () => ContentType.FHIR_JSON },
-          json: jest.fn(async () => ({
-            transactionTime: '2023-05-18T22:55:31.280Z',
-            request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
-            requiresAccessToken: false,
-            output: [
-              {
-                type: 'ProjectMembership',
-                url: 'https://api.medplum.com/storage/TEST',
-              },
-            ],
-            error: [],
-          })),
-        };
+        return mockFetchResponse(200, {
+          transactionTime: '2023-05-18T22:55:31.280Z',
+          request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
+          requiresAccessToken: false,
+          output: [
+            {
+              type: 'ProjectMembership',
+              url: 'https://api.medplum.com/storage/TEST',
+            },
+          ],
+          error: [],
+        });
       });
     });
 
@@ -2701,6 +2655,7 @@ describe('Client', () => {
   describe('Downloading resources', () => {
     const baseUrl = 'https://api.medplum.com/';
     const fhirUrlPath = 'fhir/R4/';
+    const accessToken = 'fake';
     let fetch: FetchLike;
     let client: MedplumClient;
 
@@ -2709,6 +2664,7 @@ describe('Client', () => {
         text: () => Promise.resolve(url),
       }));
       client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
     });
 
     test('Downloading resources via URL', async () => {
@@ -2718,6 +2674,7 @@ describe('Client', () => {
         expect.objectContaining({
           headers: {
             Accept: DEFAULT_ACCEPT,
+            Authorization: `Bearer ${accessToken}`,
             'X-Medplum': 'extended',
           },
         })
@@ -2732,6 +2689,7 @@ describe('Client', () => {
         expect.objectContaining({
           headers: {
             Accept: DEFAULT_ACCEPT,
+            Authorization: `Bearer ${accessToken}`,
             'X-Medplum': 'extended',
           },
         })


### PR DESCRIPTION
`startAsyncRequest` uses `Prefer: respond-async`, and polls the status URL on a timer until the async job is complete.

If, in the middle of that sequence of events, the user's token expires, then the client would go into the token refresh code path.  After successful refresh, the client would then attempt to go back to the original request.

The bug is that the "poll on `Prefer: respond-async`" was not compatible with that refresh and retry flow.

This PR fixes that, and merges the "poll on `Prefer: respond-async`" logic into the main `parseResponse` code path.

Thank you @jjdonov for finding this and writing such an excellent bug report!