### PR TITLE
Add scheduled job to upgrade dependencies

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,6 +1,11 @@
 name: Upgrade dependencies
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 9:00 AM UTC
+    # Every Monday at 1:00 AM PST (2:00 AM PDT)
+    - cron: '0 9 * * 1'
 
 jobs:
   upgrade-dependencies:


### PR DESCRIPTION
Run the "Upgrade dependencies" job every week at 1:00am PST

This does not commit anything to `main`, it just prepares the upgrade as a PR.

Github Actions uses UTC: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

Crontab visualizer: https://crontab.guru/#0_9_*_*_1