### PR TITLE
Move Danger.js github action to workflow_run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,6 @@ jobs:
           MEDPLUM_REGISTER_ENABLED: '__MEDPLUM_REGISTER_ENABLED__'
           GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
           RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
-      - name: Danger
-        run: npx danger ci
-        env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}
 
   eslint:
     name: Run eslint

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,20 @@
+name: Danger
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+jobs:
+  sonar:
+    name: Danger
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Danger
+        run: npx --yes danger ci
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Danger.js jobs failing on forks / runs without access to `secrets`.

https://github.com/medplum/medplum/actions/runs/8396284851/job/22997359781?pr=4228

<img width="719" alt="image" src="https://github.com/medplum/medplum/assets/749094/c0fdfd17-9c4c-41ca-93fa-2c7b8524a58e">

This PR moves the Danger.js job to a separate action triggered on `workflow_run`, which means it (1) gets access to `secrets`, but (2) has to use the job definitions in `.github/workflows`.