### PR TITLE
fix: `autoFocus` MFA input in sign-in form

### DIFF
--- a/packages/react/src/auth/MfaForm.tsx
+++ b/packages/react/src/auth/MfaForm.tsx
@@ -39,7 +39,7 @@ export function MfaForm(props: MfaFormProps): JSX.Element {
           </Alert>
         )}
         <Stack>
-          <TextInput name="token" label="MFA code" required />
+          <TextInput name="token" label="MFA code" required autoFocus />
         </Stack>
         <Group justify="flex-end" mt="xl">
           <Button type="submit">Submit code</Button>


### PR DESCRIPTION
Add [`autoFocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) prop to MFA sign in input to improve UX