### PR TITLE
Fix age display in PatientSummary

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -54,7 +54,7 @@ export type ResourceWithCode = Resource & Code;
 
 /**
  * Creates a reference resource.
- * @param resource - The FHIR reesource.
+ * @param resource - The FHIR resource.
  * @returns A reference resource.
  */
 export function createReference<T extends Resource>(resource: T): Reference<T> {

--- a/packages/react/src/PatientSummary/PatientSummary.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.tsx
@@ -70,9 +70,11 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
       <Text ta="center" fz="lg" fw={500}>
         {formatHumanName(patient.name?.[0] as HumanName)}
       </Text>
-      <Text ta="center" fz="xs" color="dimmed">
-        {patient.birthDate} ({calculateAgeString(patient.birthDate as string)})
-      </Text>
+      {patient.birthDate && (
+        <Text ta="center" fz="xs" c="dimmed">
+          {patient.birthDate} ({calculateAgeString(patient.birthDate)})
+        </Text>
+      )}
       <Paper withBorder p="md" my="md">
         <Group grow>
           <Flex justify="center" align="center" direction="column" gap={0} maw="33%">


### PR DESCRIPTION
Previously, if a patient's birth date wasn't populated, it would be displayed as `NaND` as show below:

<img width="346" alt="Screenshot 2024-04-30 at 11 51 25 AM" src="https://github.com/medplum/medplum/assets/933303/aeea00f0-6b6f-43b2-90ae-095ad15141e4">
