### PR TITLE
Fixes #3786 - startAsyncRequest and token refresh

### DIFF
--- a/packages/cli/src/bulk.test.ts
+++ b/packages/cli/src/bulk.test.ts
@@ -51,7 +51,13 @@ describe('CLI Bulk Commands', () => {
         if (url.includes('/$export?_since=200')) {
           return {
             status: 200,
-            headers: { get: () => ContentType.FHIR_JSON },
+            headers: {
+              get(name: string): string | undefined {
+                return {
+                  'content-type': ContentType.FHIR_JSON,
+                }[name];
+              },
+            },
             json: jest.fn(async () => {
               return {
                 resourceType: 'OperationOutcome',
@@ -104,7 +110,13 @@ describe('CLI Bulk Commands', () => {
             count++;
             return {
               status: 202,
-              headers: { get: () => ContentType.FHIR_JSON },
+              headers: {
+                get(name: string): string | undefined {
+                  return {
+                    'content-type': ContentType.FHIR_JSON,
+                  }[name];
+                },
+              },
               json: jest.fn(async () => {
                 return {};
               }),
@@ -114,7 +126,13 @@ describe('CLI Bulk Commands', () => {
 
         return {
           status: 200,
-          headers: { get: () => ContentType.FHIR_JSON },
+          headers: {
+            get(name: string): string | undefined {
+              return {
+                'content-type': ContentType.FHIR_JSON,
+              }[name];
+            },
+          },
           json: jest.fn(async () => ({
             transactionTime: '2023-05-18T22:55:31.280Z',
             request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
@@ -186,7 +204,13 @@ describe('CLI Bulk Commands', () => {
       fetch = jest.fn(async () => {
         return {
           status: 200,
-          headers: { get: () => ContentType.FHIR_JSON },
+          headers: {
+            get(name: string): string | undefined {
+              return {
+                'content-type': ContentType.FHIR_JSON,
+              }[name];
+            },
+          },
           json: jest.fn(async () => ({
             resourceType: 'Bundle',
             type: 'transaction-response',

--- a/packages/cli/src/profiles.test.ts
+++ b/packages/cli/src/profiles.test.ts
@@ -32,7 +32,13 @@ describe('Profiles', () => {
       if (url.includes('/$export?_since=200')) {
         return {
           status: 200,
-          headers: { get: () => ContentType.FHIR_JSON },
+          headers: {
+            get(name: string): string | undefined {
+              return {
+                'content-type': ContentType.FHIR_JSON,
+              }[name];
+            },
+          },
           json: jest.fn(async () => {
             return {
               resourceType: 'OperationOutcome',
@@ -85,7 +91,13 @@ describe('Profiles', () => {
           count++;
           return {
             status: 202,
-            headers: { get: () => ContentType.FHIR_JSON },
+            headers: {
+              get(name: string): string | undefined {
+                return {
+                  'content-type': ContentType.FHIR_JSON,
+                }[name];
+              },
+            },
             json: jest.fn(async () => {
               return {};
             }),
@@ -95,7 +107,13 @@ describe('Profiles', () => {
 
       return {
         status: 200,
-        headers: { get: () => ContentType.FHIR_JSON },
+        headers: {
+          get(name: string): string | undefined {
+            return {
+              'content-type': ContentType.FHIR_JSON,
+            }[name];
+          },
+        },
         json: jest.fn(async () => ({
           transactionTime: '2023-05-18T22:55:31.280Z',
           request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',

--- a/packages/core/src/client-test-utils.ts
+++ b/packages/core/src/client-test-utils.ts
@@ -12,12 +12,24 @@ export function mockFetch(
   return jest.fn((url: string, options?: any) => {
     const response = bodyFn(url, options);
     const responseStatus = isOperationOutcome(response) ? getStatus(response) : status;
-    return Promise.resolve({
-      ok: responseStatus < 400,
-      status: responseStatus,
-      headers: { get: () => contentType },
-      blob: () => Promise.resolve(response),
-      json: () => Promise.resolve(response),
-    });
+    return Promise.resolve(mockFetchResponse(responseStatus, response, { 'content-type': contentType }));
   });
+}
+
+export function mockFetchResponse(status: number, body: any, headers?: Record<string, string>): Response {
+  const headersMap = new Map<string, string>();
+  if (headers) {
+    for (const [key, value] of Object.entries(headers)) {
+      headersMap.set(key, value);
+    }
+  } else {
+    headersMap.set('content-type', ContentType.FHIR_JSON);
+  }
+  return {
+    ok: status < 400,
+    status,
+    headers: headersMap,
+    blob: () => Promise.resolve(body),
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
 }

--- a/packages/core/src/client-test-utils.ts
+++ b/packages/core/src/client-test-utils.ts
@@ -26,11 +26,19 @@ export function mockFetchResponse(status: number, body: any, headers?: Record<st
   if (!headersMap.has('content-type')) {
     headersMap.set('content-type', ContentType.FHIR_JSON);
   }
+  let streamRead = false;
+  const streamReader = async (): Promise<any> => {
+    if (streamRead) {
+      throw new Error('Stream already read');
+    }
+    streamRead = true;
+    return body;
+  };
   return {
     ok: status < 400,
     status,
     headers: headersMap,
-    blob: () => Promise.resolve(body),
-    json: () => Promise.resolve(body),
+    blob: streamReader,
+    json: streamReader,
   } as unknown as Response;
 }

--- a/packages/core/src/client-test-utils.ts
+++ b/packages/core/src/client-test-utils.ts
@@ -22,7 +22,8 @@ export function mockFetchResponse(status: number, body: any, headers?: Record<st
     for (const [key, value] of Object.entries(headers)) {
       headersMap.set(key, value);
     }
-  } else {
+  }
+  if (!headersMap.has('content-type')) {
     headersMap.set('content-type', ContentType.FHIR_JSON);
   }
   return {

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2440,17 +2440,11 @@ describe('Client', () => {
       let count = 0;
       fetch = jest.fn(async (url) => {
         if (url.includes('/$export?_since=200')) {
-          return mockFetchResponse(200, accepted('bulkdata/id/status'), {
-            'content-type': ContentType.FHIR_JSON,
-            'content-location': 'bulkdata/id/status',
-          });
+          return mockFetchResponse(200, accepted('bulkdata/id/status'), { 'content-location': 'bulkdata/id/status' });
         }
 
         if (url.includes('/$export')) {
-          return mockFetchResponse(202, accepted('bulkdata/id/status'), {
-            'content-type': ContentType.FHIR_JSON,
-            'content-location': 'bulkdata/id/status',
-          });
+          return mockFetchResponse(202, accepted('bulkdata/id/status'), { 'content-location': 'bulkdata/id/status' });
         }
 
         if (url.includes('bulkdata/id/status')) {
@@ -2635,7 +2629,7 @@ describe('Client', () => {
             // Report status complete, and send the location of the bulk export
             expect(options.method).toBeUndefined();
             expect(url).toBe('https://api.medplum.com/' + statusUrl);
-            return mockFetchResponse(201, {}, { 'content-type': 'application/json', location: locationUrl });
+            return mockFetchResponse(201, {}, { location: locationUrl });
           case 8:
             // What a journey! Finally, we can get the contents of the bulk export
             expect(options.method).toBeUndefined();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -13,9 +13,9 @@ import {
   NewProjectRequest,
   NewUserRequest,
 } from './client';
-import { mockFetch } from './client-test-utils';
+import { mockFetch, mockFetchResponse } from './client-test-utils';
 import { ContentType } from './contenttype';
-import { OperationOutcomeError, notFound, unauthorized } from './outcomes';
+import { OperationOutcomeError, accepted, forbidden, notFound, unauthorized } from './outcomes';
 import { MockAsyncClientStorage } from './storage';
 import { getDataType, isDataTypeLoaded, isProfileLoaded } from './typeschema/types';
 import { ProfileResource, createReference } from './utils';
@@ -2619,6 +2619,82 @@ describe('Client', () => {
       } catch (err) {
         expect((err as Error).message).toBe('Not found');
       }
+    });
+
+    test('Poll after token refresh', async () => {
+      const clientId = randomUUID();
+      const clientSecret = randomUUID();
+      const statusUrl = 'status-' + randomUUID();
+      const locationUrl = 'location-' + randomUUID();
+
+      const mockTokens = {
+        access_token: createFakeJwt({ client_id: clientId, login_id: '123' }),
+        refresh_token: createFakeJwt({ client_id: clientId }),
+        profile: { reference: 'Patient/123' },
+      };
+
+      const mockMe = {
+        project: { resourceType: 'Project', id: '123' },
+        membership: { resourceType: 'ProjectMembership', id: '123' },
+        profile: { resouceType: 'Practitioner', id: '123' },
+        config: { resourceType: 'UserConfiguration', id: '123' },
+        accessPolicy: { resourceType: 'AccessPolicy', id: '123' },
+      };
+
+      let count = 0;
+
+      const mockFetch = async (url: string, options: any): Promise<any> => {
+        count++;
+        switch (count) {
+          case 1:
+            // First, handle the initial startClientLogin client credentials flow
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/oauth2/token');
+            return mockFetchResponse(200, mockTokens);
+          case 2:
+            // MedplumClient will automatically fetch the user profile after token refresh
+            expect(options.method).toBe('GET');
+            expect(url).toBe('https://api.medplum.com/auth/me');
+            return mockFetchResponse(200, mockMe);
+          case 3:
+            // Next, handle the initial bulk export - mock an expired token response
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/fhir/R4/$export');
+            return mockFetchResponse(401, forbidden);
+          case 4:
+            // Now MedplumClient will try to automatically refresh the token
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/oauth2/token');
+            return mockFetchResponse(200, mockTokens);
+          case 5:
+            // And then MedplumClient will automatically fetch the user profile again
+            expect(options.method).toBe('GET');
+            expect(url).toBe('https://api.medplum.com/auth/me');
+            return mockFetchResponse(200, mockMe);
+          case 6:
+            // Ok, whew, we are refreshed, so we can finally get the bulk export
+            // However, the bulk export isn't "done", so return "Accepted"
+            expect(options.method).toBe('POST');
+            expect(url).toBe('https://api.medplum.com/fhir/R4/$export');
+            return mockFetchResponse(202, accepted(statusUrl));
+          case 7:
+            // Report status complete, and send the location of the bulk export
+            expect(options.method).toBeUndefined();
+            expect(url).toBe('https://api.medplum.com/' + statusUrl);
+            return mockFetchResponse(201, {}, { 'content-type': 'application/json', location: locationUrl });
+          case 8:
+            // What a journey! Finally, we can get the contents of the bulk export
+            expect(options.method).toBeUndefined();
+            expect(url).toBe('https://api.medplum.com/' + locationUrl);
+            return mockFetchResponse(200, { resourceType: 'Bundle' });
+        }
+        throw new Error('Unexpected fetch call: ' + url);
+      };
+
+      const medplum = new MedplumClient({ fetch: mockFetch });
+      await medplum.startClientLogin(clientId, clientSecret);
+      const result = await medplum.bulkExport();
+      expect(result).toMatchObject({ resourceType: 'Bundle' });
     });
   });
 

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2440,84 +2440,38 @@ describe('Client', () => {
       let count = 0;
       fetch = jest.fn(async (url) => {
         if (url.includes('/$export?_since=200')) {
-          return {
-            status: 200,
-            headers: { get: () => ContentType.FHIR_JSON },
-            json: jest.fn(async () => {
-              return {
-                resourceType: 'OperationOutcome',
-                id: 'accepted',
-                issue: [
-                  {
-                    severity: 'information',
-                    code: 'informational',
-                    details: {
-                      text: 'Accepted',
-                    },
-                  },
-                ],
-              };
-            }),
-          };
+          return mockFetchResponse(200, accepted('bulkdata/id/status'), {
+            'content-type': ContentType.FHIR_JSON,
+            'content-location': 'bulkdata/id/status',
+          });
         }
 
         if (url.includes('/$export')) {
-          return {
-            status: 202,
-            json: jest.fn(async () => {
-              return {
-                resourceType: 'OperationOutcome',
-                id: 'accepted',
-                issue: [
-                  {
-                    severity: 'information',
-                    code: 'informational',
-                    details: {
-                      text: 'Accepted',
-                    },
-                  },
-                ],
-              };
-            }),
-            headers: {
-              get(name: string): string | undefined {
-                return {
-                  'content-type': ContentType.FHIR_JSON,
-                  'content-location': 'bulkdata/id/status',
-                }[name];
-              },
-            },
-          };
+          return mockFetchResponse(202, accepted('bulkdata/id/status'), {
+            'content-type': ContentType.FHIR_JSON,
+            'content-location': 'bulkdata/id/status',
+          });
         }
 
         if (url.includes('bulkdata/id/status')) {
           if (count < 1) {
             count++;
-            return {
-              status: 202,
-              json: jest.fn(async () => {
-                return {};
-              }),
-            };
+            return mockFetchResponse(202, {});
           }
         }
 
-        return {
-          status: 200,
-          headers: { get: () => ContentType.FHIR_JSON },
-          json: jest.fn(async () => ({
-            transactionTime: '2023-05-18T22:55:31.280Z',
-            request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
-            requiresAccessToken: false,
-            output: [
-              {
-                type: 'ProjectMembership',
-                url: 'https://api.medplum.com/storage/TEST',
-              },
-            ],
-            error: [],
-          })),
-        };
+        return mockFetchResponse(200, {
+          transactionTime: '2023-05-18T22:55:31.280Z',
+          request: 'https://api.medplum.com/fhir/R4/$export?_type=Observation',
+          requiresAccessToken: false,
+          output: [
+            {
+              type: 'ProjectMembership',
+              url: 'https://api.medplum.com/storage/TEST',
+            },
+          ],
+          error: [],
+        });
       });
     });
 
@@ -2701,6 +2655,7 @@ describe('Client', () => {
   describe('Downloading resources', () => {
     const baseUrl = 'https://api.medplum.com/';
     const fhirUrlPath = 'fhir/R4/';
+    const accessToken = 'fake';
     let fetch: FetchLike;
     let client: MedplumClient;
 
@@ -2709,6 +2664,7 @@ describe('Client', () => {
         text: () => Promise.resolve(url),
       }));
       client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
     });
 
     test('Downloading resources via URL', async () => {
@@ -2718,6 +2674,7 @@ describe('Client', () => {
         expect.objectContaining({
           headers: {
             Accept: DEFAULT_ACCEPT,
+            Authorization: `Bearer ${accessToken}`,
             'X-Medplum': 'extended',
           },
         })
@@ -2732,6 +2689,7 @@ describe('Client', () => {
         expect.objectContaining({
           headers: {
             Accept: DEFAULT_ACCEPT,
+            Authorization: `Bearer ${accessToken}`,
             'X-Medplum': 'extended',
           },
         })

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -518,6 +518,11 @@ interface AutoBatchEntry<T = any> {
   readonly reject: (reason: any) => void;
 }
 
+interface RequestState {
+  statusUrl?: string;
+  pollCount?: number;
+}
+
 /**
  * OAuth 2.0 Grant Type Identifiers
  * Standard identifiers: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-07#name-grant-types
@@ -2764,9 +2769,15 @@ export class MedplumClient extends EventTarget {
    * @param method - The HTTP method (GET, POST, etc).
    * @param url - The target URL.
    * @param options - Optional fetch request init options.
+   * @param state - Optional request state.
    * @returns The JSON content body if available.
    */
-  private async request<T>(method: string, url: string, options: RequestInit = {}): Promise<T> {
+  private async request<T>(
+    method: string,
+    url: string,
+    options: RequestInit = {},
+    state: RequestState = {}
+  ): Promise<T> {
     await this.refreshIfExpired();
 
     options.method = method;
@@ -2774,15 +2785,6 @@ export class MedplumClient extends EventTarget {
 
     const response = await this.fetchWithRetry(url, options);
 
-    return this.parseResponse(response, method, url, options);
-  }
-
-  private async parseResponse<T>(
-    response: Response,
-    method: string,
-    url: string,
-    options: RequestInit = {}
-  ): Promise<T> {
     if (response.status === 401) {
       // Refresh and try again
       return this.handleUnauthenticated(method, url, options);
@@ -2795,26 +2797,34 @@ export class MedplumClient extends EventTarget {
 
     const contentType = response.headers.get('content-type');
     const isJson = contentType?.includes('json');
-
     if (response.status === 404 && !isJson) {
       throw new OperationOutcomeError(notFound);
     }
 
-    const contentLocation = await tryGetContentLocation(response);
+    const obj = await this.parseBody(response, isJson);
+    const contentLocation = await tryGetContentLocation(response, obj);
     const redirectMode = options.redirect ?? this.options.redirect;
-    if (response.status === 201 && contentLocation && redirectMode === 'follow') {
+    if ((response.status === 200 || response.status === 201) && contentLocation && redirectMode === 'follow') {
       // Follow redirect
       return this.request('GET', contentLocation, { ...options, body: undefined });
     }
 
-    if (
-      response.status === 202 &&
-      contentLocation &&
-      (options.headers as Record<string, string> | undefined)?.['Prefer'] === 'respond-async'
-    ) {
-      return this.pollStatus(contentLocation);
+    const preferMode = (options.headers as Record<string, string> | undefined)?.['Prefer'];
+    if (response.status === 202 && preferMode === 'respond-async') {
+      const statusUrl = contentLocation ?? state.statusUrl;
+      if (statusUrl) {
+        return this.pollStatus(statusUrl, options, state);
+      }
     }
 
+    if (response.status >= 400) {
+      throw new OperationOutcomeError(normalizeOperationOutcome(obj));
+    }
+
+    return obj;
+  }
+
+  private async parseBody(response: Response, isJson: boolean | undefined): Promise<any> {
     let obj: any = undefined;
     if (isJson) {
       try {
@@ -2826,11 +2836,6 @@ export class MedplumClient extends EventTarget {
     } else {
       obj = await response.text();
     }
-
-    if (response.status >= 400) {
-      throw new OperationOutcomeError(normalizeOperationOutcome(obj));
-    }
-
     return obj;
   }
 
@@ -2880,29 +2885,19 @@ export class MedplumClient extends EventTarget {
     }
   }
 
-  private async pollStatus<T>(statusUrl: string): Promise<T> {
-    let checkStatus = true;
-    let resultResponse;
-    const retryDelay = 2000;
-
-    while (checkStatus) {
-      const fetchOptions = {};
-      this.addFetchOptionsDefaults(fetchOptions);
-      const statusResponse = await this.fetchWithRetry(statusUrl, fetchOptions);
-      if (statusResponse.status !== 202) {
-        checkStatus = false;
-        resultResponse = statusResponse;
-
-        if (statusResponse.status === 200 || statusResponse.status === 201) {
-          const contentLocation = await tryGetContentLocation(statusResponse);
-          if (contentLocation) {
-            resultResponse = await this.fetchWithRetry(contentLocation, fetchOptions);
-          }
-        }
-      }
+  private async pollStatus<T>(statusUrl: string, options: RequestInit, state: RequestState): Promise<T> {
+    if (state.pollCount === undefined) {
+      // First request - try request immediately
+      options.redirect = 'follow';
+      state.statusUrl = statusUrl;
+      state.pollCount = 1;
+    } else {
+      // Subsequent requests - wait and retry
+      const retryDelay = 1000;
       await sleep(retryDelay);
+      state.pollCount++;
     }
-    return this.parseResponse(resultResponse as Response, 'POST', statusUrl);
+    return this.request('GET', statusUrl, options, state);
   }
 
   /**
@@ -3558,15 +3553,28 @@ function concatUrls(baseUrl: string, url: string): string {
  * most authoritative source for the content location. If this header is
  * not present, it falls back to the "Location" HTTP header.
  *
+ * Note that the FHIR spec does not follow the traditional HTTP semantics of "Content-Location" and "Location".
+ * "Content-Location" is not typically used with HTTP 202 responses because the content itself isn't available at the time of the response.
+ * However, the FHIR spec explicitly recommends it:
+ *
+ *   3.2.6.1.2 Kick-off Request
+ *   3.2.6.1.2.0.3 Response - Success
+ *   HTTP Status Code of 202 Accepted
+ *   Content-Location header with the absolute URL of an endpoint for subsequent status requests (polling location)
+ *
+ * Source: https://hl7.org/fhir/async-bulk.html
+ *
  * In cases where neither of these headers are available (for instance,
  * due to CORS restrictions), it attempts to retrieve the content location
  * from the 'diagnostics' field of the first issue in an OperationOutcome object
  * present in the response body. If all attempts fail, the function returns 'undefined'.
+ *
  * @async
  * @param response - The HTTP response object from which to extract the content location.
+ * @param body - The response body.
  * @returns A Promise that resolves to the content location string if it is found, or 'undefined' if the content location cannot be determined from the response.
  */
-async function tryGetContentLocation(response: Response): Promise<string | undefined> {
+async function tryGetContentLocation(response: Response, body: any): Promise<string | undefined> {
   // Accepted content location can come from multiple sources
   // The authoritative source is the "Content-Location" HTTP header.
   const contentLocation = response.headers.get('content-location');
@@ -3582,7 +3590,6 @@ async function tryGetContentLocation(response: Response): Promise<string | undef
 
   // However, "Content-Location" may not be available due to CORS limitations.
   // In this case, we use the OperationOutcome.diagnostics field.
-  const body = await response.json();
   if (isOperationOutcome(body) && body.issue?.[0]?.diagnostics) {
     return body.issue[0].diagnostics;
   }

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -269,7 +269,11 @@ export class MockFetchClient {
       ok: true,
       status: response?.resourceType === 'OperationOutcome' ? getStatus(response) : 200,
       headers: {
-        get: () => ContentType.FHIR_JSON,
+        get(name: string): string | undefined {
+          return {
+            'content-type': ContentType.FHIR_JSON,
+          }[name];
+        },
       } as unknown as Headers,
       blob: () => Promise.resolve(response),
       json: () => Promise.resolve(response),


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/3932 which unfortunately released with a bug.

--------

### Original PR

`startAsyncRequest` uses `Prefer: respond-async`, and polls the status URL on a timer until the async job is complete.

If, in the middle of that sequence of events, the user's token expires, then the client would go into the token refresh code path.  After successful refresh, the client would then attempt to go back to the original request.

The bug is that the "poll on `Prefer: respond-async`" was not compatible with that refresh and retry flow.

This PR fixes that, and merges the "poll on `Prefer: respond-async`" logic into the main `parseResponse` code path.

Thank you @jjdonov for finding this and writing such an excellent bug report!

--------

### Follow-up PR

The first PR had a bug where `MedplumClient` would try to double-read the `response.json()` stream.  In our mocks, that was silently ignored.  In the browser, that throws an error.

This actually revealed a another hidden bug, and a few interesting behaviors / spec discrepancies.

The hidden bug was in the async request flow.  When we first implemented async polling (see original PR: https://github.com/medplum/medplum/pull/2307), it was noted that due to CORS constraints the client may not have access to `Content-Location` or `Location` headers.  In that case, the header values would simply appear as blank.  So we followed the industry convention of including the status URL in the `OperationOutcome.issue[0].diagnostics` element.

The bug was that implementation would double-read the JSON stream if `OperationOutcome.issue[0].diagnostics` was also blank.

This was all exacerbated when we started using the `tryGetContentLocation()` helper anytime we tried to read the `Content-Location` or `Location` headers.  The bug was always there, this just brought it to the surface.

Along the way, we started researching the duality of `Content-Location` vs `Location`, because in theory we should not need to check both.  Unfortunately, the FHIR spec is somewhat misaligned with the HTTP spec in this regard.

```
 * Note that the FHIR spec does not follow the traditional HTTP semantics of "Content-Location" and "Location".
 * "Content-Location" is not typically used with HTTP 202 responses because the content itself isn't available at the time of the response.
 * However, the FHIR spec explicitly recommends it:
 *
 *   3.2.6.1.2 Kick-off Request
 *   3.2.6.1.2.0.3 Response - Success
 *   HTTP Status Code of 202 Accepted
 *   Content-Location header with the absolute URL of an endpoint for subsequent status requests (polling location)
 *
 * Source: https://hl7.org/fhir/async-bulk.html
```
