### PR TITLE
Server log cleanup

### DIFF
--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -349,13 +349,18 @@ class ResourceValidator implements ResourceVisitor {
     }
 
     const hl7BaseUrl = HTTP_HL7_ORG + '/fhir/StructureDefinition/';
+    const hl7AllResourcesUrl = hl7BaseUrl + 'Resource';
     const hl7ResourceTypeUrl = hl7BaseUrl + referenceResourceType;
 
     const medplumBaseUrl = 'https://medplum.com/fhir/StructureDefinition/';
     const medplumResourceTypeUrl = medplumBaseUrl + referenceResourceType;
 
     for (const targetProfile of targetProfiles) {
-      if (targetProfile === hl7ResourceTypeUrl || targetProfile === medplumResourceTypeUrl) {
+      if (
+        targetProfile === hl7AllResourcesUrl ||
+        targetProfile === hl7ResourceTypeUrl ||
+        targetProfile === medplumResourceTypeUrl
+      ) {
         // Found a matching profile
         return;
       }

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1512,7 +1512,7 @@ describe('Subscription Worker', () => {
 
   test('WebSocket Subscription -- Feature Flag Not Enabled', () =>
     withTestContext(async () => {
-      globalLogger.level = LogLevel.WARN;
+      globalLogger.level = LogLevel.DEBUG;
       const originalConsoleLog = console.log;
       console.log = jest.fn();
 

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1512,7 +1512,7 @@ describe('Subscription Worker', () => {
 
   test('WebSocket Subscription -- Feature Flag Not Enabled', () =>
     withTestContext(async () => {
-      globalLogger.level = LogLevel.DEBUG;
+      globalLogger.level = LogLevel.WARN;
       const originalConsoleLog = console.log;
       console.log = jest.fn();
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -222,7 +222,6 @@ export async function addSubscriptionJobs(resource: Resource, context: Backgroun
     return;
   }
   if (!project) {
-    logger.warn(`[Subscription Access Policy]: No project for resource '${getReferenceString(resource)}'`);
     return;
   }
 
@@ -375,7 +374,7 @@ async function getSubscriptions(resource: Resource, project: Project): Promise<S
         subscriptions.push(resource);
       }
     } else {
-      globalLogger.warn(
+      globalLogger.debug(
         `[WebSocket Subscriptions]: subscription for resource '${getReferenceString(resource)}' might have been fired but WebSocket subscriptions are not enabled for project '${project.name ?? getReferenceString(project)}'`
       );
     }

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -374,7 +374,7 @@ async function getSubscriptions(resource: Resource, project: Project): Promise<S
         subscriptions.push(resource);
       }
     } else {
-      globalLogger.debug(
+      globalLogger.warn(
         `[WebSocket Subscriptions]: subscription for resource '${getReferenceString(resource)}' might have been fired but WebSocket subscriptions are not enabled for project '${project.name ?? getReferenceString(project)}'`
       );
     }


### PR DESCRIPTION
1. Add `Bot` and `ClientApplication` to valid targets in `AuditEvent`
2. Handle "all resources" target profile in reference validator
3. Remove warning about "No project for resources" (many valid cases)