### PR TITLE
Replace waitFor/getBy with findBy

### DIFF
--- a/packages/app/src/BatchPage.test.tsx
+++ b/packages/app/src/BatchPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { BatchPage } from './BatchPage';
-import { act, fireEvent, render, RenderResult, screen, waitFor } from './test-utils/render';
+import { act, fireEvent, render, RenderResult, screen } from './test-utils/render';
 
 const exampleBundle = `{
   "resourceType": "Bundle",
@@ -52,10 +52,9 @@ describe('BatchPage', () => {
       fireEvent.change(fileInput, { target: { files } });
     });
 
-    await waitFor(async () => expect(screen.getByText('Output')).toBeInTheDocument());
-    expect(screen.getByText('Output')).toBeInTheDocument();
-
+    expect(await screen.findByText('Output')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Start over' })).toBeInTheDocument();
+
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Start over' }));
     });
@@ -82,10 +81,9 @@ describe('BatchPage', () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
-    await waitFor(async () => expect(screen.getByText('Output')).toBeInTheDocument());
-    expect(screen.getByText('Output')).toBeInTheDocument();
-
+    expect(await screen.findByText('Output')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Start over' })).toBeInTheDocument();
+
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Start over' }));
     });

--- a/packages/app/src/BulkAppPage.test.tsx
+++ b/packages/app/src/BulkAppPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
-import { act, render, screen, waitFor } from './test-utils/render';
+import { act, render, screen } from './test-utils/render';
 
 const medplum = new MockClient();
 
@@ -28,25 +28,21 @@ describe('BulkAppPage', () => {
 
   test('Patient apps', async () => {
     await setup('/bulk/Patient?ids=123,456');
-    await waitFor(() => screen.getByText('Vitals'));
-    expect(screen.getByText('Vitals')).toBeInTheDocument();
+    expect(await screen.findByText('Vitals')).toBeInTheDocument();
   });
 
   test('No apps for resource type', async () => {
     await setup('/bulk/DeviceDefinition?ids=123');
-    await waitFor(() => screen.getByText('No apps for DeviceDefinition'));
-    expect(screen.getByText('No apps for DeviceDefinition')).toBeInTheDocument();
+    expect(await screen.findByText('No apps for DeviceDefinition')).toBeInTheDocument();
   });
 
   test('No query params', async () => {
     await setup('/bulk/Patient');
-    await waitFor(() => screen.getByText('Vitals'));
-    expect(screen.getByText('Vitals')).toBeInTheDocument();
+    expect(await screen.findByText('Vitals')).toBeInTheDocument();
   });
 
   test('Empty IDs', async () => {
     await setup('/bulk/Patient?ids=123,,,');
-    await waitFor(() => screen.getByText('Vitals'));
-    expect(screen.getByText('Vitals')).toBeInTheDocument();
+    expect(await screen.findByText('Vitals')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/CreateResourcePage.test.tsx
+++ b/packages/app/src/CreateResourcePage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from './test-utils/render';
+import { act, fireEvent, render, screen } from './test-utils/render';
 
 const medplum = new MockClient();
 
@@ -22,15 +22,14 @@ describe('CreateResourcePage', () => {
   function formViewTests(url: string): undefined {
     test('Renders new Practitioner form page', async () => {
       await setup(url);
-      await waitFor(() => screen.getByText('New Practitioner'));
-      expect(screen.getByText('New Practitioner')).toBeInTheDocument();
+      expect(await screen.findByText('New Practitioner')).toBeInTheDocument();
       expect(screen.getByText('Resource Type')).toBeInTheDocument();
       expect(screen.getByText('OK')).toBeInTheDocument();
     });
 
     test('Form submit new Practitioner', async () => {
       await setup(url);
-      await waitFor(() => screen.getByText('OK'));
+      expect(await screen.findByText('OK')).toBeInTheDocument();
       await act(async () => {
         fireEvent.click(screen.getByText('OK'));
       });
@@ -50,14 +49,13 @@ describe('CreateResourcePage', () => {
 
     test('JSON tab renders', async () => {
       await setup('/Patient/new/json');
-      await waitFor(() => screen.getByTestId(JSON_INPUT_TEST_ID));
-      expect(screen.getByTestId(JSON_INPUT_TEST_ID)).toBeInTheDocument();
+      expect(await screen.findByTestId(JSON_INPUT_TEST_ID)).toBeInTheDocument();
       expect(screen.getByText('OK')).toBeInTheDocument();
     });
 
     test('JSON submit new Practitioner', async () => {
       await setup('/Practitioner/new/json');
-      await waitFor(() => screen.getByTestId(JSON_INPUT_TEST_ID));
+      expect(await screen.findByTestId(JSON_INPUT_TEST_ID)).toBeInTheDocument();
 
       await act(async () => {
         fireEvent.change(screen.getByTestId(JSON_INPUT_TEST_ID), {

--- a/packages/app/src/FormPage.test.tsx
+++ b/packages/app/src/FormPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from './test-utils/render';
+import { act, fireEvent, render, screen } from './test-utils/render';
 
 const medplum = new MockClient();
 
@@ -21,19 +21,17 @@ describe('FormPage', () => {
 
   test('Not found', async () => {
     await setup('/forms/not-found');
-    await waitFor(() => screen.getByTestId('error'));
-    expect(screen.getByTestId('error')).toBeInTheDocument();
+    expect(await screen.findByTestId('error')).toBeInTheDocument();
   });
 
   test('Form renders', async () => {
     await setup('/forms/123');
-    await waitFor(() => screen.getByText('First question'));
-    expect(screen.getByText('First question')).toBeInTheDocument();
+    expect(await screen.findByText('First question')).toBeInTheDocument();
   });
 
   test('Submit', async () => {
     await setup('/forms/123');
-    await waitFor(() => screen.getByText('First question'));
+    expect(await screen.findByText('First question')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Submit'));
@@ -44,9 +42,7 @@ describe('FormPage', () => {
 
   test('Patient subject', async () => {
     await setup('/forms/123?subject=Patient/123&');
-    await waitFor(() => screen.getByText('First question'));
-
-    expect(screen.getByText('First question')).toBeInTheDocument();
+    expect(await screen.findByText('First question')).toBeInTheDocument();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
 
     await act(async () => {
@@ -56,17 +52,13 @@ describe('FormPage', () => {
 
   test('ServiceRequest subject', async () => {
     await setup('/forms/123?subject=ServiceRequest/123');
-    await waitFor(() => screen.getByText('First question'));
-
-    expect(screen.getByText('First question')).toBeInTheDocument();
+    expect(await screen.findByText('First question')).toBeInTheDocument();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Multiple subjects', async () => {
     await setup('/forms/123?subject=ServiceRequest/123,ServiceRequest/456');
-    await waitFor(() => screen.getByText('First question'));
-
-    expect(screen.getByText('First question')).toBeInTheDocument();
+    expect(await screen.findByText('First question')).toBeInTheDocument();
     expect(screen.getByText('Vitals (for 2 resources)')).toBeInTheDocument();
     expect(screen.queryByText('Homer Simpson')).not.toBeInTheDocument();
   });

--- a/packages/app/src/HomePage.test.tsx
+++ b/packages/app/src/HomePage.test.tsx
@@ -30,31 +30,22 @@ describe('HomePage', () => {
 
   test('Renders default page', async () => {
     await setup('/');
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Renders with resourceType', async () => {
     await setup('/Patient');
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Renders with resourceType and fields', async () => {
     await setup('/Patient?_fields=id,_lastUpdated,name,birthDate,gender');
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Next page button', async () => {
     await setup();
-    await waitFor(() => screen.getByLabelText('Next page'));
+    expect(await screen.findByLabelText('Next page')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Next page'));
@@ -63,7 +54,7 @@ describe('HomePage', () => {
 
   test('Prev page button', async () => {
     await setup();
-    await waitFor(() => screen.getByLabelText('Previous page'));
+    expect(await screen.findByLabelText('Previous page')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Previous page'));
@@ -72,7 +63,7 @@ describe('HomePage', () => {
 
   test('New button', async () => {
     await setup();
-    await waitFor(() => screen.getByText('New...'));
+    expect(await screen.findByText('New...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('New...'));
@@ -96,7 +87,7 @@ describe('HomePage', () => {
     expect(typeof RESOURCE_TYPE_CREATION_PATHS['Bot']).toBe('string');
 
     await setup(`/Bot`, medplum);
-    await waitFor(() => screen.getByText('New...'));
+    expect(await screen.findByText('New...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('New...'));
@@ -109,7 +100,7 @@ describe('HomePage', () => {
     window.confirm = jest.fn(() => false);
 
     await setup();
-    await waitFor(() => screen.getByText('Delete...'));
+    expect(await screen.findByText('Delete...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Delete...'));
@@ -131,9 +122,9 @@ describe('HomePage', () => {
     await setup('/Patient', medplum);
 
     // Make sure the patient is on the screen
-    await waitFor(() => screen.getByText(family));
+    expect(await screen.findByText(family)).toBeInTheDocument();
 
-    await waitFor(() => screen.getByText('Delete...'));
+    expect(await screen.findByText('Delete...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText(`Checkbox for ${patient.id}`));
@@ -156,7 +147,7 @@ describe('HomePage', () => {
     medplum.router.router.add('GET', ':resourceType/$csv', async () => [allOk]);
 
     await setup('/Patient', medplum);
-    await waitFor(() => screen.getByText('Export...'));
+    expect(await screen.findByText('Export...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Export...'));
@@ -176,7 +167,7 @@ describe('HomePage', () => {
     HTMLAnchorElement.prototype.click = jest.fn();
 
     await setup('/Patient', medplum);
-    await waitFor(() => screen.getByText('Export...'));
+    expect(await screen.findByText('Export...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Export...'));
@@ -221,7 +212,7 @@ describe('HomePage', () => {
     window.open = jest.fn();
 
     await setup('/Patient');
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Homer Simpson'));
@@ -238,7 +229,7 @@ describe('HomePage', () => {
     window.open = jest.fn();
 
     await setup('/Patient');
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Homer Simpson'), { button: 1 });

--- a/packages/app/src/OAuthPage.test.tsx
+++ b/packages/app/src/OAuthPage.test.tsx
@@ -66,7 +66,7 @@ describe('OAuthPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
     });
 
-    await waitFor(() => expect(screen.getByText('Choose scope')).toBeInTheDocument());
+    expect(await screen.findByText('Choose scope')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Set scope' }));

--- a/packages/app/src/SecurityPage.test.tsx
+++ b/packages/app/src/SecurityPage.test.tsx
@@ -4,7 +4,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from './test-utils/render';
+import { act, fireEvent, render, screen } from './test-utils/render';
 
 const medplum = new MockClient();
 
@@ -56,7 +56,6 @@ describe('SecurityPage', () => {
       fireEvent.click(revokeLinks[1]);
     });
 
-    await waitFor(() => screen.getByText('Login revoked'));
-    expect(screen.getByText('Login revoked')).toBeInTheDocument();
+    expect(await screen.findByText('Login revoked')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/SignInPage.test.tsx
+++ b/packages/app/src/SignInPage.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';
 import { getConfig } from './config';
-import { act, fireEvent, render, screen, waitFor } from './test-utils/render';
+import { act, fireEvent, render, screen } from './test-utils/render';
 
 // logged out
 const medplum = new MockClient({ profile: null });
@@ -62,8 +62,7 @@ describe('SignInPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
     });
 
-    await waitFor(() => screen.getByTestId('search-control'));
-    expect(screen.getByTestId('search-control')).toBeInTheDocument();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Forgot password', async () => {
@@ -118,8 +117,7 @@ describe('SignInPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
     });
 
-    await waitFor(() => screen.getByText('Batch Create'));
-    expect(screen.getByText('Batch Create')).toBeInTheDocument();
+    expect(await screen.findByText('Batch Create')).toBeInTheDocument();
   });
 
   test('Redirects to homepage after login if bad next', async () => {
@@ -142,8 +140,7 @@ describe('SignInPage', () => {
     });
 
     // should redirect to the homepage
-    await waitFor(() => screen.getByTestId('search-control'));
-    expect(screen.getByTestId('search-control')).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Does NOT automatically redirect to next if logged in and next NOT present', async () => {
@@ -155,15 +152,13 @@ describe('SignInPage', () => {
   test('Automatically redirects to next if logged in and next present', async () => {
     setup('/signin?next=/batch', new MockClient({ profile: DrAliceSmith }));
 
-    await waitFor(() => screen.getByText('Batch Create'));
-    expect(screen.getByText('Batch Create')).toBeInTheDocument();
+    expect(await screen.findByText('Batch Create')).toBeInTheDocument();
   });
 
   test('Automatically redirects to homepage if logged with bad next', async () => {
     setup('/signin?next=https%3A%2F%2Fevil.com', new MockClient({ profile: DrAliceSmith }));
 
     // should redirect to the homepage
-    await waitFor(() => screen.getByTestId('search-control'));
-    expect(screen.getByTestId('search-control')).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/SmartSearchPage.test.tsx
+++ b/packages/app/src/SmartSearchPage.test.tsx
@@ -4,7 +4,7 @@ import { FhirPathTableField, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from './AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from './test-utils/render';
+import { act, fireEvent, render, screen } from './test-utils/render';
 
 const query = `{
 ResourceList: ServiceRequestList {
@@ -113,17 +113,14 @@ describe('SmartSearchPage', () => {
 
   test('Renders success', async () => {
     await setup(`/smart?resourceType=ServiceRequest&query=${query}&fields=${JSON.stringify(fields)}`);
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Left click on row', async () => {
     window.open = jest.fn();
 
     await setup(`/smart?resourceType=ServiceRequest&query=${query}&fields=${JSON.stringify(fields)}`);
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Homer Simpson'));
@@ -140,7 +137,7 @@ describe('SmartSearchPage', () => {
     window.open = jest.fn();
 
     await setup(`/smart?resourceType=ServiceRequest&query=${query}&fields=${JSON.stringify(fields)}`);
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Homer Simpson'), { button: 1 });

--- a/packages/app/src/admin/CreateBotPage.test.tsx
+++ b/packages/app/src/admin/CreateBotPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -45,15 +45,12 @@ describe('CreateBotPage', () => {
 
   test('Renders', async () => {
     await setup('/admin/bots/new');
-    await waitFor(() => screen.getByText('Create Bot'));
-    expect(screen.getByText('Create Bot')).toBeInTheDocument();
+    expect(await screen.findByText('Create Bot')).toBeInTheDocument();
   });
 
   test('Submit success', async () => {
     await setup('/admin/bots/new');
-    await waitFor(() => screen.getByText('Create Bot'));
-
-    expect(screen.getByText('Create Bot')).toBeInTheDocument();
+    expect(await screen.findByText('Create Bot')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Name'), {
@@ -73,9 +70,7 @@ describe('CreateBotPage', () => {
 
   test('Submit with access policy', async () => {
     await setup('/admin/bots/new');
-    await waitFor(() => screen.getByText('Create Bot'));
-
-    expect(screen.getByText('Create Bot')).toBeInTheDocument();
+    expect(await screen.findByText('Create Bot')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Name'), {

--- a/packages/app/src/admin/CreateClientPage.test.tsx
+++ b/packages/app/src/admin/CreateClientPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -45,15 +45,12 @@ describe('CreateClientPage', () => {
 
   test('Renders', async () => {
     await setup('/admin/clients/new');
-    await waitFor(() => screen.getByText('Create Client'));
-    expect(screen.getByText('Create Client')).toBeInTheDocument();
+    expect(await screen.findByText('Create Client')).toBeInTheDocument();
   });
 
   test('Submit success', async () => {
     await setup('/admin/clients/new');
-    await waitFor(() => screen.getByText('Create Client'));
-
-    expect(screen.getByText('Create Client')).toBeInTheDocument();
+    expect(await screen.findByText('Create Client')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Name'), {
@@ -76,9 +73,7 @@ describe('CreateClientPage', () => {
 
   test('Submit with access policy', async () => {
     await setup('/admin/clients/new');
-    await waitFor(() => screen.getByText('Create Client'));
-
-    expect(screen.getByText('Create Client')).toBeInTheDocument();
+    expect(await screen.findByText('Create Client')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Name'), {

--- a/packages/app/src/admin/EditMembershipPage.test.tsx
+++ b/packages/app/src/admin/EditMembershipPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 let medplum = new MockClient();
 
@@ -44,9 +44,7 @@ describe('EditMembershipPage', () => {
 
   test('Renders', async () => {
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     const badgeElement = screen.getByText('Alice Smith');
     expect(badgeElement).toBeInTheDocument();
@@ -55,9 +53,7 @@ describe('EditMembershipPage', () => {
 
   test('Submit success', async () => {
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Save'));
@@ -68,9 +64,7 @@ describe('EditMembershipPage', () => {
 
   test('Submit with access policy', async () => {
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     const input = screen.getByPlaceholderText('Access Policy') as HTMLInputElement;
 
@@ -103,9 +97,7 @@ describe('EditMembershipPage', () => {
 
   test('Submit with user configuration', async () => {
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     const input = screen.getByPlaceholderText('User Configuration') as HTMLInputElement;
 
@@ -140,9 +132,7 @@ describe('EditMembershipPage', () => {
     const medplumPostSpy = jest.spyOn(medplum, 'post');
 
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     const input = screen.getByLabelText('Admin') as HTMLInputElement;
 
@@ -168,9 +158,7 @@ describe('EditMembershipPage', () => {
     const medplumPostSpy = jest.spyOn(medplum, 'post');
 
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
-
-    expect(screen.getByText('Save')).toBeInTheDocument();
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     const input = screen.getByLabelText('Admin') as HTMLInputElement;
 
@@ -200,7 +188,7 @@ describe('EditMembershipPage', () => {
 
   test('Remove user accept confirm', async () => {
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     expect(screen.getByText('Remove user')).toBeInTheDocument();
 
@@ -215,7 +203,7 @@ describe('EditMembershipPage', () => {
 
   test('Remove user reject confirm', async () => {
     await setup('/admin/members/456');
-    await waitFor(() => screen.getByText('Save'));
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     expect(screen.getByText('Remove user')).toBeInTheDocument();
 

--- a/packages/app/src/admin/InvitePage.test.tsx
+++ b/packages/app/src/admin/InvitePage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -45,16 +45,12 @@ describe('InvitePage', () => {
 
   test('Renders', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
   });
 
   test('Submit success', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('First Name *'), {
@@ -78,9 +74,7 @@ describe('InvitePage', () => {
 
   test('Submit with access policy', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('First Name *'), {
@@ -125,9 +119,7 @@ describe('InvitePage', () => {
 
   test('Invite patient', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Role'), {
@@ -153,9 +145,7 @@ describe('InvitePage', () => {
 
   test('Invite admin', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Role'), {
@@ -185,9 +175,7 @@ describe('InvitePage', () => {
 
   test('Do not send email', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('First Name *'), {
@@ -215,9 +203,7 @@ describe('InvitePage', () => {
 
   test('Show error with bad email', async () => {
     await setup('/admin/invite');
-    await waitFor(() => screen.getByText('Invite'));
-
-    expect(screen.getByText('Invite')).toBeInTheDocument();
+    expect(await screen.findByText('Invite')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('First Name *'), {

--- a/packages/app/src/admin/ProjectPage.test.tsx
+++ b/packages/app/src/admin/ProjectPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -34,19 +34,17 @@ describe('ProjectPage', () => {
 
   test('Renders', async () => {
     await setup('/admin/details');
-    await waitFor(() => screen.queryAllByText('Project 123'));
-    expect(screen.queryAllByText('Project 123')).toHaveLength(2);
+    expect(await screen.findAllByText('Project 123')).toHaveLength(2);
   });
 
   test('Backwards compat', async () => {
     await setup('/admin/project');
-    await waitFor(() => screen.queryAllByText('Project 123'));
-    expect(screen.queryAllByText('Project 123')).toHaveLength(2);
+    expect(await screen.findAllByText('Project 123')).toHaveLength(2);
   });
 
   test('Tab change', async () => {
     await setup('/admin/details');
-    await waitFor(() => screen.getByText('Users'));
+    expect(await screen.findByText('Users')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Users'));
@@ -57,25 +55,21 @@ describe('ProjectPage', () => {
 
   test('Users page', async () => {
     await setup('/admin/users');
-    await waitFor(() => screen.getByText('Invite new user'));
-    expect(screen.getByText('Invite new user')).toBeInTheDocument();
+    expect(await screen.findByText('Invite new user')).toBeInTheDocument();
   });
 
   test('Patients page', async () => {
     await setup('/admin/patients');
-    await waitFor(() => screen.getByText('Invite new patient'));
-    expect(screen.getByText('Invite new patient')).toBeInTheDocument();
+    expect(await screen.findByText('Invite new patient')).toBeInTheDocument();
   });
 
   test('Clients page', async () => {
     await setup('/admin/clients');
-    await waitFor(() => screen.getByText('Create new client'));
-    expect(screen.getByText('Create new client')).toBeInTheDocument();
+    expect(await screen.findByText('Create new client')).toBeInTheDocument();
   });
 
   test('Bots page', async () => {
     await setup('/admin/bots');
-    await waitFor(() => screen.getByText('Create new bot'));
-    expect(screen.getByText('Create new bot')).toBeInTheDocument();
+    expect(await screen.findByText('Create new bot')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/admin/SecretsPage.test.tsx
+++ b/packages/app/src/admin/SecretsPage.test.tsx
@@ -4,7 +4,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -39,13 +39,12 @@ describe('SecretsPage', () => {
 
   test('Renders', async () => {
     await setup('/admin/secrets');
-    await waitFor(() => screen.getByText('Project Secrets'));
-    expect(screen.getByText('Project Secrets')).toBeInTheDocument();
+    expect(await screen.findByText('Project Secrets')).toBeInTheDocument();
   });
 
   test('Add and submit', async () => {
     await setup('/admin/secrets');
-    await waitFor(() => screen.getByTitle('Add Secret'));
+    expect(await screen.findByTitle('Add Secret')).toBeInTheDocument();
 
     // Click the "Add" button
     await act(async () => {
@@ -68,6 +67,6 @@ describe('SecretsPage', () => {
     });
 
     // Wait for the toast
-    await waitFor(() => screen.getByText('Saved'));
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/admin/SitesPage.test.tsx
+++ b/packages/app/src/admin/SitesPage.test.tsx
@@ -4,7 +4,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -39,13 +39,13 @@ describe('SitesPage', () => {
 
   test('Renders', async () => {
     await setup('/admin/sites');
-    await waitFor(() => screen.getByText('Project Sites'));
+    expect(await screen.findByText('Project Sites')).toBeInTheDocument();
     expect(screen.getByText('Project Sites')).toBeInTheDocument();
   });
 
   test('Add and submit', async () => {
     await setup('/admin/sites');
-    await waitFor(() => screen.getByTitle('Add Site'));
+    expect(await screen.findByTitle('Add Site')).toBeInTheDocument();
 
     // Click the "Add" button
     await act(async () => {
@@ -63,6 +63,6 @@ describe('SitesPage', () => {
     });
 
     // Wait for the toast
-    await waitFor(() => screen.getByText('Saved'));
+    expect(await screen.findByText('Saved')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/components/QuickStatus.test.tsx
+++ b/packages/app/src/components/QuickStatus.test.tsx
@@ -3,7 +3,7 @@ import { ExampleUserConfiguration, HomerServiceRequest, MockClient } from '@medp
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 medplum.getUserConfiguration = () => ExampleUserConfiguration;
@@ -25,7 +25,7 @@ describe('QuickStatus', () => {
     await setup(`/${getReferenceString(HomerServiceRequest)}`);
 
     // Wait for the page to load
-    await waitFor(() => screen.getByDisplayValue('ORDERED'));
+    expect(await screen.findByDisplayValue('ORDERED')).toBeInTheDocument();
 
     // Expect the status selector to be visible
     expect(screen.getByDisplayValue('ORDERED')).toBeInTheDocument();

--- a/packages/app/src/components/ResourceHeader.test.tsx
+++ b/packages/app/src/components/ResourceHeader.test.tsx
@@ -3,7 +3,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { randomUUID } from 'crypto';
 import { MemoryRouter } from 'react-router-dom';
-import { act, render, screen, waitFor } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { ResourceHeader } from './ResourceHeader';
 
 const medplum = new MockClient();
@@ -92,9 +92,7 @@ describe('ResourceHeader', () => {
       reference: 'Organization/123',
     });
 
-    await waitFor(() => screen.getByText('Test Organization'));
-
-    expect(screen.getByText('Test Organization')).toBeInTheDocument();
+    expect(await screen.findByText('Test Organization')).toBeInTheDocument();
   });
 
   test('Handles null identifier', async () => {

--- a/packages/app/src/index.test.tsx
+++ b/packages/app/src/index.test.tsx
@@ -1,5 +1,5 @@
 import { initApp } from './index';
-import { act, screen, waitFor } from './test-utils/render';
+import { act, screen } from './test-utils/render';
 
 describe('App Index', () => {
   beforeAll(() => {
@@ -23,10 +23,6 @@ describe('App Index', () => {
       await initApp();
     });
 
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    await act(async () => {
-      document.getElementById('root')?.remove();
-    });
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/resource/AppsPage.test.tsx
+++ b/packages/app/src/resource/AppsPage.test.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 describe('AppsPage', () => {
   async function setup(url: string, medplum = new MockClient()): Promise<void> {
@@ -30,16 +30,12 @@ describe('AppsPage', () => {
 
   test('No apps found', async () => {
     await setup('/Bot/123/apps');
-    await waitFor(() => screen.getByText('No apps found.', { exact: false }));
-
-    expect(screen.getByText('No apps found.', { exact: false })).toBeInTheDocument();
+    expect(await screen.findByText('No apps found.', { exact: false })).toBeInTheDocument();
   });
 
   test('Patient apps', async () => {
     await setup('/Patient/123/apps');
-    await waitFor(() => screen.getByText('Apps'));
-
-    expect(screen.getByText('Apps')).toBeInTheDocument();
+    expect(await screen.findByText('Apps')).toBeInTheDocument();
     expect(screen.getByText('Vitals')).toBeInTheDocument();
   });
 
@@ -53,8 +49,7 @@ describe('AppsPage', () => {
     });
 
     await setup('/Patient/123/apps');
-    await waitFor(() => screen.getByText('Apps'));
-
+    expect(await screen.findByText('Apps')).toBeInTheDocument();
     expect(screen.getByText('Inferno Client')).toBeInTheDocument();
     expect(screen.getByText('Client application used for Inferno ONC compliance testing')).toBeInTheDocument();
 
@@ -75,8 +70,7 @@ describe('AppsPage', () => {
     });
 
     await setup('/Encounter/123/apps');
-    await waitFor(() => screen.getByText('Apps'));
-
+    expect(await screen.findByText('Apps')).toBeInTheDocument();
     expect(screen.getByText('Inferno Client')).toBeInTheDocument();
     expect(screen.getByText('Client application used for Inferno ONC compliance testing')).toBeInTheDocument();
 
@@ -100,8 +94,7 @@ describe('AppsPage', () => {
     });
 
     await setup('/Patient/123/apps', medplum);
-    await waitFor(() => screen.getByText('Apps'));
-
+    expect(await screen.findByText('Apps')).toBeInTheDocument();
     expect(screen.getByText('Apps')).toBeInTheDocument();
     expect(screen.getByText('Vitals')).toBeInTheDocument();
   });

--- a/packages/app/src/resource/BotEditor.test.tsx
+++ b/packages/app/src/resource/BotEditor.test.tsx
@@ -6,7 +6,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 describe('BotEditor', () => {
   async function setup(url: string, medplum = new MockClient()): Promise<void> {
@@ -50,8 +50,8 @@ describe('BotEditor', () => {
 
   test('Bot editor', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Editor'));
-    await waitFor(() => screen.getByTestId('code-frame'));
+    expect(await screen.findByText('Editor')).toBeInTheDocument();
+    expect(await screen.findByTestId('code-frame')).toBeInTheDocument();
     expect(screen.getByText('Editor')).toBeInTheDocument();
 
     await act(async () => {
@@ -61,7 +61,7 @@ describe('BotEditor', () => {
 
   test('Save success', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Save'));
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     // Mock the code frame
     (screen.getByTestId<HTMLIFrameElement>('code-frame').contentWindow as Window).postMessage = (
@@ -81,7 +81,7 @@ describe('BotEditor', () => {
 
   test('Save error', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Save'));
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     // Mock the code frame
     (screen.getByTestId<HTMLIFrameElement>('code-frame').contentWindow as Window).postMessage = (
@@ -101,7 +101,7 @@ describe('BotEditor', () => {
 
   test('Deploy success', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Deploy'));
+    expect(await screen.findByText('Deploy')).toBeInTheDocument();
 
     // Mock the code frame
     (screen.getByTestId<HTMLIFrameElement>('code-frame').contentWindow as Window).postMessage = (
@@ -121,7 +121,7 @@ describe('BotEditor', () => {
 
   test('Deploy error', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Deploy'));
+    expect(await screen.findByText('Deploy')).toBeInTheDocument();
 
     // Mock the code frame
     (screen.getByTestId<HTMLIFrameElement>('code-frame').contentWindow as Window).postMessage = (
@@ -141,7 +141,7 @@ describe('BotEditor', () => {
 
   test('Execute success', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Execute'));
+    expect(await screen.findByText('Execute')).toBeInTheDocument();
 
     // Mock the output frame
     (screen.getByTestId<HTMLIFrameElement>('output-frame').contentWindow as Window).postMessage = (
@@ -161,7 +161,7 @@ describe('BotEditor', () => {
 
   test('Execute error', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Execute'));
+    expect(await screen.findByText('Execute')).toBeInTheDocument();
 
     // Mock the output frame
     (screen.getByTestId<HTMLIFrameElement>('output-frame').contentWindow as Window).postMessage = (
@@ -191,7 +191,7 @@ describe('BotEditor', () => {
     });
 
     await setup(`/Bot/${legacyBot.id}/editor`, medplum);
-    await waitFor(() => screen.getByText('Save'));
+    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     // Mock the code frame
     (screen.getByTestId<HTMLIFrameElement>('code-frame').contentWindow as Window).postMessage = (
@@ -215,7 +215,7 @@ describe('BotEditor', () => {
 
   test('HL7 input', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Execute'));
+    expect(await screen.findByText('Execute')).toBeInTheDocument();
 
     // Mock the output frame
     (screen.getByTestId<HTMLIFrameElement>('output-frame').contentWindow as Window).postMessage = (

--- a/packages/app/src/resource/BuilderPage.test.tsx
+++ b/packages/app/src/resource/BuilderPage.test.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -40,7 +40,7 @@ describe('BuilderPage', () => {
     } as PlanDefinition);
 
     await setup(`/PlanDefinition/${planDefinition.id}/builder`);
-    await waitFor(() => screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByRole('button', { name: 'Save' })).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -55,7 +55,7 @@ describe('BuilderPage', () => {
     } as Questionnaire);
 
     await setup(`/Questionnaire/${questionnaire.id}/builder`);
-    await waitFor(() => screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByRole('button', { name: 'Save' })).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/packages/app/src/resource/EditPage.test.tsx
+++ b/packages/app/src/resource/EditPage.test.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -32,8 +32,7 @@ describe('EditPage', () => {
 
   test('Edit tab renders', async () => {
     await setup('/Practitioner/123/edit');
-    await waitFor(() => screen.getByText('Edit'));
-    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(await screen.findByText('Edit')).toBeInTheDocument();
   });
 
   test('Submit', async () => {
@@ -54,14 +53,12 @@ describe('EditPage', () => {
 
   test('Delete button on edit page', async () => {
     await setup('/Practitioner/123/edit');
-    await waitFor(() => screen.getByText('Delete'));
-    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Delete'));
     });
 
-    await waitFor(() => screen.getByText('Are you sure you want to delete this Practitioner?'));
-    expect(screen.getByText('Are you sure you want to delete this Practitioner?')).toBeInTheDocument();
+    expect(await screen.findByText('Are you sure you want to delete this Practitioner?')).toBeInTheDocument();
   });
 });

--- a/packages/app/src/resource/JsonPage.test.tsx
+++ b/packages/app/src/resource/JsonPage.test.tsx
@@ -2,7 +2,7 @@ import { MantineProvider } from '@mantine/core';
 import { Notifications, notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
@@ -33,14 +33,14 @@ describe('JsonPage', () => {
 
   test('JSON tab renders', async () => {
     await setup('/Practitioner/123/json');
-    await waitFor(() => screen.getByTestId('resource-json'));
+    expect(await screen.findByTestId('resource-json')).toBeInTheDocument();
 
     expect(screen.getByTestId('resource-json')).toBeInTheDocument();
   });
 
   test('JSON submit', async () => {
     await setup('/Practitioner/123/json');
-    await waitFor(() => screen.getByTestId('resource-json'));
+    expect(await screen.findByTestId('resource-json')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByTestId('resource-json'), {
@@ -57,7 +57,7 @@ describe('JsonPage', () => {
 
   test('JSON submit with meta', async () => {
     await setup('/Practitioner/123/json');
-    await waitFor(() => screen.getByTestId('resource-json'));
+    expect(await screen.findByTestId('resource-json')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByTestId('resource-json'), {

--- a/packages/app/src/resource/ProfilesPage.test.tsx
+++ b/packages/app/src/resource/ProfilesPage.test.tsx
@@ -1,13 +1,13 @@
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import { loadDataType } from '@medplum/core';
 import { Patient, StructureDefinition } from '@medplum/fhirtypes';
 import { FishPatientResources, MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { loadDataType } from '@medplum/core';
 
 const medplum = new MockClient();
 
@@ -46,7 +46,7 @@ describe('ProfilesPage', () => {
         </MedplumProvider>
       );
     });
-    await waitFor(() => screen.getByText('Available Patient profiles'));
+    expect(await screen.findByText('Available Patient profiles')).toBeInTheDocument();
   }
 
   test('Can add a profile to an empty resource', async () => {

--- a/packages/app/src/resource/ResourcePage.test.tsx
+++ b/packages/app/src/resource/ResourcePage.test.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 describe('ResourcePage', () => {
   async function setup(url: string, medplum = new MockClient()): Promise<void> {
@@ -42,14 +42,13 @@ describe('ResourcePage', () => {
 
   test('Not found', async () => {
     await setup('/Practitioner/not-found');
-    await waitFor(() => screen.getByText('Not found'));
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
     expect(screen.getByText('Not found')).toBeInTheDocument();
   });
 
   test('Details tab renders', async () => {
     await setup('/Practitioner/123/details');
-    await waitFor(() => screen.queryAllByText('Name'));
-    expect(screen.queryAllByText('Name')[0]).toBeInTheDocument();
+    expect((await screen.findAllByText('Name'))[0]).toBeInTheDocument();
     expect(screen.getByText('Gender')).toBeInTheDocument();
   });
 
@@ -61,8 +60,7 @@ describe('ResourcePage', () => {
     });
 
     await setup(`/Practitioner/${practitioner.id}/delete`, medplum);
-    await waitFor(() => screen.getByText('Delete'));
-    expect(screen.getByText('Delete')).toBeInTheDocument();
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Delete'));
@@ -79,23 +77,17 @@ describe('ResourcePage', () => {
 
   test('History tab renders', async () => {
     await setup('/Practitioner/123/history');
-    await waitFor(() => screen.getByText('History'));
-
-    expect(screen.getByText('History')).toBeInTheDocument();
+    expect(await screen.findByText('History')).toBeInTheDocument();
   });
 
   test('Blame tab renders', async () => {
     await setup('/Practitioner/123/blame');
-    await waitFor(() => screen.getByText('Blame'));
-
-    expect(screen.getByText('Blame')).toBeInTheDocument();
+    expect(await screen.findByText('Blame')).toBeInTheDocument();
   });
 
   test('Patient timeline', async () => {
     await setup('/Patient/123/timeline');
-    await waitFor(() => screen.getByText('Timeline'));
-
-    expect(screen.getByText('Timeline')).toBeInTheDocument();
+    expect(await screen.findByText('Timeline')).toBeInTheDocument();
 
     // Expect identifiers
     expect(screen.getByText('abc')).toBeInTheDocument();
@@ -105,16 +97,12 @@ describe('ResourcePage', () => {
 
   test('Encounter timeline', async () => {
     await setup('/Encounter/123/timeline');
-    await waitFor(() => screen.getByText('Timeline'));
-
-    expect(screen.getByText('Timeline')).toBeInTheDocument();
+    expect(await screen.findByText('Timeline')).toBeInTheDocument();
   });
 
   test('Questionnaire preview', async () => {
     await setup('/Questionnaire/123/preview');
-    await waitFor(() => screen.getByText('Preview'));
-
-    expect(screen.getByText('Preview')).toBeInTheDocument();
+    expect(await screen.findByText('Preview')).toBeInTheDocument();
 
     window.alert = jest.fn();
 
@@ -134,9 +122,7 @@ describe('ResourcePage', () => {
     expect(bot.id).toBeDefined();
 
     await setup('/Questionnaire/123/bots');
-    await waitFor(() => screen.getByText('Connect to bot'));
-
-    expect(screen.getByText('Connect to bot')).toBeInTheDocument();
+    expect(await screen.findByText('Connect to bot')).toBeInTheDocument();
 
     // Select "Test Bot" in the bot input field
 
@@ -173,30 +159,22 @@ describe('ResourcePage', () => {
 
   test('Bot editor', async () => {
     await setup('/Bot/123/editor');
-    await waitFor(() => screen.getByText('Editor'));
-
-    expect(screen.getByText('Editor')).toBeInTheDocument();
+    expect(await screen.findByText('Editor')).toBeInTheDocument();
   });
 
   test('DiagnosticReport display', async () => {
     await setup('/DiagnosticReport/123/report');
-    await waitFor(() => screen.getByText('Report'));
-
-    expect(screen.getByText('Report')).toBeInTheDocument();
+    expect(await screen.findByText('Report')).toBeInTheDocument();
   });
 
   test('RequestGroup checklist', async () => {
     await setup('/RequestGroup/workflow-request-group-1/checklist');
-    await waitFor(() => screen.getByText('Checklist'));
-
-    expect(screen.getByText('Checklist')).toBeInTheDocument();
+    expect(await screen.findByText('Checklist')).toBeInTheDocument();
   });
 
   test('PlanDefinition apply', async () => {
     await setup('/PlanDefinition/workflow-plan-definition-1/apply');
-    await waitFor(() => screen.getByText('Subject'));
-
-    expect(screen.getByText('Subject')).toBeInTheDocument();
+    expect(await screen.findByText('Subject')).toBeInTheDocument();
   });
 
   test('Left click on tab', async () => {

--- a/packages/app/src/resource/ResourceVersionPage.test.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppRoutes } from '../AppRoutes';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 
 const medplum = new MockClient();
 
@@ -31,7 +31,7 @@ describe('ResourceVersionPage', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Resource not found'));
+      expect(await screen.findByText('Resource not found')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Resource not found')).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe('ResourceVersionPage', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Version not found'));
+      expect(await screen.findByText('Version not found')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Version not found')).toBeInTheDocument();
@@ -55,7 +55,7 @@ describe('ResourceVersionPage', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Diff'));
+      expect(await screen.findByText('Diff')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Diff')).toBeInTheDocument();
@@ -67,7 +67,7 @@ describe('ResourceVersionPage', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Diff'));
+      expect(await screen.findByText('Diff')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Diff')).toBeInTheDocument();
@@ -79,7 +79,7 @@ describe('ResourceVersionPage', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Raw'));
+      expect(await screen.findByText('Raw')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Raw')).toBeInTheDocument();
@@ -91,7 +91,7 @@ describe('ResourceVersionPage', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Diff'));
+      expect(await screen.findByText('Diff')).toBeInTheDocument();
     });
 
     await act(async () => {

--- a/packages/react-hooks/src/useSearch/useSearch.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearch.test.tsx
@@ -35,7 +35,7 @@ describe('useSearch hooks', () => {
 
   test('Happy path', async () => {
     await setup(<TestComponent />);
-    await waitFor(() => screen.getByText('All OK'));
+    expect(await screen.findByText('All OK')).toBeInTheDocument();
 
     const el = screen.getByTestId('bundle');
     expect(el).toBeInTheDocument();

--- a/packages/react-hooks/src/useSearch/useSearch.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearch.test.tsx
@@ -1,6 +1,6 @@
 import { operationOutcomeToString } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';

--- a/packages/react-hooks/src/useSearch/useSearchOne.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearchOne.test.tsx
@@ -1,6 +1,6 @@
 import { operationOutcomeToString } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';

--- a/packages/react-hooks/src/useSearch/useSearchOne.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearchOne.test.tsx
@@ -35,7 +35,7 @@ describe('useSearch hooks', () => {
 
   test('Happy path', async () => {
     await setup(<TestComponent />);
-    await waitFor(() => screen.getByText('All OK'));
+    expect(await screen.findByText('All OK')).toBeInTheDocument();
 
     const el = screen.getByTestId('patient');
     expect(el).toBeInTheDocument();

--- a/packages/react-hooks/src/useSearch/useSearchResources.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearchResources.test.tsx
@@ -1,7 +1,7 @@
 import { operationOutcomeToString } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';

--- a/packages/react-hooks/src/useSearch/useSearchResources.test.tsx
+++ b/packages/react-hooks/src/useSearch/useSearchResources.test.tsx
@@ -36,7 +36,7 @@ describe('useSearch hooks', () => {
 
   test('Happy path', async () => {
     await setup(<TestComponent />);
-    await waitFor(() => screen.getByText('All OK'));
+    expect(await screen.findByText('All OK')).toBeInTheDocument();
 
     const el = screen.getByTestId('resources');
     expect(el).toBeInTheDocument();

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.test.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.test.tsx
@@ -1,6 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { AttachmentArrayInput, AttachmentArrayInputProps } from './AttachmentArrayInput';
 
 const medplum = new MockClient();
@@ -43,7 +43,7 @@ describe('AttachmentArrayInput', () => {
       });
     });
 
-    await waitFor(() => screen.getByAltText('test.jpg'));
+    expect(await screen.findByAltText('test.jpg')).toBeInTheDocument();
   });
 
   test('Add attachment', async () => {
@@ -74,7 +74,7 @@ describe('AttachmentArrayInput', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByAltText('test.jpg'));
+      expect(await screen.findByAltText('test.jpg')).toBeInTheDocument();
     });
 
     await act(async () => {

--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.test.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.test.tsx
@@ -1,6 +1,6 @@
 import { MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen, waitFor } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { AttachmentDisplay, AttachmentDisplayProps } from './AttachmentDisplay';
 
 function mockFetch(url: string, options: any): Promise<any> {
@@ -52,7 +52,7 @@ describe('AttachmentDisplay', () => {
         url: 'https://example.com/test.jpg',
       },
     });
-    await waitFor(() => screen.getByTestId('attachment-image'));
+    expect(await screen.findByTestId('attachment-image')).toBeInTheDocument();
   });
 
   test('Renders video', async () => {
@@ -62,7 +62,7 @@ describe('AttachmentDisplay', () => {
         url: 'https://example.com/test.mp4',
       },
     });
-    await waitFor(() => screen.getByTestId('attachment-video'));
+    expect(await screen.findByTestId('attachment-video')).toBeInTheDocument();
   });
 
   test('Renders PDF', async () => {
@@ -72,7 +72,7 @@ describe('AttachmentDisplay', () => {
         url: 'https://example.com/test.pdf',
       },
     });
-    await waitFor(() => screen.getByTestId('attachment-pdf'));
+    expect(await screen.findByTestId('attachment-pdf')).toBeInTheDocument();
     expect(screen.getByText('Download')).toBeInTheDocument();
   });
 
@@ -84,7 +84,7 @@ describe('AttachmentDisplay', () => {
         title: 'test.txt',
       },
     });
-    await waitFor(() => screen.getByTestId('attachment-details'));
+    expect(await screen.findByTestId('attachment-details')).toBeInTheDocument();
     expect(screen.getByText('test.txt')).toBeInTheDocument();
   });
 
@@ -95,7 +95,7 @@ describe('AttachmentDisplay', () => {
         url: 'https://example.com/test.txt',
       },
     });
-    await waitFor(() => screen.getByTestId('attachment-details'));
+    expect(await screen.findByTestId('attachment-details')).toBeInTheDocument();
     expect(screen.getByText('Download')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/AttachmentInput/AttachmentInput.test.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.test.tsx
@@ -1,6 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { AttachmentInput, AttachmentInputProps } from './AttachmentInput';
 
 const medplum = new MockClient();
@@ -34,7 +34,7 @@ describe('AttachmentInput', () => {
       });
     });
 
-    await waitFor(() => screen.getByAltText('test.jpg'));
+    expect(await screen.findByAltText('test.jpg')).toBeInTheDocument();
   });
 
   test('Add attachment', async () => {
@@ -62,7 +62,7 @@ describe('AttachmentInput', () => {
       });
     });
 
-    await waitFor(() => screen.getByAltText('test.jpg'));
+    expect(await screen.findByAltText('test.jpg')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Remove'));

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
@@ -1,7 +1,7 @@
 import { CodeableConcept } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { CodeableConceptInput, CodeableConceptInputProps } from './CodeableConceptInput';
 
 const medplum = new MockClient();
@@ -93,13 +93,13 @@ describe('CodeableConceptInput', () => {
       fireEvent.change(input, { target: { value: 'XYZ' } });
     });
 
-    await waitFor(() => screen.getByText('+ Create XYZ'));
+    expect(await screen.findByText('+ Create XYZ')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('+ Create XYZ'));
     });
 
-    await waitFor(() => screen.getByText('XYZ'));
+    expect(await screen.findByText('XYZ')).toBeInTheDocument();
 
     expect(currValue).toMatchObject({
       coding: [
@@ -134,6 +134,6 @@ describe('CodeableConceptInput', () => {
       fireEvent.change(input, { target: { value: 'XYZ' } });
     });
 
-    await waitFor(() => screen.getByText('+ Create XYZ'));
+    expect(await screen.findByText('+ Create XYZ')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
+++ b/packages/react/src/FhirPathTable/FhirPathTable.test.tsx
@@ -1,8 +1,8 @@
 import { PropertyType } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { MemoryRouter } from 'react-router-dom';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { FhirPathTable, FhirPathTableField, FhirPathTableProps } from './FhirPathTable';
 
 const query = `{
@@ -109,14 +109,8 @@ describe('FhirPathTable', () => {
     };
 
     await setup(props);
-
-    await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
-    expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Renders with checkboxes', async () => {
@@ -128,13 +122,7 @@ describe('FhirPathTable', () => {
     };
 
     await setup(props);
-
-    await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
   });
 
   test('Bulk button', async () => {
@@ -148,7 +136,7 @@ describe('FhirPathTable', () => {
     });
 
     await act(async () => {
-      await waitFor(() => screen.getByText('Bulk...'));
+      expect(await screen.findByText('Bulk...')).toBeInTheDocument();
     });
 
     await act(async () => {
@@ -168,18 +156,10 @@ describe('FhirPathTable', () => {
     };
 
     await setup(props);
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    await act(async () => {
-      await waitFor(() => screen.getAllByTestId('search-control-row'));
-    });
-
-    await act(async () => {
-      const rows = screen.getAllByTestId('search-control-row');
-      fireEvent.click(rows[0]);
+      fireEvent.click(screen.getAllByTestId('search-control-row')[0]);
     });
 
     expect(props.onClick).toHaveBeenCalled();
@@ -196,18 +176,10 @@ describe('FhirPathTable', () => {
     };
 
     await setup(props);
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    await act(async () => {
-      await waitFor(() => screen.getAllByTestId('search-control-row'));
-    });
-
-    await act(async () => {
-      const rows = screen.getAllByTestId('search-control-row');
-      fireEvent.click(rows[0], { button: 1 });
+      fireEvent.click(screen.getAllByTestId('search-control-row')[0], { button: 1 });
     });
 
     expect(props.onClick).not.toHaveBeenCalled();
@@ -223,13 +195,7 @@ describe('FhirPathTable', () => {
     };
 
     await setup(props);
-
-    await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('all-checkbox'));
@@ -254,13 +220,7 @@ describe('FhirPathTable', () => {
     };
 
     await setup(props);
-
-    await act(async () => {
-      await waitFor(() => screen.getByTestId('search-control'));
-    });
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     const allCheckbox = screen.getByTestId('all-checkbox');
     const rowCheckbox = screen.getByTestId('row-checkbox');

--- a/packages/react/src/NotificationIcon/NotificationIcon.test.tsx
+++ b/packages/react/src/NotificationIcon/NotificationIcon.test.tsx
@@ -3,7 +3,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { IconMail } from '@tabler/icons-react';
 import 'jest-websocket-mock';
-import { act, render, screen, waitFor } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { NotificationIcon } from './NotificationIcon';
 
 describe('NotificationIcon()', () => {
@@ -51,9 +51,7 @@ describe('NotificationIcon()', () => {
     });
 
     // Wait for the indicator to change
-    await waitFor(() => screen.getByText('1'));
-
     // After emitting a message, the count should be 1, and the indicator should be shown
-    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(await screen.findByText('1')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
+++ b/packages/react/src/PlanDefinitionBuilder/PlanDefinitionBuilder.test.tsx
@@ -1,7 +1,7 @@
 import { ExampleWorkflowPlanDefinition, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router-dom';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { PlanDefinitionBuilder, PlanDefinitionBuilderProps } from './PlanDefinitionBuilder';
 
 const medplum = new MockClient();
@@ -96,7 +96,7 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByDisplayValue('Example Plan Definition'));
+    expect(await screen.findByDisplayValue('Example Plan Definition')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByDisplayValue('Example Plan Definition'), {
@@ -129,7 +129,7 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Example Action'));
+    expect(await screen.findByText('Example Action')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Example Action'));
@@ -161,13 +161,13 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Add action'));
+    expect(await screen.findByText('Add action')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Add action'));
     });
 
-    await waitFor(() => screen.getByLabelText('Title'));
+    expect(await screen.findByLabelText('Title')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Title'), {
@@ -201,13 +201,13 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Add action'));
+    expect(await screen.findByText('Add action')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Add action'));
     });
 
-    await waitFor(() => screen.getByLabelText('Title'));
+    expect(await screen.findByLabelText('Title')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Title'), {
@@ -241,13 +241,13 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Add action'));
+    expect(await screen.findByText('Add action')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Add action'));
     });
 
-    await waitFor(() => screen.getByLabelText('Title'));
+    expect(await screen.findByLabelText('Title')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Title'), {
@@ -281,13 +281,13 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Add action'));
+    expect(await screen.findByText('Add action')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Add action'));
     });
 
-    await waitFor(() => screen.getByLabelText('Title'));
+    expect(await screen.findByLabelText('Title')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Title'), {
@@ -327,7 +327,7 @@ describe('PlanDefinitionBuilder', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Remove'));
+    expect(await screen.findByText('Remove')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Remove'));

--- a/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
@@ -1,7 +1,7 @@
 import { indexStructureDefinitionBundle } from '@medplum/core';
 import { FishPatientResources, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { ReferenceInput, ReferenceInputProps } from './ReferenceInput';
 
 const medplum = new MockClient();
@@ -196,7 +196,7 @@ describe('ReferenceInput', () => {
     expect(screen.getByDisplayValue(FishPatientProfileSD.url)).toBeInTheDocument();
 
     // wait for the profile to be fetched
-    await waitFor(() => screen.getByText('Fish Patient'));
+    expect(await screen.findByText('Fish Patient')).toBeInTheDocument();
 
     // After the profile is fetched, the URl is replaced by the title
     expect(screen.queryByDisplayValue(FishPatientProfileSD.url)).toBeNull();

--- a/packages/react/src/ResourceAvatar/ResourceAvatar.test.tsx
+++ b/packages/react/src/ResourceAvatar/ResourceAvatar.test.tsx
@@ -2,7 +2,7 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router-dom';
-import { act, render, screen, waitFor } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { ResourceAvatar, ResourceAvatarProps } from './ResourceAvatar';
 import { getInitials } from './ResourceAvatar.utils';
 
@@ -41,9 +41,7 @@ describe('ResourceAvatar', () => {
       value: HomerSimpson,
     });
 
-    await waitFor(() => screen.getByAltText('Homer Simpson'));
-
-    expect(screen.getByAltText('Homer Simpson')).toBeDefined();
+    expect(await screen.findByAltText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Avatar renders resource directly as link', async () => {
@@ -52,9 +50,7 @@ describe('ResourceAvatar', () => {
       link: true,
     });
 
-    await waitFor(() => screen.getByAltText('Homer Simpson'));
-
-    expect(screen.getByAltText('Homer Simpson')).toBeDefined();
+    expect(await screen.findByAltText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Avatar renders after loading the resource', async () => {
@@ -62,9 +58,7 @@ describe('ResourceAvatar', () => {
       value: createReference(HomerSimpson),
     });
 
-    await waitFor(() => screen.getByAltText('Homer Simpson'));
-
-    expect(screen.getByAltText('Homer Simpson')).toBeDefined();
+    expect(await screen.findByAltText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('getInitials', () => {

--- a/packages/react/src/ResourceBadge/ResourceBadge.test.tsx
+++ b/packages/react/src/ResourceBadge/ResourceBadge.test.tsx
@@ -2,7 +2,7 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen, waitFor } from '../test-utils/render';
+import { render, screen } from '../test-utils/render';
 import { ResourceBadge, ResourceBadgeProps } from './ResourceBadge';
 
 const medplum = new MockClient();
@@ -28,7 +28,7 @@ describe('ResourceBadge', () => {
       value: HomerSimpson,
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
 
     expect(screen.getByText('Homer Simpson')).toBeDefined();
   });
@@ -39,7 +39,7 @@ describe('ResourceBadge', () => {
       link: true,
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
 
     expect(screen.getByText('Homer Simpson')).toBeDefined();
   });
@@ -49,7 +49,7 @@ describe('ResourceBadge', () => {
       value: createReference(HomerSimpson),
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
 
     expect(screen.getByText('Homer Simpson')).toBeDefined();
   });

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -1,7 +1,7 @@
 import { Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen, waitFor } from '../test-utils/render';
+import { act, render, screen } from '../test-utils/render';
 import { ResourceDiffTable, ResourceDiffTableProps } from './ResourceDiffTable';
 
 const medplum = new MockClient();
@@ -42,7 +42,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Replace active'));
+    expect(await screen.findByText('Replace active')).toBeInTheDocument();
 
     const removed = screen.getByText('false');
     expect(removed).toBeDefined();
@@ -89,7 +89,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Replace identifier[0].value'));
+    expect(await screen.findByText('Replace identifier[0].value')).toBeInTheDocument();
     expect(screen.getByText('Replace identifier[0].value')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
     expect(screen.getByText('123x')).toBeInTheDocument();
@@ -120,7 +120,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Add identifier.last()'));
+    expect(await screen.findByText('Add identifier.last()')).toBeInTheDocument();
 
     const operations = screen.getAllByText('Add identifier.last()');
     expect(operations).toHaveLength(1);
@@ -149,7 +149,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Replace identifier'));
+    expect(await screen.findByText('Replace identifier')).toBeInTheDocument();
 
     const operations = screen.getAllByText('Replace identifier');
     expect(operations).toHaveLength(1);
@@ -177,7 +177,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Remove identifier[1]'));
+    expect(await screen.findByText('Remove identifier[1]')).toBeInTheDocument();
 
     const operations = screen.getAllByText('Remove identifier[1]');
     expect(operations).toHaveLength(1);
@@ -206,7 +206,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Replace identifier'));
+    expect(await screen.findByText('Replace identifier')).toBeInTheDocument();
 
     const operations = screen.getAllByText('Replace identifier');
     expect(operations).toHaveLength(1);
@@ -231,7 +231,7 @@ describe('ResourceDiffTable', () => {
       setup({ original, revised });
     });
 
-    await waitFor(() => screen.getByText('Replace photo[0]'));
+    expect(await screen.findByText('Replace photo[0]')).toBeInTheDocument();
 
     // There should be 2 download links
     expect(screen.getAllByText('Download')).toHaveLength(2);

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -1,11 +1,11 @@
 import { HTTP_HL7_ORG, createReference, deepClone, loadDataType } from '@medplum/core';
+import { readJson } from '@medplum/definitions';
 import { Observation, Patient, Specimen, StructureDefinition } from '@medplum/fhirtypes';
 import { HomerObservation1, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { convertIsoToLocal, convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
-import { act, fireEvent, render, screen, waitFor, within } from '../test-utils/render';
+import { act, fireEvent, render, screen, within } from '../test-utils/render';
 import { ResourceForm, ResourceFormProps } from './ResourceForm';
-import { readJson } from '@medplum/definitions';
 
 const medplum = new MockClient();
 
@@ -55,7 +55,7 @@ describe('ResourceForm', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     const control = screen.getByText('Resource Type');
     expect(control).toBeDefined();
@@ -71,7 +71,7 @@ describe('ResourceForm', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     const control = screen.getByText('Resource Type');
     expect(control).toBeDefined();
@@ -87,7 +87,7 @@ describe('ResourceForm', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('OK'));
@@ -106,7 +106,7 @@ describe('ResourceForm', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     const control = screen.getByText('Resource Type');
     expect(control).toBeDefined();
@@ -120,7 +120,7 @@ describe('ResourceForm', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     const control = screen.getByText('Resource Type');
     expect(control).toBeDefined();
@@ -142,7 +142,7 @@ describe('ResourceForm', () => {
       onSubmit,
     });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     // Change the value[x] from Quantity to string
     // and set a value
@@ -201,7 +201,7 @@ describe('ResourceForm', () => {
 
     await setup({ defaultValue: { resourceType: 'Specimen' }, onSubmit });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByTestId('collected[x]'), { target: { value: localString } });
@@ -224,7 +224,7 @@ describe('ResourceForm', () => {
 
     await setup({ defaultValue: { resourceType: 'Patient' }, onSubmit });
 
-    await waitFor(() => screen.getByText('Resource Type'));
+    expect(await screen.findByText('Resource Type')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Active'));
@@ -332,13 +332,13 @@ describe('ResourceForm', () => {
       fireEvent.change(ombCategoryInput, { target: { value: 'custom-omb-category-value' } });
     });
 
-    await waitFor(() => screen.getByText('+ Create custom-omb-category-value'));
+    expect(await screen.findByText('+ Create custom-omb-category-value')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('+ Create custom-omb-category-value'));
     });
 
-    await waitFor(() => screen.getByText('custom-omb-category-value'));
+    expect(await screen.findByText('custom-omb-category-value')).toBeInTheDocument();
 
     await act(async () => {
       const textInput = within(within(raceExtension).getByTestId('slice-text')).getByTestId('value[x]');

--- a/packages/react/src/ResourceInput/ResourceInput.test.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.test.tsx
@@ -1,6 +1,6 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { ResourceInput, ResourceInputProps } from './ResourceInput';
 
 const medplum = new MockClient();
@@ -45,7 +45,7 @@ describe('ResourceInput', () => {
         placeholder: 'Test',
       });
     });
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
   });
 
@@ -119,7 +119,7 @@ describe('ResourceInput', () => {
       });
     });
 
-    await waitFor(() => screen.getByPlaceholderText('Test'));
+    expect(await screen.findByPlaceholderText('Test')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Test')).toBeInTheDocument();
   });
 
@@ -136,7 +136,7 @@ describe('ResourceInput', () => {
       });
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
 
     const nameSpan = screen.getByText('Homer Simpson');
@@ -163,7 +163,7 @@ describe('ResourceInput', () => {
       });
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
 
     const clearAllButton = screen.getByTitle('Clear all') as HTMLImageElement;

--- a/packages/react/src/ResourceName/ResourceName.test.tsx
+++ b/packages/react/src/ResourceName/ResourceName.test.tsx
@@ -2,7 +2,7 @@ import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router-dom';
-import { render, screen, waitFor } from '../test-utils/render';
+import { render, screen } from '../test-utils/render';
 import { ResourceName, ResourceNameProps } from './ResourceName';
 
 const medplum = new MockClient();
@@ -28,9 +28,7 @@ describe('ResourceName', () => {
       value: HomerSimpson,
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
-
-    expect(screen.getByText('Homer Simpson')).toBeDefined();
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Renders resource directly as link', async () => {
@@ -39,9 +37,7 @@ describe('ResourceName', () => {
       link: true,
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
-
-    expect(screen.getByText('Homer Simpson')).toBeDefined();
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Renders after loading the resource', async () => {
@@ -49,9 +45,7 @@ describe('ResourceName', () => {
       value: createReference(HomerSimpson),
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
-
-    expect(screen.getByText('Homer Simpson')).toBeDefined();
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
   });
 
   test('Renders operation outcome', async () => {
@@ -59,8 +53,6 @@ describe('ResourceName', () => {
       value: { reference: 'Patient/not-found' },
     });
 
-    await waitFor(() => screen.getByText('[Not found]'));
-
-    expect(screen.getByText('[Not found]')).toBeDefined();
+    expect(await screen.findByText('[Not found]')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -1,6 +1,6 @@
 import { MockClient } from '@medplum/mock';
-import { act, render, screen, waitFor } from '../test-utils/render';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { act, render, screen } from '../test-utils/render';
 import { ResourceTable, ResourceTableProps } from './ResourceTable';
 
 const medplum = new MockClient();
@@ -23,7 +23,7 @@ describe('ResourceTable', () => {
       },
     });
 
-    await waitFor(() => screen.getByText('Name'));
+    expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.getByText('ID')).toBeInTheDocument();
     expect(screen.getByText('Name')).toBeInTheDocument();
@@ -36,7 +36,7 @@ describe('ResourceTable', () => {
       },
     });
 
-    await waitFor(() => screen.getByText('Name'));
+    expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Gender')).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe('ResourceTable', () => {
       ignoreMissingValues: true,
     });
 
-    await waitFor(() => screen.getByText('Name'));
+    expect(await screen.findByText('Name')).toBeInTheDocument();
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.queryByText('Gender')).toBeNull();

--- a/packages/react/src/Scheduler/Scheduler.test.tsx
+++ b/packages/react/src/Scheduler/Scheduler.test.tsx
@@ -1,9 +1,9 @@
 import { createReference } from '@medplum/core';
 import { Reference, Schedule } from '@medplum/fhirtypes';
 import { DrAliceSmithSchedule, ExampleQuestionnaire, MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
-import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { Scheduler } from './Scheduler';
 
 const medplum = new MockClient();
@@ -36,12 +36,7 @@ describe('Scheduler', () => {
       setup(DrAliceSmithSchedule);
     });
 
-    await act(async () => {
-      await waitFor(() => screen.getByTestId('scheduler'));
-    });
-
-    const control = screen.getByTestId('scheduler');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('scheduler')).toBeInTheDocument();
 
     // Move forward one month
     await act(async () => {

--- a/packages/react/src/SearchControl/SearchControl.test.tsx
+++ b/packages/react/src/SearchControl/SearchControl.test.tsx
@@ -3,7 +3,7 @@ import { Bundle } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router-dom';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { SearchControl, SearchControlProps } from './SearchControl';
 
 describe('SearchControl', () => {
@@ -52,7 +52,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
 
     expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     expect(screen.getByText('greater than or equals', { exact: false })).toBeInTheDocument();
   });
@@ -97,11 +97,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByText('No results'));
-
-    const control = screen.getByText('No results');
-    expect(control).toBeDefined();
+    expect(await screen.findByText('No results')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
   });
 
@@ -115,11 +111,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('30 x')).toBeInTheDocument();
   });
@@ -142,11 +134,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
   });
 
@@ -167,11 +155,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByText('No results'));
-
-    const control = screen.getByText('No results');
-    expect(control).toBeDefined();
+    expect(await screen.findByText('No results')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
   });
 
@@ -185,13 +169,8 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
-
     expect(screen.getByText('chunkylover53@aol.com [home email]')).toBeInTheDocument();
     expect(screen.getByText('555-7334 [home phone]')).toBeInTheDocument();
   });
@@ -206,13 +185,8 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
-
     expect(screen.getByText('Springfield')).toBeInTheDocument();
     expect(screen.getByText('IL')).toBeInTheDocument();
   });
@@ -234,11 +208,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
   });
 
@@ -260,7 +230,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByLabelText('Next page'));
+    expect(await screen.findByLabelText('Next page')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Next page'));
@@ -286,7 +256,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByLabelText('Next page'));
+    expect(await screen.findByLabelText('Next page')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Next page'));
@@ -312,7 +282,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByLabelText('Previous page'));
+    expect(await screen.findByLabelText('Previous page')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Previous page'));
@@ -331,7 +301,7 @@ describe('SearchControl', () => {
       onNew,
     });
 
-    await waitFor(() => screen.getByText('New...'));
+    expect(await screen.findByText('New...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('New...'));
@@ -350,13 +320,13 @@ describe('SearchControl', () => {
       onExportCsv,
     });
 
-    await waitFor(() => screen.getByText('Export...'));
+    expect(await screen.findByText('Export...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Export...'));
     });
 
-    await waitFor(() => screen.getByText('Export as CSV'));
+    expect(await screen.findByText('Export as CSV')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Export as CSV'));
@@ -373,7 +343,7 @@ describe('SearchControl', () => {
       onDelete,
     });
 
-    await waitFor(() => screen.getByText('Delete...'));
+    expect(await screen.findByText('Delete...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Delete...'));
@@ -392,7 +362,7 @@ describe('SearchControl', () => {
       onBulk,
     });
 
-    await waitFor(() => screen.getByText('Bulk...'));
+    expect(await screen.findByText('Bulk...')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Bulk...'));
@@ -419,13 +389,10 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    await waitFor(() => screen.getAllByTestId('search-control-row'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
-      const rows = screen.getAllByTestId('search-control-row');
-      fireEvent.click(rows[0]);
+      fireEvent.click(screen.getAllByTestId('search-control-row')[0]);
     });
 
     expect(props.onClick).toHaveBeenCalled();
@@ -450,9 +417,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    await waitFor(() => screen.getAllByTestId('search-control-row'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     // Test response to middle mouse button
     await act(async () => {
@@ -499,13 +464,13 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Fields'));
     });
 
-    await waitFor(() => screen.getByText('OK'));
+    expect(await screen.findByText('OK')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('OK'));
@@ -529,13 +494,13 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Fields'));
     });
 
-    await waitFor(() => screen.getByLabelText('Close'));
+    expect(await screen.findByLabelText('Close')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Close'));
@@ -559,13 +524,13 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Filters'));
     });
 
-    await waitFor(() => screen.getByText('OK'));
+    expect(await screen.findByText('OK')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('OK'));
@@ -589,13 +554,13 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Filters'));
     });
 
-    await waitFor(() => screen.getByLabelText('Close'));
+    expect(await screen.findByLabelText('Close')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Close'));
@@ -620,7 +585,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByTestId('search-control'));
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Name'));
@@ -658,11 +623,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
 
     await act(async () => {
@@ -697,11 +658,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
 
     await act(async () => {
@@ -741,11 +698,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
 
     // Click on the column header to activate the popup menu
@@ -785,11 +738,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.queryByText('Patient')).not.toBeInTheDocument();
@@ -813,11 +762,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-
-    await waitFor(() => screen.getByTestId('search-control'));
-
-    const control = screen.getByTestId('search-control');
-    expect(control).toBeDefined();
+    expect(await screen.findByTestId('search-control')).toBeInTheDocument();
     expect(props.onLoad).toHaveBeenCalled();
     expect(screen.getByText('Homer Simpson')).toBeInTheDocument();
     expect(screen.queryByText('no filters')).not.toBeInTheDocument();
@@ -841,7 +786,7 @@ describe('SearchControl', () => {
 
     await setup(props);
 
-    await waitFor(() => screen.getByText('missing true'));
+    expect(await screen.findByText('missing true')).toBeInTheDocument();
 
     expect(screen.getByText('missing true')).toBeInTheDocument();
   });
@@ -865,7 +810,7 @@ describe('SearchControl', () => {
     };
 
     await setup(props);
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
     expect(onLoad).toHaveBeenCalled();
     onLoad.mockReset();
 
@@ -876,7 +821,7 @@ describe('SearchControl', () => {
       fireEvent.click(refreshButton);
     });
 
-    await waitFor(() => screen.getByText('Homer Simpson'));
+    expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
     expect(onLoad).toHaveBeenCalled();
   });
 
@@ -906,7 +851,7 @@ describe('SearchControl', () => {
         total: 5,
         entry: [{ resource: HomerSimpson }, ...Array(4).fill({ resourceType: 'Patient' })],
       });
-      await waitFor(() => screen.getByText('Homer Simpson'));
+      expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
       const element = screen.getByTestId('count-display');
       expect(element.textContent).toBe('1-5 of 5');
     });
@@ -922,7 +867,7 @@ describe('SearchControl', () => {
         total: 40,
         entry: [{ resource: HomerSimpson }, ...Array(19).fill({ resourceType: 'Patient' })],
       });
-      await waitFor(() => screen.getByText('Homer Simpson'));
+      expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
       const element = screen.getByTestId('count-display');
       expect(element.textContent).toBe('1-20 of 40');
     });
@@ -939,7 +884,7 @@ describe('SearchControl', () => {
         total: 403091,
         entry: [{ resource: HomerSimpson }, ...Array(19).fill({ resourceType: 'Patient' })],
       });
-      await waitFor(() => screen.getByText('Homer Simpson'));
+      expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
       const element = screen.getByTestId('count-display');
       expect(element.textContent).toBe('1-20 of 403,091');
     });
@@ -962,7 +907,7 @@ describe('SearchControl', () => {
           },
         ],
       });
-      await waitFor(() => screen.getByText('Homer Simpson'));
+      expect(await screen.findByText('Homer Simpson')).toBeInTheDocument();
       expect(screen.getByTestId('count-display').textContent).toBe('200,001-200,020 of 403,091');
     });
   });

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
@@ -387,9 +387,7 @@ describe('SearchFilterEditor', () => {
       fireEvent.click(screen.getByText('Save'));
     });
 
-    await act(async () => {
-      await waitFor(() => screen.getByText('6'));
-    });
+    expect(await screen.findByText('6')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('OK'));

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.test.tsx
@@ -4,7 +4,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ReactNode } from 'react';
 import { convertIsoToLocal } from '../DateTimeInput/DateTimeInput.utils';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { act, fireEvent, render, screen } from '../test-utils/render';
 import { SearchFilterValueInput } from './SearchFilterValueInput';
 
 const medplum = new MockClient();
@@ -141,9 +141,7 @@ describe('SearchFilterValueInput', () => {
     );
 
     // Wait for the resource to load
-    await act(async () => {
-      await waitFor(() => screen.getByText('Test Organization'));
-    });
+    expect(await screen.findByText('Test Organization')).toBeInTheDocument();
 
     // Clear the existing value
     const clearButton = screen.getByTitle('Clear all');

--- a/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
+++ b/packages/react/src/ServiceRequestTimeline/ServiceRequestTimeline.test.tsx
@@ -101,7 +101,7 @@ describe('ServiceRequestTimeline', () => {
     await setup({ serviceRequest: HomerServiceRequest });
 
     // Wait for initial load
-    await waitFor(() => screen.getByLabelText('Actions for ' + getReferenceString(comment)));
+    expect(await screen.findByLabelText('Actions for ' + getReferenceString(comment))).toBeInTheDocument();
 
     // Click on the actions link
     await act(async () => {
@@ -137,7 +137,7 @@ describe('ServiceRequestTimeline', () => {
     await setup({ serviceRequest: HomerServiceRequest });
 
     // Wait for initial load
-    await waitFor(() => screen.getByLabelText('Actions for ' + getReferenceString(comment)));
+    expect(await screen.findByLabelText('Actions for ' + getReferenceString(comment))).toBeInTheDocument();
 
     // Click on the actions link
     await act(async () => {
@@ -163,7 +163,7 @@ describe('ServiceRequestTimeline', () => {
     await setup({ serviceRequest: HomerServiceRequest });
 
     // Wait for initial load
-    await waitFor(() => screen.getByLabelText('Actions for ' + getReferenceString(comment)));
+    expect(await screen.findByLabelText('Actions for ' + getReferenceString(comment))).toBeInTheDocument();
 
     // Click on the actions link
     await act(async () => {
@@ -189,7 +189,7 @@ describe('ServiceRequestTimeline', () => {
     await setup({ serviceRequest: HomerServiceRequest });
 
     // Wait for initial load
-    await waitFor(() => screen.getByLabelText('Actions for ' + getReferenceString(comment)));
+    expect(await screen.findByLabelText('Actions for ' + getReferenceString(comment))).toBeInTheDocument();
 
     // Click on the actions link
     await act(async () => {

--- a/packages/react/src/auth/RegisterForm.test.tsx
+++ b/packages/react/src/auth/RegisterForm.test.tsx
@@ -1,10 +1,10 @@
 import { Title } from '@mantine/core';
 import { allOk, GoogleCredentialResponse, MedplumClient } from '@medplum/core';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
+import { MedplumProvider } from '@medplum/react-hooks';
 import { randomUUID, webcrypto } from 'crypto';
 import { MemoryRouter } from 'react-router-dom';
 import { TextEncoder } from 'util';
-import { MedplumProvider } from '@medplum/react-hooks';
+import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { RegisterForm, RegisterFormProps } from './RegisterForm';
 
 const recaptchaSiteKey = 'abc';
@@ -193,7 +193,7 @@ describe('RegisterForm', () => {
       fireEvent.click(screen.getByText('Create account'));
     });
 
-    await waitFor(() => screen.getByLabelText('Project Name', { exact: false }));
+    expect(await screen.findByLabelText('Project Name', { exact: false })).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Project Name', { exact: false }), { target: { value: 'My Project' } });
@@ -243,7 +243,7 @@ describe('RegisterForm', () => {
       fireEvent.click(screen.getByText('Create account'));
     });
 
-    await waitFor(() => screen.getByLabelText('Project Name', { exact: false }));
+    expect(await screen.findByLabelText('Project Name', { exact: false })).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Project Name', { exact: false }), { target: { value: 'My Project' } });
@@ -347,7 +347,7 @@ describe('RegisterForm', () => {
       });
     });
 
-    await waitFor(() => expect(screen.getByText('Sign in with Google')).toBeInTheDocument());
+    expect(await screen.findByText('Sign in with Google')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Sign in with Google'));

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -328,7 +328,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Sign in'));
     });
 
-    await waitFor(() => expect(screen.getByText('Choose profile')).toBeDefined());
+    expect(await screen.findByText('Choose profile')).toBeInTheDocument();
     expect(screen.getByText('Alice Smith')).toBeInTheDocument();
     expect(screen.getByText('Bob Jones')).toBeInTheDocument();
 
@@ -368,7 +368,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Sign in'));
     });
 
-    await waitFor(() => expect(screen.getByText('Choose profile')).toBeDefined());
+    expect(await screen.findByText('Choose profile')).toBeInTheDocument();
     expect(screen.getByText('Alice Smith')).toBeInTheDocument();
     expect(screen.getByText('Bob Jones')).toBeInTheDocument();
 
@@ -376,7 +376,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Bob Jones'));
     });
 
-    await waitFor(() => screen.getByText('Invalid IP address'));
+    expect(await screen.findByText('Invalid IP address')).toBeInTheDocument();
 
     expect(success).toBe(false);
   });
@@ -410,7 +410,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Sign in'));
     });
 
-    await waitFor(() => expect(screen.getByText('Choose scope')).toBeDefined());
+    expect(await screen.findByText('Choose scope')).toBeInTheDocument();
     expect(screen.getByText('openid')).toBeInTheDocument();
     expect(screen.getByText('profile')).toBeInTheDocument();
 
@@ -447,7 +447,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Sign in'));
     });
 
-    await waitFor(() => screen.getByLabelText('Project Name', { exact: false }));
+    expect(await screen.findByLabelText('Project Name', { exact: false })).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.change(screen.getByLabelText('Project Name', { exact: false }), { target: { value: 'My Project' } });
@@ -483,7 +483,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Sign in'));
     });
 
-    await waitFor(() => screen.getByTestId('text-field-error'));
+    expect(await screen.findByTestId('text-field-error')).toBeInTheDocument();
 
     expect(screen.getByTestId('text-field-error')).toBeInTheDocument();
     expect(screen.getByText('Email or password is invalid')).toBeInTheDocument();
@@ -512,9 +512,7 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Sign in'));
     });
 
-    await waitFor(() => expect(screen.getByTestId('text-field-error')).toBeInTheDocument());
-
-    expect(screen.getByTestId('text-field-error')).toBeInTheDocument();
+    expect(await screen.findByTestId('text-field-error')).toBeInTheDocument();
     expect(screen.getByText('Email or password is invalid')).toBeInTheDocument();
   });
 
@@ -596,7 +594,7 @@ describe('SignInForm', () => {
       });
     });
 
-    await waitFor(() => screen.getByLabelText('Email', { exact: false }));
+    expect(await screen.findByLabelText('Email', { exact: false })).toBeInTheDocument();
     expect(screen.queryByText('Sign in with Google')).toBeNull();
     expect(google.accounts.id.initialize).not.toHaveBeenCalled();
     expect(google.accounts.id.renderButton).not.toHaveBeenCalled();
@@ -641,15 +639,14 @@ describe('SignInForm', () => {
       });
     });
 
-    await waitFor(() => expect(screen.getByText('Sign in with Google')).toBeInTheDocument());
+    expect(await screen.findByText('Sign in with Google')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Sign in with Google'));
     });
 
     await waitFor(() => expect(onSuccess).toHaveBeenCalled());
-    await waitFor(() => expect(screen.getByText('Success')).toBeInTheDocument());
-
+    expect(await screen.findByText('Success')).toBeInTheDocument();
     expect(google.accounts.id.initialize).toHaveBeenCalled();
     expect(google.accounts.id.renderButton).toHaveBeenCalled();
     expect(google.accounts.id.prompt).toHaveBeenCalled();
@@ -694,14 +691,13 @@ describe('SignInForm', () => {
       });
     });
 
-    await waitFor(() => expect(screen.getByText('Sign in with Google')).toBeInTheDocument());
+    expect(await screen.findByText('Sign in with Google')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Sign in with Google'));
     });
 
-    await waitFor(() => expect(screen.getByText('User not found')).toBeInTheDocument());
-
+    expect(await screen.findByText('User not found')).toBeInTheDocument();
     expect(onSuccess).not.toHaveBeenCalled();
     expect(google.accounts.id.initialize).toHaveBeenCalled();
     expect(google.accounts.id.renderButton).toHaveBeenCalled();


### PR DESCRIPTION
Fast follow to https://github.com/medplum/medplum/pull/4028

Replace a bunch of cases of `waitFor`+`getBy` with `findBy`, which is faster and more correct.

100% cleanup, only touches tests, no runtime changes.