### PR TITLE
Sub-patient Search and Resource pages

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -11,6 +11,7 @@ import { EncounterTab } from './pages/patient/EncounterTab';
 import { LabsTab } from './pages/patient/LabsTab';
 import { MedsTab } from './pages/patient/MedsTab';
 import { PatientPage } from './pages/patient/PatientPage';
+import { PatientSearchPage } from './pages/patient/PatientSearchPage';
 import { TasksTab } from './pages/patient/TasksTab';
 import { TimelineTab } from './pages/patient/TimelineTab';
 
@@ -45,7 +46,9 @@ export function App(): JSX.Element | null {
                   <Route path="meds" element={<MedsTab />} />
                   <Route path="tasks" element={<TasksTab />} />
                   <Route path="timeline" element={<TimelineTab />} />
-                  <Route path="*" element={<TimelineTab />} />
+                  <Route path=":resourceType/:id" element={<ResourcePage />} />
+                  <Route path=":resourceType" element={<PatientSearchPage />} />
+                  <Route path="" element={<TimelineTab />} />
                 </Route>
                 <Route path="/:resourceType/:id" element={<ResourcePage />} />
                 <Route path="/:resourceType/:id/_history/:versionId" element={<ResourcePage />} />

--- a/examples/medplum-provider/src/pages/patient/PatientPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.tsx
@@ -6,14 +6,22 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import { usePatient } from '../../hooks/usePatient';
 import classes from './PatientPage.module.css';
 
-const tabs = ['Timeline', 'Edit', 'Encounter', 'Tasks', 'Meds', 'Labs'];
+const tabs = [
+  { id: 'timeline', url: '', label: 'Timeline' },
+  { id: 'edit', url: 'edit', label: 'Edit' },
+  { id: 'encounter', url: 'encounter', label: 'Encounter' },
+  { id: 'tasks', url: 'Task?patient=%patient.id', label: 'Tasks' },
+  { id: 'meds', url: 'MedicationRequest?patient=%patient.id', label: 'Meds' },
+  { id: 'labs', url: 'ServiceRequest?patient=%patient.id', label: 'Labs' },
+  { id: 'devices', url: 'Device?patient=%patient.id', label: 'Devices' },
+];
 
 export function PatientPage(): JSX.Element {
   const navigate = useNavigate();
   const patient = usePatient();
   const [currentTab, setCurrentTab] = useState<string>(() => {
-    const tab = window.location.pathname.split('/').pop();
-    return tab && tabs.map((t) => t.toLowerCase()).includes(tab) ? tab : tabs[0].toLowerCase();
+    const tabId = window.location.pathname.split('/')[3] ?? '';
+    return tabId && tabs.find((t) => t.id === tabId) ? tabId : tabs[0].id;
   });
 
   if (!patient) {
@@ -26,10 +34,14 @@ export function PatientPage(): JSX.Element {
    */
   function onTabChange(newTabName: string | null): void {
     if (!newTabName) {
-      newTabName = tabs[0].toLowerCase();
+      newTabName = tabs[0].id;
     }
-    setCurrentTab(newTabName);
-    navigate(`/Patient/${patient?.id}/${newTabName}`);
+
+    const tab = tabs.find((t) => t.id === newTabName);
+    if (tab) {
+      setCurrentTab(tab.id);
+      navigate(`/Patient/${patient?.id}/${tab.url.replace('%patient.id', patient?.id as string)}`);
+    }
   }
 
   return (
@@ -44,8 +56,8 @@ export function PatientPage(): JSX.Element {
               <Tabs value={currentTab.toLowerCase()} onChange={onTabChange}>
                 <Tabs.List style={{ whiteSpace: 'nowrap', flexWrap: 'nowrap' }}>
                   {tabs.map((t) => (
-                    <Tabs.Tab key={t} value={t.toLowerCase()}>
-                      {t}
+                    <Tabs.Tab key={t.id} value={t.id}>
+                      {t.label}
                     </Tabs.Tab>
                   ))}
                 </Tabs.List>

--- a/examples/medplum-provider/src/pages/patient/PatientSearchPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientSearchPage.tsx
@@ -1,0 +1,69 @@
+import { Paper } from '@mantine/core';
+import { DEFAULT_SEARCH_COUNT, formatSearchQuery, parseSearchDefinition, SearchRequest } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { usePatient } from '../../hooks/usePatient';
+
+export function PatientSearchPage(): JSX.Element {
+  const medplum = useMedplum();
+  const patient = usePatient();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [search, setSearch] = useState<SearchRequest>();
+
+  useEffect(() => {
+    if (!patient) {
+      return;
+    }
+
+    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
+    const populatedSearch = addSearchValues(patient, parsedSearch);
+
+    if (
+      location.pathname === `/Patient/${patient.id}/${populatedSearch.resourceType}` &&
+      location.search === formatSearchQuery(populatedSearch)
+    ) {
+      setSearch(populatedSearch);
+    } else {
+      navigate(`/Patient/${patient.id}/${populatedSearch.resourceType}${formatSearchQuery(populatedSearch)}`);
+    }
+  }, [medplum, patient, navigate, location]);
+
+  if (!patient || !search?.resourceType || !search.fields || search.fields.length === 0) {
+    return <Loading />;
+  }
+
+  return (
+    <Paper shadow="xs" m="md" p="xs">
+      <MemoizedSearchControl
+        checkboxesEnabled={true}
+        search={search}
+        onClick={(e) => navigate(`/Patient/${patient.id}/${e.resource.resourceType}/${e.resource.id}`)}
+        onAuxClick={(e) => window.open(`/Patient/${patient.id}/${e.resource.resourceType}/${e.resource.id}`, '_blank')}
+        onChange={(e) => {
+          navigate(`/Patient/${patient.id}/${search.resourceType}${formatSearchQuery(e.definition)}`);
+        }}
+      />
+    </Paper>
+  );
+}
+
+function addSearchValues(patient: Patient, search: SearchRequest): SearchRequest {
+  const resourceType = search.resourceType;
+  const fields = search.fields ?? ['_id', '_lastUpdated'];
+  const filters = search.filters ?? [];
+  const sortRules = search.sortRules;
+  const offset = search.offset ?? 0;
+  const count = search.count ?? DEFAULT_SEARCH_COUNT;
+  return {
+    ...search,
+    resourceType,
+    fields,
+    filters,
+    sortRules,
+    offset,
+    count,
+  };
+}


### PR DESCRIPTION
Added support for Patient-scoped "Search" and "Resource" pages:

For example, the "Tasks" tab goes to:

```
/Patient/${patientId}/Task?patient=${patientId}
```

I had hoped to use FHIR compartments for this, but unfortunately the `Task` resource does not have any mappings in the standard Patient compatment definition.

Instead, just using the normal `?patient=` search parameters.