### PR TITLE
fix(expo-polyfills): allow `reject`s in map to propagate up

### DIFF
--- a/packages/expo-polyfills/src/index.ts
+++ b/packages/expo-polyfills/src/index.ts
@@ -189,7 +189,7 @@ class SyncSecureStorage implements Storage {
           // Parse keys
           const keys = JSON.parse(keysStr) as string[];
           const promises = keys.map((key) => {
-            return new Promise<[string, string | null]>((resolve) => {
+            return new Promise<[string, string | null]>((resolve, reject) => {
               SecureStore.getItemAsync(key)
                 .then((val) => {
                   resolve([key, val]);


### PR DESCRIPTION
It's probably fine as is, but this should make sure that stack traces are preserved and is probably more correct