### PR TITLE
Add more rules to dangerfile

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -13,7 +13,7 @@ if (packageChanged && !lockfileChanged) {
 }
 
 // Gather changes
-const modifiedFiles = danger.git.modified_files.filter((path) => path.endsWith('.ts') || path.endsWith('.tsx'));
+const modifiedFiles = danger.git.modified_files.filter((path) => /\/src\/.+\.tsx?/.exec(path));
 
 // Check for console.log statements
 const statements = ['console.debug', 'console.log', 'console.warn', 'describe.only', 'test.only'];

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { danger, message, warn } from 'danger';
 import { statSync } from 'fs';
 
@@ -12,5 +13,12 @@ if (packageChanged && !lockfileChanged) {
 }
 
 // Show the size of minified JS output
-message(`@medplum/core: ${(statSync('packages/core/dist/cjs/index.cjs').size / 1024).toFixed(1)} kB`);
-message(`@medplum/react: ${(statSync('packages/react/dist/cjs/index.cjs').size / 1024).toFixed(1)} kB`);
+message(`@medplum/core: ${getAssetSizeStats('packages/core/dist/cjs/index.cjs')}`);
+message(`@medplum/react: ${getAssetSizeStats('packages/react/dist/cjs/index.cjs')}`);
+
+function getAssetSizeStats(filename: string): string {
+  const originalStats = statSync(filename);
+  execSync(`gzip -c ${filename} > ${filename}.gz`);
+  const gzippedStats = statSync(`${filename}.gz`);
+  return `${(originalStats.size / 1024).toFixed(1)} kB (${(gzippedStats.size / 1024).toFixed(1)} kB gzip)`;
+}

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3240,8 +3240,7 @@ describe('FHIR Search', () => {
         }
       }));
 
-    // Dangerfile should catch this...
-    describe.only('US Core Search Parameters', () => {
+    describe('US Core Search Parameters', () => {
       test('USCoreCareTeamRole', async () =>
         withTestContext(async () => {
           const careTeam = await repo.createResource<CareTeam>({

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3239,6 +3239,8 @@ describe('FHIR Search', () => {
           expect(outcome.issue?.[0]?.details?.text).toBe('Cannot search on Binary resource type');
         }
       }));
+
+    // Dangerfile should catch this...
     describe.only('US Core Search Parameters', () => {
       test('USCoreCareTeamRole', async () =>
         withTestContext(async () => {


### PR DESCRIPTION
1. Look for unwanted tokens (`console.log`, `describe.only`, `test.only`)
2. Add gzipped file size stats

```
$ npx danger local -- --base main --dangerfile dangerfile.ts

Danger: ✓ passed, found only messages.
## Messages
@medplum/core: 173.1 kB (48.3 kB gzip)
-
@medplum/react: 378.2 kB (77.4 kB gzip)
```