### PR TITLE
Fix display bug in `ResourcePropertyDisplay`

### DIFF
--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -71,9 +71,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     );
   }
 
-  const isArrayElement = Boolean(props.arrayElement);
-
-  if (property?.max && property.max > 1 && !isArrayElement) {
+  if (property && (property.isArray || property.max > 1) && !props.arrayElement) {
     if (propertyType === PropertyType.Attachment) {
       return (
         <AttachmentArrayDisplay


### PR DESCRIPTION
Not properly detecting arrays caused an off-by-one in the CSS grid leading to misalignment of property names and their values.

### Before
![Screenshot 2024-05-16 at 12 31 50 PM](https://github.com/medplum/medplum/assets/933303/5fa167bc-4c5d-450f-88de-dc522af23f0c)

### After
![Screenshot 2024-05-16 at 12 31 33 PM](https://github.com/medplum/medplum/assets/933303/5e46bc5e-e856-4ea1-8a48-515a4518fc89)
