### PR TITLE
fix(agent): unwrap response for `$reload-config` by id

### DIFF
--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -181,7 +181,7 @@ export function badRequest(details: string, expression?: string): OperationOutco
         details: {
           text: details,
         },
-        expression: expression ? [expression] : undefined,
+        ...(expression ? { expression: [expression] } : undefined),
       },
     ],
   };

--- a/packages/server/src/fhir/operations/agentreloadconfig.ts
+++ b/packages/server/src/fhir/operations/agentreloadconfig.ts
@@ -1,4 +1,4 @@
-import { AgentReloadConfigResponse, OperationOutcomeError, serverError } from '@medplum/core';
+import { AgentReloadConfigResponse, OperationOutcomeError, badRequest, serverError } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Agent, OperationDefinition } from '@medplum/fhirtypes';
 import { handleBulkAgentOperation, publishAgentRequest } from './utils/agentutils';
@@ -47,7 +47,7 @@ async function reloadConfig(agent: Agent): Promise<FhirResponse> {
   }
 
   if (result.type === 'agent:error') {
-    throw new OperationOutcomeError(serverError(new Error(result.body)));
+    throw new OperationOutcomeError(badRequest(result.body));
   }
 
   throw new OperationOutcomeError(serverError(new Error('Invalid response received from agent')));

--- a/packages/server/src/fhir/operations/utils/agentutils.ts
+++ b/packages/server/src/fhir/operations/utils/agentutils.ts
@@ -108,6 +108,10 @@ export async function handleBulkAgentOperation(
     return [badRequest('No agent(s) for given query')];
   }
 
+  if (req.params.id) {
+    return handler(agents[0]);
+  }
+
   const promises = agents.map((agent: Agent) => handler(agent));
   const results = await Promise.allSettled(promises);
   const entries = [] as BundleEntry<Parameters>[];


### PR DESCRIPTION
Fixes #4541 

Later we may want to consider moving the bulk version of all endpoints to something like a `$bulk` operation which takes an `op` query parameter.

For example, `Agent/$bulk?op=reload-config&name:contains=Medplum` would perform a bulk reload-config on Agents with names containing `Medplum`...

I'll open a discussion about this later, but this PR should at least move in the right direction for now.