### PR TITLE
Fixes #3975 - _format and _pretty query params

### DIFF
--- a/packages/core/src/search/parse.test.ts
+++ b/packages/core/src/search/parse.test.ts
@@ -2,7 +2,7 @@ import { readJson } from '@medplum/definitions';
 import { Bundle, SearchParameter } from '@medplum/fhirtypes';
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
-import { Operator, parseSearchRequest, parseSearchUrl, SearchRequest } from './search';
+import { Operator, SearchRequest, parseSearchRequest, parseSearchUrl } from './search';
 
 describe('Search parser', () => {
   beforeAll(() => {
@@ -652,5 +652,26 @@ describe('Search parser', () => {
     expect(() => {
       parseSearchRequest('Patient', { _revinclude: 'Patient:*' });
     }).toThrow();
+  });
+
+  test('_format', () => {
+    expect(parseSearchRequest('Patient', { _format: 'json' })).toMatchObject<SearchRequest>({
+      resourceType: 'Patient',
+      format: 'json',
+    });
+  });
+
+  test('_pretty=true', () => {
+    expect(parseSearchRequest('Patient', { _pretty: 'true' })).toMatchObject<SearchRequest>({
+      resourceType: 'Patient',
+      pretty: true,
+    });
+  });
+
+  test('_pretty=false', () => {
+    expect(parseSearchRequest('Patient', { _pretty: 'false' })).toMatchObject<SearchRequest>({
+      resourceType: 'Patient',
+      pretty: false,
+    });
   });
 });

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -18,6 +18,8 @@ export interface SearchRequest<T extends Resource = Resource> {
   include?: IncludeTarget[];
   revInclude?: IncludeTarget[];
   summary?: 'true' | 'text' | 'data';
+  format?: string;
+  pretty?: boolean;
 }
 
 export interface Filter {
@@ -256,6 +258,14 @@ function parseKeyValue(searchRequest: SearchRequest, key: string, value: string)
     case '_fields':
     case '_elements':
       searchRequest.fields = value.split(',');
+      break;
+
+    case '_format':
+      searchRequest.format = value;
+      break;
+
+    case '_pretty':
+      searchRequest.pretty = value === 'true';
       break;
 
     default: {

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -50,7 +50,7 @@ export async function inviteHandler(req: Request, res: Response): Promise<void> 
   }
 
   const { membership } = await inviteUser(inviteRequest);
-  return sendResponse(res, allOk, membership);
+  return sendResponse(req, res, allOk, membership);
 }
 
 export interface ServerInviteRequest extends InviteRequest {

--- a/packages/server/src/fhir/job.ts
+++ b/packages/server/src/fhir/job.ts
@@ -24,7 +24,7 @@ jobRouter.get(
       return;
     }
 
-    await sendResponse(res, allOk, asyncJob);
+    await sendResponse(req, res, allOk, asyncJob);
   })
 );
 

--- a/packages/server/src/fhir/operations/README.md
+++ b/packages/server/src/fhir/operations/README.md
@@ -65,6 +65,6 @@ export async function projectInitHandler(req: Request, res: Response): Promise<v
   const project = doProjectInit(params);
 
   // Special case: single `return` output parameter means respond with the Project resource directly
-  await sendOutputParameters(operation, res, created, project);
+  await sendOutputParameters(req, res, operation, created, project);
 }
 ```

--- a/packages/server/src/fhir/operations/codesystemimport.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.ts
@@ -82,7 +82,7 @@ export async function codeSystemImportHandler(req: Request, res: Response): Prom
     sendOutcome(res, normalizeOperationOutcome(err));
     return;
   }
-  await sendOutputParameters(operation, res, allOk, codeSystem);
+  await sendOutputParameters(req, res, operation, allOk, codeSystem);
 }
 
 export async function importCodeSystem(

--- a/packages/server/src/fhir/operations/codesystemlookup.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.ts
@@ -95,5 +95,5 @@ export async function codeSystemLookupHandler(req: Request, res: Response): Prom
     }
   }
 
-  await sendOutputParameters(operation, res, allOk, output);
+  await sendOutputParameters(req, res, operation, allOk, output);
 }

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.ts
@@ -66,5 +66,5 @@ export async function codeSystemValidateCodeHandler(req: Request, res: Response)
   } else {
     output.result = false;
   }
-  await sendOutputParameters(operation, res, allOk, output);
+  await sendOutputParameters(req, res, operation, allOk, output);
 }

--- a/packages/server/src/fhir/operations/conceptmaptranslate.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.ts
@@ -26,7 +26,7 @@ export async function conceptMapTranslateHandler(req: Request, res: Response): P
   }
 
   const output = conceptMapTranslate(map, params);
-  await sendOutputParameters(operation, res, allOk, output);
+  await sendOutputParameters(req, res, operation, allOk, output);
 }
 
 async function lookupConceptMap(

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -50,7 +50,7 @@ export async function evaluateMeasureHandler(req: Request, res: Response): Promi
   }
 
   const measureReport = await evaluateMeasure(ctx.repo, params, measure);
-  await sendResponse(res, created, measureReport);
+  await sendResponse(req, res, created, measureReport);
 }
 
 /**

--- a/packages/server/src/fhir/operations/getwsbindingtoken.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.ts
@@ -79,5 +79,5 @@ export async function getWsBindingTokenHandler(req: Request, res: Response): Pro
     ],
   } satisfies Parameters;
 
-  await sendResponse(res, allOk, tokenParams);
+  await sendResponse(req, res, allOk, tokenParams);
 }

--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -41,7 +41,7 @@ export async function patientEverythingHandler(req: Request, res: Response): Pro
   // Then read all of the patient data
   const bundle = await getPatientEverything(ctx.repo, patient, params);
 
-  await sendResponse(res, allOk, bundle);
+  await sendResponse(req, res, allOk, bundle);
 }
 
 /**

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -73,7 +73,7 @@ export async function planDefinitionApplyHandler(req: Request, res: Response): P
     intent: 'order',
     action: actions,
   });
-  await sendResponse(res, allOk, requestGroup);
+  await sendResponse(req, res, allOk, requestGroup);
 }
 
 /**

--- a/packages/server/src/fhir/operations/projectclone.ts
+++ b/packages/server/src/fhir/operations/projectclone.ts
@@ -26,7 +26,7 @@ export async function projectCloneHandler(req: Request, res: Response): Promise<
   const { name, resourceTypes, includeIds, excludeIds } = req.body;
   const cloner = new ProjectCloner(ctx.repo, id, name, resourceTypes, includeIds, excludeIds);
   const result = await cloner.cloneProject();
-  await sendResponse(res, created, result);
+  await sendResponse(req, res, created, result);
 }
 
 class ProjectCloner {

--- a/packages/server/src/fhir/operations/projectinit.ts
+++ b/packages/server/src/fhir/operations/projectinit.ts
@@ -111,7 +111,7 @@ export async function projectInitHandler(req: Request, res: Response): Promise<v
   }
 
   const { project } = await createProject(params.name, owner);
-  await sendOutputParameters(projectInitOperation, res, created, project);
+  await sendOutputParameters(req, res, projectInitOperation, created, project);
 }
 
 /**

--- a/packages/server/src/fhir/operations/resourcegraph.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.ts
@@ -51,7 +51,7 @@ export async function resourceGraphHandler(req: Request, res: Response): Promise
   }
   await followLinks(ctx.repo, rootResource, definition.link, results, resourceCache);
 
-  await sendResponse(res, allOk, {
+  await sendResponse(req, res, allOk, {
     resourceType: 'Bundle',
     entry: deduplicateResources(results).map((r) => ({
       resource: r,

--- a/packages/server/src/fhir/operations/structuredefinitionexpandprofile.ts
+++ b/packages/server/src/fhir/operations/structuredefinitionexpandprofile.ts
@@ -32,7 +32,7 @@ export async function structureDefinitionExpandProfileHandler(req: Request, res:
 
   const bundle = bundleResults([profile, ...sds]);
 
-  await sendResponse(res, allOk, bundle);
+  await sendResponse(req, res, allOk, bundle);
 }
 
 async function fetchProfileByUrl(repo: Repository, url: string): Promise<StructureDefinition | undefined> {

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -231,6 +231,10 @@ describe('Operation Input Parameters parsing', () => {
 });
 
 describe('Send Operation output Parameters', () => {
+  const req = {
+    query: {},
+  } as unknown as Request;
+
   const res = {
     set: jest.fn(),
     status: jest.fn(),
@@ -243,7 +247,7 @@ describe('Send Operation output Parameters', () => {
   });
 
   test('Single required parameter', async () => {
-    await sendOutputParameters(opDef, res, allOk, { singleOut: { value: 20.2, unit: 'kg/m^2' } });
+    await sendOutputParameters(req, res, opDef, allOk, { singleOut: { value: 20.2, unit: 'kg/m^2' } });
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith<[Parameters]>({
@@ -253,7 +257,7 @@ describe('Send Operation output Parameters', () => {
   });
 
   test('Optional output parameter', async () => {
-    await sendOutputParameters(opDef, res, created, {
+    await sendOutputParameters(req, res, opDef, created, {
       singleOut: { value: 20.2, unit: 'kg/m^2' },
       multiOut: [{ reference: 'Observation/height' }, { reference: 'Observation/weight' }],
     });
@@ -286,7 +290,7 @@ describe('Send Operation output Parameters', () => {
           unit: 'kg/m^2',
         },
       } as Observation;
-      await sendOutputParameters(resourceReturnOp, res, allOk, obs);
+      await sendOutputParameters(req, res, resourceReturnOp, allOk, obs);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(obs);
@@ -299,7 +303,7 @@ describe('Send Operation output Parameters', () => {
         parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
       };
       const ref = { reference: 'Observation/bmi' } as Reference;
-      await sendOutputParameters(resourceReturnOp, res, allOk, ref);
+      await sendOutputParameters(req, res, resourceReturnOp, allOk, ref);
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
@@ -324,7 +328,7 @@ describe('Send Operation output Parameters', () => {
         parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
       };
       const patient = { resourceType: 'Patient' } as Patient;
-      await sendOutputParameters(resourceReturnOp, res, allOk, patient);
+      await sendOutputParameters(req, res, resourceReturnOp, allOk, patient);
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
@@ -344,7 +348,7 @@ describe('Send Operation output Parameters', () => {
 
   test('Missing required parameter', () =>
     withTestContext(async () => {
-      await sendOutputParameters(opDef, res, allOk, { incorrectOut: { value: 20.2, unit: 'kg/m^2' } });
+      await sendOutputParameters(req, res, opDef, allOk, { incorrectOut: { value: 20.2, unit: 'kg/m^2' } });
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
@@ -363,7 +367,7 @@ describe('Send Operation output Parameters', () => {
     }));
 
   test('Omits extraneous parameters', async () => {
-    await sendOutputParameters(opDef, res, allOk, { singleOut: { value: 20.2, unit: 'kg/m^2' }, extraOut: 'foo' });
+    await sendOutputParameters(req, res, opDef, allOk, { singleOut: { value: 20.2, unit: 'kg/m^2' }, extraOut: 'foo' });
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith<[Parameters]>({
@@ -374,7 +378,7 @@ describe('Send Operation output Parameters', () => {
 
   test('Returns error on invalid output', () =>
     withTestContext(async () => {
-      await sendOutputParameters(opDef, res, allOk, { singleOut: { reference: 'Observation/foo' } });
+      await sendOutputParameters(req, res, opDef, allOk, { singleOut: { reference: 'Observation/foo' } });
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -106,8 +106,9 @@ function parseParams(
 }
 
 export async function sendOutputParameters(
-  operation: OperationDefinition,
+  req: Request,
   res: Response,
+  operation: OperationDefinition,
   outcome: OperationOutcome,
   output: any
 ): Promise<void> {
@@ -121,7 +122,7 @@ export async function sendOutputParameters(
       );
     } else {
       // Send Resource as output directly, instead of using Parameters format
-      await sendResponse(res, outcome, output);
+      await sendResponse(req, res, outcome, output);
     }
     return;
   }

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -160,11 +160,19 @@ describe('FHIR Routes', () => {
     expect(res.status).toBe(400);
   });
 
-  test('Read resourcex', async () => {
+  test('Read resource', async () => {
     const res = await request(app)
       .get(`/fhir/R4/Patient/${patientId}`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res.status).toBe(200);
+  });
+
+  test('Read resource _pretty', async () => {
+    const res = await request(app)
+      .get(`/fhir/R4/Patient/${patientId}?_pretty=true`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res.status).toBe(200);
+    expect(res.text).toEqual(JSON.stringify(res.body, undefined, 2));
   });
 
   test('Read resource invalid UUID', async () => {

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -225,7 +225,7 @@ protectedRoutes.use(
       }
       sendOutcome(res, result[0]);
     } else {
-      await sendResponse(res, result[0], result[1]);
+      await sendResponse(req, res, result[0], result[1]);
     }
   })
 );


### PR DESCRIPTION
See #3975 

Once upon a time, we silently ignored unrecognized FHIR search params, which obfuscated this issue.

Sometime 2023 we started throwing errors on unrecognized search params, which broke these params.

`_format` - currently parsing and ignoring, we only support JSON for now and for the foreseeable future

`_pretty` - now recognized and works for any FHIR request

Thanks @luis901101 for submitting this issue 🙏 
