### PR TITLE
Chromatic: maintain a clean main branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,6 +23,7 @@ jobs:
           projectToken: chpt_429b596edaecafb
           workingDir: packages/react
           buildScriptName: storybook
+          autoAcceptChanges: 'main'
           exitOnceUploaded: true
           exitZeroOnChanges: true
           onlyChanged: true


### PR DESCRIPTION
Per the advice on https://www.chromatic.com/docs/github-actions/.

According to https://www.chromatic.com/docs/github-actions/#github-squashrebase-merge-and-the-main-branch, Chromatic should have been able to detect our squash and rebase from PRs onto `main`, but that has not been happening as expected leading to test changes showing up on unrelated PRs even though they had been accepted on the relevant PR branch. For example, #4148 and several other recent PRs were flagged as having UI test changes even though they originated (and were accepted) from #4144. For some unknown reason, the acceptance of the test changes on that PR did not properly propagate to the `main` baseline in [Chromatic build 1478](https://www.chromatic.com/build?appId=657a9d11cd4bf45aa28a3ee4&number=1478)