### PR TITLE
fix(danger.js): fail CI job on error

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,7 +4,7 @@ on:
     workflows: [Build]
     types: [completed]
 jobs:
-  sonar:
+  danger:
     name: Danger
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
@@ -33,6 +33,6 @@ jobs:
         name: Install deps
         run: npm ci --maxsockets 1
       - name: Danger
-        run: npx danger ci
+        run: npx danger ci --fail-on-errors=true
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -33,6 +33,6 @@ jobs:
         name: Install deps
         run: npm ci --maxsockets 1
       - name: Danger
-        run: npx danger ci --fail-on-errors=true
+        run: npx danger ci --failOnErrors
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
By default `danger ci` doesn't fail the job for some reason. Makes no sense to me but it is what it is 🤷‍♂️ 

EDIT: They changed the flag at some point, here is what the `--help` says:
<img width="972" alt="Screenshot 2024-03-29 at 12 42 49 PM" src="https://github.com/medplum/medplum/assets/1592008/9a3bd965-60b9-4500-a579-a7af81644972">
