### PR TITLE
Add version override to prepare-release.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,6 +1,11 @@
 name: Prepare release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version (leave blank for automatic)'
+        type: string
 
 jobs:
   prepare-release:
@@ -20,6 +25,6 @@ jobs:
           git config --global user.email "${{ secrets.MEDPLUM_BOT_EMAIL }}"
           git config --global user.name "${{ secrets.MEDPLUM_BOT_NAME }}"
       - name: Prepare release
-        run: ./scripts/prepare-release.sh
+        run: ./scripts/prepare-release.sh ${{ inputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -25,7 +25,14 @@ fi
 
 # Build the new version number
 NEW_VERSION="${CURR_VERSION_PARTS[0]}.${CURR_VERSION_PARTS[1]}.${CURR_VERSION_PARTS[2]}"
-echo "New version: $NEW_VERSION"
+
+# Check if a new version is provided as a command line argument and override if present
+if [ ! -z "$1" ]; then
+    NEW_VERSION=$1
+    echo "Overriding new version to: $NEW_VERSION"
+else
+    echo "New version: $NEW_VERSION"
+fi
 
 # Use the Github gh tool to make sure the user is logged in
 gh auth status


### PR DESCRIPTION
This adds a new "Version" input to the "Prepare release" action

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

There is an upcoming release that needs a minor version bump without a data migration.

--------

### Background

Medplum versions are mostly based on semver ("major"."minor"."patch"), with the following distinction:

1. Every new release is a "patch" by default
2. Changes that require intermediate deployments for zero-downtime upgrades are "minor" version releases

For example, consider a multi-step database migration:

1. First migration adds a new column and starts populating it, but continues reading from old column
2. Next migration starts reading from new column and deletes the old column

A self-hosting customer must deploy those changes separately, otherwise there is a risk of old servers trying to use the old column.

**Therefore, self-hosting customers who want zero-downtime upgrades must deploy at least every "minor" version.**

The Medplum CLI follows this convention.  The `medplum aws upgrade-server` command will automatically fetch the version list and incrementally deploy all minor version upgrades.

The release process determines the new version by checking if there have been any new data migrations since the last release.  If there is a data migration, then it automatically uses a minor version change rather than a patch version change.

