### PR TITLE
fix: Handle Identifier case for isReference

### DIFF
--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -102,6 +102,7 @@ describe('Type Utils', () => {
     expect(isReference({})).toBe(false);
     expect(isReference({ resourceType: 'Patient' })).toBe(false);
     expect(isReference({ reference: 'Patient/123' })).toBe(true);
+    expect(isReference({ reference: { value: '123' }})).toBe(false);
   });
 
   test.each<[TypedValue, string]>([

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -413,7 +413,7 @@ export function isResource(value: unknown): value is Resource {
  * @returns True if the input is of type 'object' and contains property 'reference'
  */
 export function isReference(value: unknown): value is Reference & { reference: string } {
-  return !!(value && typeof value === 'object' && 'reference' in value);
+  return !!(value && typeof value === 'object' && 'reference' in value && typeof value.reference === 'string');
 }
 
 /**


### PR DESCRIPTION
## Why

Sometimes a `reference` is not actually a `Reference`, sometimes it is an `Identifier`.

<img width="1127" alt="Screenshot 2024-02-27 at 10 49 08 AM" src="https://github.com/medplum/medplum/assets/704789/2673e5cc-b4d0-4a1f-a6f8-24015660da5a">

## What
* Check the type of `reference` and validate that it's a string - this disambiguates it from an `Identifier`. 
* Adds a test