### PR TITLE
Fix: Added creatable prop to CodingInput in QuestionnaireChoiceSetInput at QuestionnaireFormItem.

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -322,6 +322,7 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
         name={name}
         binding={item.answerValueSet}
         onChange={(code) => onChangeAnswer({ valueCoding: code })}
+        creatable={item.type === QuestionnaireItemType.openChoice}
       />
     );
   }


### PR DESCRIPTION
The bug is that ```QuestionnaireChoiceSetInput()``` in ```packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx``` do not check if it's ```choice``` or ```openChoice``` and the ```createable``` prop on ```<CodingInput />``` is not set, so ```creatable``` is always ```true``` even though ```openChoice``` is not the type.