### PR TITLE
Run expand tests against old and new

### DIFF
--- a/packages/server/src/fhir/lookups/valuesetelement.ts
+++ b/packages/server/src/fhir/lookups/valuesetelement.ts
@@ -68,6 +68,14 @@ export class ValueSetElementTable extends LookupTable {
           }
         }
       }
+    } else if (valueSet.expansion?.contains) {
+      for (const concept of valueSet.expansion.contains) {
+        result.push({
+          system: concept.system,
+          code: concept.code,
+          display: concept.display,
+        });
+      }
     }
     return result;
   }

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -288,7 +288,7 @@ describe.each<Partial<Project>>([{ features: [] }, { features: ['terminology'] }
       version: '1',
       content: 'not-present',
     };
-    const superAdminAccessToken = await initTestAuth({ makeSuperAdmin: true });
+    const superAdminAccessToken = await initTestAuth({ superAdmin: true });
 
     // First version of code system
     const res1 = await request(app)

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -352,7 +352,7 @@ describe.each<Partial<Project>>([{ features: [] }, { features: ['terminology'] }
     expect(res6.status).toEqual(200);
   });
 
-  test.only('ValueSet that uses expansion instead of compose', async () => {
+  test('ValueSet that uses expansion instead of compose', async () => {
     const res1 = await request(app)
       .post(`/fhir/R4/ValueSet`)
       .set('Authorization', 'Bearer ' + accessToken)

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -23,7 +23,9 @@ export interface TestProjectOptions {
   project?: Partial<Project>;
   accessPolicy?: Partial<AccessPolicy>;
   membership?: Partial<ProjectMembership>;
-  superAdmin?: boolean;
+  // using `makeSuperAdmin` instead of `superAdmin` to avoid overlap with any properties
+  // of `Project`, `AccessPolicy`, `ProjectMembership`, etc.
+  makeSuperAdmin?: boolean;
   withClient?: boolean;
   withAccessToken?: boolean;
   withRepo?: boolean;
@@ -59,7 +61,7 @@ export async function createTestProject<T extends TestProjectOptions = TestProje
           valueString: 'bar',
         },
       ],
-      superAdmin: options?.superAdmin,
+      superAdmin: options?.makeSuperAdmin,
       ...options?.project,
     });
 
@@ -125,7 +127,7 @@ export async function createTestProject<T extends TestProjectOptions = TestProje
         repo = new Repository({
           projects: [project.id as string],
           author: createReference(client),
-          superAdmin: options?.superAdmin,
+          superAdmin: options?.makeSuperAdmin,
           projectAdmin: options?.membership?.admin,
           accessPolicy,
           strictMode: project.strictMode,


### PR DESCRIPTION
I came across a super subtle bug in our types in [packages/server/src/test.setup.ts](https://github.com/medplum/medplum/blob/939d67dc9bb1c0b83ba03e93d962a1513c2e3d24/packages/server/src/test.setup.ts); related to TestProjectOptions in particular. The first undesired outcome from this that I've discovered so far is that all the tests in packages/server/src/fhir/operations/expand.test.ts that are meant to run against both the old and new implementation are actually running against the old implementation twice.

Here's a TS playground [demonstrating.](https://www.typescriptlang.org/play/?#code/C4TwDgpgBACgTgewFYQMbCgXigbwFBRQCWAJgPwBcUAzsHEQHYDmA3AVAGYQCGwArnAjVKNOoyYBtALptC1PpDgBBEgFtGIgEYIEAGx4M2AXzx5QkKABUhweMjTAA8mGBEEDallzswiFOhEYbjhXbl0AHjt-YAA+WRoFCGU1DSptPQN4gHciYAALAGFdIggGYC0dfW5Ddhz8pVRUIWpLBABrUoqM6uzcvIAlCDAELqqaozY8VHdaKDBg0N0ohyogkKIwyL8HGK8cCdNpjwwANzDSKmtaZfRnVxm933t0Knn1sJvgA6mZjGo8hB8XQkABCEAAkgwzsUSJcbJ87m4PF43otPpM8AB6TFQAAyEGAAHJPLQFlAECcklA6nkoAwIFkoOYhEyEFAIAAPYbUaD5aCaPhMUzMqAAOQZnz27FIIlo9GY8S4vAEQllYmY0ni2ISihU6gYo0yeBMZnA0HFWSutm2txcSM82HwhCe0UCCw2EQtnzi7HkupSBrSlSNhBpRRKZUNPVqfQaTWoLXanSD3Rqob6g2GUfGkyOs1RHs+FtW7s2XptsT23zzp3OJGLYoZVoRdoejpdKzmpaWFYt1d+NABQNBEKhdYbFubFcRba77x7z2AFpYQA)

Since `Partial<Project>` and `TestProjectOptions` have all optional fields but have at least one field in common, they're compatible types.

The expand tests are the only ones running in to that particular issue (tested by renaming `TestProjectOptions.superAdmin` to `makeSuperAdmin`, so the types don't have any similar properties and seeing if `tsc` complains anywhere else). There could of course be similar issues in other types.

