### PR TITLE
chore(actions): add timeouts to a lot of jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       pull-requests: write
     strategy:
@@ -72,6 +73,7 @@ jobs:
   eslint:
     name: Run eslint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [build]
     env:
       SECRETS_TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -149,6 +151,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [build]
     strategy:
       matrix:
@@ -233,6 +236,7 @@ jobs:
   build-docs:
     name: Build the docs
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       pull-requests: write
     env:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,7 @@ on: push
 jobs:
   chromatic:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     if: github.repository == 'medplum/medplum'
     env:
       NODE_VERSION: '20'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,6 +11,7 @@ jobs:
   prepare-release:
     name: Prepare release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ jobs:
   build_and_check:
     name: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NODE_VERSION: '20'
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -93,6 +94,7 @@ jobs:
 
   build_agent_win64:
     runs-on: windows-latest
+    timeout-minutes: 45
     env:
       NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -168,6 +170,7 @@ jobs:
 
   build_agent_linux:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,6 +7,7 @@ jobs:
   sonar:
     name: Sonar
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Staging
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
To prevent runs like this:

<img width="1340" alt="Screenshot 2024-04-10 at 8 07 41 PM" src="https://github.com/medplum/medplum/assets/1592008/3b44d97c-c5e3-47d3-bd01-a1a5bea964c9">

I added some timeouts to a lot of the heavier jobs that are likely to hang. In preparation for using large runners, hangs like this could burn through a lot of our credits
