### PR TITLE
Don't return early on cache miss in loadProfile

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -885,6 +885,16 @@ describe('FHIR Repo', () => {
 
   test('Profile validation', async () =>
     withTestContext(async () => {
+      const clientApp = 'ClientApplication/' + randomUUID();
+      const projectId = randomUUID();
+      const repo = new Repository({
+        strictMode: true,
+        projects: [projectId],
+        author: {
+          reference: clientApp,
+        },
+      });
+
       const profile = JSON.parse(
         readFileSync(resolve(__dirname, '__test__/us-core-patient.json'), 'utf8')
       ) as StructureDefinition;
@@ -909,9 +919,9 @@ describe('FHIR Repo', () => {
         // Missing gender property is required by profile
       };
 
-      await expect(systemRepo.createResource(patient)).resolves.toBeTruthy();
-      await systemRepo.createResource(profile);
-      await expect(systemRepo.createResource(patient)).rejects.toEqual(
+      await expect(repo.createResource(patient)).resolves.toBeTruthy();
+      await repo.createResource(profile);
+      await expect(repo.createResource(patient)).rejects.toEqual(
         new Error('Missing required property (Patient.gender)')
       );
     }));

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -613,7 +613,9 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
       const cacheKeys = projectIds.map((id) => getProfileCacheKey(id, url));
       const results = await getRedis().mget(...cacheKeys);
       const cachedProfile = results.find(Boolean) as string | undefined;
-      return cachedProfile ? (JSON.parse(cachedProfile) as CacheEntry<StructureDefinition>).resource : undefined;
+      if (cachedProfile) {
+        return (JSON.parse(cachedProfile) as CacheEntry<StructureDefinition>).resource;
+      }
     }
 
     // Fall back to loading from the DB; descending version sort approximates version resolution for some cases


### PR DESCRIPTION
This bug was introduced in #3909 due to the usage of `systemRepo` in the corresponding test. Since `systemRepo` was used in the test, the block of code with the errant early return was bypassed since systemRepo doesn't have a list of project IDs.