### PR TITLE
feat(subscriptions): cleanup WS `Subscription`s, log access policy satisfied

### DIFF
--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -164,7 +164,8 @@ class Redis {
     return added;
   }
 
-  async srem(setKey: string, ...members: string[]): Promise<number> {
+  async srem(setKey: string, member: string[]): Promise<number>;
+  async srem(setKey: string, ...members: string[] | string[][]): Promise<number> {
     const keySet = sets.get(setKey);
     if (!keySet) {
       return 0;
@@ -176,7 +177,7 @@ class Redis {
     if (Array.isArray(members[0])) {
       normalizedMembers = members[0];
     } else {
-      normalizedMembers = members;
+      normalizedMembers = members as string[];
     }
     let removed = 0;
     for (const member of normalizedMembers) {

--- a/packages/server/src/__mocks__/ioredis.ts
+++ b/packages/server/src/__mocks__/ioredis.ts
@@ -128,6 +128,24 @@ class Redis {
     return added;
   }
 
+  async srem(setKey: string, members: string[]): Promise<number> {
+    const keySet = sets.get(setKey);
+    if (!keySet) {
+      return 0;
+    }
+    if (!(keySet instanceof Set)) {
+      throw new ReplyError('WRONGTYPE Operation against a key holding the wrong kind of value');
+    }
+    let removed = 0;
+    for (const member of members) {
+      if (keySet.has(member)) {
+        keySet.delete(member);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
   async smembers(setKey: string): Promise<string[]> {
     const keySet = sets.get(setKey);
     if (!keySet) {
@@ -137,6 +155,20 @@ class Redis {
       throw new ReplyError('WRONGTYPE Operation against a key holding the wrong kind of value');
     }
     return Array.from(keySet.keys());
+  }
+
+  async smismember(setKey: string, ...members: string[]): Promise<number[]> {
+    const keySet = sets.get(setKey);
+    if (!keySet) {
+      return new Array(members.length).fill(0);
+    }
+    if (!(keySet instanceof Set)) {
+      throw new ReplyError('WRONGTYPE Operation against a key holding the wrong kind of value');
+    }
+    return members.map((member) => {
+      // console.log('is a member?', member, keySet.has(member));
+      return keySet.has(member) ? 1 : 0;
+    });
   }
 
   async scard(setKey: string): Promise<number> {

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -89,7 +89,7 @@ export async function getAccessPolicyForLogin(
  * @param membership - The user project membership.
  * @returns The parameterized compound access policy.
  */
-async function buildAccessPolicy(membership: ProjectMembership): Promise<AccessPolicy> {
+export async function buildAccessPolicy(membership: ProjectMembership): Promise<AccessPolicy> {
   let access: ProjectMembershipAccess[] = [];
 
   if (membership.accessPolicy) {

--- a/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
+import { verifyJwt } from '../../oauth/keys';
 import { initTestAuth } from '../../test.setup';
 
 const app = express();
@@ -51,14 +52,25 @@ describe('Get WebSocket binding token', () => {
     expect(params.resourceType).toEqual('Parameters');
     expect(params.parameter?.length).toEqual(3);
     expect(params.parameter?.[0]).toBeDefined();
-    expect(params.parameter?.[0].name).toEqual('token');
-    expect(params.parameter?.[0].valueString).toBeDefined();
+    expect(params.parameter?.[0]?.name).toEqual('token');
+
+    const token = params.parameter?.[0]?.valueString as string;
+    expect(token).toBeDefined();
+
+    const { payload } = await verifyJwt(token);
+    expect(payload?.sub).toBeDefined();
+    expect(payload?.exp).toBeDefined();
+    expect(payload?.aud).toBeDefined();
+    expect(payload?.username).toBeDefined();
+    expect(payload?.subscription_id).toBeDefined();
+    expect(payload?.project_id).toBeDefined();
+
     expect(params.parameter?.[1]).toBeDefined();
-    expect(params.parameter?.[1].name).toEqual('expiration');
-    expect(params.parameter?.[1].valueDateTime).toBeDefined();
-    expect(new Date(params.parameter?.[1].valueDateTime as string).getTime()).toBeGreaterThanOrEqual(Date.now());
+    expect(params.parameter?.[1]?.name).toEqual('expiration');
+    expect(params.parameter?.[1]?.valueDateTime).toBeDefined();
+    expect(new Date(params.parameter?.[1]?.valueDateTime as string).getTime()).toBeGreaterThanOrEqual(Date.now());
     expect(params.parameter?.[2]).toBeDefined();
-    expect(params.parameter?.[2].name).toEqual('websocket-url');
-    expect(params.parameter?.[2].valueUrl).toBeDefined();
+    expect(params.parameter?.[2]?.name).toEqual('websocket-url');
+    expect(params.parameter?.[2]?.valueUrl).toBeDefined();
   });
 });

--- a/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
@@ -1,11 +1,11 @@
 import { ContentType } from '@medplum/core';
-import { Parameters, Subscription } from '@medplum/fhirtypes';
+import { OperationOutcome, Parameters, Subscription } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
 import { verifyJwt } from '../../oauth/keys';
-import { initTestAuth } from '../../test.setup';
+import { initTestAuth, withTestContext } from '../../test.setup';
 
 const app = express();
 let accessToken: string;
@@ -21,55 +21,97 @@ describe('Get WebSocket binding token', () => {
     await shutdownApp();
   });
 
-  test('Basic', async () => {
-    // Create Subscription
-    const res1 = await request(app)
-      .post(`/fhir/R4/Subscription`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', ContentType.FHIR_JSON)
-      .send({
-        resourceType: 'Subscription',
-        reason: 'test',
-        status: 'active',
-        criteria: 'Patient',
-        channel: {
-          type: 'websocket',
-        },
-      } satisfies Subscription);
-    const createdSub = res1.body as Subscription;
-    expect(res1.status).toBe(201);
-    expect(createdSub).toBeDefined();
-    expect(createdSub.id).toBeDefined();
+  test('Basic', () =>
+    withTestContext(async () => {
+      // Create Subscription
+      const res1 = await request(app)
+        .post(`/fhir/R4/Subscription`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: 'Patient',
+          channel: {
+            type: 'websocket',
+          },
+        } satisfies Subscription);
+      const createdSub = res1.body as Subscription;
+      expect(res1.status).toBe(201);
+      expect(createdSub).toBeDefined();
+      expect(createdSub.id).toBeDefined();
 
-    // Start the export
-    const res2 = await request(app)
-      .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res2.status).toBe(200);
-    expect(res2.body).toBeDefined();
+      // Start the export
+      const res2 = await request(app)
+        .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(res2.status).toBe(200);
+      expect(res2.body).toBeDefined();
 
-    const params = res2.body as Parameters;
-    expect(params.resourceType).toEqual('Parameters');
-    expect(params.parameter?.length).toEqual(3);
-    expect(params.parameter?.[0]).toBeDefined();
-    expect(params.parameter?.[0]?.name).toEqual('token');
+      const params = res2.body as Parameters;
+      expect(params.resourceType).toEqual('Parameters');
+      expect(params.parameter?.length).toEqual(3);
+      expect(params.parameter?.[0]).toBeDefined();
+      expect(params.parameter?.[0]?.name).toEqual('token');
 
-    const token = params.parameter?.[0]?.valueString as string;
-    expect(token).toBeDefined();
+      const token = params.parameter?.[0]?.valueString as string;
+      expect(token).toBeDefined();
 
-    const { payload } = await verifyJwt(token);
-    expect(payload?.sub).toBeDefined();
-    expect(payload?.exp).toBeDefined();
-    expect(payload?.aud).toBeDefined();
-    expect(payload?.username).toBeDefined();
-    expect(payload?.subscription_id).toBeDefined();
+      const { payload } = await verifyJwt(token);
+      expect(payload?.sub).toBeDefined();
+      expect(payload?.exp).toBeDefined();
+      expect(payload?.aud).toBeDefined();
+      expect(payload?.username).toBeDefined();
+      expect(payload?.subscription_id).toBeDefined();
 
-    expect(params.parameter?.[1]).toBeDefined();
-    expect(params.parameter?.[1]?.name).toEqual('expiration');
-    expect(params.parameter?.[1]?.valueDateTime).toBeDefined();
-    expect(new Date(params.parameter?.[1]?.valueDateTime as string).getTime()).toBeGreaterThanOrEqual(Date.now());
-    expect(params.parameter?.[2]).toBeDefined();
-    expect(params.parameter?.[2]?.name).toEqual('websocket-url');
-    expect(params.parameter?.[2]?.valueUrl).toBeDefined();
-  });
+      expect(params.parameter?.[1]).toBeDefined();
+      expect(params.parameter?.[1]?.name).toEqual('expiration');
+      expect(params.parameter?.[1]?.valueDateTime).toBeDefined();
+      expect(new Date(params.parameter?.[1]?.valueDateTime as string).getTime()).toBeGreaterThanOrEqual(Date.now());
+      expect(params.parameter?.[2]).toBeDefined();
+      expect(params.parameter?.[2]?.name).toEqual('websocket-url');
+      expect(params.parameter?.[2]?.valueUrl).toBeDefined();
+    }));
+
+  test('should return OperationOutcome error if Subscription no longer exists', () =>
+    withTestContext(async () => {
+      // Create subscription to watch patient
+      const res1 = await request(app)
+        .post(`/fhir/R4/Subscription`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: 'Patient',
+          channel: {
+            type: 'websocket',
+          },
+        } satisfies Subscription);
+      const createdSub = res1.body as Subscription;
+      expect(res1.status).toBe(201);
+      expect(createdSub).toBeDefined();
+      expect(createdSub.id).toBeDefined();
+
+      const res2 = await request(app)
+        .delete(`/fhir/R4/Subscription/${createdSub.id as string}`)
+        .set('Authorization', 'Bearer ' + accessToken);
+
+      expect(res2.body).toMatchObject<OperationOutcome>({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'information', code: 'informational' }],
+      });
+
+      // Call $get-ws-binding-token
+      const res3 = await request(app)
+        .get(`/fhir/R4/Subscription/${createdSub.id}/$get-ws-binding-token`)
+        .set('Authorization', 'Bearer ' + accessToken);
+
+      expect(res3.body).toMatchObject<OperationOutcome>({
+        resourceType: 'OperationOutcome',
+        issue: [{ severity: 'error', code: 'invalid' }],
+      });
+    }));
 });

--- a/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.test.ts
@@ -63,7 +63,6 @@ describe('Get WebSocket binding token', () => {
     expect(payload?.aud).toBeDefined();
     expect(payload?.username).toBeDefined();
     expect(payload?.subscription_id).toBeDefined();
-    expect(payload?.project_id).toBeDefined();
 
     expect(params.parameter?.[1]).toBeDefined();
     expect(params.parameter?.[1]?.name).toEqual('expiration');

--- a/packages/server/src/fhir/operations/getwsbindingtoken.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.ts
@@ -1,4 +1,4 @@
-import { allOk, badRequest, resolveId } from '@medplum/core';
+import { allOk, badRequest, normalizeErrorString, resolveId } from '@medplum/core';
 import { Parameters, Subscription } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getConfig } from '../../config';
@@ -40,8 +40,8 @@ export async function getWsBindingTokenHandler(req: Request, res: Response): Pro
   const subscriptionId = req.params.id;
   try {
     await repo.readResource<Subscription>('Subscription', subscriptionId);
-  } catch (_err: unknown) {
-    sendOutcome(res, badRequest('Subscription does not exist or does not have a project ID associated with it'));
+  } catch (err: unknown) {
+    sendOutcome(res, badRequest(`Error reading subscription: ${normalizeErrorString(err)}`));
     return;
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -200,18 +200,16 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
   }
 
   async createResource<T extends Resource>(resource: T): Promise<T> {
+    const resourceWithId = {
+      ...resource,
+      id: randomUUID(),
+    };
     try {
-      const result = await this.updateResourceImpl(
-        {
-          ...resource,
-          id: randomUUID(),
-        },
-        true
-      );
+      const result = await this.updateResourceImpl(resourceWithId, true);
       this.logEvent(CreateInteraction, AuditEventOutcome.Success, undefined, result);
       return result;
     } catch (err) {
-      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, resource);
+      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, resourceWithId);
       throw err;
     }
   }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -47,7 +47,6 @@ import {
   ResourceType,
   SearchParameter,
   StructureDefinition,
-  Subscription,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { Pool, PoolClient } from 'pg';
@@ -541,19 +540,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
         throw new OperationOutcomeError(serverError(new Error('No project connected to the specified Subscription.')));
       }
       // WebSocket Subscriptions are also cache-only, but also need to be added to a special cache key
-      const currentWsSubscriptionsStr = await redis.get(`medplum:subscriptions:r4:project:${project}`);
-      const currentWsSubscriptions = (
-        currentWsSubscriptionsStr ? JSON.parse(currentWsSubscriptionsStr) : []
-      ) as Subscription[];
-      const existingIdx = currentWsSubscriptions.findIndex(
-        (sub: Subscription) => (sub.id as string) === (result.id as string)
-      );
-      if (existingIdx !== -1) {
-        currentWsSubscriptions[existingIdx] = result;
-      } else {
-        currentWsSubscriptions.push(result);
-      }
-      await redis.set(`medplum:subscriptions:r4:project:${project}`, JSON.stringify(currentWsSubscriptions));
+      await redis.sadd(`medplum:subscriptions:r4:project:${project}:subs`, `Subscription/${result.id}`);
     }
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -540,7 +540,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
         throw new OperationOutcomeError(serverError(new Error('No project connected to the specified Subscription.')));
       }
       // WebSocket Subscriptions are also cache-only, but also need to be added to a special cache key
-      await redis.sadd(`medplum:subscriptions:r4:project:${project}:subs`, `Subscription/${result.id}`);
+      await redis.sadd(`medplum:subscriptions:r4:project:${project}:active`, `Subscription/${result.id}`);
     }
   }
 

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -60,6 +60,9 @@ describe('WebSockets Subscriptions', () => {
       },
     });
 
+    // TODO: Remove this when the websocket-subscriptions feature flag is removed
+    project = await withTestContext(() => repo.updateResource({ ...project, features: ['websocket-subscriptions'] }));
+
     await new Promise<void>((resolve) => {
       server.listen(0, 'localhost', 511, resolve);
     });

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -141,10 +141,10 @@ describe('WebSockets Subscriptions', () => {
           // Clear the queue
           queue.add.mockClear();
 
-          let isMember = false;
-          while (!isMember) {
+          let subActive = false;
+          while (!subActive) {
             await sleep(0);
-            isMember =
+            subActive =
               (
                 await getRedis().smismember(
                   `medplum:subscriptions:r4:project:${project.id}:active`,
@@ -152,7 +152,7 @@ describe('WebSockets Subscriptions', () => {
                 )
               )[0] === 1;
           }
-          expect(isMember).toEqual(true);
+          expect(subActive).toEqual(true);
         })
         .expectJson((msg: Bundle): boolean => {
           if (!msg.entry?.[1]) {
@@ -182,10 +182,10 @@ describe('WebSockets Subscriptions', () => {
       expect(subscription).toBeDefined();
       expect(subscription).toEqual(patientSubscription);
 
-      let isMember = true;
-      while (isMember) {
+      let subActive = true;
+      while (subActive) {
         await sleep(0);
-        isMember =
+        subActive =
           (
             await getRedis().smismember(
               `medplum:subscriptions:r4:project:${project.id}:active`,
@@ -193,7 +193,7 @@ describe('WebSockets Subscriptions', () => {
             )
           )[0] === 1;
       }
-      expect(isMember).toEqual(false);
+      expect(subActive).toEqual(false);
     }));
 
   test('Should reject if given an invalid binding token', () =>

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -44,8 +44,6 @@ describe('Subscription Worker', () => {
   });
 
   beforeAll(async () => {
-    globalLogger.level = LogLevel.WARN;
-
     const config = await loadTestConfig();
     await initAppServices(config);
 
@@ -79,8 +77,6 @@ describe('Subscription Worker', () => {
   });
 
   afterAll(async () => {
-    globalLogger.level = LogLevel.NONE;
-
     await shutdownApp();
     await closeSubscriptionWorker(); // Double close to ensure quite ignore
   });
@@ -1405,6 +1401,7 @@ describe('Subscription Worker', () => {
 
   test('WebSocket Subscription -- Feature Flag Not Enabled', () =>
     withTestContext(async () => {
+      globalLogger.level = LogLevel.WARN;
       const originalConsoleLog = console.log;
       console.log = jest.fn();
 
@@ -1471,5 +1468,6 @@ describe('Subscription Worker', () => {
       expect(console.log).toHaveBeenLastCalledWith(expect.stringMatching(/WebSocket Subscriptions/));
 
       console.log = originalConsoleLog;
+      globalLogger.level = LogLevel.NONE;
     }));
 });

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1,5 +1,5 @@
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
-import { ContentType, Operator, createReference, getReferenceString, stringify } from '@medplum/core';
+import { ContentType, LogLevel, Operator, createReference, getReferenceString, stringify } from '@medplum/core';
 import { AuditEvent, Bot, Observation, Patient, Project, ProjectMembership, Subscription } from '@medplum/fhirtypes';
 import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import { Job } from 'bullmq';
@@ -9,6 +9,7 @@ import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
 import { getDatabasePool } from '../database';
 import { Repository, getSystemRepo } from '../fhir/repo';
+import { globalLogger } from '../logger';
 import { getRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 import { AuditEventOutcome } from '../util/auditevent';
@@ -43,6 +44,8 @@ describe('Subscription Worker', () => {
   });
 
   beforeAll(async () => {
+    globalLogger.level = LogLevel.WARN;
+
     const config = await loadTestConfig();
     await initAppServices(config);
 
@@ -54,6 +57,7 @@ describe('Subscription Worker', () => {
         owner: {
           reference: 'User/' + randomUUID(),
         },
+        features: ['websocket-subscriptions'],
       })
     );
 
@@ -75,6 +79,8 @@ describe('Subscription Worker', () => {
   });
 
   afterAll(async () => {
+    globalLogger.level = LogLevel.NONE;
+
     await shutdownApp();
     await closeSubscriptionWorker(); // Double close to ensure quite ignore
   });
@@ -1333,7 +1339,7 @@ describe('Subscription Worker', () => {
       expect(queue.add).not.toHaveBeenCalled();
     }));
 
-  test('WebSocket Subscription', () =>
+  test('WebSocket Subscription -- Enabled', () =>
     withTestContext(async () => {
       const subscription = await repo.createResource<Subscription>({
         resourceType: 'Subscription',
@@ -1395,5 +1401,75 @@ describe('Subscription Worker', () => {
       expect(queue.add).toHaveBeenCalled();
 
       await deferredPromise;
+    }));
+
+  test('WebSocket Subscription -- Feature Flag Not Enabled', () =>
+    withTestContext(async () => {
+      const originalConsoleLog = console.log;
+      console.log = jest.fn();
+
+      const noWsSubProject = await systemRepo.createResource<Project>({
+        resourceType: 'Project',
+        name: 'Test Project',
+        owner: {
+          reference: 'User/' + randomUUID(),
+        },
+      });
+
+      const noWsSubRepo = new Repository({
+        extendedMode: true,
+        projects: [noWsSubProject.id as string],
+        author: {
+          reference: 'ClientApplication/' + randomUUID(),
+        },
+      });
+
+      const subscription = await noWsSubRepo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'websocket',
+        },
+      });
+      expect(subscription).toBeDefined();
+      expect(subscription.id).toBeDefined();
+
+      // Subscribe to the topic
+      const subscriber = getRedis().duplicate();
+      await subscriber.subscribe(subscription.id as string);
+
+      let resolve: () => void;
+      let reject: (error: Error) => void;
+
+      const deferredPromise = new Promise<void>((_resolve, _reject) => {
+        resolve = _resolve;
+        reject = _reject;
+      });
+
+      subscriber.on('message', () => {
+        reject(new Error('Should not have been called'));
+      });
+
+      const queue = getSubscriptionQueue() as any;
+      queue.add.mockClear();
+
+      const patient = await noWsSubRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      expect(patient).toBeDefined();
+      expect(queue.add).not.toHaveBeenCalled();
+
+      // Give some time for the callback to get called (it shouldn't)
+      setTimeout(() => {
+        resolve();
+      }, 150);
+
+      await deferredPromise;
+      expect(console.log).toHaveBeenLastCalledWith(expect.stringMatching(/WebSocket Subscriptions/));
+
+      console.log = originalConsoleLog;
     }));
 });

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1338,7 +1338,7 @@ describe('Subscription Worker', () => {
       expect(queue.add).not.toHaveBeenCalled();
     }));
 
-  test('Subscription -- AccessPolicy check throws', () =>
+  test('Subscription -- AccessPolicy check throws (regression in #3978, see #4003)', () =>
     withTestContext(async () => {
       globalLogger.level = LogLevel.WARN;
       const originalConsoleLog = console.log;

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1,6 +1,15 @@
 import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { ContentType, LogLevel, Operator, createReference, getReferenceString, stringify } from '@medplum/core';
-import { AuditEvent, Bot, Observation, Patient, Project, ProjectMembership, Subscription } from '@medplum/fhirtypes';
+import {
+  AccessPolicy,
+  AuditEvent,
+  Bot,
+  Observation,
+  Patient,
+  Project,
+  ProjectMembership,
+  Subscription,
+} from '@medplum/fhirtypes';
 import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import { Job } from 'bullmq';
 import { createHmac, randomUUID } from 'crypto';
@@ -51,7 +60,7 @@ describe('Subscription Worker', () => {
     const { project, client } = await withTestContext(() =>
       createTestProject({
         name: 'Test Project',
-        features: ['websocket-subscriptions'],
+        features: [],
       })
     );
 
@@ -1329,9 +1338,109 @@ describe('Subscription Worker', () => {
       expect(queue.add).not.toHaveBeenCalled();
     }));
 
+  test('Subscription -- AccessPolicy check throws', () =>
+    withTestContext(async () => {
+      globalLogger.level = LogLevel.WARN;
+      const originalConsoleLog = console.log;
+      console.log = jest.fn();
+
+      const url = 'https://example.com/subscription';
+
+      const accessPolicy = await repo.createResource<AccessPolicy>({
+        resourceType: 'AccessPolicy',
+        resource: [{ resourceType: 'Patient', readonly: false }],
+      });
+
+      const { project, client } = await createTestProject(
+        {
+          name: 'AccessPolicy Throw Project',
+          owner: {
+            reference: 'User/' + randomUUID(),
+          },
+          features: [],
+        },
+        { accessPolicy: createReference(accessPolicy) }
+      );
+
+      const apTestRepo = new Repository({
+        extendedMode: true,
+        projects: [project.id as string],
+        author: {
+          reference: getReferenceString(client),
+        },
+      });
+
+      const subscription = await apTestRepo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'rest-hook',
+          endpoint: url,
+        },
+      });
+      expect(subscription).toBeDefined();
+      expect(subscription.id).toBeDefined();
+
+      // Create the patient
+      const patient = await apTestRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+      expect(patient).toBeDefined();
+
+      // Clear the queue
+      const queue = getSubscriptionQueue() as any;
+      queue.add.mockClear();
+
+      // Clear the queue
+      queue.add.mockClear();
+
+      await systemRepo.deleteResource('AccessPolicy', accessPolicy.id as string);
+
+      // Update the patient
+      const patient2 = await apTestRepo.updateResource({ ...patient, name: [{ given: ['Bob'], family: 'Smith' }] });
+
+      expect(queue.add).toHaveBeenCalled();
+      (fetch as unknown as jest.Mock).mockImplementation(() => ({ status: 200 }));
+
+      const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
+      await execSubscriptionJob(job);
+      expect(fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: 'POST',
+          body: stringify(patient2),
+        })
+      );
+
+      expect(console.log).toHaveBeenCalledTimes(2);
+
+      globalLogger.level = LogLevel.NONE;
+      console.log = originalConsoleLog;
+    }));
+
   test('WebSocket Subscription -- Enabled', () =>
     withTestContext(async () => {
-      const subscription = await repo.createResource<Subscription>({
+      const wsSubProject = await systemRepo.createResource<Project>({
+        resourceType: 'Project',
+        name: 'WebSocket Subs Project',
+        owner: {
+          reference: 'User/' + randomUUID(),
+        },
+        features: ['websocket-subscriptions'],
+      });
+
+      const wsSubRepo = new Repository({
+        extendedMode: true,
+        projects: [wsSubProject.id as string],
+        author: {
+          reference: 'ClientApplication/' + randomUUID(),
+        },
+      });
+
+      const subscription = await wsSubRepo.createResource<Subscription>({
         resourceType: 'Subscription',
         reason: 'test',
         status: 'active',
@@ -1361,7 +1470,7 @@ describe('Subscription Worker', () => {
       const queue = getSubscriptionQueue() as any;
       queue.add.mockClear();
 
-      const patient = await repo.createResource<Patient>({
+      const patient = await wsSubRepo.createResource<Patient>({
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
       });
@@ -1377,7 +1486,7 @@ describe('Subscription Worker', () => {
       queue.add.mockClear();
 
       // Update the patient
-      await repo.updateResource({ ...patient, active: true });
+      await wsSubRepo.updateResource({ ...patient, active: true });
 
       // Update should also trigger the subscription
       expect(queue.add).toHaveBeenCalled();
@@ -1386,7 +1495,7 @@ describe('Subscription Worker', () => {
       queue.add.mockClear();
 
       // Delete the patient
-      await repo.deleteResource('Patient', patient.id as string);
+      await wsSubRepo.deleteResource('Patient', patient.id as string);
 
       expect(queue.add).toHaveBeenCalled();
 
@@ -1401,7 +1510,7 @@ describe('Subscription Worker', () => {
 
       const noWsSubProject = await systemRepo.createResource<Project>({
         resourceType: 'Project',
-        name: 'Test Project',
+        name: 'No WebSocket Subs Project',
         owner: {
           reference: 'User/' + randomUUID(),
         },

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -48,23 +48,17 @@ describe('Subscription Worker', () => {
     await initAppServices(config);
 
     // Create one simple project with no advanced features enabled
-    const testProject = await withTestContext(() =>
-      systemRepo.createResource<Project>({
-        resourceType: 'Project',
+    const { project, client } = await withTestContext(() =>
+      createTestProject({
         name: 'Test Project',
-        owner: {
-          reference: 'User/' + randomUUID(),
-        },
         features: ['websocket-subscriptions'],
       })
     );
 
     repo = new Repository({
       extendedMode: true,
-      projects: [testProject.id as string],
-      author: {
-        reference: 'ClientApplication/' + randomUUID(),
-      },
+      projects: [project.id as string],
+      author: createReference(client),
     });
 
     // Create another project, this one with bots enabled
@@ -1116,7 +1110,7 @@ describe('Subscription Worker', () => {
 
   test('AuditEvent has Subscription account details', () =>
     withTestContext(async () => {
-      const project = randomUUID();
+      const project = (await createTestProject()).project.id as string;
       const account = {
         reference: 'Organization/' + randomUUID(),
       };
@@ -1168,15 +1162,15 @@ describe('Subscription Worker', () => {
       });
       expect(bundle.entry?.length).toEqual(1);
 
-      const auditEvent = bundle.entry?.[0].resource as AuditEvent;
+      const auditEvent = bundle.entry?.[0]?.resource as AuditEvent;
       expect(auditEvent.meta?.account).toBeDefined();
       expect(auditEvent.meta?.account?.reference).toEqual(account.reference);
       expect(auditEvent.entity).toHaveLength(2);
     }));
 
-  test('Audit Event outcome from custom codes', () =>
+  test('AuditEvent outcome from custom codes', () =>
     withTestContext(async () => {
-      const project = randomUUID();
+      const project = (await createTestProject()).project.id as string;
       const account = {
         reference: 'Organization/' + randomUUID(),
       };

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -293,18 +293,7 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
   const redisOnlySubRefStrs = await getRedis().smembers(`medplum:subscriptions:r4:project:${project}:active`);
   const redisOnlySubStrs = await getRedis().mget(redisOnlySubRefStrs);
   if (redisOnlySubStrs.length) {
-    const arrLen = redisOnlySubStrs.length;
-    let subArrStr = '[';
-    for (let i = 0; i < arrLen - 1; i++) {
-      const result = redisOnlySubStrs[i];
-      if (result === null) {
-        continue;
-      }
-      subArrStr += result;
-      subArrStr += ',';
-    }
-    subArrStr += redisOnlySubStrs[arrLen - 1];
-    subArrStr += ']';
+    const subArrStr = '[' + redisOnlySubStrs.filter(Boolean).join(',') + ']';
     const inMemorySubs = JSON.parse(subArrStr) as { resource: Subscription; projectId: string }[];
     for (const { resource } of inMemorySubs) {
       subscriptions.push(resource);

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -132,9 +132,9 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
 
 /**
  * Checks if this resource should create a notification for this `Subscription` based on the access policy that should be applied for this `Subscription`.
- * The `AccessPolicy` of author's `ProjectMembership` this resource's `Project` is used when evaluating whether the `AccessPolicy` is satisfied.
+ * The `AccessPolicy` of author's `ProjectMembership` for this resource's `Project` is used when evaluating whether the `AccessPolicy` is satisfied.
  *
- * Currently we log if the `AccessPolicy` is not satifisied
+ * Currently we log if the `AccessPolicy` is not satisfied only.
  *
  * TODO: Actually prevent notifications for `Subscriptions` where the `AccessPolicy` is not satisfied.
  *

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -150,17 +150,23 @@ async function checkAccessPolicy(resource: Resource, project: Project, subscript
       const membership = await findProjectMembership(project.id as string, subAuthor);
       if (membership) {
         const accessPolicy = await buildAccessPolicy(membership);
-        const satisfied = !!satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+        const satisfied = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
         if (!satisfied) {
+          const resourceReference = getReferenceString(resource);
+          const subReference = getReferenceString(subscription);
+          const projectReference = getReferenceString(project);
           globalLogger.warn(
-            `[Subscription Access Policy]: Access Policy not satisfied on '${getReferenceString(resource)}' for '${getReferenceString(project)}'`,
-            { subscription, project: createReference(project), accessPolicy }
+            `[Subscription Access Policy]: Access Policy not satisfied on '${resourceReference}' for '${subReference}'`,
+            { subscription: subReference, project: projectReference, accessPolicy }
           );
         }
       } else {
+        const projectReference = getReferenceString(project);
+        const authorReference = getReferenceString(subAuthor);
+        const subReference = getReferenceString(subscription);
         globalLogger.warn(
-          `[Subscription Access Policy]: No membership for subscription author '${getReferenceString(subAuthor)}' in project '${getReferenceString(project)}'`,
-          { subscription }
+          `[Subscription Access Policy]: No membership for subscription author '${authorReference}' in project '${projectReference}'`,
+          { subscription: subReference }
         );
       }
     } else {
@@ -170,9 +176,11 @@ async function checkAccessPolicy(resource: Resource, project: Project, subscript
       );
     }
   } catch (err: unknown) {
+    const resourceReference = getReferenceString(resource);
+    const subReference = getReferenceString(subscription);
     globalLogger.warn(
-      `[Subscription Access Policy]: Error occurred while checking access policy for resource '${getReferenceString(resource)}' against '${getReferenceString(subscription)}'`,
-      { error: err, subscription }
+      `[Subscription Access Policy]: Error occurred while checking access policy for resource '${resourceReference}' against '${subReference}'`,
+      { error: err, subscription: subReference }
     );
   }
 }

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -131,7 +131,7 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
 }
 
 /**
- * Checks if this resource should be create a notification for this `Subscription` based on the access policy that should be applied for this `Subscription`.
+ * Checks if this resource should create a notification for this `Subscription` based on the access policy that should be applied for this `Subscription`.
  * The `AccessPolicy` of author's `ProjectMembership` this resource's `Project` is used when evaluating whether the `AccessPolicy` is satisfied.
  *
  * Currently we log if the `AccessPolicy` is not satifisied

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -143,9 +143,6 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
  * @param subscription - The `Subscription` to get the `AccessPolicy` for.
  */
 async function checkAccessPolicy(resource: Resource, project: Project, subscription: Subscription): Promise<void> {
-  if (subscription.criteria === 'Communication') {
-    console.log(subscription);
-  }
   try {
     // Check access policy
     const subAuthor = subscription.meta?.author;

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -1,4 +1,5 @@
 import {
+  AccessPolicyInteraction,
   ContentType,
   createReference,
   getExtension,
@@ -10,6 +11,7 @@ import {
   OperationOutcomeError,
   Operator,
   parseSearchUrl,
+  satisfiedAccessPolicy,
   serverError,
   stringify,
 } from '@medplum/core';
@@ -20,6 +22,7 @@ import fetch, { HeadersInit } from 'node-fetch';
 import { URL } from 'url';
 import { MedplumServerConfig } from '../config';
 import { getRequestContext, RequestContext, requestContextStore } from '../context';
+import { buildAccessPolicy } from '../fhir/accesspolicy';
 import { executeBot } from '../fhir/operations/execute';
 import { getSystemRepo, Repository } from '../fhir/repo';
 import { globalLogger } from '../logger';
@@ -128,6 +131,43 @@ export function getSubscriptionQueue(): Queue<SubscriptionJobData> | undefined {
 }
 
 /**
+ * Checks if this resource should be create a notification for this `Subscription` based on the access policy that should be applied for this `Subscription`.
+ * The `AccessPolicy` of author's `ProjectMembership` this resource's `Project` is used when evaluating whether the `AccessPolicy` is satisfied.
+ *
+ * Currently we log if the `AccessPolicy` is not satifisied
+ *
+ * TODO: Actually prevent notifications for `Subscriptions` where the `AccessPolicy` is not satisfied.
+ *
+ * @param resource - The resource to evaluate against the `AccessPolicy`.
+ * @param project - The project containing the resource.
+ * @param subscription - The `Subscription` to get the `AccessPolicy` for.
+ */
+async function checkAccessPolicy(resource: Resource, project: Project, subscription: Subscription): Promise<void> {
+  // Check access policy
+  const subAuthor = subscription.meta?.author;
+  if (subAuthor) {
+    const membership = await findProjectMembership(project.id as string, subAuthor);
+    if (membership) {
+      const accessPolicy = await buildAccessPolicy(membership);
+      const satisfied = !!satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+      if (!satisfied) {
+        globalLogger.warn(
+          `[Subscription Access Policy]: Access Policy not satisfied for '${getReferenceString(resource)}'`,
+          { author: subAuthor, project, accessPolicy }
+        );
+      }
+    } else {
+      globalLogger.warn(
+        `[Subscription Access Policy]: No membership for author '${getReferenceString(subAuthor)}' in project '${getReferenceString(project)}'`
+      );
+    }
+  } else {
+    // Log it if there is no author for this Subscription (this is not good)
+    globalLogger.warn(`[Subscription Access Policy]: No author for subscription '${getReferenceString(subscription)}'`);
+  }
+}
+
+/**
  * Adds all subscription jobs for a given resource.
  *
  * There are a few important structural considerations:
@@ -148,10 +188,28 @@ export async function addSubscriptionJobs(resource: Resource, context: Backgroun
     // Never send subscriptions for audit events
     return;
   }
+
+  const systemRepo = getSystemRepo();
+  let project: Project | undefined;
+  try {
+    const projectId = resource.meta?.project;
+    if (projectId) {
+      project = await systemRepo.readResource<Project>('Project', projectId);
+    }
+  } catch (_err: unknown) {
+    project = undefined;
+  }
+
   const requestTime = new Date().toISOString();
-  const subscriptions = await getSubscriptions(resource);
+  if (!project) {
+    ctx.logger.debug('Did not evaluate subscriptions for resource without project');
+    globalLogger.warn(`[Subscription Access Policy]: No project for resource '${getReferenceString(resource)}'`);
+    return;
+  }
+  const subscriptions = await getSubscriptions(resource, project);
   ctx.logger.debug(`Evaluate ${subscriptions.length} subscription(s)`);
   for (const subscription of subscriptions) {
+    await checkAccessPolicy(resource, project, subscription);
     const criteria = await matchesCriteria(resource, subscription, context);
     if (criteria) {
       await addSubscriptionJobData({
@@ -267,13 +325,11 @@ async function addSubscriptionJobData(job: SubscriptionJobData): Promise<void> {
 /**
  * Loads the list of all subscriptions in this repository.
  * @param resource - The resource that was created or updated.
+ * @param project - The project that contains this resource.
  * @returns The list of all subscriptions in this repository.
  */
-async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
-  const projectId = resource.meta?.project;
-  if (!projectId) {
-    return [];
-  }
+async function getSubscriptions(resource: Resource, project: Project): Promise<Subscription[]> {
+  const projectId = project.id as string;
   const systemRepo = getSystemRepo();
   const subscriptions = await systemRepo.searchResources<Subscription>({
     resourceType: 'Subscription',
@@ -291,25 +347,20 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
       },
     ],
   });
-  try {
-    const project = await systemRepo.readResource<Project>('Project', projectId);
-    const redisOnlySubRefStrs = await getRedis().smembers(`medplum:subscriptions:r4:project:${projectId}:active`);
+  const redisOnlySubRefStrs = await getRedis().smembers(`medplum:subscriptions:r4:project:${projectId}:active`);
+  if (redisOnlySubRefStrs.length) {
     const redisOnlySubStrs = await getRedis().mget(redisOnlySubRefStrs);
-    if (redisOnlySubStrs.length) {
-      if (project.features?.includes('websocket-subscriptions')) {
-        const subArrStr = '[' + redisOnlySubStrs.filter(Boolean).join(',') + ']';
-        const inMemorySubs = JSON.parse(subArrStr) as { resource: Subscription; projectId: string }[];
-        for (const { resource } of inMemorySubs) {
-          subscriptions.push(resource);
-        }
-      } else {
-        globalLogger.warn(
-          `[WebSocket Subscriptions]: subscription for resource '${getReferenceString(resource)}' might have been fired but WebSocket subscriptions are not enabled for project '${project.name ?? getReferenceString(project)}'`
-        );
+    if (project.features?.includes('websocket-subscriptions')) {
+      const subArrStr = '[' + redisOnlySubStrs.filter(Boolean).join(',') + ']';
+      const inMemorySubs = JSON.parse(subArrStr) as { resource: Subscription; projectId: string }[];
+      for (const { resource } of inMemorySubs) {
+        subscriptions.push(resource);
       }
+    } else {
+      globalLogger.warn(
+        `[WebSocket Subscriptions]: subscription for resource '${getReferenceString(resource)}' might have been fired but WebSocket subscriptions are not enabled for project '${project.name ?? getReferenceString(project)}'`
+      );
     }
-  } catch (err: unknown) {
-    globalLogger.error((err as Error).message);
   }
   return subscriptions;
 }

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -290,7 +290,7 @@ async function getSubscriptions(resource: Resource): Promise<Subscription[]> {
       },
     ],
   });
-  const redisOnlySubRefStrs = await getRedis().smembers(`medplum:subscriptions:r4:project:${project}:subs`);
+  const redisOnlySubRefStrs = await getRedis().smembers(`medplum:subscriptions:r4:project:${project}:active`);
   const redisOnlySubStrs = await getRedis().mget(redisOnlySubRefStrs);
   if (redisOnlySubStrs.length) {
     const arrLen = redisOnlySubStrs.length;


### PR DESCRIPTION
Update of #3978 with a fix.

* Wraps everything inside of `checkAccessPolicy()`  in a `try... catch`
* Adds regression test for the bug it originally introduced

Basically the `buildAccessPolicy` step within `checkAccessPolicy()` could fail on malformed subscriptions with broken references, and it would cause the for loop on `subscriptions` to terminate early and not process later `subscriptions` in the list. Now that we catch anything within `checkAccessPolicy()` this is no longer an issue.

Closes #3969