### PR TITLE
tweak(redis): add `getRedisSubscriber` for graceful shutdown safety

### DIFF
--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -16,7 +16,7 @@ import { getRepoForLogin } from '../fhir/accesspolicy';
 import { executeBot } from '../fhir/operations/execute';
 import { heartbeat } from '../heartbeat';
 import { getLoginForAccessToken } from '../oauth/utils';
-import { getRedis } from '../redis';
+import { getRedis, getRedisSubscriber } from '../redis';
 
 const STATUS_EX_SECONDS = 24 * 60 * 60; // 24 hours in seconds
 
@@ -115,7 +115,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
     const agent = await repo.readResource<Agent>('Agent', agentId);
 
     // Connect to Redis
-    redisSubscriber = getRedis().duplicate();
+    redisSubscriber = getRedisSubscriber();
     await redisSubscriber.subscribe(getReferenceString(agent));
     redisSubscriber.on('message', (_channel: string, message: string) => {
       // When a message is received, send it to the agent

--- a/packages/server/src/fhir/operations/agentpush.ts
+++ b/packages/server/src/fhir/operations/agentpush.ts
@@ -12,7 +12,7 @@ import { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { asyncWrap } from '../../async';
 import { getAuthenticatedContext } from '../../context';
-import { getRedis } from '../../redis';
+import { getRedis, getRedisSubscriber } from '../../redis';
 import { sendOutcome } from '../outcomes';
 import { getAgentForRequest, getDevice } from './agentutils';
 import { parseParameters } from './utils/parameters';
@@ -94,7 +94,7 @@ export const agentPushHandler = asyncWrap(async (req: Request, res: Response) =>
   // Otherwise, open a new redis connection in "subscribe" state
   message.callback = getReferenceString(agent) + '-' + randomUUID();
 
-  const redisSubscriber = getRedis().duplicate();
+  const redisSubscriber = getRedisSubscriber();
   await redisSubscriber.subscribe(message.callback);
   redisSubscriber.on('message', (_channel: string, message: string) => {
     const response = JSON.parse(message) as AgentTransmitResponse;

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -4,7 +4,7 @@ import { IncomingMessage } from 'http';
 import ws from 'ws';
 import { DEFAULT_HEARTBEAT_MS, heartbeat } from '../heartbeat';
 import { globalLogger } from '../logger';
-import { getRedis } from '../redis';
+import { getRedis, getRedisSubscriber } from '../redis';
 
 /**
  * Handles a new WebSocket connection to the FHIRCast hub.
@@ -20,7 +20,7 @@ export async function handleFhircastConnection(socket: ws.WebSocket, request: In
   // Once the client enters the subscribed state it is not supposed to issue any other commands,
   // except for additional SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE commands.
   const redis = getRedis();
-  const redisSubscriber = redis.duplicate();
+  const redisSubscriber = getRedisSubscriber();
 
   // Subscribe to the topic
   await redisSubscriber.subscribe(topic);

--- a/packages/server/src/redis.test.ts
+++ b/packages/server/src/redis.test.ts
@@ -1,9 +1,15 @@
-import { loadTestConfig } from './config';
-import { closeRedis, getRedis, initRedis } from './redis';
+import { Redis } from 'ioredis';
+import { MedplumServerConfig, loadTestConfig } from './config';
+import { closeRedis, getRedis, getRedisSubscriber, initRedis } from './redis';
 
 describe('Redis', () => {
+  let config: MedplumServerConfig;
+
+  beforeAll(async () => {
+    config = await loadTestConfig();
+  });
+
   test('Get redis', async () => {
-    const config = await loadTestConfig();
     initRedis(config.redis);
     expect(getRedis()).toBeDefined();
     await closeRedis();
@@ -12,5 +18,22 @@ describe('Redis', () => {
   test('Not initialized', async () => {
     expect(() => getRedis()).toThrow();
     await expect(closeRedis()).resolves.toBeUndefined();
+  });
+
+  describe('getRedisSubscriber', () => {
+    test('Not initialized', async () => {
+      await closeRedis();
+      expect(() => getRedisSubscriber()).toThrow();
+    });
+
+    test('Getting a subscriber', async () => {
+      initRedis(config.redis);
+      const subscriber = getRedisSubscriber();
+      expect(subscriber).toBeInstanceOf(Redis);
+
+      // @ts-expect-error Normally we shouldn't call quit from subscriber but we're in a test
+      // This expected TS error is actually sort of a test too
+      await subscriber.quit();
+    });
   });
 });

--- a/packages/server/src/redis.test.ts
+++ b/packages/server/src/redis.test.ts
@@ -1,6 +1,6 @@
 import { Redis } from 'ioredis';
 import { MedplumServerConfig, loadTestConfig } from './config';
-import { closeRedis, getRedis, getRedisSubscriber, initRedis } from './redis';
+import { closeRedis, getRedis, getRedisSubscriber, getRedisSubscriberCount, initRedis } from './redis';
 
 describe('Redis', () => {
   let config: MedplumServerConfig;
@@ -30,7 +30,58 @@ describe('Redis', () => {
       initRedis(config.redis);
       const subscriber = getRedisSubscriber();
       expect(subscriber).toBeInstanceOf(Redis);
+      await closeRedis();
+    });
+
+    test('Hanging subscriber still disconnects on closeRedis', async () => {
+      initRedis(config.redis);
+      const subscriber = getRedisSubscriber();
+
+      let reject: (err: Error) => void;
+      const closePromise = new Promise<void>((resolve, _reject) => {
+        subscriber.on('end', () => {
+          resolve();
+        });
+        reject = _reject;
+      });
+
+      expect(subscriber).toBeDefined();
+      await closeRedis();
+
+      const timer = setTimeout(() => {
+        reject(new Error('Timeout'));
+      }, 3500);
+
+      await expect(closePromise).resolves.toBeUndefined();
+      clearTimeout(timer);
+    });
+
+    test('Disconnecting a subscriber removes it from the list', async () => {
+      initRedis(config.redis);
+      expect(getRedisSubscriberCount()).toEqual(0);
+      const subscriber = getRedisSubscriber();
+      expect(getRedisSubscriberCount()).toEqual(1);
       subscriber.disconnect();
+
+      let reject: (err: Error) => void;
+      const closePromise = new Promise<void>((resolve, _reject) => {
+        subscriber.on('end', () => {
+          resolve();
+        });
+        reject = _reject;
+      });
+
+      expect(subscriber).toBeDefined();
+      await closeRedis();
+
+      const timer = setTimeout(() => {
+        reject(new Error('Timeout'));
+      }, 3500);
+
+      await expect(closePromise).resolves.toBeUndefined();
+      expect(getRedisSubscriberCount()).toEqual(0);
+      clearTimeout(timer);
+
       await closeRedis();
     });
   });

--- a/packages/server/src/redis.test.ts
+++ b/packages/server/src/redis.test.ts
@@ -30,10 +30,8 @@ describe('Redis', () => {
       initRedis(config.redis);
       const subscriber = getRedisSubscriber();
       expect(subscriber).toBeInstanceOf(Redis);
-
-      // @ts-expect-error Normally we shouldn't call quit from subscriber but we're in a test
-      // This expected TS error is actually sort of a test too
-      await subscriber.quit();
+      subscriber.disconnect();
+      await closeRedis();
     });
   });
 });

--- a/packages/server/src/redis.ts
+++ b/packages/server/src/redis.ts
@@ -17,9 +17,39 @@ export async function closeRedis(): Promise<void> {
   }
 }
 
-export function getRedis(): Redis {
+/**
+ * Gets the global `Redis` instance.
+ *
+ * The `duplicate` method is intentionally omitted to prevent accidental calling of `Redis.quit`
+ * which can cause the global instance to fail to shutdown gracefully later on.
+ *
+ * Instead duplicate instances for `subscriber` mode `redis` clients should only be obtained by calling
+ *
+ * See: {@link getRedisSubscriber}
+ *
+ * @returns The global `Redis` instance.
+ */
+export function getRedis(): Redis & { duplicate: never } {
   if (!redis) {
     throw new Error('Redis not initialized');
   }
+  // @ts-expect-error We don't want anyone to call `duplicate on the redis global instance
+  // This is because we want to gracefully `quit` and duplicated Redis instances will
   return redis;
+}
+
+/**
+ * Gets a `Redis` instance for use in client mode.
+ *
+ * The synchronous `.disconnect()` on this instance should be called instead of `.quit()` when you want to disconnect.
+ *
+ * @returns A `Redis` instance to use as a subscriber client.
+ */
+export function getRedisSubscriber(): Redis & { quit: never } {
+  if (!redis) {
+    throw new Error('Redis not initialized');
+  }
+  // @ts-expect-error We don't want anyone to call `.quit()` on duplicate clients
+  // because it can lead to being unable to gracefully quit the global instance client later
+  return redis.duplicate();
 }

--- a/packages/server/src/redis.ts
+++ b/packages/server/src/redis.ts
@@ -23,9 +23,7 @@ export async function closeRedis(): Promise<void> {
  * The `duplicate` method is intentionally omitted to prevent accidental calling of `Redis.quit`
  * which can cause the global instance to fail to shutdown gracefully later on.
  *
- * Instead duplicate instances for `subscriber` mode `redis` clients should only be obtained by calling
- *
- * See: {@link getRedisSubscriber}
+ * Instead {@link getRedisSubscriber} should be called to obtain a `Redis` instance for use as a subscriber-mode client.
  *
  * @returns The global `Redis` instance.
  */
@@ -39,7 +37,7 @@ export function getRedis(): Redis & { duplicate: never } {
 }
 
 /**
- * Gets a `Redis` instance for use in client mode.
+ * Gets a `Redis` instance for use in subscriber mode.
  *
  * The synchronous `.disconnect()` on this instance should be called instead of `.quit()` when you want to disconnect.
  *

--- a/packages/server/src/subscriptions/websockets.ts
+++ b/packages/server/src/subscriptions/websockets.ts
@@ -10,7 +10,7 @@ import { getFullUrl } from '../fhir/response';
 import { heartbeat } from '../heartbeat';
 import { globalLogger } from '../logger';
 import { verifyJwt } from '../oauth/keys';
-import { getRedis } from '../redis';
+import { getRedis, getRedisSubscriber } from '../redis';
 
 interface BaseSubscriptionClientMsg {
   type: string;
@@ -44,7 +44,7 @@ export async function handleR4SubscriptionConnection(socket: ws.WebSocket): Prom
       // According to Redis documentation: http://redis.io/commands/subscribe
       // Once the client enters the subscribed state it is not supposed to issue any other commands,
       // except for additional SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE commands.
-      redisSubscriber = redis.duplicate();
+      redisSubscriber = getRedisSubscriber();
 
       redisSubscriber.on('message', (channel: string, message: string) => {
         globalLogger.debug('[WS] redis message', { channel, message });

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -8,7 +8,7 @@ import { getConfig } from './config';
 import { RequestContext, requestContextStore } from './context';
 import { handleFhircastConnection } from './fhircast/websocket';
 import { globalLogger } from './logger';
-import { getRedis } from './redis';
+import { getRedis, getRedisSubscriber } from './redis';
 import { handleR4SubscriptionConnection } from './subscriptions/websockets';
 
 const handlerMap = new Map<string, (socket: ws.WebSocket, request: IncomingMessage) => Promise<void>>();
@@ -104,7 +104,7 @@ async function handleEchoConnection(socket: ws.WebSocket): Promise<void> {
   // According to Redis documentation: http://redis.io/commands/subscribe
   // Once the client enters the subscribed state it is not supposed to issue any other commands,
   // except for additional SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE and PUNSUBSCRIBE commands.
-  const redisSubscriber = getRedis().duplicate();
+  const redisSubscriber = getRedisSubscriber();
   const channel = randomUUID();
 
   await redisSubscriber.subscribe(channel);

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -26,7 +26,7 @@ import { loadTestConfig } from '../config';
 import { getDatabasePool } from '../database';
 import { Repository, getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
-import { getRedis } from '../redis';
+import { getRedisSubscriber } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 import { AuditEventOutcome } from '../util/auditevent';
 import { closeSubscriptionWorker, execSubscriptionJob, getSubscriptionQueue } from './subscription';
@@ -1517,7 +1517,7 @@ describe('Subscription Worker', () => {
       expect(subscription.id).toBeDefined();
 
       // Subscribe to the topic
-      const subscriber = getRedis().duplicate();
+      const subscriber = getRedisSubscriber();
       await subscriber.subscribe(subscription.id as string);
 
       let resolve: () => void;
@@ -1564,6 +1564,7 @@ describe('Subscription Worker', () => {
       expect(queue.add).toHaveBeenCalled();
 
       await deferredPromise;
+      // @ts-expect-error Okay to await quit in tests
       await subscriber.quit();
     }));
 
@@ -1591,7 +1592,7 @@ describe('Subscription Worker', () => {
       expect(subscription.id).toBeDefined();
 
       // Subscribe to the topic
-      const subscriber = getRedis().duplicate();
+      const subscriber = getRedisSubscriber();
       await subscriber.subscribe(subscription.id as string);
 
       let resolve: () => void;
@@ -1622,6 +1623,7 @@ describe('Subscription Worker', () => {
       }, 150);
 
       await deferredPromise;
+      // @ts-expect-error Okay to await quit in tests
       await subscriber.quit();
       expect(console.log).toHaveBeenLastCalledWith(expect.stringMatching(/WebSocket Subscriptions/));
 
@@ -1670,7 +1672,7 @@ describe('Subscription Worker', () => {
       expect(subscription.id).toBeDefined();
 
       // Subscribe to the topic
-      const subscriber = getRedis().duplicate();
+      const subscriber = getRedisSubscriber();
       await subscriber.subscribe(subscription.id as string);
 
       let resolve: () => void;
@@ -1698,6 +1700,7 @@ describe('Subscription Worker', () => {
 
       setTimeout(() => resolve(), 300);
       await deferredPromise;
+      // @ts-expect-error Okay to await quit in tests
       await subscriber.quit();
 
       expect(console.log).toHaveBeenCalledWith(
@@ -1748,7 +1751,7 @@ describe('Subscription Worker', () => {
       await superAdminRepo.deleteResource('ProjectMembership', membership.id as string);
 
       // Subscribe to the topic
-      const subscriber = getRedis().duplicate();
+      const subscriber = getRedisSubscriber();
       await subscriber.subscribe(subscription.id as string);
 
       let resolve: () => void;
@@ -1776,6 +1779,7 @@ describe('Subscription Worker', () => {
 
       setTimeout(() => resolve(), 300);
       await deferredPromise;
+      // @ts-expect-error Okay to await quit in tests
       await subscriber.quit();
 
       expect(console.log).toHaveBeenCalledWith(
@@ -1826,7 +1830,7 @@ describe('Subscription Worker', () => {
       await superAdminRepo.deleteResource('AccessPolicy', accessPolicy.id as string);
 
       // Subscribe to the topic
-      const subscriber = getRedis().duplicate();
+      const subscriber = getRedisSubscriber();
       await subscriber.subscribe(subscription.id as string);
 
       let resolve: () => void;
@@ -1854,6 +1858,7 @@ describe('Subscription Worker', () => {
 
       setTimeout(() => resolve(), 300);
       await deferredPromise;
+      // @ts-expect-error Okay to await quit in test
       await subscriber.quit();
 
       expect(console.log).toHaveBeenCalledWith(


### PR DESCRIPTION
Related to #4223

This should prevent accidentally calling `.quit` anywhere except on the main client

Also will disconnect any stray subscribers when `closeRedis()` is called to prevent shutdown from hanging. (We should maybe warn about this because this could indicate leaks, in most cases there shouldn't be anything to cleanup...)