### PR TITLE
Link sort section to search parameters

### DIFF
--- a/packages/docs/docs/search/basic-search.mdx
+++ b/packages/docs/docs/search/basic-search.mdx
@@ -324,7 +324,7 @@ You can search an exclusive range using an OR search
 
 You can sort your search results by using the special search parameter `_sort`.
 
-The `_sort` parameter allows you specify a list of search parameters to sort by, in order.
+The `_sort` parameter allows you specify a list of [search parameters](#search-parameters) to sort by, in order.
 
 The example below searches for all [`RiskAssessments`](/docs/api/fhir/resources/riskassessment), sorted by their `probability`, then by `date`.
 


### PR DESCRIPTION
This will link the sort section of the basic search page to the search parameters section to make it easier for users to understand what elements can be used to sort.