### PR TITLE
Link bot docs to vm context doc

### DIFF
--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -12,6 +12,12 @@ You can apply an [AccessPolicy](/docs/access/access-policies) to the Bot if you 
 
 Bots are disabled by default for accounts. Contact info@medplum.com if you'd like to learn more.
 
+:::note Bots in Local Development
+
+If you want to run bots locally, you should use a VM Context. For more details see the [VM Context Bots docs](/docs/bots/vm-context-bots).
+
+:::
+
 ## Example uses
 
 Consider some of these Bot use cases:

--- a/packages/docs/docs/bots/bots-in-production.md
+++ b/packages/docs/docs/bots/bots-in-production.md
@@ -11,6 +11,12 @@ Editing bots in the web editor is good for getting started quickly, but as Bots 
 - Writing unit tests for your bots
 - Deploying your bots as part of your CI/CD pipeline.
 
+:::note Bots in Local Development
+
+If you want to run bots locally, you should use a VM Context. For more details see the [VM Context Bots docs](/docs/bots/vm-context-bots).
+
+:::
+
 ## This Guide will show you
 
 - How to set up a repository to host the source code for your Bots.


### PR DESCRIPTION
This will link the bot basics and bots in production docs to the VM context bots docs so that users can easily navigate to docs to run bots locally