### PR TITLE
Idempotent resource deletion

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1048,4 +1048,11 @@ describe('FHIR Repo', () => {
         })
       ).rejects.toThrow('Multiple resources found matching condition');
     }));
+
+  test('Double DELETE', async () =>
+    withTestContext(async () => {
+      const patient = await systemRepo.createResource<Patient>({ resourceType: 'Patient' });
+      await systemRepo.deleteResource(patient.resourceType, patient.id as string);
+      await expect(systemRepo.deleteResource(patient.resourceType, patient.id as string)).resolves.toBeUndefined();
+    }));
 });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -964,9 +964,18 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
   }
 
   async deleteResource(resourceType: string, id: string): Promise<void> {
+    let resource: Resource;
     try {
-      const resource = await this.readResourceImpl(resourceType, id);
+      resource = await this.readResourceImpl(resourceType, id);
+    } catch (err) {
+      const outcomeErr = err as OperationOutcomeError;
+      if (isGone(outcomeErr.outcome)) {
+        return; // Resource is already deleted, return successfully
+      }
+      throw err;
+    }
 
+    try {
       if (!this.canWriteResourceType(resourceType) || !this.isResourceWriteable(undefined, resource)) {
         throw new OperationOutcomeError(forbidden);
       }


### PR DESCRIPTION
Updated to comply with the [FHIR spec](http://hl7.org/fhir/R4/http.html#delete), in order to make testing `transaction` Bundles easier:
> Upon successful deletion, or if the resource does not exist at all, the server should return either a 200 OK if the response contains a payload, or a 204 No Content with no response payload, or a 202 Accepted if the server wishes to be non-commital about the outcome of the delete