### PR TITLE
IF-MATCH header for resource contention

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -19,6 +19,7 @@ import {
   notFound,
   notModified,
   operationOutcomeToString,
+  preconditionFailed,
   tooManyRequests,
   unauthorized,
 } from './outcomes';
@@ -87,6 +88,7 @@ describe('Outcomes', () => {
     expect(getStatus(notFound)).toBe(404);
     expect(getStatus(conflict('bad'))).toBe(409);
     expect(getStatus(gone)).toBe(410);
+    expect(getStatus(preconditionFailed)).toBe(412);
     expect(getStatus(tooManyRequests)).toBe(429);
     expect(getStatus(badRequest('bad'))).toBe(400);
   });

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -8,6 +8,7 @@ const NOT_MODIFIED_ID = 'not-modified';
 const NOT_FOUND_ID = 'not-found';
 const CONFLICT_ID = 'conflict';
 const UNAUTHORIZED_ID = 'unauthorized';
+const PRECONDITION_FAILED_ID = 'precondition-failed';
 const FORBIDDEN_ID = 'forbidden';
 const TOO_MANY_REQUESTS_ID = 'too-many-requests';
 const ACCEPTED_ID = 'accepted';
@@ -105,6 +106,20 @@ export const gone: OperationOutcome = {
       code: 'deleted',
       details: {
         text: 'Gone',
+      },
+    },
+  ],
+};
+
+export const preconditionFailed: OperationOutcome = {
+  resourceType: 'OperationOutcome',
+  id: PRECONDITION_FAILED_ID,
+  issue: [
+    {
+      severity: 'error',
+      code: 'lock-error',
+      details: {
+        text: 'Precondition Failed',
       },
     },
   ],
@@ -250,6 +265,8 @@ export function getStatus(outcome: OperationOutcome): number {
       return 409;
     case GONE_ID:
       return 410;
+    case PRECONDITION_FAILED_ID:
+      return 412;
     case TOO_MANY_REQUESTS_ID:
       return 429;
     default:

--- a/packages/fhir-router/src/fhirrouter.test.ts
+++ b/packages/fhir-router/src/fhirrouter.test.ts
@@ -5,6 +5,7 @@ import {
   indexSearchParameterBundle,
   indexStructureDefinitionBundle,
   notFound,
+  preconditionFailed,
 } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, OperationOutcome, SearchParameter } from '@medplum/fhirtypes';
@@ -170,6 +171,24 @@ describe('FHIR Router', () => {
       repo
     );
     expect(res).toMatchObject(badRequest('Incorrect ID'));
+  });
+
+  test('Update incorrect precondition', async () => {
+    const [res] = await router.handleRequest(
+      {
+        method: 'PUT',
+        pathname: '/Patient/123',
+        body: {
+          resourceType: 'Patient',
+          id: '123',
+        },
+        params: {},
+        query: {},
+        headers: { 'if-match': 'W/"test"' },
+      },
+      repo
+    );
+    expect(res).toMatchObject(preconditionFailed);
   });
 
   test('Search by post', async () => {

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -10,6 +10,7 @@ import {
   matchesSearchRequest,
   normalizeOperationOutcome,
   notFound,
+  preconditionFailed,
 } from '@medplum/core';
 import { Bundle, BundleEntry, Reference, Resource } from '@medplum/fhirtypes';
 import { Operation, applyPatch } from 'rfc6902';
@@ -89,7 +90,7 @@ export interface FhirRepository<TClient = unknown> {
    * @param resource - The FHIR resource to update.
    * @returns The updated resource.
    */
-  updateResource<T extends Resource>(resource: T): Promise<T>;
+  updateResource<T extends Resource>(resource: T, versionId?: string): Promise<T>;
 
   /**
    * Deletes a FHIR resource.
@@ -255,8 +256,13 @@ export class MemoryRepository extends BaseRepository implements FhirRepository {
     return deepClone(result);
   }
 
-  updateResource<T extends Resource>(resource: T): Promise<T> {
+  updateResource<T extends Resource>(resource: T, versionId?: string): Promise<T> {
     const result = deepClone(resource);
+    if (versionId) {
+      if (result.meta?.versionId !== versionId) {
+        throw new OperationOutcomeError(preconditionFailed);
+      }
+    }
     if (result.meta) {
       if (result.meta.versionId) {
         delete result.meta.versionId;

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -258,10 +258,8 @@ export class MemoryRepository extends BaseRepository implements FhirRepository {
 
   updateResource<T extends Resource>(resource: T, versionId?: string): Promise<T> {
     const result = deepClone(resource);
-    if (versionId) {
-      if (result.meta?.versionId !== versionId) {
-        throw new OperationOutcomeError(preconditionFailed);
-      }
+    if (versionId && result.meta?.versionId !== versionId) {
+      throw new OperationOutcomeError(preconditionFailed);
     }
     if (result.meta) {
       if (result.meta.versionId) {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -31,6 +31,7 @@ import { getDatabasePool } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { getSystemRepo, Repository } from './repo';
+import { preconditionFailed } from '@medplum/core';
 
 jest.mock('hibp');
 
@@ -429,6 +430,35 @@ describe('FHIR Repo', () => {
         fail('Should have thrown');
       } catch (err) {
         expect((err as OperationOutcomeError).outcome).toMatchObject(badRequest('Missing id'));
+      }
+    }));
+
+  test('Update resource with matching versionId', () =>
+    withTestContext(async () => {
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family: 'Test' }],
+      });
+
+      (patient as Patient).name = [{ family: 'TestUpdated' }];
+
+      let versionId = `${patient.meta?.versionId}`;
+      await systemRepo.updateResource<Patient>(patient, versionId);
+      expect(patient.name?.at(0)?.family).toEqual('TestUpdated');
+    }));
+
+  test('Update resource with different versionId', () =>
+    withTestContext(async () => {
+      const patient1 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ family: 'Test' }],
+      });
+
+      try {
+        await systemRepo.updateResource<Patient>(patient1, 'bad-id');
+        fail('Should have thrown');
+      } catch (err) {
+        expect((err as OperationOutcomeError).outcome).toMatchObject(preconditionFailed);
       }
     }));
 

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -7,6 +7,7 @@ import {
   notFound,
   OperationOutcomeError,
   Operator,
+  preconditionFailed,
 } from '@medplum/core';
 import {
   BundleEntry,
@@ -31,7 +32,6 @@ import { getDatabasePool } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { getSystemRepo, Repository } from './repo';
-import { preconditionFailed } from '@medplum/core';
 
 jest.mock('hibp');
 
@@ -442,7 +442,7 @@ describe('FHIR Repo', () => {
 
       (patient as Patient).name = [{ family: 'TestUpdated' }];
 
-      let versionId = `${patient.meta?.versionId}`;
+      const versionId = patient.meta?.versionId;
       await systemRepo.updateResource<Patient>(patient, versionId);
       expect(patient.name?.at(0)?.family).toEqual('TestUpdated');
     }));

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -487,10 +487,8 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
         // Check before the update
         throw new OperationOutcomeError(forbidden);
       }
-      if (versionId) {
-        if (existing.meta?.versionId !== versionId) {
-          throw new OperationOutcomeError(preconditionFailed);
-        }
+      if (versionId && existing.meta?.versionId !== versionId) {
+        throw new OperationOutcomeError(preconditionFailed);
       }
     }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -25,6 +25,7 @@ import {
   normalizeOperationOutcome,
   notFound,
   parseSearchRequest,
+  preconditionFailed,
   protectedResourceTypes,
   resolveId,
   satisfiedAccessPolicy,
@@ -451,9 +452,9 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     }
   }
 
-  async updateResource<T extends Resource>(resource: T): Promise<T> {
+  async updateResource<T extends Resource>(resource: T, versionId?: string): Promise<T> {
     try {
-      const result = await this.updateResourceImpl(resource, false);
+      const result = await this.updateResourceImpl(resource, false, versionId);
       this.logEvent(UpdateInteraction, AuditEventOutcome.Success, undefined, result);
       return result;
     } catch (err) {
@@ -462,7 +463,7 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     }
   }
 
-  private async updateResourceImpl<T extends Resource>(resource: T, create: boolean): Promise<T> {
+  private async updateResourceImpl<T extends Resource>(resource: T, create: boolean, versionId?: string): Promise<T> {
     const { resourceType, id } = resource;
     if (!id) {
       throw new OperationOutcomeError(badRequest('Missing id'));
@@ -485,6 +486,11 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
       if (!this.canWriteToResource(existing)) {
         // Check before the update
         throw new OperationOutcomeError(forbidden);
+      }
+      if (versionId) {
+        if (existing.meta?.versionId !== versionId) {
+          throw new OperationOutcomeError(preconditionFailed);
+        }
       }
     }
 

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -356,6 +356,38 @@ describe('FHIR Routes', () => {
     expect(res.status).toBe(400);
   });
 
+  test('Update resource with precondition', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({ resourceType: 'Patient' });
+    expect(res.status).toBe(201);
+    const patient = res.body;
+    const res2 = await request(app)
+      .put(`/fhir/R4/Patient/${patient.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('If-Match', 'W/"' + patient.meta?.versionId + '"')
+      .send({ ...patient, active: true });
+    expect(res2.status).toBe(200);
+  });
+
+  test('Update resource with failed precondition', async () => {
+    const res = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({ resourceType: 'Patient' });
+    expect(res.status).toBe(201);
+    const patient = res.body;
+    const res2 = await request(app)
+      .put(`/fhir/R4/Patient/${patient.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('If-Match', 'W/"bad-id"')
+      .send({ ...patient, active: true });
+    expect(res2.status).toBe(412);
+  });
+
   test('Delete resource', async () => {
     const res = await request(app)
       .post(`/fhir/R4/Patient`)

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -232,6 +232,7 @@ protectedRoutes.use(
       params: req.params,
       query: req.query as Record<string, string>,
       body: req.body,
+      headers: req.headers,
     };
 
     const result = await internalFhirRouter.handleRequest(request, ctx.repo);


### PR DESCRIPTION
This PR implements [optimistic locking](https://hl7.org/fhir/R4/http.html#concurrency) using the `if-match` header for `PUT` operations.

Possible issues I've noticed:
- `lock-error` may not be the correct code to use for a `412 Precondition Failed`
- Using `IncomingHttpHeaders` in `FhirRequest` may not be the best approach
- Extracting the `versionId` with `versionId = if_match.slice(3, if_match.length - 1);` may not be robust enough

Closes #3313