### PR TITLE
fix: allows CORS for `keyvalue` API

### DIFF
--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -37,7 +37,7 @@ function isOriginAllowed(origin: string | undefined): boolean {
   return false;
 }
 
-const prefixes = ['/.well-known/', '/admin/', '/auth/', '/email/', '/fhir/', '/fhircast/', '/oauth2/'];
+const prefixes = ['/.well-known/', '/admin/', '/auth/', '/email/', '/fhir/', '/fhircast/', '/oauth2/', '/keyvalue/'];
 
 function isPathAllowed(path: string): boolean {
   return prefixes.some((prefix) => path.startsWith(prefix));


### PR DESCRIPTION
I'd like to be able to use the keyvalue API to store arbitrary user-focused app config/preferences directly from the MedplumClient within the web browser or a mobile client.

Curious if this CORS configuration was intentionally omitted and/or if there's a more appropriate approach to remotely persisting user app preferences.