### PR TITLE
[Medplum Provider] Require resource profiles

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -19,7 +19,7 @@ import {
 } from '@tabler/icons-react';
 import { Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
-import { CreateResourcePage } from './pages/CreateResourcePage';
+import { ResourceCreatePage } from './pages/resource/ResourceCreatePage';
 import { HomePage } from './pages/HomePage';
 import { OnboardingPage } from './pages/OnboardingPage';
 import { SearchPage } from './pages/SearchPage';
@@ -113,7 +113,7 @@ export function App(): JSX.Element | null {
                 <Route path="edit" element={<EditTab />} />
                 <Route path="encounter" element={<EncounterTab />} />
                 <Route path="timeline" element={<TimelineTab />} />
-                <Route path=":resourceType/new" element={<CreateResourcePage />} />
+                <Route path=":resourceType/new" element={<ResourceCreatePage />} />
                 <Route path=":resourceType/:id" element={<ResourcePage />}>
                   <Route path="" element={<ResourceDetailPage />} />
                   <Route path="edit" element={<ResourceEditPage />} />
@@ -124,7 +124,7 @@ export function App(): JSX.Element | null {
               </Route>
               <Route path="/onboarding" element={<OnboardingPage />} />
               <Route path="/signin" element={<SignInPage />} />
-              <Route path="/:resourceType/new" element={<CreateResourcePage />} />
+              <Route path="/:resourceType/new" element={<ResourceCreatePage />} />
               <Route path="/:resourceType/:id" element={<ResourcePage />}>
                 <Route path="" element={<ResourceDetailPage />} />
                 <Route path="edit" element={<ResourceEditPage />} />

--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -26,11 +26,8 @@ import { SearchPage } from './pages/SearchPage';
 import { SignInPage } from './pages/SignInPage';
 import { EditTab } from './pages/patient/EditTab';
 import { EncounterTab } from './pages/patient/EncounterTab';
-import { LabsTab } from './pages/patient/LabsTab';
-import { MedsTab } from './pages/patient/MedsTab';
 import { PatientPage } from './pages/patient/PatientPage';
 import { PatientSearchPage } from './pages/patient/PatientSearchPage';
-import { TasksTab } from './pages/patient/TasksTab';
 import { TimelineTab } from './pages/patient/TimelineTab';
 import { ResourceDetailPage } from './pages/resource/ResourceDetailPage';
 import { ResourceEditPage } from './pages/resource/ResourceEditPage';
@@ -115,9 +112,6 @@ export function App(): JSX.Element | null {
               <Route path="/Patient/:patientId" element={<PatientPage />}>
                 <Route path="edit" element={<EditTab />} />
                 <Route path="encounter" element={<EncounterTab />} />
-                <Route path="labs" element={<LabsTab />} />
-                <Route path="meds" element={<MedsTab />} />
-                <Route path="tasks" element={<TasksTab />} />
                 <Route path="timeline" element={<TimelineTab />} />
                 <Route path=":resourceType/new" element={<CreateResourcePage />} />
                 <Route path=":resourceType/:id" element={<ResourcePage />}>

--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -123,6 +123,7 @@ export function App(): JSX.Element | null {
                 <Route path="" element={<TimelineTab />} />
               </Route>
               <Route path="/onboarding" element={<OnboardingPage />} />
+              <Route path="/signin" element={<SignInPage />} />
               <Route path="/:resourceType/new" element={<CreateResourcePage />} />
               <Route path="/:resourceType/:id" element={<ResourcePage />}>
                 <Route path="" element={<ResourceDetailPage />} />

--- a/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
+++ b/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
@@ -1,0 +1,61 @@
+import { Alert } from '@mantine/core';
+import { InternalTypeSchema, normalizeErrorString, tryGetProfile } from '@medplum/core';
+import { Loading, ResourceForm, ResourceFormProps, useMedplum } from '@medplum/react';
+import { IconAlertCircle } from '@tabler/icons-react';
+import { ReactNode, useEffect, useState } from 'react';
+
+interface ResourceFormWithRequiredProfileProps extends ResourceFormProps {
+  missingProfileMessage?: ReactNode;
+}
+
+export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredProfileProps): JSX.Element {
+  const { missingProfileMessage, ...resourceFormProps } = props;
+  const profileUrl = props.profileUrl;
+
+  const medplum = useMedplum();
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [profileError, setProfileError] = useState<any>();
+  const [profile, setProfile] = useState<InternalTypeSchema>();
+
+  useEffect(() => {
+    if (!profileUrl) {
+      return;
+    }
+
+    medplum
+      .requestProfileSchema(profileUrl, { expandProfile: true })
+      .finally(() => setLoadingProfile(false))
+      .then(() => {
+        const resourceProfile = tryGetProfile(profileUrl);
+        if (resourceProfile) {
+          setProfile(resourceProfile);
+        }
+      })
+      .catch((reason) => {
+        console.error(reason);
+        setProfileError(reason);
+      });
+  }, [medplum, profileUrl]);
+
+  if (profileUrl && loadingProfile) {
+    return <Loading />;
+  }
+
+  if (profileUrl && !profile) {
+    const errorContent = (
+      <>
+        {missingProfileMessage && <p>{missingProfileMessage}</p>}
+
+        {profileError && <p>Server error: {normalizeErrorString(profileError)}</p>}
+      </>
+    );
+
+    return (
+      <Alert icon={<IconAlertCircle size={16} />} title="Not found" color="red">
+        {errorContent}
+      </Alert>
+    );
+  }
+
+  return <ResourceForm {...resourceFormProps} />;
+}

--- a/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
+++ b/examples/medplum-provider/src/components/ResourceFormWithRequiredProfile.tsx
@@ -8,9 +8,9 @@ import { Resource } from '@medplum/fhirtypes';
 
 interface ResourceFormWithRequiredProfileProps extends ResourceFormProps {
   /** (optional) If specified, an error is shown in place of `ResourceForm` if the profile cannot be loaded.  */
-  profileUrl?: string; // Also part of ResourceFormProps, but list here incase its type changes in the future
+  readonly profileUrl?: string; // Also part of ResourceFormProps, but list here incase its type changes in the future
   /** (optiona) A short error message to show if `profileUrl` cannot be found. */
-  missingProfileMessage?: ReactNode;
+  readonly missingProfileMessage?: ReactNode;
 }
 
 export function ResourceFormWithRequiredProfile(props: ResourceFormWithRequiredProfileProps): JSX.Element {

--- a/examples/medplum-provider/src/pages/CreateResourcePage.tsx
+++ b/examples/medplum-provider/src/pages/CreateResourcePage.tsx
@@ -2,11 +2,13 @@ import { Stack, Text } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { createReference, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, Patient, Resource, ResourceType } from '@medplum/fhirtypes';
-import { Document, Loading, ResourceForm, useMedplum } from '@medplum/react';
+import { Document, Loading, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { usePatient } from '../hooks/usePatient';
 import { prependPatientPath } from './patient/PatientPage.utils';
+import { ResourceFormWithRequiredProfile } from '../components/ResourceFormWithRequiredProfile';
+import { RESOURCE_PROFILE_URLS } from './resource/utils';
 
 const PatientReferencesElements: Partial<Record<ResourceType, string[]>> = {
   Task: ['for'],
@@ -47,6 +49,7 @@ export function CreateResourcePage(): JSX.Element {
   const { patientId, resourceType } = useParams() as { patientId: string | undefined; resourceType: ResourceType };
   const [loadingPatient, setLoadingPatient] = useState(Boolean(patientId));
   const [defaultValue, setDefaultValue] = useState<Partial<Resource>>(() => getDefaultValue(resourceType, patient));
+  const profileUrl = resourceType && RESOURCE_PROFILE_URLS[resourceType];
 
   useEffect(() => {
     if (patient) {
@@ -83,7 +86,12 @@ export function CreateResourcePage(): JSX.Element {
     <Document shadow="xs">
       <Stack>
         <Text fw={500}>New&nbsp;{resourceType}</Text>
-        <ResourceForm defaultValue={defaultValue} onSubmit={handleSubmit} outcome={outcome} />
+        <ResourceFormWithRequiredProfile
+          defaultValue={defaultValue}
+          onSubmit={handleSubmit}
+          outcome={outcome}
+          profileUrl={profileUrl}
+        />
       </Stack>
     </Document>
   );

--- a/examples/medplum-provider/src/pages/OnboardingPage.tsx
+++ b/examples/medplum-provider/src/pages/OnboardingPage.tsx
@@ -19,7 +19,7 @@ export function OnboardingPage(): JSX.Element | null {
   );
 }
 
-export const questionnaire: Questionnaire = {
+const questionnaire: Questionnaire = {
   id: '54127-6-x',
   meta: {
     versionId: '1',

--- a/examples/medplum-provider/src/pages/SearchPage.tsx
+++ b/examples/medplum-provider/src/pages/SearchPage.tsx
@@ -4,6 +4,7 @@ import {
   Filter,
   formatSearchQuery,
   isReference,
+  isResourceType,
   parseSearchRequest,
   SearchRequest,
   SortRule,
@@ -24,6 +25,11 @@ export function SearchPage(): JSX.Element {
     const parsedSearch = parseSearchRequest(location.pathname + location.search);
 
     const populatedSearch = addSearchValues(parsedSearch, medplum.getUserConfiguration());
+
+    if (!isResourceType(populatedSearch.resourceType)) {
+      navigate('/');
+      return;
+    }
 
     if (
       location.pathname === `/${populatedSearch.resourceType}` &&

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -6,7 +6,6 @@ import { Document, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
-import { addProfileToResource } from '../../utils';
 
 const PATIENT_PROFILE_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient';
 
@@ -39,7 +38,6 @@ export function EditTab(): JSX.Element | null {
   const handleSubmit = useCallback(
     (newResource: Resource): void => {
       setOutcome(undefined);
-      addProfileToResource(newResource, PATIENT_PROFILE_URL);
       medplum
         .updateResource(newResource)
         .then(() => {

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -1,20 +1,23 @@
+import { Anchor } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import {
-  InternalTypeSchema,
-  deepClone,
-  normalizeErrorString,
-  normalizeOperationOutcome,
-  tryGetProfile,
-} from '@medplum/core';
+import { deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, Resource } from '@medplum/fhirtypes';
-import { Document, Loading, ResourceForm, useMedplum } from '@medplum/react';
+import { Document, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
 import { addProfileToResource } from '../../utils';
-import { Alert, Anchor } from '@mantine/core';
-import { IconAlertCircle } from '@tabler/icons-react';
 
 const PATIENT_PROFILE_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient';
+
+const missingProfileMessage = (
+  <p>
+    Could not find the{' '}
+    <Anchor href={PATIENT_PROFILE_URL} target="_blank">
+      US Core Patient Profile
+    </Anchor>
+  </p>
+);
 
 export function EditTab(): JSX.Element | null {
   const medplum = useMedplum();
@@ -22,9 +25,6 @@ export function EditTab(): JSX.Element | null {
   const [value, setValue] = useState<Resource | undefined>();
   const navigate = useNavigate();
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
-  const [loadingProfile, setLoadingProfile] = useState(true);
-  const [profileError, setProfileError] = useState<any>();
-  const [profile, setProfile] = useState<InternalTypeSchema>();
 
   useEffect(() => {
     medplum
@@ -35,22 +35,6 @@ export function EditTab(): JSX.Element | null {
         showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
       });
   }, [medplum, patientId]);
-
-  useEffect(() => {
-    medplum
-      .requestProfileSchema(PATIENT_PROFILE_URL, { expandProfile: true })
-      .finally(() => setLoadingProfile(false))
-      .then(() => {
-        const patientProfile = tryGetProfile(PATIENT_PROFILE_URL);
-        if (patientProfile) {
-          setProfile(patientProfile);
-        }
-      })
-      .catch((reason) => {
-        console.error(reason);
-        setProfileError(reason);
-      });
-  }, [medplum]);
 
   const handleSubmit = useCallback(
     (newResource: Resource): void => {
@@ -70,37 +54,19 @@ export function EditTab(): JSX.Element | null {
     [medplum, navigate, patientId]
   );
 
-  if (loadingProfile) {
-    return <Loading />;
-  }
-
-  if (!profile) {
-    const errorContent = (
-      <>
-        <p>
-          Could not find the{' '}
-          <Anchor href={PATIENT_PROFILE_URL} target="_blank">
-            US Core Patient Profile
-          </Anchor>
-        </p>
-        {profileError && <p>Server error: {normalizeErrorString(profileError)}</p>}
-      </>
-    );
-
-    return (
-      <Alert icon={<IconAlertCircle size={16} />} title="Not found" color="red">
-        {errorContent}
-      </Alert>
-    );
-  }
-
   if (!value) {
     return null;
   }
 
   return (
     <Document>
-      <ResourceForm defaultValue={value} onSubmit={handleSubmit} outcome={outcome} profileUrl={PATIENT_PROFILE_URL} />
+      <ResourceFormWithRequiredProfile
+        missingProfileMessage={missingProfileMessage}
+        defaultValue={value}
+        onSubmit={handleSubmit}
+        outcome={outcome}
+        profileUrl={PATIENT_PROFILE_URL}
+      />
     </Document>
   );
 }

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -10,7 +10,7 @@ import { OperationOutcome, Resource } from '@medplum/fhirtypes';
 import { Document, Loading, ResourceForm, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { addProfileToResource, removeProfileFromResource } from '../../utils';
+import { addProfileToResource } from '../../utils';
 import { Alert, Anchor } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -1,9 +1,20 @@
 import { showNotification } from '@mantine/notifications';
-import { deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
+import {
+  InternalTypeSchema,
+  deepClone,
+  normalizeErrorString,
+  normalizeOperationOutcome,
+  tryGetProfile,
+} from '@medplum/core';
 import { OperationOutcome, Resource } from '@medplum/fhirtypes';
-import { Document, ResourceForm, useMedplum } from '@medplum/react';
+import { Document, Loading, ResourceForm, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { addProfileToResource, removeProfileFromResource } from '../../utils';
+import { Alert, Anchor } from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+
+const PATIENT_PROFILE_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patientX';
 
 export function EditTab(): JSX.Element | null {
   const medplum = useMedplum();
@@ -11,6 +22,9 @@ export function EditTab(): JSX.Element | null {
   const [value, setValue] = useState<Resource | undefined>();
   const navigate = useNavigate();
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [profileError, setProfileError] = useState<any>();
+  const [profile, setProfile] = useState<InternalTypeSchema>();
 
   useEffect(() => {
     medplum
@@ -22,9 +36,30 @@ export function EditTab(): JSX.Element | null {
       });
   }, [medplum, patientId]);
 
+  useEffect(() => {
+    medplum
+      .requestProfileSchema(PATIENT_PROFILE_URL, { expandProfile: true })
+      .finally(() => setLoadingProfile(false))
+      .then(() => {
+        const patientProfile = tryGetProfile(PATIENT_PROFILE_URL);
+        if (patientProfile) {
+          setProfile(patientProfile);
+        }
+      })
+      .catch((reason) => {
+        console.error(reason);
+        setProfileError(reason);
+      });
+  }, [medplum]);
+
   const handleSubmit = useCallback(
     (newResource: Resource): void => {
       setOutcome(undefined);
+      if (profile) {
+        addProfileToResource(newResource, PATIENT_PROFILE_URL);
+      } else {
+        removeProfileFromResource(newResource, PATIENT_PROFILE_URL);
+      }
       medplum
         .updateResource(newResource)
         .then(() => {
@@ -36,8 +71,33 @@ export function EditTab(): JSX.Element | null {
           showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
         });
     },
-    [medplum, patientId, navigate]
+    [profile, medplum, navigate, patientId]
   );
+
+  if (loadingProfile) {
+    return <Loading />;
+  }
+
+  if (!profile) {
+    let displayString: React.ReactNode;
+    if (profileError) {
+      displayString = normalizeErrorString(profileError);
+    } else {
+      displayString = (
+        <>
+          Could not find the{' '}
+          <Anchor href={PATIENT_PROFILE_URL} target="_blank">
+            US Core Patient Profile
+          </Anchor>
+        </>
+      );
+    }
+    return (
+      <Alert icon={<IconAlertCircle size={16} />} title="Not found" color="red">
+        {displayString}
+      </Alert>
+    );
+  }
 
   if (!value) {
     return null;
@@ -45,7 +105,7 @@ export function EditTab(): JSX.Element | null {
 
   return (
     <Document>
-      <ResourceForm defaultValue={value} onSubmit={handleSubmit} outcome={outcome} />
+      <ResourceForm defaultValue={value} onSubmit={handleSubmit} outcome={outcome} profileUrl={PATIENT_PROFILE_URL} />
     </Document>
   );
 }

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -6,17 +6,16 @@ import { Document, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
+import { RESOURCE_PROFILE_URLS } from '../resource/utils';
 
-const PATIENT_PROFILE_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient';
-
-const missingProfileMessage = (
+const missingProfileMessage = RESOURCE_PROFILE_URLS.Patient ? (
   <p>
     Could not find the{' '}
-    <Anchor href={PATIENT_PROFILE_URL} target="_blank">
+    <Anchor href={RESOURCE_PROFILE_URLS.Patient} target="_blank">
       US Core Patient Profile
     </Anchor>
   </p>
-);
+) : undefined;
 
 export function EditTab(): JSX.Element | null {
   const medplum = useMedplum();
@@ -63,7 +62,7 @@ export function EditTab(): JSX.Element | null {
         defaultValue={value}
         onSubmit={handleSubmit}
         outcome={outcome}
-        profileUrl={PATIENT_PROFILE_URL}
+        profileUrl={RESOURCE_PROFILE_URLS.Patient}
       />
     </Document>
   );

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -55,11 +55,7 @@ export function EditTab(): JSX.Element | null {
   const handleSubmit = useCallback(
     (newResource: Resource): void => {
       setOutcome(undefined);
-      if (profile) {
-        addProfileToResource(newResource, PATIENT_PROFILE_URL);
-      } else {
-        removeProfileFromResource(newResource, PATIENT_PROFILE_URL);
-      }
+      addProfileToResource(newResource, PATIENT_PROFILE_URL);
       medplum
         .updateResource(newResource)
         .then(() => {
@@ -71,7 +67,7 @@ export function EditTab(): JSX.Element | null {
           showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false });
         });
     },
-    [profile, medplum, navigate, patientId]
+    [medplum, navigate, patientId]
   );
 
   if (loadingProfile) {

--- a/examples/medplum-provider/src/pages/patient/EditTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/EditTab.tsx
@@ -14,7 +14,7 @@ import { addProfileToResource, removeProfileFromResource } from '../../utils';
 import { Alert, Anchor } from '@mantine/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 
-const PATIENT_PROFILE_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patientX';
+const PATIENT_PROFILE_URL = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient';
 
 export function EditTab(): JSX.Element | null {
   const medplum = useMedplum();
@@ -79,22 +79,21 @@ export function EditTab(): JSX.Element | null {
   }
 
   if (!profile) {
-    let displayString: React.ReactNode;
-    if (profileError) {
-      displayString = normalizeErrorString(profileError);
-    } else {
-      displayString = (
-        <>
+    const errorContent = (
+      <>
+        <p>
           Could not find the{' '}
           <Anchor href={PATIENT_PROFILE_URL} target="_blank">
             US Core Patient Profile
           </Anchor>
-        </>
-      );
-    }
+        </p>
+        {profileError && <p>Server error: {normalizeErrorString(profileError)}</p>}
+      </>
+    );
+
     return (
       <Alert icon={<IconAlertCircle size={16} />} title="Not found" color="red">
-        {displayString}
+        {errorContent}
       </Alert>
     );
   }

--- a/examples/medplum-provider/src/pages/patient/LabsTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/LabsTab.tsx
@@ -1,5 +1,0 @@
-import { Document } from '@medplum/react';
-
-export function LabsTab(): JSX.Element {
-  return <Document>Labs</Document>;
-}

--- a/examples/medplum-provider/src/pages/patient/MedsTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/MedsTab.tsx
@@ -1,5 +1,0 @@
-import { Document } from '@medplum/react';
-
-export function MedsTab(): JSX.Element {
-  return <Document>Meds</Document>;
-}

--- a/examples/medplum-provider/src/pages/patient/PatientPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.tsx
@@ -1,10 +1,11 @@
 import { Loader, Paper, ScrollArea, Tabs } from '@mantine/core';
-import { getReferenceString } from '@medplum/core';
-import { PatientSummary } from '@medplum/react';
+import { getReferenceString, isOk } from '@medplum/core';
+import { Document, OperationOutcomeAlert, PatientSummary } from '@medplum/react';
 import { Fragment, useState } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { usePatient } from '../../hooks/usePatient';
 import classes from './PatientPage.module.css';
+import { OperationOutcome } from '@medplum/fhirtypes';
 
 const tabs = [
   { id: 'timeline', url: '', label: 'Timeline' },
@@ -54,15 +55,28 @@ const tabs = [
 
 export function PatientPage(): JSX.Element {
   const navigate = useNavigate();
-  const patient = usePatient();
+  const [outcome, setOutcome] = useState<OperationOutcome>();
+  const patient = usePatient({ setOutcome });
   const [currentTab, setCurrentTab] = useState<string>(() => {
     const tabId = window.location.pathname.split('/')[3] ?? '';
     const tab = tabId ? tabs.find((t) => t.id === tabId || t.url.startsWith(tabId)) : undefined;
     return (tab ?? tabs[0]).id;
   });
 
+  if (outcome && !isOk(outcome)) {
+    return (
+      <Document>
+        <OperationOutcomeAlert outcome={outcome} />
+      </Document>
+    );
+  }
+
   if (!patient) {
-    return <Loader />;
+    return (
+      <Document>
+        <Loader />
+      </Document>
+    );
   }
 
   /**

--- a/examples/medplum-provider/src/pages/patient/TasksTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/TasksTab.tsx
@@ -1,5 +1,0 @@
-import { Document } from '@medplum/react';
-
-export function TasksTab(): JSX.Element {
-  return <Document>Tasks</Document>;
-}

--- a/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceCreatePage.tsx
@@ -5,10 +5,10 @@ import { OperationOutcome, Patient, Resource, ResourceType } from '@medplum/fhir
 import { Document, Loading, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { usePatient } from '../hooks/usePatient';
-import { prependPatientPath } from './patient/PatientPage.utils';
-import { ResourceFormWithRequiredProfile } from '../components/ResourceFormWithRequiredProfile';
-import { RESOURCE_PROFILE_URLS } from './resource/utils';
+import { usePatient } from '../../hooks/usePatient';
+import { prependPatientPath } from '../patient/PatientPage.utils';
+import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
+import { RESOURCE_PROFILE_URLS } from './utils';
 
 const PatientReferencesElements: Partial<Record<ResourceType, string[]>> = {
   Task: ['for'],
@@ -41,7 +41,7 @@ function getDefaultValue(resourceType: ResourceType, patient: Patient | undefine
   return dv;
 }
 
-export function CreateResourcePage(): JSX.Element {
+export function ResourceCreatePage(): JSX.Element {
   const medplum = useMedplum();
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
   const patient = usePatient({ ignoreMissingPatientId: true, setOutcome });

--- a/examples/medplum-provider/src/pages/resource/ResourceEditPage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourceEditPage.tsx
@@ -1,9 +1,11 @@
 import { showNotification } from '@mantine/notifications';
 import { deepClone, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
 import { OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
-import { ResourceForm, useMedplum } from '@medplum/react';
+import { useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ResourceFormWithRequiredProfile } from '../../components/ResourceFormWithRequiredProfile';
+import { RESOURCE_PROFILE_URLS } from './utils';
 
 export function ResourceEditPage(): JSX.Element | null {
   const medplum = useMedplum();
@@ -11,6 +13,7 @@ export function ResourceEditPage(): JSX.Element | null {
   const [value, setValue] = useState<Resource | undefined>();
   const navigate = useNavigate();
   const [outcome, setOutcome] = useState<OperationOutcome | undefined>();
+  const profileUrl = resourceType && RESOURCE_PROFILE_URLS[resourceType];
 
   useEffect(() => {
     if (resourceType && id) {
@@ -47,5 +50,13 @@ export function ResourceEditPage(): JSX.Element | null {
     return null;
   }
 
-  return <ResourceForm defaultValue={value} onSubmit={handleSubmit} onDelete={handleDelete} outcome={outcome} />;
+  return (
+    <ResourceFormWithRequiredProfile
+      defaultValue={value}
+      onSubmit={handleSubmit}
+      onDelete={handleDelete}
+      outcome={outcome}
+      profileUrl={profileUrl}
+    />
+  );
 }

--- a/examples/medplum-provider/src/pages/resource/ResourcePage.tsx
+++ b/examples/medplum-provider/src/pages/resource/ResourcePage.tsx
@@ -1,5 +1,5 @@
 import { Stack, Tabs } from '@mantine/core';
-import { getReferenceString } from '@medplum/core';
+import { getReferenceString, isResourceType } from '@medplum/core';
 import { Resource, ResourceType } from '@medplum/fhirtypes';
 import { Document, useMedplum } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
@@ -24,13 +24,18 @@ export function ResourcePage(): JSX.Element | null {
   });
 
   useEffect(() => {
+    if (resourceType && !isResourceType(resourceType)) {
+      navigate('/');
+      return;
+    }
+
     if (resourceType && id) {
       medplum
         .readResource(resourceType as ResourceType, id)
         .then(setResource)
         .catch(console.error);
     }
-  }, [medplum, resourceType, id]);
+  }, [medplum, resourceType, id, navigate]);
 
   const onTabChange = useCallback(
     (newTabName: string | null): void => {

--- a/examples/medplum-provider/src/pages/resource/utils.ts
+++ b/examples/medplum-provider/src/pages/resource/utils.ts
@@ -1,5 +1,7 @@
 import { ResourceType } from '@medplum/fhirtypes';
 
 export const RESOURCE_PROFILE_URLS: Partial<Record<ResourceType, string>> = {
-  ServiceRequest: 'http://medplum.com/StructureDefinition/medplum-provider-lab-procedure-servicerequestX',
+  Patient: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient',
+  ServiceRequest: 'http://medplum.com/StructureDefinition/medplum-provider-lab-procedure-servicerequest',
+  Device: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device',
 };

--- a/examples/medplum-provider/src/pages/resource/utils.ts
+++ b/examples/medplum-provider/src/pages/resource/utils.ts
@@ -1,0 +1,5 @@
+import { ResourceType } from '@medplum/fhirtypes';
+
+export const RESOURCE_PROFILE_URLS: Partial<Record<ResourceType, string>> = {
+  ServiceRequest: 'http://medplum.com/StructureDefinition/medplum-provider-lab-procedure-servicerequestX',
+};

--- a/examples/medplum-provider/src/utils.ts
+++ b/examples/medplum-provider/src/utils.ts
@@ -1,0 +1,27 @@
+import { Resource } from '@medplum/fhirtypes';
+
+/**
+ * Adds the supplied profileUrl to the resource.meta.profile if it is not already
+ * specified
+ * @param resource - A FHIR resource
+ * @param profileUrl - The profile URL to add
+ */
+export function addProfileToResource(resource: Resource, profileUrl: string): void {
+  if (!resource?.meta?.profile?.includes(profileUrl)) {
+    resource.meta = resource.meta ?? {};
+    resource.meta.profile = resource.meta.profile ?? [];
+    resource.meta.profile.push(profileUrl);
+  }
+}
+
+/**
+ * Removes the supplied profileUrl from the resource.meta.profile if it is present
+ * @param resource - A FHIR resource
+ * @param profileUrl - The profile URL to remove
+ */
+export function removeProfileFromResource(resource: Resource, profileUrl: string): void {
+  if (resource?.meta?.profile?.includes(profileUrl)) {
+    const index = resource.meta.profile.indexOf(profileUrl);
+    resource.meta.profile.splice(index, 1);
+  }
+}

--- a/packages/server/src/fhir/operations/structuredefinitionexpandprofile.ts
+++ b/packages/server/src/fhir/operations/structuredefinitionexpandprofile.ts
@@ -16,13 +16,13 @@ export async function structureDefinitionExpandProfileHandler(req: FhirRequest):
   const { url } = req.query;
 
   if (!url || typeof url !== 'string') {
-    return [badRequest('Profile url not specified')];
+    return [badRequest('StructureDefinition profile url not specified')];
   }
 
   const profile = await fetchProfileByUrl(ctx.repo, url);
 
   if (!profile) {
-    return [badRequest('Profile not found')];
+    return [badRequest(`StructureDefinition profile with URL ${url} not found`)];
   }
 
   const sds = await loadNestedStructureDefinitions(ctx.repo, profile, new Set([url]), 1);


### PR DESCRIPTION
Fixes #4239 and #4243
 
In the Medplum Provider example app, edits to the patient resource must conform to the US Core Patient Profile.

**The US Core Patient Profile edit form**
![Screenshot 2024-04-17 at 11 50 39 AM](https://github.com/medplum/medplum/assets/933303/9c4aa09d-4a27-4389-b74f-643d5214e8b1)

**Error state when the profile cannot be found**
![Screenshot 2024-04-17 at 11 49 16 AM](https://github.com/medplum/medplum/assets/933303/03ced263-28a9-4c40-92bf-cd9c00f88adf)



Similarly, labs (i.e. `ServiceRequest`) that are created/edited in the provider app conform to a newly created `ServiceRequest` profile. The profile's `StructureDefinition` and a supporting `ValueSet` are added to the main medplum bundles in `@medplum/definitions`. It doesn't feel like the best location....we could of course create new bundle files for the provider app if that'd be preferable. Of course I'm open to other suggestions as well!

**Excerpt from the  ServiceRequest profile being shown on the new Lab page showing profile constraints on `ServiceRequest.category` and `ServiceRequest.code`**
![Screenshot 2024-04-18 at 1 12 51 PM](https://github.com/medplum/medplum/assets/933303/ad239501-b968-48b7-8fc7-674733944fe5)

**Error state when the profile cannot be found**
![Screenshot 2024-04-18 at 12 44 30 PM](https://github.com/medplum/medplum/assets/933303/b56f89f1-e80d-4208-a089-b9608aad64e2)

