### PR TITLE
Note that GraphQL does not support chained search

### DIFF
--- a/packages/docs/docs/graphql/basic-queries.mdx
+++ b/packages/docs/docs/graphql/basic-queries.mdx
@@ -175,6 +175,10 @@ In the example below, we first search for a `Patient` by id, and then find all t
 
 See the "[Reverse References](https://hl7.org/fhir/r4/graphql.html#searching)" section of the FHIR GraphQL specification for more information.
 
+:::note Chained Search in GraphQL
+When searching on references in GraphQL, you _cannot_ filter on the parameters of the referenced resources. This is called chained search and it is not supported by the FHIR GraphQL spec. However, it is supported in the FHIR Rest API. For more details see the [Chained Search docs](/docs/search/chained-search).
+:::
+
 ## Filtering lists with field arguments
 
 FHIR GraphQL supports filtering array properties using field arguments. For example, you can filter the `Patient.name` array by the `use` field:

--- a/packages/docs/docs/search/chained-search.md
+++ b/packages/docs/docs/search/chained-search.md
@@ -9,6 +9,12 @@ Chaining search parameters allows you to filter your searches based on the param
 
 Chained searches are similar to using [`_include` or `_revinclude` parameters](/docs/search/includes), but it will not return the referenced resources, only filter based on their parameters. The primary benefit of this is it allows for easy pagination since you know you will only receive results of one resource type. See the [paginated search docs](/docs/search/paginated-search) for more details.
 
+:::note Chained Search Availability
+
+Chained search is only available when using the FHIR Rest API as described here. If you are using GraphQL, chained search functionality is not supported.
+
+:::
+
 ## Forward Chained Search
 
 [Search parameters](/docs/search/basic-search) with the `reference` type can be chained together to search on the elements of the referenced resource.


### PR DESCRIPTION
Adds a note to the graphql docs and the chained search docs that chained search is not supported in graphql