### PR TITLE
fix(agent): align `pkg` target and `node` version used to compile agent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: '20'
+      NODE_VERSION: '18'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: ${{ secrets.TURBO_REMOTE_ONLY }}
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: '20'
+      NODE_VERSION: '18'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: ${{ secrets.TURBO_REMOTE_ONLY }}
@@ -186,7 +186,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/packages/agent/src/main.test.ts
+++ b/packages/agent/src/main.test.ts
@@ -38,6 +38,26 @@ describe('Main', () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
+  test('Help command', async () => {
+    try {
+      await main(['node', 'index.js', '--help']);
+    } catch (err: any) {
+      expect(err.message).toBe('process.exit');
+    }
+    expect(console.log).toHaveBeenCalledWith('Expected arguments:');
+    expect(process.exit).toHaveBeenLastCalledWith(0);
+
+    (console.log as jest.Mock).mockClear();
+
+    try {
+      await main(['node', 'index.js', '-h']);
+    } catch (err: any) {
+      expect(err.message).toBe('process.exit');
+    }
+    expect(console.log).toHaveBeenCalledWith('Expected arguments:');
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
   test('Command line arguments success', async () => {
     const app = await main(['node', 'index.js', 'http://example.com', 'clientId', 'clientSecret', 'agentId']);
     app.stop();

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -14,7 +14,7 @@ export async function main(argv: string[]): Promise<App> {
   let args: Args;
   if (argv.length >= 6) {
     args = readCommandLineArgs(argv);
-  } else if ((argv.length === 3 && argv[2] === '-h') || argv[2] === '--help') {
+  } else if (argv.length === 3 && (argv[2] === '-h' || argv[2] === '--help')) {
     console.log('Expected arguments:');
     console.log('    baseUrl: The Medplum server base URL.');
     console.log('    clientId: The OAuth client ID.');

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -14,6 +14,13 @@ export async function main(argv: string[]): Promise<App> {
   let args: Args;
   if (argv.length >= 6) {
     args = readCommandLineArgs(argv);
+  } else if ((argv.length === 3 && argv[2] === '-h') || argv[2] === '--help') {
+    console.log('Expected arguments:');
+    console.log('    baseUrl: The Medplum server base URL.');
+    console.log('    clientId: The OAuth client ID.');
+    console.log('    clientSecret: The OAuth client secret.');
+    console.log('    agentId: The Medplum agent ID.');
+    process.exit(0);
   } else if (existsSync('agent.properties')) {
     args = readPropertiesFile('agent.properties');
   } else {

--- a/scripts/build-agent-installer-linux.sh
+++ b/scripts/build-agent-installer-linux.sh
@@ -26,5 +26,8 @@ sha256sum --check "medplum-agent-$MEDPLUM_VERSION-linux.sha256"
 # Check the build output within dist folder
 ls -la
 
+# Make sure binary runs
+./medplum-agent-$MEDPLUM_VERSION-linux --help
+
 # Move back to root
 popd

--- a/scripts/build-agent-installer-linux.sh
+++ b/scripts/build-agent-installer-linux.sh
@@ -15,7 +15,7 @@ pushd packages/agent
 npm run build
 
 # Build the executable
-npx pkg ./dist/cjs/index.cjs --targets node20-linux --output "medplum-agent-$MEDPLUM_VERSION-linux" --options no-warnings
+npx pkg ./dist/cjs/index.cjs --targets node18-linux --output "medplum-agent-$MEDPLUM_VERSION-linux" --options no-warnings
 
 # Generate the installer checksum
 sha256sum "medplum-agent-$MEDPLUM_VERSION-linux" > "medplum-agent-$MEDPLUM_VERSION-linux.sha256"

--- a/scripts/build-agent-installer-linux.sh
+++ b/scripts/build-agent-installer-linux.sh
@@ -15,7 +15,7 @@ pushd packages/agent
 npm run build
 
 # Build the executable
-npx pkg ./dist/cjs/index.cjs --targets node18-linux --output "medplum-agent-$MEDPLUM_VERSION-linux" --options no-warnings
+npx pkg ./dist/cjs/index.cjs --targets node20-linux --output "medplum-agent-$MEDPLUM_VERSION-linux" --options no-warnings
 
 # Generate the installer checksum
 sha256sum "medplum-agent-$MEDPLUM_VERSION-linux" > "medplum-agent-$MEDPLUM_VERSION-linux.sha256"

--- a/scripts/build-agent-installer-win64.sh
+++ b/scripts/build-agent-installer-win64.sh
@@ -116,5 +116,8 @@ sha256sum --check "medplum-agent-installer-$MEDPLUM_VERSION.exe.sha256"
 # Check the build output
 ls -la
 
+# Make sure binary runs
+dist/medplum-agent-$MEDPLUM_VERSION-win64.exe --help
+
 # Move back to root
 popd

--- a/scripts/build-agent-installer-win64.sh
+++ b/scripts/build-agent-installer-win64.sh
@@ -67,7 +67,7 @@ pushd packages/agent
 npm run build
 
 # Build the executable
-npx pkg ./dist/cjs/index.cjs --targets node18-win-x64 --output "dist/medplum-agent-$MEDPLUM_VERSION-win64.exe" --options no-warnings
+npx pkg ./dist/cjs/index.cjs --targets node20-win-x64 --output "dist/medplum-agent-$MEDPLUM_VERSION-win64.exe" --options no-warnings
 
 # Download JSign
 if [ ! -f "jsign-5.0.jar" ]; then

--- a/scripts/build-agent-installer-win64.sh
+++ b/scripts/build-agent-installer-win64.sh
@@ -67,7 +67,7 @@ pushd packages/agent
 npm run build
 
 # Build the executable
-npx pkg ./dist/cjs/index.cjs --targets node20-win-x64 --output "dist/medplum-agent-$MEDPLUM_VERSION-win64.exe" --options no-warnings
+npx pkg ./dist/cjs/index.cjs --targets node18-win-x64 --output "dist/medplum-agent-$MEDPLUM_VERSION-win64.exe" --options no-warnings
 
 # Download JSign
 if [ ! -f "jsign-5.0.jar" ]; then


### PR DESCRIPTION
Thought this might fix: https://github.com/medplum/medplum/issues/4449, but was a bit of a red herring. We should still update this though