### PR TITLE
Fixes #4204 - FHIR Binary improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Danger
         run: npx danger ci
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}
 
   eslint:
     name: Run eslint

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -16,7 +16,7 @@ if (packageChanged && !lockfileChanged) {
 const modifiedFiles = danger.git.modified_files.filter((path) => /\/src\/.+\.tsx?/.exec(path));
 
 // Check for console.log statements
-const statements = ['console.debug', 'console.log', 'console.warn', 'describe.only', 'test.only'];
+const statements = ['console.debug', 'describe.only', 'test.only'];
 modifiedFiles.forEach((file) => {
   const content = readFileSync(file).toString();
   for (const statement of statements) {

--- a/examples/medplum-demo-bots/src/create-pdf.ts
+++ b/examples/medplum-demo-bots/src/create-pdf.ts
@@ -5,10 +5,12 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
 
   // Generate the PDF
   const binary = await medplum.createPdf({
-    content: [
-      'First paragraph',
-      'Another paragraph, this time a little bit longer to make sure, this line will be divided into at least two lines',
-    ],
+    docDefinition: {
+      content: [
+        'First paragraph',
+        'Another paragraph, this time a little bit longer to make sure, this line will be divided into at least two lines',
+      ],
+    },
   });
 
   // Create a Media, representing an attachment

--- a/examples/medplum-demo-bots/src/form-data-upload.ts
+++ b/examples/medplum-demo-bots/src/form-data-upload.ts
@@ -5,7 +5,9 @@ import fetch from 'node-fetch';
 export async function handler(medplum: MedplumClient): Promise<any> {
   // Create the PDF
   const binary = await medplum.createPdf({
-    content: ['Hello Medplum'],
+    docDefinition: {
+      content: ['Hello Medplum'],
+    },
   });
   console.log('Binary result', JSON.stringify(binary, null, 2));
 

--- a/packages/agent/src/dicom.test.ts
+++ b/packages/agent/src/dicom.test.ts
@@ -66,8 +66,6 @@ describe('DICOM', () => {
     //
     // C-ECHO
     //
-    console.log('CODY sending C-ECHO');
-
     const echoResponse = (await new Promise((resolve, reject) => {
       const request = new dimse.requests.CEchoRequest();
       request.on('response', resolve);

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2642,7 +2642,7 @@ describe('Client', () => {
         baseUrl,
         expect.objectContaining({
           headers: {
-            Accept: DEFAULT_ACCEPT,
+            Accept: '*/*',
             Authorization: `Bearer ${accessToken}`,
             'X-Medplum': 'extended',
           },
@@ -2657,7 +2657,7 @@ describe('Client', () => {
         `${baseUrl}${fhirUrlPath}Binary/fake-id`,
         expect.objectContaining({
           headers: {
-            Accept: DEFAULT_ACCEPT,
+            Accept: '*/*',
             Authorization: `Bearer ${accessToken}`,
             'X-Medplum': 'extended',
           },

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1437,6 +1437,27 @@ describe('Client', () => {
   test('Create attachment', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
+    const result = await client.createAttachment({
+      data: 'Hello world',
+      contentType: ContentType.TEXT,
+    });
+    expect(result).toBeDefined();
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/fhir/R4/Binary',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Accept: DEFAULT_ACCEPT,
+          'Content-Type': ContentType.TEXT,
+          'X-Medplum': 'extended',
+        },
+      })
+    );
+  });
+
+  test('Create attachment (deprecated legacy version)', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
     const result = await client.createAttachment('Hello world', undefined, ContentType.TEXT);
     expect(result).toBeDefined();
     expect(fetch).toHaveBeenCalledWith(
@@ -1455,7 +1476,10 @@ describe('Client', () => {
   test('Create binary', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
-    const result = await client.createBinary('Hello world', undefined, ContentType.TEXT);
+    const result = await client.createBinary({
+      data: 'Hello world',
+      contentType: ContentType.TEXT,
+    });
     expect(result).toBeDefined();
     expect(fetch).toHaveBeenCalledWith(
       'https://api.medplum.com/fhir/R4/Binary',
@@ -1471,6 +1495,46 @@ describe('Client', () => {
   });
 
   test('Create binary with filename', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const result = await client.createBinary({
+      data: 'Hello world',
+      contentType: ContentType.TEXT,
+      filename: 'hello.txt',
+    });
+    expect(result).toBeDefined();
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/fhir/R4/Binary?_filename=hello.txt',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Accept: DEFAULT_ACCEPT,
+          'Content-Type': ContentType.TEXT,
+          'X-Medplum': 'extended',
+        },
+      })
+    );
+  });
+
+  test('Create binary (deprecated legacy version)', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const result = await client.createBinary('Hello world', undefined, ContentType.TEXT);
+    expect(result).toBeDefined();
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/fhir/R4/Binary',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Accept: DEFAULT_ACCEPT,
+          'Content-Type': ContentType.TEXT,
+          'X-Medplum': 'extended',
+        },
+      })
+    );
+  });
+
+  test('Create binary with filename (deprecated legacy version)', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
     const result = await client.createBinary('Hello world', 'hello.txt', ContentType.TEXT);

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2668,23 +2668,63 @@ describe('Client', () => {
   });
 
   describe('Media', () => {
-    test('Upload Media', async () => {
+    test('Create Media', async () => {
       const fetch = mockFetch(200, {});
+      fetch.mockImplementationOnce(async () => mockFetchResponse(201, { resourceType: 'Media', id: '123' }));
+      fetch.mockImplementationOnce(async () =>
+        mockFetchResponse(201, { resourceType: 'Binary', id: '456', url: 'Binary/456' })
+      );
+      fetch.mockImplementationOnce(async () => mockFetchResponse(200, { resourceType: 'Media', id: '123' }));
+
       const client = new MedplumClient({ fetch });
-      const media = await client.uploadMedia('Hello world', 'text/plain', 'hello.txt');
+      const media = await client.createMedia({
+        data: 'Hello world',
+        contentType: 'text/plain',
+        filename: 'hello.txt',
+      });
       expect(media).toBeDefined();
-      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(3);
 
       const calls = fetch.mock.calls;
-      expect(calls).toHaveLength(2);
-      expect(calls[0][0]).toEqual('https://api.medplum.com/fhir/R4/Binary?_filename=hello.txt');
-      expect(calls[1][0]).toEqual('https://api.medplum.com/fhir/R4/Media');
-      expect(JSON.parse(calls[1][1].body)).toMatchObject({
+      expect(calls).toHaveLength(3);
+      expect(calls[0][0]).toEqual('https://api.medplum.com/fhir/R4/Media');
+      expect(calls[1][0]).toEqual('https://api.medplum.com/fhir/R4/Binary?_filename=hello.txt');
+      expect(calls[2][0]).toEqual('https://api.medplum.com/fhir/R4/Media/123');
+      expect(JSON.parse(calls[2][1].body)).toMatchObject({
         resourceType: 'Media',
         status: 'completed',
         content: {
           contentType: 'text/plain',
-          url: 'Binary/undefined',
+          url: 'Binary/456',
+          title: 'hello.txt',
+        },
+      });
+    });
+
+    test('Upload Media', async () => {
+      const fetch = mockFetch(200, {});
+      fetch.mockImplementationOnce(async () => mockFetchResponse(201, { resourceType: 'Media', id: '123' }));
+      fetch.mockImplementationOnce(async () =>
+        mockFetchResponse(201, { resourceType: 'Binary', id: '456', url: 'Binary/456' })
+      );
+      fetch.mockImplementationOnce(async () => mockFetchResponse(200, { resourceType: 'Media', id: '123' }));
+
+      const client = new MedplumClient({ fetch });
+      const media = await client.uploadMedia('Hello world', 'text/plain', 'hello.txt');
+      expect(media).toBeDefined();
+      expect(fetch).toHaveBeenCalledTimes(3);
+
+      const calls = fetch.mock.calls;
+      expect(calls).toHaveLength(3);
+      expect(calls[0][0]).toEqual('https://api.medplum.com/fhir/R4/Media');
+      expect(calls[1][0]).toEqual('https://api.medplum.com/fhir/R4/Binary?_filename=hello.txt');
+      expect(calls[2][0]).toEqual('https://api.medplum.com/fhir/R4/Media/123');
+      expect(JSON.parse(calls[2][1].body)).toMatchObject({
+        resourceType: 'Media',
+        status: 'completed',
+        content: {
+          contentType: 'text/plain',
+          url: 'Binary/456',
           title: 'hello.txt',
         },
       });

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1526,7 +1526,7 @@ describe('Client', () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
     try {
-      await client.createPdf({ content: ['Hello world'] });
+      await client.createPdf({ docDefinition: { content: ['Hello world'] } });
     } catch (err) {
       expect((err as Error).message).toEqual('PDF creation not enabled');
     }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3956,8 +3956,8 @@ export function normalizeCreateBinaryOptions(
     return arg1;
   }
   return {
-    data: arg1 as BinarySource,
-    filename: arg2 as string,
+    data: arg1,
+    filename: arg2 as string | undefined,
     contentType: arg3 as string,
     onProgress: arg4,
   };

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2151,6 +2151,14 @@ export class MedplumClient extends EventTarget {
       xhr.setRequestHeader('Cache-Control', 'no-cache, no-store, max-age=0');
       xhr.setRequestHeader('Content-Type', contentType);
       xhr.setRequestHeader('X-Medplum', 'extended');
+
+      if (options?.headers) {
+        const headers = options.headers as Record<string, string>;
+        for (const [key, value] of Object.entries(headers)) {
+          xhr.setRequestHeader(key, value);
+        }
+      }
+
       xhr.send(data);
     });
   }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2674,6 +2674,17 @@ export class MedplumClient extends EventTarget {
     if (urlString.startsWith(BINARY_URL_PREFIX)) {
       url = this.fhirUrl(urlString);
     }
+
+    let headers = options.headers as Record<string, string> | undefined;
+    if (!headers) {
+      headers = {};
+      options.headers = headers;
+    }
+
+    if (!headers['Accept']) {
+      headers['Accept'] = '*/*';
+    }
+
     this.addFetchOptionsDefaults(options);
     const response = await this.fetchWithRetry(url.toString(), options);
     return response.blob();

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2006,7 +2006,7 @@ export class MedplumClient extends EventTarget {
    * @param onProgress - Optional callback for progress events. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
    * @param options - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
    * @returns The result of the create operation.
-   * @deprecated Use `createAttachment` with `CreateBinaryOptions` instead.
+   * @deprecated Use `createAttachment` with `CreateBinaryOptions` instead. To be removed in Medplum 4.0.
    */
   createAttachment(
     data: BinarySource,
@@ -2067,7 +2067,7 @@ export class MedplumClient extends EventTarget {
    * @param onProgress - Optional callback for progress events. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
    * @param options - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
    * @returns The result of the create operation.
-   * @deprecated Use `createBinary` with `CreateBinaryOptions` instead.
+   * @deprecated Use `createBinary` with `CreateBinaryOptions` instead. To be removed in Medplum 4.0.
    */
   createBinary(
     data: BinarySource,
@@ -2195,7 +2195,7 @@ export class MedplumClient extends EventTarget {
    * @param tableLayouts - Optional pdfmake custom table layout.
    * @param fonts - Optional pdfmake custom font dictionary.
    * @returns The result of the create operation.
-   * @deprecated Use `createPdf` with `CreatePdfOptions` instead.
+   * @deprecated Use `createPdf` with `CreatePdfOptions` instead. To be removed in Medplum 4.0.
    */
   createPdf(
     docDefinition: TDocumentDefinitions,
@@ -2870,7 +2870,7 @@ export class MedplumClient extends EventTarget {
    * @param additionalFields - Additional fields for Media.
    * @param options - Optional fetch options.
    * @returns Promise that resolves to the created Media
-   * @deprecated Use `createMedia` with `CreateMediaOptions` instead.
+   * @deprecated Use `createMedia` with `CreateMediaOptions` instead. To be removed in Medplum 4.0.
    */
   async uploadMedia(
     contents: string | Uint8Array | File | Blob,
@@ -3954,6 +3954,7 @@ function isCreateBinaryOptions(input: unknown): input is CreateBinaryOptions {
   return isObject(input) && 'data' in input && 'contentType' in input;
 }
 
+// This function can be deleted after Medplum 4.0 and we remove the legacy createBinary method
 export function normalizeCreateBinaryOptions(
   arg1: BinarySource | CreateBinaryOptions,
   arg2: string | undefined | MedplumRequestOptions,
@@ -3975,6 +3976,7 @@ function isCreatePdfOptions(input: unknown): input is CreatePdfOptions {
   return isObject(input) && 'docDefinition' in input;
 }
 
+// This function can be deleted after Medplum 4.0 and we remove the legacy createPdf method
 export function normalizeCreatePdfOptions(
   arg1: TDocumentDefinitions | CreatePdfOptions,
   arg2: string | undefined | MedplumRequestOptions,

--- a/packages/health-gorilla/src/utils.ts
+++ b/packages/health-gorilla/src/utils.ts
@@ -178,7 +178,11 @@ export async function checkAbn(
     const abnUint8Array = new Uint8Array(abnArrayBuffer);
 
     // Create a Medplum media resource
-    const media = await medplum.uploadMedia(abnUint8Array, 'application/pdf', 'RequestGroup-ABN.pdf');
+    const media = await medplum.createMedia({
+      data: abnUint8Array,
+      contentType: 'application/pdf',
+      filename: 'RequestGroup-ABN.pdf',
+    });
     console.log('Uploaded ABN PDF as media: ' + media.id);
   }
 }

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -297,12 +297,12 @@ describe('MockClient', () => {
 
   test('Create PDF', async () => {
     const client = new MockClient();
-    const result = await client.createPdf({ content: ['Hello World'] });
+    const result = await client.createPdf({ docDefinition: { content: ['Hello World'] } });
     expect(result).toBeDefined();
 
     console.log = jest.fn();
     const client2 = new MockClient({ debug: true });
-    const result2 = await client2.createPdf({ content: ['Hello World'] });
+    const result2 = await client2.createPdf({ docDefinition: { content: ['Hello World'] } });
     expect(result2).toBeDefined();
     expect(console.log).toHaveBeenCalled();
   });

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -1,10 +1,6 @@
 import {
-  allOk,
-  badRequest,
+  BinaryUploadOptions,
   ContentType,
-  getStatus,
-  indexSearchParameter,
-  loadDataType,
   LoginState,
   MedplumClient,
   MedplumClientOptions,
@@ -12,6 +8,11 @@ import {
   OperationOutcomeError,
   ProfileResource,
   SubscriptionEmitter,
+  allOk,
+  badRequest,
+  getStatus,
+  indexSearchParameter,
+  loadDataType,
 } from '@medplum/core';
 import { FhirRequest, FhirRouter, HttpMethod, MemoryRepository } from '@medplum/fhir-router';
 import {
@@ -38,7 +39,6 @@ import {
   ExampleQuestionnaire,
   ExampleQuestionnaireResponse,
   ExampleSubscription,
-  exampleValueSet,
   HomerCommunication,
   HomerDiagnosticReport,
   HomerEncounter,
@@ -55,8 +55,9 @@ import {
   HomerSimpson,
   HomerSimpsonPreviousVersion,
   HomerSimpsonSpecimen,
-  makeDrAliceSmithSlots,
   TestOrganization,
+  exampleValueSet,
+  makeDrAliceSmithSlots,
 } from './mocks';
 import { ExampleAccessPolicy, ExampleStatusValueSet, ExampleUserConfiguration } from './mocks/accesspolicy';
 import { TestProject, TestProjectMembership } from './mocks/project';
@@ -178,10 +179,12 @@ export class MockClient extends MedplumClient {
 
   async createBinary(
     data: string | File | Blob | Uint8Array,
-    filename: string | undefined,
+    filenameOrUploadOption: BinaryUploadOptions | string | undefined,
     contentType: string,
     onProgress?: (e: ProgressEvent) => void
   ): Promise<Binary> {
+    const filename =
+      typeof filenameOrUploadOption === 'string' ? filenameOrUploadOption : filenameOrUploadOption?.filename;
     if (filename?.endsWith('.exe')) {
       return Promise.reject(badRequest('Invalid file type'));
     }

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -1,6 +1,7 @@
 import {
-  BinaryUploadOptionsOrFilename,
+  BinarySource,
   ContentType,
+  CreateBinaryOptions,
   LoginState,
   MedplumClient,
   MedplumClientOptions,
@@ -13,6 +14,7 @@ import {
   getStatus,
   indexSearchParameter,
   loadDataType,
+  normalizeCreateBinaryOptions,
 } from '@medplum/core';
 import { FhirRequest, FhirRouter, HttpMethod, MemoryRepository } from '@medplum/fhir-router';
 import {
@@ -178,13 +180,14 @@ export class MockClient extends MedplumClient {
   }
 
   async createBinary(
-    data: string | File | Blob | Uint8Array,
-    uploadOptionsOrFilename: BinaryUploadOptionsOrFilename,
-    contentType: string,
-    onProgress?: (e: ProgressEvent) => void
+    arg1: BinarySource | CreateBinaryOptions,
+    arg2: string | undefined | MedplumRequestOptions,
+    arg3?: string,
+    arg4?: (e: ProgressEvent) => void
   ): Promise<Binary> {
-    const filename =
-      typeof uploadOptionsOrFilename === 'string' ? uploadOptionsOrFilename : uploadOptionsOrFilename?.filename;
+    const createBinaryOptions = normalizeCreateBinaryOptions(arg1, arg2, arg3, arg4);
+    const { filename, contentType, onProgress } = createBinaryOptions;
+
     if (filename?.endsWith('.exe')) {
       return Promise.reject(badRequest('Invalid file type'));
     }

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -1,5 +1,5 @@
 import {
-  BinaryUploadOptions,
+  BinaryUploadOptionsOrFilename,
   ContentType,
   LoginState,
   MedplumClient,
@@ -179,12 +179,12 @@ export class MockClient extends MedplumClient {
 
   async createBinary(
     data: string | File | Blob | Uint8Array,
-    filenameOrUploadOption: BinaryUploadOptions | string | undefined,
+    uploadOptionsOrFilename: BinaryUploadOptionsOrFilename,
     contentType: string,
     onProgress?: (e: ProgressEvent) => void
   ): Promise<Binary> {
     const filename =
-      typeof filenameOrUploadOption === 'string' ? filenameOrUploadOption : filenameOrUploadOption?.filename;
+      typeof uploadOptionsOrFilename === 'string' ? uploadOptionsOrFilename : uploadOptionsOrFilename?.filename;
     if (filename?.endsWith('.exe')) {
       return Promise.reject(badRequest('Invalid file type'));
     }

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -1,5 +1,5 @@
 import { normalizeOperationOutcome } from '@medplum/core';
-import { Attachment, Binary, OperationOutcome, Reference } from '@medplum/fhirtypes';
+import { Attachment, OperationOutcome, Reference } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { ChangeEvent, MouseEvent, ReactNode, useRef } from 'react';
 import { killEvent } from '../utils/dom';
@@ -48,17 +48,15 @@ export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {
       props.onUploadStart();
     }
 
-    const filename = file.name;
-    const contentType = file.type || 'application/octet-stream';
     medplum
-      .createBinary(file, filename, contentType, props.onUploadProgress)
-      .then((binary: Binary) => {
-        props.onUpload({
-          contentType: binary.contentType,
-          url: binary.url,
-          title: filename,
-        });
+      .createAttachment({
+        data: file,
+        contentType: file.type || 'application/octet-stream',
+        filename: file.name,
+        securityContext: props.securityContext,
+        onProgress: props.onUploadProgress,
       })
+      .then((attachment: Attachment) => props.onUpload(attachment))
       .catch((err) => {
         if (props.onUploadError) {
           props.onUploadError(normalizeOperationOutcome(err));

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -1,10 +1,11 @@
 import { normalizeOperationOutcome } from '@medplum/core';
-import { Attachment, Binary, OperationOutcome } from '@medplum/fhirtypes';
+import { Attachment, Binary, OperationOutcome, Reference } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { ChangeEvent, MouseEvent, ReactNode, useRef } from 'react';
 import { killEvent } from '../utils/dom';
 
 export interface AttachmentButtonProps {
+  readonly securityContext?: Reference;
   readonly onUpload: (attachment: Attachment) => void;
   readonly onUploadStart?: () => void;
   readonly onUploadProgress?: (e: ProgressEvent) => void;

--- a/packages/react/src/AttachmentInput/AttachmentInput.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mantine/core';
-import { Attachment } from '@medplum/fhirtypes';
+import { Attachment, Reference } from '@medplum/fhirtypes';
 import { MouseEvent, useState } from 'react';
 import { AttachmentButton } from '../AttachmentButton/AttachmentButton';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
@@ -9,6 +9,7 @@ export interface AttachmentInputProps {
   readonly name: string;
   readonly defaultValue?: Attachment;
   readonly arrayElement?: boolean;
+  readonly securityContext?: Reference;
   readonly onChange?: (value: Attachment | undefined) => void;
 }
 
@@ -39,6 +40,8 @@ export function AttachmentInput(props: AttachmentInputProps): JSX.Element {
   }
 
   return (
-    <AttachmentButton onUpload={setValueWrapper}>{(props) => <Button {...props}>Upload...</Button>}</AttachmentButton>
+    <AttachmentButton securityContext={props.securityContext} onUpload={setValueWrapper}>
+      {(props) => <Button {...props}>Upload...</Button>}
+    </AttachmentButton>
   );
 }

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -1,6 +1,12 @@
 import { ActionIcon, Center, Group, Loader, Menu, ScrollArea, TextInput } from '@mantine/core';
 import { showNotification, updateNotification } from '@mantine/notifications';
-import { getReferenceString, MedplumClient, normalizeErrorString, ProfileResource } from '@medplum/core';
+import {
+  MedplumClient,
+  ProfileResource,
+  createReference,
+  getReferenceString,
+  normalizeErrorString,
+} from '@medplum/core';
 import {
   Attachment,
   AuditEvent,
@@ -293,6 +299,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
                 <IconMessage size={16} />
               </ActionIcon>
               <AttachmentButton
+                securityContext={createReference(resource)}
                 onUpload={createMedia}
                 onUploadStart={onUploadStart}
                 onUploadProgress={onUploadProgress}

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -38,6 +38,7 @@ binaryRouter.get(
       // then the content should be returned with the content type stated in the resource in the Content-Type header.
       // E.g. if the content type in the resource is "application/pdf", then the content should be returned as a PDF directly.
       sendResponseHeaders(req, res, allOk, binary);
+      res.contentType(binary.contentType as string);
       const stream = await getBinaryStorage().readBinary(binary);
       stream.pipe(res);
     }

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -1,5 +1,5 @@
-import { badRequest, normalizeOperationOutcome } from '@medplum/core';
-import { Binary } from '@medplum/fhirtypes';
+import { ContentType, OperationOutcomeError, allOk, badRequest, created, isResource } from '@medplum/core';
+import { Binary, OperationOutcome } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import internal from 'stream';
 import zlib from 'zlib';
@@ -7,71 +7,17 @@ import { asyncWrap } from '../async';
 import { getAuthenticatedContext } from '../context';
 import { authenticateRequest } from '../oauth/middleware';
 import { sendOutcome } from './outcomes';
+import { sendResponse } from './response';
 import { getPresignedUrl } from './signer';
-import { getBinaryStorage } from './storage';
+import { BinarySource, getBinaryStorage } from './storage';
 
 export const binaryRouter = Router().use(authenticateRequest);
 
 // Create a binary
-binaryRouter.post(
-  '/',
-  asyncWrap(async (req: Request, res: Response) => {
-    const ctx = getAuthenticatedContext();
-    const filename = req.query['_filename'] as string | undefined;
-    const contentType = req.get('Content-Type') as string;
-    const resource = await ctx.repo.createResource<Binary>({
-      resourceType: 'Binary',
-      contentType,
-      meta: {
-        project: req.query['_project'] as string | undefined,
-      },
-    });
-
-    const stream = getContentStream(req);
-    if (!stream) {
-      sendOutcome(res, badRequest('Unsupported content encoding'));
-      return;
-    }
-
-    try {
-      await getBinaryStorage().writeBinary(resource, filename, contentType, stream);
-      res.status(201).json({
-        ...resource,
-        url: getPresignedUrl(resource),
-      });
-    } catch (err) {
-      sendOutcome(res, normalizeOperationOutcome(err));
-    }
-  })
-);
+binaryRouter.post('/', asyncWrap(handleBinaryWriteRequest));
 
 // Update a binary
-binaryRouter.put(
-  '/:id',
-  asyncWrap(async (req: Request, res: Response) => {
-    const ctx = getAuthenticatedContext();
-    const { id } = req.params;
-    const filename = req.query['_filename'] as string | undefined;
-    const contentType = req.get('Content-Type') as string;
-    const resource = await ctx.repo.updateResource<Binary>({
-      resourceType: 'Binary',
-      id,
-      contentType,
-      meta: {
-        project: req.query['_project'] as string | undefined,
-      },
-    });
-
-    const stream = getContentStream(req);
-    if (!stream) {
-      sendOutcome(res, badRequest('Unsupported content encoding'));
-      return;
-    }
-
-    await getBinaryStorage().writeBinary(resource, filename, contentType, stream);
-    res.status(200).json(resource);
-  })
-);
+binaryRouter.put('/:id', asyncWrap(handleBinaryWriteRequest));
 
 // Get binary content
 binaryRouter.get(
@@ -87,6 +33,82 @@ binaryRouter.get(
     stream.pipe(res);
   })
 );
+
+async function handleBinaryWriteRequest(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
+  const create = req.method === 'POST';
+  const { id } = req.params;
+  const contentType = req.get('Content-Type') as string;
+
+  const stream = getContentStream(req);
+  if (!stream) {
+    sendOutcome(res, badRequest('Unsupported content encoding'));
+    return;
+  }
+
+  let binary: Binary | undefined = undefined;
+  let binarySource: BinarySource = stream;
+
+  // From the spec: https://hl7.org/fhir/R4/binary.html#rest
+  //
+  // """
+  //   When binary data is written to the server (create/update - POST or PUT),
+  //   the data is accepted as is and treated as the content of a Binary,
+  //   including when the content type is "application/fhir+xml" or "application/fhir+json",
+  //   except for the special case where the content is actually a Binary resource.
+  // """
+  let binaryContentSpecialCase = false;
+
+  if (contentType === ContentType.FHIR_JSON) {
+    try {
+      // The binary handler does *not* use Express body-parser in order to support raw binary data.
+      // Therefore, we need to manually parse the body stream as JSON.
+      const str = await readStreamToString(stream);
+      const body = JSON.parse(str);
+      if (isResource(body) && body.resourceType === 'Binary' && body.id === id) {
+        // Special case where the content is actually a Binary resource.
+        binary = body as Binary;
+        binaryContentSpecialCase = true;
+      } else {
+        // We have already consumed the stream, so we need to create a new one.
+        // Instead, use the original string as the source.
+        binarySource = str;
+      }
+    } catch (err) {
+      throw new OperationOutcomeError(badRequest('Invalid JSON'));
+    }
+  }
+
+  if (!binary) {
+    const securityContext = req.get('X-Security-Context');
+    binary = {
+      resourceType: 'Binary',
+      id,
+      contentType,
+      securityContext: securityContext ? { reference: securityContext } : undefined,
+    };
+  }
+
+  let outcome: OperationOutcome;
+
+  if (create) {
+    binary = await ctx.repo.createResource<Binary>(binary);
+    outcome = created;
+  } else {
+    binary = await ctx.repo.updateResource<Binary>(binary);
+    outcome = allOk;
+  }
+
+  if (!binaryContentSpecialCase) {
+    const filename = req.query['_filename'] as string | undefined;
+    await getBinaryStorage().writeBinary(binary, filename, contentType, binarySource);
+  }
+
+  await sendResponse(req, res, outcome, {
+    ...binary,
+    url: getPresignedUrl(binary),
+  });
+}
 
 /**
  * Get the content stream of the request.
@@ -118,4 +140,14 @@ function getContentStream(req: Request): internal.Readable | undefined {
   }
 
   return undefined;
+}
+
+async function readStreamToString(stream: internal.Readable): Promise<string> {
+  let data = '';
+  // Set the encoding to UTF-8 to ensure each chunk is a string
+  stream.setEncoding('utf8');
+  for await (const chunk of stream) {
+    data += chunk;
+  }
+  return data;
 }

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -25,7 +25,6 @@ export function sendResponseHeaders(_req: Request, res: Response, outcome: Opera
   }
 
   res.status(getStatus(outcome));
-  res.set('Content-Type', ContentType.FHIR_JSON);
 }
 
 export async function sendResponse(
@@ -35,6 +34,7 @@ export async function sendResponse(
   body: Resource
 ): Promise<void> {
   sendResponseHeaders(req, res, outcome, body);
+  res.set('Content-Type', ContentType.FHIR_JSON);
 
   const ctx = getAuthenticatedContext();
   const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, body);

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -13,13 +13,7 @@ export function getFullUrl(resourceType: string, id: string): string {
   return concatUrls(getConfig().baseUrl, `/fhir/R4/${resourceType}/${id}`);
 }
 
-export async function sendResponse(
-  req: Request,
-  res: Response,
-  outcome: OperationOutcome,
-  body: Resource
-): Promise<void> {
-  const ctx = getAuthenticatedContext();
+export function sendResponseHeaders(_req: Request, res: Response, outcome: OperationOutcome, body: Resource): void {
   if (body.meta?.versionId) {
     res.set('ETag', `W/"${body.meta.versionId}"`);
   }
@@ -32,7 +26,17 @@ export async function sendResponse(
 
   res.status(getStatus(outcome));
   res.set('Content-Type', ContentType.FHIR_JSON);
+}
 
+export async function sendResponse(
+  req: Request,
+  res: Response,
+  outcome: OperationOutcome,
+  body: Resource
+): Promise<void> {
+  sendResponseHeaders(req, res, outcome, body);
+
+  const ctx = getAuthenticatedContext();
   const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, body);
 
   if (req.query._pretty === 'true') {

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -206,6 +206,9 @@ export async function execDownloadJob(job: Job<DownloadJobData>): Promise<void> 
       meta: {
         project: resource.meta?.project,
       },
+      securityContext: {
+        reference: `${resource.resourceType}/${resource.id}`,
+      },
     });
     if (response.body === null) {
       throw new Error('Received null response body');


### PR DESCRIPTION
* [x] Add `Binary` write special case
    * If the request `Content-Type` is `application/fhir+json`
    * And the request body is a FHIR `Binary`
    * The write the resource as a normal `POST` or `PUT` operation
    * Otherwise, by default, treat the request body as the binary contents
* [x] Add `Binary` read special case
    * If the request `Accept` header is `application/fhir+json`
    * Then return the `Binary` JSON content
    * Otherwise, by default, return the binary contents
* [x] Add support for `X-Security-Context` header
    * On write operations, if the `X-Security-Context` header is present, use that as `Binary.securityContext.reference`
* [x] Update `MedplumClient.download` to use `Accept: */*`, to not trigger the reading special case
* [x] Update auto-downloader to set `Binary.securityContext`
* [x] Added standard HTTP response headers to `Binary` endpoints (`ETag`, `Last-Modified`, `Location`)
* [x] Update `MedplumClient.createBinary` to use `X-Security-Context`
  * [x] `Medplum.createAttachment`
  * [x] `Medplum.createPdf`
  * [x] `Medplum.createMedia` (previously `Medplum.uploadMedia`, now deprecated)

--------

## `MedplumClient` API changes

Careful effort was made to preserve backwards compatibility in `MedplumClient`.  However, to be able to take advantage of these new features, be aware of the following API changes

`createBinary()` is the "low level" method to create a FHIR `Binary` by uploading binary contents.

Here is the previous function signature:

```ts
  /**
   * @category Create
   * @param data - The binary data to upload.
   * @param filename - Optional filename for the binary.
   * @param contentType - Content type for the binary.
   * @param onProgress - Optional callback for progress events. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
   * @param options - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
   * @returns The result of the create operation.
   * @deprecated Use `createBinary` with `CreateBinaryOptions` instead.
   */
  createBinary(
    data: BinarySource,
    filename: string | undefined,
    contentType: string,
    onProgress?: (e: ProgressEvent) => void,
    options?: MedplumRequestOptions
  ): Promise<Binary>;
```

That function signature is preserved but now deprecated.  `MedplumClient` now includes a new overload for `createBinary()`:

```ts
  /**
   * Creates a FHIR `Binary` resource with the provided data content.
   *
   * The return value is the newly created resource, including the ID and meta.
   *
   * The `data` parameter can be a string or a `File` object.
   *
   * A `File` object often comes from a `<input type="file">` element.
   *
   * @example
   * Example:
   *
   * ```typescript
   * const result = await medplum.createBinary(myFile, 'test.jpg', 'image/jpeg');
   * console.log(result.id);
   * ```
   *
   * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
   *
   * @category Create
   * @param createBinaryOptions -The binary options. See `CreateBinaryOptions` for full details.
   * @param requestOptions - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
   * @returns The result of the create operation.
   */
  createBinary(createBinaryOptions: CreateBinaryOptions, requestOptions?: MedplumRequestOptions): Promise<Binary>;
```

There is a single `createBinaryOptions` object for all of the various required and optional arguments.

Example:

```ts
await medplum.createBinary({
    data: myFile,
    contentType: 'text/plain',
    securityContext: { reference: 'Patient/123' },
});
```

Similar changes + overloads were added for the following methods:

* `MedplumClient.createAttachment`
* `MedplumClient.createMedia` (previously `uploadMedia`)
* `MedplumClient.createPdf`

--------

## Demo 1 - Attach security context in app

Using the Medplum app, upload an image to a patient timeline:

<img width="966" alt="image" src="https://github.com/medplum/medplum/assets/749094/beec8365-4bc5-4955-bf9b-11ccb0bc152d">

Note the `X-Security-Context` header in the upload request (as described in the [spec](https://hl7.org/fhir/R4/binary.html#rest))

<img width="996" alt="image" src="https://github.com/medplum/medplum/assets/749094/9927926b-8f33-4c63-86b2-570607a4ba57">

And note that the `Binary` now includes a `securityContext` value:

<img width="969" alt="image" src="https://github.com/medplum/medplum/assets/749094/88c653dc-bc77-4ff1-a7bc-b414ee1e9159">


--------

## Demo 2 - Update a `Binary` resource

Historically, if you tried to `POST` JSON and update a FHIR `Binary`, the contents would be "lost", because the contents were associated `meta.versionId`.

After this PR, you can update a `Binary` in the same way as any FHIR resource, and the contents will be carried forward to the new `meta.versionId`:

<img width="772" alt="image" src="https://github.com/medplum/medplum/assets/749094/d87db90b-171f-44ab-b64f-4a13bcd7be54">

