### PR TITLE
Check user read permissions in export operation

### DIFF
--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -96,7 +96,7 @@ describe('Export', () => {
   });
 
   test('System Export Accepted with GET', async () => {
-    const accessToken = await initTestAuth({ membership: { admin: true } });
+    const accessToken = await initTestAuth();
 
     // Start the export
     const initRes = await request(app)
@@ -111,7 +111,7 @@ describe('Export', () => {
   });
 
   test('Patient Export Accepted with GET', async () => {
-    const accessToken = await initTestAuth({ membership: { admin: true } });
+    const accessToken = await initTestAuth();
 
     // Start the export
     const initRes = await request(app)
@@ -126,7 +126,7 @@ describe('Export', () => {
   });
 
   test('exportResourceType iterating through paginated search results', async () => {
-    const { project } = await createTestProject({ membership: { admin: true } });
+    const { project } = await createTestProject();
     expect(project).toBeDefined();
     const exporter = new BulkExporter(systemRepo, undefined);
     const exportWriteResourceSpy = jest.spyOn(exporter, 'writeResource');

--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -23,10 +23,7 @@ describe('Export', () => {
   });
 
   test('Success', async () => {
-    const { project } = await createTestProject();
-    expect(project).toBeDefined();
-
-    const accessToken = await initTestAuth();
+    const accessToken = await initTestAuth({ membership: { admin: true } });
     expect(accessToken).toBeDefined();
 
     const res1 = await request(app)
@@ -99,7 +96,7 @@ describe('Export', () => {
   });
 
   test('System Export Accepted with GET', async () => {
-    const accessToken = await initTestAuth();
+    const accessToken = await initTestAuth({ membership: { admin: true } });
 
     // Start the export
     const initRes = await request(app)
@@ -114,7 +111,7 @@ describe('Export', () => {
   });
 
   test('Patient Export Accepted with GET', async () => {
-    const accessToken = await initTestAuth();
+    const accessToken = await initTestAuth({ membership: { admin: true } });
 
     // Start the export
     const initRes = await request(app)
@@ -129,7 +126,7 @@ describe('Export', () => {
   });
 
   test('exportResourceType iterating through paginated search results', async () => {
-    const { project } = await createTestProject();
+    const { project } = await createTestProject({ membership: { admin: true } });
     expect(project).toBeDefined();
     const exporter = new BulkExporter(systemRepo, undefined);
     const exportWriteResourceSpy = jest.spyOn(exporter, 'writeResource');

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -2,10 +2,10 @@ import { accepted, getResourceTypes, protectedResourceTypes } from '@medplum/cor
 import { Project, ResourceType } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getConfig } from '../../config';
+import { getAuthenticatedContext } from '../../context';
 import { sendOutcome } from '../outcomes';
 import { getPatientResourceTypes } from '../patient';
 import { BulkExporter } from './utils/bulkexporter';
-import { getAuthenticatedContext } from '../../context';
 
 /**
  * Handles a bulk export request.
@@ -63,7 +63,11 @@ export async function exportResources(
   const resourceTypes = getResourceTypesByExportLevel(exportLevel);
 
   for (const resourceType of resourceTypes) {
-    if (!canBeExported(resourceType) || (types && !types.includes(resourceType))) {
+    if (
+      !canBeExported(resourceType) ||
+      (types && !types.includes(resourceType)) ||
+      !exporter.repo.canReadResourceType(resourceType)
+    ) {
       continue;
     }
     await exportResourceType(exporter, resourceType);


### PR DESCRIPTION
Before: If a user had an access policy that restricted resource types, the export operation would fail when trying to search for that resource type.

After: Only export resource types that the user has access to.