### PR TITLE
feat: enable unit testing subscription criteria

### DIFF
--- a/packages/core/src/subscriptions/index.test.ts
+++ b/packages/core/src/subscriptions/index.test.ts
@@ -1,6 +1,12 @@
-import { Bundle, Communication, Parameters, SubscriptionStatus } from '@medplum/fhirtypes';
+import { Bundle, Communication, Parameters, Subscription, SubscriptionStatus } from '@medplum/fhirtypes';
 import WS from 'jest-websocket-mock';
-import { RobustWebSocket, SubscriptionEmitter, SubscriptionEventMap, SubscriptionManager } from '.';
+import {
+  RobustWebSocket,
+  SubscriptionEmitter,
+  SubscriptionEventMap,
+  SubscriptionManager,
+  resourceMatchesSubscriptionCriteria,
+} from '.';
 import { MockMedplumClient } from '../client-test-utils';
 import { generateId } from '../crypto';
 import { OperationOutcomeError } from '../outcomes';
@@ -747,5 +753,55 @@ describe('SubscriptionManager', () => {
       expect(console.error).toHaveBeenCalledTimes(1);
       console.error = originalError;
     });
+  });
+});
+
+describe('resourceMatchesSubscriptionCriteria', () => {
+  it('should return true for a resource that matches the criteria', async () => {
+    const subscription: Subscription = {
+      resourceType: 'Subscription',
+      status: 'active',
+      reason: 'test subscription',
+      criteria: 'Communication',
+      channel: {
+        type: 'rest-hook',
+        endpoint: 'Bot/123',
+      },
+      extension: [
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/fhir-path-criteria-expression',
+          valueString: '%previous.status = "in-progress" and %current.status = "completed"',
+        },
+        {
+          url: 'https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction',
+          valueCode: 'update',
+        },
+      ],
+    };
+
+    const result1 = await resourceMatchesSubscriptionCriteria({
+      resource: {
+        resourceType: 'Communication',
+        status: 'in-progress',
+      },
+      subscription,
+      context: { interaction: 'create' },
+      getPreviousResource: async () => undefined,
+    });
+    expect(result1).toBe(false);
+
+    const result2 = await resourceMatchesSubscriptionCriteria({
+      resource: {
+        resourceType: 'Communication',
+        status: 'completed',
+      },
+      subscription,
+      context: { interaction: 'update' },
+      getPreviousResource: async () => ({
+        resourceType: 'Communication',
+        status: 'in-progress',
+      }),
+    });
+    expect(result2).toBe(true);
   });
 });

--- a/packages/server/src/workers/context.ts
+++ b/packages/server/src/workers/context.ts
@@ -1,5 +1,0 @@
-export type BackgroundJobInteraction = 'create' | 'update' | 'delete';
-
-export interface BackgroundJobContext {
-  interaction: BackgroundJobInteraction;
-}

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -1,7 +1,7 @@
 import { Resource } from '@medplum/fhirtypes';
+import { BackgroundJobContext } from '@medplum/core';
 import { MedplumServerConfig } from '../config';
 import { globalLogger } from '../logger';
-import { BackgroundJobContext } from './context';
 import { addCronJobs, closeCronWorker, initCronWorker } from './cron';
 import { addDownloadJobs, closeDownloadWorker, initDownloadWorker } from './download';
 import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } from './subscription';

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -1,5 +1,7 @@
 import {
   AccessPolicyInteraction,
+  BackgroundJobContext,
+  BackgroundJobInteraction,
   ContentType,
   OperationOutcomeError,
   Operator,
@@ -8,18 +10,12 @@ import {
   getExtensionValue,
   getReferenceString,
   isGone,
-  normalizeOperationOutcome,
-  OperationOutcomeError,
-  Operator,
-  resourceMatchesSubscriptionCriteria,
   isNotFound,
-  matchesSearchRequest,
-  parseSearchRequest,
+  normalizeOperationOutcome,
+  resourceMatchesSubscriptionCriteria,
   satisfiedAccessPolicy,
   serverError,
   stringify,
-  BackgroundJobContext,
-  BackgroundJobInteraction,
 } from '@medplum/core';
 import { Bot, Project, ProjectMembership, Reference, Resource, ResourceType, Subscription } from '@medplum/fhirtypes';
 import { Job, Queue, QueueBaseOptions, Worker } from 'bullmq';

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -1,4 +1,4 @@
-import { createReference, evalFhirPathTyped, getExtension, isResource, Operator, toTypedValue } from '@medplum/core';
+import { createReference, getExtension, isResource, Operator } from '@medplum/core';
 import {
   AuditEvent,
   AuditEventEntity,
@@ -109,24 +109,7 @@ export function getAuditEventEntityRole(resource: Resource): Coding {
   }
 }
 
-export async function isFhirCriteriaMet(subscription: Subscription, currentResource: Resource): Promise<boolean> {
-  const criteria = getExtension(
-    subscription,
-    'https://medplum.com/fhir/StructureDefinition/fhir-path-criteria-expression'
-  );
-  if (!criteria?.valueString) {
-    return true;
-  }
-  const previous = await getPreviousResource(currentResource);
-  const evalInput = {
-    '%current': toTypedValue(currentResource),
-    '%previous': toTypedValue(previous ?? {}),
-  };
-  const evalValue = evalFhirPathTyped(criteria.valueString, [toTypedValue(currentResource)], evalInput);
-  return evalValue?.[0]?.value === true;
-}
-
-async function getPreviousResource(currentResource: Resource): Promise<Resource | undefined> {
+export async function getPreviousResource(currentResource: Resource): Promise<Resource | undefined> {
   const systemRepo = getSystemRepo();
   const history = await systemRepo.readHistory(currentResource.resourceType, currentResource?.id as string);
 


### PR DESCRIPTION
Related to discord thread https://discord.com/channels/905144809105260605/1241055626008727633/1241055626008727633

The story for unit testing subscriptions is currently not great. Given the free-form fhir path expressions and criteria fields, enabling unit testing and shortening the feedback loop for issues in expressions would be nice.