### PR TITLE
Update default project access policy for new systemSetting

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -165,7 +165,9 @@
       "SmartAppLaunch": "#/definitions/SmartAppLaunch",
       "DomainConfiguration": "#/definitions/DomainConfiguration",
       "AsyncJob": "#/definitions/AsyncJob",
-      "Agent": "#/definitions/Agent"
+      "Agent": "#/definitions/Agent",
+      "IdentityProvider": "#/definitions/IdentityProvider",
+      "UserSecurityRequest": "#/definitions/UserSecurityRequest"
     }
   },
   "oneOf": [
@@ -651,6 +653,12 @@
     },
     {
       "$ref": "#/definitions/Agent"
+    },
+    {
+      "$ref": "#/definitions/IdentityProvider"
+    },
+    {
+      "$ref": "#/definitions/UserSecurityRequest"
     }
   ],
   "definitions": {
@@ -1138,6 +1146,12 @@
         },
         {
           "$ref": "#/definitions/Agent"
+        },
+        {
+          "$ref": "#/definitions/IdentityProvider"
+        },
+        {
+          "$ref": "#/definitions/UserSecurityRequest"
         }
       ]
     },
@@ -59245,7 +59259,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59258,6 +59272,13 @@
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
+        },
+        "identifier": {
+          "description": "An identifier for this project.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
         },
         "name": {
           "description": "A name associated with the Project.",
@@ -59286,7 +59307,15 @@
         "features": {
           "description": "A list of optional features that are enabled for the project.",
           "items": {
-            "enum": ["bots", "cron", "email", "google-auth-required", "graphql-introspection"]
+            "enum": [
+              "bots",
+              "cron",
+              "email",
+              "google-auth-required",
+              "graphql-introspection",
+              "terminology",
+              "websocket-subscriptions"
+            ]
           },
           "type": "array"
         },
@@ -59294,17 +59323,45 @@
           "description": "The default access policy for patients using open registration.",
           "$ref": "#/definitions/Reference"
         },
-        "secret": {
-          "description": "Secure environment variable that can be used to store secrets for bots.",
+        "setting": {
+          "description": "Option or parameter that can be adjusted within the Medplum Project to customize its behavior.",
           "items": {
-            "$ref": "#/definitions/Project_Secret"
+            "$ref": "#/definitions/ProjectSetting"
+          },
+          "type": "array"
+        },
+        "secret": {
+          "description": "Option or parameter that can be adjusted within the Medplum Project to customize its behavior, only visible to project administrators.",
+          "items": {
+            "$ref": "#/definitions/ProjectSetting"
+          },
+          "type": "array"
+        },
+        "systemSetting": {
+          "description": "Option or parameter that can be adjusted within the Medplum Project to customize its behavior, only modifiable by system administrators.",
+          "items": {
+            "$ref": "#/definitions/ProjectSetting"
+          },
+          "type": "array"
+        },
+        "systemSecret": {
+          "description": "Option or parameter that can be adjusted within the Medplum Project to customize its behavior, only visible to system administrators.",
+          "items": {
+            "$ref": "#/definitions/ProjectSetting"
           },
           "type": "array"
         },
         "site": {
           "description": "Web application or web site that is associated with the project.",
           "items": {
-            "$ref": "#/definitions/Project_Site"
+            "$ref": "#/definitions/ProjectSite"
+          },
+          "type": "array"
+        },
+        "link": {
+          "description": "Linked Projects whose contents are made available to this one",
+          "items": {
+            "$ref": "#/definitions/ProjectLink"
           },
           "type": "array"
         }
@@ -59382,7 +59439,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59412,8 +59469,12 @@
           "description": "Reference to the resource that represents the user profile within the project.",
           "$ref": "#/definitions/Reference"
         },
+        "userName": {
+          "description": "SCIM userName. A service provider\u0027s unique identifier for the user, typically used by the user to directly authenticate to the service provider. Often displayed to the user as their unique identifier within the system (as opposed to \"id\" or \"externalId\", which are generally opaque and not user-friendly identifiers).  Each User MUST include a non-empty userName value.  This identifier MUST be unique across the service provider\u0027s entire set of Users.  This attribute is REQUIRED and is case insensitive.",
+          "$ref": "#/definitions/string"
+        },
         "externalId": {
-          "description": "A String that is an identifier for the resource as defined by the provisioning client.  The \"externalId\" may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain\u0027s identifier of the resource and the identifier used by the service provider.  Each resource MAY include a non-empty \"externalId\" value.  The value of the \"externalId\" attribute is always issued by the provisioning client and MUST NOT be specified by the service provider.  The service provider MUST always interpret the externalId as scoped to the provisioning domain.",
+          "description": "SCIM externalId. A String that is an identifier for the resource as defined by the provisioning client.  The \"externalId\" may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain\u0027s identifier of the resource and the identifier used by the service provider.  Each resource MAY include a non-empty \"externalId\" value.  The value of the \"externalId\" attribute is always issued by the provisioning client and MUST NOT be specified by the service provider.  The service provider MUST always interpret the externalId as scoped to the provisioning domain.",
           "$ref": "#/definitions/string"
         },
         "accessPolicy": {
@@ -59423,7 +59484,7 @@
         "access": {
           "description": "Extended access configuration using parameterized access policies.",
           "items": {
-            "$ref": "#/definitions/ProjectMembership_Access"
+            "$ref": "#/definitions/ProjectMembershipAccess"
           },
           "type": "array"
         },
@@ -59448,7 +59509,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59461,6 +59522,10 @@
         "language": {
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
+        },
+        "status": {
+          "description": "The client application status. The status is active by default. The status can be set to error to indicate that the client application is not working properly. The status can be set to off to indicate that the client application is no longer in use.",
+          "enum": ["active", "off", "error"]
         },
         "name": {
           "description": "A name associated with the ClientApplication.",
@@ -59507,7 +59572,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59521,6 +59586,13 @@
           "description": "The base language in which the resource is written.",
           "$ref": "#/definitions/code"
         },
+        "identifier": {
+          "description": "An identifier for this user.",
+          "items": {
+            "$ref": "#/definitions/Identifier"
+          },
+          "type": "array"
+        },
         "firstName": {
           "description": "The first name or given name of the user. This is the value as entered when the user is created. It is used to populate the profile resource.",
           "$ref": "#/definitions/string"
@@ -59530,7 +59602,7 @@
           "$ref": "#/definitions/string"
         },
         "externalId": {
-          "description": "DEPRECATED Replaced by ProjectMembership.externalId.",
+          "description": "@deprecated Replaced by ProjectMembership.externalId.",
           "$ref": "#/definitions/string"
         },
         "email": {
@@ -59542,7 +59614,7 @@
           "$ref": "#/definitions/boolean"
         },
         "admin": {
-          "description": "DEPRECATED",
+          "description": "@deprecated",
           "$ref": "#/definitions/boolean"
         },
         "passwordHash": {
@@ -59574,7 +59646,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59657,11 +59729,11 @@
           "$ref": "#/definitions/boolean"
         },
         "admin": {
-          "description": "DEPRECATED",
+          "description": "@deprecated",
           "$ref": "#/definitions/boolean"
         },
         "superAdmin": {
-          "description": "Whether this login has super administrator privileges.",
+          "description": "@deprecated",
           "$ref": "#/definitions/boolean"
         },
         "launch": {
@@ -59681,7 +59753,7 @@
       "required": ["resourceType", "user", "authMethod", "authTime"]
     },
     "PasswordChangeRequest": {
-      "description": "Password change request for the \u0027forgot password\u0027 flow.",
+      "description": "@deprecated Password change request for the \u0027forgot password\u0027 flow. Use UserSecurityCheck instead.",
       "properties": {
         "resourceType": {
           "description": "This is a PasswordChangeRequest resource",
@@ -59689,7 +59761,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59736,7 +59808,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59833,7 +59905,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59909,7 +59981,7 @@
           "$ref": "#/definitions/Attachment"
         },
         "code": {
-          "description": "DEPRECATED Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
+          "description": "@deprecated Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
           "$ref": "#/definitions/string"
         }
       },
@@ -59925,7 +59997,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -59950,14 +60022,14 @@
         "resource": {
           "description": "Access details for a resource type.",
           "items": {
-            "$ref": "#/definitions/AccessPolicy_Resource"
+            "$ref": "#/definitions/AccessPolicyResource"
           },
           "type": "array"
         },
         "ipAccessRule": {
           "description": "Use IP Access Rules to allowlist, block, and challenge traffic based on the visitor IP address.",
           "items": {
-            "$ref": "#/definitions/AccessPolicy_IpAccessRule"
+            "$ref": "#/definitions/AccessPolicyIpAccessRule"
           },
           "type": "array"
         }
@@ -60018,7 +60090,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -60039,21 +60111,21 @@
         "menu": {
           "description": "Optional menu of shortcuts to URLs.",
           "items": {
-            "$ref": "#/definitions/UserConfiguration_Menu"
+            "$ref": "#/definitions/UserConfigurationMenu"
           },
           "type": "array"
         },
         "search": {
           "description": "Shortcut links to URLs.",
           "items": {
-            "$ref": "#/definitions/UserConfiguration_Search"
+            "$ref": "#/definitions/UserConfigurationSearch"
           },
           "type": "array"
         },
         "option": {
           "description": "User options that control the display of the application.",
           "items": {
-            "$ref": "#/definitions/UserConfiguration_Option"
+            "$ref": "#/definitions/UserConfigurationOption"
           },
           "type": "array"
         }
@@ -60151,6 +60223,10 @@
           "description": "Remote URL for the external Identity Provider token endpoint.",
           "$ref": "#/definitions/string"
         },
+        "tokenAuthMethod": {
+          "description": "Client Authentication method used by Clients to authenticate to the Authorization Server when using the Token Endpoint. If no method is registered, the default method is client_secret_basic.",
+          "enum": ["client_secret_basic", "client_secret_post"]
+        },
         "userInfoUrl": {
           "description": "Remote URL for the external Identity Provider userinfo endpoint.",
           "$ref": "#/definitions/string"
@@ -60162,6 +60238,10 @@
         "clientSecret": {
           "description": "External Identity Provider client secret.",
           "$ref": "#/definitions/string"
+        },
+        "usePkce": {
+          "description": "Optional flag to use PKCE in the token request.",
+          "$ref": "#/definitions/boolean"
         },
         "useSubject": {
           "description": "Optional flag to use the subject field instead of the email field.",
@@ -60217,7 +60297,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -60254,21 +60334,21 @@
         "output": {
           "description": "An array of file items with one entry for each generated file. If no resources are returned from the kick-off request, the server SHOULD return an empty array.",
           "items": {
-            "$ref": "#/definitions/BulkDataExport_Output"
+            "$ref": "#/definitions/BulkDataExportOutput"
           },
           "type": "array"
         },
         "deleted": {
           "description": "An array of deleted file items following the same structure as the output array.",
           "items": {
-            "$ref": "#/definitions/BulkDataExport_Deleted"
+            "$ref": "#/definitions/BulkDataExportDeleted"
           },
           "type": "array"
         },
         "error": {
           "description": "Array of message file items following the same structure as the output array.",
           "items": {
-            "$ref": "#/definitions/BulkDataExport_Error"
+            "$ref": "#/definitions/BulkDataExportError"
           },
           "type": "array"
         }
@@ -60330,7 +60410,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -60365,7 +60445,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -60419,7 +60499,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -60448,6 +60528,10 @@
         "request": {
           "description": "The full URL of the original kick-off request. In the case of a POST request, this URL will not include the request parameters.",
           "$ref": "#/definitions/uri"
+        },
+        "output": {
+          "description": "Outputs resulting from the async job.",
+          "$ref": "#/definitions/Parameters"
         }
       },
       "additionalProperties": false,
@@ -60462,7 +60546,7 @@
         },
         "id": {
           "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-          "$ref": "#/definitions/id"
+          "$ref": "#/definitions/string"
         },
         "meta": {
           "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
@@ -60498,20 +60582,20 @@
         "setting": {
           "description": "The settings for the agent.",
           "items": {
-            "$ref": "#/definitions/Agent_Setting"
+            "$ref": "#/definitions/AgentSetting"
           },
           "type": "array"
         },
         "channel": {
           "description": "Details where to send notifications when resources are received that meet the criteria.",
           "items": {
-            "$ref": "#/definitions/Agent_Channel"
+            "$ref": "#/definitions/AgentChannel"
           },
           "type": "array"
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType", "name", "status", "channel"]
+      "required": ["resourceType", "name", "status"]
     },
     "Agent_Channel": {
       "description": "Details where to send notifications when resources are received that meet the criteria.",
@@ -60572,6 +60656,53 @@
         }
       },
       "additionalProperties": false
+    },
+    "UserSecurityRequest": {
+      "description": "User security request for the \u0027forgot password\u0027 flow, email verification, etc.",
+      "properties": {
+        "resourceType": {
+          "description": "This is a UserSecurityRequest resource",
+          "const": "UserSecurityRequest"
+        },
+        "id": {
+          "description": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+          "$ref": "#/definitions/string"
+        },
+        "meta": {
+          "description": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+          "$ref": "#/definitions/Meta"
+        },
+        "implicitRules": {
+          "description": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+          "$ref": "#/definitions/uri"
+        },
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "$ref": "#/definitions/code"
+        },
+        "type": {
+          "description": "The type of user security request.",
+          "enum": ["invite", "verify-email", "reset"]
+        },
+        "user": {
+          "description": "The user performing the security request.",
+          "$ref": "#/definitions/Reference"
+        },
+        "secret": {
+          "description": "Secret string used to verify the identity of the user.",
+          "$ref": "#/definitions/string"
+        },
+        "used": {
+          "description": "Whether this request has been used, and is therefore no longer valid.",
+          "$ref": "#/definitions/boolean"
+        },
+        "redirectUri": {
+          "description": "Redirect URI used when redirecting a client back to the client application.",
+          "$ref": "#/definitions/uri"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["resourceType", "user", "secret"]
     }
   }
 }

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -838,7 +838,7 @@
           {
             "id" : "User.externalId",
             "path" : "User.externalId",
-            "definition" : "DEPRECATED Replaced by ProjectMembership.externalId.",
+            "definition" : "@deprecated Replaced by ProjectMembership.externalId.",
             "min" : 0,
             "max" : "1",
             "type" : [{
@@ -883,8 +883,8 @@
           {
             "id" : "User.admin",
             "path" : "User.admin",
-            "short" : "DEPRECATED",
-            "definition" : "DEPRECATED",
+            "short" : "@deprecated",
+            "definition" : "@deprecated",
             "min" : 0,
             "max" : "1",
             "type" : [{
@@ -1574,7 +1574,7 @@
           {
             "id" : "Bot.code",
             "path" : "Bot.code",
-            "definition" : "DEPRECATED Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
+            "definition" : "@deprecated Bot logic script. Use Bot.sourceCode or Bot.executableCode instead.",
             "min" : 0,
             "max" : "1",
             "type" : [{
@@ -2044,7 +2044,7 @@
       "abstract" : false,
       "type" : "PasswordChangeRequest",
       "baseDefinition" : "http://hl7.org/fhir/StructureDefinition/DomainResource",
-      "description" : "DEPRECATED Password change request for the 'forgot password' flow. Use UserSecurityCheck instead.",
+      "description" : "@deprecated Password change request for the 'forgot password' flow. Use UserSecurityCheck instead.",
       "snapshot" : {
         "element" : [
           {
@@ -2895,7 +2895,7 @@
           {
             "id" : "AccessPolicy.resource.compartment",
             "path" : "AccessPolicy.resource.compartment",
-            "definition" : "DEPRECATED Optional compartment restriction for the resource type.",
+            "definition" : "@deprecated Optional compartment restriction for the resource type.",
             "min" : 0,
             "max" : "1",
             "type" : [{

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -104,7 +104,7 @@ export interface AccessPolicyResource {
   resourceType: string;
 
   /**
-   * DEPRECATED Optional compartment restriction for the resource type.
+   * @deprecated Optional compartment restriction for the resource type.
    */
   compartment?: Reference;
 

--- a/packages/fhirtypes/dist/Bot.d.ts
+++ b/packages/fhirtypes/dist/Bot.d.ts
@@ -117,7 +117,7 @@ export interface Bot {
   executableCode?: Attachment;
 
   /**
-   * DEPRECATED Bot logic script. Use Bot.sourceCode or Bot.executableCode
+   * @deprecated Bot logic script. Use Bot.sourceCode or Bot.executableCode
    * instead.
    */
   code?: string;

--- a/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
+++ b/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
@@ -8,8 +8,8 @@ import { Reference } from './Reference';
 import { User } from './User';
 
 /**
- * DEPRECATED Password change request for the 'forgot password' flow. Use
- * UserSecurityCheck instead.
+ * @deprecated Password change request for the 'forgot password' flow.
+ * Use UserSecurityCheck instead.
  */
 export interface PasswordChangeRequest {
 

--- a/packages/fhirtypes/dist/User.d.ts
+++ b/packages/fhirtypes/dist/User.d.ts
@@ -62,7 +62,7 @@ export interface User {
   lastName: string;
 
   /**
-   * DEPRECATED Replaced by ProjectMembership.externalId.
+   * @deprecated Replaced by ProjectMembership.externalId.
    */
   externalId?: string;
 
@@ -78,7 +78,7 @@ export interface User {
   emailVerified?: boolean;
 
   /**
-   * DEPRECATED
+   * @deprecated
    */
   admin?: boolean;
 

--- a/packages/generator/src/jsonschema.ts
+++ b/packages/generator/src/jsonschema.ts
@@ -51,7 +51,7 @@ export function main(): void {
   indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
 
   const medplumBundle = readJson('fhir/r4/profiles-medplum.json') as Bundle<StructureDefinition>;
-  const medplumTypes = medplumBundle.entry?.map((e) => e.id) ?? [];
+  const medplumTypes = medplumBundle.entry?.map((e) => e.resource?.id) ?? [];
   indexStructureDefinitionBundle(medplumBundle);
 
   // Start with the existing schema
@@ -182,7 +182,7 @@ const excludedValueSets = [
 function getEnumValues(elementDefinition: InternalSchemaElement): string[] | undefined {
   const valueSet = elementDefinition.binding?.valueSet;
   if (valueSet) {
-    if (excludedValueSets.includes(valueSet)) {
+    if (!excludedValueSets.includes(valueSet)) {
       const values = getValueSetValues(valueSet);
       if (values && values.length > 0) {
         return values;

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -1624,7 +1624,11 @@ describe('AccessPolicy', () => {
 
   test('Project admin cannot modify protected fields', () =>
     withTestContext(async () => {
-      const project = await systemRepo.createResource<Project>({ resourceType: 'Project', name: 'Test Project' });
+      const project = await systemRepo.createResource<Project>({
+        resourceType: 'Project',
+        name: 'Test Project',
+        systemSecret: [{ name: 'mySecret', valueString: 'foo' }],
+      });
 
       const membership = await systemRepo.createResource<ProjectMembership>({
         resourceType: 'ProjectMembership',
@@ -1649,11 +1653,19 @@ describe('AccessPolicy', () => {
 
       // Try to change protected fields
       // This should be a no-op
-      const check3 = await repo2.updateResource<Project>({ ...check2, superAdmin: true, features: ['bots'] });
+      const check3 = await repo2.updateResource<Project>({
+        ...check2,
+        superAdmin: true,
+        features: ['bots'],
+        systemSetting: [{ name: 'rateLimt', valueInteger: 1000000 }],
+        systemSecret: [{ name: 'mySecret', valueString: 'bar' }],
+      });
       expect(check3.id).toEqual(project.id);
       expect(check3.meta?.versionId).toEqual(check2.meta?.versionId);
       expect(check3.superAdmin).toBeUndefined();
       expect(check3.features).toBeUndefined();
+      expect(check3.systemSetting).toBeUndefined();
+      expect(check3.systemSecret).toBeUndefined();
 
       const check4 = await repo2.readResource<ProjectMembership>('ProjectMembership', membership.id as string);
       expect(check4.id).toEqual(membership.id);

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -1657,7 +1657,7 @@ describe('AccessPolicy', () => {
         ...check2,
         superAdmin: true,
         features: ['bots'],
-        systemSetting: [{ name: 'rateLimt', valueInteger: 1000000 }],
+        systemSetting: [{ name: 'rateLimit', valueInteger: 1000000 }],
         systemSecret: [{ name: 'mySecret', valueString: 'bar' }],
       });
       expect(check3.id).toEqual(project.id);

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -222,7 +222,8 @@ function applyProjectAdminAccessPolicy(
     accessPolicy.resource.push({
       resourceType: 'Project',
       criteria: `Project?_id=${resolveId(membership.project)}`,
-      readonlyFields: ['superAdmin', 'features', 'link'],
+      readonlyFields: ['superAdmin', 'features', 'link', 'systemSetting'],
+      hiddenFields: ['systemSecret'],
     });
 
     accessPolicy.resource.push({


### PR DESCRIPTION
1. Updated default project admin access policy
    * Added `systemSetting` to `readonlyFields`
    * Added `systemSecret` to `hiddenFields`
2. Fixed a couple bugs in JSONSchema generator
    * Two lingering bugs that have been hiding since the switch from `ElementDefinition` to `InternalElementDefinition`
    * `medplumTypes` was wrong, so no JSONSchema updates were ever coming through
    * `excludedValueSets` check was inverted, so we never used JSONSchema `enum`
    * In practice, this only affects projects not using strict mode, which is increasingly rare, which is why this hid for as long as it did
3. Replaced all `DEPRECATED` with `@deprecated` for TypeScript TSDoc annotations
    * This is mostly a cosmetic change, but nice to be consistent
