### PR TITLE
Always build synthetic access policy

### DIFF
--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -29,7 +29,7 @@ import { inviteUser } from '../admin/invite';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { createTestProject, withTestContext } from '../test.setup';
+import { addTestUser, createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { getSystemRepo, Repository } from './repo';
 

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -29,7 +29,7 @@ import { inviteUser } from '../admin/invite';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { addTestUser, createTestProject, withTestContext } from '../test.setup';
+import { createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { getSystemRepo, Repository } from './repo';
 

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { initTestAuth, withTestContext } from '../test.setup';
+import { addTestUser, createTestProject, initTestAuth, withTestContext } from '../test.setup';
 
 const app = express();
 let accessToken: string;
@@ -524,4 +524,35 @@ describe('FHIR Routes', () => {
       .send({});
     expect(res.status).toBe(200);
   });
+
+  test('ProjectMembership with null access policy', async () =>
+    withTestContext(async () => {
+      const adminRegistration = await createTestProject({
+        membership: { admin: true },
+        withRepo: true,
+        withAccessToken: true,
+      });
+      expect(adminRegistration).toBeDefined();
+
+      const normalRegistration = await addTestUser(adminRegistration.project);
+      expect(normalRegistration).toBeDefined();
+
+      const membership = normalRegistration.membership;
+
+      const res1 = await request(app)
+        .get(`/fhir/R4/ProjectMembership/${membership.id}`)
+        .set('Authorization', 'Bearer ' + adminRegistration.accessToken);
+      expect(res1.status).toBe(200);
+
+      const res2 = await request(app)
+        .get(`/fhir/R4/ProjectMembership/${membership.id}`)
+        .set('Authorization', 'Bearer ' + normalRegistration.accessToken);
+      expect(res2.status).toBe(403);
+
+      const res3 = await request(app)
+        .put(`/fhir/R4/ProjectMembership/${membership.id}`)
+        .set('Authorization', 'Bearer ' + normalRegistration.accessToken)
+        .send({ ...membership, accessPolicy: undefined });
+      expect(res3.status).toBe(403);
+    }));
 });

--- a/packages/server/src/fhir/smart.test.ts
+++ b/packages/server/src/fhir/smart.test.ts
@@ -89,7 +89,9 @@ describe('SMART on FHIR', () => {
   });
 
   test('Generate access policy', () => {
-    expect(applySmartScopes(undefined, 'patient/Observation.cruds patient/Patient.cruds')).toMatchObject({
+    expect(
+      applySmartScopes({ resourceType: 'AccessPolicy' }, 'patient/Observation.cruds patient/Patient.cruds')
+    ).toMatchObject({
       resourceType: 'AccessPolicy',
       resource: [
         {

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -133,30 +133,26 @@ export function parseSmartScopes(scope: string | undefined): SmartScope[] {
  * @param scope - The OAuth scope string.
  * @returns Updated access policy with the OAuth scope applied.
  */
-export function applySmartScopes(
-  accessPolicy: AccessPolicy | undefined,
-  scope: string | undefined
-): AccessPolicy | undefined {
+export function applySmartScopes(accessPolicy: AccessPolicy, scope: string | undefined): AccessPolicy {
   const smartScopes = parseSmartScopes(scope);
   if (smartScopes.length === 0) {
     // No SMART scopes, so no changes to the access policy
     return accessPolicy;
   }
 
-  if (accessPolicy) {
-    // Build an access policy that is the intersection of the existing access policy and the SMART scopes
-    return intersectSmartScopes(accessPolicy, smartScopes);
-  }
-
-  // Otherwise, generate an AccessPolicy from scratch
-  return generateSmartScopesPolicy(smartScopes);
+  // Build an access policy that is the intersection of the existing access policy and the SMART scopes
+  return intersectSmartScopes(accessPolicy, smartScopes);
 }
 
 function intersectSmartScopes(accessPolicy: AccessPolicy, smartScope: SmartScope[]): AccessPolicy {
   const result = deepClone(accessPolicy);
 
   // Build list of AccessPolicy entries
-  const accessPolicyEntries = result.resource as AccessPolicyResource[];
+  const accessPolicyEntries = result.resource;
+  if (!accessPolicyEntries) {
+    // If none specified, generate an AccessPolicy from scratch
+    return generateSmartScopesPolicy(smartScope);
+  }
 
   // Sort both by resource type
   accessPolicyEntries.sort((a, b) => (a.resourceType as string).localeCompare(b.resourceType as string));


### PR DESCRIPTION
This is prep refactoring for future where `AccessPolicy` is required for all `ProjectMembership`

Currently, Medplum has the notion of a "null access policy", which is the source of confusion and abuse.  We always recommend that all users have an access policy assigned to prevent that confusion.

This PR is performing some prep refactoring to always build a "synthetic" access policy, so even if an access policy is not explicitly defined, an "effective" access policy is available.

There will be additional future work to fill this out:
* Default access policies to alleviate the burden of writing access policies from scratch
* Migration tools to ensure all project memberships have an access policy
* And then eventually the change to require an access policy