### PR TITLE
fix(react-native-ex): add `minWidth` to inputs

### DIFF
--- a/examples/medplum-react-native-example/src/Home.tsx
+++ b/examples/medplum-react-native-example/src/Home.tsx
@@ -154,6 +154,7 @@ const styles = StyleSheet.create({
     height: '60%',
   },
   input: {
+    minWidth: 200,
     height: 40,
     padding: 10,
     borderWidth: 1.5,


### PR DESCRIPTION
While verifying that the `Module not found: Can't resolve 'crypto'` error was fixed for React Native Web, I noticed that the styling was kind of broken after the last update. This just adds a min size for inputs. 