### PR TITLE
Fixes #2021 - support _type search parameter

### DIFF
--- a/packages/core/src/search/parse.test.ts
+++ b/packages/core/src/search/parse.test.ts
@@ -674,4 +674,11 @@ describe('Search parser', () => {
       pretty: false,
     });
   });
+
+  test('_type', () => {
+    expect(parseSearchRequest('Patient', { _type: 'Patient,Observation' })).toMatchObject<SearchRequest>({
+      resourceType: 'Patient',
+      types: ['Patient', 'Observation'],
+    });
+  });
 });

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -20,6 +20,7 @@ export interface SearchRequest<T extends Resource = Resource> {
   summary?: 'true' | 'text' | 'data';
   format?: string;
   pretty?: boolean;
+  types?: T['resourceType'][];
 }
 
 export interface Filter {
@@ -303,6 +304,10 @@ function parseKeyValue(searchRequest: SearchRequest, key: string, value: string)
     case '_fields':
     case '_elements':
       searchRequest.fields = value.split(',');
+      break;
+
+    case '_type':
+      searchRequest.types = value.split(',') as Resource['resourceType'][];
       break;
 
     case '_format':

--- a/packages/fhir-router/src/fhirrouter.test.ts
+++ b/packages/fhir-router/src/fhirrouter.test.ts
@@ -188,4 +188,21 @@ describe('FHIR Router', () => {
     expect(res).toMatchObject(allOk);
     expect(bundle).toBeDefined();
   });
+
+  test('Search multiple types', async () => {
+    const [res, bundle] = await router.handleRequest(
+      {
+        method: 'GET',
+        pathname: '/',
+        body: {},
+        params: {},
+        query: {
+          _type: 'Patient,Observation',
+        },
+      },
+      repo
+    );
+    expect(res).toMatchObject(allOk);
+    expect(bundle).toBeDefined();
+  });
 });

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -48,6 +48,17 @@ async function search(req: FhirRequest, repo: FhirRepository): Promise<FhirRespo
   return [allOk, bundle];
 }
 
+// Search multiple types
+async function searchMultipleTypes(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
+  const query = req.query as Record<string, string[] | string | undefined>;
+  const searchRequest = parseSearchRequest('MultipleTypes' as ResourceType, query);
+  if (!searchRequest.types || searchRequest.types.length === 0) {
+    return [badRequest('No types specified')];
+  }
+  const bundle = await repo.search(searchRequest);
+  return [allOk, bundle];
+}
+
 // Search by POST
 async function searchByPost(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
   const { resourceType } = req.params;
@@ -127,6 +138,7 @@ export class FhirRouter extends EventTarget {
     super();
     this.options = options;
 
+    this.router.add('GET', '', searchMultipleTypes);
     this.router.add('POST', '', batch);
     this.router.add('GET', ':resourceType', search);
     this.router.add('POST', ':resourceType/_search', searchByPost);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1055,7 +1055,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
         } else if (policy.criteria) {
           // Add subquery for access policy criteria.
           const searchRequest = parseSearchRequest(policy.criteria);
-          const accessPolicyExpression = buildSearchExpression(builder, searchRequest);
+          const accessPolicyExpression = buildSearchExpression(builder, searchRequest.resourceType, searchRequest);
           if (accessPolicyExpression) {
             expressions.push(accessPolicyExpression);
           }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -111,18 +111,26 @@ export async function searchImpl<T extends Resource>(
   };
 }
 
+/**
+ * Validates that the resource type(s) are valid and that the user has permission to read them.
+ * @param repo - The user's repository.
+ * @param searchRequest - The incoming search request.
+ */
 function validateSearchResourceTypes(repo: Repository, searchRequest: SearchRequest): void {
-  if (searchRequest.resourceType) {
-    validateSearchResourceType(repo, searchRequest.resourceType);
-  }
-
   if (searchRequest.types) {
     for (const resourceType of searchRequest.types) {
       validateSearchResourceType(repo, resourceType);
     }
+  } else {
+    validateSearchResourceType(repo, searchRequest.resourceType);
   }
 }
 
+/**
+ * Validates that the resource type is valid and that the user has permission to read it.
+ * @param repo - The user's repository.
+ * @param resourceType - The resource type to validate.
+ */
 function validateSearchResourceType(repo: Repository, resourceType: ResourceType): void {
   validateResourceType(resourceType);
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -57,6 +57,7 @@ import {
   periodToRangeString,
   SelectQuery,
   Operator as SQL,
+  Union,
 } from './sql';
 
 /**
@@ -79,12 +80,7 @@ export async function searchImpl<T extends Resource>(
   repo: Repository,
   searchRequest: SearchRequest<T>
 ): Promise<Bundle<T>> {
-  const resourceType = searchRequest.resourceType;
-  validateResourceType(resourceType);
-
-  if (!repo.canReadResourceType(resourceType)) {
-    throw new OperationOutcomeError(forbidden);
-  }
+  validateSearchResourceTypes(repo, searchRequest);
 
   // Ensure that "count" is set.
   // Count is an optional field.  From this point on, it is safe to assume it is a number.
@@ -115,6 +111,26 @@ export async function searchImpl<T extends Resource>(
   };
 }
 
+function validateSearchResourceTypes(repo: Repository, searchRequest: SearchRequest): void {
+  if (searchRequest.resourceType) {
+    validateSearchResourceType(repo, searchRequest.resourceType);
+  }
+
+  if (searchRequest.types) {
+    for (const resourceType of searchRequest.types) {
+      validateSearchResourceType(repo, resourceType);
+    }
+  }
+}
+
+function validateSearchResourceType(repo: Repository, resourceType: ResourceType): void {
+  validateResourceType(resourceType);
+
+  if (!repo.canReadResourceType(resourceType)) {
+    throw new OperationOutcomeError(forbidden);
+  }
+}
+
 /**
  * Returns the bundle entries for a search request.
  * @param repo - The repository.
@@ -125,15 +141,9 @@ async function getSearchEntries<T extends Resource>(
   repo: Repository,
   searchRequest: SearchRequest
 ): Promise<{ entry: BundleEntry<T>[]; rowCount: number; hasMore: boolean }> {
-  const resourceType = searchRequest.resourceType;
-  const builder = new SelectQuery(resourceType)
-    .column({ tableName: resourceType, columnName: 'id' })
-    .column({ tableName: resourceType, columnName: 'content' });
+  const builder = getBaseSelectQuery(repo, searchRequest);
 
   addSortRules(builder, searchRequest);
-  repo.addDeletedFilter(builder);
-  repo.addSecurityFilters(builder, resourceType);
-  addSearchFilters(builder, searchRequest);
 
   const count = searchRequest.count as number;
   builder.limit(count + 1); // Request one extra to test if there are more results
@@ -145,7 +155,7 @@ async function getSearchEntries<T extends Resource>(
   const entries = resources.map(
     (resource) =>
       ({
-        fullUrl: getFullUrl(resourceType, resource.id as string),
+        fullUrl: getFullUrl(resource.resourceType, resource.id as string),
         resource,
       }) as BundleEntry
   );
@@ -166,6 +176,41 @@ async function getSearchEntries<T extends Resource>(
     rowCount,
     hasMore: rows.length > count,
   };
+}
+
+function getBaseSelectQuery(repo: Repository, searchRequest: SearchRequest, addColumns = true): SelectQuery {
+  let builder: SelectQuery;
+  if (searchRequest.types) {
+    const queries: SelectQuery[] = [];
+    for (const resourceType of searchRequest.types) {
+      queries.push(getBaseSelectQueryForResourceType(repo, resourceType, searchRequest, addColumns));
+    }
+    builder = new SelectQuery('combined', new Union(...queries));
+    if (addColumns) {
+      builder.column('id').column('content');
+    }
+  } else {
+    builder = getBaseSelectQueryForResourceType(repo, searchRequest.resourceType, searchRequest, addColumns);
+  }
+  return builder;
+}
+
+function getBaseSelectQueryForResourceType(
+  repo: Repository,
+  resourceType: ResourceType,
+  searchRequest: SearchRequest,
+  addColumns = true
+): SelectQuery {
+  const builder = new SelectQuery(resourceType);
+  if (addColumns) {
+    builder
+      .column({ tableName: resourceType, columnName: 'id' })
+      .column({ tableName: resourceType, columnName: 'content' });
+  }
+  repo.addDeletedFilter(builder);
+  repo.addSecurityFilters(builder, resourceType);
+  addSearchFilters(builder, resourceType, searchRequest);
+  return builder;
 }
 
 function removeResourceFields(resource: Resource, repo: Repository, searchRequest: SearchRequest): void {
@@ -416,10 +461,7 @@ async function getCount(repo: Repository, searchRequest: SearchRequest, rowCount
  * @returns The total number of matching results.
  */
 async function getAccurateCount(repo: Repository, searchRequest: SearchRequest): Promise<number> {
-  const builder = new SelectQuery(searchRequest.resourceType);
-  repo.addDeletedFilter(builder);
-  repo.addSecurityFilters(builder, searchRequest.resourceType);
-  addSearchFilters(builder, searchRequest);
+  const builder = getBaseSelectQuery(repo, searchRequest, false);
 
   if (builder.joins.length > 0) {
     builder.raw(`COUNT (DISTINCT "${searchRequest.resourceType}"."id")::int AS "count"`);
@@ -445,11 +487,7 @@ async function getEstimateCount(
   searchRequest: SearchRequest,
   rowCount: number | undefined
 ): Promise<number> {
-  const resourceType = searchRequest.resourceType;
-  const builder = new SelectQuery(resourceType).column('id');
-  repo.addDeletedFilter(builder);
-  repo.addSecurityFilters(builder, searchRequest.resourceType);
-  addSearchFilters(builder, searchRequest);
+  const builder = getBaseSelectQuery(repo, searchRequest);
   builder.explain = true;
 
   // See: https://wiki.postgresql.org/wiki/Count_estimate
@@ -474,16 +512,21 @@ async function getEstimateCount(
 /**
  * Adds all search filters as "WHERE" clauses to the query builder.
  * @param selectQuery - The select query builder.
+ * @param resourceType - The type of resources requested.
  * @param searchRequest - The search request.
  */
-function addSearchFilters(selectQuery: SelectQuery, searchRequest: SearchRequest): void {
-  const expr = buildSearchExpression(selectQuery, searchRequest);
+function addSearchFilters(selectQuery: SelectQuery, resourceType: ResourceType, searchRequest: SearchRequest): void {
+  const expr = buildSearchExpression(selectQuery, resourceType, searchRequest);
   if (expr) {
     selectQuery.predicate.expressions.push(expr);
   }
 }
 
-export function buildSearchExpression(selectQuery: SelectQuery, searchRequest: SearchRequest): Expression | undefined {
+export function buildSearchExpression(
+  selectQuery: SelectQuery,
+  resourceType: ResourceType,
+  searchRequest: SearchRequest
+): Expression | undefined {
   const expressions: Expression[] = [];
   if (searchRequest.filters) {
     for (const filter of searchRequest.filters) {
@@ -493,12 +536,7 @@ export function buildSearchExpression(selectQuery: SelectQuery, searchRequest: S
         continue;
       }
 
-      const expr = buildSearchFilterExpression(
-        selectQuery,
-        searchRequest.resourceType,
-        searchRequest.resourceType,
-        filter
-      );
+      const expr = buildSearchFilterExpression(selectQuery, resourceType, resourceType, filter);
       if (expr) {
         expressions.push(expr);
       }


### PR DESCRIPTION
Quick and dirty implementation of `_type`

I anticipate the most controversial choice here was to add `types` to `SearchRequest` rather than changing `resourceType` to an array.  We could totally do that, but it would probably 10x the size of this diff.

As implemented, this treats `SearchRequest.types` as an optional override.  If present, then `SearchRequest.resourceType` is basically ignored.

Everything else proved to be pretty natural and clean.