### PR TITLE
Bugfix: domain-level IDP should be case-insensitive

### DIFF
--- a/packages/docs/docs/auth/methods/domain-level-identity-providers.md
+++ b/packages/docs/docs/auth/methods/domain-level-identity-providers.md
@@ -90,7 +90,7 @@ Create a [`DomainConfiguration`](/docs/api/fhir/medplum/domainconfiguration) res
 
 - Add the values for the five elements above
 - Leave "useSubject" **unchecked**
-- Set the `domain` field to the users' email domain (e.g. "d) Once the resource has been saved, all new authentication requests from that domain will use Okta authentication.
+- Set the `domain` field to the users' email domain (e.g. "mydomain.com") **in all lower-case**. Once the resource has been saved, all new authentication requests from that domain will use Okta authentication.
 
 :::caution Note
 

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -63,7 +63,7 @@ export const externalCallbackHandler = async (req: Request, res: Response): Prom
   if (idp.useSubject) {
     externalId = userInfo.sub as string;
   } else {
-    email = userInfo.email as string;
+    email = (userInfo.email as string).toLowerCase();
   }
 
   if (body.domain && !email?.endsWith('@' + body.domain)) {

--- a/packages/server/src/auth/method.test.ts
+++ b/packages/server/src/auth/method.test.ts
@@ -66,6 +66,30 @@ describe('Method', () => {
     expect(res2.status).toBe(200);
   });
 
+  test('Domain config case sensitivity', async () => {
+    const domain = randomUUID() + '.example.com';
+    await withTestContext(() =>
+      systemRepo.createResource<DomainConfiguration>({
+        resourceType: 'DomainConfiguration',
+        domain,
+        identityProvider: {
+          authorizeUrl: 'https://example.com/oauth2/authorize',
+          tokenUrl: 'https://example.com/oauth2/token',
+          userInfoUrl: 'https://example.com/oauth2/userinfo',
+          clientId: '123',
+          clientSecret: '456',
+        },
+      })
+    );
+
+    // Domain config found
+    const res1 = await request(app)
+      .post('/auth/method')
+      .type('json')
+      .send({ email: 'alice@' + domain.toUpperCase() });
+    expect(res1.status).toBe(200);
+  });
+
   test('Domain config authorize url without protocol', async () => {
     const domain = randomUUID() + '.example.com';
     await withTestContext(() =>

--- a/packages/server/src/auth/method.ts
+++ b/packages/server/src/auth/method.ts
@@ -75,7 +75,7 @@ export async function getDomainConfiguration(domain: string): Promise<DomainConf
       {
         code: 'domain',
         operator: Operator.EQUALS,
-        value: domain,
+        value: domain.toLowerCase(),
       },
     ],
   });


### PR DESCRIPTION
As currently implented, domain level IdPs treat the email domain as case-sensitive
(e.g. mydomain.com is different than MyDomain.com). 

This creates problems when the Idp (e.g. Azure SSO) stores the user info with different casing than they way the user enters their email