### PR TITLE
Fixes #4084 - validate reference resource type

### DIFF
--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -35,7 +35,6 @@ import { OperationOutcomeError } from '../outcomes';
 import { createReference, deepClone } from '../utils';
 import { indexStructureDefinitionBundle } from './types';
 import { validateResource } from './validation';
-import { Logger } from '../logger';
 
 describe('FHIR resource validation', () => {
   let typesBundle: Bundle;
@@ -1374,14 +1373,13 @@ describe('FHIR resource validation', () => {
       ],
     };
 
-    const write = jest.fn();
-    const logger = new Logger(write);
-
     // TODO: Change this check from warning to error
     // Duplicate entries for choice-of-type property is currently a warning
     // We need to first log and track this, and notify customers of breaking changes
-    expect(() => validateResource(carePlan, { logger })).not.toThrow();
-    expect(write).toHaveBeenCalledWith(expect.stringContaining('Validator warning: Duplicate choice of type property'));
+    const issues = validateResource(carePlan);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].details?.text).toContain('Duplicate choice of type property');
   });
 
   test('Reference type check', () => {
@@ -1395,14 +1393,13 @@ describe('FHIR resource validation', () => {
       relatesTo: [{ code: 'appends', target: { reference: 'Patient/123' } }],
     };
 
-    const write = jest.fn();
-    const logger = new Logger(write);
-
     // TODO: Change this check from warning to error
     // Duplicate entries for choice-of-type property is currently a warning
     // We need to first log and track this, and notify customers of breaking changes
-    expect(() => validateResource(docRef, { logger })).not.toThrow();
-    expect(write).toHaveBeenCalledWith(expect.stringContaining('Validator warning: Invalid reference for'));
+    const issues = validateResource(docRef);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].details?.text).toContain('Invalid reference for');
   });
 });
 

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -9,6 +9,7 @@ import {
   CodeSystem,
   Condition,
   DiagnosticReport,
+  DocumentReference,
   ElementDefinition,
   Encounter,
   Extension,
@@ -1381,6 +1382,27 @@ describe('FHIR resource validation', () => {
     // We need to first log and track this, and notify customers of breaking changes
     expect(() => validateResource(carePlan, { logger })).not.toThrow();
     expect(write).toHaveBeenCalledWith(expect.stringContaining('Validator warning: Duplicate choice of type property'));
+  });
+
+  test('Reference type check', () => {
+    const docRef: DocumentReference = {
+      resourceType: 'DocumentReference',
+      status: 'current',
+      content: [{ attachment: { data: 'aGVsbG8gd29ybGQ=' } }],
+
+      // Note that "relatesTo.target" must be a Reference to a DocumentReference
+      // This reference to a Patient is invalid
+      relatesTo: [{ code: 'appends', target: { reference: 'Patient/123' } }],
+    };
+
+    const write = jest.fn();
+    const logger = new Logger(write);
+
+    // TODO: Change this check from warning to error
+    // Duplicate entries for choice-of-type property is currently a warning
+    // We need to first log and track this, and notify customers of breaking changes
+    expect(() => validateResource(docRef, { logger })).not.toThrow();
+    expect(write).toHaveBeenCalledWith(expect.stringContaining('Validator warning: Invalid reference for'));
   });
 });
 

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -51,7 +51,7 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
     if (!input.parameter) {
       return {} as any;
     }
-    validateResource(input as Parameters, { logger: getLogger() });
+    validateResource(input as Parameters);
     return parseParams(inputParameters, input.parameter) as any;
   } else {
     return Object.fromEntries(
@@ -224,7 +224,7 @@ export async function sendOutputParameters(
   }
 
   try {
-    validateResource(response, { logger: getLogger() });
+    validateResource(response);
     res.status(getStatus(outcome)).json(response);
   } catch (err: any) {
     getLogger().error('Malformed operation output Parameters', { error: err.toString() });


### PR DESCRIPTION
Also moved the warning logs from `core` to `server` so we can tag it with more metadata such as project ID.