### PR TITLE
feat(getwsbindingtoken): add feature gate on `websocket-subscriptions`

### DIFF
--- a/packages/server/src/fhir/operations/getwsbindingtoken.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.ts
@@ -27,8 +27,13 @@ export type AdditionalWsBindingClaims = {
  * @param res - The HTTP response.
  */
 export async function getWsBindingTokenHandler(req: Request, res: Response): Promise<void> {
-  const { login, profile, repo } = getAuthenticatedContext();
+  const { login, profile, repo, project } = getAuthenticatedContext();
   const { baseUrl } = getConfig();
+
+  if (!project.features?.includes('websocket-subscriptions')) {
+    sendOutcome(res, badRequest('WebSocket subscriptions not enabled for current project'));
+    return;
+  }
 
   const clientId = login.client && resolveId(login.client);
   const userId = resolveId(login.user);

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -14,11 +14,10 @@ import { Server } from 'http';
 import { randomUUID } from 'node:crypto';
 import request from 'superwstest';
 import { initApp, shutdownApp } from '../app';
-import { registerNew } from '../auth/register';
 import { MedplumServerConfig, loadTestConfig } from '../config';
 import { Repository } from '../fhir/repo';
 import { getRedis } from '../redis';
-import { withTestContext } from '../test.setup';
+import { createTestProject, withTestContext } from '../test.setup';
 import { execSubscriptionJob, getSubscriptionQueue } from '../workers/subscription';
 
 jest.mock('hibp');
@@ -39,18 +38,15 @@ describe('WebSockets Subscriptions', () => {
     server = await initApp(app, config);
     await getRedis().flushdb();
 
-    const response = await withTestContext(() =>
-      registerNew({
-        firstName: 'Alice',
-        lastName: 'Smith',
-        projectName: 'Alice Project',
-        email: `alice${randomUUID()}@example.com`,
-        password: 'password!@#',
+    const result = await withTestContext(() =>
+      createTestProject({
+        project: { features: ['websocket-subscriptions'] },
+        withAccessToken: true,
       })
     );
 
-    project = response.project;
-    accessToken = response.accessToken;
+    project = result.project;
+    accessToken = result.accessToken;
 
     repo = new Repository({
       extendedMode: true,
@@ -285,18 +281,15 @@ describe('Subscription Heartbeat', () => {
     server = await initApp(app, config);
     await getRedis().flushdb();
 
-    const response = await withTestContext(() =>
-      registerNew({
-        firstName: 'Alice',
-        lastName: 'Smith',
-        projectName: 'Alice Project',
-        email: `alice${randomUUID()}@example.com`,
-        password: 'password!@#',
+    const result = await withTestContext(() =>
+      createTestProject({
+        project: { features: ['websocket-subscriptions'] },
+        withAccessToken: true,
       })
     );
 
-    project = response.project;
-    accessToken = response.accessToken;
+    project = result.project;
+    accessToken = result.accessToken;
 
     repo = new Repository({
       extendedMode: true,


### PR DESCRIPTION
Closes #4190 

This should save a lot of debugging time by preventing connecting to the `WebSocket Subscription` endpoint early by returning an `OperationOutcome` error when a project doesn't have the feature enabled.