### PR TITLE
Fix - #4123 Correctly display task codes in charting demo

### DIFF
--- a/examples/medplum-chart-demo/src/components/tasks/TaskList.tsx
+++ b/examples/medplum-chart-demo/src/components/tasks/TaskList.tsx
@@ -174,7 +174,7 @@ function TaskTitle(props: TaskCellProps): JSX.Element {
     } else if (props.resource.resourceType === 'QuestionnaireResponse') {
       fetchQuestionnaireTitle().catch(console.error);
     } else {
-      setTitle(<>{props.task.code}</>);
+      setTitle(<CodeableConceptDisplay value={props.task.code} />);
     }
   }, [props.resource, props.task, medplum]);
 


### PR DESCRIPTION
This puts the `Task.code` into a <CodeableConceptDisplay /> component so that it correctly displays and does not throw an error.