### PR TITLE
fix(ci): remove attempt to comment on PR in `prettier-fmt`

### DIFF
--- a/.github/workflows/prettier-fmt.yml
+++ b/.github/workflows/prettier-fmt.yml
@@ -54,41 +54,13 @@ jobs:
             cat prettier-fmt1.err >> "${GITHUB_OUTPUT}"
             echo "${delimiter}" >> "${GITHUB_OUTPUT}"
           fi
-      - name: Comment on PR
-        if: steps.fmt.outputs.prettier_fmt_errs != ''
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          comment_tag: prettier-fmt
-          message: |
-            ❌ @${{ github.actor }} `prettier` reported errors
-
-            ```js
-            ${{ steps.fmt.outputs.prettier_fmt_errs }}
-            ```
-
-            To one-off fix this manually, run:
-            ```sh
-            npm run prettier
-            ```
-
-            You might need to run `npm install` locally and configure your text editor to [auto-format on save](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode).
-
-            <sup>[#${{github.sha}}](https://github.com/medplum/medplum/commits/${{github.sha}})</sup>
-      - name: Uncomment on PR
-        if: steps.fmt.outputs.prettier_fmt_errs == ''
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          comment_tag: prettier-fmt
-          mode: upsert
-          create_if_not_exists: false
-          message: |
-            ✅ `prettier` errors have been resolved. Thank you.
-
-            <sup>[#${{github.sha}}](https://github.com/medplum/medplum/commits/${{github.sha}})</sup>
       - name: Fail the job
         if: steps.fmt.outputs.prettier_fmt_errs != ''
         run: |
           echo "❌ \"prettier\" reported errors"
+          echo ""
+          echo "${{ steps.fmt.outputs.prettier_fmt_errs }}"
+          echo ""
           echo ""
           echo "To one-off fix this manually, run:"
           echo ""


### PR DESCRIPTION
We are removing the commenting step from `prettier-fmt` due to complications of trying to comment on PRs originating from fork branches.

TL;DR To comment on a PR you need write perms and the only way to get that on a PR originating from a fork is by dispatching the workflow on `pull_request_target` and not the `pull_request` event due to security concerns. Running a workflow off of `pull_request_target`, however, runs the action in the base ref and therefore prevents you from running prettier against the code in the desired commit. There is likely a way to get this to work but it's probably not worth the effort.