### PR TITLE
Remove vercel commands from medplum-provider/vercel.json

### DIFF
--- a/examples/medplum-provider/vercel.json
+++ b/examples/medplum-provider/vercel.json
@@ -1,5 +1,3 @@
 {
-  "installCommand": "npm install",
-  "buildCommand": "npm run build",
   "routes": [{ "src": "/[^.]+", "dest": "/", "status": 200 }]
 }


### PR DESCRIPTION
I thought we would be able to override these settings in the Vercel admin tool, but apparently not.

When deploying from `medplum/medplum`, we want to use `@medplum/core` and `@medplum/react` from the mono repo.  So the commands are:

- Root directory: `examples/medplum-provider/`
- Install: `cd ../.. && npm ci`
- Build: `cd ../.. && npm run build -- --filter=medplum-provider`

We need to do that, rather than just use `/` as the root directory, because that's the only way for Vercel to recognize `examples/medplum-provider/vercel.json` for other config settings.