### PR TITLE
Fixes #4213 - CLI and external auth DomainConfiguration

### DIFF
--- a/packages/app/src/OAuthPage.tsx
+++ b/packages/app/src/OAuthPage.tsx
@@ -33,6 +33,7 @@ export function OAuthPage(): JSX.Element | null {
       onRegister={() => navigate('/register')}
       googleClientId={getConfig().googleClientId}
       clientId={clientId || undefined}
+      redirectUri={params.get('redirect_uri') || undefined}
       scope={scope}
       nonce={params.get('nonce') || undefined}
       launch={params.get('launch') || undefined}

--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -84,7 +84,7 @@ describe('CLI auth', () => {
   test('Login basic auth', async () => {
     expect(medplum.getActiveLogin()).toBeUndefined();
     await main(['node', 'index.js', 'login', '--auth-type', 'basic']);
-    expect(console.log).toHaveBeenCalledWith('Login successful');
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   test('Login client credentials', async () => {
@@ -100,7 +100,7 @@ describe('CLI auth', () => {
       '--client-secret',
       'abc',
     ]);
-    expect(console.log).toHaveBeenCalledWith('Login successful');
+    expect(console.error).not.toHaveBeenCalled();
   });
 
   test('Load credentials from disk', async () => {

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -1,4 +1,10 @@
-import { ContentType, getDisplayString, MedplumClient, normalizeErrorString } from '@medplum/core';
+import {
+  ContentType,
+  getDisplayString,
+  MEDPLUM_CLI_CLIENT_ID,
+  MedplumClient,
+  normalizeErrorString,
+} from '@medplum/core';
 import { exec } from 'child_process';
 import { createServer } from 'http';
 import { platform } from 'os';
@@ -6,7 +12,7 @@ import { createMedplumClient } from './util/client';
 import { createMedplumCommand } from './util/command';
 import { jwtAssertionLogin, jwtBearerLogin, Profile, saveProfile } from './utils';
 
-const clientId = 'medplum-cli';
+const clientId = MEDPLUM_CLI_CLIENT_ID;
 const redirectUri = 'http://localhost:9615';
 
 export const login = createMedplumCommand('login');
@@ -47,8 +53,6 @@ async function startLogin(medplum: MedplumClient, profile: Profile): Promise<voi
       await jwtAssertionLogin(medplum, profile);
       break;
   }
-
-  console.log('Login successful');
 }
 
 async function startWebServer(medplum: MedplumClient): Promise<void> {

--- a/packages/cli/src/profiles.test.ts
+++ b/packages/cli/src/profiles.test.ts
@@ -174,8 +174,6 @@ describe('Profiles', () => {
     await main(['node', 'index.js', 'profile', 'describe', profileName]);
     expect(console.log).toHaveBeenCalledWith(obj);
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringMatching('testProfile profile create'));
-
     // Replace the previous values
     const obj2 = {
       name: profileName,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -258,7 +258,6 @@ export function saveProfile(profileName: string, options: Profile): Profile {
   const storage = new FileSystemStorage(profileName);
   const optionsObject = { name: profileName, ...options };
   storage.setObject('options', optionsObject);
-  console.log(`${profileName} profile created`);
   return optionsObject;
 }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -83,6 +83,7 @@ import {
 } from './utils';
 
 export const MEDPLUM_VERSION = import.meta.env.MEDPLUM_VERSION ?? '';
+export const MEDPLUM_CLI_CLIENT_ID = 'medplum-cli';
 export const DEFAULT_ACCEPT = ContentType.FHIR_JSON + ', */*; q=0.1';
 
 const DEFAULT_BASE_URL = 'https://api.medplum.com/';

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -2,7 +2,7 @@ import { showNotification } from '@mantine/notifications';
 import { BaseLoginRequest, LoginAuthenticationResponse, normalizeErrorString } from '@medplum/core';
 import { ProjectMembership } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Document } from '../Document/Document';
 import { AuthenticationForm } from './AuthenticationForm';
 import { ChooseProfileForm } from './ChooseProfileForm';
@@ -46,6 +46,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
   } = props;
   const medplum = useMedplum();
   const [login, setLogin] = useState<string>();
+  const loginRequested = useRef(false);
   const [mfaRequired, setAuthenticatorRequired] = useState(false);
   const [memberships, setMemberships] = useState<ProjectMembership[]>();
 
@@ -102,13 +103,14 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
     // The `useMedplum` hook will return a new instance of the MedplumClient on login
     // We do not want to request the login status again in that case
     // Only request login status once
-    if (loginCode && !login) {
+    if (loginCode && !loginRequested.current && !login) {
+      loginRequested.current = true;
       medplum
         .get('auth/login/' + loginCode)
         .then(handleAuthResponse)
         .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err) }));
     }
-  }, [medplum, loginCode, login, handleAuthResponse]);
+  }, [medplum, loginCode, loginRequested, login, handleAuthResponse]);
 
   return (
     <Document width={450} px="sm" py="md">

--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -134,7 +134,7 @@ async function getIdentityProvider(
   if (state.clientId) {
     client = await getClientApplication(state.clientId);
     if (client.identityProvider) {
-      idp = client.identityProvider;
+      return { idp: client.identityProvider, client };
     }
   }
 

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -214,15 +214,15 @@ async function handleAuthorizationCode(req: Request, res: Response): Promise<voi
   }
 
   let client: ClientApplication | undefined;
-  if (clientId) {
-    try {
+  try {
+    if (clientId) {
       client = await getClientApplication(clientId);
-    } catch (err) {
-      sendTokenError(res, 'invalid_request', 'Invalid client');
-      return;
+    } else if (login.client) {
+      client = await getClientApplication(resolveId(login.client) as string);
     }
-  } else if (login.client) {
-    client = await systemRepo.readReference(login.client);
+  } catch (err) {
+    sendTokenError(res, 'invalid_request', 'Invalid client');
+    return;
   }
 
   if (clientSecret) {

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -5,6 +5,7 @@ import {
   Filter,
   getDateProperty,
   getReferenceString,
+  MEDPLUM_CLI_CLIENT_ID,
   OperationOutcomeError,
   Operator,
   ProfileResource,
@@ -111,10 +112,10 @@ export interface GoogleCredentialClaims extends JWTPayload {
  * @returns The client application.
  */
 export async function getClientApplication(clientId: string): Promise<ClientApplication> {
-  if (clientId === 'medplum-cli') {
+  if (clientId === MEDPLUM_CLI_CLIENT_ID) {
     return {
       resourceType: 'ClientApplication',
-      id: 'medplum-cli',
+      id: MEDPLUM_CLI_CLIENT_ID,
       redirectUri: 'http://localhost:9615',
       pkceOptional: true,
     };


### PR DESCRIPTION
There were a few issues here:

1. `OAuthPage.tsx` did not pass `redirecUri` into `SignInForm`
    1. In the common case, this is fine, because `OAuthPage.tsx` handles the redirect
    2. In the external auth case, this is broken because `SignInForm` handles the external auth redirect
2. Handle the special "Medplum CLI" `ClientApplication` in `external.ts`
    1. Any time we read a `ClientApplication` for auth, we need to use `getClientApplication`, not `readResource()`
    2. This handles the special case of the CLI client application
    3. Rather than juggling special cases, maybe this client application should have been added in a data migration 🤷‍♂️ 
    4. Either way, for now, it's just one of those things you need to know when working in auth
3. Handle `redirectUri` from `ClientApplication` and `identityProvider` from `DomainConfiguration`
    1. This fixes the Okta case
    2. @rahul1  - you may remember that there was some ambiguity about precedence of `DomainConfiguration` and `ClientApplication`, this PR changes/breaks that assumption.

Other minor drive-by fixes:

1. Added a constant for `medplum-cli`
5. Removed a bunch of confusing/incorrect `console.log()` statements from CLI
6. Fixed React dev-mode double `useEffect` bug which double requested `/oauth2/token` in dev-mode 😠 