### PR TITLE
Cleanup core search parse utils

### DIFF
--- a/examples/medplum-chart-demo/src/pages/SearchPage.tsx
+++ b/examples/medplum-chart-demo/src/pages/SearchPage.tsx
@@ -3,7 +3,7 @@ import {
   DEFAULT_SEARCH_COUNT,
   Filter,
   formatSearchQuery,
-  parseSearchDefinition,
+  parseSearchRequest,
   SearchRequest,
   SortRule,
 } from '@medplum/core';
@@ -20,7 +20,7 @@ export function SearchPage(): JSX.Element {
   const [search, setSearch] = useState<SearchRequest>();
 
   useEffect(() => {
-    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
+    const parsedSearch = parseSearchRequest(location.pathname + location.search);
 
     const populatedSearch = addSearchValues(parsedSearch, medplum.getUserConfiguration());
 

--- a/examples/medplum-provider/src/pages/SearchPage.tsx
+++ b/examples/medplum-provider/src/pages/SearchPage.tsx
@@ -3,7 +3,7 @@ import {
   DEFAULT_SEARCH_COUNT,
   Filter,
   formatSearchQuery,
-  parseSearchDefinition,
+  parseSearchRequest,
   SearchRequest,
   SortRule,
 } from '@medplum/core';
@@ -20,7 +20,7 @@ export function SearchPage(): JSX.Element {
   const [search, setSearch] = useState<SearchRequest>();
 
   useEffect(() => {
-    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
+    const parsedSearch = parseSearchRequest(location.pathname + location.search);
 
     const populatedSearch = addSearchValues(parsedSearch, medplum.getUserConfiguration());
 

--- a/examples/medplum-provider/src/pages/patient/PatientSearchPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientSearchPage.tsx
@@ -1,5 +1,5 @@
 import { Paper } from '@mantine/core';
-import { DEFAULT_SEARCH_COUNT, formatSearchQuery, parseSearchDefinition, SearchRequest } from '@medplum/core';
+import { DEFAULT_SEARCH_COUNT, formatSearchQuery, parseSearchRequest, SearchRequest } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
@@ -18,7 +18,7 @@ export function PatientSearchPage(): JSX.Element {
       return;
     }
 
-    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
+    const parsedSearch = parseSearchRequest(location.pathname + location.search);
     const populatedSearch = addSearchValues(patient, parsedSearch);
 
     if (

--- a/examples/medplum-task-demo/src/pages/SearchPage.tsx
+++ b/examples/medplum-task-demo/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from '@mantine/core';
-import { formatSearchQuery, getReferenceString, Operator, parseSearchDefinition, SearchRequest } from '@medplum/core';
+import { formatSearchQuery, getReferenceString, Operator, parseSearchRequest, SearchRequest } from '@medplum/core';
 import { Document, Loading, SearchControl, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -14,24 +14,24 @@ export function SearchPage(): JSX.Element {
   const [isNewOpen, setIsNewOpen] = useState<boolean>(false);
 
   const [showTabs, setShowTabs] = useState<boolean>(() => {
-    const search = parseSearchDefinition(window.location.pathname + window.location.search);
+    const search = parseSearchRequest(window.location.pathname + window.location.search);
     return shouldShowTabs(search);
   });
 
   const tabs = ['Active', 'Completed'];
   const searchQuery = window.location.search;
-  const currentSearch = parseSearchDefinition(searchQuery);
+  const currentSearch = parseSearchRequest(searchQuery);
 
   const currentTab = handleInitialTab(currentSearch);
 
   useEffect(() => {
-    const searchQuery = parseSearchDefinition(location.pathname + location.search);
+    const searchQuery = parseSearchRequest(location.pathname + location.search);
     setShowTabs(shouldShowTabs(searchQuery));
   }, [location]);
 
   useEffect(() => {
     // Parse the search definition from the url and get the correct fields for the resource type
-    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
+    const parsedSearch = parseSearchRequest(location.pathname + location.search);
     if (!parsedSearch.resourceType) {
       navigate('/Task');
       return;

--- a/packages/app/src/HomePage.tsx
+++ b/packages/app/src/HomePage.tsx
@@ -1,6 +1,6 @@
 import { Paper } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { formatSearchQuery, normalizeErrorString, parseSearchDefinition, SearchRequest } from '@medplum/core';
+import { formatSearchQuery, normalizeErrorString, parseSearchRequest, SearchRequest } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
@@ -17,7 +17,7 @@ export function HomePage(): JSX.Element {
 
   useEffect(() => {
     // Parse the search from the URL
-    const parsedSearch = parseSearchDefinition(location.pathname + location.search);
+    const parsedSearch = parseSearchRequest(location.pathname + location.search);
 
     // Fill in the search with default values
     const populatedSearch = addSearchValues(parsedSearch, medplum.getUserConfiguration());

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -1,6 +1,6 @@
 import { AccessPolicy, AccessPolicyResource, Resource, ResourceType } from '@medplum/fhirtypes';
 import { matchesSearchRequest } from './search/match';
-import { parseCriteriaAsSearchRequest } from './search/search';
+import { parseSearchRequest } from './search/search';
 
 const universalAccessPolicy: AccessPolicyResource = {
   resourceType: '*',
@@ -180,10 +180,7 @@ function matchesAccessPolicyResourcePolicy(
     // Deprecated - to be removed
     return false;
   }
-  if (
-    resourcePolicy.criteria &&
-    !matchesSearchRequest(resource, parseCriteriaAsSearchRequest(resourcePolicy.criteria))
-  ) {
+  if (resourcePolicy.criteria && !matchesSearchRequest(resource, parseSearchRequest(resourcePolicy.criteria))) {
     return false;
   }
   return true;

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -13,7 +13,7 @@ import {
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { matchesSearchRequest } from './match';
-import { Operator, SearchRequest, parseSearchDefinition } from './search';
+import { Operator, SearchRequest, parseSearchRequest } from './search';
 
 // Dimensions:
 // 1. Search parameter type
@@ -308,25 +308,25 @@ describe('Search matching', () => {
       expect(
         matchesSearchRequest(
           { resourceType: 'DiagnosticReport', status: 'preliminary' } as DiagnosticReport,
-          parseSearchDefinition('DiagnosticReport?status=cancelled')
+          parseSearchRequest('DiagnosticReport?status=cancelled')
         )
       ).toBe(false);
       expect(
         matchesSearchRequest(
           { resourceType: 'DiagnosticReport', status: 'preliminary' } as DiagnosticReport,
-          parseSearchDefinition('DiagnosticReport?status:not=cancelled')
+          parseSearchRequest('DiagnosticReport?status:not=cancelled')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
           { resourceType: 'DiagnosticReport', status: 'cancelled' } as DiagnosticReport,
-          parseSearchDefinition('DiagnosticReport?status=cancelled')
+          parseSearchRequest('DiagnosticReport?status=cancelled')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
           { resourceType: 'DiagnosticReport', status: 'cancelled' } as DiagnosticReport,
-          parseSearchDefinition('DiagnosticReport?status:not=cancelled')
+          parseSearchRequest('DiagnosticReport?status:not=cancelled')
         )
       ).toBe(false);
 
@@ -335,25 +335,25 @@ describe('Search matching', () => {
       expect(
         matchesSearchRequest(
           { resourceType: 'ServiceRequest', orderDetail: [{ text: 'ORDERED' }] } as ServiceRequest,
-          parseSearchDefinition('ServiceRequest?order-detail=VOIDED,CANCELLED')
+          parseSearchRequest('ServiceRequest?order-detail=VOIDED,CANCELLED')
         )
       ).toBe(false);
       expect(
         matchesSearchRequest(
           { resourceType: 'ServiceRequest', orderDetail: [{ text: 'ORDERED' }] } as ServiceRequest,
-          parseSearchDefinition('ServiceRequest?order-detail:not=VOIDED,CANCELLED')
+          parseSearchRequest('ServiceRequest?order-detail:not=VOIDED,CANCELLED')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
           { resourceType: 'ServiceRequest', orderDetail: [{ text: 'VOIDED' }] } as ServiceRequest,
-          parseSearchDefinition('ServiceRequest?order-detail=VOIDED,CANCELLED')
+          parseSearchRequest('ServiceRequest?order-detail=VOIDED,CANCELLED')
         )
       ).toBe(true);
       expect(
         matchesSearchRequest(
           { resourceType: 'ServiceRequest', orderDetail: [{ text: 'VOIDED' }] } as ServiceRequest,
-          parseSearchDefinition('ServiceRequest?order-detail:not=VOIDED,CANCELLED')
+          parseSearchRequest('ServiceRequest?order-detail:not=VOIDED,CANCELLED')
         )
       ).toBe(false);
     });

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -2,13 +2,76 @@ import { readJson } from '@medplum/definitions';
 import { Bundle, Patient, SearchParameter } from '@medplum/fhirtypes';
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
-import { Operator, SearchRequest, formatSearchQuery, parseSearchDefinition, parseXFhirQuery } from './search';
+import {
+  Operator,
+  SearchRequest,
+  formatSearchQuery,
+  parseSearchDefinition,
+  parseSearchRequest,
+  parseSearchUrl,
+  parseXFhirQuery,
+} from './search';
 
 describe('Search Utils', () => {
   beforeAll(() => {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
     indexSearchParameterBundle(readJson('fhir/r4/search-parameters.json') as Bundle<SearchParameter>);
     indexSearchParameterBundle(readJson('fhir/r4/search-parameters-medplum.json') as Bundle<SearchParameter>);
+  });
+
+  test('parseSearchRequest', () => {
+    expect(() => parseSearchRequest(null as unknown as string)).toThrow('Invalid search URL');
+    expect(() => parseSearchRequest(undefined as unknown as string)).toThrow('Invalid search URL');
+    expect(() => parseSearchRequest('')).toThrow('Invalid search URL');
+
+    expect(parseSearchRequest('Patient')).toMatchObject({ resourceType: 'Patient' });
+    expect(parseSearchRequest('Patient?name=alice')).toMatchObject({
+      resourceType: 'Patient',
+      filters: [{ code: 'name', operator: Operator.EQUALS, value: 'alice' }],
+    });
+    expect(parseSearchRequest('Patient?_fields=id,name,birthDate')).toMatchObject({
+      resourceType: 'Patient',
+      fields: ['id', 'name', 'birthDate'],
+    });
+
+    expect(parseSearchRequest('Patient')).toMatchObject({ resourceType: 'Patient' });
+    expect(parseSearchRequest('Patient', { name: 'alice' })).toMatchObject({
+      resourceType: 'Patient',
+      filters: [{ code: 'name', operator: Operator.EQUALS, value: 'alice' }],
+    });
+    expect(parseSearchRequest('Patient', { name: ['alice'] })).toMatchObject({
+      resourceType: 'Patient',
+      filters: [{ code: 'name', operator: Operator.EQUALS, value: 'alice' }],
+    });
+    expect(parseSearchRequest('Patient', { _fields: 'id,name,birthDate' })).toMatchObject({
+      resourceType: 'Patient',
+      fields: ['id', 'name', 'birthDate'],
+    });
+
+    expect(parseSearchRequest(new URL('https://example.com/Patient'))).toMatchObject({ resourceType: 'Patient' });
+    expect(parseSearchRequest(new URL('https://example.com/Patient?name=alice'))).toMatchObject({
+      resourceType: 'Patient',
+      filters: [{ code: 'name', operator: Operator.EQUALS, value: 'alice' }],
+    });
+    expect(parseSearchRequest(new URL('https://example.com/Patient?_fields=id,name,birthDate'))).toMatchObject({
+      resourceType: 'Patient',
+      fields: ['id', 'name', 'birthDate'],
+    });
+  });
+
+  test('parseSearchUrl', () => {
+    expect(() => parseSearchUrl(null as unknown as URL)).toThrow('Invalid search URL');
+    expect(() => parseSearchUrl(undefined as unknown as URL)).toThrow('Invalid search URL');
+
+    expect(parseSearchUrl(new URL('https://example.com/Patient'))).toMatchObject({ resourceType: 'Patient' });
+    expect(parseSearchUrl(new URL('https://example.com/Patient?name=alice'))).toMatchObject({
+      resourceType: 'Patient',
+      filters: [{ code: 'name', operator: Operator.EQUALS, value: 'alice' }],
+    });
+    expect(parseSearchUrl(new URL('https://example.com/Patient?_fields=id,name,birthDate'))).toMatchObject({
+      resourceType: 'Patient',
+      fields: ['id', 'name', 'birthDate'],
+    });
   });
 
   test('Parse Patient search', () => {

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -183,7 +183,7 @@ export function parseSearchRequest<T extends Resource = Resource>(
   }
 
   // Finally we can move on to the actual parsing
-  return parseSearchImpl(resourceType as ResourceType, queryArray);
+  return parseSearchImpl(resourceType, queryArray);
 }
 
 /**
@@ -459,7 +459,7 @@ export function parseXFhirQuery(query: string, variables: Record<string, TypedVa
     }
     return stringifyTypedValue(replacement[0]);
   });
-  return parseCriteriaAsSearchRequest(query);
+  return parseSearchRequest(query);
 }
 
 /**

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -6,7 +6,7 @@ import {
   isOk,
   normalizeOperationOutcome,
   OperationOutcomeError,
-  parseSearchUrl,
+  parseSearchRequest,
   resolveId,
 } from '@medplum/core';
 import { Bundle, BundleEntry, BundleEntryRequest, OperationOutcome, Resource } from '@medplum/fhirtypes';
@@ -103,7 +103,7 @@ class BatchProcessor {
     if (entry.resource?.resourceType && request.ifNoneExist) {
       const baseUrl = `https://example.com/${entry.resource.resourceType}`;
       const searchUrl = new URL('?' + request.ifNoneExist, baseUrl);
-      const searchBundle = await this.repo.search(parseSearchUrl(searchUrl));
+      const searchBundle = await this.repo.search(parseSearchRequest(searchUrl));
       const entries = searchBundle.entry as BundleEntry[];
       if (entries.length > 1) {
         return buildBundleResponse(badRequest('Multiple matches'));

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -101,9 +101,9 @@ class BatchProcessor {
     const request = entry.request as BundleEntryRequest;
 
     if (entry.resource?.resourceType && request.ifNoneExist) {
-      const baseUrl = `https://example.com/${entry.resource.resourceType}`;
-      const searchUrl = new URL('?' + request.ifNoneExist, baseUrl);
-      const searchBundle = await this.repo.search(parseSearchRequest(searchUrl));
+      const searchBundle = await this.repo.search(
+        parseSearchRequest(`${entry.resource.resourceType}?${request.ifNoneExist}`)
+      );
       const entries = searchBundle.entry as BundleEntry[];
       if (entries.length > 1) {
         return buildBundleResponse(badRequest('Multiple matches'));

--- a/packages/fhir-router/src/repo.test.ts
+++ b/packages/fhir-router/src/repo.test.ts
@@ -4,7 +4,7 @@ import {
   indexStructureDefinitionBundle,
   notFound,
   OperationOutcomeError,
-  parseSearchDefinition,
+  parseSearchRequest,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, Observation, Patient, ResourceType, SearchParameter } from '@medplum/fhirtypes';
@@ -83,21 +83,21 @@ describe('MemoryRepository', () => {
   test('searchResources helper', async () => {
     const family = randomUUID();
     const patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
-    const resources = await repo.searchResources<Patient>(parseSearchDefinition('Patient?family=' + family));
+    const resources = await repo.searchResources<Patient>(parseSearchRequest('Patient?family=' + family));
     expect(resources).toHaveLength(1);
     expect(resources[0].id).toBe(patient.id);
 
-    const emptyResources = await repo.searchResources<Patient>(parseSearchDefinition('Patient?family=' + randomUUID()));
+    const emptyResources = await repo.searchResources<Patient>(parseSearchRequest('Patient?family=' + randomUUID()));
     expect(emptyResources).toHaveLength(0);
   });
 
   test('searchOne helper', async () => {
     const family = randomUUID();
     const patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ family }] });
-    const resource = await repo.searchOne<Patient>(parseSearchDefinition('Patient?family=' + family));
+    const resource = await repo.searchOne<Patient>(parseSearchRequest('Patient?family=' + family));
     expect(resource?.id).toBe(patient.id);
 
-    const emptyResource = await repo.searchOne<Patient>(parseSearchDefinition('Patient?family=' + randomUUID()));
+    const emptyResource = await repo.searchOne<Patient>(parseSearchRequest('Patient?family=' + randomUUID()));
     expect(emptyResource).toBeUndefined();
   });
 

--- a/packages/server/src/fhir/operations/agentpush.ts
+++ b/packages/server/src/fhir/operations/agentpush.ts
@@ -5,7 +5,7 @@ import {
   BaseAgentRequestMessage,
   getReferenceString,
   Operator,
-  parseSearchDefinition,
+  parseSearchRequest,
 } from '@medplum/core';
 import { Agent, Device } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
@@ -150,7 +150,7 @@ async function getDevice(repo: Repository, destination: string): Promise<Device 
     }
   }
   if (destination.startsWith('Device?')) {
-    return repo.searchOne<Device>(parseSearchDefinition(destination));
+    return repo.searchOne<Device>(parseSearchRequest(destination));
   }
   if (isIPv4(destination)) {
     return { resourceType: 'Device', url: destination };

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -1,4 +1,4 @@
-import { Operator, badRequest, created, parseSearchDefinition } from '@medplum/core';
+import { Operator, badRequest, created, parseSearchRequest } from '@medplum/core';
 import {
   Measure,
   MeasureGroup,
@@ -177,7 +177,7 @@ async function evaluateCount(
   criteria: string,
   params: EvaluateMeasureParameters
 ): Promise<number | undefined> {
-  const searchDefinition = parseSearchDefinition(criteria);
+  const searchDefinition = parseSearchRequest(criteria);
   searchDefinition.total = 'accurate';
 
   if (!searchDefinition.filters) {

--- a/packages/server/src/fhir/operations/resourcegraph.ts
+++ b/packages/server/src/fhir/operations/resourcegraph.ts
@@ -7,7 +7,7 @@ import {
   notFound,
   OperationOutcomeError,
   Operator,
-  parseSearchDefinition,
+  parseSearchRequest,
   PropertyType,
   toTypedValue,
   TypedValue,
@@ -251,7 +251,7 @@ async function followSearchLink(
     const searchParams = params.replace('{ref}', getReferenceString(resource));
 
     // Formulate the searchURL string
-    const searchRequest = parseSearchDefinition(`${searchResourceType}?${searchParams}`);
+    const searchRequest = parseSearchRequest(`${searchResourceType}?${searchParams}`);
 
     // Parse the max count from the link description, if available
     searchRequest.count = Math.min(parseCardinality(link.max), 5000);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -24,7 +24,7 @@ import {
   normalizeErrorString,
   normalizeOperationOutcome,
   notFound,
-  parseCriteriaAsSearchRequest,
+  parseSearchRequest,
   protectedResourceTypes,
   resolveId,
   satisfiedAccessPolicy,
@@ -1017,7 +1017,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
           expressions.push(new Condition('compartments', 'ARRAY_CONTAINS', policyCompartmentId, 'UUID[]'));
         } else if (policy.criteria) {
           // Add subquery for access policy criteria.
-          const searchRequest = parseCriteriaAsSearchRequest(policy.criteria);
+          const searchRequest = parseSearchRequest(policy.criteria);
           const accessPolicyExpression = buildSearchExpression(builder, searchRequest);
           if (accessPolicyExpression) {
             expressions.push(accessPolicyExpression);

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -6,9 +6,7 @@ import {
   normalizeOperationOutcome,
   OperationOutcomeError,
   Operator,
-  parseSearchDefinition,
   parseSearchRequest,
-  parseSearchUrl,
   SearchRequest,
   SNOMED,
 } from '@medplum/core';
@@ -44,7 +42,7 @@ import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
-import { Repository, getSystemRepo } from './repo';
+import { getSystemRepo, Repository } from './repo';
 
 jest.mock('hibp');
 jest.mock('ioredis');
@@ -1330,14 +1328,14 @@ describe('FHIR Search', () => {
 
         // Test singlet reference column
         let results = await repo.searchResources(
-          parseSearchDefinition(`Patient?identifier=${patientIdentifier}&organization:missing=false`)
+          parseSearchRequest(`Patient?identifier=${patientIdentifier}&organization:missing=false`)
         );
         expect(results).toHaveLength(1);
         expect(results[0]?.id).toEqual(patient.id);
 
         // Test array reference column
         results = await repo.searchResources(
-          parseSearchDefinition(`Patient?identifier=${patientIdentifier}&general-practitioner:missing=false`)
+          parseSearchRequest(`Patient?identifier=${patientIdentifier}&general-practitioner:missing=false`)
         );
         expect(results).toHaveLength(1);
         expect(results[0]?.id).toEqual(patient.id);
@@ -1671,7 +1669,7 @@ describe('FHIR Search', () => {
 
         // Search chain
         const searchResult = await repo.search(
-          parseSearchDefinition(
+          parseSearchRequest(
             `Patient?general-practitioner:Practitioner._has:CareTeam:participant:category=${categorySystem}|${code}`
           )
         );
@@ -1706,7 +1704,7 @@ describe('FHIR Search', () => {
         });
 
         const result = await repo.search(
-          parseSearchDefinition(`Patient?_has:Observation:subject:encounter:Encounter.class=${code}`)
+          parseSearchRequest(`Patient?_has:Observation:subject:encounter:Encounter.class=${code}`)
         );
         expect(result.entry?.[0]?.resource?.id).toEqual(patient.id);
       }));
@@ -1715,7 +1713,7 @@ describe('FHIR Search', () => {
       withTestContext(async () => {
         await expect(() =>
           repo.search(
-            parseSearchDefinition(
+            parseSearchRequest(
               `Patient?_has:Observation:subject:encounter:Encounter._has:DiagnosticReport:encounter:result.specimen.parent.collected=2023`
             )
           )
@@ -1736,7 +1734,7 @@ describe('FHIR Search', () => {
       ],
       ['Patient?_has:Observation:status=active', 'Invalid search chain: _has:Observation:status'],
     ])('Invalid chained search parameters: %s', (searchString: string, errorMsg: string) => {
-      return expect(repo.search(parseSearchDefinition(searchString))).rejects.toEqual(new Error(errorMsg));
+      return expect(repo.search(parseSearchRequest(searchString))).rejects.toEqual(new Error(errorMsg));
     });
 
     test('Include references success', () =>
@@ -2452,7 +2450,7 @@ describe('FHIR Search', () => {
         });
 
         const bundle = await repo.search(
-          parseSearchUrl(
+          parseSearchRequest(
             new URL(`https://x/Condition?subject=${getReferenceString(p)}&code:not=x&_count=1&_total=accurate`)
           )
         );
@@ -2524,22 +2522,20 @@ describe('FHIR Search', () => {
         });
 
         // Search with system
-        const bundle1 = await repo.search(
-          parseSearchDefinition(`Condition?code=${code}&subject:identifier=mrn|123456`)
-        );
+        const bundle1 = await repo.search(parseSearchRequest(`Condition?code=${code}&subject:identifier=mrn|123456`));
         expect(bundle1.entry?.length).toEqual(1);
         expect(bundleContains(bundle1, c1)).toBeTruthy();
         expect(bundleContains(bundle1, c2)).not.toBeTruthy();
 
         // Search without system
-        const bundle2 = await repo.search(parseSearchDefinition(`Condition?code=${code}&subject:identifier=123456`));
+        const bundle2 = await repo.search(parseSearchRequest(`Condition?code=${code}&subject:identifier=123456`));
         expect(bundle2.entry?.length).toEqual(2);
         expect(bundleContains(bundle2, c1)).toBeTruthy();
         expect(bundleContains(bundle2, c2)).toBeTruthy();
 
         // Search with count
         const bundle3 = await repo.search(
-          parseSearchDefinition(`Condition?code=${code}&subject:identifier=mrn|123456&_total=accurate`)
+          parseSearchRequest(`Condition?code=${code}&subject:identifier=mrn|123456&_total=accurate`)
         );
         expect(bundle3.entry?.length).toEqual(1);
         expect(bundle3.total).toBe(1);
@@ -2575,7 +2571,7 @@ describe('FHIR Search', () => {
         // Search by "subject"
         // This will include both Tasks, because the "subject" search parameter does not care about "type"
         const bundle1 = await repo.search(
-          parseSearchDefinition(`Task?subject:identifier=mrn|${identifier}&_total=accurate`)
+          parseSearchRequest(`Task?subject:identifier=mrn|${identifier}&_total=accurate`)
         );
         expect(bundle1.total).toEqual(2);
         expect(bundle1.entry?.length).toEqual(2);
@@ -2585,7 +2581,7 @@ describe('FHIR Search', () => {
         // Search by "patient"
         // This will only include the Task with the explicit "Patient" type, because the "patient" search parameter does care about "type"
         const bundle2 = await repo.search(
-          parseSearchDefinition(`Task?patient:identifier=mrn|${identifier}&_total=accurate`)
+          parseSearchRequest(`Task?patient:identifier=mrn|${identifier}&_total=accurate`)
         );
         expect(bundle2.total).toEqual(1);
         expect(bundle2.entry?.length).toEqual(1);

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -2450,9 +2450,7 @@ describe('FHIR Search', () => {
         });
 
         const bundle = await repo.search(
-          parseSearchRequest(
-            new URL(`https://x/Condition?subject=${getReferenceString(p)}&code:not=x&_count=1&_total=accurate`)
-          )
+          parseSearchRequest(`https://x/Condition?subject=${getReferenceString(p)}&code:not=x&_count=1&_total=accurate`)
         );
         expect(bundle.entry?.length).toEqual(1);
 

--- a/packages/server/src/oauth/token.test.ts
+++ b/packages/server/src/oauth/token.test.ts
@@ -5,7 +5,7 @@ import {
   OAuthGrantType,
   OAuthTokenType,
   parseJWTPayload,
-  parseSearchDefinition,
+  parseSearchRequest,
 } from '@medplum/core';
 import { AccessPolicy, ClientApplication, Login, Project, SmartAppLaunch } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
@@ -509,7 +509,7 @@ describe('OAuth2 Token', () => {
     expect(res.status).toBe(200);
 
     // Find the login
-    const loginBundle = await systemRepo.search<Login>(parseSearchDefinition('Login?code=' + res.body.code));
+    const loginBundle = await systemRepo.search<Login>(parseSearchRequest('Login?code=' + res.body.code));
     expect(loginBundle.entry).toHaveLength(1);
 
     // Revoke the login
@@ -865,7 +865,7 @@ describe('OAuth2 Token', () => {
     expect(res2.body.refresh_token).toBeDefined();
 
     // Find the login
-    const loginBundle = await systemRepo.search<Login>(parseSearchDefinition('Login?code=' + res.body.code));
+    const loginBundle = await systemRepo.search<Login>(parseSearchRequest('Login?code=' + res.body.code));
     expect(loginBundle.entry).toHaveLength(1);
 
     // Revoke the login

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -10,7 +10,7 @@ import {
   normalizeOperationOutcome,
   OperationOutcomeError,
   Operator,
-  parseSearchUrl,
+  parseSearchRequest,
   satisfiedAccessPolicy,
   serverError,
   stringify,
@@ -279,7 +279,7 @@ async function matchesCriteria(
     return false;
   }
 
-  const searchRequest = parseSearchUrl(new URL(subscriptionCriteria, 'https://api.medplum.com/'));
+  const searchRequest = parseSearchRequest(new URL(subscriptionCriteria, 'https://api.medplum.com/'));
   if (resource.resourceType !== searchRequest.resourceType) {
     ctx.logger.debug(
       `Ignore rest hook for different resourceType (wanted "${searchRequest.resourceType}", received "${resource.resourceType}")`

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -19,7 +19,6 @@ import { Bot, Project, ProjectMembership, Reference, Resource, Subscription } fr
 import { Job, Queue, QueueBaseOptions, Worker } from 'bullmq';
 import { createHmac } from 'crypto';
 import fetch, { HeadersInit } from 'node-fetch';
-import { URL } from 'url';
 import { MedplumServerConfig } from '../config';
 import { getRequestContext, RequestContext, requestContextStore } from '../context';
 import { buildAccessPolicy } from '../fhir/accesspolicy';
@@ -279,7 +278,7 @@ async function matchesCriteria(
     return false;
   }
 
-  const searchRequest = parseSearchRequest(new URL(subscriptionCriteria, 'https://api.medplum.com/'));
+  const searchRequest = parseSearchRequest(subscriptionCriteria);
   if (resource.resourceType !== searchRequest.resourceType) {
     ctx.logger.debug(
       `Ignore rest hook for different resourceType (wanted "${searchRequest.resourceType}", received "${resource.resourceType}")`


### PR DESCRIPTION
`@medplum/core` includes 4 utility methods which all do basically the same thing.

`packages/core/src/search/search.ts`

1. `parseSearchRequest(resourceType, query)`
2. `parseSearchUrl(url: URL)`
3. `parseSearchDefinition(url: string)`
4. `parseCriteriaAsSearchRequest(criteria: string)`

This PR attempts to clean that up.

1. Make `parseSearchRequest(url, query?)` the singular preferred utility method
    a. The `url` param can be `T['resourceType']`, `URL`, or `string`
    b. Fully support backwards compatibility
    c. Handle all of the permutations with minimal excess parsing
2. Deprecate all of the other utility methods
3. Replace all usage of the other utility methods throughout the monorepo

