### PR TITLE
Remove unneeded console.assert

### DIFF
--- a/packages/react/src/SliceDisplay/SliceDisplay.tsx
+++ b/packages/react/src/SliceDisplay/SliceDisplay.tsx
@@ -35,7 +35,6 @@ export function SliceDisplay(props: SliceDisplayProps): JSX.Element {
         profileUrl: slice.typeSchema?.url,
       });
     }
-    console.assert(false, 'Expected sliceElements to always be populated', props.path);
     return undefined;
   }, [parentContext, props.path, slice.typeSchema?.url, sliceElements]);
 

--- a/packages/react/src/SliceInput/SliceInput.tsx
+++ b/packages/react/src/SliceInput/SliceInput.tsx
@@ -46,7 +46,6 @@ export function SliceInput(props: SliceInputProps): JSX.Element | null {
         profileUrl: slice.typeSchema?.url,
       });
     }
-    console.assert(false, 'Expected sliceElements to always be populated', props.path);
     return undefined;
   }, [parentElementsContextValue, props.path, slice.typeSchema?.url, sliceElements]);
 


### PR DESCRIPTION
Slices don't have to have nested elements such as `Observation.category:SocialHistory` in `USCoreSmokingStatusProfile`