### PR TITLE
Clear auth state on auth failure

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -916,7 +916,9 @@ export class MedplumClient extends EventTarget {
    */
   clear(): void {
     this.storage.clear();
-    sessionStorage.clear();
+    if (typeof window !== 'undefined') {
+      sessionStorage.clear();
+    }
     this.clearActiveLogin();
   }
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3292,7 +3292,7 @@ export class MedplumClient extends EventTarget {
     if (this.refresh()) {
       return this.request(method, url, options);
     }
-    this.clearActiveLogin();
+    this.clear();
     if (this.onUnauthenticated) {
       this.onUnauthenticated();
     }

--- a/packages/docs/docs/auth/methods/index.md
+++ b/packages/docs/docs/auth/methods/index.md
@@ -114,6 +114,7 @@ All three implementations types will have tokens or client credentials with syst
 - Consider disabling local storage on device for shared workstations or in accordance with institution policy.
 - Organizations with mobile devices or laptops should enable a Mobile Device Management (MDM) solution for workstations
 - [IP restrictions](/docs/access/ip-access-rules) can be enabled when especially sensitive data, such as personal health information (PHI), is being accessed.
+- Reusing the same `MedplumClient` instance for different users is discouraged. Consider creating new instances of `MedplumClient` instead.
 
 ### Server Authentication
 
@@ -122,6 +123,7 @@ All three implementations types will have tokens or client credentials with syst
 - Restrict access to host via VPC or other mechanism - do not allow access from general internet.
 - Use a secrets management to store access keys - do not store credentials on disk.
 - Ensure host is patched and has security updates applied regularly.
+- Consider creating a new instance of `MedplumClient`, particularly when switching to another user.
 
 ### Host authentication
 


### PR DESCRIPTION
This PR clears previous auth states when the user authentication fails. The documentation has also been updated to encourage creating a new instance of `medplumClient` for a different user instead of reusing the old one.

Closes #3711 