### PR TITLE
Add supported protocols to agent page

### DIFF
--- a/packages/docs/docs/agent/index.md
+++ b/packages/docs/docs/agent/index.md
@@ -176,7 +176,7 @@ Keep the terminal open so that you can see the logs. At this point you can start
 ## Supported Protocols
 
 - [HL7 v2](https://www.hl7.org): A low-level transfer protocol for HL7 content.
-- [DICOM C-Store](https://dicom.nema.org/dicom/2013/output/chtml/part07/sect_9.3.html): A protocol used for storing medical imaging data.
+- [DICOM C-Store](https://dicom.nema.org/dicom/2013/output/chtml/part07/sect_9.3.html): A protocol used for storing metadata about medical images.
 - [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems.
 
 ## See also

--- a/packages/docs/docs/agent/index.md
+++ b/packages/docs/docs/agent/index.md
@@ -173,6 +173,12 @@ npm run agent <base_url> <client_id> <client_secret> <agent_id>
 
 Keep the terminal open so that you can see the logs. At this point you can start sending messages to the agent.
 
+## Supported Protocols
+
+- [HL7 v2](https://www.hl7.org): A low-level transfer protocol for HL7 content.
+- [DICOM C-Store](https://dicom.nema.org/dicom/2013/output/chtml/part07/sect_9.3.html): A protocol used for storing medical imaging data.
+- [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems.
+
 ## See also
 
 - [Medplum Agent design discussion](https://github.com/medplum/medplum/discussions/2012)

--- a/packages/docs/docs/agent/index.md
+++ b/packages/docs/docs/agent/index.md
@@ -176,8 +176,8 @@ Keep the terminal open so that you can see the logs. At this point you can start
 ## Supported Protocols
 
 - [HL7 v2](https://www.hl7.org): A widely used low-level message protocol for healthcare data exchange.
-- [DICOM C-Store](https://dicom.nema.org/dicom/2013/output/chtml/part07/sect_9.3.html): A protocol used for storing metadata about medical images.
-- [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems.
+- [DICOM](https://www.dicomstandard.org/): A protocol used for storing metadata about medical images. Currently, Medplum supports the C-STORE and C-ECHO operations. Support for other DICOM operations such C-FIND, C-GET, and C-MOVE is coming soon.
+- [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems. ASTM support is still in alpha.
 
 ## See also
 

--- a/packages/docs/docs/agent/index.md
+++ b/packages/docs/docs/agent/index.md
@@ -175,7 +175,7 @@ Keep the terminal open so that you can see the logs. At this point you can start
 
 ## Supported Protocols
 
-- [HL7 v2](https://www.hl7.org): A low-level transfer protocol for HL7 content.
+- [HL7 v2](https://www.hl7.org): A widely used low-level message protocol for healthcare data exchange.
 - [DICOM C-Store](https://dicom.nema.org/dicom/2013/output/chtml/part07/sect_9.3.html): A protocol used for storing metadata about medical images.
 - [ASTM](https://www.astm.org/): Used to transfer data between clinical instruments and computer systems.
 


### PR DESCRIPTION
This adds a section to the agent documentation about which protocols are currently supported. Related to #4293 