### PR TITLE
[Medplum Provider app] Integrate specialized Tasks tab from examples/medplum-task-demo

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -34,6 +34,7 @@ import { ResourceEditPage } from './pages/resource/ResourceEditPage';
 import { ResourceHistoryPage } from './pages/resource/ResourceHistoryPage';
 import { ResourcePage } from './pages/resource/ResourcePage';
 import { CommunicationTab } from './pages/patient/CommunicationTab';
+import { TaskTab } from './pages/patient/TaskTab';
 
 export function App(): JSX.Element | null {
   const medplum = useMedplum();
@@ -115,6 +116,7 @@ export function App(): JSX.Element | null {
                 <Route path="encounter" element={<EncounterTab />} />
                 <Route path="communication" element={<CommunicationTab />} />
                 <Route path="communication/:id" element={<CommunicationTab />} />
+                <Route path="task/:id/*" element={<TaskTab />} />
                 <Route path="timeline" element={<TimelineTab />} />
                 <Route path=":resourceType" element={<PatientSearchPage />} />
                 <Route path=":resourceType/new" element={<ResourceCreatePage />} />

--- a/examples/medplum-provider/src/components/tasks/TaskList.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskList.tsx
@@ -173,10 +173,14 @@ function TaskTitle(props: TaskCellProps): JSX.Element {
       setTitle(<>{props.resource.title}</>);
     } else if (props.resource.resourceType === 'QuestionnaireResponse') {
       fetchQuestionnaireTitle().catch(console.error);
+    } else if (props.task.code) {
+      setTitle(<CodeableConceptDisplay value={props.task.code} />);
     } else {
+      // TODO what should this else actually be?
       setTitle(<>{props.task.code}</>);
     }
   }, [props.resource, props.task, medplum]);
 
+  console.log('TaskTitle', title);
   return title ?? <></>;
 }

--- a/examples/medplum-provider/src/components/tasks/TaskList.tsx
+++ b/examples/medplum-provider/src/components/tasks/TaskList.tsx
@@ -1,5 +1,5 @@
 import { Box, Card, Divider, Flex, Group, Text, Title } from '@mantine/core';
-import { formatDate } from '@medplum/core';
+import { formatDate, getDisplayString } from '@medplum/core';
 import { CodeableConcept, Questionnaire, Reference, Resource, Task } from '@medplum/fhirtypes';
 import {
   CodeableConceptDisplay,
@@ -176,11 +176,9 @@ function TaskTitle(props: TaskCellProps): JSX.Element {
     } else if (props.task.code) {
       setTitle(<CodeableConceptDisplay value={props.task.code} />);
     } else {
-      // TODO what should this else actually be?
-      setTitle(<>{props.task.code}</>);
+      setTitle(<>{getDisplayString(props.task)}</>);
     }
   }, [props.resource, props.task, medplum]);
 
-  console.log('TaskTitle', title);
   return title ?? <></>;
 }

--- a/examples/medplum-provider/src/components/tasks/actions/AddDueDate.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/AddDueDate.tsx
@@ -1,0 +1,101 @@
+import { Button, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { getQuestionnaireAnswers, MedplumClient, normalizeErrorString, PatchOperation } from '@medplum/core';
+import { Questionnaire, QuestionnaireResponse, Task, TaskRestriction } from '@medplum/fhirtypes';
+import { QuestionnaireForm, useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface AddDueDateProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function AddDueDate(props: AddDueDateProps): JSX.Element {
+  const medplum = useMedplum();
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleAddDueDate = async (
+    date: string,
+    task: Task,
+    medplum: MedplumClient,
+    onChange: (task: Task) => void
+  ): Promise<void> => {
+    const taskId = task.id as string;
+
+    // We use a patch operation here to avoid race conditions. This ensures that if multiple users try to update the due-date simultaneously, only one will be successful.
+    const ops: PatchOperation[] = [{ op: 'test', path: '/meta/versionId', value: task.meta?.versionId }];
+
+    // Create a restriction period with the due-date if one doesn't already exist and add it to the PatchOperation. For more details on task due-dates, see https://www.medplum.com/docs/careplans/tasks#task-start--due-dates
+    const restriction: TaskRestriction = {
+      ...task.restriction,
+      period: {
+        ...task?.restriction?.period,
+        end: date,
+      },
+    };
+
+    const op: PatchOperation['op'] = task.restriction ? 'replace' : 'add';
+
+    ops.push({ op, path: '/restriction', value: restriction });
+
+    // Patch the resource with the new due-date
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Due-date updated.',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: normalizeErrorString(error),
+      });
+    }
+  };
+
+  const onQuestionnaireSubmit = (formData: QuestionnaireResponse): void => {
+    const dueDate = getQuestionnaireAnswers(formData)['due-date'].valueDate;
+
+    if (dueDate) {
+      handleAddDueDate(dueDate, props.task, medplum, props.onChange).catch((error) => console.error(error));
+    }
+
+    close();
+  };
+
+  return (
+    <div>
+      {props.task.restriction?.period?.end ? (
+        <Button fullWidth onClick={toggle}>
+          Change Due-Date
+        </Button>
+      ) : (
+        <Button fullWidth onClick={toggle}>
+          Add Due-Date
+        </Button>
+      )}
+      <Modal opened={opened} onClose={close}>
+        <QuestionnaireForm questionnaire={dueDateQuestionnaire} onSubmit={onQuestionnaireSubmit} />
+      </Modal>
+    </div>
+  );
+}
+
+const dueDateQuestionnaire: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'active',
+  id: 'due-date',
+  title: 'Due-Date',
+  item: [
+    {
+      linkId: 'due-date',
+      text: 'The date the task should be completed',
+      type: 'date',
+    },
+  ],
+};

--- a/examples/medplum-provider/src/components/tasks/actions/AddNote.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/AddNote.tsx
@@ -1,0 +1,106 @@
+import { Button, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import {
+  createReference,
+  getQuestionnaireAnswers,
+  MedplumClient,
+  normalizeErrorString,
+  PatchOperation,
+} from '@medplum/core';
+import { Annotation, Questionnaire, QuestionnaireResponse, Task } from '@medplum/fhirtypes';
+import { QuestionnaireForm, useMedplum, useMedplumProfile } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface AddCommentProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function AddNote(props: AddCommentProps): JSX.Element {
+  const medplum = useMedplum();
+  const author = useMedplumProfile();
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleAddComment = async (
+    comment: Annotation,
+    task: Task,
+    medplum: MedplumClient,
+    onChange: (task: Task) => void
+  ): Promise<void> => {
+    const taskId = task.id as string;
+
+    // We use a patch operation here to avoid race conditions. This ensures that if multiple users try to add a note simultaneously, only one will be successful.
+    const ops: PatchOperation[] = [{ op: 'test', path: '/meta/versionId', value: task.meta?.versionId }];
+
+    // Get the task notes if they exist and add the new note to the list. See https://www.medplum.com/docs/careplans/tasks#task-comments
+    const taskNotes = task?.note || [];
+    taskNotes.push(comment);
+
+    const op: PatchOperation['op'] = task.note ? 'replace' : 'add';
+
+    ops.push({ op, path: '/note', value: taskNotes });
+
+    // Update the resource on the server using a patch request. See https://www.medplum.com/docs/sdk/core.medplumclient.patchresource
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Comment added.',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: normalizeErrorString(error),
+      });
+    }
+  };
+
+  const onQuestionnaireSubmit = (formData: QuestionnaireResponse): void => {
+    const answer = getQuestionnaireAnswers(formData)['new-comment'].valueString;
+
+    // Create a new note
+    if (answer) {
+      const newNote: Annotation = {
+        text: answer,
+        authorReference: author && createReference(author),
+        time: new Date().toISOString(),
+      };
+
+      // Add the note to the task
+      handleAddComment(newNote, props.task, medplum, props.onChange).catch((error) => console.error(error));
+    }
+
+    // Close the modal
+    close();
+  };
+
+  return (
+    <div>
+      <Button fullWidth onClick={toggle}>
+        Add a Note
+      </Button>
+      <Modal opened={opened} onClose={close}>
+        <QuestionnaireForm questionnaire={commentQuestionnaire} onSubmit={onQuestionnaireSubmit} />
+      </Modal>
+    </div>
+  );
+}
+
+const commentQuestionnaire: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'active',
+  id: 'add-comment',
+  title: 'Add a comment',
+  item: [
+    {
+      linkId: 'new-comment',
+      text: 'Add a comment',
+      type: 'string',
+    },
+  ],
+};

--- a/examples/medplum-provider/src/components/tasks/actions/AssignRole.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/AssignRole.tsx
@@ -1,0 +1,90 @@
+import { Button, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { MedplumClient, PatchOperation, getQuestionnaireAnswers, normalizeErrorString } from '@medplum/core';
+import { CodeableConcept, Coding, Questionnaire, QuestionnaireResponse, Task } from '@medplum/fhirtypes';
+import { QuestionnaireForm, useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface AssignTaskProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function AssignRole(props: AssignTaskProps): JSX.Element {
+  const medplum = useMedplum();
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleAssignToRole = async (
+    role: Coding,
+    task: Task,
+    medplum: MedplumClient,
+    onChange: (task: Task) => void
+  ): Promise<void> => {
+    const taskId = task.id as string;
+
+    const updatedRole: CodeableConcept = { coding: [role] };
+
+    const ops: PatchOperation[] = [{ op: 'test', path: '/meta/versionId', value: task.meta?.versionId }];
+    const op: PatchOperation['op'] = task.performerType ? 'replace' : 'add';
+
+    const updatedRoles = task.performerType ? [...task.performerType] : [];
+
+    updatedRoles.push(updatedRole);
+
+    ops.push({ op, path: '/performerType', value: updatedRoles });
+
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Task assigned',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: normalizeErrorString(error),
+      });
+    }
+  };
+
+  const onQuestionnaireSubmit = (formData: QuestionnaireResponse): void => {
+    const role = getQuestionnaireAnswers(formData)['assign-role'].valueCoding;
+
+    if (role) {
+      handleAssignToRole(role, props.task, medplum, props.onChange).catch((error) => console.error(error));
+    }
+
+    close();
+  };
+
+  return (
+    <div>
+      <Button fullWidth onClick={toggle}>
+        Assign to a Role
+      </Button>
+      <Modal opened={opened} onClose={close}>
+        <QuestionnaireForm questionnaire={assignRoleQuestionnaire} onSubmit={onQuestionnaireSubmit} />
+      </Modal>
+    </div>
+  );
+}
+
+const assignRoleQuestionnaire: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'active',
+  id: 'assign-role',
+  title: 'Assign to a Role',
+  item: [
+    {
+      linkId: 'assign-role',
+      text: 'Select Role',
+      type: 'choice',
+      answerValueSet: 'http://medplum.com/medplum-task-demo/practitioner-role-codes',
+    },
+  ],
+};

--- a/examples/medplum-provider/src/components/tasks/actions/AssignTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/AssignTask.tsx
@@ -1,0 +1,100 @@
+import { Button, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { getQuestionnaireAnswers, MedplumClient, PatchOperation } from '@medplum/core';
+import { Questionnaire, QuestionnaireResponse, Reference, Task } from '@medplum/fhirtypes';
+import { QuestionnaireForm, useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface AssignTaskProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function AssignTask(props: AssignTaskProps): JSX.Element {
+  const medplum = useMedplum();
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleAssignTask = async (
+    owner: Reference,
+    task: Task,
+    medplum: MedplumClient,
+    onChange: (task: Task) => void
+  ): Promise<void> => {
+    const taskId = task.id as string;
+
+    // We use a patch operation here to avoid race conditions. This ensures that if multiple users try to reassign the task simultaneously, only one will be successful.
+    const ops: PatchOperation[] = [{ op: 'test', path: '/meta/versionId', value: task.meta?.versionId }];
+    const op: PatchOperation['op'] = task.owner ? 'replace' : 'add';
+
+    // Assign the task to the new owner. For more details on assigning task, see https://www.medplum.com/docs/careplans/tasks#task-assignment
+    ops.push({ op, path: '/owner', value: owner });
+
+    // Patch the task with the new owner
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Task assigned',
+      });
+      onChange(result);
+    } catch {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: 'Another user modified the task.',
+      });
+    }
+  };
+
+  const onQuestionnaireSubmit = (formData: QuestionnaireResponse): void => {
+    const owner = getQuestionnaireAnswers(formData)['owner'].valueReference;
+
+    if (owner) {
+      handleAssignTask(owner, props.task, medplum, props.onChange).catch((error) => console.error(error));
+    }
+
+    close();
+  };
+
+  return (
+    <div>
+      <Button fullWidth onClick={toggle}>
+        {props.task.owner ? 'Reassign Task' : 'Assign Task'}
+      </Button>
+      <Modal opened={opened} onClose={close}>
+        <QuestionnaireForm questionnaire={assignTaskQuestionnaire} onSubmit={onQuestionnaireSubmit} />
+      </Modal>
+    </div>
+  );
+}
+
+const assignTaskQuestionnaire: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'active',
+  id: 'assign-task',
+  title: 'Assign Owner to the Task',
+  item: [
+    {
+      linkId: 'owner',
+      text: 'Owner',
+      type: 'reference',
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-referenceResource',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/fhir-types',
+                display: 'Practitioner',
+                code: 'Practitioner',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/examples/medplum-provider/src/components/tasks/actions/ClaimTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/ClaimTask.tsx
@@ -1,0 +1,64 @@
+import { Button, Group, Modal, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { createReference, MedplumClient, PatchOperation } from '@medplum/core';
+import { Practitioner, Task } from '@medplum/fhirtypes';
+import { useMedplum, useMedplumProfile } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface ClaimTaskProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function ClaimTask(props: ClaimTaskProps): JSX.Element {
+  const medplum = useMedplum();
+  const currentUser = useMedplumProfile() as Practitioner;
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleClaimTask = async (task: Task, medplum: MedplumClient, onChange: (task: Task) => void): Promise<void> => {
+    const taskId = task.id as string;
+
+    // Create a patch operation to update the owner to the current user. For more details on task assignment, see https://www.medplum.com/docs/careplans/tasks#task-assignment
+    // We use a patch operation here to avoid race conditions. This ensures that if multiple users try to claim the task simultaneously, only one will be successful.
+    const ops: PatchOperation[] = [
+      { op: 'test', path: '/meta/versionId', value: task.meta?.versionId },
+      { op: 'add', path: '/owner', value: createReference(currentUser) },
+    ];
+
+    // Patch the task with the current user as the new owner
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Task claimed',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: 'Another user modified this task.',
+      });
+    }
+
+    close();
+  };
+
+  return (
+    <div>
+      <Button fullWidth onClick={toggle}>
+        Claim Task
+      </Button>
+      <Modal opened={opened} onClose={close}>
+        <Text fw={700}>Are you sure you want to assign this task to yourself?</Text>
+        <Group>
+          <Button onClick={() => handleClaimTask(props.task, medplum, props.onChange)}>Claim</Button>
+          <Button variant="outline">Cancel</Button>
+        </Group>
+      </Modal>
+    </div>
+  );
+}

--- a/examples/medplum-provider/src/components/tasks/actions/ClaimTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/ClaimTask.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, Modal, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { createReference, MedplumClient, PatchOperation } from '@medplum/core';
+import { createReference, PatchOperation } from '@medplum/core';
 import { Practitioner, Task } from '@medplum/fhirtypes';
 import { useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
@@ -14,9 +14,9 @@ interface ClaimTaskProps {
 export function ClaimTask(props: ClaimTaskProps): JSX.Element {
   const medplum = useMedplum();
   const currentUser = useMedplumProfile() as Practitioner;
-  const [opened, { toggle, close }] = useDisclosure(false);
+  const [opened, { open, close }] = useDisclosure(false);
 
-  const handleClaimTask = async (task: Task, medplum: MedplumClient, onChange: (task: Task) => void): Promise<void> => {
+  const handleClaimTask = async (task: Task, onChange: (task: Task) => void): Promise<void> => {
     const taskId = task.id as string;
 
     // Create a patch operation to update the owner to the current user. For more details on task assignment, see https://www.medplum.com/docs/careplans/tasks#task-assignment
@@ -49,14 +49,18 @@ export function ClaimTask(props: ClaimTaskProps): JSX.Element {
 
   return (
     <div>
-      <Button fullWidth onClick={toggle}>
+      <Button fullWidth onClick={open}>
         Claim Task
       </Button>
       <Modal opened={opened} onClose={close}>
-        <Text fw={700}>Are you sure you want to assign this task to yourself?</Text>
-        <Group>
-          <Button onClick={() => handleClaimTask(props.task, medplum, props.onChange)}>Claim</Button>
-          <Button variant="outline">Cancel</Button>
+        <Text fw={500} size="lg">
+          Assign this task to yourself?
+        </Text>
+        <Group justify="flex-end" mt="xl" gap="xs">
+          <Button variant="outline" onClick={close}>
+            Cancel
+          </Button>
+          <Button onClick={() => handleClaimTask(props.task, props.onChange)}>Claim</Button>
         </Group>
       </Modal>
     </div>

--- a/examples/medplum-provider/src/components/tasks/actions/CompleteTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/CompleteTask.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { PatchOperation } from '@medplum/core';
+import { Task } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface CompleteTaskProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function CompleteTask({ task, onChange }: CompleteTaskProps): JSX.Element {
+  const medplum = useMedplum();
+  const handleCompleteTask = async (): Promise<void> => {
+    const taskId = task.id as string;
+
+    const ops: PatchOperation[] = [
+      { op: 'test', path: '/meta/versionId', value: task.meta?.versionId },
+      { op: 'replace', path: '/status', value: 'completed' },
+    ];
+
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: ops[1].value === 'on-hold' ? 'Task paused' : 'Task resumed',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: 'Another user modified this task.',
+      });
+    }
+  };
+
+  return (
+    <div>
+      {task.status === 'completed' ? null : (
+        <Button fullWidth onClick={handleCompleteTask}>
+          Complete Task
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/examples/medplum-provider/src/components/tasks/actions/CompleteTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/CompleteTask.tsx
@@ -4,13 +4,14 @@ import { PatchOperation } from '@medplum/core';
 import { Task } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+import { ReactNode } from 'react';
 
 interface CompleteTaskProps {
   readonly task: Task;
   readonly onChange: (updatedTask: Task) => void;
 }
 
-export function CompleteTask({ task, onChange }: CompleteTaskProps): JSX.Element {
+export function CompleteTask({ task, onChange }: CompleteTaskProps): ReactNode {
   const medplum = useMedplum();
   const handleCompleteTask = async (): Promise<void> => {
     const taskId = task.id as string;
@@ -39,12 +40,12 @@ export function CompleteTask({ task, onChange }: CompleteTaskProps): JSX.Element
   };
 
   return (
-    <div>
-      {task.status === 'completed' ? null : (
+    task.status !== 'completed' && (
+      <div>
         <Button fullWidth onClick={handleCompleteTask}>
           Complete Task
         </Button>
-      )}
-    </div>
+      </div>
+    )
   );
 }

--- a/examples/medplum-provider/src/components/tasks/actions/DeleteTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/DeleteTask.tsx
@@ -1,0 +1,63 @@
+import { Alert, Button, Group, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { MedplumClient, normalizeErrorString } from '@medplum/core';
+import { Task } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import { IconAlertCircle, IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+import { NavigateFunction, useNavigate } from 'react-router-dom';
+
+interface DeleteTaskProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function DeleteTask(props: DeleteTaskProps): JSX.Element {
+  const medplum = useMedplum();
+  const navigate = useNavigate();
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleDelete = async (task: Task, medplum: MedplumClient, navigate: NavigateFunction): Promise<void> => {
+    // Get the task id
+    const taskId = task.id as string;
+
+    try {
+      // Delete the task and navigate back to the main page
+      await medplum.deleteResource('Task', taskId);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Task deleted',
+      });
+      navigate('/Task');
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: normalizeErrorString(error),
+      });
+    }
+  };
+
+  return (
+    <div>
+      <Button fullWidth onClick={toggle} color="red">
+        Delete Task
+      </Button>
+      <Modal opened={opened} onClose={close} withCloseButton={false}>
+        <Alert color="red" title="Warning" icon={<IconAlertCircle />}>
+          Are you sure you want to delete this task?
+          <Group>
+            <Button onClick={() => handleDelete(props.task, medplum, navigate)} color="red">
+              Yes, Delete
+            </Button>
+            <Button onClick={close} color="red" variant="outline">
+              Cancel
+            </Button>
+          </Group>
+        </Alert>
+      </Modal>
+    </div>
+  );
+}

--- a/examples/medplum-provider/src/components/tasks/actions/DeleteTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/DeleteTask.tsx
@@ -5,31 +5,26 @@ import { normalizeErrorString } from '@medplum/core';
 import { Task } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
-import { NavigateFunction, useNavigate } from 'react-router-dom';
 
 interface DeleteTaskProps {
   readonly task: Task;
-  readonly onChange: (updatedTask: Task) => void;
+  readonly onDeleted: () => void;
 }
 
 export function DeleteTask(props: DeleteTaskProps): JSX.Element {
   const medplum = useMedplum();
-  const navigate = useNavigate();
   const [opened, { open, close }] = useDisclosure(false);
 
-  const handleDelete = async (task: Task, navigate: NavigateFunction): Promise<void> => {
-    // Get the task id
-    const taskId = task.id as string;
-
+  const handleDelete = async (task: Task): Promise<void> => {
     try {
       // Delete the task and navigate back to task list
-      await medplum.deleteResource('Task', taskId);
+      await medplum.deleteResource('Task', task.id as string);
       notifications.show({
         icon: <IconCircleCheck />,
         title: 'Success',
         message: 'Task deleted',
       });
-      navigate('..', { relative: 'path' });
+      props.onDeleted();
     } catch (error) {
       notifications.show({
         color: 'red',
@@ -54,7 +49,7 @@ export function DeleteTask(props: DeleteTaskProps): JSX.Element {
             <Button onClick={close} color="red" variant="outline">
               Cancel
             </Button>
-            <Button onClick={() => handleDelete(props.task, navigate)} color="red">
+            <Button onClick={() => handleDelete(props.task)} color="red">
               Yes, delete
             </Button>
           </Group>

--- a/examples/medplum-provider/src/components/tasks/actions/DeleteTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/DeleteTask.tsx
@@ -1,10 +1,10 @@
-import { Alert, Button, Group, Modal } from '@mantine/core';
+import { Alert, Button, Group, Modal, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { notifications } from '@mantine/notifications';
-import { MedplumClient, normalizeErrorString } from '@medplum/core';
+import { normalizeErrorString } from '@medplum/core';
 import { Task } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react';
-import { IconAlertCircle, IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 
 interface DeleteTaskProps {
@@ -15,21 +15,21 @@ interface DeleteTaskProps {
 export function DeleteTask(props: DeleteTaskProps): JSX.Element {
   const medplum = useMedplum();
   const navigate = useNavigate();
-  const [opened, { toggle, close }] = useDisclosure(false);
+  const [opened, { open, close }] = useDisclosure(false);
 
-  const handleDelete = async (task: Task, medplum: MedplumClient, navigate: NavigateFunction): Promise<void> => {
+  const handleDelete = async (task: Task, navigate: NavigateFunction): Promise<void> => {
     // Get the task id
     const taskId = task.id as string;
 
     try {
-      // Delete the task and navigate back to the main page
+      // Delete the task and navigate back to task list
       await medplum.deleteResource('Task', taskId);
       notifications.show({
         icon: <IconCircleCheck />,
         title: 'Success',
         message: 'Task deleted',
       });
-      navigate('/Task');
+      navigate('..', { relative: 'path' });
     } catch (error) {
       notifications.show({
         color: 'red',
@@ -42,18 +42,20 @@ export function DeleteTask(props: DeleteTaskProps): JSX.Element {
 
   return (
     <div>
-      <Button fullWidth onClick={toggle} color="red">
+      <Button fullWidth onClick={open} color="red">
         Delete Task
       </Button>
-      <Modal opened={opened} onClose={close} withCloseButton={false}>
-        <Alert color="red" title="Warning" icon={<IconAlertCircle />}>
-          Are you sure you want to delete this task?
-          <Group>
-            <Button onClick={() => handleDelete(props.task, medplum, navigate)} color="red">
-              Yes, Delete
-            </Button>
+      <Modal opened={opened} onClose={close}>
+        <Alert color="red">
+          <Text size="lg" fw={500} c="red">
+            Are you sure you want to delete this task?
+          </Text>
+          <Group justify="flex-end" mt="xl" gap="xs">
             <Button onClick={close} color="red" variant="outline">
               Cancel
+            </Button>
+            <Button onClick={() => handleDelete(props.task, navigate)} color="red">
+              Yes, delete
             </Button>
           </Group>
         </Alert>

--- a/examples/medplum-provider/src/components/tasks/actions/PauseResumeTask.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/PauseResumeTask.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@mantine/core';
+import { notifications } from '@mantine/notifications';
+import { PatchOperation } from '@medplum/core';
+import { Task } from '@medplum/fhirtypes';
+import { useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface PauseResumeTaskProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function PauseResumeTask({ task, onChange }: PauseResumeTaskProps): JSX.Element {
+  const medplum = useMedplum();
+  const handleChangeTaskStatus = async (): Promise<void> => {
+    const taskId = task.id as string;
+
+    // We use a patch operation here to avoid race conditions. This ensures that if multiple users try to update the status simultaneously, only one will be successful.
+    const ops: PatchOperation[] = [{ op: 'test', path: '/meta/versionId', value: task.meta?.versionId }];
+
+    // If the task is paused, resume it, otherwise pause it
+    const value: PatchOperation['value'] = task.status === 'on-hold' ? 'in-progress' : 'on-hold';
+    ops.push({ op: 'replace', path: '/status', value });
+
+    // Patch the task with the updated status
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: ops[1].value === 'on-hold' ? 'Task paused' : 'Task resumed',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: 'Another user modified this task.',
+      });
+    }
+  };
+
+  return (
+    <div>
+      {task.status === 'on-hold' ? (
+        <Button fullWidth onClick={handleChangeTaskStatus}>
+          Resume Task
+        </Button>
+      ) : (
+        <Button fullWidth onClick={handleChangeTaskStatus}>
+          Pause Task
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/examples/medplum-provider/src/components/tasks/actions/TaskActions.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/TaskActions.tsx
@@ -1,0 +1,42 @@
+import { Stack, Title } from '@mantine/core';
+import { Task } from '@medplum/fhirtypes';
+import { Loading, useResource } from '@medplum/react';
+import { AddNote } from './AddNote';
+import { AddDueDate } from './AddDueDate';
+import { UpdateBusinessStatus } from './UpdateBusinessStatus';
+import { AssignTask } from './AssignTask';
+import { AssignRole } from './AssignRole';
+import { ClaimTask } from './ClaimTask';
+import { DeleteTask } from './DeleteTask';
+import { PauseResumeTask } from './PauseResumeTask';
+import { CompleteTask } from './CompleteTask';
+
+interface TaskActionsProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function TaskActions(props: TaskActionsProps): JSX.Element {
+  const task = useResource(props.task);
+
+  if (!task) {
+    return <Loading />;
+  }
+
+  return (
+    <Stack>
+      <Title>Task Actions</Title>
+      <Stack>
+        <AddNote task={task} onChange={props.onChange} />
+        <AddDueDate task={task} onChange={props.onChange} />
+        <UpdateBusinessStatus task={task} onChange={props.onChange} />
+        <AssignTask task={task} onChange={props.onChange} />
+        <AssignRole task={task} onChange={props.onChange} />
+        {!task.owner ? <ClaimTask task={task} onChange={props.onChange} /> : null}
+        <PauseResumeTask task={task} onChange={props.onChange} />
+        <CompleteTask task={task} onChange={props.onChange} />
+        <DeleteTask task={task} onChange={props.onChange} />
+      </Stack>
+    </Stack>
+  );
+}

--- a/examples/medplum-provider/src/components/tasks/actions/TaskActions.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/TaskActions.tsx
@@ -14,6 +14,7 @@ import { CompleteTask } from './CompleteTask';
 interface TaskActionsProps {
   readonly task: Task;
   readonly onChange: (updatedTask: Task) => void;
+  readonly onDeleted: () => void;
 }
 
 export function TaskActions(props: TaskActionsProps): JSX.Element {
@@ -35,7 +36,7 @@ export function TaskActions(props: TaskActionsProps): JSX.Element {
         {!task.owner ? <ClaimTask task={task} onChange={props.onChange} /> : null}
         <PauseResumeTask task={task} onChange={props.onChange} />
         <CompleteTask task={task} onChange={props.onChange} />
-        <DeleteTask task={task} onChange={props.onChange} />
+        <DeleteTask task={task} onDeleted={props.onDeleted} />
       </Stack>
     </Stack>
   );

--- a/examples/medplum-provider/src/components/tasks/actions/UpdateBusinessStatus.tsx
+++ b/examples/medplum-provider/src/components/tasks/actions/UpdateBusinessStatus.tsx
@@ -1,0 +1,89 @@
+import { Button, Modal } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { notifications } from '@mantine/notifications';
+import { getQuestionnaireAnswers, MedplumClient, normalizeErrorString, PatchOperation } from '@medplum/core';
+import { CodeableConcept, Coding, Questionnaire, QuestionnaireResponse, Task } from '@medplum/fhirtypes';
+import { QuestionnaireForm, useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+
+interface UpdateBusinessStatusProps {
+  readonly task: Task;
+  readonly onChange: (updatedTask: Task) => void;
+}
+
+export function UpdateBusinessStatus(props: UpdateBusinessStatusProps): JSX.Element {
+  const medplum = useMedplum();
+  const [opened, { toggle, close }] = useDisclosure(false);
+
+  const handleUpdateStatus = async (
+    status: Coding,
+    task: Task,
+    medplum: MedplumClient,
+    onChange: (task: Task) => void
+  ): Promise<void> => {
+    const taskId = task.id as string;
+
+    // Create a businessStatus to add to the task. For more details, see https://www.medplum.com/docs/careplans/tasks#task-status
+    const businessStatus: CodeableConcept = { coding: [status] };
+
+    // We use a patch operation here to avoid race conditions. This ensures that if multiple users try to update the status simultaneously, only one will be successful.
+    const ops: PatchOperation[] = [{ op: 'test', path: '/meta/versionId', value: task.meta?.versionId }];
+    const op: PatchOperation['op'] = task.businessStatus ? 'replace' : 'add';
+
+    ops.push({ op, path: '/businessStatus', value: businessStatus });
+
+    // Patch the task with the new businessStatus
+    try {
+      const result = await medplum.patchResource('Task', taskId, ops);
+      notifications.show({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Status updated.',
+      });
+      onChange(result);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: normalizeErrorString(error),
+      });
+    }
+  };
+
+  const onQuestionnaireSubmit = (formData: QuestionnaireResponse): void => {
+    const status = getQuestionnaireAnswers(formData)['update-status'].valueCoding;
+
+    if (status) {
+      handleUpdateStatus(status, props.task, medplum, props.onChange).catch((error) => console.error(error));
+    }
+
+    close();
+  };
+
+  return (
+    <div>
+      <Button fullWidth onClick={toggle}>
+        Update Business Status
+      </Button>
+      <Modal opened={opened} onClose={close}>
+        <QuestionnaireForm questionnaire={updateStatusQuestionnaire} onSubmit={onQuestionnaireSubmit} />
+      </Modal>
+    </div>
+  );
+}
+
+const updateStatusQuestionnaire: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'active',
+  id: 'update-status',
+  title: 'Update the Status of the Task',
+  item: [
+    {
+      linkId: 'update-status',
+      text: 'Update Status',
+      type: 'choice',
+      answerValueSet: 'https://medplum.com/medplum-task-example-app/task-status',
+    },
+  ],
+};

--- a/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
@@ -13,20 +13,18 @@ export function prependPatientPath(patient: Patient | undefined, path: string): 
 }
 
 export function formatPatientPageTabUrl(patientId: string, tab: PatientPageTabInfo): string {
-  return `${patientPathPrefix(patientId)}/${tab.url}${tab.search ? '?' + tab.search.replace('%patient.id', patientId) : ''}`;
+  return `${patientPathPrefix(patientId)}/${tab.url.replace('%patient.id', patientId)}`;
 }
 
 export type PatientPageTabInfo = {
   id: string;
   url: string;
-  search?: string;
   label: string;
 };
 
 export const TasksTab: PatientPageTabInfo = {
   id: 'tasks',
-  url: 'Task',
-  search: '_fields=_lastUpdated,code,status,focus&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+  url: 'Task?_fields=_lastUpdated,code,status,focus&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
   label: 'Tasks',
 };
 
@@ -34,50 +32,41 @@ export const PatientPageTabs: PatientPageTabInfo[] = [
   { id: 'timeline', url: '', label: 'Timeline' },
   { id: 'edit', url: 'edit', label: 'Edit' },
   { id: 'encounter', url: 'encounter', label: 'Encounter' },
-  { id: 'communication', url: 'communication', label: 'Communications' },
   TasksTab,
   {
     id: 'meds',
-    url: 'MedicationRequest',
-    search: '_fields=medication[x],intent,status&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    url: 'MedicationRequest?_fields=medication[x],intent,status&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
     label: 'Meds',
   },
   {
     id: 'labs',
-    url: 'ServiceRequest',
-    search:
-      '_fields=_lastUpdated,code,status,orderDetail,category&_offset=0&_sort=-_lastUpdated&category=108252007&patient=%patient.id',
+    url: 'ServiceRequest?_fields=_lastUpdated,code,status,orderDetail,category&_offset=0&_sort=-_lastUpdated&category=108252007&patient=%patient.id',
     label: 'Labs',
   },
   {
     id: 'devices',
-    url: 'Device',
-    search:
-      '_fields=manufacturer,deviceName,status,distinctIdentifier,serialNumber&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    url: 'Device?_fields=manufacturer,deviceName,status,distinctIdentifier,serialNumber&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
     label: 'Devices',
   },
   {
     id: 'diagnosticreports',
-    url: 'DiagnosticReport',
-    search: '_fields=_lastUpdated,category,code,status&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    url: 'DiagnosticReport?_fields=_lastUpdated,category,code,status&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
     label: 'Reports',
   },
   {
     id: 'documentreference',
-    url: 'DocumentReference',
-    search: '_fields=_lastUpdated,category,type,status,author&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    url: 'DocumentReference?_fields=_lastUpdated,category,type,status,author&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
     label: 'Documents',
   },
   {
     id: 'appointments',
-    url: 'Appointment',
-    search: '_fields=_lastUpdated,category,type,status,author&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    url: 'Appointment?_fields=_lastUpdated,category,type,status,author&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
     label: 'Appointments',
   },
   {
     id: 'careplan',
-    url: 'CarePlan',
-    search: '_fields=_lastUpdated,status,intent,category,period&_sort=-_lastUpdated&patient=%patient.id',
+    url: 'CarePlan?_fields=_lastUpdated,status,intent,category,period&_sort=-_lastUpdated&patient=%patient.id',
     label: 'Care Plans',
   },
+  { id: 'communication', url: 'communication', label: 'Communications' },
 ];

--- a/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.utils.ts
@@ -11,3 +11,73 @@ export function prependPatientPath(patient: Patient | undefined, path: string): 
 
   return path;
 }
+
+export function formatPatientPageTabUrl(patientId: string, tab: PatientPageTabInfo): string {
+  return `${patientPathPrefix(patientId)}/${tab.url}${tab.search ? '?' + tab.search.replace('%patient.id', patientId) : ''}`;
+}
+
+export type PatientPageTabInfo = {
+  id: string;
+  url: string;
+  search?: string;
+  label: string;
+};
+
+export const TasksTab: PatientPageTabInfo = {
+  id: 'tasks',
+  url: 'Task',
+  search: '_fields=_lastUpdated,code,status,focus&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+  label: 'Tasks',
+};
+
+export const PatientPageTabs: PatientPageTabInfo[] = [
+  { id: 'timeline', url: '', label: 'Timeline' },
+  { id: 'edit', url: 'edit', label: 'Edit' },
+  { id: 'encounter', url: 'encounter', label: 'Encounter' },
+  { id: 'communication', url: 'communication', label: 'Communications' },
+  TasksTab,
+  {
+    id: 'meds',
+    url: 'MedicationRequest',
+    search: '_fields=medication[x],intent,status&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    label: 'Meds',
+  },
+  {
+    id: 'labs',
+    url: 'ServiceRequest',
+    search:
+      '_fields=_lastUpdated,code,status,orderDetail,category&_offset=0&_sort=-_lastUpdated&category=108252007&patient=%patient.id',
+    label: 'Labs',
+  },
+  {
+    id: 'devices',
+    url: 'Device',
+    search:
+      '_fields=manufacturer,deviceName,status,distinctIdentifier,serialNumber&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    label: 'Devices',
+  },
+  {
+    id: 'diagnosticreports',
+    url: 'DiagnosticReport',
+    search: '_fields=_lastUpdated,category,code,status&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    label: 'Reports',
+  },
+  {
+    id: 'documentreference',
+    url: 'DocumentReference',
+    search: '_fields=_lastUpdated,category,type,status,author&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    label: 'Documents',
+  },
+  {
+    id: 'appointments',
+    url: 'Appointment',
+    search: '_fields=_lastUpdated,category,type,status,author&_offset=0&_sort=-_lastUpdated&patient=%patient.id',
+    label: 'Appointments',
+  },
+  {
+    id: 'careplan',
+    url: 'CarePlan',
+    search: '_fields=_lastUpdated,status,intent,category,period&_sort=-_lastUpdated&patient=%patient.id',
+    label: 'Care Plans',
+  },
+];

--- a/examples/medplum-provider/src/pages/patient/PatientSearchPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientSearchPage.tsx
@@ -1,6 +1,5 @@
 import { Paper } from '@mantine/core';
 import { DEFAULT_SEARCH_COUNT, formatSearchQuery, parseSearchRequest, SearchRequest } from '@medplum/core';
-import { Patient } from '@medplum/fhirtypes';
 import { Loading, MemoizedSearchControl, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -23,7 +22,7 @@ export function PatientSearchPage(): JSX.Element {
     }
 
     const parsedSearch = parseSearchRequest(location.pathname + location.search);
-    const populatedSearch = addSearchValues(patient, parsedSearch);
+    const populatedSearch = addDefaultSearchValues(parsedSearch);
 
     if (
       location.pathname === `/Patient/${patient.id}/${populatedSearch.resourceType}` &&
@@ -57,19 +56,13 @@ export function PatientSearchPage(): JSX.Element {
   );
 }
 
-function addSearchValues(patient: Patient, search: SearchRequest): SearchRequest {
-  const resourceType = search.resourceType;
+function addDefaultSearchValues(search: SearchRequest): SearchRequest {
   const fields = search.fields ?? ['_id', '_lastUpdated'];
-  const filters = search.filters ?? [];
-  const sortRules = search.sortRules;
   const offset = search.offset ?? 0;
   const count = search.count ?? DEFAULT_SEARCH_COUNT;
   return {
     ...search,
-    resourceType,
     fields,
-    filters,
-    sortRules,
     offset,
     count,
   };

--- a/examples/medplum-provider/src/pages/patient/TaskTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/TaskTab.tsx
@@ -1,0 +1,148 @@
+import { Blockquote, Group, Paper, Stack, Tabs, Title } from '@mantine/core';
+import { formatCodeableConcept, getDisplayString } from '@medplum/core';
+import { Annotation, Task } from '@medplum/fhirtypes';
+import { Container, DefaultResourceTimeline, Document, ResourceTable, useResource } from '@medplum/react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { TaskActions } from '../../components/tasks/actions/TaskActions';
+
+const tabs = ['Details', 'Timeline', 'Notes'];
+
+export function TaskTab(): JSX.Element {
+  // const medplum = useMedplum();
+  const navigate = useNavigate();
+  // const navigate = useMedplumNavigate();
+  const { id } = useParams() as { id: string };
+  const task = useResource<Task>({ reference: `Task/${id}` });
+  // const [task, setTask] = useState<Task | undefined>(undefined);
+
+  // Set the current tab to what is in the URL, otherwise default to 'Details'
+  const tab = window.location.pathname.split('/').pop();
+  const currentTab = tab && tabs.map((t) => t.toLowerCase()).includes(tab) ? tab : tabs[0].toLowerCase();
+
+  // useEffect(() => {
+  // //Fetch the task that is specified in the URL
+  // const fetchTask = async (): Promise<void> => {
+  // try {
+  // const taskData = await medplum.readResource('Task', id);
+  // setTask(taskData);
+  // } catch (error) {
+  // console.error(error);
+  // }
+  // };
+  //
+  // fetchTask().catch((error) => console.error(error));
+  // }, [medplum, id]);
+
+  // Update the current tab and navigate to its URL
+  const handleTabChange = (newTab: string | null): void => {
+    console.log('newTab:', newTab);
+    navigate(`./${newTab}`);
+  };
+
+  const onTaskChange = (updatedTask: Task): void => {
+    console.log('updatedTask:', JSON.stringify(updatedTask));
+    // setTask(updatedTask);
+  };
+
+  if (!task) {
+    return <Document>No Task found</Document>;
+  }
+
+  return (
+    <Container size="none">
+      <Group mt="md" align="flex-start">
+        <Paper flex={1} maw={600} p="md" key={task?.id ?? 'loading'}>
+          <TaskDetails task={task} tabs={tabs} currentTab={currentTab} handleTabChange={handleTabChange} />
+        </Paper>
+        <Paper p="md" w={250}>
+          <TaskActions task={task} onChange={onTaskChange} />
+        </Paper>
+      </Group>
+    </Container>
+  );
+}
+
+interface TaskDetailsProps {
+  readonly task: Task;
+  readonly tabs: string[];
+  readonly currentTab: string;
+  readonly handleTabChange: (newTab: string | null) => void;
+}
+
+function TaskDetails({ task, tabs, currentTab, handleTabChange }: TaskDetailsProps): JSX.Element {
+  return (
+    <>
+      <Title>{task.code ? formatCodeableConcept(task.code) : getDisplayString(task)}</Title>
+      <Tabs value={currentTab.toLowerCase()} onChange={handleTabChange}>
+        <Tabs.List style={{ whiteSpace: 'nowrap', flexWrap: 'nowrap' }}>
+          {tabs.map((tab) => (
+            <Tabs.Tab key={tab} value={tab.toLowerCase()}>
+              {tab}
+            </Tabs.Tab>
+          ))}
+        </Tabs.List>
+        <Tabs.Panel value="details">
+          <ResourceTable key={`Task/${task.id}`} value={task} ignoreMissingValues={true} />
+        </Tabs.Panel>
+        <Tabs.Panel value="timeline">
+          <DefaultResourceTimeline resource={task} />
+        </Tabs.Panel>
+        <Tabs.Panel value="notes">
+          <NotesPage task={task} />
+        </Tabs.Panel>
+      </Tabs>
+    </>
+  );
+}
+
+export interface NotesPageProps {
+  readonly task: Task;
+}
+
+export function NotesPage(props: NotesPageProps): JSX.Element {
+  const notes = props.task.note;
+
+  if (!notes) {
+    return (
+      <div>
+        <p>No Notes</p>
+      </div>
+    );
+  }
+
+  // Sort notes so the most recent are at the top of the page
+  const sortedNotes = sortNotesByTime(notes);
+
+  // Display if the task does not have any notes
+
+  return (
+    <Document>
+      <Stack>
+        {sortedNotes.map(
+          (note) =>
+            note.text && (
+              <Blockquote
+                key={`note-${note.text}`}
+                cite={`${note.authorReference?.display || note.authorString} – ${note.time?.slice(0, 10)}`}
+                icon={null}
+              >
+                {note.text}
+              </Blockquote>
+            )
+        )}
+      </Stack>
+    </Document>
+  );
+}
+
+function sortNotesByTime(notes: Annotation[]): Annotation[] {
+  const compareTimes = (a: Annotation, b: Annotation): number => {
+    const timeA = new Date(a.time || 0).getTime();
+    const timeB = new Date(b.time || 0).getTime();
+
+    return timeB - timeA;
+  };
+
+  const sortedNotes = notes.sort(compareTimes);
+  return sortedNotes;
+}

--- a/examples/medplum-provider/src/pages/patient/TaskTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/TaskTab.tsx
@@ -1,47 +1,45 @@
-import { Blockquote, Group, Paper, Stack, Tabs, Title } from '@mantine/core';
+import { Blockquote, Group, Paper, Stack, Tabs, Title, Text } from '@mantine/core';
 import { formatCodeableConcept, getDisplayString } from '@medplum/core';
 import { Annotation, Task } from '@medplum/fhirtypes';
-import { Container, DefaultResourceTimeline, Document, ResourceTable, useResource } from '@medplum/react';
+import { Container, DefaultResourceTimeline, Document, ResourceTable, useMedplum } from '@medplum/react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TaskActions } from '../../components/tasks/actions/TaskActions';
+import { useEffect, useState } from 'react';
 
 const tabs = ['Details', 'Timeline', 'Notes'];
 
 export function TaskTab(): JSX.Element {
-  // const medplum = useMedplum();
+  const medplum = useMedplum();
   const navigate = useNavigate();
-  // const navigate = useMedplumNavigate();
   const { id } = useParams() as { id: string };
-  const task = useResource<Task>({ reference: `Task/${id}` });
-  // const [task, setTask] = useState<Task | undefined>(undefined);
+  const [task, setTask] = useState<Task | undefined>(undefined);
 
   // Set the current tab to what is in the URL, otherwise default to 'Details'
   const tab = window.location.pathname.split('/').pop();
   const currentTab = tab && tabs.map((t) => t.toLowerCase()).includes(tab) ? tab : tabs[0].toLowerCase();
 
-  // useEffect(() => {
-  // //Fetch the task that is specified in the URL
-  // const fetchTask = async (): Promise<void> => {
-  // try {
-  // const taskData = await medplum.readResource('Task', id);
-  // setTask(taskData);
-  // } catch (error) {
-  // console.error(error);
-  // }
-  // };
-  //
-  // fetchTask().catch((error) => console.error(error));
-  // }, [medplum, id]);
+  useEffect(() => {
+    const fetchTask = async (): Promise<void> => {
+      try {
+        const taskData = await medplum.readResource('Task', id);
+        setTask(taskData);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchTask().catch((error) => console.error(error));
+  }, [medplum, id]);
 
   // Update the current tab and navigate to its URL
   const handleTabChange = (newTab: string | null): void => {
     console.log('newTab:', newTab);
-    navigate(`./${newTab}`);
+    navigate(`./${newTab}`, { relative: 'path' });
   };
 
   const onTaskChange = (updatedTask: Task): void => {
-    console.log('updatedTask:', JSON.stringify(updatedTask));
-    // setTask(updatedTask);
+    // console.log('updatedTask:', JSON.stringify(updatedTask));
+    setTask(updatedTask);
   };
 
   if (!task) {
@@ -74,7 +72,7 @@ function TaskDetails({ task, tabs, currentTab, handleTabChange }: TaskDetailsPro
     <>
       <Title>{task.code ? formatCodeableConcept(task.code) : getDisplayString(task)}</Title>
       <Tabs value={currentTab.toLowerCase()} onChange={handleTabChange}>
-        <Tabs.List style={{ whiteSpace: 'nowrap', flexWrap: 'nowrap' }}>
+        <Tabs.List my="md" style={{ whiteSpace: 'nowrap', flexWrap: 'nowrap' }}>
           {tabs.map((tab) => (
             <Tabs.Tab key={tab} value={tab.toLowerCase()}>
               {tab}
@@ -103,11 +101,7 @@ export function NotesPage(props: NotesPageProps): JSX.Element {
   const notes = props.task.note;
 
   if (!notes) {
-    return (
-      <div>
-        <p>No Notes</p>
-      </div>
-    );
+    return <Text>No Notes</Text>;
   }
 
   // Sort notes so the most recent are at the top of the page

--- a/examples/medplum-provider/src/pages/patient/TaskTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/TaskTab.tsx
@@ -5,13 +5,14 @@ import { Container, DefaultResourceTimeline, Document, ResourceTable, useMedplum
 import { useNavigate, useParams } from 'react-router-dom';
 import { TaskActions } from '../../components/tasks/actions/TaskActions';
 import { useEffect, useState } from 'react';
+import { TasksTab, formatPatientPageTabUrl } from './PatientPage.utils';
 
 const tabs = ['Details', 'Timeline', 'Notes'];
 
 export function TaskTab(): JSX.Element {
   const medplum = useMedplum();
   const navigate = useNavigate();
-  const { id } = useParams() as { id: string };
+  const { patientId, id } = useParams() as { patientId: string; id: string };
   const [task, setTask] = useState<Task | undefined>(undefined);
 
   // Set the current tab to what is in the URL, otherwise default to 'Details'
@@ -38,8 +39,11 @@ export function TaskTab(): JSX.Element {
   };
 
   const onTaskChange = (updatedTask: Task): void => {
-    // console.log('updatedTask:', JSON.stringify(updatedTask));
     setTask(updatedTask);
+  };
+
+  const onTaskDeleted = (): void => {
+    navigate(formatPatientPageTabUrl(patientId, TasksTab));
   };
 
   if (!task) {
@@ -53,7 +57,7 @@ export function TaskTab(): JSX.Element {
           <TaskDetails task={task} tabs={tabs} currentTab={currentTab} handleTabChange={handleTabChange} />
         </Paper>
         <Paper p="md" w={250}>
-          <TaskActions task={task} onChange={onTaskChange} />
+          <TaskActions task={task} onChange={onTaskChange} onDeleted={onTaskDeleted} />
         </Paper>
       </Group>
     </Container>


### PR DESCRIPTION
* I was almost entirely able to copy/paste in components from `examples/medplum-task-demo` and use them as is.
* I cleaned up and normalized the styling of some of the modals shown for various task actions to be consistent with the styling in the other modals which are derived from `QuestionnaireForm`. I have NOT back-ported those to `examples/medplum-task-demo`. If that's desirable, we should make an issue for it. It's a bit unfortunate that we'll have duplicate code in separate examples that'll start drifting apart over time...
* Some complexity had to be added when deleting a task to correctly wind up back at list view of a patient's task with the correct search parameters set, e.g. `/Patient/6391816a-5fc9-405f-9097-b51c2ca9315c/Task?_count=20&_fields=_lastUpdated,code,status,focus&_offset=0&_sort=-_lastUpdated&patient=6391816a-5fc9-405f-9097-b51c2ca9315c`.

### Task detail view:
![Screenshot 2024-04-29 at 2 19 50 PM](https://github.com/medplum/medplum/assets/933303/dea07a67-4032-48fc-b67b-8f0b72f77a85)

### Updated task actions modals:

#### Claim Task

| Before | After |
|--------|--------|
| ![Screenshot 2024-04-29 at 2 36 00 PM](https://github.com/medplum/medplum/assets/933303/c5545ec9-3694-409d-b8cd-9455c7b2b2e1) | ![Screenshot 2024-04-29 at 3 01 54 PM](https://github.com/medplum/medplum/assets/933303/fcee9230-0eb2-445f-87ed-91efec319c93) |




#### Delete Task
| Before | After |
|--------|--------|
| ![Screenshot 2024-04-29 at 2 36 14 PM](https://github.com/medplum/medplum/assets/933303/18825370-c6ce-42b5-8a31-015a04222c2f) | ![Screenshot 2024-04-29 at 2 30 12 PM](https://github.com/medplum/medplum/assets/933303/10ea6ea4-48b0-4dd0-81c2-cd8a892bf07a) |

### Patient's task list view remains unchanged:
![Screenshot 2024-04-29 at 2 19 31 PM](https://github.com/medplum/medplum/assets/933303/34616219-8263-495d-8361-45f20d1706a4)

Fixes #4249 