### PR TITLE
Demo Bot: Agent Setup

### DIFF
--- a/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.questionnaire.json
+++ b/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.questionnaire.json
@@ -1,0 +1,94 @@
+{
+  "resourceType": "Questionnaire",
+  "status": "active",
+  "item": [
+    {
+      "id": "id-6",
+      "linkId": "g5",
+      "type": "group",
+      "text": "Organization",
+      "item": [
+        {
+          "id": "id-7",
+          "linkId": "organization-name",
+          "type": "string",
+          "text": "Name"
+        }
+      ]
+    },
+    {
+      "id": "id-2",
+      "linkId": "endpoint-details",
+      "type": "group",
+      "text": "Endpoint",
+      "repeats": true,
+      "item": [
+        {
+          "id": "id-12",
+          "linkId": "q1",
+          "type": "display",
+          "text": "The agent endpoints describe the addresses the Agent will expose to the remote site's network"
+        },
+        {
+          "id": "id-3",
+          "linkId": "endpoint-name",
+          "type": "string",
+          "text": "Name"
+        },
+        {
+          "id": "id-4",
+          "linkId": "endpoint-ip",
+          "type": "string",
+          "text": "IP Address"
+        },
+        {
+          "id": "id-13",
+          "linkId": "endpoint-port",
+          "type": "integer",
+          "text": "Port"
+        }
+      ]
+    },
+    {
+      "id": "id-8",
+      "linkId": "device-group",
+      "type": "group",
+      "text": "Devices",
+      "item": [
+        {
+          "id": "id-14",
+          "linkId": "q3",
+          "type": "display",
+          "text": "The Device resource describes the local address of the target device the Agent will connect to on the remote site's network"
+        },
+        {
+          "id": "id-9",
+          "linkId": "device-details",
+          "type": "group",
+          "text": "Details",
+          "repeats": true,
+          "item": [
+            {
+              "id": "id-10",
+              "linkId": "device-name",
+              "type": "string",
+              "text": "Name"
+            },
+            {
+              "id": "id-11",
+              "linkId": "device-address",
+              "type": "string",
+              "text": "IP Address"
+            },
+            {
+              "id": "id-15",
+              "linkId": "device-port",
+              "type": "integer",
+              "text": "Port"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.questionnaireresponse.json
+++ b/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.questionnaireresponse.json
@@ -1,0 +1,193 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "status": "completed",
+  "item": [
+    {
+      "id": "id-1",
+      "linkId": "g5",
+      "text": "Organization",
+      "item": [
+        {
+          "id": "id-2",
+          "linkId": "organization-name",
+          "text": "Name",
+          "answer": [
+            {
+              "valueString": "Foo Medical"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "id-3",
+      "linkId": "endpoint-details",
+      "text": "Endpoint",
+      "item": [
+        {
+          "id": "id-4",
+          "linkId": "q1",
+          "text": "The agent endpoints describe the addresses the Agent will expose to the remote site's network"
+        },
+        {
+          "id": "id-5",
+          "linkId": "endpoint-name",
+          "text": "Name",
+          "answer": [
+            {
+              "valueString": "Test Channel"
+            }
+          ]
+        },
+        {
+          "id": "id-6",
+          "linkId": "endpoint-ip",
+          "text": "IP Address",
+          "answer": [
+            {
+              "valueString": "129.1.21.1"
+            }
+          ]
+        },
+        {
+          "id": "id-7",
+          "linkId": "endpoint-port",
+          "text": "Port",
+          "answer": [
+            {
+              "valueInteger": 1234
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "id-14",
+      "linkId": "endpoint-details",
+      "text": "Endpoint",
+      "item": [
+        {
+          "id": "id-15",
+          "linkId": "q1",
+          "text": "The agent endpoints describe the addresses the Agent will expose to the remote site's network"
+        },
+        {
+          "id": "id-16",
+          "linkId": "endpoint-name",
+          "text": "Name",
+          "answer": [
+            {
+              "valueString": "Production Channel"
+            }
+          ]
+        },
+        {
+          "id": "id-17",
+          "linkId": "endpoint-ip",
+          "text": "IP Address",
+          "answer": [
+            {
+              "valueString": "129.1.21.2"
+            }
+          ]
+        },
+        {
+          "id": "id-18",
+          "linkId": "endpoint-port",
+          "text": "Port",
+          "answer": [
+            {
+              "valueInteger": 8889
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "id-8",
+      "linkId": "device-group",
+      "text": "Devices",
+      "item": [
+        {
+          "id": "id-9",
+          "linkId": "q3",
+          "text": "The Device resource describes the local address of the target device the Agent will connect to on the remote site's network"
+        },
+        {
+          "id": "id-10",
+          "linkId": "device-details",
+          "text": "Details",
+          "item": [
+            {
+              "id": "id-11",
+              "linkId": "device-name",
+              "text": "Name",
+              "answer": [
+                {
+                  "valueString": "Foo LIS"
+                }
+              ]
+            },
+            {
+              "id": "id-12",
+              "linkId": "device-address",
+              "text": "IP Address",
+              "answer": [
+                {
+                  "valueString": "10.1.1.2"
+                }
+              ]
+            },
+            {
+              "id": "id-13",
+              "linkId": "device-port",
+              "text": "Port",
+              "answer": [
+                {
+                  "valueInteger": 1234
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "id-19",
+          "linkId": "device-details",
+          "text": "Details",
+          "item": [
+            {
+              "id": "id-20",
+              "linkId": "device-name",
+              "text": "Name",
+              "answer": [
+                {
+                  "valueString": "Foo RIS"
+                }
+              ]
+            },
+            {
+              "id": "id-21",
+              "linkId": "device-address",
+              "text": "IP Address",
+              "answer": [
+                {
+                  "valueString": "10.1.1.2"
+                }
+              ]
+            },
+            {
+              "id": "id-22",
+              "linkId": "device-port",
+              "text": "Port",
+              "answer": [
+                {
+                  "valueInteger": 5642
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.test.ts
+++ b/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.test.ts
@@ -1,0 +1,102 @@
+import {
+  ContentType,
+  createReference,
+  getReferenceString,
+  indexSearchParameterBundle,
+  indexStructureDefinitionBundle,
+} from '@medplum/core';
+import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
+import { Bot, Bundle, ClientApplication, QuestionnaireResponse, SearchParameter } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { handler } from './setup-medplum-agent';
+import response from './setup-medplum-agent.questionnaireresponse.json';
+import { randomUUID } from 'crypto';
+
+describe('Setup Medplum Agent', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+    for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+      indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+    }
+  });
+
+  test('Set up Agent', async () => {
+    const medplum = new MockClient();
+    vi.spyOn(medplum, 'post').mockImplementation(async (path: string | URL, body: any): Promise<any> => {
+      if (path.toString().match(/admin\/projects\/.*\/bot/)) {
+        const bot: Bot = {
+          resourceType: 'Bot',
+          name: body.name,
+        };
+        return medplum.repo.createResource(bot);
+      }
+      if (path.toString().match(/admin\/projects\/.*\/client/)) {
+        const clientApp: ClientApplication = {
+          resourceType: 'ClientApplication',
+          name: body.name,
+          secret: randomUUID(),
+        };
+        return medplum.repo.createResource(clientApp);
+      }
+      return MockClient.prototype.post(path, body);
+    });
+    await handler(medplum, {
+      input: response as QuestionnaireResponse,
+      secrets: {},
+      contentType: ContentType.FHIR_JSON,
+      bot: {},
+    });
+    // Check that organization is in place
+    const checkOrganization = await medplum.searchOne('Organization', { name: 'Foo Medical' });
+    expect(checkOrganization).toBeDefined();
+    const endpoints = await medplum.searchResources('Endpoint', {
+      organization: checkOrganization && getReferenceString(checkOrganization),
+    });
+
+    // Check for incoming channels
+    expect(endpoints).toHaveLength(2);
+    const channel1 = endpoints.find((e) => e.name === 'Test Channel');
+    const channel2 = endpoints.find((e) => e.name === 'Production Channel');
+    expect(channel1?.address).toBe('mllp://129.1.21.1:1234');
+    expect(channel2?.address).toBe('mllp://129.1.21.2:8889');
+
+    // Check for Inbound Bots
+    const bot1 = await medplum.searchOne('Bot', { name: 'Foo Medical: Test Channel [Inbound]' });
+    const bot2 = await medplum.searchOne('Bot', { name: 'Foo Medical: Production Channel [Inbound]' });
+    expect(bot1).toBeDefined();
+    expect(bot2).toBeDefined();
+
+    // Check for Agent resource
+    const agent = await medplum.searchOne('Agent', { identifier: 'http://example.com/agent-id|foo-medical-agent' });
+    expect(agent).toBeDefined();
+    expect(agent?.channel?.[0]).toMatchObject({
+      name: 'Test Channel',
+      endpoint: channel1 && createReference(channel1),
+    });
+    expect(agent?.channel?.[1]).toMatchObject({
+      name: 'Production Channel',
+      endpoint: channel2 && createReference(channel2),
+    });
+
+    // Check for ClientApp
+    const client = await medplum.searchOne('ClientApplication', {
+      name: 'Foo Medical Agent Client',
+    });
+    expect(client).toBeDefined();
+
+    // Check for device resources
+    const lisDevice = await medplum.searchOne('Device', { identifier: 'foo-medical-foo-lis' });
+    const risDevice = await medplum.searchOne('Device', { identifier: 'foo-medical-foo-ris' });
+
+    expect(lisDevice).toBeDefined();
+    expect(lisDevice?.url).toBe('mllp://10.1.1.2:1234');
+    expect(risDevice).toBeDefined();
+    expect(risDevice?.url).toBe('mllp://10.1.1.2:5642');
+
+    // Check for Outbound Bots
+    const outboundBot = await medplum.searchOne('Bot', { name: 'Foo Medical [Outbound]' });
+    expect(outboundBot).toBeDefined();
+  });
+});

--- a/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.ts
+++ b/examples/medplum-demo-bots/src/hl7-integration/setup-medplum-agent.ts
@@ -1,0 +1,137 @@
+import {
+  BotEvent,
+  MedplumClient,
+  createReference,
+  getAllQuestionnaireAnswers,
+  getReferenceString,
+} from '@medplum/core';
+import { AgentChannel, Bot, Endpoint, QuestionnaireResponse } from '@medplum/fhirtypes';
+
+export async function handler(medplum: MedplumClient, event: BotEvent<QuestionnaireResponse>): Promise<void> {
+  const response = event.input;
+  const answers = getAllQuestionnaireAnswers(response);
+
+  // Create an organization representing the remote site
+  const organizationName = answers['organization-name']?.[0]?.valueString;
+  if (!organizationName) {
+    throw new Error('Missing organization name');
+  }
+
+  const organization = await medplum.upsertResource(
+    {
+      resourceType: 'Organization',
+      name: organizationName,
+    },
+    { name: organizationName }
+  );
+
+  /* Inbound Communications */
+  const endpoints = await Promise.all(
+    answers['endpoint-name'].map((endpointName, index) => {
+      const endpointAddress = answers['endpoint-ip']?.at(index)?.valueString;
+      const endpointPort = answers['endpoint-port']?.at(index)?.valueInteger;
+      const identifier = toIdentifier(endpointName.valueString ?? '');
+      const endpoint: Endpoint = {
+        resourceType: 'Endpoint',
+        name: endpointName?.valueString,
+        identifier: [
+          {
+            system: 'http://example.com',
+            value: identifier,
+          },
+        ],
+        status: 'active',
+        managingOrganization: createReference(organization),
+        connectionType: {
+          system: 'http://terminology.hl7.org/CodeSystem/endpoint-connection-type',
+          code: 'hl7v2-mllp',
+          display: 'HL7 v2 MLLP',
+        },
+        payloadType: [
+          {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/endpoint-payload-type',
+                code: 'any',
+                display: 'Any',
+              },
+            ],
+          },
+        ],
+        address: `mllp://${endpointAddress}:${endpointPort}`,
+      };
+      return medplum.upsertResource(endpoint, {
+        organization: getReferenceString(organization),
+        identifier,
+      });
+    })
+  );
+
+  // Create a new Bot to listen on each agent channel
+  const projectId = medplum.getProject()?.id;
+  const bots = await Promise.all(
+    endpoints.map(async (endpoint) => {
+      return medplum.post(`/admin/projects/${projectId}/bot`, {
+        name: `${organization.name}: ${endpoint.name} [Inbound]`,
+      }) as Promise<Bot>;
+    })
+  );
+
+  // Create the Agent resource, that represents the Medplum agent installed on-site
+  const agentId = {
+    system: 'http://example.com/agent-id',
+    value: toIdentifier(organizationName) + '-agent',
+  };
+  const agent = await medplum.upsertResource(
+    {
+      resourceType: 'Agent',
+      status: 'active',
+      name: `${organization.name} Agent`,
+      identifier: [agentId],
+      channel: endpoints.map(
+        (endpoint, index): AgentChannel => ({
+          name: endpoint.name ?? '',
+          endpoint: createReference(endpoint),
+          targetReference: createReference(bots[index]),
+        })
+      ),
+    },
+    {
+      identifier: `${agentId.system}|${agentId.value}`,
+    }
+  );
+
+  // Create a ClientApplication to provide manage credentials for the on-site Agent
+  await medplum.post(`admin/projects/${projectId}/client`, {
+    name: `${agent.name} Client`,
+    description: `Client ID/Secret for ${agent.name}`,
+  });
+
+  /* Outbound Communication */
+  // Set up Device resources for remote devices (e.g. remote EMR, LIS, or RIS systems)
+  await Promise.all(
+    answers['device-name'].map((deviceName, index) => {
+      const ip = answers['device-address']?.at(index)?.valueString;
+      const port = answers['device-port']?.at(index)?.valueInteger;
+      const deviceId = `${toIdentifier(organizationName)}-${toIdentifier(deviceName.valueString ?? '')}`;
+      return medplum.upsertResource(
+        {
+          resourceType: 'Device',
+          identifier: [{ system: 'http://example.com/device-id', value: deviceId }],
+          name: deviceName.valueString,
+          url: `mllp://${ip}:${port}`,
+        },
+        { identifier: deviceId }
+      );
+    })
+  );
+
+  // Create a placeholder Bot to handle outbound communications
+  await medplum.post(`/admin/projects/${projectId}/bot`, {
+    name: `${organization.name} [Outbound]`,
+  });
+}
+
+function toIdentifier(s: string): string {
+  return s.toLowerCase().replaceAll(/(\s+|\.+)/g, '-');
+}

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -430,6 +430,44 @@ describe('Core Utils', () => {
     ).toMatchObject({
       q1: [{ valueString: 'xyz' }, { valueString: 'abc' }],
     });
+
+    // Test repeated groups
+    expect(
+      getAllQuestionnaireAnswers({
+        resourceType: 'QuestionnaireResponse',
+        status: 'completed',
+        item: [
+          {
+            linkId: 'group1',
+            item: [
+              {
+                linkId: 'q1',
+                answer: [
+                  {
+                    valueString: 'xyz',
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            linkId: 'group1',
+            item: [
+              {
+                linkId: 'q1',
+                answer: [
+                  {
+                    valueString: '123',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    ).toMatchObject({
+      q1: [{ valueString: 'xyz' }, { valueString: '123' }],
+    });
   });
 
   test('Get identifier', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -350,7 +350,11 @@ function buildAllQuestionnaireAnswerItems(
   if (items) {
     for (const item of items) {
       if (item.linkId && item.answer && item.answer.length > 0) {
-        result[item.linkId] = item.answer;
+        if (result[item.linkId]) {
+          result[item.linkId] = [...result[item.linkId], ...item.answer];
+        } else {
+          result[item.linkId] = item.answer;
+        }
       }
       buildAllQuestionnaireAnswerItems(item.item, result);
     }


### PR DESCRIPTION
This PR includes a demo-bot to set up the following resources for bi-directional remote device communication via the Medplum Agent: 

- `Organization`
- `Endpoint`
- `Agent`
- `ClientApplication`
- `Bots` (for inbound and outbound)
- `Device` 

This bot responds to a QuestionnaireResponse, where an admin user can enter the relevant details to set up a new site


It also includes a drive-by fix for `getAllQuestionnaireAnswers`, which could be split into a new PR, if needed.