### PR TITLE
fix: registration by not passing the `new` `projectId`

### DIFF
--- a/packages/server/src/auth/newuser.test.ts
+++ b/packages/server/src/auth/newuser.test.ts
@@ -50,6 +50,7 @@ describe('New user', () => {
         email: `alex${randomUUID()}@example.com`,
         password: 'password!@#',
         recaptchaToken: 'xyz',
+        projectId: 'new',
       });
 
     expect(res.status).toBe(200);

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -63,6 +63,7 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
     existingUser = await getUserByEmailInProject(email, req.body.projectId);
   } else {
     existingUser = await getUserByEmailWithoutProject(email);
+    req.body.projectId = null; // if req.body.projectId is 'new', set it to null
   }
   if (existingUser) {
     sendOutcome(res, badRequest('Email already registered', 'email'));

--- a/packages/server/src/auth/newuser.ts
+++ b/packages/server/src/auth/newuser.ts
@@ -63,7 +63,6 @@ export async function newUserHandler(req: Request, res: Response): Promise<void>
     existingUser = await getUserByEmailInProject(email, req.body.projectId);
   } else {
     existingUser = await getUserByEmailWithoutProject(email);
-    req.body.projectId = null; // if req.body.projectId is 'new', set it to null
   }
   if (existingUser) {
     sendOutcome(res, badRequest('Email already registered', 'email'));
@@ -112,7 +111,7 @@ export async function createUser(request: Omit<NewUserRequest, 'recaptchaToken'>
     lastName,
     email,
     passwordHash,
-    project: projectId ? { reference: `Project/${projectId}` } : undefined,
+    project: projectId && projectId !== 'new' ? { reference: `Project/${projectId}` } : undefined,
   });
   globalLogger.info('User created', { id: result.id, email });
   return result;


### PR DESCRIPTION
First of all really fantastic project, an absolute banger 🚀 

When trying to register on [app.medplum.com](https://app.medplum.com/register)

I get the following error.

![Screenshot 2024-04-08 at 18 40 22](https://github.com/medplum/medplum/assets/1493766/e3666364-315a-48f7-93e0-d669cb709657)

I then decided to install it locally and got the same one. I do believe that this error was introduced with this PR: [#4321](https://github.com/medplum/medplum/pull/4321)

This PR should prevent the propagation of `new` to `createUser`.
