### PR TITLE
ci(upgrade): add 2 separate PRs so we can choose between them

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -31,8 +31,8 @@ npx npm-check-updates --workspaces --root --upgrade --reject "$EXCLUDE" --target
 # Commit and push before running NPM install
 git add -u .
 git commit -m "Dependency upgrades - step 1"
-git push origin "$BRANCH_NAME"
-gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --draft
+git push origin "$BRANCH_NAME":"$BRANCH_NAME-no-major-bumps"
+gh pr create --title "Dependency upgrades $DATE - no major bumps" --body "Dependency upgrades" --draft
 
 # Reinstall all dependencies
 ./scripts/reinstall.sh --update
@@ -40,7 +40,7 @@ gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --
 # Commit and push after running NPM install
 git add -u .
 git commit -m "Dependency upgrades - step 2"
-git push origin "$BRANCH_NAME"
+git push origin "$BRANCH_NAME":"$BRANCH_NAME-no-major-bumps"
 gh pr ready
 
 # Next, optimistically upgrade to the latest versions
@@ -51,6 +51,7 @@ npx npm-check-updates --workspaces --root --upgrade --reject "$EXCLUDE" --target
 git add -u .
 git commit -m "Dependency upgrades - step 3"
 git push origin "$BRANCH_NAME"
+gh pr create --title "Dependency upgrades $DATE - latest" --body "Dependency upgrades" --draft
 
 # Reinstall all dependencies
 ./scripts/reinstall.sh --update
@@ -59,3 +60,4 @@ git push origin "$BRANCH_NAME"
 git add -u .
 git commit -m "Dependency upgrades - step 4"
 git push origin "$BRANCH_NAME"
+gh pr ready


### PR DESCRIPTION
Currently the PR with no major versions is immediately overwritten by the PR with latest. This means if we want to accept only the minor version bumps, we have to revert the commits for the latest and wait for CI to pass. With 2 PRs, we have the choice to accept either the latest or only the minor PR and both will run CI independently on their own branch.