### PR TITLE
Fixed AuditEvent type definition

### DIFF
--- a/packages/fhirtypes/dist/AuditEvent.d.ts
+++ b/packages/fhirtypes/dist/AuditEvent.d.ts
@@ -3,6 +3,8 @@
  * Do not edit manually.
  */
 
+import { Bot } from './Bot';
+import { ClientApplication } from './ClientApplication';
 import { CodeableConcept } from './CodeableConcept';
 import { Coding } from './Coding';
 import { Device } from './Device';
@@ -523,7 +525,7 @@ export interface AuditEventSource {
   /**
    * Identifier of the source where the event was detected.
    */
-  observer: Reference<PractitionerRole | Practitioner | Organization | Device | Patient | RelatedPerson>;
+  observer: Reference<PractitionerRole | Practitioner | Organization | Device | Patient | RelatedPerson | Bot | ClientApplication>;
 
   /**
    * Code specifying the type of source where event originated.


### PR DESCRIPTION
In https://github.com/medplum/medplum/pull/4112 we added `Bot` and `ClientApplication` to valid targets in `AuditEvent`

This PR updates the `AuditEvent` TypeScript type definition accordingly.