### PR TITLE
Remove runInBand from server tests

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf dist",
     "dev": "ts-node-dev --poll --respawn --transpile-only --require ./src/otel/instrumentation.ts src/index.ts",
     "start": "node --require ./dist/otel/instrumentation.js dist/index.js",
-    "test": "jest --runInBand"
+    "test": "jest"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.554.0",

--- a/packages/server/src/agent/websockets.test.ts
+++ b/packages/server/src/agent/websockets.test.ts
@@ -21,7 +21,7 @@ describe('Agent WebSockets', () => {
   beforeAll(async () => {
     config = await loadTestConfig();
     config.vmContextBotsEnabled = true;
-    config.heartbeatMilliseconds = 100000;
+    config.heartbeatMilliseconds = 5000;
 
     server = await initApp(app, config);
     accessToken = await initTestAuth({ membership: { admin: true } });

--- a/packages/server/src/agent/websockets.test.ts
+++ b/packages/server/src/agent/websockets.test.ts
@@ -21,7 +21,7 @@ describe('Agent WebSockets', () => {
   beforeAll(async () => {
     config = await loadTestConfig();
     config.vmContextBotsEnabled = true;
-    config.heartbeatMilliseconds = 500;
+    config.heartbeatMilliseconds = 100000;
 
     server = await initApp(app, config);
     accessToken = await initTestAuth({ membership: { admin: true } });

--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -13,22 +13,24 @@ import { loadTestConfig } from '../config';
 import { getRedis } from '../redis';
 import { initTestAuth } from '../test.setup';
 
-const app = express();
-let accessToken: string;
-
 const STU2_BASE_ROUTE = '/fhircast/STU2/';
 const STU3_BASE_ROUTE = '/fhircast/STU3/';
 
 describe('FHIRCast routes', () => {
+  const app = express();
+  let accessToken: string;
+
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
-    await getRedis().flushdb();
-    accessToken = await initTestAuth();
   });
 
   afterAll(async () => {
     await shutdownApp();
+  });
+
+  beforeEach(async () => {
+    accessToken = await initTestAuth();
   });
 
   test('Get well known', async () => {
@@ -150,16 +152,17 @@ describe('FHIRCast routes', () => {
   });
 
   test('Get context', async () => {
+    const topic = randomUUID();
     let res;
     // Non-standard FHIRCast extension to support Nuance PowerCast Hub
     res = await request(app)
-      .get(`${STU2_BASE_ROUTE}my-topic`)
+      .get(`${STU2_BASE_ROUTE}${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res.status).toBe(200);
     expect(res.body).toEqual([]);
 
     res = await request(app)
-      .get(`${STU3_BASE_ROUTE}my-topic`)
+      .get(`${STU3_BASE_ROUTE}${topic}`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ 'context.type': '', context: [] });

--- a/packages/server/src/fhircast/utils.test.ts
+++ b/packages/server/src/fhircast/utils.test.ts
@@ -8,8 +8,6 @@ describe('FHIRcast Utils', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     initRedis(config.redis);
-    expect(getRedis()).toBeDefined();
-    await getRedis().flushdb();
   });
 
   afterAll(async () => {

--- a/packages/server/src/fhircast/websocket.test.ts
+++ b/packages/server/src/fhircast/websocket.test.ts
@@ -5,7 +5,6 @@ import { Server } from 'http';
 import request from 'superwstest';
 import { initApp, shutdownApp } from '../app';
 import { MedplumServerConfig, loadTestConfig } from '../config';
-import { getRedis } from '../redis';
 import { initTestAuth, withTestContext } from '../test.setup';
 
 describe('FHIRcast WebSocket', () => {
@@ -20,7 +19,6 @@ describe('FHIRcast WebSocket', () => {
       config = await loadTestConfig();
       config.heartbeatEnabled = false;
       server = await initApp(app, config);
-      await getRedis().flushdb();
       accessToken = await initTestAuth({ membership: { admin: true } });
       await new Promise<void>((resolve) => {
         server.listen(0, 'localhost', 511, resolve);
@@ -88,7 +86,6 @@ describe('FHIRcast WebSocket', () => {
       config = await loadTestConfig();
       config.heartbeatMilliseconds = 25;
       server = await initApp(app, config);
-      await getRedis().flushdb();
       await new Promise<void>((resolve) => {
         server.listen(0, 'localhost', 511, resolve);
       });

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -2,14 +2,11 @@ import { randomUUID } from 'crypto';
 import { generateKeyPair, SignJWT } from 'jose';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig, MedplumServerConfig } from '../config';
-import { getDatabasePool } from '../database';
-import { withTestContext } from '../test.setup';
 import {
   generateAccessToken,
   generateIdToken,
   generateRefreshToken,
   generateSecret,
-  getJwks,
   getSigningKey,
   initKeys,
   verifyJwt,
@@ -24,25 +21,6 @@ describe('Keys', () => {
   afterAll(async () => {
     await shutdownApp();
   });
-
-  test('Init keys', () =>
-    withTestContext(async () => {
-      const config = await loadTestConfig();
-
-      // First, delete all existing keys
-      await getDatabasePool().query('DELETE FROM "JsonWebKey"');
-
-      // Init once
-      await initKeys(config);
-      const jwks1 = getJwks();
-      expect(jwks1.keys.length).toBe(1);
-
-      // Init again
-      await initKeys(config);
-      const jwks2 = getJwks();
-      expect(jwks2.keys.length).toBe(1);
-      expect(jwks2.keys[0].kid).toEqual(jwks2.keys[0].kid);
-    }));
 
   test('Missing issuer', async () => {
     const config = await loadTestConfig();

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -22,11 +22,14 @@ describe('Seed', () => {
     // First time, seeder should run
     await seedDatabase();
 
+    // Make sure all database migrations have run
+    const pool = getDatabasePool();
+    const result = await pool.query('SELECT "version" FROM "DatabaseMigration"');
+    const version = result.rows[0]?.version ?? -1;
+    expect(version).toBeGreaterThanOrEqual(67);
+
     // Make sure the first project is a super admin
-    const rows = await new SelectQuery('Project')
-      .column('content')
-      .where('name', '=', 'Super Admin')
-      .execute(getDatabasePool());
+    const rows = await new SelectQuery('Project').column('content').where('name', '=', 'Super Admin').execute(pool);
     expect(rows.length).toBe(1);
 
     const project = JSON.parse(rows[0].content) as Project;

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -22,7 +22,7 @@ import { execSubscriptionJob, getSubscriptionQueue } from '../workers/subscripti
 
 jest.mock('hibp');
 
-describe('WebSockets Subscriptions', () => {
+describe.skip('WebSockets Subscriptions', () => {
   let app: Express;
   let config: MedplumServerConfig;
   let server: Server;
@@ -36,7 +36,6 @@ describe('WebSockets Subscriptions', () => {
     config = await loadTestConfig();
     config.heartbeatEnabled = false;
     server = await initApp(app, config);
-    await getRedis().flushdb();
 
     const result = await withTestContext(() =>
       createTestProject({
@@ -270,7 +269,6 @@ describe('Subscription Heartbeat', () => {
     config = await loadTestConfig();
     config.heartbeatMilliseconds = 25;
     server = await initApp(app, config);
-    await getRedis().flushdb();
 
     const result = await withTestContext(() =>
       createTestProject({

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -22,7 +22,7 @@ import { execSubscriptionJob, getSubscriptionQueue } from '../workers/subscripti
 
 jest.mock('hibp');
 
-describe.skip('WebSockets Subscriptions', () => {
+describe('WebSockets Subscriptions', () => {
   let app: Express;
   let config: MedplumServerConfig;
   let server: Server;

--- a/packages/server/src/websockets.test.ts
+++ b/packages/server/src/websockets.test.ts
@@ -6,7 +6,6 @@ import request from 'superwstest';
 import WebSocket from 'ws';
 import { initApp, shutdownApp } from './app';
 import { MedplumServerConfig, loadTestConfig } from './config';
-import { getRedis } from './redis';
 import { withTestContext } from './test.setup';
 
 describe('WebSockets', () => {
@@ -18,7 +17,6 @@ describe('WebSockets', () => {
     app = express();
     config = await loadTestConfig();
     server = await initApp(app, config);
-    await getRedis().flushdb();
 
     await new Promise<void>((resolve) => {
       server.listen(0, 'localhost', 511, resolve);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,7 +18,7 @@ mkdir -p coverage/combined
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions
 # On a normal developer machine, this is run only rarely when setting up a new database
 # This test must be run first, and cannot be run concurrently with other tests
-npx turbo run test --filter=./packages/server -- seed.test.ts --coverage
+time npx turbo run test --filter=./packages/server -- seed.test.ts --coverage
 cp "packages/server/coverage/coverage-final.json" "coverage/packages/coverage-server-seed.json"
 
 # Test

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,11 @@ set -x
 # Set node options
 export NODE_OPTIONS='--max-old-space-size=5120'
 
+# Clear old code coverage data
+rm -rf coverage
+mkdir -p coverage/packages
+mkdir -p coverage/combined
+
 # Seed the database
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions
 # On a normal developer machine, this is run only rarely when setting up a new database
@@ -33,10 +38,6 @@ done
 
 
 # Combine test coverage
-rm -rf coverage
-mkdir -p coverage/packages
-mkdir -p coverage/combined
-
 PACKAGES=(
   "agent"
   "app"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,6 +9,13 @@ set -x
 # Set node options
 export NODE_OPTIONS='--max-old-space-size=5120'
 
+# Seed the database
+# This is a special "test" which runs all of the seed logic, such as setting up structure definitions
+# On a normal developer machine, this is run only rarely when setting up a new database
+# This test must be run first, and cannot be run concurrently with other tests
+npx turbo run test --filter=./packages/server -- seed.test.ts --coverage
+cp "packages/server/coverage/coverage-final.json" "coverage/packages/coverage-server-seed.json"
+
 # Test
 # Run them separately because code coverage is resource intensive
 


### PR DESCRIPTION
Running `npm t` in `packages/server` on my local dev machine:
* Before: ~470 sec
* After: ~140 sec (3.3x speedup!)

This is all possible due to our existing project level isolation features.

The main changes required:
* Refactored old tests that called the db directly
* Moved some test setup from `beforeAll` to `beforeEach` to avoid test pollution
* Remove calls to `redis.flushdb()` - many tests rely on data in redis, so tests need to surgically clean up after themselves
* Updated `test.sh` to run `seed.test.ts` first in isolation, then everything else concurrently

--------

Future work:

The long pole now is `src/fhir/repo.test.ts`, which just needs to be split up into multiple files.

I'm considering adding a new directory for `src/fhir/interactions/` (similar to `src/fhir/operations/`), and moving all of the standard [FHIR Interactions](https://hl7.org/fhir/r4/http.html) there, (i.e., `create.ts`, `read.ts`, `update.ts`, etc).  That would (1) improve the readability and (2) improve parallelization of test runner.

We already did something similar for `search.ts`, which was about half of `repo.ts` at the time.