### PR TITLE
feat(cli): add `token` command to get access token

### DIFF
--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -41,7 +41,7 @@ token.action(async (options) => {
   if (!token) {
     throw new Error('Not logged in');
   }
-  console.log(`Access token:`);
+  console.log('Access token:');
   console.log();
   console.log(token);
 });

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -17,6 +17,7 @@ const redirectUri = 'http://localhost:9615';
 
 export const login = createMedplumCommand('login');
 export const whoami = createMedplumCommand('whoami');
+export const token = createMedplumCommand('token');
 
 login.action(async (options) => {
   const profileName = options.profile ?? 'default';
@@ -31,6 +32,18 @@ login.action(async (options) => {
 whoami.action(async (options) => {
   const medplum = await createMedplumClient(options);
   printMe(medplum);
+});
+
+token.action(async (options) => {
+  const medplum = await createMedplumClient(options);
+  await medplum.getProfileAsync();
+  const token = medplum.getAccessToken();
+  if (!token) {
+    throw new Error('Not logged in');
+  }
+  console.log(`Access token:`);
+  console.log();
+  console.log(token);
 });
 
 async function startLogin(medplum: MedplumClient, profile: Profile): Promise<void> {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import { MEDPLUM_VERSION, normalizeErrorString } from '@medplum/core';
 import { Command, CommanderError } from 'commander';
 import dotenv from 'dotenv';
-import { login, whoami } from './auth';
+import { login, token, whoami } from './auth';
 import { buildAwsCommand } from './aws/index';
 import { bot, createBotDeprecate, deployBotDeprecate, saveBotDeprecate } from './bots';
 import { bulk } from './bulk';
@@ -20,6 +20,7 @@ export async function main(argv: string[]): Promise<void> {
   // Auth commands
   index.addCommand(login);
   index.addCommand(whoami);
+  index.addCommand(token);
 
   // REST commands
   index.addCommand(get);


### PR DESCRIPTION
Adds a convenience command for getting the token of the current profile, useful for testing in local environments