### PR TITLE
FHIR Mapper: Maintain type information for sub-properties of mapping target

### DIFF
--- a/packages/core/src/fhirmapper/transform.ts
+++ b/packages/core/src/fhirmapper/transform.ts
@@ -345,15 +345,12 @@ function evalTarget(ctx: TransformContext, target: StructureMapGroupRuleTarget):
   const isArray = isArrayProperty(targetContext, target.element as string) || Array.isArray(originalValue);
 
   if (!target.transform) {
+    const elementTypes = tryGetPropertySchema(targetContext, target.element as string)?.type;
+    const elementType = elementTypes?.length === 1 ? elementTypes[0].code : undefined;
     if (isArray || originalValue === undefined) {
-      const types = tryGetPropertySchema(targetContext, target.element as string)?.type;
-      if (types?.length === 1) {
-        targetValue = [{ type: types[0].code, value: {} }];
-      } else {
-        targetValue = [toTypedValue({})];
-      }
+      targetValue = [elementType ? { type: elementType, value: {} } : toTypedValue({})];
     } else {
-      targetValue = [toTypedValue(originalValue)];
+      targetValue = [elementType ? { type: elementType, value: originalValue } : toTypedValue(originalValue)];
     }
   } else {
     switch (target.transform) {

--- a/packages/core/src/fhirmapper/transform.types.test.ts
+++ b/packages/core/src/fhirmapper/transform.types.test.ts
@@ -1,0 +1,42 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
+import { indexStructureDefinitionBundle } from '../typeschema/types';
+import { parseMappingLanguage } from './parse';
+import { structureMapTransform } from './transform';
+import { TypedValue } from '../types';
+
+describe('FHIR Mapper transform - dependent', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  });
+
+  test('Patient name', () => {
+    const map = `
+      group PIDToPatient(source src: PID, target tgt: Patient) {
+        src -> tgt.resourceType = 'Patient';
+        src.PID_5 as s_name -> tgt.name as t_name then xpnToName(s_name, t_name);
+      }
+
+      group xpnToName(source srcName: XPN, target tgtName: HumanName) {
+        srcName._0  as s_family_name -> tgtName.family = s_family_name;
+        srcName._1  as s_given0 -> tgtName.given = s_given0;
+        srcName._2  as s_given1 -> tgtName.given = s_given1;
+      }
+    `;
+
+    const input: TypedValue[] = [
+      toTypedValue({
+        PID_5: { _0: 'DOE', _1: 'JANE', _2: 'Q' },
+      }),
+      { type: 'Patient', value: {} } as TypedValue,
+    ];
+
+    const structureMap = parseMappingLanguage(map);
+    const actual = structureMapTransform(structureMap, input);
+    const expected = [{ value: { resourceType: 'Patient', name: [{ family: 'DOE', given: ['JANE', 'Q'] }] } }];
+
+    expect(actual).toMatchObject(expected);
+  });
+});


### PR DESCRIPTION
## Background
This PR came about when running an experiment to see if our current FHIR Mapping Language could be used to map HL7v2 to FHIR. 

The target example was converting a PID segment into a `Patient` resource.

## Previously
Orginally, if `tgt` was of type `Patient`, accessing `tgt.name` would be treated as a `BackboneElement`. This would lose the infomration that `tgt.name.given` should be an array

## In this PR
We use the schema information to propgate type information to sub-elements, if it exists
