### PR TITLE
Update practitioner invite with externalId

### DIFF
--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -141,17 +141,20 @@ export async function inviteUser(request: ServerInviteRequest): Promise<ServerIn
 }
 
 async function createUser(request: ServerInviteRequest): Promise<User> {
-  const { firstName, lastName, externalId } = request;
+  const { firstName, lastName } = request;
   const email = request.email?.toLowerCase();
   const password = request.password ?? generateSecret(16);
   const passwordHash = await bcryptHashPassword(password);
 
   let project: Reference<Project> | undefined = undefined;
-  if (request.resourceType === 'Patient' || externalId) {
+  if (request.resourceType === 'Patient') {
     // Users can optionally be scoped to a project.
-    // We force users to be scoped to a project if:
-    // 1) They are a patient
-    // 2) They are a practitioner with an externalId
+    // We force patient users to be project scoped.
+    //
+    // In the past, Practitioners with externalId auth were also project scoped.
+    // That was because, in the original implementation of externalId auth, the externalId was unique across all projects.
+    // Later, we moved externalId to ProjectMembership, so it is no longer global.
+    // And therefore, Practitioners with externalId auth are no longer project scoped.
     project = createReference(request.project);
   }
 


### PR DESCRIPTION
Context:
* `User` objects can be "global scoped" or "project scoped"
    * Global scoped `User`:
        * Does not have `User.project`
        * Can be a member of multiple projects
        * Cannot be accessed or modified by project admins
    * Project scoped `User`:
        * Has `User.project`
        * Can only be a member of that one project
        * Project admins have limited read/write access to the `User` object
        * For example, project admins can force set the project scoped `User` password
* Users can have an `externalId`
    * This is used for external authentication (i.e., Auth0, Okta, etc)
    * The `externalId` can be used as an alternative to `email` (`email` would otherwise be a required field)
* In the first implementation, `externalId` was on the `User` resource (`User.externalId`)
    * However, that meant that any user with `externalId` had to be project scoped
    * That led to some awkward contortions in the code
    * While our original expectation was that it would only apply to `Patient` users, Medplum customers quickly started using it for `Practitioner` users as well
* We then moved `externalId` to the `ProjectMembership` resource (`ProjectMembership.externalId`)
  * We deprecated `User.externalId`
  * After that, project admins can freely read/write the `ProjectMembership.externalId` value, because that resource is project scoped

But that meant we have this lingering odd special case of "Inviting a `Practitioner` with externalId creates a project scoped `User`"

I'm not 100% sure we actually want to do this.  Or rather, we may want to, but we may also want to preserve the ability to invite as project scoped?

Considerations:
* If a Medplum customer wants to create a 100% white-labeled experience on hosted Medplum, they  would need to create project-scoped `User` accounts (otherwise the global-scoped `User` could experience unique constraints on `User.email`)
* If a Medplum customer wants the ability to manage a `Practitioner` user's password, they need a project-scoped `User`