### PR TITLE
Don't mutate input array in getPropertyValueWithSchema

### DIFF
--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -255,6 +255,26 @@ describe('FHIRPath utils', () => {
     });
   });
 
+  test('getTypedPropertyValueWithSchema with primitive extensions', () => {
+    const humanName = {
+      given: ['John', 'Johnny'],
+      _given: [{ extension: [{ url: 'http://example.com', valueBoolean: true }] }],
+    };
+    const given: InternalSchemaElement = {
+      description: '',
+      path: 'HumanName.given',
+      min: 0,
+      max: 2,
+      isArray: true,
+      type: [{ code: 'string' }],
+    };
+    getTypedPropertyValueWithSchema({ type: 'HumanName', value: humanName }, 'given', given);
+    expect(humanName.given).toEqual(expect.arrayContaining(['John', 'Johnny']));
+    // with primitive extensions, array values can be changed into a `String` type which has a typeof 'object'
+    // ensure the original input array values is not mutated as such
+    expect(humanName.given.every((g) => typeof g === 'string')).toBe(true);
+  });
+
   test('isDateString', () => {
     expect(isDateString(undefined)).toBe(false);
     expect(isDateString(null)).toBe(false);

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -159,6 +159,7 @@ export function getTypedPropertyValueWithSchema(
   // In the case of [x] choice-of-type, the type must be resolved to a single type.
   if (primitiveExtension) {
     if (Array.isArray(resultValue)) {
+      resultValue = resultValue.slice();
       for (let i = 0; i < Math.max(resultValue.length, primitiveExtension.length); i++) {
         resultValue[i] = assignPrimitiveExtension(resultValue[i], primitiveExtension[i]);
       }

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -159,6 +159,7 @@ export function getTypedPropertyValueWithSchema(
   // In the case of [x] choice-of-type, the type must be resolved to a single type.
   if (primitiveExtension) {
     if (Array.isArray(resultValue)) {
+      // Slice to avoid mutating the array in the input value
       resultValue = resultValue.slice();
       for (let i = 0; i < Math.max(resultValue.length, primitiveExtension.length); i++) {
         resultValue[i] = assignPrimitiveExtension(resultValue[i], primitiveExtension[i]);
@@ -547,6 +548,13 @@ function assignPrimitiveExtension(target: any, primitiveExtension: any): any {
   return target;
 }
 
+/**
+ * For primitive string, number, boolean, the return value will be the corresponding
+ * `String`, `Number`, or `Boolean` version of the type.
+ * @param target - The value to have `source` properties assigned to.
+ * @param source - An object to be assigned to `target`.
+ * @returns The `target` value with the properties of `source` assigned to it.
+ */
 function safeAssign(target: any, source: any): any {
   delete source.__proto__; //eslint-disable-line no-proto
   delete source.constructor;


### PR DESCRIPTION
This was a tricky one to track down! The `StructureDefinition` of US Core Service Request specifies a primitive extension for each targetProfile in the type of `ServiceRequest.requester`:

```javascript
{
  "id": "ServiceRequest.requester",
  "path": "ServiceRequest.requester",
  "type": [
    {
      "code": "Reference",
      "targetProfile": [
        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
        "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-relatedperson",
        "http://hl7.org/fhir/StructureDefinition/Device"
      ],
      "_targetProfile": [
        {
          "extension": [
            {
              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
              "valueBoolean": true
            }
          ]
        },
        {
          "extension": [
            {
              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
              "valueBoolean": false
            }
          ]
        },
        {
          "extension": [
            {
              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
              "valueBoolean": false
            }
          ]
        },
        {
          "extension": [
            {
              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
              "valueBoolean": false
            }
          ]
        },
        {
          "extension": [
            {
              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
              "valueBoolean": false
            }
          ]
        },
        {
          "extension": [
            {
              "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
              "valueBoolean": false
            }
          ]
        }
      ]
    }
  ],
  "mustSupport": true
}
```

When attempting to create the StructureDefinition, it is first validated. During validation, constraint `eld-17` which has an expression of `(code='Reference' or code = 'canonical' or code = 'CodeableReference') or targetProfile.empty()` is checked. To check that constraint, `getPropertyValueWithSchema` winds up being called on the `targetProfile` property of the element definition's type. The way primitive extensions are handled causes primitive strings to be cast to `String` objects. That casting mixed with the underlying bug of the input array, in this case the `targetProfile` array with six entries, having each member reassigned to the result of `assignPrimitiveExtension` resulted in the input StructureDefinition subtly having its contents mutated.

Later on, after validation, in `updateResourceImpl`, the call to `rewriteAttachments` recursively iterates through the entire input resource, rewriting all object properties found. This is where the change to `String` caused an issue. Since `typeof new String('foo') === 'object'`, the `String` entries of `targetProfile` [pass the check for objects](https://github.com/medplum/medplum/blob/d963867722ce94e0993a079087f1ab34fa669b9a/packages/server/src/fhir/rewrite.ts#L76). A few lines down when `Object.entries` and then `Object.fromEntries` is called on a `String`, it explodes each targetProfile string into the structure shown below which is what causes the error in #4122.

```
{
  "0": "h",
  "1": "t",
  "2": "t",
  "3": "p",
  "4": ":",
  "5": "/",
  "6": "/",
  "7": "h",
  "8": "l",
  "9": "7",
  "10": ".",
  "11": "o",
  "12": "r",
  "13": "g",
  "14": "/",
  "15": "f",
  "16": "h",
  "17": "i",
  "18": "r",
  "19": "/",
  "20": "S",
  "21": "t",
  "22": "r",
  "23": "u",
  "24": "c",
  "25": "t",
  "26": "u",
  "27": "r",
  "28": "e",
  "29": "D",
  "30": "e",
  "31": "f",
  "32": "i",
  "33": "n",
  "34": "i",
  "35": "t",
  "36": "i",
  "37": "o",
  "38": "n",
  "39": "/",
  "40": "D",
  "41": "e",
  "42": "v",
  "43": "i",
  "44": "c",
  "45": "e"
}
```

Fixes #4122 