### PR TITLE
Don't warn on primitive extensions

### DIFF
--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -1319,16 +1319,6 @@ describe('FHIR resource validation', () => {
       } as Patient)
     ).toHaveLength(0);
 
-    expect(
-      validateResource({
-        resourceType: 'Patient',
-        multipleBirthInteger: 2,
-        _multipleBirthInteger: {
-          extension: [],
-        },
-      } as Patient)
-    ).toHaveLength(0);
-
     // check both orders of the properties
     expect(
       validateResource({

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -1259,6 +1259,19 @@ describe('FHIR resource validation', () => {
     expect(() => validateResource(e3, { profile })).toThrow();
   });
 
+  // TODO: Change this check from warning to error
+  // Duplicate entries for choice-of-type property is currently a warning
+  // We need to first log and track this, and notify customers of breaking changes
+  function expectOneWarning(resource: Resource, textContains: string): void {
+    const issues = validateResource(resource);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('warning');
+    expect(issues[0].details?.text).toContain(textContains);
+  }
+
+  const DUPLICATE_CHOICE_OF_TYPE_PROPERTY = 'Duplicate choice of type property';
+  const PRIMITIVE_EXTENSION_TYPE_MISMATCH = 'Type of primitive extension does not match the type of property';
+
   test('Multiple values for choice of type property', () => {
     const carePlan: CarePlan = {
       resourceType: 'CarePlan',
@@ -1286,13 +1299,101 @@ describe('FHIR resource validation', () => {
       ],
     };
 
-    // TODO: Change this check from warning to error
-    // Duplicate entries for choice-of-type property is currently a warning
-    // We need to first log and track this, and notify customers of breaking changes
-    const issues = validateResource(carePlan);
-    expect(issues).toHaveLength(1);
-    expect(issues[0].severity).toBe('warning');
-    expect(issues[0].details?.text).toContain('Duplicate choice of type property');
+    expectOneWarning(carePlan, DUPLICATE_CHOICE_OF_TYPE_PROPERTY);
+  });
+
+  test('Valid choice of type properties with primitive extensions', () => {
+    expect(
+      validateResource({
+        resourceType: 'Patient',
+        multipleBirthInteger: 2,
+      } as Patient)
+    ).toHaveLength(0);
+
+    expect(
+      validateResource({
+        resourceType: 'Patient',
+        _multipleBirthInteger: {
+          extension: [],
+        },
+      } as Patient)
+    ).toHaveLength(0);
+
+    expect(
+      validateResource({
+        resourceType: 'Patient',
+        multipleBirthInteger: 2,
+        _multipleBirthInteger: {
+          extension: [],
+        },
+      } as Patient)
+    ).toHaveLength(0);
+
+    // check both orders of the properties
+    expect(
+      validateResource({
+        resourceType: 'Patient',
+        multipleBirthInteger: 2,
+        _multipleBirthInteger: {
+          extension: [],
+        },
+      } as Patient)
+    ).toHaveLength(0);
+    expect(
+      validateResource({
+        resourceType: 'Patient',
+        multipleBirthInteger: 2,
+        _multipleBirthInteger: {
+          extension: [],
+        },
+      } as Patient)
+    ).toHaveLength(0);
+  });
+
+  test('Invalid choice of type properties with primitive extensions', () => {
+    expectOneWarning(
+      {
+        resourceType: 'Patient',
+        multipleBirthBoolean: true,
+        multipleBirthInteger: 2,
+      } as Patient,
+      DUPLICATE_CHOICE_OF_TYPE_PROPERTY
+    );
+
+    expectOneWarning(
+      {
+        resourceType: 'Patient',
+        _multipleBirthInteger: {
+          extension: [],
+        },
+        _multipleBirthBoolean: {
+          extension: [],
+        },
+      } as Patient,
+      DUPLICATE_CHOICE_OF_TYPE_PROPERTY
+    );
+
+    // Primitive extension type mismatch, check both orders of the properties
+    expectOneWarning(
+      {
+        resourceType: 'Patient',
+        multipleBirthInteger: 2,
+        _multipleBirthBoolean: {
+          extension: [],
+        },
+      } as Patient,
+      PRIMITIVE_EXTENSION_TYPE_MISMATCH
+    );
+    expectOneWarning(
+      {
+        resourceType: 'Patient',
+        _multipleBirthBoolean: {
+          extension: [],
+        },
+        multipleBirthInteger: 2,
+      } as Patient,
+      PRIMITIVE_EXTENSION_TYPE_MISMATCH
+    );
   });
 
   test('Reference type check', () => {

--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -283,13 +283,38 @@ class ResourceValidator implements ResourceVisitor {
     if (!object) {
       return;
     }
-    const choiceOfTypeElements: Record<string, boolean> = {};
+    const choiceOfTypeElements: Record<string, string> = {};
     for (const key of Object.keys(object)) {
       if (key === 'resourceType') {
         continue; // Skip special resource type discriminator property in JSON
       }
       const choiceOfTypeElementName = isChoiceOfType(parent, key, properties);
       if (choiceOfTypeElementName) {
+        // check that the type of the primitive extension matches the type of the property
+        let relatedElementName: string;
+        let requiredRelatedElementName: string | undefined;
+        if (choiceOfTypeElementName.startsWith('_')) {
+          relatedElementName = choiceOfTypeElementName.slice(1);
+          requiredRelatedElementName = key.slice(1);
+        } else {
+          relatedElementName = '_' + choiceOfTypeElementName;
+          requiredRelatedElementName = '_' + key;
+        }
+
+        if (
+          relatedElementName in choiceOfTypeElements &&
+          choiceOfTypeElements[relatedElementName] !== requiredRelatedElementName
+        ) {
+          this.issues.push(
+            createOperationOutcomeIssue(
+              'warning',
+              'structure',
+              `Type of primitive extension does not match the type of property "${choiceOfTypeElementName.startsWith('_') ? choiceOfTypeElementName.slice(1) : choiceOfTypeElementName}"`,
+              choiceOfTypeElementName
+            )
+          );
+        }
+
         if (choiceOfTypeElements[choiceOfTypeElementName]) {
           // Found a duplicate choice of type property
           // TODO: This should be an error, but it's currently a warning to avoid breaking existing code
@@ -303,7 +328,7 @@ class ResourceValidator implements ResourceVisitor {
             )
           );
         }
-        choiceOfTypeElements[choiceOfTypeElementName] = true;
+        choiceOfTypeElements[choiceOfTypeElementName] = key;
         continue;
       }
       if (!(key in properties) && !(key.startsWith('_') && key.slice(1) in properties)) {
@@ -486,8 +511,10 @@ function isChoiceOfType(
   key: string,
   propertyDefinitions: Record<string, InternalSchemaElement>
 ): string | undefined {
+  let prefix = '';
   if (key.startsWith('_')) {
     key = key.slice(1);
+    prefix = '_';
   }
   const parts = key.split(/(?=[A-Z])/g); // Split before capital letters
   let testProperty = '';
@@ -496,7 +523,7 @@ function isChoiceOfType(
     const elementName = testProperty + '[x]';
     if (propertyDefinitions[elementName]) {
       const typedPropertyValue = getTypedPropertyValue(typedValue, testProperty);
-      return typedPropertyValue ? elementName : undefined;
+      return typedPropertyValue ? prefix + elementName : undefined;
     }
   }
   return undefined;

--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -292,7 +292,7 @@ class ResourceValidator implements ResourceVisitor {
       if (choiceOfTypeElementName) {
         // check that the type of the primitive extension matches the type of the property
         let relatedElementName: string;
-        let requiredRelatedElementName: string | undefined;
+        let requiredRelatedElementName: string;
         if (choiceOfTypeElementName.startsWith('_')) {
           relatedElementName = choiceOfTypeElementName.slice(1);
           requiredRelatedElementName = key.slice(1);


### PR DESCRIPTION
The presence of a primitive type extension alongside its related choice-of-type value, e.g. `_valueString` and `valueString` was triggering the duplicate choice-of-type property warning when it shouldn't have been.