### PR TITLE
FHIR search lookup table optimizations

### DIFF
--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -99,20 +99,18 @@ export class AddressTable extends LookupTable {
     const resourceId = resource.id as string;
     const values = [];
 
-    for (let i = 0; i < addresses.length; i++) {
-      const address = addresses[i];
-      values.push({
-        id: randomUUID(),
-        resourceId,
-        index: i,
-        content: stringify(address),
-        address: formatAddress(address),
-        city: address.city?.trim(),
-        country: address.country?.trim(),
-        postalCode: address.postalCode?.trim(),
-        state: address.state?.trim(),
-        use: address.use?.trim(),
-      });
+const values = addresses.map((address, index) => ({
+  id: randomUUID(),
+  resourceId,
+  index,
+  content: stringify(address),
+  address: formatAddress(address),
+  city: address.city?.trim(),
+  country: address.country?.trim(),
+  postalCode: address.postalCode?.trim(),
+  state: address.state?.trim(),
+  use: address.use?.trim(),
+}));
     }
 
     await this.insertValuesForResource(client, resourceType, values);

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -97,21 +97,18 @@ export class AddressTable extends LookupTable {
 
     const resourceType = resource.resourceType;
     const resourceId = resource.id as string;
-    const values = [];
-
-const values = addresses.map((address, index) => ({
-  id: randomUUID(),
-  resourceId,
-  index,
-  content: stringify(address),
-  address: formatAddress(address),
-  city: address.city?.trim(),
-  country: address.country?.trim(),
-  postalCode: address.postalCode?.trim(),
-  state: address.state?.trim(),
-  use: address.use?.trim(),
-}));
-    }
+    const values = addresses.map((address, index) => ({
+      id: randomUUID(),
+      resourceId,
+      index,
+      content: stringify(address),
+      address: formatAddress(address),
+      city: address.city?.trim(),
+      country: address.country?.trim(),
+      postalCode: address.postalCode?.trim(),
+      state: address.state?.trim(),
+      use: address.use?.trim(),
+    }));
 
     await this.insertValuesForResource(client, resourceType, values);
   }

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -3,13 +3,12 @@ import { Address, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { PoolClient } from 'pg';
 import { LookupTable } from './lookuptable';
-import { compareArrays } from './util';
 
 /**
  * The AddressTable class is used to index and search Address properties.
  * Each Address is represented as a separate row in the "Address" table.
  */
-export class AddressTable extends LookupTable<Address> {
+export class AddressTable extends LookupTable {
   private static readonly knownParams: Set<string> = new Set<string>([
     'individual-address',
     'individual-address-city',
@@ -83,9 +82,14 @@ export class AddressTable extends LookupTable<Address> {
    * Attempts to reuse existing Addresses if they are correct.
    * @param client - The database client.
    * @param resource - The resource to index.
+   * @param create - True if the resource should be created (vs updated).
    * @returns Promise on completion.
    */
-  async indexResource(client: PoolClient, resource: Resource): Promise<void> {
+  async indexResource(client: PoolClient, resource: Resource, create: boolean): Promise<void> {
+    if (!create) {
+      await this.deleteValuesForResource(client, resource);
+    }
+
     const addresses = this.getIncomingAddresses(resource);
     if (!addresses || !Array.isArray(addresses)) {
       return;
@@ -93,33 +97,25 @@ export class AddressTable extends LookupTable<Address> {
 
     const resourceType = resource.resourceType;
     const resourceId = resource.id as string;
-    const existing = await this.getExistingValues(client, resourceType, resourceId);
+    const values = [];
 
-    if (!compareArrays(addresses, existing)) {
-      if (existing.length > 0) {
-        await this.deleteValuesForResource(client, resource);
-      }
-
-      const values = [];
-
-      for (let i = 0; i < addresses.length; i++) {
-        const address = addresses[i];
-        values.push({
-          id: randomUUID(),
-          resourceId,
-          index: i,
-          content: stringify(address),
-          address: formatAddress(address),
-          city: address.city?.trim(),
-          country: address.country?.trim(),
-          postalCode: address.postalCode?.trim(),
-          state: address.state?.trim(),
-          use: address.use?.trim(),
-        });
-      }
-
-      await this.insertValuesForResource(client, resourceType, values);
+    for (let i = 0; i < addresses.length; i++) {
+      const address = addresses[i];
+      values.push({
+        id: randomUUID(),
+        resourceId,
+        index: i,
+        content: stringify(address),
+        address: formatAddress(address),
+        city: address.city?.trim(),
+        country: address.country?.trim(),
+        postalCode: address.postalCode?.trim(),
+        state: address.state?.trim(),
+        use: address.use?.trim(),
+      });
     }
+
+    await this.insertValuesForResource(client, resourceType, values);
   }
 
   private getIncomingAddresses(resource: Resource): Address[] | undefined {

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -3,13 +3,12 @@ import { HumanName, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { PoolClient } from 'pg';
 import { LookupTable } from './lookuptable';
-import { compareArrays } from './util';
 
 /**
  * The HumanNameTable class is used to index and search "name" properties on "Person" resources.
  * Each name is represented as a separate row in the "HumanName" table.
  */
-export class HumanNameTable extends LookupTable<HumanName> {
+export class HumanNameTable extends LookupTable {
   private static readonly knownParams: Set<string> = new Set<string>([
     'individual-given',
     'individual-family',
@@ -50,9 +49,10 @@ export class HumanNameTable extends LookupTable<HumanName> {
    * Attempts to reuse existing identifiers if they are correct.
    * @param client - The database client.
    * @param resource - The resource to index.
+   * @param create - True if the resource should be created (vs updated).
    * @returns Promise on completion.
    */
-  async indexResource(client: PoolClient, resource: Resource): Promise<void> {
+  async indexResource(client: PoolClient, resource: Resource, create: boolean): Promise<void> {
     if (
       resource.resourceType !== 'Patient' &&
       resource.resourceType !== 'Person' &&
@@ -62,6 +62,10 @@ export class HumanNameTable extends LookupTable<HumanName> {
       return;
     }
 
+    if (!create) {
+      await this.deleteValuesForResource(client, resource);
+    }
+
     const names: HumanName[] | undefined = resource.name;
     if (!names || !Array.isArray(names)) {
       return;
@@ -69,30 +73,22 @@ export class HumanNameTable extends LookupTable<HumanName> {
 
     const resourceType = resource.resourceType;
     const resourceId = resource.id as string;
-    const existing = await this.getExistingValues(client, resourceType, resourceId);
+    const values = [];
 
-    if (!compareArrays(names, existing)) {
-      if (existing.length > 0) {
-        await this.deleteValuesForResource(client, resource);
-      }
-
-      const values = [];
-
-      for (let i = 0; i < names.length; i++) {
-        const name = names[i];
-        values.push({
-          id: randomUUID(),
-          resourceId,
-          index: i,
-          content: stringify(name),
-          name: getNameString(name),
-          given: formatGivenName(name),
-          family: formatFamilyName(name),
-        });
-      }
-
-      await this.insertValuesForResource(client, resourceType, values);
+    for (let i = 0; i < names.length; i++) {
+      const name = names[i];
+      values.push({
+        id: randomUUID(),
+        resourceId,
+        index: i,
+        content: stringify(name),
+        name: getNameString(name),
+        given: formatGivenName(name),
+        family: formatFamilyName(name),
+      });
     }
+
+    await this.insertValuesForResource(client, resourceType, values);
   }
 }
 

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -22,7 +22,7 @@ import {
  *   2) Human Names - structured names on Patients, Practitioners, and other person resource types
  *   3) Contact Points - email addresses and phone numbers
  */
-export abstract class LookupTable<T> {
+export abstract class LookupTable {
   /**
    * Returns the unique name of the lookup table.
    * @param resourceType - The resource type.
@@ -48,8 +48,9 @@ export abstract class LookupTable<T> {
    * Indexes the resource in the lookup table.
    * @param client - The database client.
    * @param resource - The resource to index.
+   * @param create - True if the resource should be created (vs updated).
    */
-  abstract indexResource(client: PoolClient, resource: Resource): Promise<void>;
+  abstract indexResource(client: PoolClient, resource: Resource, create: boolean): Promise<void>;
 
   /**
    * Builds a "where" condition for the select query builder.
@@ -120,27 +121,6 @@ export abstract class LookupTable<T> {
       joinOnExpression
     );
     selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending);
-  }
-
-  /**
-   * Returns the existing list of indexed addresses.
-   * @param client - The database client.
-   * @param resourceType - The FHIR resource type.
-   * @param resourceId - The FHIR resource ID.
-   * @returns Promise for the list of indexed addresses.
-   */
-  protected async getExistingValues(
-    client: Pool | PoolClient,
-    resourceType: ResourceType,
-    resourceId: string
-  ): Promise<T[]> {
-    const tableName = this.getTableName(resourceType);
-    return new SelectQuery(tableName)
-      .column('content')
-      .where('resourceId', '=', resourceId)
-      .orderBy('index')
-      .execute(client)
-      .then((result) => result.map((row) => JSON.parse(row.content) as T));
   }
 
   /**

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -1,25 +1,4 @@
-import { stringify } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
-
-/**
- * Compares two arrays of objects.
- * @param incoming - The incoming array of elements.
- * @param existing - The existing array of elements.
- * @returns True if the arrays are equal.  False if they are different.
- */
-export function compareArrays(incoming: any[], existing: any[]): boolean {
-  if (incoming.length !== existing.length) {
-    return false;
-  }
-
-  for (let i = 0; i < incoming.length; i++) {
-    if (stringify(incoming[i]) !== stringify(existing[i])) {
-      return false;
-    }
-  }
-
-  return true;
-}
 
 /**
  * Derives an "identifier" search parameter from a reference search parameter.

--- a/packages/server/src/fhir/lookups/valuesetelement.ts
+++ b/packages/server/src/fhir/lookups/valuesetelement.ts
@@ -8,7 +8,7 @@ import { LookupTable } from './lookuptable';
  * Each element is represented as a separate row in the "ValueSetElementTable" table.
  * Elements can be found in ValueSet and CodeSystem resources.
  */
-export class ValueSetElementTable extends LookupTable<ValueSetExpansionContains> {
+export class ValueSetElementTable extends LookupTable {
   getTableName(): string {
     return 'ValueSetElement';
   }
@@ -26,7 +26,11 @@ export class ValueSetElementTable extends LookupTable<ValueSetExpansionContains>
     return false;
   }
 
-  async indexResource(client: PoolClient, resource: Resource): Promise<void> {
+  async indexResource(client: PoolClient, resource: Resource, create: boolean): Promise<void> {
+    if (!create) {
+      await this.deleteValuesForResource(client, resource);
+    }
+
     const resourceType = resource.resourceType;
     const resourceId = resource.id as string;
     let elements: ValueSetExpansionContains[] | undefined = undefined;
@@ -40,8 +44,6 @@ export class ValueSetElementTable extends LookupTable<ValueSetExpansionContains>
     if (!elements || elements.length === 0) {
       return;
     }
-
-    await this.deleteValuesForResource(client, resource);
 
     const values = [];
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -171,7 +171,7 @@ export interface CacheEntry<T extends Resource = Resource> {
 /**
  * The lookup tables array includes a list of special tables for search indexing.
  */
-const lookupTables: LookupTable<unknown>[] = [
+const lookupTables: LookupTable[] = [
   new AddressTable(),
   new HumanNameTable(),
   new TokenTable(),
@@ -1868,7 +1868,7 @@ export function isIndexTable(resourceType: string, searchParam: SearchParameter)
   return !!getLookupTable(resourceType, searchParam);
 }
 
-export function getLookupTable(resourceType: string, searchParam: SearchParameter): LookupTable<unknown> | undefined {
+export function getLookupTable(resourceType: string, searchParam: SearchParameter): LookupTable | undefined {
   for (const lookupTable of lookupTables) {
     if (lookupTable.isIndexed(searchParam, resourceType)) {
       return lookupTable;


### PR DESCRIPTION
Consider the process of writing a resource:

1. Start a postgres transaction
2. Write the resource to the main resource table
3. Write a version to the history table
4. Update lookup tables
5. Commit the transaction

Now focus on step 4: "Update lookup tables"

Most FHIR search parameters are implemented as precomputed values directly on the main resource table.  For example, `Patient-birthdate` is a simple `date` search parameter, and therefore is a simple column on the `Patient` table.

Some FHIR search parameters have more complex behaviors, and require additional tables.  For example, complex `token` parameters need lookup tables to fully support all of the different syntaxes of `token` search (i.e., `value`, `system|value`, `system|`, `|value`, etc).

So, when writing a resource, we iterate over all of the lookup table implementations:

1. Does this lookup table apply to this resource + search parameter?
2. If yes, continue
3. Get existing values from the lookup table
4. Compare the existing values with the values in the updated resource
5. If changed, delete the existing values and write the new values

In practice, that is suboptimal.

1. We do more "creates" than "updates", so the create flow should be optimized
2. In practice, conditionally updating the lookup values rarely saved us anything
3. `SELECT`+`DELETE`+`INSERT` is slower than `DELETE`+`INSERT`

So the new process implemented in this PR is:

1. Does this lookup table apply to this resource + search parameter?
2. If yes, continue
3. If creating, delete existing values
4. Write new values

Also, bonus, expliclty excluding `_compartment` search parameter from `references.ts`.  The `_compartment` search parameter is an internal Medplum thing and handled separately.