### PR TITLE
Use FhirRouter for FHIR operations

### DIFF
--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -154,6 +154,10 @@ export class FhirRouter extends EventTarget {
     this.router.add('POST', '$graphql', graphqlHandler);
   }
 
+  add(method: HttpMethod, path: string, handler: FhirRouteHandler): void {
+    this.router.add(method, path, handler);
+  }
+
   async handleRequest(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
     const result = this.router.find(req.method, req.pathname);
     if (!result) {

--- a/packages/server/src/fhir/operations/README.md
+++ b/packages/server/src/fhir/operations/README.md
@@ -18,7 +18,7 @@ Utility functions that use the `OperationDefinition` to automate implementation 
 - [`parseInputParameters`](./utils/parameters.ts) takes either standard `Parameters` input or plain JSON key-value pairs
   for compatibility, and produces an object containing all defined input parameter values
   - Validates number of parameter values, including required parameters
-- [`sendOutputParameters`](./utils/parameters.ts) handles sending a set of output values as the response
+- [`buildOutputParameters`](./utils/parameters.ts) handles sending a set of output values as the response
   - Only sends parameters defined in the `OperationDefinition`
   - Validates parameter cardinality and throws a server error when response wouldn't match `OperationDefinition`
   - Can be passed a `Resource` when there is one matching output parameter named `return`
@@ -26,7 +26,7 @@ Utility functions that use the `OperationDefinition` to automate implementation 
 ### Example: Project $init
 
 ```ts
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { created } from '@medplum/core';
 import { Reference, OperationDefinition } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
@@ -58,13 +58,13 @@ interface ProjectInitParameters {
   ownerEmail?: string;
 }
 
-export async function projectInitHandler(req: Request, res: Response): Promise<void> {
+export async function projectInitHandler(req: FhirRequest): Promise<FhirResponse> {
   const params = parseInputParameters<ProjectInitParameters>(operation, req);
 
   // Handle operation business logic...
   const project = doProjectInit(params);
 
   // Special case: single `return` output parameter means respond with the Project resource directly
-  await sendOutputParameters(req, res, operation, created, project);
+  return [created, project];
 }
 ```

--- a/packages/server/src/fhir/operations/agentutils.ts
+++ b/packages/server/src/fhir/operations/agentutils.ts
@@ -1,4 +1,5 @@
 import { Operator, parseSearchRequest } from '@medplum/core';
+import { FhirRequest } from '@medplum/fhir-router';
 import { Agent, Device } from '@medplum/fhirtypes';
 import { Request } from 'express';
 import { isIPv4 } from 'node:net';
@@ -19,7 +20,7 @@ import { Repository } from '../repo';
  * @param repo - The repository.
  * @returns The agent, or undefined if not found.
  */
-export async function getAgentForRequest(req: Request, repo: Repository): Promise<Agent | undefined> {
+export async function getAgentForRequest(req: Request | FhirRequest, repo: Repository): Promise<Agent | undefined> {
   // Prefer to search by ID from path parameter
   const { id } = req.params;
   if (id) {

--- a/packages/server/src/fhir/operations/codesystemlookup.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.ts
@@ -1,13 +1,12 @@
 import { OperationOutcomeError, TypedValue, allOk, append, badRequest, notFound } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
+import { getAuthenticatedContext } from '../../context';
 import { getDatabasePool } from '../../database';
-import { sendOutcome } from '../outcomes';
 import { Column, Condition, SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { findTerminologyResource } from './utils/terminology';
-import { getAuthenticatedContext } from '../../context';
 
 const operation = getOperationDefinition('CodeSystem', 'lookup');
 
@@ -19,7 +18,7 @@ type CodeSystemLookupParameters = {
   property?: string[];
 };
 
-export async function codeSystemLookupHandler(req: Request, res: Response): Promise<void> {
+export async function codeSystemLookupHandler(req: FhirRequest): Promise<FhirResponse> {
   const params = parseInputParameters<CodeSystemLookupParameters>(operation, req);
 
   let codeSystem: CodeSystem;
@@ -30,8 +29,7 @@ export async function codeSystemLookupHandler(req: Request, res: Response): Prom
   } else if (params.coding?.system) {
     codeSystem = await findTerminologyResource<CodeSystem>('CodeSystem', params.coding.system, params.version);
   } else {
-    sendOutcome(res, badRequest('No code system specified'));
-    return;
+    return [badRequest('No code system specified')];
   }
 
   let coding: Coding;
@@ -40,12 +38,11 @@ export async function codeSystemLookupHandler(req: Request, res: Response): Prom
   } else if (params.code) {
     coding = { system: params.system ?? codeSystem.url, code: params.code };
   } else {
-    sendOutcome(res, badRequest('No coding specified'));
-    return;
+    return [badRequest('No coding specified')];
   }
 
   const output = await lookupCoding(codeSystem, coding);
-  await sendOutputParameters(req, res, operation, allOk, output);
+  return [allOk, buildOutputParameters(operation, output)];
 }
 
 export type CodeSystemLookupOutput = {

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.ts
@@ -1,13 +1,12 @@
 import { allOk, badRequest } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
+import { getAuthenticatedContext } from '../../context';
 import { getDatabasePool } from '../../database';
-import { sendOutcome } from '../outcomes';
 import { SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { findTerminologyResource } from './utils/terminology';
-import { getAuthenticatedContext } from '../../context';
 
 const operation = getOperationDefinition('CodeSystem', 'validate-code');
 
@@ -24,10 +23,10 @@ type CodeSystemValidateCodeParameters = {
  * Endpoint - CodeSystem resource type
  *   [fhir base]/CodeSystem/$validate-code
  *
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function codeSystemValidateCodeHandler(req: Request, res: Response): Promise<void> {
+export async function codeSystemValidateCodeHandler(req: FhirRequest): Promise<FhirResponse> {
   const params = parseInputParameters<CodeSystemValidateCodeParameters>(operation, req);
 
   let codeSystem: CodeSystem;
@@ -38,8 +37,7 @@ export async function codeSystemValidateCodeHandler(req: Request, res: Response)
   } else if (params.coding?.system) {
     codeSystem = await findTerminologyResource<CodeSystem>('CodeSystem', params.coding.system, params.version);
   } else {
-    sendOutcome(res, badRequest('No code system specified'));
-    return;
+    return [badRequest('No code system specified')];
   }
 
   let coding: Coding;
@@ -48,8 +46,7 @@ export async function codeSystemValidateCodeHandler(req: Request, res: Response)
   } else if (params.code) {
     coding = { system: params.url ?? codeSystem.url, code: params.code };
   } else {
-    sendOutcome(res, badRequest('No coding specified'));
-    return;
+    return [badRequest('No coding specified')];
   }
 
   const result = await validateCoding(codeSystem, coding);
@@ -61,7 +58,7 @@ export async function codeSystemValidateCodeHandler(req: Request, res: Response)
   } else {
     output.result = false;
   }
-  await sendOutputParameters(req, res, operation, allOk, output);
+  return [allOk, buildOutputParameters(operation, output)];
 }
 
 export async function validateCoding(codeSystem: CodeSystem, coding: Coding): Promise<Coding | undefined> {

--- a/packages/server/src/fhir/operations/conceptmaptranslate.ts
+++ b/packages/server/src/fhir/operations/conceptmaptranslate.ts
@@ -6,22 +6,22 @@ import {
   badRequest,
   conceptMapTranslate,
 } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { ConceptMap } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../../context';
 import { getOperationDefinition } from './definitions';
-import { parseInputParameters, sendOutputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { findTerminologyResource } from './utils/terminology';
 
 const operation = getOperationDefinition('ConceptMap', 'translate');
 
-export async function conceptMapTranslateHandler(req: Request, res: Response): Promise<void> {
+export async function conceptMapTranslateHandler(req: FhirRequest): Promise<FhirResponse> {
   const params = parseInputParameters<ConceptMapTranslateParameters>(operation, req);
 
   const map = await lookupConceptMap(params, req.params.id);
 
   const output = conceptMapTranslate(map, params);
-  await sendOutputParameters(req, res, operation, allOk, output);
+  return [allOk, buildOutputParameters(operation, output)];
 }
 
 async function lookupConceptMap(params: ConceptMapTranslateParameters, id?: string): Promise<ConceptMap> {

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -9,16 +9,14 @@ import {
   UpdateFunctionCodeCommand,
   UpdateFunctionConfigurationCommand,
 } from '@aws-sdk/client-lambda';
-import { ContentType, allOk, badRequest, getReferenceString, sleep } from '@medplum/core';
+import { ContentType, allOk, badRequest, getReferenceString, normalizeOperationOutcome, sleep } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Binary, Bot } from '@medplum/fhirtypes';
 import { ConfiguredRetryStrategy } from '@smithy/util-retry';
-import { Request, Response } from 'express';
 import JSZip from 'jszip';
 import { Readable } from 'stream';
-import { asyncWrap } from '../../async';
 import { getConfig } from '../../config';
 import { getAuthenticatedContext, getRequestContext } from '../../context';
-import { sendOutcome } from '../outcomes';
 import { getSystemRepo } from '../repo';
 import { getBinaryStorage } from '../storage';
 import { isBotEnabled } from './execute';
@@ -101,15 +99,14 @@ function createPdf(docDefinition, tableLayouts, fonts) {
 }
 `;
 
-export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
+export async function deployHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { id } = req.params;
 
   // Validate that the request body has a code property
   const code = req.body.code as string | undefined;
   if (!code) {
-    sendOutcome(res, badRequest('Missing code'));
-    return;
+    return [badRequest('Missing code')];
   }
 
   // First read the bot as the user to verify access
@@ -120,8 +117,7 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
   const bot = await systemRepo.readResource<Bot>('Bot', id);
 
   if (!(await isBotEnabled(bot))) {
-    sendOutcome(res, badRequest('Bots not enabled'));
-    return;
+    return [badRequest('Bots not enabled')];
   }
 
   try {
@@ -150,11 +146,11 @@ export const deployHandler = asyncWrap(async (req: Request, res: Response) => {
       await deployLambda(updatedBot, code);
     }
 
-    sendOutcome(res, allOk);
+    return [allOk];
   } catch (err) {
-    sendOutcome(res, badRequest((err as Error).message));
+    return [normalizeOperationOutcome(err)];
   }
-});
+}
 
 async function deployLambda(bot: Bot, code: string): Promise<void> {
   const ctx = getRequestContext();

--- a/packages/server/src/fhir/operations/evaluatemeasure.test.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.test.ts
@@ -124,7 +124,9 @@ describe('Measure evaluate-measure', () => {
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
     expect(res2.status).toBe(400);
-    expect(res2.text).toEqual('Unsupported content type');
+    expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      "Expected at least 1 value(s) for required input parameter 'periodStart'"
+    );
   });
 
   test('Unsupported parameters type', async () => {
@@ -146,7 +148,9 @@ describe('Measure evaluate-measure', () => {
         resourceType: 'Patient',
       });
     expect(res2.status).toBe(400);
-    expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Incorrect parameters type');
+    expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      "Expected at least 1 value(s) for required input parameter 'periodStart'"
+    );
   });
 
   test('Missing period', async () => {
@@ -174,7 +178,9 @@ describe('Measure evaluate-measure', () => {
         ],
       });
     expect(res2.status).toBe(400);
-    expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Missing periodStart parameter');
+    expect((res2.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      'Expected 1 value(s) for input parameter periodStart, but 0 provided'
+    );
 
     const res3 = await request(app)
       .post(`/fhir/R4/Measure/${res1.body.id}/$evaluate-measure`)
@@ -190,6 +196,8 @@ describe('Measure evaluate-measure', () => {
         ],
       });
     expect(res3.status).toBe(400);
-    expect((res3.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Missing periodEnd parameter');
+    expect((res3.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      'Expected 1 value(s) for input parameter periodEnd, but 0 provided'
+    );
   });
 });

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -1,4 +1,5 @@
-import { Operator, badRequest, created, parseSearchRequest } from '@medplum/core';
+import { Operator, created, parseSearchRequest } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import {
   Measure,
   MeasureGroup,
@@ -6,13 +7,35 @@ import {
   MeasureReport,
   MeasureReportGroup,
   MeasureReportGroupPopulation,
-  Resource,
+  OperationDefinition,
 } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../../context';
-import { sendOutcome } from '../outcomes';
 import { Repository } from '../repo';
-import { isFhirJsonContentType, sendResponse } from '../response';
+import { parseInputParameters } from './utils/parameters';
+
+const operation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  id: 'Measure-evaluate-measure',
+  url: 'http://hl7.org/fhir/OperationDefinition/Measure-evaluate-measure',
+  name: 'Evaluate Measure',
+  status: 'draft',
+  kind: 'operation',
+  code: 'evaluate-measure',
+  resource: ['Measure'],
+  system: false,
+  type: true,
+  instance: true,
+  parameter: [
+    { name: 'periodStart', use: 'in', min: 1, max: '1', type: 'date' },
+    { name: 'periodEnd', use: 'in', min: 1, max: '1', type: 'date' },
+    { name: 'measure', use: 'in', min: 0, max: '1', type: 'Reference' },
+    { name: 'reportType', use: 'in', min: 0, max: '1', type: 'code' },
+    { name: 'subject', use: 'in', min: 0, max: '1', type: 'Reference' },
+    { name: 'practitioner', use: 'in', min: 0, max: '1', type: 'Reference' },
+    { name: 'lastReceivedOn', use: 'in', min: 0, max: '1', type: 'dateTime' },
+    { name: 'return', use: 'out', min: 1, max: '1', type: 'MeasureReport' },
+  ],
+};
 
 interface EvaluateMeasureParameters {
   readonly periodStart: string;
@@ -36,58 +59,16 @@ interface EvaluateMeasureParameters {
  * 4. location parameter
  *
  * See: https://hl7.org/fhir/measure-operation-evaluate-measure.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function evaluateMeasureHandler(req: Request, res: Response): Promise<void> {
+export async function evaluateMeasureHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { id } = req.params;
   const measure = await ctx.repo.readResource<Measure>('Measure', id);
-
-  const params = await validateParameters(req, res);
-  if (!params) {
-    return;
-  }
-
+  const params = parseInputParameters<EvaluateMeasureParameters>(operation, req);
   const measureReport = await evaluateMeasure(ctx.repo, params, measure);
-  await sendResponse(req, res, created, measureReport);
-}
-
-/**
- * Parses and validates the operation parameters.
- * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
- * @returns The operation parameters if available; otherwise, undefined.
- */
-async function validateParameters(req: Request, res: Response): Promise<EvaluateMeasureParameters | undefined> {
-  if (!isFhirJsonContentType(req)) {
-    res.status(400).send('Unsupported content type');
-    return undefined;
-  }
-
-  const body = req.body as Resource;
-  if (body.resourceType !== 'Parameters') {
-    sendOutcome(res, badRequest('Incorrect parameters type'));
-    return undefined;
-  }
-
-  const periodStartParam = body.parameter?.find((param) => param.name === 'periodStart');
-  if (!periodStartParam?.valueDate) {
-    sendOutcome(res, badRequest('Missing periodStart parameter'));
-    return undefined;
-  }
-
-  const periodEndParam = body.parameter?.find((param) => param.name === 'periodEnd');
-  if (!periodEndParam?.valueDate) {
-    sendOutcome(res, badRequest('Missing periodEnd parameter'));
-    return undefined;
-  }
-
-  return {
-    periodStart: periodStartParam.valueDate,
-    periodEnd: periodEndParam.valueDate,
-  };
+  return [created, measureReport];
 }
 
 /**

--- a/packages/server/src/fhir/operations/evaluatemeasure.ts
+++ b/packages/server/src/fhir/operations/evaluatemeasure.ts
@@ -7,35 +7,13 @@ import {
   MeasureReport,
   MeasureReportGroup,
   MeasureReportGroupPopulation,
-  OperationDefinition,
 } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { Repository } from '../repo';
+import { getOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
-  id: 'Measure-evaluate-measure',
-  url: 'http://hl7.org/fhir/OperationDefinition/Measure-evaluate-measure',
-  name: 'Evaluate Measure',
-  status: 'draft',
-  kind: 'operation',
-  code: 'evaluate-measure',
-  resource: ['Measure'],
-  system: false,
-  type: true,
-  instance: true,
-  parameter: [
-    { name: 'periodStart', use: 'in', min: 1, max: '1', type: 'date' },
-    { name: 'periodEnd', use: 'in', min: 1, max: '1', type: 'date' },
-    { name: 'measure', use: 'in', min: 0, max: '1', type: 'Reference' },
-    { name: 'reportType', use: 'in', min: 0, max: '1', type: 'code' },
-    { name: 'subject', use: 'in', min: 0, max: '1', type: 'Reference' },
-    { name: 'practitioner', use: 'in', min: 0, max: '1', type: 'Reference' },
-    { name: 'lastReceivedOn', use: 'in', min: 0, max: '1', type: 'dateTime' },
-    { name: 'return', use: 'out', min: 1, max: '1', type: 'MeasureReport' },
-  ],
-};
+const operation = getOperationDefinition('Measure', 'evaluate-measure');
 
 interface EvaluateMeasureParameters {
   readonly periodStart: string;

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -1,9 +1,8 @@
-import { accepted, getResourceTypes, protectedResourceTypes } from '@medplum/core';
+import { accepted, concatUrls, getResourceTypes, protectedResourceTypes } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Project, ResourceType } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getConfig } from '../../config';
 import { getAuthenticatedContext } from '../../context';
-import { sendOutcome } from '../outcomes';
 import { getPatientResourceTypes } from '../patient';
 import { BulkExporter } from './utils/bulkexporter';
 
@@ -15,11 +14,11 @@ import { BulkExporter } from './utils/bulkexporter';
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html
  * See: https://hl7.org/fhir/R4/async.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function bulkExportHandler(req: Request, res: Response): Promise<void> {
-  await startExport(req, res, 'System');
+export async function bulkExportHandler(req: FhirRequest): Promise<FhirResponse> {
+  return startExport(req, 'System');
 }
 
 /**
@@ -30,14 +29,14 @@ export async function bulkExportHandler(req: Request, res: Response): Promise<vo
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html#endpoint---all-patients
  * See: https://hl7.org/fhir/R4/async.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function patientExportHandler(req: Request, res: Response): Promise<void> {
-  await startExport(req, res, 'Patient');
+export async function patientExportHandler(req: FhirRequest): Promise<FhirResponse> {
+  return startExport(req, 'Patient');
 }
 
-async function startExport(req: Request, res: Response, exportType: string): Promise<void> {
+async function startExport(req: FhirRequest, exportType: string): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { baseUrl } = getConfig();
   const query = req.query as Record<string, string | undefined>;
@@ -45,13 +44,13 @@ async function startExport(req: Request, res: Response, exportType: string): Pro
   const types = query._type?.split(',');
 
   const exporter = new BulkExporter(ctx.repo, since);
-  const bulkDataExport = await exporter.start(req.protocol + '://' + req.get('host') + req.originalUrl);
+  const bulkDataExport = await exporter.start(concatUrls(baseUrl, 'fhir/R4' + req.pathname));
 
   exportResources(exporter, ctx.project, types, exportType)
     .then(() => ctx.logger.info('Export completed', { exportType, id: ctx.project.id }))
     .catch((err) => ctx.logger.error('Export failure', { exportType, id: ctx.project.id, error: err }));
 
-  sendOutcome(res, accepted(`${baseUrl}fhir/R4/bulkdata/export/${bulkDataExport.id}`));
+  return [accepted(`${baseUrl}fhir/R4/bulkdata/export/${bulkDataExport.id}`)];
 }
 
 export async function exportResources(

--- a/packages/server/src/fhir/operations/getwsbindingtoken.ts
+++ b/packages/server/src/fhir/operations/getwsbindingtoken.ts
@@ -1,11 +1,9 @@
 import { allOk, badRequest, normalizeErrorString, resolveId } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Parameters, Subscription } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getConfig } from '../../config';
 import { getAuthenticatedContext } from '../../context';
 import { generateAccessToken } from '../../oauth/keys';
-import { sendOutcome } from '../outcomes';
-import { sendResponse } from '../response';
 
 const ONE_HOUR = 60 * 60 * 1000;
 
@@ -23,31 +21,28 @@ export type AdditionalWsBindingClaims = {
  *   URL: [base]/Subscription/[id]/$get-ws-binding-token
  *
  * See: https://build.fhir.org/subscription-operation-get-ws-binding-token.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function getWsBindingTokenHandler(req: Request, res: Response): Promise<void> {
+export async function getWsBindingTokenHandler(req: FhirRequest): Promise<FhirResponse> {
   const { login, profile, repo, project } = getAuthenticatedContext();
   const { baseUrl } = getConfig();
 
   if (!project.features?.includes('websocket-subscriptions')) {
-    sendOutcome(res, badRequest('WebSocket subscriptions not enabled for current project'));
-    return;
+    return [badRequest('WebSocket subscriptions not enabled for current project')];
   }
 
   const clientId = login.client && resolveId(login.client);
   const userId = resolveId(login.user);
   if (!userId) {
-    sendOutcome(res, badRequest('Login missing user'));
-    return;
+    return [badRequest('Login missing user')];
   }
 
   const subscriptionId = req.params.id;
   try {
     await repo.readResource<Subscription>('Subscription', subscriptionId);
   } catch (err: unknown) {
-    sendOutcome(res, badRequest(`Error reading subscription: ${normalizeErrorString(err)}`));
-    return;
+    return [badRequest(`Error reading subscription: ${normalizeErrorString(err)}`)];
   }
 
   const token = await generateAccessToken(
@@ -83,5 +78,5 @@ export async function getWsBindingTokenHandler(req: Request, res: Response): Pro
     ],
   } satisfies Parameters;
 
-  await sendResponse(req, res, allOk, tokenParams);
+  return [allOk, tokenParams];
 }

--- a/packages/server/src/fhir/operations/groupexport.ts
+++ b/packages/server/src/fhir/operations/groupexport.ts
@@ -1,9 +1,8 @@
-import { accepted } from '@medplum/core';
+import { accepted, concatUrls } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Group, Patient, Project } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getConfig } from '../../config';
 import { getAuthenticatedContext, getLogger } from '../../context';
-import { sendOutcome } from '../outcomes';
 import { Repository } from '../repo';
 import { getPatientEverything } from './patienteverything';
 import { BulkExporter } from './utils/bulkexporter';
@@ -16,10 +15,10 @@ import { BulkExporter } from './utils/bulkexporter';
  *
  * See: https://hl7.org/fhir/uv/bulkdata/export.html
  * See: https://hl7.org/fhir/R4/async.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function groupExportHandler(req: Request, res: Response): Promise<void> {
+export async function groupExportHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { baseUrl } = getConfig();
   const { id } = req.params;
@@ -32,13 +31,13 @@ export async function groupExportHandler(req: Request, res: Response): Promise<v
 
   // Start the exporter
   const exporter = new BulkExporter(ctx.repo, since, types);
-  const bulkDataExport = await exporter.start(req.protocol + '://' + req.get('host') + req.originalUrl);
+  const bulkDataExport = await exporter.start(concatUrls(baseUrl, 'fhir/R4' + req.pathname));
 
   groupExportResources(exporter, ctx.project, group, ctx.repo)
     .then(() => ctx.logger.info('Group export completed', { id: ctx.project.id }))
     .catch((err) => ctx.logger.error('Group export failed', { id: ctx.project.id, error: err }));
 
-  sendOutcome(res, accepted(`${baseUrl}fhir/R4/bulkdata/export/${bulkDataExport.id}`));
+  return [accepted(`${baseUrl}fhir/R4/bulkdata/export/${bulkDataExport.id}`)];
 }
 
 export async function groupExportResources(

--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -1,4 +1,5 @@
 import { allOk, getReferenceString, Operator, SearchRequest } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import {
   Bundle,
   BundleEntry,
@@ -7,11 +8,10 @@ import {
   Resource,
   ResourceType,
 } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../../context';
 import { getPatientCompartments } from '../patient';
 import { Repository } from '../repo';
-import { getFullUrl, sendResponse } from '../response';
+import { getFullUrl } from '../response';
 import { getOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
@@ -27,10 +27,10 @@ type PatientEverythingParameters = {
 /**
  * Handles a Patient everything request.
  * Searches for all resources related to the patient.
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function patientEverythingHandler(req: Request, res: Response): Promise<void> {
+export async function patientEverythingHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { id } = req.params;
   const params = parseInputParameters<PatientEverythingParameters>(operation, req);
@@ -41,7 +41,7 @@ export async function patientEverythingHandler(req: Request, res: Response): Pro
   // Then read all of the patient data
   const bundle = await getPatientEverything(ctx.repo, patient, params);
 
-  await sendResponse(req, res, allOk, bundle);
+  return [allOk, bundle];
 }
 
 /**

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -88,7 +88,7 @@ describe('PlanDefinition apply', () => {
         parameter: [
           {
             name: 'subject',
-            valueReference: createReference(res3.body as Patient),
+            valueString: getReferenceString(res3.body as Patient),
           },
         ],
       });
@@ -135,7 +135,9 @@ describe('PlanDefinition apply', () => {
       .set('Content-Type', ContentType.TEXT)
       .send('hello');
     expect(res4.status).toBe(400);
-    expect(res4.text).toEqual('Unsupported content type');
+    expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      "Expected at least 1 value(s) for required input parameter 'subject'"
+    );
   });
 
   test('Incorrect parameters type', async () => {
@@ -158,7 +160,9 @@ describe('PlanDefinition apply', () => {
         resourceType: 'Patient',
       });
     expect(res4.status).toBe(400);
-    expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Incorrect parameters type');
+    expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      "Expected at least 1 value(s) for required input parameter 'subject'"
+    );
   });
 
   test('Missing subject', async () => {
@@ -182,7 +186,9 @@ describe('PlanDefinition apply', () => {
         parameter: [],
       });
     expect(res4.status).toBe(400);
-    expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual('Missing subject parameter');
+    expect((res4.body as OperationOutcome).issue?.[0]?.details?.text).toEqual(
+      'Expected 1..NaN value(s) for input parameter subject, but 0 provided'
+    );
   });
 
   test('General task', async () => {
@@ -221,7 +227,7 @@ describe('PlanDefinition apply', () => {
         parameter: [
           {
             name: 'subject',
-            valueReference: createReference(res3.body as Patient),
+            valueString: getReferenceString(res3.body as Patient),
           },
         ],
       });

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,7 +1,6 @@
 import { allOk, createReference, getReferenceString, ProfileResource } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import {
-  OperationDefinition,
   Patient,
   PlanDefinition,
   PlanDefinitionAction,
@@ -13,34 +12,10 @@ import {
 } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { Repository } from '../repo';
+import { getOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
 
-const operation: OperationDefinition = {
-  resourceType: 'OperationDefinition',
-  id: 'PlanDefinition-apply',
-  version: '4.0.1',
-  name: 'Apply',
-  status: 'draft',
-  kind: 'operation',
-  code: 'apply',
-  resource: ['PlanDefinition'],
-  system: false,
-  type: true,
-  instance: true,
-  parameter: [
-    { name: 'planDefinition', use: 'in', min: 0, max: '1', type: 'PlanDefinition' },
-    { name: 'subject', use: 'in', min: 1, max: '*', type: 'string', searchType: 'reference' },
-    { name: 'encounter', use: 'in', min: 0, max: '1', type: 'string', searchType: 'reference' },
-    { name: 'practitioner', use: 'in', min: 0, max: '1', type: 'string', searchType: 'reference' },
-    { name: 'organization', use: 'in', min: 0, max: '1', type: 'string', searchType: 'reference' },
-    { name: 'userType', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
-    { name: 'userLanguage', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
-    { name: 'userTaskContext', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
-    { name: 'setting', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
-    { name: 'settingContext', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
-    { name: 'return', use: 'out', min: 1, max: '1', type: 'CarePlan' },
-  ],
-};
+const operation = getOperationDefinition('PlanDefinition', 'apply');
 
 interface PlanDefinitionApplyParameters {
   readonly subject: string[];

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,41 +1,49 @@
-import { allOk, badRequest, createReference, getReferenceString, ProfileResource } from '@medplum/core';
+import { allOk, createReference, getReferenceString, ProfileResource } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import {
-  CareTeam,
-  Device,
-  Group,
-  HealthcareService,
-  Organization,
+  OperationDefinition,
   Patient,
   PlanDefinition,
   PlanDefinitionAction,
-  Practitioner,
-  PractitionerRole,
   Reference,
-  RelatedPerson,
   RequestGroup,
   RequestGroupAction,
-  Resource,
   Task,
   TaskInput,
 } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../../context';
-import { sendOutcome } from '../outcomes';
 import { Repository } from '../repo';
-import { isFhirJsonContentType, sendResponse } from '../response';
+import { parseInputParameters } from './utils/parameters';
 
-type SubjectType =
-  | CareTeam
-  | Device
-  | HealthcareService
-  | Organization
-  | Patient
-  | Practitioner
-  | PractitionerRole
-  | RelatedPerson;
+const operation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  id: 'PlanDefinition-apply',
+  version: '4.0.1',
+  name: 'Apply',
+  status: 'draft',
+  kind: 'operation',
+  code: 'apply',
+  resource: ['PlanDefinition'],
+  system: false,
+  type: true,
+  instance: true,
+  parameter: [
+    { name: 'planDefinition', use: 'in', min: 0, max: '1', type: 'PlanDefinition' },
+    { name: 'subject', use: 'in', min: 1, max: '*', type: 'string', searchType: 'reference' },
+    { name: 'encounter', use: 'in', min: 0, max: '1', type: 'string', searchType: 'reference' },
+    { name: 'practitioner', use: 'in', min: 0, max: '1', type: 'string', searchType: 'reference' },
+    { name: 'organization', use: 'in', min: 0, max: '1', type: 'string', searchType: 'reference' },
+    { name: 'userType', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
+    { name: 'userLanguage', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
+    { name: 'userTaskContext', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
+    { name: 'setting', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
+    { name: 'settingContext', use: 'in', min: 0, max: '1', type: 'CodeableConcept' },
+    { name: 'return', use: 'out', min: 1, max: '1', type: 'CarePlan' },
+  ],
+};
 
 interface PlanDefinitionApplyParameters {
-  readonly subject: SubjectType;
+  readonly subject: string[];
 }
 
 /**
@@ -44,106 +52,71 @@ interface PlanDefinitionApplyParameters {
  * The operation converts a PlanDefinition to a RequestGroup.
  *
  * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
+ * @param req - The FHIR request.
+ * @returns The FHIR response.
  */
-export async function planDefinitionApplyHandler(req: Request, res: Response): Promise<void> {
+export async function planDefinitionApplyHandler(req: FhirRequest): Promise<FhirResponse> {
   const ctx = getAuthenticatedContext();
   const { id } = req.params;
-
   const planDefinition = await ctx.repo.readResource<PlanDefinition>('PlanDefinition', id);
-
-  const params = await validateParameters(req, res);
-  if (!params) {
-    return;
-  }
+  const params = parseInputParameters<PlanDefinitionApplyParameters>(operation, req);
+  const subject = await ctx.repo.readReference<Patient>({ reference: params.subject[0] });
+  const subjectRef = createReference(subject);
 
   const actions: RequestGroupAction[] = [];
   if (planDefinition.action) {
     for (const action of planDefinition.action) {
-      actions.push(await createAction(ctx.repo, ctx.profile, params, action));
+      actions.push(await createAction(ctx.repo, ctx.profile, subjectRef, action));
     }
   }
 
   const requestGroup = await ctx.repo.createResource<RequestGroup>({
     resourceType: 'RequestGroup',
     instantiatesCanonical: [getReferenceString(planDefinition)],
-    subject: createReference(params.subject) as Reference<Patient | Group>,
+    subject: subjectRef,
     status: 'active',
     intent: 'order',
     action: actions,
   });
-  await sendResponse(req, res, allOk, requestGroup);
-}
 
-/**
- * Parses and validates the operation parameters.
- * See: https://hl7.org/fhir/plandefinition-operation-apply.html
- * @param req - The HTTP request.
- * @param res - The HTTP response.
- * @returns The operation parameters if available; otherwise, undefined.
- */
-async function validateParameters(req: Request, res: Response): Promise<PlanDefinitionApplyParameters | undefined> {
-  const ctx = getAuthenticatedContext();
-  if (!isFhirJsonContentType(req)) {
-    res.status(400).send('Unsupported content type');
-    return undefined;
-  }
-
-  const body = req.body as Resource;
-  if (body.resourceType !== 'Parameters') {
-    sendOutcome(res, badRequest('Incorrect parameters type'));
-    return undefined;
-  }
-
-  const subjectParam = body.parameter?.find((param) => param.name === 'subject');
-  if (!subjectParam?.valueReference) {
-    sendOutcome(res, badRequest('Missing subject parameter'));
-    return undefined;
-  }
-
-  const subject = await ctx.repo.readReference(subjectParam.valueReference as Reference<SubjectType>);
-
-  return {
-    subject,
-  };
+  return [allOk, requestGroup];
 }
 
 /**
  * Creates a Task and RequestGroup action for the given PlanDefinition action.
  * @param repo - The repository configured for the current user.
  * @param requester - The user who requested the plan definition.
- * @param params - The apply operation parameters (subject, etc).
+ * @param subject - The subject of the plan definition.
  * @param action - The PlanDefinition action.
  * @returns The RequestGroup action.
  */
 async function createAction(
   repo: Repository,
   requester: Reference<ProfileResource>,
-  params: PlanDefinitionApplyParameters,
+  subject: Reference<Patient>,
   action: PlanDefinitionAction
 ): Promise<RequestGroupAction> {
   if (action.definitionCanonical?.startsWith('Questionnaire/')) {
-    return createQuestionnaireTask(repo, requester, params, action);
+    return createQuestionnaireTask(repo, requester, subject, action);
   }
-  return createTask(repo, requester, params, action);
+  return createTask(repo, requester, subject, action);
 }
 
 /**
  * Creates a Task and RequestGroup action to complete a Questionnaire.
  * @param repo - The repository configured for the current user.
  * @param requester - The user who requested the plan definition.
- * @param params - The apply operation parameters (subject, etc).
+ * @param subject - The subject of the plan definition.
  * @param action - The PlanDefinition action.
  * @returns The RequestGroup action.
  */
 async function createQuestionnaireTask(
   repo: Repository,
   requester: Reference<ProfileResource>,
-  params: PlanDefinitionApplyParameters,
+  subject: Reference<Patient>,
   action: PlanDefinitionAction
 ): Promise<RequestGroupAction> {
-  return createTask(repo, requester, params, action, [
+  return createTask(repo, requester, subject, action, [
     {
       type: {
         text: 'Questionnaire',
@@ -160,7 +133,7 @@ async function createQuestionnaireTask(
  * Creates a Task and RequestGroup action for a PlanDefinition action.
  * @param repo - The repository configured for the current user.
  * @param requester - The requester profile.
- * @param params - The apply operation parameters (subject, etc).
+ * @param subject - The subject of the plan definition.
  * @param action - The PlanDefinition action.
  * @param input - Optional input details.
  * @returns The RequestGroup action.
@@ -168,7 +141,7 @@ async function createQuestionnaireTask(
 async function createTask(
   repo: Repository,
   requester: Reference<ProfileResource>,
-  params: PlanDefinitionApplyParameters,
+  subject: Reference<Patient>,
   action: PlanDefinitionAction,
   input?: TaskInput[] | undefined
 ): Promise<RequestGroupAction> {
@@ -178,8 +151,8 @@ async function createTask(
     status: 'requested',
     authoredOn: new Date().toISOString(),
     requester,
-    for: createReference(params.subject),
-    owner: createReference(params.subject),
+    for: subject,
+    owner: subject,
     description: action.description,
     focus: input?.[0]?.valueReference,
     input,

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -1,18 +1,16 @@
-import { allOk, created, indexStructureDefinitionBundle } from '@medplum/core';
+import { indexStructureDefinitionBundle } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import {
   Observation,
   OperationDefinition,
-  OperationOutcome,
   Parameters,
   ParametersParameter,
   Patient,
   Reference,
 } from '@medplum/fhirtypes';
-import { Request, Response } from 'express';
-import { withTestContext } from '../../../test.setup';
-import { parseInputParameters, parseParameters, sendOutputParameters } from './parameters';
+import { Request } from 'express';
 import { parse } from 'qs';
+import { buildOutputParameters, parseInputParameters, parseParameters } from './parameters';
 
 describe('FHIR Parameters parsing', () => {
   test('Read Parameters', () => {
@@ -255,39 +253,24 @@ describe('Operation Input Parameters parsing', () => {
 });
 
 describe('Send Operation output Parameters', () => {
-  const req = {
-    query: {},
-  } as unknown as Request;
-
-  const res = {
-    set: jest.fn(),
-    status: jest.fn(),
-    json: jest.fn(),
-  } as unknown as Response;
-
   beforeEach(() => {
     jest.resetAllMocks();
-    (res.status as jest.Mock).mockReturnThis();
   });
 
   test('Single required parameter', async () => {
-    await sendOutputParameters(req, res, opDef, allOk, { singleOut: { value: 20.2, unit: 'kg/m^2' } });
-
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith<[Parameters]>({
+    const parameters = buildOutputParameters(opDef, { singleOut: { value: 20.2, unit: 'kg/m^2' } });
+    expect(parameters).toMatchObject({
       resourceType: 'Parameters',
       parameter: [{ name: 'singleOut', valueQuantity: { value: 20.2, unit: 'kg/m^2' } }],
     });
   });
 
   test('Optional output parameter', async () => {
-    await sendOutputParameters(req, res, opDef, created, {
+    const parameters = buildOutputParameters(opDef, {
       singleOut: { value: 20.2, unit: 'kg/m^2' },
       multiOut: [{ reference: 'Observation/height' }, { reference: 'Observation/weight' }],
     });
-
-    expect(res.status).toHaveBeenCalledWith(201);
-    expect(res.json).toHaveBeenCalledWith<[Parameters]>({
+    expect(parameters).toMatchObject({
       resourceType: 'Parameters',
       parameter: [
         { name: 'singleOut', valueQuantity: { value: 20.2, unit: 'kg/m^2' } },
@@ -297,126 +280,79 @@ describe('Send Operation output Parameters', () => {
     });
   });
 
-  test('Return resource output', () =>
-    withTestContext(async () => {
-      const resourceReturnOp: OperationDefinition = {
-        ...opDef,
-        parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
-      };
-      const obs = {
-        resourceType: 'Observation',
-        status: 'final',
-        code: {
-          coding: [{ system: 'http://loinc.org', code: '39156-5', display: 'Body mass index (BMI) [Ratio]' }],
-        },
-        valueQuantity: {
-          value: 19.6,
-          unit: 'kg/m^2',
-        },
-      } as Observation;
-      await sendOutputParameters(req, res, resourceReturnOp, allOk, obs);
+  test('Return resource output', () => {
+    const resourceReturnOp: OperationDefinition = {
+      ...opDef,
+      parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
+    };
+    const obs = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: {
+        coding: [{ system: 'http://loinc.org', code: '39156-5', display: 'Body mass index (BMI) [Ratio]' }],
+      },
+      valueQuantity: {
+        value: 19.6,
+        unit: 'kg/m^2',
+      },
+    } as Observation;
+    const output = buildOutputParameters(resourceReturnOp, obs);
+    expect(output).toMatchObject(obs);
+  });
 
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(obs);
-    }));
+  test('Returns error on non-resource', () => {
+    const resourceReturnOp: OperationDefinition = {
+      ...opDef,
+      parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
+    };
+    const ref = { reference: 'Observation/bmi' } as Reference;
 
-  test('Returns error on non-resource', () =>
-    withTestContext(async () => {
-      const resourceReturnOp: OperationDefinition = {
-        ...opDef,
-        parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
-      };
-      const ref = { reference: 'Observation/bmi' } as Reference;
-      await sendOutputParameters(req, res, resourceReturnOp, allOk, ref);
+    try {
+      buildOutputParameters(resourceReturnOp, ref);
+      throw new Error('expected error');
+    } catch (err: any) {
+      expect(err.message).toBe('Expected Observation output, but got unexpected object');
+    }
+  });
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
-        expect.objectContaining({
-          resourceType: 'OperationOutcome',
-          issue: [
-            {
-              severity: 'error',
-              code: 'exception',
-              details: { text: 'Internal server error' },
-              diagnostics: 'Error: Expected Observation output, but got unexpected object',
-            },
-          ],
-        })
-      );
-    }));
+  test('Returns error on incorrect resource type', () => {
+    const resourceReturnOp: OperationDefinition = {
+      ...opDef,
+      parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
+    };
+    const patient = { resourceType: 'Patient' } as Patient;
 
-  test('Returns error on incorrect resource type', () =>
-    withTestContext(async () => {
-      const resourceReturnOp: OperationDefinition = {
-        ...opDef,
-        parameter: [{ name: 'return', use: 'out', type: 'Observation', min: 1, max: '1' }],
-      };
-      const patient = { resourceType: 'Patient' } as Patient;
-      await sendOutputParameters(req, res, resourceReturnOp, allOk, patient);
+    try {
+      buildOutputParameters(resourceReturnOp, patient);
+      throw new Error('expected error');
+    } catch (err: any) {
+      expect(err.message).toBe('Expected Observation output, but got unexpected object');
+    }
+  });
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
-        expect.objectContaining({
-          resourceType: 'OperationOutcome',
-          issue: [
-            {
-              severity: 'error',
-              code: 'exception',
-              details: { text: 'Internal server error' },
-              diagnostics: 'Error: Expected Observation output, but got unexpected object',
-            },
-          ],
-        })
-      );
-    }));
-
-  test('Missing required parameter', () =>
-    withTestContext(async () => {
-      await sendOutputParameters(req, res, opDef, allOk, { incorrectOut: { value: 20.2, unit: 'kg/m^2' } });
-
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
-        expect.objectContaining({
-          resourceType: 'OperationOutcome',
-          issue: [
-            {
-              severity: 'error',
-              code: 'exception',
-              details: { text: 'Internal server error' },
-              diagnostics: "Error: Expected 1 or more values for output parameter 'singleOut', got 0",
-            },
-          ],
-        })
-      );
-    }));
+  test('Missing required parameter', () => {
+    try {
+      buildOutputParameters(opDef, { incorrectOut: { value: 20.2, unit: 'kg/m^2' } });
+      throw new Error('expected error');
+    } catch (err: any) {
+      expect(err.message).toBe("Expected 1 or more values for output parameter 'singleOut', got 0");
+    }
+  });
 
   test('Omits extraneous parameters', async () => {
-    await sendOutputParameters(req, res, opDef, allOk, { singleOut: { value: 20.2, unit: 'kg/m^2' }, extraOut: 'foo' });
-
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith<[Parameters]>({
+    const parameters = buildOutputParameters(opDef, { singleOut: { value: 20.2, unit: 'kg/m^2' }, extraOut: 'foo' });
+    expect(parameters).toMatchObject({
       resourceType: 'Parameters',
       parameter: [{ name: 'singleOut', valueQuantity: { value: 20.2, unit: 'kg/m^2' } }],
     });
   });
 
-  test('Returns error on invalid output', () =>
-    withTestContext(async () => {
-      await sendOutputParameters(req, res, opDef, allOk, { singleOut: { reference: 'Observation/foo' } });
-
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith<[OperationOutcome]>(
-        expect.objectContaining({
-          resourceType: 'OperationOutcome',
-          issue: [
-            {
-              severity: 'error',
-              code: 'exception',
-              details: { text: 'Internal server error' },
-              diagnostics: 'Error: Invalid additional property "reference" (Parameters.parameter.value[x].reference)',
-            },
-          ],
-        })
-      );
-    }));
+  test('Returns error on invalid output', () => {
+    try {
+      buildOutputParameters(opDef, { singleOut: { reference: 'Observation/foo' } });
+      throw new Error('expected error');
+    } catch (err: any) {
+      expect(err.message).toBe('Invalid additional property "reference" (Parameters.parameter.value[x].reference)');
+    }
+  });
 });


### PR DESCRIPTION
Before: Most FHIR operation routes were handled by the Express router, not by the `FhirRouter`

That wasn't inherently bad, but it meant that those FHIR operations were not accessible via FHIR batch operations.

After:  Most FHIR operation routes are now handled by `FhirRouter`, and therefore are available via FHIR batch.

This paves the way in the future for projects to be able to configure Medplum Bots as FHIR operation handlers...

Note I said "most", as some operations are currently not compatible with the `FhirRouter` API:

* `$csv` - exports a CSV representation of search results, and therefore sets content-type, etc
* `Bot/$execute` - Bot execution can return HL7, DICOM, etc
* `Agent/$push` - Agents can return HL7, DICOM, etc

The diff is large, but it's actually pretty straightforward and procedural changes.

Two of our older FHIR operations predate @mattwiller's FHIR `Parameter` utils, so I went ahead and ported those over:

* `Measure/$evaluate-measure`
* `PlanDefinition/$apply`

In both cases, the transition was pretty straightforward, just different error messages.