### PR TITLE
Fix sessionStorage flaky test

### DIFF
--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -705,17 +705,6 @@ describe('SignInForm', () => {
   });
 
   test('Redirect to external auth', async () => {
-    Object.defineProperty(window, 'sessionStorage', {
-      value: {
-        getItem: function (key: string): string {
-          return this[key];
-        },
-        setItem: function (key: string, value: string): void {
-          this[key] = value;
-        },
-      },
-      writable: true,
-    });
     Object.defineProperty(window, 'location', {
       value: {
         assign: jest.fn(),


### PR DESCRIPTION
We've noticed a few instances of flaky tests due to `sessionStorage.clear()`.  I think this is the culprit.

https://github.com/medplum/medplum/actions/runs/8558611160/job/23455049864?pr=4312

![image](https://github.com/medplum/medplum/assets/749094/d21977f6-0f04-4cd2-9764-103e3b3999cd)

cc @dillonstreator 