### PR TITLE
fix(client): make `QueryTypes` more accurate

### DIFF
--- a/examples/medplum-demo-bots/src/deduplication/find-matching-patients.ts
+++ b/examples/medplum-demo-bots/src/deduplication/find-matching-patients.ts
@@ -30,7 +30,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Patient>):
   // Search for potential active duplicate patients by matching first name, last name, birthdate, and postal code.
   const candidateMatches = await medplum.searchResources('Patient', {
     'family:exact': srcPatient.name?.[0]?.family,
-    'given:exact': srcPatient.name?.[0]?.given,
+    'given:exact': srcPatient.name?.[0]?.given?.join(' '),
     birthdate: srcPatient.birthDate,
     'address-postalcode': srcPatient.address?.[0]?.postalCode,
     // only search for patients that are 'active' (have not already been)

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -74,10 +74,12 @@ import { indexStructureDefinitionBundle, isDataTypeLoaded, isProfileLoaded, load
 import {
   CodeChallengeMethod,
   ProfileResource,
+  QueryTypes,
   arrayBufferToBase64,
   concatUrls,
   createReference,
   ensureTrailingSlash,
+  getQueryString,
   getReferenceString,
   getWebSocketUrl,
   isObject,
@@ -320,18 +322,6 @@ export interface MedplumRequestOptions extends RequestInit {
 }
 
 export type FetchLike = (url: string, options?: any) => Promise<any>;
-
-/**
- * QueryTypes defines the different ways to specify FHIR search parameters.
- *
- * Can be any valid input to the URLSearchParams() constructor.
- *
- * TypeScript definitions for URLSearchParams do not match runtime behavior.
- * The official spec only accepts string values.
- * Web browsers and Node.js automatically coerce values to strings.
- * See: https://github.com/microsoft/TypeScript/issues/32951
- */
-export type QueryTypes = URLSearchParams | string[][] | Record<string, any> | string | undefined;
 
 /**
  * ResourceArray is an array of resources with a bundle property.
@@ -1363,7 +1353,7 @@ export class MedplumClient extends EventTarget {
   fhirSearchUrl(resourceType: ResourceType, query: QueryTypes): URL {
     const url = this.fhirUrl(resourceType);
     if (query) {
-      url.search = new URLSearchParams(query).toString();
+      url.search = getQueryString(query);
     }
     return url;
   }

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -35,6 +35,7 @@ import {
   getIdentifier,
   getImageSrc,
   getPathDifference,
+  getQueryString,
   getQuestionnaireAnswers,
   getReferenceString,
   getWebSocketUrl,
@@ -1320,5 +1321,22 @@ describe('Core Utils', () => {
     expect(getWebSocketUrl(new URL('https://foo.com/foo/bar/'), '/ws/subscriptions-r4')).toEqual(
       'wss://foo.com/foo/bar/ws/subscriptions-r4'
     );
+  });
+
+  test('getQueryString', () => {
+    expect(getQueryString('?bestEhr=medplum')).toEqual('bestEhr=medplum');
+    expect(
+      getQueryString([
+        ['bestEhr', 'medplum'],
+        ['foo', 'bar'],
+      ])
+    ).toEqual('bestEhr=medplum&foo=bar');
+    expect(getQueryString({ bestEhr: 'medplum', numberOne: true, medplumRanking: 1 })).toEqual(
+      'bestEhr=medplum&numberOne=true&medplumRanking=1'
+    );
+    expect(getQueryString(new URLSearchParams({ bestEhr: 'medplum', numberOne: 'true', medplumRanking: '1' }))).toEqual(
+      'bestEhr=medplum&numberOne=true&medplumRanking=1'
+    );
+    expect(getQueryString(undefined)).toEqual('');
   });
 });

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1334,6 +1334,9 @@ describe('Core Utils', () => {
     expect(getQueryString({ bestEhr: 'medplum', numberOne: true, medplumRanking: 1 })).toEqual(
       'bestEhr=medplum&numberOne=true&medplumRanking=1'
     );
+    expect(
+      getQueryString({ bestEhr: 'medplum', numberOne: true, medplumRanking: 1, betterThanMedplum: undefined })
+    ).toEqual('bestEhr=medplum&numberOne=true&medplumRanking=1');
     expect(getQueryString(new URLSearchParams({ bestEhr: 'medplum', numberOne: 'true', medplumRanking: '1' }))).toEqual(
       'bestEhr=medplum&numberOne=true&medplumRanking=1'
     );

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -22,6 +22,18 @@ import { formatCodeableConcept, formatHumanName } from './format';
 import { OperationOutcomeError, validationError } from './outcomes';
 import { isReference } from './types';
 
+/**
+ * QueryTypes defines the different ways to specify FHIR search parameters.
+ *
+ * Can be any valid input to the URLSearchParams() constructor.
+ *
+ * TypeScript definitions for URLSearchParams do not match runtime behavior.
+ * The official spec only accepts string values.
+ * Web browsers and Node.js automatically coerce values to strings.
+ * See: https://github.com/microsoft/TypeScript/issues/32951
+ */
+export type QueryTypes = URLSearchParams | string[][] | Record<string, string | number | boolean> | string | undefined;
+
 export type ProfileResource = Patient | Practitioner | RelatedPerson;
 
 /**
@@ -1096,6 +1108,26 @@ export function concatUrls(baseUrl: string | URL, path: string): string {
   return new URL(ensureNoLeadingSlash(path), ensureTrailingSlash(baseUrl.toString())).toString();
 }
 
+/**
+ * Concatenates a given base URL and path, ensuring the URL has the appropriate `ws://` or `wss://` protocol instead of `http://` or `https://`.
+ *
+ * @param baseUrl - The base URL.
+ * @param path - The URL to concat. Can be relative or absolute.
+ * @returns The concatenated WebSocket URL.
+ */
 export function getWebSocketUrl(baseUrl: URL | string, path: string): string {
   return concatUrls(baseUrl, path).toString().replace('http://', 'ws://').replace('https://', 'wss://');
+}
+
+/**
+ * Converts the given `query` to a string.
+ *
+ * @param query - The query to convert. The type can be any member of `QueryTypes`.
+ * @returns The query as a string.
+ */
+export function getQueryString(query: QueryTypes): string {
+  // @ts-expect-error Technically `Record<string, string, number, boolean>` is not valid to pass into `URLSearchParams` constructor since `boolean` and `number`
+  // are not considered to be valid values based on the WebIDL definition from WhatWG. The current runtime behavior relies on implementation-specific coercion to string under the hood.
+  // Source: https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams:~:text=6.2.%20URLSearchParams,)%20init%20%3D%20%22%22)%3B
+  return new URLSearchParams(query).toString();
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -32,7 +32,12 @@ import { isReference } from './types';
  * Web browsers and Node.js automatically coerce values to strings.
  * See: https://github.com/microsoft/TypeScript/issues/32951
  */
-export type QueryTypes = URLSearchParams | string[][] | Record<string, string | number | boolean> | string | undefined;
+export type QueryTypes =
+  | URLSearchParams
+  | string[][]
+  | Record<string, string | number | boolean | undefined>
+  | string
+  | undefined;
 
 export type ProfileResource = Patient | Practitioner | RelatedPerson;
 
@@ -1126,6 +1131,9 @@ export function getWebSocketUrl(baseUrl: URL | string, path: string): string {
  * @returns The query as a string.
  */
 export function getQueryString(query: QueryTypes): string {
+  if (typeof query === 'object' && !Array.isArray(query) && !(query instanceof URLSearchParams)) {
+    query = Object.fromEntries(Object.entries(query).filter((entry) => entry[1] !== undefined));
+  }
   // @ts-expect-error Technically `Record<string, string, number, boolean>` is not valid to pass into `URLSearchParams` constructor since `boolean` and `number`
   // are not considered to be valid values based on the WebIDL definition from WhatWG. The current runtime behavior relies on implementation-specific coercion to string under the hood.
   // Source: https://url.spec.whatwg.org/#dom-urlsearchparams-urlsearchparams:~:text=6.2.%20URLSearchParams,)%20init%20%3D%20%22%22)%3B


### PR DESCRIPTION
Restricts values in objects passed in as `QueryTypes` to `string`, `number`, and `boolean` types, from previous allowance of `any`. Fixes #4325