### PR TITLE
Throw an error when a patch attempts to modify resourceType or Id

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -509,6 +509,12 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     if (!validator.isUUID(id)) {
       throw new OperationOutcomeError(badRequest('Invalid id'));
     }
+    if (resource.resourceType !== resourceType) {
+      throw new OperationOutcomeError(badRequest('Incorrect resource type'));
+    }
+    if (resource.id !== id) {
+      throw new OperationOutcomeError(badRequest('Incorrect ID'));
+    }
     await this.validateResource(resource);
 
     if (!this.canWriteResourceType(resourceType)) {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1019,6 +1019,13 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     try {
       const resource = await this.readResourceImpl(resourceType, id);
 
+      if (patch.find((operation) => operation.path === '/resourceType')) {
+        throw new OperationOutcomeError(badRequest('Incorrect Resource Type'));
+      }
+      if (patch.find((operation) => operation.path === '/id')) {
+        throw new OperationOutcomeError(badRequest('Incorrect Id'));
+      }
+
       try {
         const patchResult = applyPatch(resource, patch).filter(Boolean);
         if (patchResult.length > 0) {


### PR DESCRIPTION
This PR addresses https://github.com/medplum/medplum/issues/3888

When a resource is PATCHed and the field attempted to be updated is either `id` or `resourceType`, an error is thrown

