### PR TITLE
Add callout about using AuditEvent as Subscription criteria

### DIFF
--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -215,6 +215,12 @@ Change "Criteria" field to `Patient`
 
 ![Subscription Criteria](/img/app/bots/subscription_criteria.png)
 
+:::warning Subscriptions on `AuditEvents`
+
+The criteria of a subscription cannot be set to an [`AuditEvent`](/docs/api/fhir/resources/auditevent) resource. When a subscription is triggered it creates an [`AuditEvent`](/docs/api/fhir/resources/auditevent), so using it as criteria would create a notification spiral.
+
+:::
+
 Next, we specify action should be taken when the subscription is triggered, using the "Channel" field.
 
 Because, Bots can be are executed using HTTP requests, we will select the Channel "Type" as `Rest Hook` and the Channel "Endpoint" as as `Bot/<BOT_ID>`.

--- a/packages/docs/docs/subscriptions/publish-and-subscribe.md
+++ b/packages/docs/docs/subscriptions/publish-and-subscribe.md
@@ -38,6 +38,12 @@ To set up your [Subscription](https://app.medplum.com/Subscription) page in Medp
 - The `Criteria` section in the setup is what determines the triggering event for notifications. For example you put "ServiceRequest" in the `Criteria` section, all changes to ServiceRequests will generate a notification.
 - The `Endpoint` is the place where the subscribing web application URL should be placed. A full JSON representation of the object will be posted to the URL provided.
 
+:::warning Subscriptions on `AuditEvents`
+
+The `Criteria` of a subscription cannot be set to an [`AuditEvent`](/docs/api/fhir/resources/auditevent) resource. When a subscription is triggered it creates an [`AuditEvent`](/docs/api/fhir/resources/auditevent), so using it as criteria would create a notification spiral.
+
+:::
+
 You can find more instructions on setting up a subscription in the [Medplum Bots documentation](/docs/bots/bot-basics#executing-automatically-using-a-subscription).
 
 Before moving on to the rest of the tutorial, **we recommend testing your subscription** by attempting to trigger the webhook and inspect the data. If you have set up your webhook correctly you should see events when you [create a new](https://app.medplum.com/ServiceRequest/new) ServiceRequest or edit an existing [ServiceRequest](https://app.medplum.com/ServiceRequest). You will also see [AuditEvents](https://app.medplum.com/AuditEvent) created for the Subscription.


### PR DESCRIPTION
This will add callouts to the docs to let users know that AuditEvent resources cannot be used as criteria for subscriptions