### PR TITLE
fix: typos `Mepdlum` in documents and react-hooks

### DIFF
--- a/packages/docs/docs/fhir-datastore/resource-history.md
+++ b/packages/docs/docs/fhir-datastore/resource-history.md
@@ -40,7 +40,7 @@ The history of a resouce can also be viewed by accessing the `/_history` endpoin
 
 To access the `/_history` endpoint, make a GET request to the url of the desired resource or resource type.
 
-The Mepdlum SDK also provides the `readHistory` helper function to access the `/_history` endpoint.
+The Medplum SDK also provides the `readHistory` helper function to access the `/_history` endpoint.
 
 <Tabs groupId="language">
   <TabItem value="ts" label="Typescript">

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -63,7 +63,7 @@ export function MyComponent() {
 ```ts
 interface MedplumContext {
   medplum: MedplumClient;
-  navigate: MepdlumNavigateFunction;
+  navigate: MedplumNavigateFunction;
   profile?: ProfileResource;
   loading: boolean;
 }

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.context.ts
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.context.ts
@@ -3,11 +3,11 @@ import { createContext, useContext } from 'react';
 
 export const reactContext = createContext(undefined as MedplumContext | undefined);
 
-export type MepdlumNavigateFunction = (path: string) => void;
+export type MedplumNavigateFunction = (path: string) => void;
 
 export interface MedplumContext {
   medplum: MedplumClient;
-  navigate: MepdlumNavigateFunction;
+  navigate: MedplumNavigateFunction;
   profile?: ProfileResource;
   loading: boolean;
 }
@@ -33,7 +33,7 @@ export function useMedplum(): MedplumClient {
  * Returns the Medplum navigate function.
  * @returns The Medplum navigate function.
  */
-export function useMedplumNavigate(): MepdlumNavigateFunction {
+export function useMedplumNavigate(): MedplumNavigateFunction {
   return useMedplumContext().navigate;
 }
 

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
@@ -1,10 +1,10 @@
 import { MedplumClient } from '@medplum/core';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
-import { MepdlumNavigateFunction, reactContext } from './MedplumProvider.context';
+import { MedplumNavigateFunction, reactContext } from './MedplumProvider.context';
 
 export interface MedplumProviderProps {
   readonly medplum: MedplumClient;
-  readonly navigate?: MepdlumNavigateFunction;
+  readonly navigate?: MedplumNavigateFunction;
   readonly children: ReactNode;
 }
 


### PR DESCRIPTION
Fix typos `Mepdlum` in documents and react-hooks