### PR TITLE
chore(otel): add `bullmq` open telemetry instrumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10290,6 +10290,79 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@jenniferplusplus/opentelemetry-instrumentation-bullmq/-/opentelemetry-instrumentation-bullmq-0.5.0.tgz",
+      "integrity": "sha512-g0xaSIb9h18SV1xHlPuHW6eA4v3FGxeV5AWIoUFX2F9cVKZnobETB4OVrAVg0kOBgNLEdxWc21s2NULOkmuQYg==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "^1.8.0",
+        "flat": "^5.0.2"
+      },
+      "peerDependencies": {
+        "bullmq": "^2 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
+      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "dependencies": {
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/require-in-the-middle": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jenniferplusplus/opentelemetry-instrumentation-bullmq/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/@jest/console": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
@@ -31110,7 +31183,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -57865,6 +57937,7 @@
         "@aws-sdk/cloudfront-signer": "3.521.0",
         "@aws-sdk/lib-storage": "3.521.0",
         "@aws-sdk/types": "3.521.0",
+        "@jenniferplusplus/opentelemetry-instrumentation-bullmq": "^0.5.0",
         "@medplum/core": "3.0.6",
         "@medplum/definitions": "3.0.6",
         "@medplum/fhir-router": "3.0.6",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "@aws-sdk/cloudfront-signer": "3.521.0",
     "@aws-sdk/lib-storage": "3.521.0",
     "@aws-sdk/types": "3.521.0",
+    "@jenniferplusplus/opentelemetry-instrumentation-bullmq": "^0.5.0",
     "@medplum/core": "3.0.6",
     "@medplum/definitions": "3.0.6",
     "@medplum/fhir-router": "3.0.6",

--- a/packages/server/src/otel/instrumentation.ts
+++ b/packages/server/src/otel/instrumentation.ts
@@ -8,6 +8,7 @@ import { MetricReader, PeriodicExportingMetricReader } from '@opentelemetry/sdk-
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { BullMQInstrumentation } from '@jenniferplusplus/opentelemetry-instrumentation-bullmq';
 
 // This file includes OpenTelemetry instrumentation.
 // Note that this file is related but separate from the OpenTelemetry helpers in otel.ts.
@@ -46,7 +47,7 @@ export function initOpenTelemetry(): void {
     traceExporter = new OTLPTraceExporter({ url: OTLP_TRACES_ENDPOINT });
   }
 
-  const instrumentations = [getNodeAutoInstrumentations()];
+  const instrumentations = [getNodeAutoInstrumentations(), new BullMQInstrumentation()];
 
   sdk = new NodeSDK({
     resource,


### PR DESCRIPTION
Followup of https://github.com/medplum/medplum/pull/3920

`@opentelemetry/auto-instrumentations-node` does not include `bullmq`. As it is a core component of the system, it should be instrumented.
https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node#supported-instrumentations

https://github.com/jenniferplusplus/opentelemetry-instrumentation-bullmq looks like a good option and supports the bullmq v5.