### PR TITLE
Resource table profile support

### DIFF
--- a/packages/app/src/resource/DetailsPage.module.css
+++ b/packages/app/src/resource/DetailsPage.module.css
@@ -1,0 +1,16 @@
+.selectProfileBtn {
+  line-height: 1;
+  font-size: var(--mantine-font-size-xs);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: var(--mantine-radius-xl);
+  padding: 0.25rem 0.625rem;
+  padding-right: 0.5rem;
+  gap: 0.25rem;
+}
+
+.chevron {
+  width: 0.875rem;
+  height: 0.875rem;
+}

--- a/packages/app/src/resource/DetailsPage.tsx
+++ b/packages/app/src/resource/DetailsPage.tsx
@@ -1,18 +1,53 @@
+import { ComboboxItem, Group, NativeSelect, Stack } from '@mantine/core';
+import { isPopulated } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceTable, useResource } from '@medplum/react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 export function DetailsPage(): JSX.Element | null {
   const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
   const resource = useResource({ reference: resourceType + '/' + id });
+  const [profileUrl, setProfileUrl] = useState<string | undefined>();
+
+  const profileUrlOptions: ComboboxItem[] | undefined = useMemo(() => {
+    if (!isPopulated(resource?.meta?.profile)) {
+      return undefined;
+    }
+
+    return [{ label: 'none', value: '' }, ...resource.meta.profile.map((p) => ({ label: p, value: p }))];
+  }, [resource?.meta?.profile]);
+
+  useEffect(() => {
+    if (resource?.meta?.profile?.length === 1) {
+      setProfileUrl(resource.meta.profile[0]);
+    }
+  }, [resource?.meta?.profile]);
 
   if (!resource) {
     return null;
   }
 
+  let profileSelect: JSX.Element | undefined;
+  if (isPopulated(profileUrlOptions)) {
+    profileSelect = (
+      <div style={{ maxWidth: 600 }}>
+        <NativeSelect
+          label="Profile to display"
+          data={profileUrlOptions}
+          value={profileUrl}
+          onChange={(e) => setProfileUrl(e.currentTarget.value || undefined)} // coalesce empty string to undefined
+        />
+      </div>
+    );
+  }
+
   return (
     <Document>
-      <ResourceTable value={resource} />
+      <Stack gap="xl">
+        <Group justify="flex-end">{profileSelect}</Group>
+        <ResourceTable value={resource} profileUrl={profileUrl} />
+      </Stack>
     </Document>
   );
 }

--- a/packages/app/src/resource/DetailsPage.tsx
+++ b/packages/app/src/resource/DetailsPage.tsx
@@ -1,21 +1,35 @@
-import { ComboboxItem, Group, NativeSelect, Stack } from '@mantine/core';
+import { Box, Combobox, Group, Stack, useCombobox, Text, UnstyledButton, Code } from '@mantine/core';
 import { isPopulated } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceTable, useResource } from '@medplum/react';
+import { IconChevronDown } from '@tabler/icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import classes from './DetailsPage.module.css';
 
 export function DetailsPage(): JSX.Element | null {
   const { resourceType, id } = useParams() as { resourceType: ResourceType; id: string };
   const resource = useResource({ reference: resourceType + '/' + id });
-  const [profileUrl, setProfileUrl] = useState<string | undefined>();
+  const [profileUrl, setProfileUrl] = useState<string>();
 
-  const profileUrlOptions: ComboboxItem[] | undefined = useMemo(() => {
+  const combobox = useCombobox({
+    onDropdownClose: () => combobox.resetSelectedOption(),
+  });
+  const profileUrlOptions = useMemo(() => {
     if (!isPopulated(resource?.meta?.profile)) {
       return undefined;
     }
 
-    return [{ label: 'none', value: '' }, ...resource.meta.profile.map((p) => ({ label: p, value: p }))];
+    return [
+      <Combobox.Option value="" key="">
+        None
+      </Combobox.Option>,
+      ...resource.meta.profile.map((p) => (
+        <Combobox.Option value={p} key={p}>
+          {p}
+        </Combobox.Option>
+      )),
+    ];
   }, [resource?.meta?.profile]);
 
   useEffect(() => {
@@ -31,21 +45,58 @@ export function DetailsPage(): JSX.Element | null {
   let profileSelect: JSX.Element | undefined;
   if (isPopulated(profileUrlOptions)) {
     profileSelect = (
-      <div style={{ maxWidth: 600 }}>
-        <NativeSelect
-          label="Profile to display"
-          data={profileUrlOptions}
-          value={profileUrl}
-          onChange={(e) => setProfileUrl(e.currentTarget.value || undefined)} // coalesce empty string to undefined
-        />
-      </div>
+      <Group justify="flex-end">
+        <Stack align="flex-end" gap="xs">
+          <Combobox
+            store={combobox}
+            width={250}
+            position="bottom-end"
+            withinPortal={false}
+            onOptionSubmit={(val) => {
+              setProfileUrl(val);
+              combobox.closeDropdown();
+            }}
+          >
+            <Combobox.Target>
+              <UnstyledButton onClick={() => combobox.toggleDropdown()}>
+                <Code fw="bold" fs="sm" className={classes.selectProfileBtn}>
+                  <span>Pick profile</span>
+                  <IconChevronDown stroke={1.5} className={classes.chevron} />
+                </Code>
+              </UnstyledButton>
+            </Combobox.Target>
+
+            <Combobox.Dropdown w="max-content">
+              <Combobox.Options>{profileUrlOptions}</Combobox.Options>
+            </Combobox.Dropdown>
+          </Combobox>
+
+          <Box>
+            {profileUrl ? (
+              <>
+                <Text span size="sm" c="dimmed">
+                  Displaying profile:&nbsp;
+                </Text>
+
+                <Text span size="sm">
+                  {profileUrl || 'Nothing selected'}
+                </Text>
+              </>
+            ) : (
+              <Text span size="sm" c="dimmed">
+                No profile displayed
+              </Text>
+            )}
+          </Box>
+        </Stack>
+      </Group>
     );
   }
 
   return (
     <Document>
       <Stack gap="xl">
-        <Group justify="flex-end">{profileSelect}</Group>
+        {profileSelect}
         <ResourceTable value={resource} profileUrl={profileUrl} />
       </Stack>
     </Document>

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1691,7 +1691,7 @@ export class MedplumClient extends EventTarget {
         if (options?.expandProfile) {
           const url = this.fhirUrl('StructureDefinition', '$expand-profile');
           url.search = new URLSearchParams({ url: profileUrl }).toString();
-          const sdBundle = await this.get<Bundle<StructureDefinition>>(url.toString());
+          const sdBundle = (await this.post(url.toString(), {})) as Bundle<StructureDefinition>;
           return bundleToResourceArray(sdBundle).map((sd) => {
             loadDataType(sd, sd.url);
             return sd.url;

--- a/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
+++ b/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
@@ -1,19 +1,38 @@
 import { Attachment } from '@medplum/fhirtypes';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
+import { DescriptionListEntry } from '../DescriptionList/DescriptionList';
+import { InternalSchemaElement, getPathDisplayName, isPopulated } from '@medplum/core';
 
 export interface AttachmentArrayDisplayProps {
+  readonly path?: string;
   readonly values?: Attachment[];
   readonly maxWidth?: number;
+  readonly includeDescriptionListEntry?: boolean;
+  readonly property?: InternalSchemaElement;
 }
 
 export function AttachmentArrayDisplay(props: AttachmentArrayDisplayProps): JSX.Element {
-  return (
-    <div>
-      {props.values?.map((v, index) => (
-        <div key={'attatchment-' + index}>
-          <AttachmentDisplay value={v} maxWidth={props.maxWidth} />
-        </div>
-      ))}
+  const attachmentElements = props.values?.map((v, index) => (
+    <div key={'attatchment-' + index}>
+      <AttachmentDisplay value={v} maxWidth={props.maxWidth} />
     </div>
-  );
+  ));
+
+  let content: JSX.Element;
+  if (props.includeDescriptionListEntry) {
+    if (props.property === undefined) {
+      throw new Error('props.property is required when includeDescriptionListEntry is true');
+    }
+
+    if (!isPopulated(props.path)) {
+      throw new Error('props.path is required when includeDescriptionListEntry is true');
+    }
+
+    // Since arrays are responsible for rendering their own DescriptionListEntry, we must find the key
+    const key = props.path.split('.').pop() as string;
+    content = <DescriptionListEntry term={getPathDisplayName(key)}>{attachmentElements}</DescriptionListEntry>;
+  } else {
+    content = <>{attachmentElements}</>;
+  }
+  return content;
 }

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.stories.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.stories.tsx
@@ -11,6 +11,7 @@ export default {
 export const Basic = (): JSX.Element => (
   <Document>
     <BackboneElementDisplay
+      path="Patient.contact"
       value={{
         type: 'PatientContact',
         value: {
@@ -28,6 +29,7 @@ export const Basic = (): JSX.Element => (
 export const IgnoreMissingValues = (): JSX.Element => (
   <Document>
     <BackboneElementDisplay
+      path="Patient.contact"
       value={{
         type: 'PatientContact',
         value: {

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.test.tsx
@@ -1,30 +1,34 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { BackboneElementDisplay, BackboneElementDisplayProps } from './BackboneElementDisplay';
 
 const medplum = new MockClient();
 
 describe('BackboneElementDisplay', () => {
-  function setup(args: BackboneElementDisplayProps): void {
-    render(
-      <MemoryRouter>
-        <MedplumProvider medplum={medplum}>
-          <BackboneElementDisplay {...args} />
-        </MedplumProvider>
-      </MemoryRouter>
+  async function setup(args: BackboneElementDisplayProps): Promise<void> {
+    await act(async () =>
+      render(
+        <MemoryRouter>
+          <MedplumProvider medplum={medplum}>
+            <BackboneElementDisplay {...args} />
+          </MedplumProvider>
+        </MemoryRouter>
+      )
     );
   }
 
-  test('Renders null', () => {
-    setup({
+  test('Renders null', async () => {
+    await setup({
+      path: 'Patient.contact',
       value: { type: 'PatientContact', value: null },
     });
   });
 
-  test('Renders value', () => {
-    setup({
+  test('Renders value', async () => {
+    await setup({
+      path: 'Patient.contact',
       value: {
         type: 'PatientContact',
         value: {
@@ -39,8 +43,9 @@ describe('BackboneElementDisplay', () => {
     expect(screen.getByText('Name')).toBeInTheDocument();
   });
 
-  test('Ignore missing properties', () => {
-    setup({
+  test('Ignore missing properties', async () => {
+    await setup({
+      path: 'Patient.contact',
       value: {
         type: 'PatientContact',
         value: {
@@ -52,8 +57,9 @@ describe('BackboneElementDisplay', () => {
     expect(screen.queryByText('Name')).not.toBeInTheDocument();
   });
 
-  test('Renders simple name', () => {
-    setup({
+  test('Renders simple name', async () => {
+    await setup({
+      path: 'Patient.contact',
       value: {
         type: 'PatientContact',
         value: {
@@ -64,8 +70,9 @@ describe('BackboneElementDisplay', () => {
     expect(screen.getByText('Simple Name')).toBeInTheDocument();
   });
 
-  test('Handles name object value', () => {
-    setup({
+  test('Handles name object value', async () => {
+    await setup({
+      path: 'Organization.contact',
       value: {
         type: 'OrganizationContact',
         value: {
@@ -79,8 +86,9 @@ describe('BackboneElementDisplay', () => {
     expect(screen.getByText('John Doe')).toBeInTheDocument();
   });
 
-  test('Not implemented', () => {
-    setup({
+  test('Not implemented', async () => {
+    await setup({
+      path: 'Foo',
       value: {
         type: 'Foo',
         value: {

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -14,8 +14,8 @@ import { useContext, useMemo } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
-const EXTENSION_KEYS = new Set(['extension', 'modifierExtension']);
-const IGNORED_PROPERTIES = new Set(DEFAULT_IGNORED_PROPERTIES.filter((prop) => !EXTENSION_KEYS.has(prop)));
+const EXTENSION_KEYS = ['extension', 'modifierExtension'];
+const IGNORED_PROPERTIES = DEFAULT_IGNORED_PROPERTIES.filter((prop) => !EXTENSION_KEYS.includes(prop));
 
 export interface BackboneElementDisplayProps {
   readonly value: TypedValue;
@@ -75,10 +75,10 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
     newElementsContext,
     <DescriptionList compact={props.compact}>
       {Object.entries(elementsContext.elements).map(([key, property]) => {
-        if (EXTENSION_KEYS.has(key) && isEmpty(property.slicing?.slices)) {
+        if (EXTENSION_KEYS.includes(key) && isEmpty(property.slicing?.slices)) {
           // an extension property without slices has no nested extensions
           return null;
-        } else if (IGNORED_PROPERTIES.has(key)) {
+        } else if (IGNORED_PROPERTIES.includes(key)) {
           return null;
         } else if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && property.path.split('.').length === 2) {
           return null;

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -15,7 +15,7 @@ import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 const EXTENSION_KEYS = new Set(['extension', 'modifierExtension']);
-const IGNORED_PROPERTIES = new Set(['id', ...DEFAULT_IGNORED_PROPERTIES].filter((prop) => !EXTENSION_KEYS.has(prop)));
+const IGNORED_PROPERTIES = new Set(DEFAULT_IGNORED_PROPERTIES.filter((prop) => !EXTENSION_KEYS.has(prop)));
 
 export interface BackboneElementDisplayProps {
   readonly value: TypedValue;

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -96,16 +96,32 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
           return null;
         }
 
+        if (props.path.endsWith('.extension') && (key === 'url' || key === 'id')) {
+          return null;
+        }
+
+        // Array values provide their own DescriptionListEntry wrapper(s)
+        const isArrayProperty = property.max > 1 || property.isArray;
+        const resourcePropertyDisplay = (
+          <ResourcePropertyDisplay
+            key={key}
+            property={property}
+            propertyType={propertyType}
+            path={props.path + '.' + key}
+            value={propertyValue}
+            ignoreMissingValues={props.ignoreMissingValues}
+            includeArrayDescriptionListEntry={isArrayProperty}
+            link={props.link}
+          />
+        );
+
+        if (isArrayProperty) {
+          return resourcePropertyDisplay;
+        }
+
         return (
           <DescriptionListEntry key={key} term={getPathDisplayName(key)}>
-            <ResourcePropertyDisplay
-              property={property}
-              propertyType={propertyType}
-              path={props.path + '.' + key}
-              value={propertyValue}
-              ignoreMissingValues={props.ignoreMissingValues}
-              link={props.link}
-            />
+            {resourcePropertyDisplay}
           </DescriptionListEntry>
         );
       })}

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -1,25 +1,31 @@
-import { getPathDisplayName, tryGetDataType, TypedValue } from '@medplum/core';
+import { getPathDisplayName, isEmpty, tryGetDataType, TypedValue } from '@medplum/core';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { DescriptionList, DescriptionListEntry } from '../DescriptionList/DescriptionList';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
+import { useMemo } from 'react';
+
+const EXTENSION_KEYS = new Set(['extension', 'modifierExtension']);
+const IGNORED_PROPERTIES = new Set(['id', ...DEFAULT_IGNORED_PROPERTIES].filter((prop) => !EXTENSION_KEYS.has(prop)));
 
 export interface BackboneElementDisplayProps {
   readonly value: TypedValue;
   readonly compact?: boolean;
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
+  /** (optional) Profile URL of the structure definition represented by the backbone element */
+  readonly profileUrl?: string;
 }
 
 export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.Element | null {
   const typedValue = props.value;
-  const value = typedValue.value;
-  if (!value) {
+  const { value, type: typeName } = typedValue;
+  const typeSchema = useMemo(() => tryGetDataType(typeName, props.profileUrl), [props.profileUrl, typeName]);
+
+  if (isEmpty(value)) {
     return null;
   }
 
-  const typeName = typedValue.type;
-  const typeSchema = tryGetDataType(typeName);
   if (!typeSchema) {
     return <div>{typeName}&nbsp;not implemented</div>;
   }
@@ -38,21 +44,28 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
 
   return (
     <DescriptionList compact={props.compact}>
-      {Object.entries(typeSchema.elements).map((entry) => {
-        const [key, property] = entry;
-        if (DEFAULT_IGNORED_PROPERTIES.includes(key)) {
+      {Object.entries(typeSchema.elements).map(([key, property]) => {
+        if (EXTENSION_KEYS.has(key) && isEmpty(property.slicing?.slices)) {
+          // an extension property without slices has no nested extensions
+          return null;
+        } else if (IGNORED_PROPERTIES.has(key)) {
+          return null;
+        } else if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && property.path.split('.').length === 2) {
           return null;
         }
-        if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && property.path.split('.').length === 2) {
-          return null;
+
+        // Profiles can include nested elements in addition to their containing element, e.g.:
+        // identifier, identifier.use, identifier.system
+        // Skip nested elements, e.g. identifier.use, since they are handled by the containing element
+        if (key.includes('.')) {
+          return false;
         }
+
         const [propertyValue, propertyType] = getValueAndType(typedValue, key);
-        if (
-          props.ignoreMissingValues &&
-          (!propertyValue || (Array.isArray(propertyValue) && propertyValue.length === 0))
-        ) {
+        if (props.ignoreMissingValues && isEmpty(propertyValue)) {
           return null;
         }
+
         return (
           <DescriptionListEntry key={key} term={getPathDisplayName(key)}>
             <ResourcePropertyDisplay

--- a/packages/react/src/DescriptionList/DescriptionList.module.css
+++ b/packages/react/src/DescriptionList/DescriptionList.module.css
@@ -6,6 +6,7 @@
   & > dt,
   & > dd {
     padding: var(--mantine-spacing-sm);
+    padding-right: 0;
     border-top: 0.1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     margin: 0;
   }
@@ -13,6 +14,13 @@
   & > dt:first-of-type,
   & > dd:first-of-type {
     border-top: 0;
+    padding-top: 0;
+  }
+
+  & > dt:last-of-type,
+  & > dd:last-of-type {
+    border-bottom: 0;
+    padding-bottom: 0;
   }
 }
 
@@ -21,7 +29,13 @@
 
   & > dt,
   & > dd {
-    padding: 0 var(--mantine-spacing-xs) var(--mantine-spacing-xs);
+    padding: 0 0 var(--mantine-spacing-xs) var(--mantine-spacing-xs);
     border: 0;
+  }
+
+  & > dt:last-of-type,
+  & > dd:last-of-type {
+    border-bottom: 0;
+    padding-bottom: 0;
   }
 }

--- a/packages/react/src/DescriptionList/DescriptionList.module.css
+++ b/packages/react/src/DescriptionList/DescriptionList.module.css
@@ -5,17 +5,9 @@
 
   & > dt,
   & > dd {
-    padding: var(--mantine-spacing-sm) 0;
+    padding: var(--mantine-spacing-sm);
     border-top: 0.1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     margin: 0;
-  }
-
-  & > dt {
-    padding-right: var(--mantine-spacing-sm);
-  }
-
-  & > dd {
-    padding-left: var(--mantine-spacing-sm);
   }
 
   & > dt:first-of-type,
@@ -35,8 +27,7 @@
 
   & > dt,
   & > dd {
-    padding-top: 0;
-    padding-bottom: var(--mantine-spacing-xs);
+    padding: 0 0 var(--mantine-spacing-xs);
     border-top: 0;
   }
 

--- a/packages/react/src/DescriptionList/DescriptionList.module.css
+++ b/packages/react/src/DescriptionList/DescriptionList.module.css
@@ -5,10 +5,17 @@
 
   & > dt,
   & > dd {
-    padding: var(--mantine-spacing-sm);
-    padding-right: 0;
+    padding: var(--mantine-spacing-sm) 0;
     border-top: 0.1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     margin: 0;
+  }
+
+  & > dt {
+    padding-right: var(--mantine-spacing-sm);
+  }
+
+  & > dd {
+    padding-left: var(--mantine-spacing-sm);
   }
 
   & > dt:first-of-type,
@@ -19,23 +26,30 @@
 
   & > dt:last-of-type,
   & > dd:last-of-type {
-    border-bottom: 0;
     padding-bottom: 0;
   }
 }
 
 .compact {
-  grid-template-columns: 20% 80%;
+  grid-template-columns: auto 1fr;
 
   & > dt,
   & > dd {
-    padding: 0 0 var(--mantine-spacing-xs) var(--mantine-spacing-xs);
-    border: 0;
+    padding-top: 0;
+    padding-bottom: var(--mantine-spacing-xs);
+    border-top: 0;
+  }
+
+  & > dt {
+    padding-right: var(--mantine-spacing-xs);
+  }
+
+  & > dd {
+    padding-left: var(--mantine-spacing-xs);
   }
 
   & > dt:last-of-type,
   & > dd:last-of-type {
-    border-bottom: 0;
     padding-bottom: 0;
   }
 }

--- a/packages/react/src/DescriptionList/DescriptionList.module.css
+++ b/packages/react/src/DescriptionList/DescriptionList.module.css
@@ -9,6 +9,11 @@
     border-top: 0.1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
     margin: 0;
   }
+
+  & > dt:first-of-type,
+  & > dd:first-of-type {
+    border-top: 0;
+  }
 }
 
 .compact {

--- a/packages/react/src/ElementsInput/ElementsInput.tsx
+++ b/packages/react/src/ElementsInput/ElementsInput.tsx
@@ -10,8 +10,8 @@ import { ResourcePropertyInput } from '../ResourcePropertyInput/ResourceProperty
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { ElementsContext } from './ElementsInput.utils';
 
-const EXTENSION_KEYS = new Set(['extension', 'modifierExtension']);
-const IGNORED_PROPERTIES = new Set(['id', ...DEFAULT_IGNORED_PROPERTIES].filter((prop) => !EXTENSION_KEYS.has(prop)));
+const EXTENSION_KEYS = ['extension', 'modifierExtension'];
+const IGNORED_PROPERTIES = ['id', ...DEFAULT_IGNORED_PROPERTIES].filter((prop) => !EXTENSION_KEYS.includes(prop));
 
 export interface ElementsInputProps {
   readonly type: string;
@@ -61,7 +61,7 @@ export function ElementsInput(props: ElementsInputProps): JSX.Element {
         );
 
         // no FormSection wrapper for extensions
-        if (props.type === 'Extension' || EXTENSION_KEYS.has(key)) {
+        if (props.type === 'Extension' || EXTENSION_KEYS.includes(key)) {
           return resourcePropertyInput;
         }
 
@@ -113,10 +113,10 @@ function getElementsToRender(inputElements: Record<string, InternalSchemaElement
       return false;
     }
 
-    if (EXTENSION_KEYS.has(key) && !isPopulated(element.slicing?.slices)) {
+    if (EXTENSION_KEYS.includes(key) && !isPopulated(element.slicing?.slices)) {
       // an extension property without slices has no nested extensions
       return false;
-    } else if (IGNORED_PROPERTIES.has(key)) {
+    } else if (IGNORED_PROPERTIES.includes(key)) {
       return false;
     } else if (DEFAULT_IGNORED_NON_NESTED_PROPERTIES.includes(key) && element.path.split('.').length === 2) {
       return false;

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.test.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.test.tsx
@@ -1,0 +1,104 @@
+import { HTTP_HL7_ORG, loadDataType, tryGetProfile } from '@medplum/core';
+import { act, render, screen } from '../test-utils/render';
+import { ExtensionDisplay, ExtensionDisplayProps } from './ExtensionDisplay';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import { readJson } from '@medplum/definitions';
+import { StructureDefinition } from '@medplum/fhirtypes';
+
+const medplum = new MockClient();
+
+const defaultProps: ExtensionDisplayProps = {
+  value: undefined,
+  path: 'Resource.extension',
+  elementDefinitionType: { code: 'Extension', profile: [] },
+};
+
+describe('ExtensionDisplay', () => {
+  async function setup(props: ExtensionDisplayProps): Promise<void> {
+    await act(async () => {
+      render(
+        <MedplumProvider medplum={medplum}>
+          <ExtensionDisplay {...props} />
+        </MedplumProvider>
+      );
+    });
+  }
+
+  test('Renders simple value', async () => {
+    // const extensionType = getDataType('Extension');
+    // extensionType.elements['value[x]'];
+
+    await setup({
+      ...defaultProps,
+      value: { url: 'https://example.com', valueString: 'extension str value' },
+    });
+    expect(screen.getByText('extension str value')).toBeInTheDocument();
+  });
+
+  test('Renders with extension profile', async () => {
+    const USCoreStructureDefinitions: StructureDefinition[] = readJson(
+      'fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json'
+    );
+    const profileUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-patient`;
+    const profilesToLoad = [profileUrl, `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-race`];
+    for (const url of profilesToLoad) {
+      const sd = USCoreStructureDefinitions.find((sd) => sd.url === url);
+      if (!sd) {
+        fail(`could not find structure definition for ${url}`);
+      }
+      loadDataType(sd, sd.url);
+    }
+    const schema = tryGetProfile(profileUrl);
+    const slice = schema?.elements['extension'].slicing?.slices.find((slice) => slice.name === 'race');
+    if (!slice) {
+      fail('Expected to find race slice');
+    }
+
+    const value = {
+      url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
+      extension: [
+        {
+          url: 'ombCategory',
+          valueCoding: {
+            system: 'urn:oid:2.16.840.1.113883.6.238',
+            code: '2076-8',
+            display: 'Native Hawaiian or Other Pacific Islander',
+          },
+        },
+        {
+          url: 'detailed',
+          valueCoding: {
+            system: 'urn:oid:2.16.840.1.113883.6.238',
+            code: '1006-6',
+            display: 'Abenaki',
+          },
+        },
+        {
+          url: 'detailed',
+          valueCoding: {
+            system: 'urn:oid:2.16.840.1.113883.6.238',
+            code: '1011-6',
+            display: 'Chiricahua',
+          },
+        },
+        {
+          url: 'text',
+          valueString: 'Race text entry',
+        },
+      ],
+    };
+    await setup({
+      ...defaultProps,
+      value,
+      elementDefinitionType: slice?.type?.[0],
+    });
+    expect(screen.getByText('OMB Category')).toBeInTheDocument();
+    expect(screen.getByText('Native Hawaiian or Other Pacific Islander')).toBeInTheDocument();
+    expect(screen.getByText('Detailed')).toBeInTheDocument();
+    expect(screen.getByText('Abenaki')).toBeInTheDocument();
+    expect(screen.getByText('Chiricahua')).toBeInTheDocument();
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByText('Race text entry')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
@@ -1,16 +1,22 @@
-import { InternalTypeSchema, getDataType, isPopulated, isProfileLoaded, tryGetProfile } from '@medplum/core';
+import {
+  ElementType,
+  InternalTypeSchema,
+  getDataType,
+  isPopulated,
+  isProfileLoaded,
+  tryGetProfile,
+} from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
-import { useState, useMemo, useEffect, useContext } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
-import { ElementDefinitionType } from '@medplum/fhirtypes';
-import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 
 export type ExtensionDisplayProps = {
   /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
   readonly path: string;
-  readonly elementDefinitionType?: ElementDefinitionType;
+  readonly elementDefinitionType?: ElementType;
   readonly value: any;
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
@@ -21,8 +21,6 @@ export type ExtensionDisplayProps = {
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
   readonly compact?: boolean;
-  /** (optional) Profile URL of the structure definition represented by the backbone element */
-  readonly profileUrl?: string;
 };
 
 export function ExtensionDisplay(props: ExtensionDisplayProps): JSX.Element | null {

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
@@ -1,8 +1,11 @@
 import { InternalTypeSchema, getDataType, isPopulated, isProfileLoaded, tryGetProfile } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useContext } from 'react';
 import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
 import { ElementDefinitionType } from '@medplum/fhirtypes';
+import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 
 export type ExtensionDisplayProps = {
   /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
@@ -20,6 +23,7 @@ export function ExtensionDisplay(props: ExtensionDisplayProps): JSX.Element | nu
   const { elementDefinitionType } = props;
 
   const medplum = useMedplum();
+  const ctx = useContext(ElementsContext);
   const [typeSchema, setTypeSchema] = useState<InternalTypeSchema>(getDataType('Extension'));
   const profileUrl: string | undefined = useMemo(() => {
     if (!isPopulated(elementDefinitionType?.profile)) {
@@ -51,6 +55,17 @@ export function ExtensionDisplay(props: ExtensionDisplayProps): JSX.Element | nu
 
   if (profileUrl && (loadingProfile || !isProfileLoaded(profileUrl))) {
     return <div>Loading...</div>;
+  }
+
+  const valueElement = typeSchema.elements['value[x]'];
+  const extensionHasValue = valueElement?.max !== 0;
+  if (extensionHasValue) {
+    const [propertyValue, propertyType] = getValueAndType(
+      { type: 'Extension', value: props.value },
+      'value[x]',
+      profileUrl ?? ctx.profileUrl
+    );
+    return <ResourcePropertyDisplay propertyType={propertyType} value={propertyValue} />;
   }
 
   return (

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
@@ -1,0 +1,66 @@
+import { InternalTypeSchema, getDataType, isPopulated, isProfileLoaded, tryGetProfile } from '@medplum/core';
+import { useMedplum } from '@medplum/react-hooks';
+import { useState, useMemo, useEffect } from 'react';
+import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
+import { ElementDefinitionType } from '@medplum/fhirtypes';
+
+export type ExtensionDisplayProps = {
+  /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
+  readonly path: string;
+  readonly elementDefinitionType?: ElementDefinitionType;
+  readonly value: any;
+  readonly ignoreMissingValues?: boolean;
+  readonly link?: boolean;
+  readonly compact?: boolean;
+  /** (optional) Profile URL of the structure definition represented by the backbone element */
+  readonly profileUrl?: string;
+};
+
+export function ExtensionDisplay(props: ExtensionDisplayProps): JSX.Element | null {
+  const { elementDefinitionType } = props;
+
+  const medplum = useMedplum();
+  const [typeSchema, setTypeSchema] = useState<InternalTypeSchema>(getDataType('Extension'));
+  const profileUrl: string | undefined = useMemo(() => {
+    if (!isPopulated(elementDefinitionType?.profile)) {
+      return undefined;
+    }
+
+    return elementDefinitionType.profile[0] satisfies string;
+  }, [elementDefinitionType]);
+  const [loadingProfile, setLoadingProfile] = useState(profileUrl !== undefined);
+
+  useEffect(() => {
+    if (profileUrl) {
+      setLoadingProfile(true);
+      medplum
+        .requestProfileSchema(profileUrl)
+        .then(() => {
+          const profile = tryGetProfile(profileUrl);
+          setLoadingProfile(false);
+          if (profile) {
+            setTypeSchema(profile);
+          }
+        })
+        .catch((reason) => {
+          setLoadingProfile(false);
+          console.warn(reason);
+        });
+    }
+  }, [medplum, profileUrl]);
+
+  if (profileUrl && (loadingProfile || !isProfileLoaded(profileUrl))) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <BackboneElementDisplay
+      path={props.path}
+      value={{ type: typeSchema.name, value: props.value }}
+      compact={props.compact}
+      ignoreMissingValues={props.ignoreMissingValues}
+      link={props.link}
+      profileUrl={profileUrl}
+    />
+  );
+}

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,11 +1,11 @@
-import { InternalSchemaElement, SliceDefinitionWithTypes } from '@medplum/core';
+import { InternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { useState, useContext, useEffect } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { prepareSlices, assignValuesIntoSlices } from '../ResourceArrayInput/ResourceArrayInput.utils';
 import { useMedplum } from '@medplum/react-hooks';
 import { SliceDisplay } from '../SliceDisplay/SliceDisplay';
-import { Stack } from '@mantine/core';
+import { DescriptionListEntry } from '../DescriptionList/DescriptionList';
 
 export interface ResourceArrayDisplayProps {
   /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
@@ -15,6 +15,7 @@ export interface ResourceArrayDisplayProps {
   readonly values: any[];
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
+  readonly includeDescriptionListEntry?: boolean;
 }
 
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element | null {
@@ -47,43 +48,66 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
     return <div>Loading...</div>;
   }
 
-  const nonSliceIndex = slices.length;
-  const nonSliceValues = slicedValues[nonSliceIndex];
+  let nonSliceContent: JSX.Element | undefined;
   const showNonSliceValues = property.type[0]?.code !== 'Extension';
+  if (showNonSliceValues) {
+    const nonSliceValues = slicedValues[slices.length];
+    const nonSliceElements = nonSliceValues.map((value, valueIndex) => (
+      <div key={`${valueIndex}-${nonSliceValues.length}`}>
+        <ResourcePropertyDisplay
+          path={props.path}
+          arrayElement={true}
+          property={property}
+          propertyType={propertyType}
+          value={value}
+          ignoreMissingValues={props.ignoreMissingValues}
+          link={props.link}
+        />
+      </div>
+    ));
+
+    if (props.includeDescriptionListEntry) {
+      // Since arrays are responsible for rendering their own DescriptionListEntry, we must find the key
+      const key: string | undefined = Object.entries(ctx.elements).find(([_key, elem]) => elem === props.property)?.[0];
+      if (key === undefined) {
+        throw new Error('Could not find props.property within ElementsContext');
+      }
+      const nonSliceTerm = getPathDisplayName(key);
+      nonSliceContent = <DescriptionListEntry term={nonSliceTerm}>{nonSliceElements}</DescriptionListEntry>;
+    } else {
+      nonSliceContent = <>{nonSliceElements}</>;
+    }
+  }
 
   return (
-    <Stack gap="sm">
+    <>
       {slices.map((slice, sliceIndex) => {
         if (!props.path) {
           throw Error(`Displaying a resource property with slices of type ${props.propertyType} requires path`);
         }
-        return (
+        const sliceDisplay = (
           <SliceDisplay
+            key={slice.name}
             path={props.path}
             slice={slice}
-            key={slice.name}
             property={property}
             value={slicedValues[sliceIndex]}
             ignoreMissingValues={props.ignoreMissingValues}
             link={props.link}
           />
         );
+
+        if (props.includeDescriptionListEntry) {
+          return (
+            <DescriptionListEntry key={slice.name} term={getPathDisplayName(slice.name)}>
+              {sliceDisplay}
+            </DescriptionListEntry>
+          );
+        }
+        return sliceDisplay;
       })}
 
-      {showNonSliceValues &&
-        nonSliceValues.map((value, valueIndex) => (
-          <div key={`${valueIndex}-${nonSliceValues.length}`}>
-            <ResourcePropertyDisplay
-              path={props.path}
-              arrayElement={true}
-              property={property}
-              propertyType={propertyType}
-              value={value}
-              ignoreMissingValues={props.ignoreMissingValues}
-              link={props.link}
-            />
-          </div>
-        ))}
-    </Stack>
+      {nonSliceContent}
+    </>
   );
 }

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,4 +1,4 @@
-import { InternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
+import { InternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName, isPopulated } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { useState, useContext, useEffect } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
@@ -68,12 +68,11 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
 
     if (props.includeDescriptionListEntry) {
       // Since arrays are responsible for rendering their own DescriptionListEntry, we must find the key
-      const key: string | undefined = Object.entries(ctx.elements).find(([_key, elem]) => elem === props.property)?.[0];
-      if (key === undefined) {
-        throw new Error('Could not find props.property within ElementsContext');
+      if (!isPopulated(props.path)) {
+        throw new Error('props.path is required when includeDescriptionListEntry is true');
       }
-      const nonSliceTerm = getPathDisplayName(key);
-      nonSliceContent = <DescriptionListEntry term={nonSliceTerm}>{nonSliceElements}</DescriptionListEntry>;
+      const key = props.path.split('.').pop() as string;
+      nonSliceContent = <DescriptionListEntry term={getPathDisplayName(key)}>{nonSliceElements}</DescriptionListEntry>;
     } else {
       nonSliceContent = <>{nonSliceElements}</>;
     }

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,4 +1,4 @@
-import { InternalSchemaElement, SliceDefinitionWithTypes, isEmpty } from '@medplum/core';
+import { InternalSchemaElement, SliceDefinitionWithTypes } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { useState, useContext, useEffect } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
@@ -9,7 +9,7 @@ import { Stack } from '@mantine/core';
 
 export interface ResourceArrayDisplayProps {
   /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
-  readonly path: string;
+  readonly path?: string;
   readonly property: InternalSchemaElement;
   readonly propertyType: string;
   readonly values: any[];
@@ -18,7 +18,8 @@ export interface ResourceArrayDisplayProps {
 }
 
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element | null {
-  const { property, propertyType, values } = props;
+  const { property, propertyType } = props;
+  const [values] = useState<any[]>(() => (Array.isArray(props.values) ? props.values : []));
   const medplum = useMedplum();
   const [loading, setLoading] = useState(true);
   const [slices, setSlices] = useState<SliceDefinitionWithTypes[]>([]);
@@ -46,10 +47,6 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
     return <div>Loading...</div>;
   }
 
-  if (isEmpty(props.values)) {
-    return null;
-  }
-
   const nonSliceIndex = slices.length;
   const nonSliceValues = slicedValues[nonSliceIndex];
   const showNonSliceValues = property.type[0]?.code !== 'Extension';
@@ -57,6 +54,9 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
   return (
     <Stack gap="sm">
       {slices.map((slice, sliceIndex) => {
+        if (!props.path) {
+          throw Error(`Displaying a resource property with slices of type ${props.propertyType} requires path`);
+        }
         return (
           <SliceDisplay
             path={props.path}

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,7 +1,15 @@
-import { InternalSchemaElement, isEmpty } from '@medplum/core';
+import { InternalSchemaElement, SliceDefinitionWithTypes, isEmpty } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
+import { useState, useContext, useEffect } from 'react';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { prepareSlices, assignValuesIntoSlices } from '../ResourceArrayInput/ResourceArrayInput.utils';
+import { useMedplum } from '@medplum/react-hooks';
+import { SliceDisplay } from '../SliceDisplay/SliceDisplay';
+import { Stack } from '@mantine/core';
 
 export interface ResourceArrayDisplayProps {
+  /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
+  readonly path: string;
   readonly property: InternalSchemaElement;
   readonly propertyType: string;
   readonly values: any[];
@@ -11,25 +19,70 @@ export interface ResourceArrayDisplayProps {
 
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element | null {
   const { property, propertyType, values } = props;
+  const medplum = useMedplum();
+  const [loading, setLoading] = useState(true);
+  const [slices, setSlices] = useState<SliceDefinitionWithTypes[]>([]);
+  const [slicedValues, setSlicedValues] = useState<any[][]>(() => [values]);
+  const ctx = useContext(ElementsContext);
+
+  useEffect(() => {
+    prepareSlices({
+      medplum,
+      property,
+    })
+      .then((slices) => {
+        setSlices(slices);
+        const slicedValues = assignValuesIntoSlices(values, slices, property.slicing, ctx.profileUrl);
+        setSlicedValues(slicedValues);
+        setLoading(false);
+      })
+      .catch((reason) => {
+        console.error(reason);
+        setLoading(false);
+      });
+  }, [medplum, property, ctx.profileUrl, setSlicedValues, values]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
 
   if (isEmpty(props.values)) {
     return null;
   }
 
+  const nonSliceIndex = slices.length;
+  const nonSliceValues = slicedValues[nonSliceIndex];
+  const showNonSliceValues = property.type[0]?.code !== 'Extension';
+
   return (
-    <>
-      {values.map((v: any, index: number) => (
-        <div key={`${index}-${values.length}`}>
-          <ResourcePropertyDisplay
-            arrayElement={true}
+    <Stack gap="sm">
+      {slices.map((slice, sliceIndex) => {
+        return (
+          <SliceDisplay
+            path={props.path}
+            slice={slice}
+            key={slice.name}
             property={property}
-            propertyType={propertyType}
-            value={v}
-            ignoreMissingValues={props.ignoreMissingValues}
-            link={props.link}
+            value={slicedValues[sliceIndex]}
+            testId={`slice-${slice.name}`}
           />
-        </div>
-      ))}
-    </>
+        );
+      })}
+
+      {showNonSliceValues &&
+        nonSliceValues.map((value, valueIndex) => (
+          <div key={`${valueIndex}-${nonSliceValues.length}`}>
+            <ResourcePropertyDisplay
+              path={props.path}
+              arrayElement={true}
+              property={property}
+              propertyType={propertyType}
+              value={value}
+              ignoreMissingValues={props.ignoreMissingValues}
+              link={props.link}
+            />
+          </div>
+        ))}
+    </Stack>
   );
 }

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,18 +1,22 @@
-import { InternalSchemaElement } from '@medplum/core';
+import { InternalSchemaElement, isEmpty } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 
 export interface ResourceArrayDisplayProps {
   readonly property: InternalSchemaElement;
+  readonly propertyType: string;
   readonly values: any[];
-  readonly arrayElement?: boolean;
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
 }
 
-export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element {
-  const { property, values } = props;
-  const propertyType = property.type[0].code;
-  return props.values ? (
+export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element | null {
+  const { property, propertyType, values } = props;
+
+  if (isEmpty(props.values)) {
+    return null;
+  }
+
+  return (
     <>
       {values.map((v: any, index: number) => (
         <div key={`${index}-${values.length}`}>
@@ -27,7 +31,5 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
         </div>
       ))}
     </>
-  ) : (
-    <></>
   );
 }

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -84,7 +84,7 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
         if (!props.path) {
           throw Error(`Displaying a resource property with slices of type ${props.propertyType} requires path`);
         }
-        const sliceDisplay = (
+        let sliceDisplay = (
           <SliceDisplay
             key={slice.name}
             path={props.path}
@@ -97,7 +97,7 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
         );
 
         if (props.includeDescriptionListEntry) {
-          return (
+          sliceDisplay = (
             <DescriptionListEntry key={slice.name} term={getPathDisplayName(slice.name)}>
               {sliceDisplay}
             </DescriptionListEntry>

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -64,7 +64,8 @@ export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Elem
             key={slice.name}
             property={property}
             value={slicedValues[sliceIndex]}
-            testId={`slice-${slice.name}`}
+            ignoreMissingValues={props.ignoreMissingValues}
+            link={props.link}
           />
         );
       })}

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,6 +1,6 @@
 import { InternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName, isPopulated } from '@medplum/core';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
-import { useState, useContext, useEffect } from 'react';
+import { useState, useContext, useEffect, useMemo } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { prepareSlices, assignValuesIntoSlices } from '../ResourceArrayInput/ResourceArrayInput.utils';
 import { useMedplum } from '@medplum/react-hooks';
@@ -20,8 +20,8 @@ export interface ResourceArrayDisplayProps {
 
 export function ResourceArrayDisplay(props: ResourceArrayDisplayProps): JSX.Element | null {
   const { property, propertyType } = props;
-  const [values] = useState<any[]>(() => (Array.isArray(props.values) ? props.values : []));
   const medplum = useMedplum();
+  const values = useMemo<any[]>(() => (Array.isArray(props.values) ? props.values : []), [props.values]);
   const [loading, setLoading] = useState(true);
   const [slices, setSlices] = useState<SliceDefinitionWithTypes[]>([]);
   const [slicedValues, setSlicedValues] = useState<any[][]>(() => [values]);

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -42,6 +42,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
       .then((slices) => {
         setSlices(slices);
         const slicedValues = assignValuesIntoSlices(defaultValue, slices, property.slicing, ctx.profileUrl);
+        addPlaceholderValues(slicedValues, slices);
         setSlicedValues(slicedValues);
         setLoading(false);
       })
@@ -138,4 +139,15 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
       )}
     </Stack>
   );
+}
+
+function addPlaceholderValues(slicedValues: any[][], slices: SliceDefinitionWithTypes[]): void {
+  for (let sliceIndex = 0; sliceIndex < slices.length; sliceIndex++) {
+    const slice = slices[sliceIndex];
+    const sliceValues = slicedValues[sliceIndex];
+
+    while (sliceValues.length < slice.min) {
+      sliceValues.push(undefined);
+    }
+  }
 }

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -49,7 +49,7 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
         console.error(reason);
         setLoading(false);
       });
-  }, [medplum, property, defaultValue, ctx.profileUrl, setSlicedValues, props.path]);
+  }, [medplum, property, defaultValue, ctx.profileUrl, setSlicedValues]);
 
   function setValuesWrapper(newValues: any[], sliceIndex: number): void {
     const newSlicedValues = [...slicedValues];

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.ts
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.ts
@@ -36,16 +36,6 @@ export function assignValuesIntoSlices(
     slicedValues[sliceIndex].push(value);
   }
 
-  // add placeholder empty values for required slices
-  for (let sliceIndex = 0; sliceIndex < slices.length; sliceIndex++) {
-    const slice = slices[sliceIndex];
-    const sliceValues = slicedValues[sliceIndex];
-
-    while (sliceValues.length < slice.min) {
-      sliceValues.push(undefined);
-    }
-  }
-
   return slicedValues;
 }
 

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -41,7 +41,7 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
     const typedRevised = [toTypedValue(revised)];
     const result = [];
 
-    // First, we filter and conslidate the patch operations
+    // First, we filter and consolidate the patch operations
     // We can do this because we do not use the "value" field in the patch operations
     // Remove patch operations on meta elements such as "meta.lastUpdated" and "meta.versionId"
     // Consolidate patch operations on arrays
@@ -57,6 +57,7 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
       result.push({
         key: `op-${op.op}-${op.path}`,
         name: `${capitalize(op.op)} ${fhirPath}`,
+        path: property?.path ?? original.resourceType + '.' + fhirPath,
         property: property,
         originalValue: touchUpValue(property, originalValue),
         revisedValue: touchUpValue(property, revisedValue),
@@ -86,6 +87,7 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
             <Table.Td className={classes.removed}>
               {row.originalValue && (
                 <ResourcePropertyDisplay
+                  path={row.path}
                   property={row.property}
                   propertyType={row.originalValue.type}
                   value={row.originalValue.value}
@@ -96,6 +98,7 @@ export function ResourceDiffTable(props: ResourceDiffTableProps): JSX.Element | 
             <Table.Td className={classes.added}>
               {row.revisedValue && (
                 <ResourcePropertyDisplay
+                  path={row.path}
                   property={row.property}
                   propertyType={row.revisedValue.type}
                   value={row.revisedValue.value}

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.module.css
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.module.css
@@ -1,0 +1,3 @@
+.leftBorder {
+  border-left: 3px solid var(--mantine-color-gray-4);
+}

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.module.css
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.module.css
@@ -1,3 +1,0 @@
-.leftBorder {
-  border-left: 3px solid var(--mantine-color-gray-4);
-}

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.test.tsx
@@ -19,7 +19,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { ResourcePropertyDisplay } from './ResourcePropertyDisplay';
 
 const medplum = new MockClient();
@@ -32,13 +32,16 @@ const baseProperty: Omit<InternalSchemaElement, 'type'> = {
   constraints: [],
   path: '',
 };
+
 describe('ResourcePropertyDisplay', () => {
-  function setup(children: ReactNode): void {
-    render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
+  async function setup(children: ReactNode): Promise<void> {
+    await act(async () => {
+      render(<MedplumProvider medplum={medplum}>{children}</MedplumProvider>);
+    });
   }
 
-  test('Renders null value', () => {
-    setup(
+  test('Renders null value', async () => {
+    await await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'string' }] }}
         propertyType={PropertyType.string}
@@ -47,8 +50,8 @@ describe('ResourcePropertyDisplay', () => {
     );
   });
 
-  test('Renders boolean true', () => {
-    setup(
+  test('Renders boolean true', async () => {
+    await await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'boolean' }] }}
         propertyType={PropertyType.boolean}
@@ -59,8 +62,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.queryByText('false')).toBeNull();
   });
 
-  test('Renders boolean false', () => {
-    setup(
+  test('Renders boolean false', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'boolean' }] }}
         propertyType={PropertyType.boolean}
@@ -71,8 +74,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.queryByText('true')).toBeNull();
   });
 
-  test('Renders boolean undefined', () => {
-    setup(
+  test('Renders boolean undefined', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'boolean' }] }}
         propertyType={PropertyType.boolean}
@@ -83,8 +86,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.queryByText('false')).toBeNull();
   });
 
-  test('Renders string', () => {
-    setup(
+  test('Renders string', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'string' }] }}
         propertyType={PropertyType.string}
@@ -94,8 +97,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
-  test('Renders string with newline', () => {
-    setup(
+  test('Renders string with newline', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'string' }] }}
         propertyType={PropertyType.string}
@@ -109,8 +112,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(numberOfLines).not.toBe(1);
   });
 
-  test('Renders canonical', () => {
-    setup(
+  test('Renders canonical', async () => {
+    await setup(
       <MemoryRouter>
         <ResourcePropertyDisplay propertyType={PropertyType.canonical} value="Patient/123" />
       </MemoryRouter>
@@ -121,8 +124,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(el).toBeInstanceOf(HTMLAnchorElement);
   });
 
-  test('Renders url', () => {
-    setup(
+  test('Renders url', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'url' }] }}
         propertyType={PropertyType.url}
@@ -132,8 +135,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('https://example.com')).toBeInTheDocument();
   });
 
-  test('Renders uri', () => {
-    setup(
+  test('Renders uri', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'uri' }] }}
         propertyType={PropertyType.uri}
@@ -143,8 +146,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('https://example.com')).toBeInTheDocument();
   });
 
-  test('Renders string array', () => {
-    setup(
+  test('Renders string array', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'string' }], max: Number.POSITIVE_INFINITY }}
         propertyType={PropertyType.string}
@@ -155,8 +158,8 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('world')).toBeInTheDocument();
   });
 
-  test('Renders markdown', () => {
-    setup(
+  test('Renders markdown', async () => {
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'markdown' }] }}
         propertyType={PropertyType.markdown}
@@ -166,12 +169,12 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
-  test('Renders Address', () => {
+  test('Renders Address', async () => {
     const value: Address = {
       city: 'London',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Address' }] }}
         propertyType={PropertyType.Address}
@@ -182,12 +185,12 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('London')).toBeInTheDocument();
   });
 
-  test('Renders Annotation', () => {
+  test('Renders Annotation', async () => {
     const value: Annotation = {
       text: 'hello',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Annotation' }] }}
         propertyType={PropertyType.Annotation}
@@ -198,14 +201,14 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('hello')).toBeInTheDocument();
   });
 
-  test('Renders Attachment', () => {
+  test('Renders Attachment', async () => {
     const value: Attachment = {
       contentType: 'text/plain',
       url: 'https://example.com/file.txt',
       title: 'file.txt',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Attachment' }] }}
         propertyType={PropertyType.Attachment}
@@ -216,7 +219,7 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('file.txt')).toBeInTheDocument();
   });
 
-  test('Renders Attachment array', () => {
+  test('Renders Attachment array', async () => {
     const value: Attachment[] = [
       {
         contentType: 'text/plain',
@@ -230,7 +233,7 @@ describe('ResourcePropertyDisplay', () => {
       },
     ];
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Attachment' }], max: Number.POSITIVE_INFINITY }}
         propertyType={PropertyType.Attachment}
@@ -241,12 +244,12 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('file2.txt')).toBeInTheDocument();
   });
 
-  test('Renders CodeableConcept', () => {
+  test('Renders CodeableConcept', async () => {
     const value: CodeableConcept = {
       text: 'foo',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'CodeableConcept' }] }}
         propertyType={PropertyType.CodeableConcept}
@@ -257,13 +260,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('foo')).toBeInTheDocument();
   });
 
-  test('Renders Coding', () => {
+  test('Renders Coding', async () => {
     const value: Coding = {
       display: 'Test Coding',
       code: 'test-coding',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Coding' }] }}
         propertyType={PropertyType.Coding}
@@ -274,13 +277,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('Test Coding')).toBeInTheDocument();
   });
 
-  test('Renders ContactPoint', () => {
+  test('Renders ContactPoint', async () => {
     const value: ContactPoint = {
       system: 'email',
       value: 'foo@example.com',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'ContactPoint' }] }}
         propertyType={PropertyType.ContactPoint}
@@ -291,12 +294,12 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('foo@example.com [email]')).toBeInTheDocument();
   });
 
-  test('Renders HumanName', () => {
+  test('Renders HumanName', async () => {
     const value: HumanName = {
       family: 'Smith',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'HumanName' }] }}
         propertyType={PropertyType.HumanName}
@@ -307,13 +310,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('Smith')).toBeInTheDocument();
   });
 
-  test('Renders Identifier', () => {
+  test('Renders Identifier', async () => {
     const value: Identifier = {
       system: 'xyz',
       value: 'xyz123',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Identifier' }] }}
         propertyType={PropertyType.Identifier}
@@ -324,13 +327,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('xyz: xyz123')).toBeInTheDocument();
   });
 
-  test('Renders Period', () => {
+  test('Renders Period', async () => {
     const value: Period = {
       start: '2021-06-01T12:00:00Z',
       end: '2021-06-30T12:00:00Z',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Period' }] }}
         propertyType={PropertyType.Period}
@@ -341,13 +344,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('2021', { exact: false })).toBeInTheDocument();
   });
 
-  test('Renders Quantity', () => {
+  test('Renders Quantity', async () => {
     const value: Quantity = {
       value: 1,
       unit: 'mg',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Quantity' }] }}
         propertyType={PropertyType.Quantity}
@@ -358,13 +361,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('1 mg')).toBeInTheDocument();
   });
 
-  test('Renders Range', () => {
+  test('Renders Range', async () => {
     const value: Range = {
       low: { value: 5, unit: 'mg' },
       high: { value: 10, unit: 'mg' },
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Range' }] }}
         propertyType={PropertyType.Range}
@@ -375,13 +378,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('5 - 10 mg')).toBeInTheDocument();
   });
 
-  test('Renders Ratio', () => {
+  test('Renders Ratio', async () => {
     const value: Ratio = {
       numerator: { value: 5, unit: 'mg' },
       denominator: { value: 10, unit: 'ml' },
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
         property={{ ...baseProperty, type: [{ code: 'Ratio' }] }}
         propertyType={PropertyType.Ratio}
@@ -392,13 +395,13 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText('5 mg / 10 ml')).toBeInTheDocument();
   });
 
-  test('Renders Reference', () => {
+  test('Renders Reference', async () => {
     const value: Reference = {
       reference: 'Patient/123',
       display: 'John Smith',
     };
 
-    setup(
+    await setup(
       <MemoryRouter>
         <ResourcePropertyDisplay
           property={{ ...baseProperty, type: [{ code: 'Reference' }] }}
@@ -411,14 +414,15 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText(value.display as string)).toBeInTheDocument();
   });
 
-  test('Renders BackboneElement', () => {
+  test('Renders BackboneElement', async () => {
     const value: SubscriptionChannel = {
       type: 'rest-hook',
       endpoint: 'https://example.com/hook',
     };
 
-    setup(
+    await setup(
       <ResourcePropertyDisplay
+        path="Subscription.channel"
         property={{ ...baseProperty, path: 'Subscription.channel', type: [{ code: 'SubscriptionChannel' }] }}
         propertyType={PropertyType.BackboneElement}
         value={value}
@@ -428,11 +432,11 @@ describe('ResourcePropertyDisplay', () => {
     expect(screen.getByText(value.endpoint as string)).toBeInTheDocument();
   });
 
-  test('Handles unknown property', () => {
+  test('Handles unknown property', async () => {
     console.error = jest.fn();
-    expect(() => setup(<ResourcePropertyDisplay propertyType={PropertyType.BackboneElement} value={{}} />)).toThrow(
-      new Error('Displaying property of type BackboneElement requires element schema')
-    );
+    await expect(
+      setup(<ResourcePropertyDisplay propertyType={PropertyType.BackboneElement} value={{}} />)
+    ).rejects.toThrow('Displaying property of type BackboneElement requires element schema');
     expect(console.error).toHaveBeenCalled();
   });
 });

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -37,8 +37,9 @@ export interface ResourcePropertyDisplayProps {
   readonly maxWidth?: number;
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
+  /** (Optional) The `ElemendDefinitionType` to display the property against. Used when displaying extensions.  */
   readonly elementDefinitionType?: ElementDefinitionType;
-  /** (Optional) If true and `property` is an array, a DescriptionListEntry wraps the output  */
+  /** (Optional) If true and `property` is an array, output is wrapped with a DescriptionListEntry */
   readonly includeArrayDescriptionListEntry?: boolean;
 }
 
@@ -74,7 +75,15 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
 
   if (property?.max && property.max > 1 && !isArrayElement) {
     if (propertyType === PropertyType.Attachment) {
-      return <AttachmentArrayDisplay values={value} maxWidth={props.maxWidth} />;
+      return (
+        <AttachmentArrayDisplay
+          values={value}
+          maxWidth={props.maxWidth}
+          includeDescriptionListEntry={props.includeArrayDescriptionListEntry}
+          property={property}
+          path={props.path}
+        />
+      );
     }
     return (
       <ResourceArrayDisplay

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -70,6 +70,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     return (
       <ResourceArrayDisplay
         property={property}
+        propertyType={propertyType}
         values={value}
         ignoreMissingValues={props.ignoreMissingValues}
         link={props.link}

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -31,7 +31,7 @@ import classes from './ResourcePropertyDisplay.module.css';
 export interface ResourcePropertyDisplayProps {
   readonly property?: InternalSchemaElement;
   /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */
-  readonly path: string;
+  readonly path?: string;
   readonly propertyType: string;
   readonly value: any;
   readonly arrayElement?: boolean;
@@ -149,6 +149,9 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       return <>{formatTiming(value)}</>;
     case PropertyType.Dosage:
     case PropertyType.UsageContext:
+      if (!props.path) {
+        throw Error(`Displaying property of type ${props.propertyType} requires path`);
+      }
       return (
         <BackboneElementDisplay
           path={props.path}
@@ -158,6 +161,9 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
         />
       );
     case PropertyType.Extension:
+      if (!props.path) {
+        throw Error(`Displaying property of type ${props.propertyType} requires path`);
+      }
       return maybeWithLeftBorder(
         isArrayElement,
         <ExtensionDisplay
@@ -171,6 +177,9 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     default:
       if (!property) {
         throw Error(`Displaying property of type ${props.propertyType} requires element schema`);
+      }
+      if (!props.path) {
+        throw Error(`Displaying property of type ${props.propertyType} requires path`);
       }
       return maybeWithLeftBorder(
         isArrayElement,

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -26,7 +26,6 @@ import { ReferenceDisplay } from '../ReferenceDisplay/ReferenceDisplay';
 import { ResourceArrayDisplay } from '../ResourceArrayDisplay/ResourceArrayDisplay';
 import { ExtensionDisplay } from '../ExtensionDisplay/ExtensionDisplay';
 import { ElementDefinitionType } from '@medplum/fhirtypes';
-import classes from './ResourcePropertyDisplay.module.css';
 
 export interface ResourcePropertyDisplayProps {
   readonly property?: InternalSchemaElement;
@@ -39,10 +38,8 @@ export interface ResourcePropertyDisplayProps {
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
   readonly elementDefinitionType?: ElementDefinitionType;
-}
-
-function maybeWithLeftBorder(withLeftBorder: boolean, element: JSX.Element): JSX.Element {
-  return withLeftBorder ? <div className={classes.leftBorder}>{element}</div> : element;
+  /** (Optional) If true and `property` is an array, a DescriptionListEntry wraps the output  */
+  readonly includeArrayDescriptionListEntry?: boolean;
 }
 
 /**
@@ -85,6 +82,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
         property={property}
         propertyType={propertyType}
         values={value}
+        includeDescriptionListEntry={props.includeArrayDescriptionListEntry}
         ignoreMissingValues={props.ignoreMissingValues}
         link={props.link}
       />
@@ -164,8 +162,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       if (!props.path) {
         throw Error(`Displaying property of type ${props.propertyType} requires path`);
       }
-      return maybeWithLeftBorder(
-        isArrayElement,
+      return (
         <ExtensionDisplay
           path={props.path}
           value={value}
@@ -181,8 +178,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
       if (!props.path) {
         throw Error(`Displaying property of type ${props.propertyType} requires path`);
       }
-      return maybeWithLeftBorder(
-        isArrayElement,
+      return (
         <BackboneElementDisplay
           path={props.path}
           value={{ type: property.type[0].code, value }}

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.utils.ts
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.utils.ts
@@ -13,10 +13,11 @@ import {
  * This function returns the value and the type.
  * @param context - The base context (usually a FHIR resource).
  * @param path - The property path.
+ * @param profileUrl - The property path.
  * @returns The value of the property and the property type.
  */
-export function getValueAndType(context: TypedValue, path: string): [any, string] {
-  const typedResult = getTypedPropertyValue(context, path);
+export function getValueAndType(context: TypedValue, path: string, profileUrl?: string): [any, string] {
+  const typedResult = getTypedPropertyValue(context, path, { profileUrl });
   if (!typedResult) {
     return [undefined, 'undefined'];
   }

--- a/packages/react/src/ResourceTable/ResourceTable.stories.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.stories.tsx
@@ -1,4 +1,9 @@
-import { HomerObservation1, HomerSimpson } from '@medplum/mock';
+import {
+  HomerObservation1,
+  HomerSimpson,
+  HomerSimpsonUSCorePatient,
+  USCoreStructureDefinitionList,
+} from '@medplum/mock';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import {
@@ -8,6 +13,10 @@ import {
   Covid19ReviewReport,
 } from '../stories/covid19';
 import { ResourceTable } from './ResourceTable';
+import { MedplumClient, RequestProfileSchemaOptions, deepClone, loadDataType } from '@medplum/core';
+import { StructureDefinition } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react-hooks';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 export default {
   title: 'Medplum/ResourceTable',
@@ -55,3 +64,79 @@ export const Covid19ObservationDefinition = (): JSX.Element => (
     <ResourceTable value={Covid19PCRObservationDefinition} ignoreMissingValues={true} />
   </Document>
 );
+
+function useUSCoreDataTypes({ medplum }: { medplum: MedplumClient }): { loaded: boolean } {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    (async (): Promise<boolean> => {
+      for (const sd of USCoreStructureDefinitionList) {
+        loadDataType(sd, sd.url);
+      }
+      return true;
+    })()
+      .then(setLoaded)
+      .catch(console.error);
+  }, [medplum]);
+
+  const result = useMemo(() => {
+    return { loaded };
+  }, [loaded]);
+
+  return result;
+}
+
+function useFakeRequestProfileSchema(medplum: MedplumClient): void {
+  useLayoutEffect(() => {
+    const realRequestProfileSchema = medplum.requestProfileSchema;
+    async function fakeRequestProfileSchema(
+      profileUrl: string,
+      options?: RequestProfileSchemaOptions
+    ): Promise<string[]> {
+      console.log(
+        'Fake medplum.requestProfileSchema invoked but not doing anything; ensure expected profiles are already loaded',
+        profileUrl,
+        options
+      );
+      return [profileUrl];
+    }
+
+    medplum.requestProfileSchema = fakeRequestProfileSchema;
+
+    return () => {
+      medplum.requestProfileSchema = realRequestProfileSchema;
+    };
+  }, [medplum]);
+}
+
+function useUSCoreProfile(profileName: string): StructureDefinition {
+  const profileSD = useMemo<StructureDefinition>(() => {
+    const result = USCoreStructureDefinitionList.find((sd) => sd.name === profileName);
+    if (!result) {
+      throw new Error(`Could not find ${profileName}`);
+    }
+    return result;
+  }, [profileName]);
+
+  return profileSD;
+}
+
+export const USCorePatient = (): JSX.Element => {
+  const medplum = useMedplum();
+  useFakeRequestProfileSchema(medplum);
+  const { loaded } = useUSCoreDataTypes({ medplum });
+  const profileSD = useUSCoreProfile('USCorePatientProfile');
+
+  const homerSimpsonUSCorePatient = useMemo(() => {
+    return deepClone(HomerSimpsonUSCorePatient);
+  }, []);
+
+  if (!loaded) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Document>
+      <ResourceTable value={homerSimpsonUSCorePatient} profileUrl={profileSD.url} ignoreMissingValues />
+    </Document>
+  );
+};

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -1,15 +1,18 @@
-import { MockClient } from '@medplum/mock';
+import { HomerSimpsonUSCorePatient, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '../test-utils/render';
 import { ResourceTable, ResourceTableProps } from './ResourceTable';
+import { HTTP_HL7_ORG, loadDataType } from '@medplum/core';
+import { StructureDefinition } from '@medplum/fhirtypes';
+import { readJson } from '@medplum/definitions';
 
 const medplum = new MockClient();
 
 describe('ResourceTable', () => {
-  async function setup(props: ResourceTableProps): Promise<void> {
+  async function setup(props: ResourceTableProps, client?: MockClient): Promise<void> {
     await act(async () => {
       render(
-        <MedplumProvider medplum={medplum}>
+        <MedplumProvider medplum={client ?? medplum}>
           <ResourceTable {...props} />
         </MedplumProvider>
       );
@@ -54,5 +57,45 @@ describe('ResourceTable', () => {
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.queryByText('Gender')).toBeNull();
+  });
+
+  test.only('US Core Patient profile', async () => {
+    const USCoreStructureDefinitions = readJson(
+      'fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json'
+    ) as StructureDefinition[];
+    const profileUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-patient`;
+    const raceExtensionUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-race`;
+    const ethnicityExtensionUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-ethnicity`;
+    const profileUrls = [
+      profileUrl,
+      raceExtensionUrl,
+      ethnicityExtensionUrl,
+      `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-birthsex`,
+      `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-genderIdentity`,
+    ];
+    for (const url of profileUrls) {
+      const sd = USCoreStructureDefinitions.find((sd) => sd.url === url);
+      if (!sd) {
+        fail(`could not find structure definition for ${url}`);
+      }
+      loadDataType(sd, sd.url);
+    }
+
+    const mockedMedplum = new MockClient();
+    const fakeRequestProfileSchema = jest.fn(async (profileUrl: string) => {
+      return [profileUrl];
+    });
+    mockedMedplum.requestProfileSchema = fakeRequestProfileSchema;
+
+    const value = HomerSimpsonUSCorePatient;
+    await setup({ value, profileUrl }, mockedMedplum);
+
+    expect(screen.getByText('Race')).toBeInTheDocument();
+    expect(screen.getAllByText('OMB Category')).toHaveLength(2);
+    expect(screen.getByText('Ethnicity')).toBeInTheDocument();
+    expect(screen.getByText('Not Hispanic or Latino')).toBeInTheDocument();
+    expect(screen.getByText('Birthsex')).toBeInTheDocument();
+    expect(screen.getByText('Gender Identity')).toBeInTheDocument();
+    expect(screen.getByText('Male')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -59,7 +59,7 @@ describe('ResourceTable', () => {
     expect(screen.queryByText('Gender')).toBeNull();
   });
 
-  test.only('US Core Patient profile', async () => {
+  test('US Core Patient profile', async () => {
     const USCoreStructureDefinitions = readJson(
       'fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json'
     ) as StructureDefinition[];

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -2,7 +2,7 @@ import { Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { useEffect, useState } from 'react';
 import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
-import { isPopulated, tryGetProfile } from '@medplum/core';
+import { tryGetProfile } from '@medplum/core';
 
 export interface ResourceTableProps {
   /**
@@ -28,16 +28,10 @@ export interface ResourceTableProps {
 }
 
 export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
+  const { profileUrl } = props;
   const medplum = useMedplum();
   const value = useResource(props.value);
   const [schemaLoaded, setSchemaLoaded] = useState<string>();
-  // TODO{mattlong} - This is a hack to get the profile URL from the resource;
-  // There should be a UI to select a profile from the resource instead similar to the profile tabs in ResourceForm
-  const profileUrls = value?.meta?.profile;
-  if (isPopulated(profileUrls)) {
-    console.log(`Resource has ${profileUrls.length} profiles`);
-  }
-  const profileUrl: string | undefined = props.profileUrl ?? profileUrls?.[0];
 
   useEffect(() => {
     if (!value) {

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -22,6 +22,9 @@ export interface ResourceTableProps {
    * and not use the latest version.
    */
   readonly forceUseInput?: boolean;
+
+  /** (optional) URL of the resource profile used to display the form. */
+  readonly profileUrl?: string;
 }
 
 export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
@@ -34,7 +37,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
   if (isPopulated(profileUrls)) {
     console.log(`Resource has ${profileUrls.length} profiles`);
   }
-  const profileUrl: string | undefined = profileUrls?.[0];
+  const profileUrl: string | undefined = props.profileUrl ?? profileUrls?.[0];
 
   useEffect(() => {
     if (!value) {

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -72,6 +72,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
 
   return (
     <BackboneElementDisplay
+      path={value.resourceType}
       value={{
         type: schemaLoaded,
         value: props.forceUseInput ? props.value : value,

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -548,6 +548,7 @@ function renderPropertyValue(resource: Resource, elementDefinition: InternalSche
 
   return (
     <ResourcePropertyDisplay
+      path={elementDefinition.path}
       property={elementDefinition}
       propertyType={propertyType}
       value={value}

--- a/packages/react/src/SliceDisplay/SliceDisplay.tsx
+++ b/packages/react/src/SliceDisplay/SliceDisplay.tsx
@@ -1,0 +1,64 @@
+import {
+  SliceDefinitionWithTypes,
+  InternalSchemaElement,
+  ElementsContextType,
+  buildElementsContext,
+  isPopulated,
+} from '@medplum/core';
+import { useContext, useMemo } from 'react';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+
+export interface SliceDisplayProps {
+  readonly path: string;
+  readonly slice: SliceDefinitionWithTypes;
+  readonly property: InternalSchemaElement;
+  readonly value: any[];
+  readonly ignoreMissingValues?: boolean;
+  readonly link?: boolean;
+  readonly testId?: string;
+}
+
+export function SliceDisplay(props: SliceDisplayProps): JSX.Element {
+  const { slice, property } = props;
+
+  const sliceElements = slice.typeSchema?.elements ?? slice.elements;
+
+  const parentContext = useContext(ElementsContext);
+
+  const contextValue: ElementsContextType | undefined = useMemo(() => {
+    if (isPopulated(sliceElements)) {
+      return buildElementsContext({
+        parentContext: parentContext,
+        elements: sliceElements,
+        path: props.path,
+        profileUrl: slice.typeSchema?.url,
+      });
+    }
+    console.assert(false, 'Expected sliceElements to always be populated', props.path);
+    return undefined;
+  }, [parentContext, props.path, slice.typeSchema?.url, sliceElements]);
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    contextValue,
+    <>
+      {props.value.map((value, valueIndex) => {
+        return (
+          <ResourcePropertyDisplay
+            key={`${valueIndex}-${value.length}`}
+            property={property}
+            path={props.path}
+            arrayElement={true}
+            elementDefinitionType={slice.type[0]}
+            propertyType={slice.type[0].code}
+            value={value}
+            ignoreMissingValues={props.ignoreMissingValues}
+            link={props.link}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/packages/react/src/SliceDisplay/SliceDisplay.tsx
+++ b/packages/react/src/SliceDisplay/SliceDisplay.tsx
@@ -47,7 +47,7 @@ export function SliceDisplay(props: SliceDisplayProps): JSX.Element {
       {props.value.map((value, valueIndex) => {
         return (
           <ResourcePropertyDisplay
-            key={`${valueIndex}-${value.length}`}
+            key={`${valueIndex}-${props.value.length}`}
             property={property}
             path={props.path}
             arrayElement={true}

--- a/packages/react/src/SliceDisplay/SliceDisplay.tsx
+++ b/packages/react/src/SliceDisplay/SliceDisplay.tsx
@@ -17,7 +17,6 @@ export interface SliceDisplayProps {
   readonly value: any[];
   readonly ignoreMissingValues?: boolean;
   readonly link?: boolean;
-  readonly testId?: string;
 }
 
 export function SliceDisplay(props: SliceDisplayProps): JSX.Element {
@@ -46,17 +45,18 @@ export function SliceDisplay(props: SliceDisplayProps): JSX.Element {
     <>
       {props.value.map((value, valueIndex) => {
         return (
-          <ResourcePropertyDisplay
-            key={`${valueIndex}-${props.value.length}`}
-            property={property}
-            path={props.path}
-            arrayElement={true}
-            elementDefinitionType={slice.type[0]}
-            propertyType={slice.type[0].code}
-            value={value}
-            ignoreMissingValues={props.ignoreMissingValues}
-            link={props.link}
-          />
+          <div key={`${valueIndex}-${props.value.length}`}>
+            <ResourcePropertyDisplay
+              property={property}
+              path={props.path}
+              arrayElement={true}
+              elementDefinitionType={slice.type[0]}
+              propertyType={slice.type[0].code}
+              value={value}
+              ignoreMissingValues={props.ignoreMissingValues}
+              link={props.link}
+            />
+          </div>
         );
       })}
     </>

--- a/packages/server/src/fhir/operations/structuredefinitionexpandprofile.test.ts
+++ b/packages/server/src/fhir/operations/structuredefinitionexpandprofile.test.ts
@@ -58,7 +58,7 @@ describe('StructureDefinition $expand-profile', () => {
     await createSDs(expectedProfiles, accessToken);
 
     const res = await request(app)
-      .get(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
+      .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
     expect(res.status).toEqual(200);
@@ -79,7 +79,7 @@ describe('StructureDefinition $expand-profile', () => {
     await createSDs(expectedProfiles, accessToken);
 
     const res = await request(app)
-      .get(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
+      .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
     expect(res.status).toEqual(200);
@@ -98,7 +98,7 @@ describe('StructureDefinition $expand-profile', () => {
     // Note that nothing is created in the database, so we expect an empty bundle
 
     const res = await request(app)
-      .get(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
+      .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
     expect(res.status).toEqual(400);
@@ -106,7 +106,7 @@ describe('StructureDefinition $expand-profile', () => {
 
   test('Profile URL not specified', async () => {
     const res = await request(app)
-      .get(`/fhir/R4/StructureDefinition/$expand-profile`)
+      .post(`/fhir/R4/StructureDefinition/$expand-profile`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
     expect(res.status).toEqual(400);
@@ -119,7 +119,7 @@ describe('StructureDefinition $expand-profile', () => {
     expect(sds.length).toBe(extensionCount + 1);
     const profileUrl = sds[0].url;
     const res = await request(app)
-      .get(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
+      .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
     expect(res.status).toEqual(200);
@@ -137,7 +137,7 @@ describe('StructureDefinition $expand-profile', () => {
     expect(sds.length).toBe(extensionCount + 1);
     const profileUrl = sds[0].url;
     const res = await request(app)
-      .get(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
+      .post(`/fhir/R4/StructureDefinition/$expand-profile?url=${profileUrl}`)
       .set('Authorization', 'Bearer ' + accessToken)
       .send();
     expect(res.status).toEqual(200);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -166,7 +166,10 @@ protectedRoutes.post('/:resourceType/:id/([$]|%24)expunge', asyncWrap(expungeHan
 protectedRoutes.get('/Subscription/:id/([$]|%24)get-ws-binding-token', asyncWrap(getWsBindingTokenHandler));
 
 // StructureDefinition $expand-profile operation
-protectedRoutes.get('/StructureDefinition/([$]|%24)expand-profile', asyncWrap(structureDefinitionExpandProfileHandler));
+protectedRoutes.post(
+  '/StructureDefinition/([$]|%24)expand-profile',
+  asyncWrap(structureDefinitionExpandProfileHandler)
+);
 
 // Validate create resource
 protectedRoutes.post(


### PR DESCRIPTION
`ResourceTable` now displays array slices and extensions (when the supporting profile is available).

Each slice of an array appears as its own separate row in the table. Achieving this somewhat complicated the props of `ResourcePropertyDisplay` and some other components, but it was all done in what I believe was a fully backwards compatible way.

Slice and extension support reused a lot of code from their `ResourceForm` equivalents which was nice to see. I didn't bother to DRY up all the duplicated code since it was all fairly straightforward blocks of code that I didn't think merit abstracting away just yet.

I also tweaked the general table display to not put a border above the first row and have more symmetric padding at the top/bottom of the table. However, in reviewing the storybook diffs, I'm not so sure removing the border above the first row is desirable across the board. e.g. in the timeline components, the top border might actually be beneficial. On `DetailPage`, where `ResourceTable` is displayed standalone, it looks cleaner without that top border. Open to changing it back or adding an optional prop on `ResourceTable` to control inclusion of the top border.

Also, notice the new UI in the top right of the screenshot below for selecting the profile to display on the details page. The select input is only displayed when profiles exist in `resource.meta.profile`.

![Screenshot 2024-02-27 at 4 14 27 PM](https://github.com/medplum/medplum/assets/933303/7bdfa78c-eb04-4432-a5d4-aa6224c4c9bc)
