### PR TITLE
Add error message when `cli` fails on login

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -107,7 +107,14 @@ async function openBrowser(url: string): Promise<void> {
     default:
       throw new Error('Unsupported platform: ' + os);
   }
-  exec(cmd);
+  exec(cmd, (error, _, stderr) => {
+    if (error) {
+      throw error;
+    }
+    if (stderr) {
+      throw new Error("Could not open browser: " + { stderr });
+    }
+  });
 }
 
 /**

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -112,7 +112,7 @@ async function openBrowser(url: string): Promise<void> {
       throw error;
     }
     if (stderr) {
-      throw new Error("Could not open browser: " + { stderr });
+      throw new Error('Could not open browser: ' + { stderr });
     }
   });
 }

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -112,7 +112,7 @@ async function openBrowser(url: string): Promise<void> {
       throw error;
     }
     if (stderr) {
-      throw new Error('Could not open browser: ' + { stderr });
+      throw new Error('Could not open browser: ' + stderr);
     }
   });
 }


### PR DESCRIPTION
Thank you for this fantastic piece of software. :-) I am currently doing more tests and ran into an error when logging in with the `cli`. Ultimately, I noticed the problem was with my browser, but there was no error at all, and it just stayed forever on login.

This helped me to debug my error. Maybe it will help someone down the line :-) 

Feel free to close this in case you think this is overkill :-)