### PR TITLE
Added --update option to reinstall.sh

### DIFF
--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -7,7 +7,6 @@ set -e
 set -x
 
 rm -rf node_modules
-rm -rf package-lock.json
 
 for dir in `ls packages`; do
   if test -d "packages/$dir/node_modules"; then
@@ -21,4 +20,10 @@ for dir in `ls examples`; do
   fi
 done
 
-npm i --strict-peer-deps
+# If called with "--update", then use npm i
+if [ "$1" == "--update" ]; then
+  rm -rf package-lock.json
+  npm i --strict-peer-deps
+else
+  npm ci --strict-peer-deps
+fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -40,7 +40,7 @@ git push origin "$BRANCH_NAME"
 gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --draft
 
 # Reinstall all dependencies
-./scripts/reinstall.sh
+./scripts/reinstall.sh --update
 
 # Commit and push after running NPM install
 git add -u .


### PR DESCRIPTION
Before:

1. `reinstall.sh` did not take any options, and always deleted `package-lock.json` and always used `npm i`

After:

1. By default, `reinstall.sh` now uses `npm ci` which uses `package-lock.json`, which should put the project in a clean state
2. You can now pass in `reinstall.sh --update` to delete `package-lock.json`, use `npm i`, which creates a fresh new `package-lock.json`