### PR TITLE
fix(server): Fix server tests failing intermittently due to `ioredis`

### DIFF
--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -85,7 +85,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
     AsyncLocalStorage.bind(async () => {
       await updateStatus('disconnected');
       heartbeat.removeEventListener('heartbeat', heartbeatHandler);
-      redisSubscriber?.quit().catch(console.error);
+      redisSubscriber?.disconnect();
       redisSubscriber = undefined;
       agentId = undefined;
     })

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -4,13 +4,8 @@ import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config';
 import { getDatabasePool } from './database';
 import { globalLogger } from './logger';
-import { closeRedis } from './redis';
 
 describe('App', () => {
-  afterEach(async () => {
-    await closeRedis();
-  });
-
   test('Get HTTP config', async () => {
     const app = express();
     const config = await loadTestConfig();

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -4,8 +4,13 @@ import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config';
 import { getDatabasePool } from './database';
 import { globalLogger } from './logger';
+import { closeRedis } from './redis';
 
 describe('App', () => {
+  afterEach(async () => {
+    await closeRedis();
+  });
+
   test('Get HTTP config', async () => {
     const app = express();
     const config = await loadTestConfig();
@@ -15,7 +20,7 @@ describe('App', () => {
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['referrer-policy']).toBeDefined();
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test('Use /api/', async () => {
@@ -27,7 +32,7 @@ describe('App', () => {
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['referrer-policy']).toBeDefined();
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test('Get HTTPS config', async () => {
@@ -40,7 +45,7 @@ describe('App', () => {
     expect(res.headers['cache-control']).toBeDefined();
     expect(res.headers['content-security-policy']).toBeDefined();
     expect(res.headers['strict-transport-security']).toBeDefined();
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test('robots.txt', async () => {
@@ -50,7 +55,7 @@ describe('App', () => {
     const res = await request(app).get('/robots.txt');
     expect(res.status).toBe(200);
     expect(res.text).toBe('User-agent: *\nDisallow: /');
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test('No CORS', async () => {
@@ -60,11 +65,10 @@ describe('App', () => {
     const res = await request(app).get('/').set('Origin', 'https://blackhat.xyz');
     expect(res.status).toBe(200);
     expect(res.headers['origin']).toBeUndefined();
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test('Internal Server Error', async () => {
-    console.log = jest.fn();
     const app = express();
     app.get('/throw', () => {
       throw new Error('Catastrophe!');
@@ -74,7 +78,7 @@ describe('App', () => {
     const res = await request(app).get('/throw');
     expect(res.status).toBe(500);
     expect(res.body).toMatchObject({ msg: 'Internal Server Error' });
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test('Database disconnect', async () => {
@@ -82,15 +86,11 @@ describe('App', () => {
     const config = await loadTestConfig();
     await initApp(app, config);
 
-    // Mock database disconnect
-    // Error should be logged, but should not crash the server
-    console.log = jest.fn();
     const loggerError = jest.spyOn(globalLogger, 'error').mockReturnValueOnce();
     const error = new Error('Mock database disconnect');
     getDatabasePool().emit('error', error);
     expect(loggerError).toHaveBeenCalledWith('Database connection error', error);
-
-    await shutdownApp();
+    expect(await shutdownApp()).toBeUndefined();
   });
 
   test.skip('Preflight max age', async () => {
@@ -99,6 +99,5 @@ describe('App', () => {
     expect(res.status).toBe(204);
     expect(res.header['access-control-max-age']).toBe('86400');
     expect(res.header['cache-control']).toBe('public, max-age=86400');
-    await shutdownApp();
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -206,10 +206,10 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
 }
 
 export async function shutdownApp(): Promise<void> {
-  await closeWorkers();
-  await closeDatabase();
   cleanupHeartbeat();
   await closeWebSockets();
+  await closeWorkers();
+  await closeDatabase();
   await closeRedis();
   closeRateLimiter();
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -214,7 +214,9 @@ export async function shutdownApp(): Promise<void> {
   closeRateLimiter();
 
   if (server) {
-    server.close();
+    await new Promise((resolve) => {
+      (server as ReturnType<typeof http.createServer>).close(resolve);
+    });
     server = undefined;
   }
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -215,7 +215,7 @@ export async function shutdownApp(): Promise<void> {
 
   if (server) {
     await new Promise((resolve) => {
-      (server as ReturnType<typeof http.createServer>).close(resolve);
+      (server as http.Server).close(resolve);
     });
     server = undefined;
   }

--- a/packages/server/src/auth/revoke.test.ts
+++ b/packages/server/src/auth/revoke.test.ts
@@ -5,9 +5,9 @@ import { inviteUser } from '../admin/invite';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
 import { tryLogin } from '../oauth/utils';
+import { withTestContext } from '../test.setup';
 import { registerNew } from './register';
 import { setPassword } from './setpassword';
-import { withTestContext } from '../test.setup';
 
 jest.mock('@aws-sdk/client-sesv2');
 

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -55,7 +55,7 @@ export async function handleFhircastConnection(socket: ws.WebSocket, request: In
 
   socket.on('close', () => {
     heartbeat.removeEventListener('heartbeat', heartbeatHandler);
-    redisSubscriber.quit().catch(console.error);
+    redisSubscriber.disconnect();
   });
 
   // Send initial connection verification

--- a/packages/server/src/redis.ts
+++ b/packages/server/src/redis.ts
@@ -1,3 +1,4 @@
+import { sleep } from '@medplum/core';
 import Redis from 'ioredis';
 import { MedplumRedisConfig } from './config';
 
@@ -9,8 +10,10 @@ export function initRedis(config: MedplumRedisConfig): void {
 
 export async function closeRedis(): Promise<void> {
   if (redis) {
-    await redis.quit();
+    const tmpRedis = redis;
     redis = undefined;
+    await tmpRedis.quit();
+    await sleep(100);
   }
 }
 

--- a/packages/server/src/subscriptions/websockets.ts
+++ b/packages/server/src/subscriptions/websockets.ts
@@ -52,7 +52,7 @@ export async function handleR4SubscriptionConnection(socket: ws.WebSocket): Prom
       });
 
       onDisconnect = async (): Promise<void> => {
-        await redisSubscriber?.quit();
+        redisSubscriber?.disconnect();
         const cacheEntryStr = (await redis.get(`Subscription/${subscriptionId}`)) as string | null;
         if (!cacheEntryStr) {
           globalLogger.error('[WS] Failed to retrieve subscription cache entry on WebSocket disconnect.');

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -257,7 +257,7 @@ export function waitFor(fn: () => Promise<void>): Promise<void> {
 }
 
 export async function waitForAsyncJob(contentLocation: string, app: Express, accessToken: string): Promise<AsyncJob> {
-  for (let i = 0; i < 30; i++) {
+  for (let i = 0; i < 45; i++) {
     const res = await request(app)
       .get(new URL(contentLocation).pathname)
       .set('Authorization', 'Bearer ' + accessToken);

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -17,7 +17,14 @@ handlerMap.set('agent', handleAgentConnection);
 handlerMap.set('fhircast', handleFhircastConnection);
 handlerMap.set('subscriptions-r4', handleR4SubscriptionConnection);
 
+type WebSocketState = {
+  readonly sockets: Set<ws>;
+  readonly socketsClosedPromise: Promise<void>;
+  readonly socketsClosedResolve: () => void;
+};
+
 let wsServer: ws.Server | undefined = undefined;
+let wsState: WebSocketState | undefined = undefined;
 
 /**
  * Initializes a websocket listener on the given HTTP server.
@@ -34,10 +41,32 @@ export function initWebSockets(server: http.Server): void {
     // See: https://github.com/websockets/ws/blob/master/doc/ws.md#websocketbinarytype
     socket.binaryType = 'nodebuffer';
 
+    if (!wsState?.sockets.size) {
+      let socketsClosedResolve!: () => void;
+      const socketsClosedPromise = new Promise<void>((resolve) => {
+        socketsClosedResolve = resolve;
+      });
+      wsState = { sockets: new Set(), socketsClosedPromise, socketsClosedResolve };
+    }
+    wsState.sockets.add(socket);
+
     // Add a default error handler to the socket
     // If we don't do this, then errors will be thrown and crash the server
     socket.on('error', (err) => {
       globalLogger.error('WebSocket connection error', { error: err });
+    });
+
+    socket.on('close', () => {
+      if (!wsState) {
+        return;
+      }
+      const { sockets, socketsClosedResolve } = wsState;
+      if (sockets.size) {
+        sockets.delete(socket);
+        if (sockets.size === 0) {
+          (socketsClosedResolve as () => void)();
+        }
+      }
     });
 
     const path = getWebSocketPath(request.url as string);
@@ -93,7 +122,7 @@ async function handleEchoConnection(socket: ws.WebSocket): Promise<void> {
   );
 
   socket.on('close', () => {
-    redisSubscriber.quit().catch(console.error);
+    redisSubscriber.disconnect();
   });
 }
 
@@ -101,5 +130,9 @@ export async function closeWebSockets(): Promise<void> {
   if (wsServer) {
     wsServer.close();
     wsServer = undefined;
+  }
+  if (wsState) {
+    // Wait for all sockets to close
+    await wsState.socketsClosedPromise;
   }
 }

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -64,7 +64,7 @@ export function initWebSockets(server: http.Server): void {
       if (sockets.size) {
         sockets.delete(socket);
         if (sockets.size === 0) {
-          (socketsClosedResolve as () => void)();
+          socketsClosedResolve();
         }
       }
     });


### PR DESCRIPTION
A few contributors have reported flakiness of tests in `packages/server/src/app.test.ts`, specifically since using real Redis in tests. There were a few things that indicated it may be to weird interplay between `jest` and `redis`, although the details are unclear. I tweaked a few things that makes it feel more stable (haven't had another test failure yet) but not 100% confident this is the fix.