### PR TITLE
Respect AccessPolicy.resource.{readonlyFields,hiddenFields} in ResourceForm

### DIFF
--- a/packages/core/src/elements-context.test.ts
+++ b/packages/core/src/elements-context.test.ts
@@ -13,7 +13,7 @@ import { AccessPolicyInteraction, satisfiedAccessPolicy } from './access';
 
 describe('buildElementsContext', () => {
   const DEFAULT_EXTENDED_PROPS = { readonly: false, hidden: false };
-  const HIDDEN = { readonly: false, hidden: true };
+  const HIDDEN = { readonly: true, hidden: true };
   const READONLY = { readonly: true, hidden: false };
   let USCoreStructureDefinitions: StructureDefinition[];
 

--- a/packages/core/src/elements-context.test.ts
+++ b/packages/core/src/elements-context.test.ts
@@ -27,7 +27,6 @@ describe('buildElementsContext', () => {
   beforeAll(() => {
     USCoreStructureDefinitions = readJson('fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json');
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
-    // indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
   });
 
   test('deeply nested schema', () => {

--- a/packages/core/src/elements-context.test.ts
+++ b/packages/core/src/elements-context.test.ts
@@ -12,6 +12,9 @@ import { readJson } from '@medplum/definitions';
 import { AccessPolicyInteraction, satisfiedAccessPolicy } from './access';
 
 describe('buildElementsContext', () => {
+  const DEFAULT_EXTENDED_PROPS = { readonly: false, hidden: false };
+  const HIDDEN = { readonly: false, hidden: true };
+  const READONLY = { readonly: true, hidden: false };
   let USCoreStructureDefinitions: StructureDefinition[];
 
   function getSchemaFromProfileUrl(url: string): InternalTypeSchema {
@@ -147,6 +150,12 @@ describe('buildElementsContext', () => {
     const entriesAfter = Object.values(context.elements).filter(Boolean).length;
 
     expect(entriesBefore - entriesAfter).toEqual(0);
+    for (const key of Object.keys(context.elements)) {
+      expect(context.getExtendedProps('Patient.' + key)).toEqual(DEFAULT_EXTENDED_PROPS);
+    }
+    expect(context.getExtendedProps('Patient')).toBeUndefined();
+    expect(context.getExtendedProps('Patient.')).toBeUndefined();
+    expect(context.getExtendedProps('Patient.badKey')).toEqual(DEFAULT_EXTENDED_PROPS);
   });
 
   test('some hidden fields', () => {
@@ -154,7 +163,7 @@ describe('buildElementsContext', () => {
 
     const accessPolicy: AccessPolicy = {
       resourceType: 'AccessPolicy',
-      resource: [{ resourceType: 'Patient', hiddenFields: ['gender'] }],
+      resource: [{ resourceType: 'Patient', hiddenFields: ['gender', 'multipleBirthInteger'] }],
     };
     const resource: Patient = {
       resourceType: 'Patient',
@@ -175,8 +184,13 @@ describe('buildElementsContext', () => {
     }
     const entriesAfter = Object.values(context.elements).filter(Boolean).length;
 
+    // "multipelBirthInteger" is one of the possible types for "multipleBirth[x]", but
+    // InternalTypeSchema references elements by their path, i.e. "multipleBirth[x]", so
+    // attempting to hide "multipleBirthInteger" is expected to have no effect
     expect(context.elements['gender']).toBeUndefined();
     expect(entriesBefore - entriesAfter).toEqual(1);
+
+    expect(context.getExtendedProps('Patient.gender')).toEqual(HIDDEN);
   });
 
   test('hidden parent element also removes child elements', () => {
@@ -206,6 +220,9 @@ describe('buildElementsContext', () => {
 
     // includes name, name.id, name.use, name.family, name.given, etc.
     expect(entriesBefore - entriesAfter).toEqual(10);
+    expect(context.getExtendedProps('Patient.name')).toEqual(HIDDEN);
+    expect(context.getExtendedProps('Patient.name.given')).toEqual(HIDDEN);
+    expect(context.getExtendedProps('Patient.name.family')).toEqual(HIDDEN);
   });
 
   test('hidden nested field leaves parent and siblings', () => {
@@ -237,5 +254,60 @@ describe('buildElementsContext', () => {
 
     expect(context.elements['name.family']).toBeUndefined();
     expect(entriesBefore - entriesAfter).toEqual(1);
+  });
+
+  test('readonly fields are marked as readonly', () => {
+    const schema = getDataType('Patient');
+
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        { resourceType: 'Patient', readonlyFields: ['gender', 'multipleBirthInteger', 'name.given', 'identifier'] },
+      ],
+    };
+    const resource: Patient = {
+      resourceType: 'Patient',
+    };
+    const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+
+    expect(schema.elements['gender']).toBeDefined();
+
+    const entriesBefore = Object.values(schema.elements).filter(Boolean).length;
+    const context = buildElementsContext({
+      elements: schema.elements,
+      path: 'Patient',
+      parentContext: undefined,
+      accessPolicyResource: apr,
+    });
+    if (context === undefined) {
+      fail('Expected context to be defined');
+    }
+    const entriesAfter = Object.values(context.elements).filter(Boolean).length;
+
+    expect(entriesBefore - entriesAfter).toEqual(0);
+
+    expect(context.elements['gender'].readonly).toBe(true);
+    expect(context.getExtendedProps('Patient.gender')).toEqual(READONLY);
+
+    // "multipelBirthInteger" is one of the possible types for "multipleBirth[x]", but
+    // InternalTypeSchema references elements by their path, i.e. "multipleBirth[x]", so
+    // attempting to hide "multipleBirthInteger" is expected to have no effect
+    expect(context.elements['multipleBirth[x]']).toBeDefined();
+    expect(context.elements['multipleBirth[x]'].readonly).toBeUndefined();
+    expect(context.getExtendedProps('Patient.multipleBirth[x]')).toEqual(DEFAULT_EXTENDED_PROPS);
+
+    // name.given isn't explicitly an element in the schema, but it should still be marked as readonly via getExtendedProps
+    // parent and sibling elements are not marked as readonly
+    expect(context.elements['name.given']).toBeUndefined();
+    expect(context.getExtendedProps('Patient.name.given')).toEqual(READONLY);
+    expect(context.getExtendedProps('Patient.name')).toEqual(DEFAULT_EXTENDED_PROPS);
+    expect(context.getExtendedProps('Patient.name.family')).toEqual(DEFAULT_EXTENDED_PROPS);
+
+    // nested elements are also marked as readonly
+    expect(context.elements['identifier'].readonly).toBe(true);
+    expect(context.elements['identifier.system']).toBeUndefined();
+    expect(context.getExtendedProps('Patient.identifier')).toEqual(READONLY);
+    expect(context.getExtendedProps('Patient.identifier.system')).toEqual(READONLY);
+    expect(context.getExtendedProps('Patient.identifier.value')).toEqual(READONLY);
   });
 });

--- a/packages/core/src/elements-context.test.ts
+++ b/packages/core/src/elements-context.test.ts
@@ -1,4 +1,4 @@
-import { removeHiddenFields, buildElementsContext } from './elements-context';
+import { buildElementsContext } from './elements-context';
 import { HTTP_HL7_ORG } from './constants';
 import { isPopulated } from './utils';
 import {
@@ -23,6 +23,8 @@ describe('buildElementsContext', () => {
   }
   beforeAll(() => {
     USCoreStructureDefinitions = readJson('fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json');
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    // indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
   });
 
   test('deeply nested schema', () => {
@@ -115,27 +117,9 @@ describe('buildElementsContext', () => {
       value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
     });
   });
-});
-
-describe.only('#applyHiddenFields', () => {
-  let USCoreStructureDefinitions: StructureDefinition[];
-
-  function getSchemaFromProfileUrl(url: string): InternalTypeSchema {
-    const sd = USCoreStructureDefinitions.find((sd) => sd.url === url);
-    if (!isPopulated(sd)) {
-      fail(`Expected structure definition for ${url} to be found`);
-    }
-    return parseStructureDefinition(sd);
-  }
-  beforeAll(() => {
-    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
-    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
-    USCoreStructureDefinitions = readJson('fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json');
-  });
 
   test('no hidden fields', () => {
     const schema = getDataType('Patient');
-    const elements = schema.elements;
 
     const accessPolicy: AccessPolicy = {
       resourceType: 'AccessPolicy',
@@ -147,18 +131,26 @@ describe.only('#applyHiddenFields', () => {
     const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
     expect(apr).toBeDefined();
 
-    const entriesBefore = Object.values(elements).filter(Boolean).length;
+    const entriesBefore = Object.values(schema.elements).filter(Boolean).length;
     expect(entriesBefore).toEqual(24); // sanity check
 
-    const result = removeHiddenFields(elements, apr);
-    const entriesAfter = Object.values(result).filter(Boolean).length;
+    const context = buildElementsContext({
+      elements: schema.elements,
+      path: 'Patient',
+      parentContext: undefined,
+      accessPolicyResource: apr,
+    });
+    if (context === undefined) {
+      fail('Expected context to be defined');
+    }
+
+    const entriesAfter = Object.values(context.elements).filter(Boolean).length;
 
     expect(entriesBefore - entriesAfter).toEqual(0);
   });
 
   test('some hidden fields', () => {
     const schema = getDataType('Patient');
-    const before = schema.elements;
 
     const accessPolicy: AccessPolicy = {
       resourceType: 'AccessPolicy',
@@ -169,22 +161,27 @@ describe.only('#applyHiddenFields', () => {
     };
     const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
 
-    expect(before['gender']).toBeDefined();
+    expect(schema.elements['gender']).toBeDefined();
 
-    const entriesBefore = Object.values(before).filter(Boolean).length;
-    const result = removeHiddenFields(before, apr);
-    const entriesAfter = Object.values(result).filter(Boolean).length;
+    const entriesBefore = Object.values(schema.elements).filter(Boolean).length;
+    const context = buildElementsContext({
+      elements: schema.elements,
+      path: 'Patient',
+      parentContext: undefined,
+      accessPolicyResource: apr,
+    });
+    if (context === undefined) {
+      fail('Expected context to be defined');
+    }
+    const entriesAfter = Object.values(context.elements).filter(Boolean).length;
 
-    expect(result['gender']).toBeUndefined();
-
+    expect(context.elements['gender']).toBeUndefined();
     expect(entriesBefore - entriesAfter).toEqual(1);
   });
 
   test('hidden parent element also removes child elements', () => {
     const profileUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-patient`;
     const schema = getSchemaFromProfileUrl(profileUrl);
-
-    const before = schema.elements;
 
     const accessPolicy: AccessPolicy = {
       resourceType: 'AccessPolicy',
@@ -195,19 +192,25 @@ describe.only('#applyHiddenFields', () => {
     };
     const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
 
-    const entriesBefore = Object.values(before).filter(Boolean).length;
-    const after = removeHiddenFields(before, apr);
-    const entriesAfter = Object.values(after).filter(Boolean).length;
+    const entriesBefore = Object.values(schema.elements).filter(Boolean).length;
+    const context = buildElementsContext({
+      elements: schema.elements,
+      path: 'Patient',
+      parentContext: undefined,
+      accessPolicyResource: apr,
+    });
+    if (context === undefined) {
+      fail('Expected context to be defined');
+    }
+    const entriesAfter = Object.values(context.elements).filter(Boolean).length;
 
     // includes name, name.id, name.use, name.family, name.given, etc.
     expect(entriesBefore - entriesAfter).toEqual(10);
   });
 
-  test('hidden nested fields leave parent and siblings', () => {
+  test('hidden nested field leaves parent and siblings', () => {
     const profileUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-patient`;
     const schema = getSchemaFromProfileUrl(profileUrl);
-
-    const before = schema.elements;
 
     const accessPolicy: AccessPolicy = {
       resourceType: 'AccessPolicy',
@@ -218,14 +221,21 @@ describe.only('#applyHiddenFields', () => {
     };
     const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
 
-    expect(before['name.family']).toBeDefined();
+    expect(schema.elements['name.family']).toBeDefined();
 
-    const entriesBefore = Object.values(before).filter(Boolean).length;
-    const after = removeHiddenFields(before, apr);
-    const entriesAfter = Object.values(after).filter(Boolean).length;
+    const entriesBefore = Object.values(schema.elements).filter(Boolean).length;
+    const context = buildElementsContext({
+      elements: schema.elements,
+      path: 'Patient',
+      parentContext: undefined,
+      accessPolicyResource: apr,
+    });
+    if (context === undefined) {
+      fail('Expected context to be defined');
+    }
+    const entriesAfter = Object.values(context.elements).filter(Boolean).length;
 
-    expect(after['name.family']).toBeUndefined();
-
+    expect(context.elements['name.family']).toBeUndefined();
     expect(entriesBefore - entriesAfter).toEqual(1);
   });
 });

--- a/packages/core/src/elements-context.test.ts
+++ b/packages/core/src/elements-context.test.ts
@@ -1,9 +1,15 @@
-import { buildElementsContext } from './elements-context';
+import { removeHiddenFields, buildElementsContext } from './elements-context';
 import { HTTP_HL7_ORG } from './constants';
 import { isPopulated } from './utils';
-import { InternalTypeSchema, parseStructureDefinition } from './typeschema/types';
-import { StructureDefinition } from '@medplum/fhirtypes';
+import {
+  InternalTypeSchema,
+  getDataType,
+  indexStructureDefinitionBundle,
+  parseStructureDefinition,
+} from './typeschema/types';
+import { AccessPolicy, Bundle, Patient, StructureDefinition } from '@medplum/fhirtypes';
 import { readJson } from '@medplum/definitions';
+import { AccessPolicyInteraction, satisfiedAccessPolicy } from './access';
 
 describe('buildElementsContext', () => {
   let USCoreStructureDefinitions: StructureDefinition[];
@@ -108,5 +114,118 @@ describe('buildElementsContext', () => {
       type: 'uri',
       value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
     });
+  });
+});
+
+describe.only('#applyHiddenFields', () => {
+  let USCoreStructureDefinitions: StructureDefinition[];
+
+  function getSchemaFromProfileUrl(url: string): InternalTypeSchema {
+    const sd = USCoreStructureDefinitions.find((sd) => sd.url === url);
+    if (!isPopulated(sd)) {
+      fail(`Expected structure definition for ${url} to be found`);
+    }
+    return parseStructureDefinition(sd);
+  }
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    USCoreStructureDefinitions = readJson('fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json');
+  });
+
+  test('no hidden fields', () => {
+    const schema = getDataType('Patient');
+    const elements = schema.elements;
+
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [{ resourceType: 'Patient', hiddenFields: [] }],
+    };
+    const resource: Patient = {
+      resourceType: 'Patient',
+    };
+    const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+    expect(apr).toBeDefined();
+
+    const entriesBefore = Object.values(elements).filter(Boolean).length;
+    expect(entriesBefore).toEqual(24); // sanity check
+
+    const result = removeHiddenFields(elements, apr);
+    const entriesAfter = Object.values(result).filter(Boolean).length;
+
+    expect(entriesBefore - entriesAfter).toEqual(0);
+  });
+
+  test('some hidden fields', () => {
+    const schema = getDataType('Patient');
+    const before = schema.elements;
+
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [{ resourceType: 'Patient', hiddenFields: ['gender'] }],
+    };
+    const resource: Patient = {
+      resourceType: 'Patient',
+    };
+    const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+
+    expect(before['gender']).toBeDefined();
+
+    const entriesBefore = Object.values(before).filter(Boolean).length;
+    const result = removeHiddenFields(before, apr);
+    const entriesAfter = Object.values(result).filter(Boolean).length;
+
+    expect(result['gender']).toBeUndefined();
+
+    expect(entriesBefore - entriesAfter).toEqual(1);
+  });
+
+  test('hidden parent element also removes child elements', () => {
+    const profileUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-patient`;
+    const schema = getSchemaFromProfileUrl(profileUrl);
+
+    const before = schema.elements;
+
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [{ resourceType: 'Patient', hiddenFields: ['name'] }],
+    };
+    const resource: Patient = {
+      resourceType: 'Patient',
+    };
+    const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+
+    const entriesBefore = Object.values(before).filter(Boolean).length;
+    const after = removeHiddenFields(before, apr);
+    const entriesAfter = Object.values(after).filter(Boolean).length;
+
+    // includes name, name.id, name.use, name.family, name.given, etc.
+    expect(entriesBefore - entriesAfter).toEqual(10);
+  });
+
+  test('hidden nested fields leave parent and siblings', () => {
+    const profileUrl = `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-patient`;
+    const schema = getSchemaFromProfileUrl(profileUrl);
+
+    const before = schema.elements;
+
+    const accessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [{ resourceType: 'Patient', hiddenFields: ['name.family'] }],
+    };
+    const resource: Patient = {
+      resourceType: 'Patient',
+    };
+    const apr = satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
+
+    expect(before['name.family']).toBeDefined();
+
+    const entriesBefore = Object.values(before).filter(Boolean).length;
+    const after = removeHiddenFields(before, apr);
+    const entriesAfter = Object.values(after).filter(Boolean).length;
+
+    expect(after['name.family']).toBeUndefined();
+
+    expect(entriesBefore - entriesAfter).toEqual(1);
   });
 });

--- a/packages/core/src/elements-context.ts
+++ b/packages/core/src/elements-context.ts
@@ -119,9 +119,11 @@ export function buildElementsContext({
       }
 
       if (!memoizedExtendedProps[key]) {
+        const hidden = matchesKeyPrefixes(key, accessPolicyResource?.hiddenFields);
         memoizedExtendedProps[key] = {
-          readonly: matchesKeyPrefixes(key, accessPolicyResource?.readonlyFields),
-          hidden: matchesKeyPrefixes(key, accessPolicyResource?.hiddenFields),
+          hidden,
+          // hidden implies readonly even if it's not explicitly marked as such
+          readonly: hidden || matchesKeyPrefixes(key, accessPolicyResource?.readonlyFields),
         };
       }
       return memoizedExtendedProps[key];

--- a/packages/core/src/elements-context.ts
+++ b/packages/core/src/elements-context.ts
@@ -30,6 +30,7 @@ export type ElementsContextType = {
   debugMode: boolean;
   accessPolicyResource?: AccessPolicyResource;
   getExtendedProps(path: string): ExtendedElementProps | undefined;
+  isDefault?: boolean;
 };
 
 type ExtendedElementProps = { readonly: boolean; hidden: boolean };
@@ -81,7 +82,7 @@ export function buildElementsContext({
   // memoize getExtendedProps since its input are full paths regardless of the depth/location of the
   // ElementsContext within the resource.
   let getExtendedProps: (path: string) => ExtendedElementProps | undefined;
-  if (parentContext) {
+  if (parentContext?.isDefault === false) {
     getExtendedProps = parentContext.getExtendedProps;
   } else {
     const memoizedExtendedProps: Record<string, ExtendedElementProps> = Object.create(null);
@@ -102,6 +103,7 @@ export function buildElementsContext({
   }
 
   return {
+    isDefault: false,
     path: path,
     elements: mergedElements,
     elementsByPath,
@@ -185,7 +187,7 @@ function markReadonlyFields(
   const result: Record<string, AnnotatedInternalSchemaElement> = Object.create(null);
 
   for (const [key, element] of Object.entries(elements)) {
-    const isReadonly = matchesKeyPrefixes(key, accessPolicyResource.readonlyFields) || true;
+    const isReadonly = matchesKeyPrefixes(key, accessPolicyResource.readonlyFields);
     if (isReadonly) {
       result[key] = { ...element, readonly: true };
     } else {
@@ -208,5 +210,6 @@ function matchesKeyPrefixes(key: string, prefixes: string[] | undefined): boolea
       return true;
     }
   }
+  return true; //TODO remove this line
   return false;
 }

--- a/packages/core/src/elements-context.ts
+++ b/packages/core/src/elements-context.ts
@@ -114,7 +114,7 @@ function mergeElementsForContext(
   return result;
 }
 
-export function removeHiddenFields(
+function removeHiddenFields(
   elements: Record<string, InternalSchemaElement>,
   accessPolicyResource: AccessPolicyResource | undefined
 ): Record<string, InternalSchemaElement> {

--- a/packages/core/src/elements-context.ts
+++ b/packages/core/src/elements-context.ts
@@ -208,6 +208,7 @@ function markReadonlyFields(
   for (const [key, element] of Object.entries(elements)) {
     const isReadonly = matchesKeyPrefixes(prefix + key, accessPolicyResource.readonlyFields);
     if (isReadonly) {
+      // shallow-clone `element` to avoid modifying the in-memory DATA_TYPES cache access via `getDataType`
       result[key] = { ...element, readonly: true };
     } else {
       result[key] = element;

--- a/packages/core/src/elements-context.ts
+++ b/packages/core/src/elements-context.ts
@@ -185,11 +185,6 @@ function removeHiddenFields(
     return elements;
   }
 
-  const hiddenKeyPrefixes = new Set<string>();
-  for (const field of accessPolicyResource.hiddenFields) {
-    hiddenKeyPrefixes.add(field);
-  }
-
   const prefix = keyPrefix ? keyPrefix + '.' : '';
   return Object.fromEntries(
     Object.entries(elements).filter(([key]) => !matchesKeyPrefixes(prefix + key, accessPolicyResource.hiddenFields))
@@ -221,6 +216,10 @@ function markReadonlyFields(
 }
 
 function matchesKeyPrefixes(key: string, prefixes: string[] | undefined): boolean {
+  // It might be a performance win to convert prefixes to a set, but the
+  // cardinality of prefixes, i.e. hidden/readonly fields, is expected to be small (< 10)
+  // such that the memory overhead of a set is not worth the performance gain.
+
   if (!prefixes?.length) {
     return false;
   }

--- a/packages/core/src/elements-context.ts
+++ b/packages/core/src/elements-context.ts
@@ -99,7 +99,6 @@ export function buildElementsContext({
     getExtendedProps = (path: string): ExtendedElementProps | undefined => {
       const key = splitN(path, '.', 2)[1] as string | undefined;
       if (!key) {
-        console.warn(key, `getExtendedProps called with invalid path: "${path}"`);
         return undefined;
       }
 
@@ -176,17 +175,10 @@ function removeHiddenFields(
     hiddenKeyPrefixes.add(field);
   }
 
-  const result: Record<string, InternalSchemaElement> = Object.create(null);
-
   const prefix = keyPrefix ? keyPrefix + '.' : '';
-  for (const [key, element] of Object.entries(elements)) {
-    const isHidden = matchesKeyPrefixes(prefix + key, accessPolicyResource.hiddenFields);
-    if (!isHidden) {
-      result[key] = element;
-    }
-  }
-
-  return result;
+  return Object.fromEntries(
+    Object.entries(elements).filter(([key]) => !matchesKeyPrefixes(prefix + key, accessPolicyResource.hiddenFields))
+  );
 }
 
 function markReadonlyFields(

--- a/packages/react/src/AddressInput/AddressInput.stories.tsx
+++ b/packages/react/src/AddressInput/AddressInput.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { AddressInput } from './AddressInput';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { buildElementsContext } from '@medplum/core';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/AddressInput',
@@ -31,3 +34,59 @@ export const DefaultValue = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <AddressInput
+      name="address"
+      path="Patient.address"
+      disabled={true}
+      defaultValue={{
+        use: 'home',
+        type: 'physical',
+        line: ['123 Happy St'],
+        city: 'Springfield',
+        state: 'IL',
+        postalCode: '44444',
+      }}
+      onChange={undefined}
+      outcome={undefined}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Patient',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Patient',
+      readonlyFields: ['address.type', 'address.city', 'address.postalCode'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <AddressInput
+        name="address"
+        path="Patient.address"
+        defaultValue={{
+          use: 'home',
+          type: 'physical',
+          line: ['123 Happy St'],
+          city: 'Springfield',
+          state: 'IL',
+          postalCode: '44444',
+        }}
+        onChange={undefined}
+        outcome={undefined}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/AddressInput/AddressInput.tsx
+++ b/packages/react/src/AddressInput/AddressInput.tsx
@@ -1,7 +1,8 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Address } from '@medplum/fhirtypes';
-import { useRef, useState } from 'react';
+import { useContext, useMemo, useRef, useState } from 'react';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 
 function getLine(address: Address, index: number): string {
   return address.line && address.line.length > index ? address.line[index] : '';
@@ -23,6 +24,15 @@ export function AddressInput(props: AddressInputProps): JSX.Element {
 
   const valueRef = useRef<Address>();
   valueRef.current = value;
+
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [useProps, typeProps, line1Props, line2Props, cityProps, stateProps, postalCodeProps] = useMemo(
+    () =>
+      ['use', 'type', 'line1', 'line2', 'city', 'state', 'postalCode'].map((field) =>
+        getExtendedProps(props.path + '.' + field)
+      ),
+    [getExtendedProps, props.path]
+  );
 
   // TODO{profiles} is it worth the complexity of subbing in an autocomplete input when
   // a binding is defined in a profile? If so, it should go in a new wrapper around TextInput
@@ -66,30 +76,45 @@ export function AddressInput(props: AddressInputProps): JSX.Element {
   return (
     <Group gap="xs" wrap="nowrap" grow>
       <NativeSelect
+        disabled={props.disabled || useProps?.readonly}
         data-testid="address-use"
         defaultValue={value.use}
         onChange={(e) => setUse(e.currentTarget.value as 'home' | 'work' | 'temp' | 'old' | 'billing')}
         data={['', 'home', 'work', 'temp', 'old', 'billing']}
       />
       <NativeSelect
+        disabled={props.disabled || typeProps?.readonly}
         data-testid="address-type"
         defaultValue={value.type}
         onChange={(e) => setType(e.currentTarget.value as 'postal' | 'physical' | 'both')}
         data={['', 'postal', 'physical', 'both']}
       />
       <TextInput
+        disabled={props.disabled || line1Props?.readonly}
         placeholder="Line 1"
         defaultValue={getLine(value, 0)}
         onChange={(e) => setLine1(e.currentTarget.value)}
       />
       <TextInput
+        disabled={props.disabled || line2Props?.readonly}
         placeholder="Line 2"
         defaultValue={getLine(value, 1)}
         onChange={(e) => setLine2(e.currentTarget.value)}
       />
-      <TextInput placeholder="City" defaultValue={value.city} onChange={(e) => setCity(e.currentTarget.value)} />
-      <TextInput placeholder="State" defaultValue={value.state} onChange={(e) => setState(e.currentTarget.value)} />
       <TextInput
+        disabled={props.disabled || cityProps?.readonly}
+        placeholder="City"
+        defaultValue={value.city}
+        onChange={(e) => setCity(e.currentTarget.value)}
+      />
+      <TextInput
+        disabled={props.disabled || stateProps?.readonly}
+        placeholder="State"
+        defaultValue={value.state}
+        onChange={(e) => setState(e.currentTarget.value)}
+      />
+      <TextInput
+        disabled={props.disabled || postalCodeProps?.readonly}
         placeholder="Postal Code"
         defaultValue={value.postalCode}
         onChange={(e) => setPostalCode(e.currentTarget.value)}

--- a/packages/react/src/AddressInput/AddressInput.tsx
+++ b/packages/react/src/AddressInput/AddressInput.tsx
@@ -76,45 +76,45 @@ export function AddressInput(props: AddressInputProps): JSX.Element {
   return (
     <Group gap="xs" wrap="nowrap" grow>
       <NativeSelect
-        disabled={props.disabled || useProps.readonly}
+        disabled={props.disabled || useProps?.readonly}
         data-testid="address-use"
         defaultValue={value.use}
         onChange={(e) => setUse(e.currentTarget.value as 'home' | 'work' | 'temp' | 'old' | 'billing')}
         data={['', 'home', 'work', 'temp', 'old', 'billing']}
       />
       <NativeSelect
-        disabled={props.disabled || typeProps.readonly}
+        disabled={props.disabled || typeProps?.readonly}
         data-testid="address-type"
         defaultValue={value.type}
         onChange={(e) => setType(e.currentTarget.value as 'postal' | 'physical' | 'both')}
         data={['', 'postal', 'physical', 'both']}
       />
       <TextInput
-        disabled={props.disabled || line1Props.readonly}
+        disabled={props.disabled || line1Props?.readonly}
         placeholder="Line 1"
         defaultValue={getLine(value, 0)}
         onChange={(e) => setLine1(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || line2Props.readonly}
+        disabled={props.disabled || line2Props?.readonly}
         placeholder="Line 2"
         defaultValue={getLine(value, 1)}
         onChange={(e) => setLine2(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || cityProps.readonly}
+        disabled={props.disabled || cityProps?.readonly}
         placeholder="City"
         defaultValue={value.city}
         onChange={(e) => setCity(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || stateProps.readonly}
+        disabled={props.disabled || stateProps?.readonly}
         placeholder="State"
         defaultValue={value.state}
         onChange={(e) => setState(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || postalCodeProps.readonly}
+        disabled={props.disabled || postalCodeProps?.readonly}
         placeholder="Postal Code"
         defaultValue={value.postalCode}
         onChange={(e) => setPostalCode(e.currentTarget.value)}

--- a/packages/react/src/AddressInput/AddressInput.tsx
+++ b/packages/react/src/AddressInput/AddressInput.tsx
@@ -76,45 +76,45 @@ export function AddressInput(props: AddressInputProps): JSX.Element {
   return (
     <Group gap="xs" wrap="nowrap" grow>
       <NativeSelect
-        disabled={props.disabled || useProps?.readonly}
+        disabled={props.disabled || useProps.readonly}
         data-testid="address-use"
         defaultValue={value.use}
         onChange={(e) => setUse(e.currentTarget.value as 'home' | 'work' | 'temp' | 'old' | 'billing')}
         data={['', 'home', 'work', 'temp', 'old', 'billing']}
       />
       <NativeSelect
-        disabled={props.disabled || typeProps?.readonly}
+        disabled={props.disabled || typeProps.readonly}
         data-testid="address-type"
         defaultValue={value.type}
         onChange={(e) => setType(e.currentTarget.value as 'postal' | 'physical' | 'both')}
         data={['', 'postal', 'physical', 'both']}
       />
       <TextInput
-        disabled={props.disabled || line1Props?.readonly}
+        disabled={props.disabled || line1Props.readonly}
         placeholder="Line 1"
         defaultValue={getLine(value, 0)}
         onChange={(e) => setLine1(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || line2Props?.readonly}
+        disabled={props.disabled || line2Props.readonly}
         placeholder="Line 2"
         defaultValue={getLine(value, 1)}
         onChange={(e) => setLine2(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || cityProps?.readonly}
+        disabled={props.disabled || cityProps.readonly}
         placeholder="City"
         defaultValue={value.city}
         onChange={(e) => setCity(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || stateProps?.readonly}
+        disabled={props.disabled || stateProps.readonly}
         placeholder="State"
         defaultValue={value.state}
         onChange={(e) => setState(e.currentTarget.value)}
       />
       <TextInput
-        disabled={props.disabled || postalCodeProps?.readonly}
+        disabled={props.disabled || postalCodeProps.readonly}
         placeholder="Postal Code"
         defaultValue={value.postalCode}
         onChange={(e) => setPostalCode(e.currentTarget.value)}

--- a/packages/react/src/AnnotationInput/AnnotationInput.stories.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.stories.tsx
@@ -21,6 +21,7 @@ export const Basic = (): JSX.Element => (
       }
       onChange={console.log}
       name="annotation"
+      path="Extension.value[x]"
     />
   </Document>
 );

--- a/packages/react/src/AnnotationInput/AnnotationInput.stories.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.stories.tsx
@@ -25,3 +25,20 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <AnnotationInput
+      disabled={true}
+      defaultValue={
+        {
+          authorReference: createReference(DrAliceSmith),
+          text: 'This is an annotation',
+        } as Annotation
+      }
+      onChange={console.log}
+      name="annotation"
+      path="Extension.value[x]"
+    />
+  </Document>
+);

--- a/packages/react/src/AnnotationInput/AnnotationInput.test.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.test.tsx
@@ -16,6 +16,7 @@ function setup(args: AnnotationInputProps): void {
 describe('AnnotationInput', () => {
   test('Renders undefined value', () => {
     setup({
+      path: '',
       name: 'a',
     });
     expect(screen.queryByDisplayValue('Hello world')).toBeNull();
@@ -23,6 +24,7 @@ describe('AnnotationInput', () => {
 
   test('Renders default value', () => {
     setup({
+      path: '',
       name: 'a',
       defaultValue: {
         text: 'Hello world',
@@ -35,6 +37,7 @@ describe('AnnotationInput', () => {
     const onChange = jest.fn();
 
     setup({
+      path: '',
       name: 'a',
       onChange,
     });
@@ -57,6 +60,7 @@ describe('AnnotationInput', () => {
 
   test('Set value without change listener', async () => {
     setup({
+      path: '',
       name: 'a',
     });
 
@@ -73,6 +77,7 @@ describe('AnnotationInput', () => {
     const onChange = jest.fn();
 
     setup({
+      path: '',
       name: 'a',
       defaultValue: {
         text: 'Hello world',

--- a/packages/react/src/AnnotationInput/AnnotationInput.tsx
+++ b/packages/react/src/AnnotationInput/AnnotationInput.tsx
@@ -3,12 +3,9 @@ import { createReference } from '@medplum/core';
 import { Annotation } from '@medplum/fhirtypes';
 import { useMedplumProfile } from '@medplum/react-hooks';
 import { useState } from 'react';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface AnnotationInputProps {
-  readonly name: string;
-  readonly defaultValue?: Annotation;
-  readonly onChange?: (value: Annotation) => void;
-}
+export interface AnnotationInputProps extends ComplexTypeInputProps<Annotation> {}
 
 export function AnnotationInput(props: AnnotationInputProps): JSX.Element {
   const author = useMedplumProfile();
@@ -31,6 +28,7 @@ export function AnnotationInput(props: AnnotationInputProps): JSX.Element {
 
   return (
     <TextInput
+      disabled={props.disabled}
       name={props.name}
       placeholder="Annotation text"
       defaultValue={value.text}

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.stories.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.stories.tsx
@@ -15,6 +15,12 @@ export const Basic = (): JSX.Element => (
 
 export const DefaultValue = (): JSX.Element => (
   <Document>
-    <AttachmentArrayInput name="photo" defaultValue={[{}]} />
+    <AttachmentArrayInput name="photo" defaultValue={[{ title: 'default.png' }]} />
+  </Document>
+);
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <AttachmentArrayInput name="photo" defaultValue={[{}]} disabled={true} />
   </Document>
 );

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
@@ -41,6 +41,7 @@ export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Elem
             </td>
             <td>
               <ActionIcon
+                disabled={props.disabled}
                 title="Remove"
                 variant="subtle"
                 size="sm"

--- a/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
+++ b/packages/react/src/AttachmentArrayInput/AttachmentArrayInput.tsx
@@ -11,6 +11,7 @@ export interface AttachmentArrayInputProps {
   readonly defaultValue?: Attachment[];
   readonly arrayElement?: boolean;
   readonly onChange?: (value: Attachment[]) => void;
+  readonly disabled?: boolean;
 }
 
 export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Element {
@@ -60,12 +61,13 @@ export function AttachmentArrayInput(props: AttachmentArrayInputProps): JSX.Elem
           <td></td>
           <td>
             <AttachmentButton
+              disabled={props.disabled}
               onUpload={(attachment: Attachment) => {
                 setValuesWrapper([...(valuesRef.current as Attachment[]), attachment]);
               }}
             >
               {(props) => (
-                <ActionIcon {...props} title="Add" variant="subtle" size="sm" color="green">
+                <ActionIcon {...props} title="Add" variant="subtle" size="sm" color={props.disabled ? 'gray' : 'green'}>
                   <IconCloudUpload />
                 </ActionIcon>
               )}

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -11,7 +11,7 @@ export interface AttachmentButtonProps {
   readonly onUploadProgress?: (e: ProgressEvent) => void;
   readonly onUploadError?: (outcome: OperationOutcome) => void;
   children(props: { disabled?: boolean; onClick(e: MouseEvent): void }): ReactNode;
-  disabled?: boolean;
+  readonly disabled?: boolean;
 }
 
 export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {

--- a/packages/react/src/AttachmentButton/AttachmentButton.tsx
+++ b/packages/react/src/AttachmentButton/AttachmentButton.tsx
@@ -10,7 +10,8 @@ export interface AttachmentButtonProps {
   readonly onUploadStart?: () => void;
   readonly onUploadProgress?: (e: ProgressEvent) => void;
   readonly onUploadError?: (outcome: OperationOutcome) => void;
-  children(props: { onClick(e: MouseEvent): void }): ReactNode;
+  children(props: { disabled?: boolean; onClick(e: MouseEvent): void }): ReactNode;
+  disabled?: boolean;
 }
 
 export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {
@@ -67,13 +68,14 @@ export function AttachmentButton(props: AttachmentButtonProps): JSX.Element {
   return (
     <>
       <input
+        disabled={props.disabled}
         type="file"
         data-testid="upload-file-input"
         style={{ display: 'none' }}
         ref={fileInputRef}
         onChange={(e) => onFileChange(e)}
       />
-      {props.children({ onClick })}
+      {props.children({ onClick, disabled: props.disabled })}
     </>
   );
 }

--- a/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
@@ -18,3 +18,9 @@ export const DefaultValue = (): JSX.Element => (
     <AttachmentInput path="" name="attachment" defaultValue={{}} />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <AttachmentInput path="" name="attachment" defaultValue={{}} disabled />
+  </Document>
+);

--- a/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
@@ -9,12 +9,12 @@ export default {
 
 export const Basic = (): JSX.Element => (
   <Document>
-    <AttachmentInput name="attachment" />
+    <AttachmentInput path="" name="attachment" />
   </Document>
 );
 
 export const DefaultValue = (): JSX.Element => (
   <Document>
-    <AttachmentInput name="attachment" defaultValue={{}} />
+    <AttachmentInput path="" name="attachment" defaultValue={{}} />
   </Document>
 );

--- a/packages/react/src/AttachmentInput/AttachmentInput.test.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.test.tsx
@@ -8,7 +8,7 @@ const medplum = new MockClient();
 function setup(args?: AttachmentInputProps): void {
   render(
     <MedplumProvider medplum={medplum}>
-      <AttachmentInput name="test" {...args} />
+      <AttachmentInput path="" name="test" {...args} />
     </MedplumProvider>
   );
 }
@@ -25,6 +25,7 @@ describe('AttachmentInput', () => {
   test('Renders attachments', async () => {
     await act(async () => {
       await setup({
+        path: '',
         name: 'test',
         defaultValue: {
           contentType: 'image/jpeg',
@@ -53,6 +54,7 @@ describe('AttachmentInput', () => {
   test('Remove attachment', async () => {
     await act(async () => {
       await setup({
+        path: '',
         name: 'test',
         defaultValue: {
           contentType: 'image/jpeg',
@@ -75,6 +77,7 @@ describe('AttachmentInput', () => {
     const onChange = jest.fn();
 
     setup({
+      path: '',
       name: 'test',
       onChange,
     });

--- a/packages/react/src/AttachmentInput/AttachmentInput.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.tsx
@@ -4,10 +4,9 @@ import { MouseEvent, useState } from 'react';
 import { AttachmentButton } from '../AttachmentButton/AttachmentButton';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { killEvent } from '../utils/dom';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface AttachmentInputProps {
-  readonly name: string;
-  readonly defaultValue?: Attachment;
+export interface AttachmentInputProps extends ComplexTypeInputProps<Attachment> {
   readonly arrayElement?: boolean;
   readonly securityContext?: Reference;
   readonly onChange?: (value: Attachment | undefined) => void;
@@ -28,6 +27,7 @@ export function AttachmentInput(props: AttachmentInputProps): JSX.Element {
       <>
         <AttachmentDisplay value={value} maxWidth={200} />
         <Button
+          disabled={props.disabled}
           onClick={(e: MouseEvent) => {
             killEvent(e);
             setValueWrapper(undefined);
@@ -40,7 +40,7 @@ export function AttachmentInput(props: AttachmentInputProps): JSX.Element {
   }
 
   return (
-    <AttachmentButton securityContext={props.securityContext} onUpload={setValueWrapper}>
+    <AttachmentButton disabled={props.disabled} securityContext={props.securityContext} onUpload={setValueWrapper}>
       {(props) => <Button {...props}>Upload...</Button>}
     </AttachmentButton>
   );

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -13,6 +13,7 @@ import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisp
 import { useContext, useMemo } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { AccessPolicyResource } from '@medplum/fhirtypes';
 
 const EXTENSION_KEYS = ['extension', 'modifierExtension'];
 const IGNORED_PROPERTIES = DEFAULT_IGNORED_PROPERTIES.filter((prop) => !EXTENSION_KEYS.includes(prop));
@@ -26,6 +27,10 @@ export interface BackboneElementDisplayProps {
   readonly link?: boolean;
   /** (optional) Profile URL of the structure definition represented by the backbone element */
   readonly profileUrl?: string;
+  /**
+   * (optional) If provided, inputs specified in `accessPolicyResource.hiddenFields` are not shown.
+   */
+  readonly accessPolicyResource?: AccessPolicyResource;
 }
 
 export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.Element | null {
@@ -44,8 +49,9 @@ export function BackboneElementDisplay(props: BackboneElementDisplayProps): JSX.
       elements: typeSchema.elements,
       path: props.path,
       profileUrl: typeSchema.url,
+      accessPolicyResource: props.accessPolicyResource,
     });
-  }, [typeSchema, props.path, parentElementsContext]);
+  }, [typeSchema, parentElementsContext, props.path, props.accessPolicyResource]);
 
   if (isEmpty(value)) {
     return null;

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -16,8 +16,8 @@ export interface BackboneElementInputProps extends BaseInputProps {
   /** (optional) Profile URL of the structure definition represented by the backbone element */
   readonly profileUrl?: string;
   /**
-   * (optional) If provided, inputs specified in `accessPolicy.readonlyFields` are not editable
-   * and inputs specified in `accessPolicy.hiddenFields` are not shown.
+   * (optional) If provided, inputs specified in `accessPolicyResource.readonlyFields` are not editable
+   * and inputs specified in `accessPolicyResource.hiddenFields` are not shown.
    */
   readonly accessPolicyResource?: AccessPolicyResource;
 }

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -4,6 +4,7 @@ import { ElementsInput } from '../ElementsInput/ElementsInput';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 import { BaseInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { AccessPolicyResource } from '@medplum/fhirtypes';
 
 export interface BackboneElementInputProps extends BaseInputProps {
   /** Type name the backbone element represents */
@@ -14,6 +15,11 @@ export interface BackboneElementInputProps extends BaseInputProps {
   readonly onChange?: (value: any) => void;
   /** (optional) Profile URL of the structure definition represented by the backbone element */
   readonly profileUrl?: string;
+  /**
+   * (optional) If provided, inputs specified in `accessPolicy.readonlyFields` are not editable
+   * and inputs specified in `accessPolicy.hiddenFields` are not shown.
+   */
+  readonly accessPolicyResource?: AccessPolicyResource;
 }
 
 export function BackboneElementInput(props: BackboneElementInputProps): JSX.Element {
@@ -32,8 +38,9 @@ export function BackboneElementInput(props: BackboneElementInputProps): JSX.Elem
       elements: typeSchema.elements,
       path: props.path,
       profileUrl: typeSchema.url,
+      accessPolicyResource: props.accessPolicyResource,
     });
-  }, [typeSchema, props.path, parentElementsContext]);
+  }, [typeSchema, parentElementsContext, props.path, props.accessPolicyResource]);
 
   if (!typeSchema) {
     return <div>{type}&nbsp;not implemented</div>;

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -32,7 +32,7 @@ export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Elemen
         <Input.Wrapper
           id={props.htmlFor}
           label={label}
-          classNames={{ label: props?.readonly && classes.dimmed }}
+          classNames={{ label: props?.readonly ? classes.dimmed : undefined }}
           description={props.description}
           withAsterisk={props.withAsterisk}
         >

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -24,7 +24,7 @@ export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Elemen
     label = props.title;
   }
   return maybeWrapWithTooltip(
-    props.readonly ? READ_ONLY_TOOLTIP_TEXT : undefined,
+    props?.readonly ? READ_ONLY_TOOLTIP_TEXT : undefined,
     <Group wrap="nowrap" data-testid={props.testId}>
       <div>{props.children}</div>
       <div>

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -2,6 +2,7 @@ import { Group, Input } from '@mantine/core';
 import { ReactNode, useContext } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
+import classes from '../FormSection/FormSection.module.css';
 
 export interface CheckboxFormSectionProps {
   readonly htmlFor?: string;
@@ -31,6 +32,7 @@ export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Elemen
         <Input.Wrapper
           id={props.htmlFor}
           label={label}
+          classNames={{ label: props?.readonly && classes.dimmed }}
           description={props.description}
           withAsterisk={props.withAsterisk}
         >

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -1,6 +1,7 @@
 import { Group, Input } from '@mantine/core';
 import { ReactNode, useContext } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
 
 export interface CheckboxFormSectionProps {
   readonly htmlFor?: string;
@@ -10,6 +11,7 @@ export interface CheckboxFormSectionProps {
   readonly children?: ReactNode;
   readonly testId?: string;
   readonly fhirPath?: string;
+  readonly readonly?: boolean;
 }
 
 export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Element {
@@ -21,7 +23,8 @@ export function CheckboxFormSection(props: CheckboxFormSectionProps): JSX.Elemen
   } else {
     label = props.title;
   }
-  return (
+  return maybeWrapWithTooltip(
+    props.readonly ? READ_ONLY_TOOLTIP_TEXT : undefined,
     <Group wrap="nowrap" data-testid={props.testId}>
       <div>{props.children}</div>
       <div>

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.stories.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.stories.tsx
@@ -33,3 +33,17 @@ export const DefaultValue = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <CodeableConceptInput
+      disabled
+      name="foo"
+      binding={valueSet}
+      defaultValue={{ coding: [{ code: 'M', display: 'Married' }] }}
+      onChange={console.log}
+      path={'Patient.maritalStatus'}
+      outcome={undefined}
+    />
+  </Document>
+);

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.tsx
@@ -4,9 +4,9 @@ import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourceProperty
 import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodeableConceptInputProps
-  extends Omit<ValueSetAutocompleteProps, 'name' | 'defaultValue' | 'onChange'>,
+  extends Omit<ValueSetAutocompleteProps, 'name' | 'defaultValue' | 'onChange' | 'disabled'>,
     ComplexTypeInputProps<CodeableConcept> {
-  readonly onChange: ((value: CodeableConcept | undefined) => void) | undefined;
+  readonly onChange?: (value: CodeableConcept | undefined) => void;
 }
 
 export function CodeableConceptInput(props: CodeableConceptInputProps): JSX.Element {

--- a/packages/react/src/CodingInput/CodingInput.stories.tsx
+++ b/packages/react/src/CodingInput/CodingInput.stories.tsx
@@ -11,24 +11,24 @@ const valueSet = 'http://hl7.org/fhir/ValueSet/marital-status';
 
 export const Basic = (): JSX.Element => (
   <Document>
-    <CodingInput binding={valueSet} name="code" />
+    <CodingInput path="" binding={valueSet} name="code" />
   </Document>
 );
 
 export const WithWrapperText = (): JSX.Element => (
   <Document>
-    <CodingInput binding={valueSet} name="code" label="My Label" description="My help text" />
+    <CodingInput path="" binding={valueSet} name="code" label="My Label" description="My help text" />
   </Document>
 );
 
 export const WithError = (): JSX.Element => (
   <Document>
-    <CodingInput binding={valueSet} name="code" label="My Label" description="My help text" error="My error" />
+    <CodingInput path="" binding={valueSet} name="code" label="My Label" description="My help text" error="My error" />
   </Document>
 );
 
 export const MultipleValues = (): JSX.Element => (
   <Document>
-    <CodingInput binding={valueSet} name="code" label="Max Values 2" maxValues={2} />
+    <CodingInput path="" binding={valueSet} name="code" label="Max Values 2" maxValues={2} />
   </Document>
 );

--- a/packages/react/src/CodingInput/CodingInput.stories.tsx
+++ b/packages/react/src/CodingInput/CodingInput.stories.tsx
@@ -32,3 +32,16 @@ export const MultipleValues = (): JSX.Element => (
     <CodingInput path="" binding={valueSet} name="code" label="Max Values 2" maxValues={2} />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <CodingInput
+      path=""
+      binding={valueSet}
+      name="code"
+      label="My Label"
+      defaultValue={{ display: 'display' }}
+      disabled
+    />
+  </Document>
+);

--- a/packages/react/src/CodingInput/CodingInput.test.tsx
+++ b/packages/react/src/CodingInput/CodingInput.test.tsx
@@ -26,20 +26,20 @@ describe('CodingInput', () => {
   }
 
   test('Renders', async () => {
-    await setup(<CodingInput binding={binding} name="test" />);
+    await setup(<CodingInput path="" binding={binding} name="test" />);
 
     expect(screen.getByRole('searchbox')).toBeInTheDocument();
   });
 
   test('Renders Coding default value', async () => {
-    await setup(<CodingInput binding={binding} name="test" defaultValue={{ code: 'abc' }} />);
+    await setup(<CodingInput path="" binding={binding} name="test" defaultValue={{ code: 'abc' }} />);
 
     expect(screen.queryByRole('searchbox')).not.toBeInTheDocument();
     expect(screen.getByText('abc')).toBeDefined();
   });
 
   test('Searches for results', async () => {
-    await setup(<CodingInput binding={binding} name="test" />);
+    await setup(<CodingInput path="" binding={binding} name="test" />);
 
     const input = screen.getByRole('searchbox') as HTMLInputElement;
 
@@ -67,7 +67,7 @@ describe('CodingInput', () => {
   });
 
   test('Renders with empty binding property', async () => {
-    await setup(<CodingInput binding={undefined} name="test" />);
+    await setup(<CodingInput path="" binding={undefined} name="test" />);
 
     const input = screen.getByRole('searchbox') as HTMLInputElement;
 

--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -1,11 +1,11 @@
 import { Coding, ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { useState } from 'react';
 import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface CodingInputProps extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange'> {
-  readonly defaultValue?: Coding;
-  readonly onChange?: (value: Coding | undefined) => void;
-}
+export interface CodingInputProps
+  extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange' | 'disabled' | 'name'>,
+    ComplexTypeInputProps<Coding> {}
 
 export function CodingInput(props: CodingInputProps): JSX.Element {
   const { defaultValue, onChange, withHelpText, ...rest } = props;

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.stories.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.stories.tsx
@@ -2,6 +2,9 @@ import { ContactDetail } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { ContactDetailInput } from './ContactDetailInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/ContactDetailInput',
@@ -30,3 +33,67 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <ContactDetailInput
+      disabled
+      defaultValue={
+        {
+          name: 'Foo',
+          telecom: [
+            {
+              use: 'home',
+              system: 'email',
+              value: 'abc@example.com',
+            },
+          ],
+        } as ContactDetail
+      }
+      onChange={console.log}
+      name="contact"
+      path="Patient.contact"
+      outcome={undefined}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Patient',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Patient',
+      readonlyFields: ['contact.telecom.use', 'contact.name'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <ContactDetailInput
+        defaultValue={
+          {
+            name: 'Foo',
+            telecom: [
+              {
+                use: 'home',
+                system: 'email',
+                value: 'abc@example.com',
+              },
+            ],
+          } as ContactDetail
+        }
+        onChange={console.log}
+        name="contact"
+        path="Patient.contact"
+        outcome={undefined}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.tsx
@@ -45,7 +45,7 @@ export function ContactDetailInput(props: ContactDetailInputProps): JSX.Element 
   return (
     <Group gap="xs" grow wrap="nowrap">
       <TextInput
-        disabled={props.disabled || nameProps.readonly}
+        disabled={props.disabled || nameProps?.readonly}
         data-testid={props.name + '-name'}
         name={props.name + '-name'}
         placeholder="Name"
@@ -54,7 +54,7 @@ export function ContactDetailInput(props: ContactDetailInputProps): JSX.Element 
         onChange={(e) => setName(e.currentTarget.value)}
       />
       <ContactPointInput
-        disabled={props.disabled || telecomProps.readonly}
+        disabled={props.disabled || telecomProps?.readonly}
         name={props.name + '-telecom'}
         path={props.path + '.telecom'}
         defaultValue={contactPoint?.telecom?.[0]}

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.tsx
@@ -1,8 +1,9 @@
 import { Group, TextInput } from '@mantine/core';
 import { ContactDetail, ContactPoint } from '@medplum/fhirtypes';
-import { useRef, useState } from 'react';
+import { useContext, useMemo, useRef, useState } from 'react';
 import { ContactPointInput } from '../ContactPointInput/ContactPointInput';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 
 export type ContactDetailInputProps = ComplexTypeInputProps<ContactDetail>;
 
@@ -11,6 +12,12 @@ export function ContactDetailInput(props: ContactDetailInputProps): JSX.Element 
 
   const ref = useRef<ContactDetail>();
   ref.current = contactPoint;
+
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [nameProps, telecomProps] = useMemo(
+    () => ['name', 'telecom'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   function setContactDetailWrapper(newValue: ContactDetail): void {
     setContactDetail(newValue);
@@ -38,6 +45,7 @@ export function ContactDetailInput(props: ContactDetailInputProps): JSX.Element 
   return (
     <Group gap="xs" grow wrap="nowrap">
       <TextInput
+        disabled={props.disabled || nameProps.readonly}
         data-testid={props.name + '-name'}
         name={props.name + '-name'}
         placeholder="Name"
@@ -46,6 +54,7 @@ export function ContactDetailInput(props: ContactDetailInputProps): JSX.Element 
         onChange={(e) => setName(e.currentTarget.value)}
       />
       <ContactPointInput
+        disabled={props.disabled || telecomProps.readonly}
         name={props.name + '-telecom'}
         path={props.path + '.telecom'}
         defaultValue={contactPoint?.telecom?.[0]}

--- a/packages/react/src/ContactPointInput/ContactPointInput.stories.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.stories.tsx
@@ -2,6 +2,9 @@ import { ContactPoint } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { ContactPointInput } from './ContactPointInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/ContactPointInput',
@@ -19,3 +22,44 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <ContactPointInput
+      disabled
+      name="test"
+      path="Patient.contact"
+      defaultValue={{ use: 'home', system: 'email', value: 'homer@example.com' } as ContactPoint}
+      onChange={console.log}
+      outcome={undefined}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Patient',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Patient',
+      readonlyFields: ['contact.telecom.system', 'contact.telecom.value'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <ContactPointInput
+        name="test"
+        path="Patient.contact.telecom"
+        defaultValue={{ use: 'home', system: 'email', value: 'homer@example.com' } as ContactPoint}
+        onChange={console.log}
+        outcome={undefined}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -6,7 +6,7 @@ import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { getErrorsForInput } from '../utils/outcomes';
 
 export type ContactPointInputProps = ComplexTypeInputProps<ContactPoint> & {
-  readonly onChange: ((value: ContactPoint | undefined) => void) | undefined;
+  readonly onChange?: (value: ContactPoint | undefined) => void;
 };
 
 export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
@@ -65,7 +65,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
       <NativeSelect
-        disabled={props.disabled || systemProps?.readonly}
+        disabled={props.disabled || systemProps.readonly}
         data-testid="system"
         defaultValue={contactPoint?.system}
         required={(systemElement?.min ?? 0) > 0}
@@ -76,7 +76,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.system')}
       />
       <NativeSelect
-        disabled={props.disabled || useProps?.readonly}
+        disabled={props.disabled || useProps.readonly}
         data-testid="use"
         defaultValue={contactPoint?.use}
         required={(useElement?.min ?? 0) > 0}
@@ -85,7 +85,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.use')}
       />
       <TextInput
-        disabled={props.disabled || valueProps?.readonly}
+        disabled={props.disabled || valueProps.readonly}
         placeholder="Value"
         defaultValue={contactPoint?.value}
         required={(valueElement?.min ?? 0) > 0}

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -11,7 +11,7 @@ export type ContactPointInputProps = ComplexTypeInputProps<ContactPoint> & {
 
 export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
   const { path, outcome } = props;
-  const { elementsByPath } = useContext(ElementsContext);
+  const { elementsByPath, getExtendedProps } = useContext(ElementsContext);
   const [contactPoint, setContactPoint] = useState(props.defaultValue);
 
   const ref = useRef<ContactPoint>();
@@ -20,6 +20,10 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
   const [systemElement, useElement, valueElement] = useMemo(
     () => ['system', 'use', 'value'].map((field) => elementsByPath[path + '.' + field]),
     [elementsByPath, path]
+  );
+  const [systemProps, useProps, valueProps] = useMemo(
+    () => ['system', 'use', 'value'].map((field) => getExtendedProps(path + '.' + field)),
+    [getExtendedProps, path]
   );
 
   function setContactPointWrapper(newValue: ContactPoint | undefined): void {
@@ -61,6 +65,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
       <NativeSelect
+        disabled={props.disabled || systemProps?.readonly}
         data-testid="system"
         defaultValue={contactPoint?.system}
         required={(systemElement?.min ?? 0) > 0}
@@ -71,6 +76,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.system')}
       />
       <NativeSelect
+        disabled={props.disabled || useProps?.readonly}
         data-testid="use"
         defaultValue={contactPoint?.use}
         required={(useElement?.min ?? 0) > 0}
@@ -79,6 +85,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.use')}
       />
       <TextInput
+        disabled={props.disabled || valueProps?.readonly}
         placeholder="Value"
         defaultValue={contactPoint?.value}
         required={(valueElement?.min ?? 0) > 0}

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -65,7 +65,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
       <NativeSelect
-        disabled={props.disabled || systemProps.readonly}
+        disabled={props.disabled || systemProps?.readonly}
         data-testid="system"
         defaultValue={contactPoint?.system}
         required={(systemElement?.min ?? 0) > 0}
@@ -76,7 +76,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.system')}
       />
       <NativeSelect
-        disabled={props.disabled || useProps.readonly}
+        disabled={props.disabled || useProps?.readonly}
         data-testid="use"
         defaultValue={contactPoint?.use}
         required={(useElement?.min ?? 0) > 0}
@@ -85,7 +85,7 @@ export function ContactPointInput(props: ContactPointInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.use')}
       />
       <TextInput
-        disabled={props.disabled || valueProps.readonly}
+        disabled={props.disabled || valueProps?.readonly}
         placeholder="Value"
         defaultValue={contactPoint?.value}
         required={(valueElement?.min ?? 0) > 0}

--- a/packages/react/src/DateTimeInput/DateTimeInput.stories.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 export const Basic = (): JSX.Element => (
   <Document>
-    <DateTimeInput onChange={console.log} />
+    <DateTimeInput name="demo" onChange={console.log} />
   </Document>
 );

--- a/packages/react/src/DateTimeInput/DateTimeInput.stories.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.stories.tsx
@@ -12,3 +12,9 @@ export const Basic = (): JSX.Element => (
     <DateTimeInput name="demo" onChange={console.log} />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <DateTimeInput name="demo" onChange={console.log} disabled />
+  </Document>
+);

--- a/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.test.tsx
@@ -27,7 +27,7 @@ describe('DateTimeInput', () => {
   test('onChange without listener', async () => {
     const value = convertIsoToLocal(new Date().toISOString());
 
-    render(<DateTimeInput placeholder="Placeholder" />);
+    render(<DateTimeInput name="a" placeholder="Placeholder" />);
 
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText('Placeholder'), { target: { value } });
@@ -45,7 +45,7 @@ describe('DateTimeInput', () => {
     const isoString = date.toISOString();
     const localString = convertIsoToLocal(isoString);
 
-    render(<DateTimeInput placeholder="Placeholder" onChange={onChange} />);
+    render(<DateTimeInput name="a" placeholder="Placeholder" onChange={onChange} />);
 
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText('Placeholder'), { target: { value: localString } });

--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -13,6 +13,7 @@ export interface DateTimeInputProps {
   readonly required?: boolean;
   readonly outcome?: OperationOutcome;
   readonly onChange?: (value: string) => void;
+  readonly disabled?: boolean;
 }
 
 /**
@@ -33,6 +34,7 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
       data-testid={props.name}
       placeholder={props.placeholder}
       required={props.required}
+      disabled={props.disabled}
       type={getInputType()}
       defaultValue={convertIsoToLocal(props.defaultValue)}
       autoFocus={props.autoFocus}

--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -3,17 +3,15 @@ import { OperationOutcome } from '@medplum/fhirtypes';
 import { ChangeEvent } from 'react';
 import { getErrorsForInput } from '../utils/outcomes';
 import { convertIsoToLocal, convertLocalToIso } from './DateTimeInput.utils';
+import { PrimitiveTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface DateTimeInputProps {
-  readonly name?: string;
+export interface DateTimeInputProps extends PrimitiveTypeInputProps {
   readonly label?: string;
   readonly placeholder?: string;
   readonly defaultValue?: string;
   readonly autoFocus?: boolean;
-  readonly required?: boolean;
   readonly outcome?: OperationOutcome;
   readonly onChange?: (value: string) => void;
-  readonly disabled?: boolean;
 }
 
 /**
@@ -31,7 +29,7 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
       name={props.name}
       label={props.label}
       data-autofocus={props.autoFocus}
-      data-testid={props.name}
+      data-testid={props['data-testid'] ?? props.name}
       placeholder={props.placeholder}
       required={props.required}
       disabled={props.disabled}

--- a/packages/react/src/ElementsInput/ElementsInput.test.tsx
+++ b/packages/react/src/ElementsInput/ElementsInput.test.tsx
@@ -25,6 +25,7 @@ const elementsContext: ElementsContextType = {
   },
   path: 'elements',
   profileUrl: 'testProfileUrl',
+  getExtendedProps: () => undefined,
 };
 
 const onChange = jest.fn();

--- a/packages/react/src/ElementsInput/ElementsInput.tsx
+++ b/packages/react/src/ElementsInput/ElementsInput.tsx
@@ -68,6 +68,7 @@ export function ElementsInput(props: ElementsInputProps): JSX.Element {
               htmlFor={key}
               fhirPath={element.path}
               withAsterisk={required}
+              readonly={element.readonly}
             >
               {resourcePropertyInput}
             </CheckboxFormSection>
@@ -84,6 +85,7 @@ export function ElementsInput(props: ElementsInputProps): JSX.Element {
             outcome={props.outcome}
             fhirPath={element.path}
             errorExpression={valuePath}
+            readonly={element.readonly}
           >
             {resourcePropertyInput}
           </FormSection>

--- a/packages/react/src/ElementsInput/ElementsInput.utils.ts
+++ b/packages/react/src/ElementsInput/ElementsInput.utils.ts
@@ -1,9 +1,8 @@
-import { AnnotatedInternalSchemaElement, ElementsContextType, isPopulated } from '@medplum/core';
+import { ExtendedInternalSchemaElement, ElementsContextType, isPopulated } from '@medplum/core';
 import { createContext } from 'react';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 
 export const ElementsContext = createContext<ElementsContextType>({
-  isDefault: true,
   path: '',
   profileUrl: undefined,
   elements: Object.create(null),
@@ -11,6 +10,7 @@ export const ElementsContext = createContext<ElementsContextType>({
   getExtendedProps: () => ({ readonly: false, hidden: false }),
   accessPolicyResource: undefined,
   debugMode: false,
+  isDefaultContext: true,
 });
 ElementsContext.displayName = 'ElementsContext';
 
@@ -20,8 +20,8 @@ export const IGNORED_PROPERTIES = ['id', ...DEFAULT_IGNORED_PROPERTIES].filter(
 );
 
 export function getElementsToRender(
-  inputElements: Record<string, AnnotatedInternalSchemaElement>
-): [string, AnnotatedInternalSchemaElement][] {
+  inputElements: Record<string, ExtendedInternalSchemaElement>
+): [string, ExtendedInternalSchemaElement][] {
   const result = Object.entries(inputElements).filter(([key, element]) => {
     if (!isPopulated(element.type)) {
       return false;

--- a/packages/react/src/ElementsInput/ElementsInput.utils.ts
+++ b/packages/react/src/ElementsInput/ElementsInput.utils.ts
@@ -3,11 +3,13 @@ import { createContext } from 'react';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 
 export const ElementsContext = createContext<ElementsContextType>({
+  isDefault: true,
   path: '',
   profileUrl: undefined,
   elements: Object.create(null),
   elementsByPath: Object.create(null),
   getExtendedProps: () => ({ readonly: false, hidden: false }),
+  accessPolicyResource: undefined,
   debugMode: false,
 });
 ElementsContext.displayName = 'ElementsContext';

--- a/packages/react/src/ElementsInput/ElementsInput.utils.ts
+++ b/packages/react/src/ElementsInput/ElementsInput.utils.ts
@@ -7,7 +7,10 @@ export const ElementsContext = createContext<ElementsContextType>({
   profileUrl: undefined,
   elements: Object.create(null),
   elementsByPath: Object.create(null),
-  getExtendedProps: () => ({ readonly: false, hidden: false }),
+  getExtendedProps: () => {
+    console.warn('Calling the placeholder getExtendedProps function');
+    return { readonly: false, hidden: false };
+  },
   accessPolicyResource: undefined,
   debugMode: false,
   isDefaultContext: true,

--- a/packages/react/src/ElementsInput/ElementsInput.utils.ts
+++ b/packages/react/src/ElementsInput/ElementsInput.utils.ts
@@ -1,4 +1,4 @@
-import { ElementsContextType, InternalSchemaElement, isPopulated } from '@medplum/core';
+import { AnnotatedInternalSchemaElement, ElementsContextType, isPopulated } from '@medplum/core';
 import { createContext } from 'react';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 
@@ -18,8 +18,8 @@ export const IGNORED_PROPERTIES = ['id', ...DEFAULT_IGNORED_PROPERTIES].filter(
 );
 
 export function getElementsToRender(
-  inputElements: Record<string, InternalSchemaElement>
-): [string, InternalSchemaElement][] {
+  inputElements: Record<string, AnnotatedInternalSchemaElement>
+): [string, AnnotatedInternalSchemaElement][] {
   const result = Object.entries(inputElements).filter(([key, element]) => {
     if (!isPopulated(element.type)) {
       return false;

--- a/packages/react/src/ElementsInput/ElementsInput.utils.ts
+++ b/packages/react/src/ElementsInput/ElementsInput.utils.ts
@@ -7,6 +7,7 @@ export const ElementsContext = createContext<ElementsContextType>({
   profileUrl: undefined,
   elements: Object.create(null),
   elementsByPath: Object.create(null),
+  getExtendedProps: () => ({ readonly: false, hidden: false }),
   debugMode: false,
 });
 ElementsContext.displayName = 'ElementsContext';

--- a/packages/react/src/FormSection/FormSection.module.css
+++ b/packages/react/src/FormSection/FormSection.module.css
@@ -1,0 +1,3 @@
+.dimmed {
+  color: var(--mantine-color-dimmed);
+}

--- a/packages/react/src/FormSection/FormSection.stories.tsx
+++ b/packages/react/src/FormSection/FormSection.stories.tsx
@@ -40,3 +40,23 @@ export const Basic = (): JSX.Element => (
     </Form>
   </Document>
 );
+
+export const Readonly = (): JSX.Element => (
+  <Document>
+    <FormSection
+      readonly
+      title="Demographics"
+      description="Basic Patient Information
+      "
+    >
+      <HumanNameInput
+        disabled
+        name="patient-name"
+        path="Patient.name"
+        defaultValue={{ given: ['Homer'], family: 'Simpson' } as HumanName}
+        onChange={undefined}
+        outcome={undefined}
+      />
+    </FormSection>
+  </Document>
+);

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -28,7 +28,7 @@ export function FormSection(props: FormSectionProps): JSX.Element {
     label = props.title;
   }
   return maybeWrapWithTooltip(
-    props.readonly ? READ_ONLY_TOOLTIP_TEXT : undefined,
+    props?.readonly ? READ_ONLY_TOOLTIP_TEXT : undefined,
     <Input.Wrapper
       id={props.htmlFor}
       label={label}

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -3,6 +3,7 @@ import { OperationOutcome } from '@medplum/fhirtypes';
 import { ReactNode, useContext } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { getErrorsForInput } from '../utils/outcomes';
+import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
 
 export interface FormSectionProps {
   readonly title?: string;
@@ -14,6 +15,7 @@ export interface FormSectionProps {
   readonly testId?: string;
   readonly fhirPath?: string;
   readonly errorExpression?: string;
+  readonly readonly?: boolean;
 }
 
 export function FormSection(props: FormSectionProps): JSX.Element {
@@ -25,7 +27,8 @@ export function FormSection(props: FormSectionProps): JSX.Element {
   } else {
     label = props.title;
   }
-  return (
+  return maybeWrapWithTooltip(
+    props.readonly ? READ_ONLY_TOOLTIP_TEXT : undefined,
     <Input.Wrapper
       id={props.htmlFor}
       label={label}

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -33,7 +33,7 @@ export function FormSection(props: FormSectionProps): JSX.Element {
     <Input.Wrapper
       id={props.htmlFor}
       label={label}
-      classNames={{ label: props?.readonly && classes.dimmed }}
+      classNames={{ label: props?.readonly ? classes.dimmed : undefined }}
       description={props.description}
       withAsterisk={props.withAsterisk}
       error={getErrorsForInput(props.outcome, props.errorExpression ?? props.htmlFor)}

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useContext } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { getErrorsForInput } from '../utils/outcomes';
 import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
+import classes from './FormSection.module.css';
 
 export interface FormSectionProps {
   readonly title?: string;
@@ -32,6 +33,7 @@ export function FormSection(props: FormSectionProps): JSX.Element {
     <Input.Wrapper
       id={props.htmlFor}
       label={label}
+      classNames={{ label: props?.readonly && classes.dimmed }}
       description={props.description}
       withAsterisk={props.withAsterisk}
       error={getErrorsForInput(props.outcome, props.errorExpression ?? props.htmlFor)}

--- a/packages/react/src/HumanNameInput/HumanNameInput.stories.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.stories.tsx
@@ -2,6 +2,9 @@ import { HumanName } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { HumanNameInput } from './HumanNameInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/HumanNameInput',
@@ -19,3 +22,45 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <HumanNameInput
+      disabled
+      name="patient-name"
+      path="Patient.name"
+      defaultValue={{ prefix: ['Mr.'], given: ['Homer', 'J.'], family: 'Simpson' } as HumanName}
+      onChange={console.log}
+      outcome={undefined}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Patient',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Patient',
+      readonlyFields: ['name.use', 'name.given', 'name.suffix'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <HumanNameInput
+        name="patient-name"
+        path="Patient.name"
+        defaultValue={{ prefix: ['Mr.'], given: ['Homer', 'J.'], family: 'Simpson' } as HumanName}
+        onChange={console.log}
+        outcome={undefined}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/HumanNameInput/HumanNameInput.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.tsx
@@ -62,7 +62,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <NativeSelect
-        disabled={props.disabled || useProps.readonly}
+        disabled={props.disabled || useProps?.readonly}
         defaultValue={value?.use}
         name={props.name + '-use'}
         data-testid="use"
@@ -73,7 +73,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.use')}
       />
       <TextInput
-        disabled={props.disabled || prefixProps.readonly}
+        disabled={props.disabled || prefixProps?.readonly}
         placeholder="Prefix"
         name={props.name + '-prefix'}
         defaultValue={value?.prefix?.join(' ')}
@@ -81,7 +81,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.prefix')}
       />
       <TextInput
-        disabled={props.disabled || givenProps.readonly}
+        disabled={props.disabled || givenProps?.readonly}
         placeholder="Given"
         name={props.name + '-given'}
         defaultValue={value?.given?.join(' ')}
@@ -89,7 +89,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.given')}
       />
       <TextInput
-        disabled={props.disabled || familyProps.readonly}
+        disabled={props.disabled || familyProps?.readonly}
         name={props.name + '-family'}
         placeholder="Family"
         defaultValue={value?.family}
@@ -97,7 +97,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.family')}
       />
       <TextInput
-        disabled={props.disabled || suffixProps.readonly}
+        disabled={props.disabled || suffixProps?.readonly}
         placeholder="Suffix"
         name={props.name + '-suffix'}
         defaultValue={value?.suffix?.join(' ')}

--- a/packages/react/src/HumanNameInput/HumanNameInput.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.tsx
@@ -1,14 +1,21 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { HumanName } from '@medplum/fhirtypes';
-import { useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { getErrorsForInput } from '../utils/outcomes';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 
 export type HumanNameInputProps = ComplexTypeInputProps<HumanName>;
 
 export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
   const { outcome, path } = props;
   const [value, setValue] = useState<HumanName | undefined>(props.defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+
+  const [useProps, prefixProps, givenProps, familyProps, suffixProps] = useMemo(
+    () => ['use', 'prefix', 'given', 'family', 'suffix'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   function setValueWrapper(newValue: HumanName): void {
     setValue(newValue);
@@ -56,6 +63,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <NativeSelect
+        disabled={props.disabled || useProps?.readonly}
         defaultValue={value?.use}
         name={props.name + '-use'}
         data-testid="use"
@@ -66,6 +74,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.use')}
       />
       <TextInput
+        disabled={props.disabled || prefixProps?.readonly}
         placeholder="Prefix"
         name={props.name + '-prefix'}
         defaultValue={value?.prefix?.join(' ')}
@@ -73,6 +82,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.prefix')}
       />
       <TextInput
+        disabled={props.disabled || givenProps?.readonly}
         placeholder="Given"
         name={props.name + '-given'}
         defaultValue={value?.given?.join(' ')}
@@ -80,6 +90,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.given')}
       />
       <TextInput
+        disabled={props.disabled || familyProps?.readonly}
         name={props.name + '-family'}
         placeholder="Family"
         defaultValue={value?.family}
@@ -87,6 +98,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.family')}
       />
       <TextInput
+        disabled={props.disabled || suffixProps?.readonly}
         placeholder="Suffix"
         name={props.name + '-suffix'}
         defaultValue={value?.suffix?.join(' ')}

--- a/packages/react/src/HumanNameInput/HumanNameInput.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.tsx
@@ -11,7 +11,6 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
   const { outcome, path } = props;
   const [value, setValue] = useState<HumanName | undefined>(props.defaultValue);
   const { getExtendedProps } = useContext(ElementsContext);
-
   const [useProps, prefixProps, givenProps, familyProps, suffixProps] = useMemo(
     () => ['use', 'prefix', 'given', 'family', 'suffix'].map((field) => getExtendedProps(props.path + '.' + field)),
     [getExtendedProps, props.path]
@@ -63,7 +62,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <NativeSelect
-        disabled={props.disabled || useProps?.readonly}
+        disabled={props.disabled || useProps.readonly}
         defaultValue={value?.use}
         name={props.name + '-use'}
         data-testid="use"
@@ -74,7 +73,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.use')}
       />
       <TextInput
-        disabled={props.disabled || prefixProps?.readonly}
+        disabled={props.disabled || prefixProps.readonly}
         placeholder="Prefix"
         name={props.name + '-prefix'}
         defaultValue={value?.prefix?.join(' ')}
@@ -82,7 +81,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.prefix')}
       />
       <TextInput
-        disabled={props.disabled || givenProps?.readonly}
+        disabled={props.disabled || givenProps.readonly}
         placeholder="Given"
         name={props.name + '-given'}
         defaultValue={value?.given?.join(' ')}
@@ -90,7 +89,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.given')}
       />
       <TextInput
-        disabled={props.disabled || familyProps?.readonly}
+        disabled={props.disabled || familyProps.readonly}
         name={props.name + '-family'}
         placeholder="Family"
         defaultValue={value?.family}
@@ -98,7 +97,7 @@ export function HumanNameInput(props: HumanNameInputProps): JSX.Element {
         error={getErrorsForInput(outcome, errorPath + '.family')}
       />
       <TextInput
-        disabled={props.disabled || suffixProps?.readonly}
+        disabled={props.disabled || suffixProps.readonly}
         placeholder="Suffix"
         name={props.name + '-suffix'}
         defaultValue={value?.suffix?.join(' ')}

--- a/packages/react/src/IdentifierInput/IdentifierInput.stories.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.stories.tsx
@@ -2,6 +2,9 @@ import { Identifier } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { IdentifierInput } from './IdentifierInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/IdentifierInput',
@@ -24,3 +27,55 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <IdentifierInput
+      disabled
+      name="patient-identifier"
+      path="Patient.identifier"
+      defaultValue={
+        {
+          system: 'http://hl7.org/fhir/sid/us-ssn',
+          value: '011-11-1234',
+        } as Identifier
+      }
+      onChange={console.log}
+      outcome={undefined}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Patient',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Patient',
+      readonlyFields: ['identifier.system'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <IdentifierInput
+        name="patient-identifier"
+        path="Patient.identifier"
+        defaultValue={
+          {
+            system: 'http://hl7.org/fhir/sid/us-ssn',
+            value: '011-11-1234',
+          } as Identifier
+        }
+        onChange={console.log}
+        outcome={undefined}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/IdentifierInput/IdentifierInput.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.tsx
@@ -32,7 +32,7 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
       <TextInput
-        disabled={props.disabled || systemProps.readonly}
+        disabled={props.disabled || systemProps?.readonly}
         placeholder="System"
         required={(systemElement?.min ?? 0) > 0}
         defaultValue={value?.system}
@@ -40,7 +40,7 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
         error={getErrorsForInput(props.outcome, errorPath + '.system')}
       />
       <TextInput
-        disabled={props.disabled || valueProps.readonly}
+        disabled={props.disabled || valueProps?.readonly}
         placeholder="Value"
         required={(valueElement?.min ?? 0) > 0}
         defaultValue={value?.value}

--- a/packages/react/src/IdentifierInput/IdentifierInput.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.tsx
@@ -9,11 +9,16 @@ export type IdentifierInputProps = ComplexTypeInputProps<Identifier>;
 
 export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
-  const { elementsByPath } = useContext(ElementsContext);
+  const { elementsByPath, getExtendedProps } = useContext(ElementsContext);
 
   const [systemElement, valueElement] = useMemo(
     () => ['system', 'value'].map((field) => elementsByPath[props.path + '.' + field]),
     [elementsByPath, props.path]
+  );
+
+  const [systemProps, valueProps] = useMemo(
+    () => ['system', 'value'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
   );
 
   function setValueWrapper(newValue: Identifier): void {
@@ -27,7 +32,7 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
       <TextInput
-        disabled={systemElement?.readonly || props.disabled}
+        disabled={props.disabled || systemProps.readonly}
         placeholder="System"
         required={(systemElement?.min ?? 0) > 0}
         defaultValue={value?.system}
@@ -35,7 +40,7 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
         error={getErrorsForInput(props.outcome, errorPath + '.system')}
       />
       <TextInput
-        disabled={valueElement?.readonly || props.disabled}
+        disabled={props.disabled || valueProps.readonly}
         placeholder="Value"
         required={(valueElement?.min ?? 0) > 0}
         defaultValue={value?.value}

--- a/packages/react/src/IdentifierInput/IdentifierInput.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.tsx
@@ -27,6 +27,7 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
       <TextInput
+        disabled={systemElement?.readonly || props.disabled}
         placeholder="System"
         required={(systemElement?.min ?? 0) > 0}
         defaultValue={value?.system}
@@ -34,6 +35,7 @@ export function IdentifierInput(props: IdentifierInputProps): JSX.Element {
         error={getErrorsForInput(props.outcome, errorPath + '.system')}
       />
       <TextInput
+        disabled={valueElement?.readonly || props.disabled}
         placeholder="Value"
         required={(valueElement?.min ?? 0) > 0}
         defaultValue={value?.value}

--- a/packages/react/src/MoneyInput/MoneyInput.stories.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { MoneyInput } from './MoneyInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/MoneyInput',
@@ -18,3 +21,37 @@ export const DefaultValue = (): JSX.Element => (
     <MoneyInput path="" name="demo" onChange={console.log} defaultValue={{ value: 101.55, currency: 'USD' }} />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <MoneyInput disabled path="" name="demo" onChange={console.log} defaultValue={{ value: 101.55, currency: 'USD' }} />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Claim',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Claim',
+      readonlyFields: ['total.currency'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <MoneyInput
+        path="Claim.total"
+        name="demo"
+        onChange={console.log}
+        defaultValue={{ value: 101.55, currency: 'USD' }}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/MoneyInput/MoneyInput.stories.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.stories.tsx
@@ -9,12 +9,12 @@ export default {
 
 export const Basic = (): JSX.Element => (
   <Document>
-    <MoneyInput name="foo" onChange={console.log} />
+    <MoneyInput path="" name="demo" onChange={console.log} />
   </Document>
 );
 
 export const DefaultValue = (): JSX.Element => (
   <Document>
-    <MoneyInput name="foo" onChange={console.log} defaultValue={{ value: 101.55, currency: 'USD' }} />
+    <MoneyInput path="" name="demo" onChange={console.log} defaultValue={{ value: 101.55, currency: 'USD' }} />
   </Document>
 );

--- a/packages/react/src/MoneyInput/MoneyInput.test.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.test.tsx
@@ -4,13 +4,13 @@ import { MoneyInput } from './MoneyInput';
 
 describe('MoneyInput', () => {
   test('Renders', () => {
-    render(<MoneyInput name="a" defaultValue={{ value: 123, currency: 'USD' }} />);
+    render(<MoneyInput path="" name="a" defaultValue={{ value: 123, currency: 'USD' }} />);
     expect(screen.getByDisplayValue('123')).toBeDefined();
     expect(screen.getByDisplayValue('USD')).toBeDefined();
   });
 
   test('Renders undefined value', () => {
-    render(<MoneyInput name="a" />);
+    render(<MoneyInput path="" name="a" />);
     expect(screen.getByPlaceholderText('Value')).toBeDefined();
     expect(screen.getByDisplayValue('USD')).toBeDefined();
   });
@@ -18,7 +18,7 @@ describe('MoneyInput', () => {
   test('Set value', async () => {
     let lastValue: Money | undefined = undefined;
 
-    render(<MoneyInput name="a" onChange={(value) => (lastValue = value)} />);
+    render(<MoneyInput path="" name="a" onChange={(value) => (lastValue = value)} />);
 
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText('Value'), {

--- a/packages/react/src/MoneyInput/MoneyInput.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.tsx
@@ -1,7 +1,9 @@
 import { NativeSelect, TextInput } from '@mantine/core';
 import { Money } from '@medplum/fhirtypes';
 import { IconCurrencyDollar } from '@tabler/icons-react';
-import { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useContext, useMemo, useState } from 'react';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 /*
  * Based on: https://github.com/mantinedev/ui.mantine.dev/blob/master/components/CurrencyInput/CurrencyInput.tsx
@@ -20,17 +22,19 @@ import { ChangeEvent, useCallback, useState } from 'react';
  */
 const data = ['USD', 'EUR', 'CAD', 'GBP', 'AUD'];
 
-export interface MoneyInputProps {
-  readonly name: string;
+export interface MoneyInputProps extends ComplexTypeInputProps<Money> {
   readonly label?: string;
   readonly placeholder?: string;
-  readonly defaultValue?: Money;
-  readonly onChange?: (value: Money) => void;
 }
 
 export function MoneyInput(props: MoneyInputProps): JSX.Element {
   const { onChange } = props;
   const [value, setValue] = useState(props.defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [currencyProps, valueProps] = useMemo(
+    () => ['currency', 'value'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   const setValueWrapper = useCallback(
     (newValue: Money): void => {
@@ -64,6 +68,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
 
   const select = (
     <NativeSelect
+      disabled={props.disabled || currencyProps.readonly}
       defaultValue={value?.currency}
       data={data}
       styles={{
@@ -80,6 +85,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
 
   return (
     <TextInput
+      disabled={props.disabled || valueProps.readonly}
       type="number"
       name={props.name}
       label={props.label}

--- a/packages/react/src/MoneyInput/MoneyInput.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.tsx
@@ -68,7 +68,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
 
   const select = (
     <NativeSelect
-      disabled={props.disabled || currencyProps.readonly}
+      disabled={props.disabled || currencyProps?.readonly}
       defaultValue={value?.currency}
       data={data}
       styles={{
@@ -85,7 +85,7 @@ export function MoneyInput(props: MoneyInputProps): JSX.Element {
 
   return (
     <TextInput
-      disabled={props.disabled || valueProps.readonly}
+      disabled={props.disabled || valueProps?.readonly}
       type="number"
       name={props.name}
       label={props.label}

--- a/packages/react/src/PeriodInput/PeriodInput.stories.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.stories.tsx
@@ -9,13 +9,14 @@ export default {
 
 export const Example = (): JSX.Element => (
   <Document>
-    <PeriodInput name="demo" />
+    <PeriodInput path="" name="demo" />
   </Document>
 );
 
 export const DefaultValue = (): JSX.Element => (
   <Document>
     <PeriodInput
+      path=""
       name="demo"
       defaultValue={{
         start: '2021-12-01T00:00:00.000Z',

--- a/packages/react/src/PeriodInput/PeriodInput.stories.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { PeriodInput } from './PeriodInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/PeriodInput',
@@ -25,3 +28,47 @@ export const DefaultValue = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <PeriodInput
+      disabled
+      path=""
+      name="demo"
+      defaultValue={{
+        start: '2021-12-01T00:00:00.000Z',
+        end: '2021-12-05T00:00:00.000Z',
+      }}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Claim',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Claim',
+      readonlyFields: ['billablePeriod.end'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <PeriodInput
+        path="Claim.billablePeriod"
+        name="demo"
+        defaultValue={{
+          start: '2021-12-01T00:00:00.000Z',
+          end: '2021-12-05T00:00:00.000Z',
+        }}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/PeriodInput/PeriodInput.test.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.test.tsx
@@ -7,19 +7,19 @@ const endDateTime = '2021-01-02T00:00:00.000Z';
 
 describe('PeriodInput', () => {
   test('Renders undefined value', () => {
-    render(<PeriodInput name="a" />);
+    render(<PeriodInput path="" name="a" />);
     expect(screen.getByPlaceholderText('Start')).toBeDefined();
     expect(screen.getByPlaceholderText('End')).toBeDefined();
   });
 
   test('Renders', () => {
-    render(<PeriodInput name="a" defaultValue={{ start: startDateTime, end: endDateTime }} />);
+    render(<PeriodInput path="" name="a" defaultValue={{ start: startDateTime, end: endDateTime }} />);
     expect(screen.getByPlaceholderText('Start')).toBeDefined();
     expect(screen.getByPlaceholderText('End')).toBeDefined();
   });
 
   test('Set value', async () => {
-    render(<PeriodInput name="a" />);
+    render(<PeriodInput path="" name="a" />);
 
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText('Start'), {
@@ -40,7 +40,7 @@ describe('PeriodInput', () => {
   test('Change event', async () => {
     let lastValue: Period | undefined = undefined;
 
-    render(<PeriodInput name="a" onChange={(value) => (lastValue = value)} />);
+    render(<PeriodInput path="" name="a" onChange={(value) => (lastValue = value)} />);
 
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText('Start'), {

--- a/packages/react/src/PeriodInput/PeriodInput.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.tsx
@@ -1,16 +1,19 @@
 import { Group } from '@mantine/core';
 import { Period } from '@medplum/fhirtypes';
-import { useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface PeriodInputProps {
-  readonly name: string;
-  readonly defaultValue?: Period;
-  readonly onChange?: (value: Period) => void;
-}
+export interface PeriodInputProps extends ComplexTypeInputProps<Period> {}
 
 export function PeriodInput(props: PeriodInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [startProps, endProps] = useMemo(
+    () => ['start', 'end'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   function setValueWrapper(newValue: Period): void {
     setValue(newValue);
@@ -22,12 +25,14 @@ export function PeriodInput(props: PeriodInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <DateTimeInput
+        disabled={props.disabled || startProps.readonly}
         name={props.name + '.start'}
         placeholder="Start"
         defaultValue={value?.start}
         onChange={(newValue) => setValueWrapper({ ...value, start: newValue })}
       />
       <DateTimeInput
+        disabled={props.disabled || endProps.readonly}
         name={props.name + '.end'}
         placeholder="End"
         defaultValue={value?.end}

--- a/packages/react/src/PeriodInput/PeriodInput.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.tsx
@@ -25,14 +25,14 @@ export function PeriodInput(props: PeriodInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <DateTimeInput
-        disabled={props.disabled || startProps.readonly}
+        disabled={props.disabled || startProps?.readonly}
         name={props.name + '.start'}
         placeholder="Start"
         defaultValue={value?.start}
         onChange={(newValue) => setValueWrapper({ ...value, start: newValue })}
       />
       <DateTimeInput
-        disabled={props.disabled || endProps.readonly}
+        disabled={props.disabled || endProps?.readonly}
         name={props.name + '.end'}
         placeholder="End"
         defaultValue={value?.end}

--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -9,13 +9,14 @@ export default {
 
 export const Example = (): JSX.Element => (
   <Document>
-    <QuantityInput name="demo" />
+    <QuantityInput path="" name="demo" />
   </Document>
 );
 
 export const DefaultValue = (): JSX.Element => (
   <Document>
     <QuantityInput
+      path=""
       name="demo"
       defaultValue={{
         value: 10,
@@ -29,6 +30,7 @@ export const DefaultValue = (): JSX.Element => (
 export const ScrollWheelDisabled = (): JSX.Element => (
   <Document>
     <QuantityInput
+      path=""
       name="demo"
       disableWheel
       defaultValue={{

--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { QuantityInput } from './QuantityInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/QuantityInput',
@@ -40,3 +43,49 @@ export const ScrollWheelDisabled = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <QuantityInput
+      disabled
+      path=""
+      name="demo"
+      defaultValue={{
+        value: 10,
+        comparator: '<',
+        unit: 'mg',
+      }}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'MolecularSequence',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'MolecularSequence',
+      readonlyFields: ['quantity.comparator', 'quantity.unit'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <QuantityInput
+        path="MolecularSequence.quantity"
+        name="demo"
+        defaultValue={{
+          value: 10,
+          comparator: '<',
+          unit: 'mg',
+        }}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/QuantityInput/QuantityInput.test.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.test.tsx
@@ -4,13 +4,13 @@ import { QuantityInput } from './QuantityInput';
 
 describe('QuantityInput', () => {
   test('Renders', () => {
-    render(<QuantityInput name="a" defaultValue={{ value: 123, unit: 'mg' }} />);
+    render(<QuantityInput path="" name="a" defaultValue={{ value: 123, unit: 'mg' }} />);
     expect(screen.getByDisplayValue('123')).toBeDefined();
     expect(screen.getByDisplayValue('mg')).toBeDefined();
   });
 
   test('Renders undefined value', () => {
-    render(<QuantityInput name="a" />);
+    render(<QuantityInput path="" name="a" />);
     expect(screen.getByPlaceholderText('Value')).toBeDefined();
     expect(screen.getByPlaceholderText('Unit')).toBeDefined();
   });
@@ -18,7 +18,7 @@ describe('QuantityInput', () => {
   test('Set value', async () => {
     let lastValue: Quantity | undefined = undefined;
 
-    render(<QuantityInput name="a" onChange={(value) => (lastValue = value)} />);
+    render(<QuantityInput path="" name="a" onChange={(value) => (lastValue = value)} />);
 
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText('Value'), {
@@ -39,7 +39,7 @@ describe('QuantityInput', () => {
   test('Set value with comparator', async () => {
     let lastValue: Quantity | undefined = undefined;
 
-    render(<QuantityInput name="a" onChange={(value) => (lastValue = value)} />);
+    render(<QuantityInput path="" name="a" onChange={(value) => (lastValue = value)} />);
 
     await act(async () => {
       fireEvent.change(screen.getByTestId('a-comparator'), {
@@ -64,7 +64,7 @@ describe('QuantityInput', () => {
   });
 
   test('Set value with wheel', async () => {
-    render(<QuantityInput name="a" defaultValue={{ value: 2.3, unit: 'ng' }} />);
+    render(<QuantityInput path="" name="a" defaultValue={{ value: 2.3, unit: 'ng' }} />);
 
     const valueInput = screen.getByPlaceholderText('Value');
     fireEvent.wheel(valueInput, {
@@ -78,7 +78,7 @@ describe('QuantityInput', () => {
   });
 
   test('Disable wheel', async () => {
-    render(<QuantityInput name="a" disableWheel defaultValue={{ value: 2.3, unit: 'ng' }} />);
+    render(<QuantityInput path="" name="a" disableWheel defaultValue={{ value: 2.3, unit: 'ng' }} />);
 
     const valueInput = screen.getByPlaceholderText('Value');
 

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -28,7 +28,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <NativeSelect
-        disabled={props.disabled || comparatorProps.readonly}
+        disabled={props.disabled || comparatorProps?.readonly}
         style={{ width: 80 }}
         data-testid={props.name + '-comparator'}
         defaultValue={value?.comparator}
@@ -41,7 +41,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
         }
       />
       <TextInput
-        disabled={props.disabled || valueProps.readonly}
+        disabled={props.disabled || valueProps?.readonly}
         id={props.name}
         name={props.name}
         required={props.required}
@@ -65,7 +65,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
         }}
       />
       <TextInput
-        disabled={props.disabled || unitProps.readonly}
+        disabled={props.disabled || unitProps?.readonly}
         placeholder="Unit"
         data-testid={props.name + '-unit'}
         defaultValue={value?.unit}

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -1,18 +1,22 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Quantity } from '@medplum/fhirtypes';
-import { useState, WheelEvent } from 'react';
+import { useContext, useMemo, useState, WheelEvent } from 'react';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 
-export interface QuantityInputProps {
-  readonly name: string;
-  readonly defaultValue?: Quantity;
+export interface QuantityInputProps extends ComplexTypeInputProps<Quantity> {
   readonly autoFocus?: boolean;
   readonly required?: boolean;
-  readonly onChange?: (value: Quantity) => void;
   readonly disableWheel?: boolean;
 }
 
 export function QuantityInput(props: QuantityInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [comparatorProps, valueProps, unitProps] = useMemo(
+    () => ['comparator', 'value', 'unit'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   function setValueWrapper(newValue: Quantity): void {
     setValue(newValue);
@@ -24,6 +28,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <NativeSelect
+        disabled={props.disabled || comparatorProps.readonly}
         style={{ width: 80 }}
         data-testid={props.name + '-comparator'}
         defaultValue={value?.comparator}
@@ -36,6 +41,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
         }
       />
       <TextInput
+        disabled={props.disabled || valueProps.readonly}
         id={props.name}
         name={props.name}
         required={props.required}
@@ -59,6 +65,7 @@ export function QuantityInput(props: QuantityInputProps): JSX.Element {
         }}
       />
       <TextInput
+        disabled={props.disabled || unitProps.readonly}
         placeholder="Unit"
         data-testid={props.name + '-unit'}
         defaultValue={value?.unit}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -179,6 +179,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <Group py={4}>
           <AttachmentInput
+            path=""
             name={name}
             defaultValue={defaultValue?.value}
             onChange={(newValue) => onChangeAnswer({ valueAttachment: newValue })}
@@ -199,6 +200,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
     case QuestionnaireItemType.quantity:
       return (
         <QuantityInput
+          path=""
           name={name}
           required={item.required}
           defaultValue={defaultValue?.value}
@@ -319,6 +321,7 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
   if (item.answerValueSet) {
     return (
       <CodingInput
+        path=""
         name={name}
         binding={item.answerValueSet}
         onChange={(code) => onChangeAnswer({ valueCoding: code })}

--- a/packages/react/src/RangeInput/RangeInput.stories.tsx
+++ b/packages/react/src/RangeInput/RangeInput.stories.tsx
@@ -11,6 +11,7 @@ export default {
 export const Basic = (): JSX.Element => (
   <Document>
     <RangeInput
+      path=""
       name="range"
       defaultValue={
         {

--- a/packages/react/src/RangeInput/RangeInput.stories.tsx
+++ b/packages/react/src/RangeInput/RangeInput.stories.tsx
@@ -2,6 +2,9 @@ import { Range } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { RangeInput } from './RangeInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/RangeInput',
@@ -25,3 +28,57 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <RangeInput
+      disabled
+      path=""
+      name="range"
+      defaultValue={
+        {
+          low: {
+            comparator: '>',
+            value: 10,
+            unit: 'mg',
+          },
+        } as Range
+      }
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'SpecimenDefinition',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'SpecimenDefinition',
+      readonlyFields: ['handling.temperatureRange.high'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <RangeInput
+        path="SpecimenDefinition.handling.temperatureRange"
+        name="range"
+        defaultValue={
+          {
+            low: {
+              comparator: '>',
+              value: 10,
+              unit: 'mg',
+            },
+          } as Range
+        }
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/RangeInput/RangeInput.test.tsx
+++ b/packages/react/src/RangeInput/RangeInput.test.tsx
@@ -4,14 +4,16 @@ import { RangeInput } from './RangeInput';
 
 describe('RangeInput', () => {
   test('Renders', () => {
-    render(<RangeInput name="a" defaultValue={{ low: { value: 5, unit: 'mg' }, high: { value: 10, unit: 'mg' } }} />);
+    render(
+      <RangeInput path="" name="a" defaultValue={{ low: { value: 5, unit: 'mg' }, high: { value: 10, unit: 'mg' } }} />
+    );
     expect(screen.getByDisplayValue('5')).toBeDefined();
     expect(screen.getByDisplayValue('10')).toBeDefined();
     expect(screen.getAllByDisplayValue('mg').length).toBe(2);
   });
 
   test('Renders undefined value', () => {
-    render(<RangeInput name="a" />);
+    render(<RangeInput path="" name="a" />);
     expect(screen.getAllByPlaceholderText('Value').length).toBe(2);
     expect(screen.getAllByPlaceholderText('Unit').length).toBe(2);
   });
@@ -19,7 +21,7 @@ describe('RangeInput', () => {
   test('Set value', async () => {
     let lastValue: Range | undefined = undefined;
 
-    render(<RangeInput name="a" onChange={(value) => (lastValue = value)} />);
+    render(<RangeInput path="" name="a" onChange={(value) => (lastValue = value)} />);
 
     await act(async () => {
       fireEvent.change(screen.getAllByPlaceholderText('Value')[0], {

--- a/packages/react/src/RangeInput/RangeInput.tsx
+++ b/packages/react/src/RangeInput/RangeInput.tsx
@@ -32,7 +32,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element {
     <Group gap="xs" grow wrap="nowrap">
       <QuantityInput
         path={props.path + '.low'}
-        disabled={props.disabled || lowProps.readonly}
+        disabled={props.disabled || lowProps?.readonly}
         name={props.name + '-low'}
         defaultValue={value?.low}
         onChange={(v) =>
@@ -45,7 +45,7 @@ export function RangeInput(props: RangeInputProps): JSX.Element {
 
       <QuantityInput
         path={props.path + '.high'}
-        disabled={props.disabled || highProps.readonly}
+        disabled={props.disabled || highProps?.readonly}
         name={props.name + '-high'}
         defaultValue={value?.high}
         onChange={(v) =>

--- a/packages/react/src/RangeInput/RangeInput.tsx
+++ b/packages/react/src/RangeInput/RangeInput.tsx
@@ -1,13 +1,11 @@
 import { Group } from '@mantine/core';
 import { Range } from '@medplum/fhirtypes';
-import { useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface RangeInputProps {
-  readonly name: string;
-  readonly defaultValue?: Range;
-  readonly onChange?: (value: Range) => void;
-}
+export interface RangeInputProps extends ComplexTypeInputProps<Range> {}
 
 /**
  * Renders a Range input.
@@ -17,6 +15,11 @@ export interface RangeInputProps {
  */
 export function RangeInput(props: RangeInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [lowProps, highProps] = useMemo(
+    () => ['low', 'high'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   function setValueWrapper(newValue: Range): void {
     setValue(newValue);
@@ -28,6 +31,8 @@ export function RangeInput(props: RangeInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <QuantityInput
+        path={props.path + '.low'}
+        disabled={props.disabled || lowProps.readonly}
         name={props.name + '-low'}
         defaultValue={value?.low}
         onChange={(v) =>
@@ -39,6 +44,8 @@ export function RangeInput(props: RangeInputProps): JSX.Element {
       />
 
       <QuantityInput
+        path={props.path + '.high'}
+        disabled={props.disabled || highProps.readonly}
         name={props.name + '-high'}
         defaultValue={value?.high}
         onChange={(v) =>

--- a/packages/react/src/RatioInput/RatioInput.stories.tsx
+++ b/packages/react/src/RatioInput/RatioInput.stories.tsx
@@ -11,6 +11,7 @@ export default {
 export const Basic = (): JSX.Element => (
   <Document>
     <RatioInput
+      path=""
       name="dosage"
       defaultValue={
         {

--- a/packages/react/src/RatioInput/RatioInput.stories.tsx
+++ b/packages/react/src/RatioInput/RatioInput.stories.tsx
@@ -2,6 +2,9 @@ import { Ratio } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { RatioInput } from './RatioInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/RatioInput',
@@ -22,3 +25,50 @@ export const Basic = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <RatioInput
+      disabled
+      path=""
+      name="dosage"
+      defaultValue={
+        {
+          numerator: { value: 10, unit: 'mg', system: 'http://unitsofmeasure.org' },
+          denominator: { value: 1, unit: 'h', system: 'http://unitsofmeasure.org' },
+        } as Ratio
+      }
+    />
+  </Document>
+);
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'Medication',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'Medication',
+      readonlyFields: ['amount.denominator'],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <RatioInput
+        path="Medication.amount"
+        name="dosage"
+        defaultValue={
+          {
+            numerator: { value: 10, unit: 'mg', system: 'http://unitsofmeasure.org' },
+            denominator: { value: 1, unit: 'h', system: 'http://unitsofmeasure.org' },
+          } as Ratio
+        }
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/RatioInput/RatioInput.test.tsx
+++ b/packages/react/src/RatioInput/RatioInput.test.tsx
@@ -7,6 +7,7 @@ describe('RatioInput', () => {
     render(
       <RatioInput
         name="a"
+        path=""
         defaultValue={{ numerator: { value: 5, unit: 'mg' }, denominator: { value: 10, unit: 'ml' } }}
       />
     );
@@ -17,7 +18,7 @@ describe('RatioInput', () => {
   });
 
   test('Renders undefined value', () => {
-    render(<RatioInput name="a" />);
+    render(<RatioInput name="a" path="" />);
     expect(screen.getAllByPlaceholderText('Value').length).toBe(2);
     expect(screen.getAllByPlaceholderText('Unit').length).toBe(2);
   });
@@ -25,7 +26,7 @@ describe('RatioInput', () => {
   test('Set value', async () => {
     let lastValue: Ratio | undefined = undefined;
 
-    render(<RatioInput name="a" onChange={(value) => (lastValue = value)} />);
+    render(<RatioInput name="a" path="" onChange={(value) => (lastValue = value)} />);
 
     await act(async () => {
       fireEvent.change(screen.getAllByPlaceholderText('Value')[0], {

--- a/packages/react/src/RatioInput/RatioInput.tsx
+++ b/packages/react/src/RatioInput/RatioInput.tsx
@@ -32,7 +32,7 @@ export function RatioInput(props: RatioInputProps): JSX.Element {
     <Group gap="xs" grow wrap="nowrap">
       <QuantityInput
         path={props.path + '.numerator'}
-        disabled={props.disabled || numeratorProps.readonly}
+        disabled={props.disabled || numeratorProps?.readonly}
         name={props.name + '-numerator'}
         defaultValue={value?.numerator}
         onChange={(v) =>
@@ -44,7 +44,7 @@ export function RatioInput(props: RatioInputProps): JSX.Element {
       />
       <QuantityInput
         path={props.path + '.denominator'}
-        disabled={props.disabled || denominatorProps.readonly}
+        disabled={props.disabled || denominatorProps?.readonly}
         name={props.name + '-denominator'}
         defaultValue={value?.denominator}
         onChange={(v) =>

--- a/packages/react/src/RatioInput/RatioInput.tsx
+++ b/packages/react/src/RatioInput/RatioInput.tsx
@@ -1,13 +1,11 @@
 import { Group } from '@mantine/core';
 import { Ratio } from '@medplum/fhirtypes';
-import { useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { QuantityInput } from '../QuantityInput/QuantityInput';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
-export interface RatioInputProps {
-  readonly name: string;
-  readonly defaultValue?: Ratio;
-  readonly onChange?: (value: Ratio) => void;
-}
+export interface RatioInputProps extends ComplexTypeInputProps<Ratio> {}
 
 /**
  * Renders a Ratio input.
@@ -17,6 +15,11 @@ export interface RatioInputProps {
  */
 export function RatioInput(props: RatioInputProps): JSX.Element {
   const [value, setValue] = useState(props.defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [numeratorProps, denominatorProps] = useMemo(
+    () => ['numerator', 'denominator'].map((field) => getExtendedProps(props.path + '.' + field)),
+    [getExtendedProps, props.path]
+  );
 
   function setValueWrapper(newValue: Ratio): void {
     setValue(newValue);
@@ -28,6 +31,8 @@ export function RatioInput(props: RatioInputProps): JSX.Element {
   return (
     <Group gap="xs" grow wrap="nowrap">
       <QuantityInput
+        path={props.path + '.numerator'}
+        disabled={props.disabled || numeratorProps.readonly}
         name={props.name + '-numerator'}
         defaultValue={value?.numerator}
         onChange={(v) =>
@@ -38,6 +43,8 @@ export function RatioInput(props: RatioInputProps): JSX.Element {
         }
       />
       <QuantityInput
+        path={props.path + '.denominator'}
+        disabled={props.disabled || denominatorProps.readonly}
         name={props.name + '-denominator'}
         defaultValue={value?.denominator}
         onChange={(v) =>

--- a/packages/react/src/ReferenceInput/ReferenceInput.stories.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.stories.tsx
@@ -50,3 +50,15 @@ export const PatientProfileAndPatient = (): JSX.Element => {
     </Document>
   );
 };
+
+export const DisabledTargetProfile = (): JSX.Element => (
+  <Document>
+    <ReferenceInput disabled name="foo" targetTypes={['Practitioner', 'Patient']} />
+  </Document>
+);
+
+export const DisabledFreeText = (): JSX.Element => (
+  <Document>
+    <ReferenceInput disabled name="foo" />
+  </Document>
+);

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -154,8 +154,9 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
 
   return (
     <Group gap="xs" grow wrap="nowrap">
-      {!props.disabled && targetTypes && targetTypes.length > 1 && (
+      {targetTypes && targetTypes.length > 1 && (
         <NativeSelect
+          disabled={props.disabled}
           data-autofocus={props.autoFocus}
           data-testid="reference-input-resource-type-select"
           defaultValue={targetType?.resourceType}
@@ -168,8 +169,9 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
           data={typeSelectOptions}
         />
       )}
-      {!props.disabled && !targetTypes && (
+      {!targetTypes && (
         <ResourceTypeInput
+          disabled={props.disabled}
           autoFocus={props.autoFocus}
           testId="reference-input-resource-type-input"
           defaultValue={targetType?.resourceType as ResourceType}

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -23,6 +23,7 @@ export interface ReferenceInputProps {
   readonly autoFocus?: boolean;
   readonly required?: boolean;
   readonly onChange?: (value: Reference | undefined) => void;
+  readonly disabled?: boolean;
 }
 
 interface BaseTargetType {
@@ -153,7 +154,7 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
 
   return (
     <Group gap="xs" grow wrap="nowrap">
-      {targetTypes && targetTypes.length > 1 && (
+      {!props.disabled && targetTypes && targetTypes.length > 1 && (
         <NativeSelect
           data-autofocus={props.autoFocus}
           data-testid="reference-input-resource-type-select"
@@ -167,7 +168,7 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
           data={typeSelectOptions}
         />
       )}
-      {!targetTypes && (
+      {!props.disabled && !targetTypes && (
         <ResourceTypeInput
           autoFocus={props.autoFocus}
           testId="reference-input-resource-type-input"
@@ -191,6 +192,7 @@ export function ReferenceInput(props: ReferenceInputProps): JSX.Element {
         defaultValue={value}
         searchCriteria={searchCriteria}
         onChange={setValueHelper}
+        disabled={props.disabled}
       />
     </Group>
   );

--- a/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
+++ b/packages/react/src/ReferenceRangeEditor/ReferenceRangeEditor.tsx
@@ -219,6 +219,7 @@ export function ReferenceRangeGroupEditor(props: ReferenceRangeGroupEditorProps)
             </Group>
 
             <RangeInput
+              path=""
               onChange={(range) => {
                 props.onChange(intervalGroup.id, { ...interval, range });
               }}
@@ -303,6 +304,7 @@ function ReferenceRangeGroupFilters(props: ReferenceRangeGroupFiltersProps): JSX
         </Text>
         <div id={`div-age-${intervalGroup.id}`}>
           <RangeInput
+            path=""
             key={`age-${intervalGroup.id}`}
             name={`age-${intervalGroup.id}`}
             defaultValue={intervalGroup.filters['age']}

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -1,5 +1,5 @@
 import { Group, Stack } from '@mantine/core';
-import { AnnotatedInternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
+import { ExtendedInternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
 import { MouseEvent, useContext, useEffect, useState } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
@@ -13,7 +13,7 @@ import { assignValuesIntoSlices, prepareSlices } from './ResourceArrayInput.util
 import { BaseInputProps, getValuePath } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface ResourceArrayInputProps extends BaseInputProps {
-  readonly property: AnnotatedInternalSchemaElement;
+  readonly property: ExtendedInternalSchemaElement;
   readonly name: string;
   readonly defaultValue?: any[];
   readonly indent?: boolean;

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -1,5 +1,5 @@
 import { Group, Stack } from '@mantine/core';
-import { InternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
+import { AnnotatedInternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
 import { MouseEvent, useContext, useEffect, useState } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
@@ -13,7 +13,7 @@ import { assignValuesIntoSlices, prepareSlices } from './ResourceArrayInput.util
 import { BaseInputProps, getValuePath } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface ResourceArrayInputProps extends BaseInputProps {
-  readonly property: InternalSchemaElement;
+  readonly property: AnnotatedInternalSchemaElement;
   readonly name: string;
   readonly defaultValue?: any[];
   readonly indent?: boolean;
@@ -111,19 +111,21 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
                 outcome={props.outcome}
               />
             </div>
-            <ArrayRemoveButton
-              propertyDisplayName={propertyDisplayName}
-              testId={`nonsliced-remove-${valueIndex}`}
-              onClick={(e: MouseEvent) => {
-                killEvent(e);
-                const newNonSliceValues = [...nonSliceValues];
-                newNonSliceValues.splice(valueIndex, 1);
-                setValuesWrapper(newNonSliceValues, nonSliceIndex);
-              }}
-            />
+            {!props.property.readonly && (
+              <ArrayRemoveButton
+                propertyDisplayName={propertyDisplayName}
+                testId={`nonsliced-remove-${valueIndex}`}
+                onClick={(e: MouseEvent) => {
+                  killEvent(e);
+                  const newNonSliceValues = [...nonSliceValues];
+                  newNonSliceValues.splice(valueIndex, 1);
+                  setValuesWrapper(newNonSliceValues, nonSliceIndex);
+                }}
+              />
+            )}
           </Group>
         ))}
-      {showNonSliceValues && slicedValues.flat().length < property.max && (
+      {!props.property.readonly && showNonSliceValues && slicedValues.flat().length < property.max && (
         <Group wrap="nowrap" style={{ justifyContent: 'flex-start' }}>
           <ArrayAddButton
             propertyDisplayName={propertyDisplayName}

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine/core';
 import { ExtendedInternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName } from '@medplum/core';
 import { useMedplum } from '@medplum/react-hooks';
 import { MouseEvent, useContext, useEffect, useState } from 'react';
@@ -21,7 +21,7 @@ export interface ResourceArrayInputProps extends BaseInputProps {
   readonly hideNonSliceValues?: boolean;
 }
 
-export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element {
+export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element | null {
   const { property } = props;
   const medplum = useMedplum();
   const [loading, setLoading] = useState(true);
@@ -71,9 +71,11 @@ export function ResourceArrayInput(props: ResourceArrayInputProps): JSX.Element 
   // Hide non-sliced values when handling sliced extensions
   const showNonSliceValues = !(props.hideNonSliceValues ?? (propertyTypeCode === 'Extension' && slices.length > 0));
   const propertyDisplayName = getPathDisplayName(property.path);
+  const showEmptyMessage = props.property.readonly && slices.length === 0 && defaultValue.length === 0;
 
   return (
     <Stack className={props.indent ? classes.indented : undefined}>
+      {showEmptyMessage && <Text c="dimmed">(empty)</Text>}
       {slices.map((slice, sliceIndex) => {
         return (
           <SliceInput

--- a/packages/react/src/ResourceForm/ResourceForm.stories.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.stories.tsx
@@ -81,7 +81,7 @@ export const PartiallyHiddenPatient = (): JSX.Element => {
       resource: [
         {
           resourceType: 'Patient',
-          hiddenFields: ['identifier', 'name.given', 'name.family', 'birthDate', 'link', 'contact'],
+          hiddenFields: ['identifier', 'name.use', 'name.prefix', 'name.suffix', 'birthDate', 'link', 'contact'],
         },
       ],
     }),

--- a/packages/react/src/ResourceForm/ResourceForm.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.tsx
@@ -1,5 +1,12 @@
 import { Alert, Button, Group, Stack, TextInput } from '@mantine/core';
-import { applyDefaultValuesToResource, canWriteResourceType, isPopulated, tryGetProfile } from '@medplum/core';
+import {
+  AccessPolicyInteraction,
+  applyDefaultValuesToResource,
+  canWriteResourceType,
+  isPopulated,
+  satisfiedAccessPolicy,
+  tryGetProfile,
+} from '@medplum/core';
 import { OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
@@ -57,6 +64,10 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
     }
   }, [medplum, defaultValue, props.schemaName, props.profileUrl]);
 
+  const accessPolicyResource = useMemo(() => {
+    return defaultValue && satisfiedAccessPolicy(defaultValue, AccessPolicyInteraction.READ, accessPolicy);
+  }, [accessPolicy, defaultValue]);
+
   const canWrite = useMemo<boolean>(() => {
     if (medplum.isSuperAdmin()) {
       return true;
@@ -112,6 +123,7 @@ export function ResourceForm(props: ResourceFormProps): JSX.Element {
         outcome={outcome}
         onChange={setValue}
         profileUrl={props.profileUrl}
+        accessPolicyResource={accessPolicyResource}
       />
       <Group justify="flex-end" mt="xl">
         <Button type="submit">OK</Button>

--- a/packages/react/src/ResourceInput/ResourceInput.stories.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.stories.tsx
@@ -20,3 +20,9 @@ export const Patients = (): JSX.Element => (
     <ResourceInput name="foo" resourceType="Patient" defaultValue={createReference(HomerSimpson)} />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <ResourceInput disabled name="foo" resourceType="Patient" defaultValue={createReference(HomerSimpson)} />
+  </Document>
+);

--- a/packages/react/src/ResourceInput/ResourceInput.tsx
+++ b/packages/react/src/ResourceInput/ResourceInput.tsx
@@ -81,6 +81,7 @@ export interface ResourceInputProps<T extends Resource = Resource> {
   readonly loadOnFocus?: boolean;
   readonly required?: boolean;
   readonly onChange?: (value: T | undefined) => void;
+  readonly disabled?: boolean;
 }
 
 function toOption<T extends Resource>(resource: T): AsyncAutocompleteOption<T> {
@@ -131,6 +132,7 @@ export function ResourceInput<T extends Resource = Resource>(props: ResourceInpu
 
   return (
     <AsyncAutocomplete<T>
+      disabled={props.disabled}
       name={props.name}
       required={props.required}
       itemComponent={ItemComponent}

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -1,10 +1,10 @@
 import { Checkbox, Group, NativeSelect, Textarea, TextInput } from '@mantine/core';
 import {
+  AnnotatedInternalSchemaElement,
   applyDefaultValuesToElement,
   capitalize,
   getPathDifference,
   HTTP_HL7_ORG,
-  InternalSchemaElement,
   isComplexTypeCode,
   isEmpty,
   isPopulated,
@@ -40,7 +40,7 @@ import { getErrorsForInput } from '../utils/outcomes';
 import { BaseInputProps, ComplexTypeInputProps, PrimitiveTypeInputProps } from './ResourcePropertyInput.utils';
 
 export interface ResourcePropertyInputProps extends BaseInputProps {
-  readonly property: InternalSchemaElement;
+  readonly property: AnnotatedInternalSchemaElement;
   readonly name: string;
   readonly defaultPropertyType?: string | undefined;
   readonly defaultValue: any;
@@ -95,6 +95,7 @@ export function ResourcePropertyInput(props: ResourcePropertyInputProps): JSX.El
         binding={property.binding}
         path={props.path}
         valuePath={props.valuePath}
+        readOnly={property.readonly}
       />
     );
   }
@@ -159,10 +160,11 @@ export interface ElementDefinitionTypeInputProps
   readonly min: number;
   readonly max: number;
   readonly binding: ElementDefinitionBinding | undefined;
+  readonly readOnly?: boolean;
 }
 
 export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProps): JSX.Element {
-  const { name, onChange, outcome, binding, path, valuePath } = props;
+  const { name, onChange, outcome, binding, path, valuePath, readOnly } = props;
   const required = props.min !== undefined && props.min > 0;
 
   const propertyType = props.elementDefinitionType.code;
@@ -212,6 +214,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
       defaultValue,
       required,
       error,
+      disabled: readOnly,
     };
   }
 

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, Group, NativeSelect, Textarea, TextInput } from '@mantine/core';
 import {
-  AnnotatedInternalSchemaElement,
+  ExtendedInternalSchemaElement,
   applyDefaultValuesToElement,
   capitalize,
   getPathDifference,
@@ -40,7 +40,7 @@ import { getErrorsForInput } from '../utils/outcomes';
 import { BaseInputProps, ComplexTypeInputProps, PrimitiveTypeInputProps } from './ResourcePropertyInput.utils';
 
 export interface ResourcePropertyInputProps extends BaseInputProps {
-  readonly property: AnnotatedInternalSchemaElement;
+  readonly property: ExtendedInternalSchemaElement;
   readonly name: string;
   readonly defaultPropertyType?: string | undefined;
   readonly defaultValue: any;

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -45,7 +45,7 @@ export interface ResourcePropertyInputProps extends BaseInputProps {
   readonly defaultPropertyType?: string | undefined;
   readonly defaultValue: any;
   readonly arrayElement?: boolean | undefined;
-  readonly onChange: ((value: any, propName?: string) => void) | undefined;
+  readonly onChange?: (value: any, propName?: string) => void;
 }
 
 export function ResourcePropertyInput(props: ResourcePropertyInputProps): JSX.Element {
@@ -124,24 +124,23 @@ export function ElementDefinitionInputSelector(props: ElementDefinitionSelectorP
   const [selectedType, setSelectedType] = useState(initialPropertyType);
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
-      {!props.property.readonly && (
-        <NativeSelect
-          style={{ width: '200px' }}
-          defaultValue={selectedType.code}
-          data-testid={props.name && props.name + '-selector'}
-          onChange={(e) => {
-            setSelectedType(
-              propertyTypes.find(
-                (type: ElementDefinitionType) => type.code === e.currentTarget.value
-              ) as ElementDefinitionType
-            );
-          }}
-          data={propertyTypes.map((type: ElementDefinitionType) => ({
-            value: type.code as string,
-            label: type.code as string,
-          }))}
-        />
-      )}
+      <NativeSelect
+        disabled={props.property.readonly}
+        style={{ width: '200px' }}
+        defaultValue={selectedType.code}
+        data-testid={props.name && props.name + '-selector'}
+        onChange={(e) => {
+          setSelectedType(
+            propertyTypes.find(
+              (type: ElementDefinitionType) => type.code === e.currentTarget.value
+            ) as ElementDefinitionType
+          );
+        }}
+        data={propertyTypes.map((type: ElementDefinitionType) => ({
+          value: type.code as string,
+          label: type.code as string,
+        }))}
+      />
       <ElementDefinitionTypeInput
         name={props.name}
         defaultValue={props.defaultValue}
@@ -275,7 +274,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
       );
     case PropertyType.dateTime:
     case PropertyType.instant:
-      return <DateTimeInput name={name} defaultValue={defaultValue} onChange={onChange} outcome={outcome} />;
+      return <DateTimeInput {...getPrimitiveInputProps()} onChange={onChange} outcome={outcome} />;
     case PropertyType.decimal:
     case PropertyType.integer:
     case PropertyType.positiveInt:

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -58,7 +58,14 @@ export function ResourcePropertyInput(props: ResourcePropertyInputProps): JSX.El
 
   if ((property.isArray || property.max > 1) && !props.arrayElement) {
     if (defaultPropertyType === PropertyType.Attachment) {
-      return <AttachmentArrayInput name={name} defaultValue={defaultValue} onChange={onChange} />;
+      return (
+        <AttachmentArrayInput
+          name={name}
+          defaultValue={defaultValue}
+          onChange={onChange}
+          disabled={property.readonly}
+        />
+      );
     }
 
     // Extensions are a special type of array that shouldn't be indented

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -117,22 +117,24 @@ export function ElementDefinitionInputSelector(props: ElementDefinitionSelectorP
   const [selectedType, setSelectedType] = useState(initialPropertyType);
   return (
     <Group gap="xs" grow wrap="nowrap" align="flex-start">
-      <NativeSelect
-        style={{ width: '200px' }}
-        defaultValue={selectedType.code}
-        data-testid={props.name && props.name + '-selector'}
-        onChange={(e) => {
-          setSelectedType(
-            propertyTypes.find(
-              (type: ElementDefinitionType) => type.code === e.currentTarget.value
-            ) as ElementDefinitionType
-          );
-        }}
-        data={propertyTypes.map((type: ElementDefinitionType) => ({
-          value: type.code as string,
-          label: type.code as string,
-        }))}
-      />
+      {!props.property.readonly && (
+        <NativeSelect
+          style={{ width: '200px' }}
+          defaultValue={selectedType.code}
+          data-testid={props.name && props.name + '-selector'}
+          onChange={(e) => {
+            setSelectedType(
+              propertyTypes.find(
+                (type: ElementDefinitionType) => type.code === e.currentTarget.value
+              ) as ElementDefinitionType
+            );
+          }}
+          data={propertyTypes.map((type: ElementDefinitionType) => ({
+            value: type.code as string,
+            label: type.code as string,
+          }))}
+        />
+      )}
       <ElementDefinitionTypeInput
         name={props.name}
         defaultValue={props.defaultValue}
@@ -148,6 +150,7 @@ export function ElementDefinitionInputSelector(props: ElementDefinitionSelectorP
         binding={props.property.binding}
         path={props.property.path}
         valuePath={props.valuePath}
+        readOnly={props.property.readonly}
       />
     </Group>
   );
@@ -202,7 +205,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
   }
 
   function getComplexInputProps(): ComplexTypeInputProps<any> {
-    return { name, defaultValue, onChange, outcome, path, valuePath };
+    return { name, defaultValue, onChange, outcome, path, valuePath, disabled: readOnly };
   }
 
   function getPrimitiveInputProps(): PrimitiveTypeInputProps {

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.utils.ts
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.utils.ts
@@ -22,6 +22,7 @@ export interface PrimitiveTypeInputProps {
   defaultValue?: any;
   required: boolean;
   error: string | undefined;
+  disabled?: boolean | undefined;
 }
 
 export function getValuePath(elementPath: string, valuePath: string | undefined, arrayIndex?: number): string {

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.utils.ts
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.utils.ts
@@ -13,6 +13,7 @@ export interface ComplexTypeInputProps<ValueType> extends BaseInputProps {
   name: string;
   defaultValue?: ValueType;
   onChange: ((value: ValueType, propName?: string) => void) | undefined;
+  disabled?: boolean;
 }
 
 export interface PrimitiveTypeInputProps {
@@ -22,7 +23,7 @@ export interface PrimitiveTypeInputProps {
   defaultValue?: any;
   required: boolean;
   error: string | undefined;
-  disabled?: boolean | undefined;
+  disabled?: boolean;
 }
 
 export function getValuePath(elementPath: string, valuePath: string | undefined, arrayIndex?: number): string {

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.utils.ts
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.utils.ts
@@ -10,20 +10,20 @@ export interface BaseInputProps {
 }
 
 export interface ComplexTypeInputProps<ValueType> extends BaseInputProps {
-  name: string;
-  defaultValue?: ValueType;
-  onChange: ((value: ValueType, propName?: string) => void) | undefined;
-  disabled?: boolean;
+  readonly name: string;
+  readonly defaultValue?: ValueType;
+  readonly onChange?: (value: ValueType, propName?: string) => void;
+  readonly disabled?: boolean;
 }
 
 export interface PrimitiveTypeInputProps {
-  id: string;
-  name: string;
-  'data-testid': string;
-  defaultValue?: any;
-  required: boolean;
-  error: string | undefined;
-  disabled?: boolean;
+  readonly id?: string;
+  readonly name: string;
+  readonly 'data-testid'?: string;
+  readonly defaultValue?: any;
+  readonly required?: boolean;
+  readonly error?: string;
+  readonly disabled?: boolean;
 }
 
 export function getValuePath(elementPath: string, valuePath: string | undefined, arrayIndex?: number): string {

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -1,8 +1,8 @@
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
-import { tryGetProfile } from '@medplum/core';
+import { AccessPolicyInteraction, satisfiedAccessPolicy, tryGetProfile } from '@medplum/core';
 
 export interface ResourceTableProps {
   /**
@@ -30,6 +30,7 @@ export interface ResourceTableProps {
 export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
   const { profileUrl } = props;
   const medplum = useMedplum();
+  const accessPolicy = medplum.getAccessPolicy();
   const value = useResource(props.value);
   const [schemaLoaded, setSchemaLoaded] = useState<string>();
 
@@ -63,6 +64,10 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
     }
   }, [medplum, profileUrl, value]);
 
+  const accessPolicyResource = useMemo(() => {
+    return value && satisfiedAccessPolicy(value, AccessPolicyInteraction.READ, accessPolicy);
+  }, [accessPolicy, value]);
+
   if (!schemaLoaded || !value) {
     return null;
   }
@@ -76,6 +81,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
       }}
       profileUrl={profileUrl}
       ignoreMissingValues={props.ignoreMissingValues}
+      accessPolicyResource={accessPolicyResource}
     />
   );
 }

--- a/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
+++ b/packages/react/src/ResourceTypeInput/ResourceTypeInput.tsx
@@ -10,6 +10,7 @@ export interface ResourceTypeInputProps {
   readonly testId?: string;
   readonly maxValues?: number;
   readonly onChange?: (value: ResourceType | undefined) => void;
+  readonly disabled?: boolean;
 }
 
 export function ResourceTypeInput(props: ResourceTypeInputProps): JSX.Element {
@@ -28,6 +29,7 @@ export function ResourceTypeInput(props: ResourceTypeInputProps): JSX.Element {
 
   return (
     <CodeInput
+      disabled={props.disabled}
       data-autofocus={props.autoFocus}
       data-testid={props.testId}
       defaultValue={resourceType}

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
@@ -87,6 +87,7 @@ export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.
       return (
         <QuantityInput
           name={name}
+          path=""
           defaultValue={tryParseQuantity(props.defaultValue)}
           autoFocus={props.autoFocus}
           onChange={(newQuantity: Quantity | undefined) => {

--- a/packages/react/src/SliceInput/SliceInput.tsx
+++ b/packages/react/src/SliceInput/SliceInput.tsx
@@ -1,4 +1,4 @@
-import { Group, Stack } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine/core';
 import {
   ExtendedInternalSchemaElement,
   ElementsContextType,
@@ -60,6 +60,7 @@ export function SliceInput(props: SliceInputProps): JSX.Element | null {
   // e.g. USCorePatientProfile -> USCoreEthnicityExtension -> {ombCategory, detailed, text}
   const indentedStack = isEmpty(slice.elements);
   const propertyDisplayName = getPropertyDisplayName(slice.name);
+  const showEmptyMessage = props.property.readonly && values.length === 0;
   return maybeWrapWithContext(
     ElementsContext.Provider,
     contextValue,
@@ -69,59 +70,64 @@ export function SliceInput(props: SliceInputProps): JSX.Element | null {
       withAsterisk={required}
       fhirPath={`${property.path}:${slice.name}`}
       testId={props.testId}
+      readonly={props.property.readonly}
     >
-      <Stack className={indentedStack ? classes.indented : undefined}>
-        {values.map((value, valueIndex) => {
-          return (
-            <Group key={`${valueIndex}-${values.length}`} wrap="nowrap">
-              <div style={{ flexGrow: 1 }} data-testid={props.testId && `${props.testId}-elements-${valueIndex}`}>
-                <ElementDefinitionTypeInput
-                  elementDefinitionType={slice.type[0]}
-                  name={slice.name}
-                  defaultValue={value}
-                  onChange={(newValue) => {
-                    const newValues = [...values];
-                    newValues[valueIndex] = newValue;
-                    setValuesWrapper(newValues);
-                  }}
-                  outcome={props.outcome}
-                  min={slice.min}
-                  max={slice.max}
-                  binding={slice.binding}
-                  path={props.path}
-                  valuePath={undefined /* `valuePath` not supported in slices */}
-                  readOnly={props.property.readonly}
-                />
-              </div>
-              {!props.property.readonly && values.length > slice.min && (
-                <ArrayRemoveButton
-                  propertyDisplayName={propertyDisplayName}
-                  testId={props.testId && `${props.testId}-remove-${valueIndex}`}
-                  onClick={(e: MouseEvent) => {
-                    killEvent(e);
-                    const newValues = [...values];
-                    newValues.splice(valueIndex, 1);
-                    setValuesWrapper(newValues);
-                  }}
-                />
-              )}
+      {showEmptyMessage ? (
+        <Text c="dimmed">(empty)</Text>
+      ) : (
+        <Stack className={indentedStack ? classes.indented : undefined}>
+          {values.map((value, valueIndex) => {
+            return (
+              <Group key={`${valueIndex}-${values.length}`} wrap="nowrap">
+                <div style={{ flexGrow: 1 }} data-testid={props.testId && `${props.testId}-elements-${valueIndex}`}>
+                  <ElementDefinitionTypeInput
+                    elementDefinitionType={slice.type[0]}
+                    name={slice.name}
+                    defaultValue={value}
+                    onChange={(newValue) => {
+                      const newValues = [...values];
+                      newValues[valueIndex] = newValue;
+                      setValuesWrapper(newValues);
+                    }}
+                    outcome={props.outcome}
+                    min={slice.min}
+                    max={slice.max}
+                    binding={slice.binding}
+                    path={props.path}
+                    valuePath={undefined /* `valuePath` not supported in slices */}
+                    readOnly={props.property.readonly}
+                  />
+                </div>
+                {!props.property.readonly && values.length > slice.min && (
+                  <ArrayRemoveButton
+                    propertyDisplayName={propertyDisplayName}
+                    testId={props.testId && `${props.testId}-remove-${valueIndex}`}
+                    onClick={(e: MouseEvent) => {
+                      killEvent(e);
+                      const newValues = [...values];
+                      newValues.splice(valueIndex, 1);
+                      setValuesWrapper(newValues);
+                    }}
+                  />
+                )}
+              </Group>
+            );
+          })}
+          {!props.property.readonly && values.length < slice.max && (
+            <Group wrap="nowrap" style={{ justifyContent: 'flex-start' }}>
+              <ArrayAddButton
+                propertyDisplayName={propertyDisplayName}
+                onClick={(e: MouseEvent) => {
+                  killEvent(e);
+                  const newValues = [...values, undefined];
+                  setValuesWrapper(newValues);
+                }}
+                testId={props.testId && `${props.testId}-add`}
+              />
             </Group>
-          );
-        })}
-        {!props.property.readonly && values.length < slice.max && (
-          <Group wrap="nowrap" style={{ justifyContent: 'flex-start' }}>
-            <ArrayAddButton
-              propertyDisplayName={propertyDisplayName}
-              onClick={(e: MouseEvent) => {
-                killEvent(e);
-                const newValues = [...values, undefined];
-                setValuesWrapper(newValues);
-              }}
-              testId={props.testId && `${props.testId}-add`}
-            />
-          </Group>
-        )}
-      </Stack>
+          )}
+        </Stack>
+      )}
     </FormSection>
   );
 }

--- a/packages/react/src/SliceInput/SliceInput.tsx
+++ b/packages/react/src/SliceInput/SliceInput.tsx
@@ -1,6 +1,6 @@
 import { Group, Stack } from '@mantine/core';
 import {
-  AnnotatedInternalSchemaElement,
+  ExtendedInternalSchemaElement,
   ElementsContextType,
   SliceDefinitionWithTypes,
   buildElementsContext,
@@ -21,7 +21,7 @@ import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export interface SliceInputProps extends BaseInputProps {
   readonly slice: SliceDefinitionWithTypes;
-  readonly property: AnnotatedInternalSchemaElement;
+  readonly property: ExtendedInternalSchemaElement;
   readonly defaultValue: any[];
   readonly onChange: (newValue: any[]) => void;
   readonly testId?: string;

--- a/packages/react/src/SliceInput/SliceInput.tsx
+++ b/packages/react/src/SliceInput/SliceInput.tsx
@@ -1,7 +1,7 @@
 import { Group, Stack } from '@mantine/core';
 import {
+  AnnotatedInternalSchemaElement,
   ElementsContextType,
-  InternalSchemaElement,
   SliceDefinitionWithTypes,
   buildElementsContext,
   getPropertyDisplayName,
@@ -21,7 +21,7 @@ import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export interface SliceInputProps extends BaseInputProps {
   readonly slice: SliceDefinitionWithTypes;
-  readonly property: InternalSchemaElement;
+  readonly property: AnnotatedInternalSchemaElement;
   readonly defaultValue: any[];
   readonly onChange: (newValue: any[]) => void;
   readonly testId?: string;
@@ -90,9 +90,10 @@ export function SliceInput(props: SliceInputProps): JSX.Element | null {
                   binding={slice.binding}
                   path={props.path}
                   valuePath={undefined /* `valuePath` not supported in slices */}
+                  readOnly={props.property.readonly}
                 />
               </div>
-              {values.length > slice.min && (
+              {!props.property.readonly && values.length > slice.min && (
                 <ArrayRemoveButton
                   propertyDisplayName={propertyDisplayName}
                   testId={props.testId && `${props.testId}-remove-${valueIndex}`}
@@ -107,7 +108,7 @@ export function SliceInput(props: SliceInputProps): JSX.Element | null {
             </Group>
           );
         })}
-        {values.length < slice.max && (
+        {!props.property.readonly && values.length < slice.max && (
           <Group wrap="nowrap" style={{ justifyContent: 'flex-start' }}>
             <ArrayAddButton
               propertyDisplayName={propertyDisplayName}

--- a/packages/react/src/TimingInput/TimingInput.stories.tsx
+++ b/packages/react/src/TimingInput/TimingInput.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const Example = (): JSX.Element => (
   <Document>
-    <TimingInput name="demo" />
+    <TimingInput name="demo" path="Extension.value[x]" />
   </Document>
 );
 
@@ -17,6 +17,7 @@ export const DefaultValue = (): JSX.Element => (
   <Document>
     <TimingInput
       name="demo"
+      path="Extension.value[x]"
       defaultValue={{
         repeat: {
           periodUnit: 'wk',

--- a/packages/react/src/TimingInput/TimingInput.stories.tsx
+++ b/packages/react/src/TimingInput/TimingInput.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { TimingInput } from './TimingInput';
+import { buildElementsContext } from '@medplum/core';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export default {
   title: 'Medplum/TimingInput',
@@ -28,3 +31,58 @@ export const DefaultValue = (): JSX.Element => (
     />
   </Document>
 );
+
+export const Disabled = (): JSX.Element => (
+  <Document>
+    <TimingInput
+      disabled
+      name="demo"
+      path="Extension.value[x]"
+      defaultValue={{
+        repeat: {
+          periodUnit: 'wk',
+          dayOfWeek: ['mon', 'wed', 'fri'],
+          timeOfDay: ['09:00:00', '12:00:00', '03:00:00'],
+        },
+      }}
+    />
+  </Document>
+);
+
+export const PartiallyDisabled = (): JSX.Element => {
+  const context = buildElementsContext({
+    parentContext: undefined,
+    path: 'NutritionOrder',
+    elements: {},
+    accessPolicyResource: {
+      resourceType: 'NutritionOrder',
+      readonlyFields: [
+        'oralDiet.schedule.event',
+        'oralDiet.schedule.repeat.period',
+        'oralDiet.schedule.repeat.dayOfWeek',
+      ],
+    },
+  });
+  if (!context) {
+    return <div>Context unexpectedly undefined</div>;
+  }
+
+  return maybeWrapWithContext(
+    ElementsContext.Provider,
+    context,
+    <Document>
+      <TimingInput
+        name="demo"
+        path="NutritionOrder.oralDiet.schedule"
+        defaultModalOpen
+        defaultValue={{
+          repeat: {
+            periodUnit: 'wk',
+            dayOfWeek: ['mon', 'wed', 'fri'],
+            timeOfDay: ['09:00:00', '12:00:00', '03:00:00'],
+          },
+        }}
+      />
+    </Document>
+  );
+};

--- a/packages/react/src/TimingInput/TimingInput.stories.tsx
+++ b/packages/react/src/TimingInput/TimingInput.stories.tsx
@@ -70,7 +70,7 @@ export const PartiallyDisabled = (): JSX.Element => {
   return maybeWrapWithContext(
     ElementsContext.Provider,
     context,
-    <Document>
+    <Document h={500}>
       <TimingInput
         name="demo"
         path="NutritionOrder.oralDiet.schedule"

--- a/packages/react/src/TimingInput/TimingInput.test.tsx
+++ b/packages/react/src/TimingInput/TimingInput.test.tsx
@@ -1,15 +1,17 @@
 import { act, fireEvent, render, screen } from '../test-utils/render';
-import { TimingInput } from './TimingInput';
+import { TimingInput, TimingInputProps } from './TimingInput';
 
 describe('TimingInput', () => {
+  const defaultProps: Pick<TimingInputProps, 'path' | 'name'> = { name: 'example', path: 'Extension.value[x]' };
+
   test('Renders', async () => {
-    render(<TimingInput name="example" />);
+    render(<TimingInput {...defaultProps} />);
     expect(screen.getByText('No repeat')).toBeDefined();
     expect(screen.getByText('Edit')).toBeDefined();
   });
 
   test('Open dialog', async () => {
-    render(<TimingInput name="example" />);
+    render(<TimingInput {...defaultProps} />);
     expect(screen.getByText('Edit')).toBeDefined();
 
     await act(async () => {
@@ -22,7 +24,7 @@ describe('TimingInput', () => {
   test('Cancel', async () => {
     const onChange = jest.fn();
 
-    render(<TimingInput name="example" onChange={onChange} />);
+    render(<TimingInput {...defaultProps} onChange={onChange} />);
     expect(screen.getByText('Edit')).toBeDefined();
 
     await act(async () => {
@@ -40,7 +42,7 @@ describe('TimingInput', () => {
   test('Add repeat', async () => {
     const onChange = jest.fn();
 
-    render(<TimingInput name="example" defaultValue={{}} onChange={onChange} />);
+    render(<TimingInput {...defaultProps} defaultValue={{}} onChange={onChange} />);
     expect(screen.getByText('Edit')).toBeDefined();
 
     await act(async () => {
@@ -64,7 +66,7 @@ describe('TimingInput', () => {
     const onChange = jest.fn();
 
     render(
-      <TimingInput name="example" defaultValue={{ repeat: { period: 1, periodUnit: 'd' } }} onChange={onChange} />
+      <TimingInput {...defaultProps} defaultValue={{ repeat: { period: 1, periodUnit: 'd' } }} onChange={onChange} />
     );
     expect(screen.getByText('Edit')).toBeDefined();
 
@@ -88,7 +90,7 @@ describe('TimingInput', () => {
   test('Change start', async () => {
     const onChange = jest.fn();
 
-    render(<TimingInput name="example" onChange={onChange} />);
+    render(<TimingInput {...defaultProps} onChange={onChange} />);
     expect(screen.getByText('Edit')).toBeDefined();
 
     await act(async () => {
@@ -111,7 +113,7 @@ describe('TimingInput', () => {
   test('Change period', async () => {
     const onChange = jest.fn();
 
-    render(<TimingInput name="example" onChange={onChange} />);
+    render(<TimingInput {...defaultProps} onChange={onChange} />);
     expect(screen.getByText('Edit')).toBeDefined();
 
     await act(async () => {
@@ -138,7 +140,7 @@ describe('TimingInput', () => {
   test('Change day of week', async () => {
     const onChange = jest.fn();
 
-    render(<TimingInput name="example" onChange={onChange} />);
+    render(<TimingInput {...defaultProps} onChange={onChange} />);
     expect(screen.getByText('Edit')).toBeDefined();
 
     await act(async () => {

--- a/packages/react/src/TimingInput/TimingInput.tsx
+++ b/packages/react/src/TimingInput/TimingInput.tsx
@@ -108,13 +108,13 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
       <Stack>
         <FormSection title="Starts on" htmlFor="timing-dialog-start">
           <DateTimeInput
-            disabled={eventProps.readonly}
+            disabled={eventProps?.readonly}
             name="timing-dialog-start"
             onChange={(newValue) => setStart(newValue)}
           />
         </FormSection>
         <Switch
-          disabled={repeatProps.readonly}
+          disabled={repeatProps?.readonly}
           label="Repeat"
           checked={!!value.repeat}
           onChange={(e) => setRepeat(e.currentTarget.checked ? defaultValue.repeat : undefined)}
@@ -124,7 +124,7 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
             <FormSection title="Repeat every" htmlFor="timing-dialog-period">
               <Group gap="xs" grow wrap="nowrap">
                 <TextInput
-                  disabled={repeatPeriodProps.readonly}
+                  disabled={repeatPeriodProps?.readonly}
                   type="number"
                   step={1}
                   id="timing-dialog-period"
@@ -133,7 +133,7 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
                   onChange={(e) => setPeriod(parseInt(e.currentTarget.value, 10) || 1)}
                 />
                 <NativeSelect
-                  disabled={repeatPeriodUnitProps.readonly}
+                  disabled={repeatPeriodUnitProps?.readonly}
                   id="timing-dialog-periodUnit"
                   name="timing-dialog-periodUnit"
                   defaultValue={value.repeat.periodUnit}
@@ -155,7 +155,7 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
                 <Chip.Group multiple onChange={setDaysOfWeek as (v: string[] | undefined) => void}>
                   <Group justify="space-between" mt="md" gap="xs">
                     {daysOfWeek.map((day) => (
-                      <Chip key={day} value={day} size="xs" radius="xl" disabled={repeatDayOfWeekProps.readonly}>
+                      <Chip key={day} value={day} size="xs" radius="xl" disabled={repeatDayOfWeekProps?.readonly}>
                         {day.charAt(0).toUpperCase()}
                       </Chip>
                     ))}

--- a/packages/react/src/TimingInput/TimingInput.tsx
+++ b/packages/react/src/TimingInput/TimingInput.tsx
@@ -1,9 +1,11 @@
 import { Button, Chip, Group, Modal, NativeSelect, Stack, Switch, TextInput } from '@mantine/core';
 import { formatTiming } from '@medplum/core';
 import { Timing, TimingRepeat } from '@medplum/fhirtypes';
-import { useRef, useState } from 'react';
+import { useContext, useMemo, useRef, useState } from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
 import { FormSection } from '../FormSection/FormSection';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 
 const daysOfWeek = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
 
@@ -11,11 +13,7 @@ type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
 
 type PeriodUnit = 'a' | 's' | 'min' | 'h' | 'd' | 'wk' | 'mo';
 
-export interface TimingInputProps {
-  readonly name: string;
-  readonly defaultValue?: Timing;
-  readonly onChange?: (newValue: Timing) => void;
-}
+export interface TimingInputProps extends ComplexTypeInputProps<Timing> {}
 
 export function TimingInput(props: TimingInputProps): JSX.Element {
   const [value, setValue] = useState<Timing | undefined>(props.defaultValue);
@@ -28,25 +26,31 @@ export function TimingInput(props: TimingInputProps): JSX.Element {
     <>
       <Group gap="xs" grow wrap="nowrap">
         <span>{formatTiming(valueRef.current) || 'No repeat'}</span>
-        <Button onClick={() => setOpen(true)}>Edit</Button>
+        <Button disabled={props.disabled} onClick={() => setOpen(true)}>
+          Edit
+        </Button>
       </Group>
-      <TimingEditorDialog
-        visible={open}
-        defaultValue={valueRef.current}
-        onOk={(newValue) => {
-          if (props.onChange) {
-            props.onChange(newValue);
-          }
-          setValue(newValue);
-          setOpen(false);
-        }}
-        onCancel={() => setOpen(false)}
-      />
+      {!props.disabled && (
+        <TimingEditorDialog
+          path={props.path}
+          visible={open}
+          defaultValue={valueRef.current}
+          onOk={(newValue) => {
+            if (props.onChange) {
+              props.onChange(newValue);
+            }
+            setValue(newValue);
+            setOpen(false);
+          }}
+          onCancel={() => setOpen(false)}
+        />
+      )}
     </>
   );
 }
 
 interface TimingEditorDialogProps {
+  readonly path: string;
   readonly visible: boolean;
   readonly defaultValue?: Timing;
   readonly onOk: (newValue: Timing) => void;
@@ -62,6 +66,14 @@ const defaultValue: Timing = {
 
 function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
   const [value, setValue] = useState<Timing>(props.defaultValue || defaultValue);
+  const { getExtendedProps } = useContext(ElementsContext);
+  const [eventProps, repeatProps, repeatPeriodProps, repeatPeriodUnitProps, repeatDayOfWeekProps] = useMemo(
+    () =>
+      ['event', 'repeat', 'repeat.period', 'repeat.periodUnit', 'repeat.dayOfWeek'].map((field) =>
+        getExtendedProps(props.path + '.' + field)
+      ),
+    [getExtendedProps, props.path]
+  );
 
   const valueRef = useRef<Timing>();
   valueRef.current = value;
@@ -95,9 +107,14 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
     >
       <Stack>
         <FormSection title="Starts on" htmlFor="timing-dialog-start">
-          <DateTimeInput name="timing-dialog-start" onChange={(newValue) => setStart(newValue)} />
+          <DateTimeInput
+            disabled={eventProps.readonly}
+            name="timing-dialog-start"
+            onChange={(newValue) => setStart(newValue)}
+          />
         </FormSection>
         <Switch
+          disabled={repeatProps.readonly}
           label="Repeat"
           checked={!!value.repeat}
           onChange={(e) => setRepeat(e.currentTarget.checked ? defaultValue.repeat : undefined)}
@@ -107,6 +124,7 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
             <FormSection title="Repeat every" htmlFor="timing-dialog-period">
               <Group gap="xs" grow wrap="nowrap">
                 <TextInput
+                  disabled={repeatPeriodProps.readonly}
                   type="number"
                   step={1}
                   id="timing-dialog-period"
@@ -115,6 +133,7 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
                   onChange={(e) => setPeriod(parseInt(e.currentTarget.value, 10) || 1)}
                 />
                 <NativeSelect
+                  disabled={repeatPeriodUnitProps.readonly}
                   id="timing-dialog-periodUnit"
                   name="timing-dialog-periodUnit"
                   defaultValue={value.repeat.periodUnit}
@@ -136,7 +155,7 @@ function TimingEditorDialog(props: TimingEditorDialogProps): JSX.Element {
                 <Chip.Group multiple onChange={setDaysOfWeek as (v: string[] | undefined) => void}>
                   <Group justify="space-between" mt="md" gap="xs">
                     {daysOfWeek.map((day) => (
-                      <Chip key={day} value={day} size="xs" radius="xl">
+                      <Chip key={day} value={day} size="xs" radius="xl" disabled={repeatDayOfWeekProps.readonly}>
                         {day.charAt(0).toUpperCase()}
                       </Chip>
                     ))}

--- a/packages/react/src/TimingInput/TimingInput.tsx
+++ b/packages/react/src/TimingInput/TimingInput.tsx
@@ -13,11 +13,13 @@ type DayOfWeek = 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat';
 
 type PeriodUnit = 'a' | 's' | 'min' | 'h' | 'd' | 'wk' | 'mo';
 
-export interface TimingInputProps extends ComplexTypeInputProps<Timing> {}
+export interface TimingInputProps extends ComplexTypeInputProps<Timing> {
+  readonly defaultModalOpen?: boolean;
+}
 
 export function TimingInput(props: TimingInputProps): JSX.Element {
   const [value, setValue] = useState<Timing | undefined>(props.defaultValue);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(!props.disabled && (props.defaultModalOpen ?? false));
 
   const valueRef = useRef<Timing>();
   valueRef.current = value;

--- a/packages/react/src/utils/maybeWrapWithTooltip.tsx
+++ b/packages/react/src/utils/maybeWrapWithTooltip.tsx
@@ -1,0 +1,7 @@
+import { Tooltip } from '@mantine/core';
+
+export const READ_ONLY_TOOLTIP_TEXT = 'Read Only';
+
+export function maybeWrapWithTooltip(tooltipText: string | undefined, children: JSX.Element): JSX.Element {
+  return tooltipText ? <Tooltip.Floating label={tooltipText}>{children}</Tooltip.Floating> : children;
+}

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -22,7 +22,7 @@ describe('Config', () => {
     process.env.MEDPLUM_PORT = '3000';
     process.env.MEDPLUM_DATABASE_PORT = '5432';
     process.env.MEDPLUM_REDIS_TLS = '{}';
-    process.env.MEDPLUM_DATABASE_SSL = '{"require":true}'
+    process.env.MEDPLUM_DATABASE_SSL = '{"require":true}';
     const config = await loadConfig('env');
     expect(config).toBeDefined();
     expect(config.baseUrl).toEqual('http://localhost:3000');

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -884,12 +884,58 @@ describe('AccessPolicy', () => {
       const writeResource = await repo2.updateResource<Patient>({
         ...readResource,
         active: true,
-        name: [{ given: ['Bob'], family: 'Smith' }],
+        name: [{ given: ['Morty'], family: 'Smith' }],
       });
       expect(writeResource).toMatchObject({
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
         birthDate: '1970-01-01',
+        active: true,
+      });
+    }));
+
+  test.skip('Readonly choice-of-type fields on write', () =>
+    withTestContext(async () => {
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        birthDate: '1970-01-01',
+        multipleBirthInteger: 2,
+      });
+
+      const accessPolicy: AccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          {
+            resourceType: 'Patient',
+            readonlyFields: ['multipleBirth[x]'],
+          },
+        ],
+      };
+
+      const repo2 = new Repository({
+        author: {
+          reference: 'Practitioner/123',
+        },
+        accessPolicy,
+      });
+
+      const readResource = await repo2.readResource<Patient>('Patient', patient.id as string);
+      expect(readResource).toMatchObject({
+        resourceType: 'Patient',
+        birthDate: '1970-01-01',
+        multipleBirthInteger: 2,
+      });
+
+      // multipleBirthInteger is readonly and should be ignored
+      const writeResource = await repo2.updateResource<Patient>({
+        ...readResource,
+        active: true,
+        multipleBirthInteger: 3,
+      });
+      expect(writeResource).toMatchObject({
+        resourceType: 'Patient',
+        birthDate: '1970-01-01',
+        multipleBirthInteger: 2,
         active: true,
       });
     }));
@@ -923,6 +969,37 @@ describe('AccessPolicy', () => {
         identifier: [{ system: 'https://example.com/', value }],
       });
       expect(patient.identifier).toBeUndefined();
+    }));
+
+  test.skip('Try to create with readonly choice-of-type property', () =>
+    withTestContext(async () => {
+      const accessPolicy: AccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          {
+            resourceType: 'Patient',
+            readonlyFields: ['multipleBirth[x]'],
+          },
+        ],
+      };
+
+      const repo = new Repository({
+        author: {
+          reference: 'Practitioner/123',
+        },
+        accessPolicy,
+      });
+
+      const patient = await repo.createResource<Patient>({
+        resourceType: 'Patient',
+        active: false,
+        multipleBirthBoolean: true,
+      });
+      expect(patient.multipleBirthBoolean).toBeUndefined();
+      expect(patient).toMatchObject({
+        resourceType: 'Patient',
+        active: false,
+      });
     }));
 
   test('Try to add readonly property', () =>
@@ -1045,6 +1122,42 @@ describe('AccessPolicy', () => {
       expect(bundle2.entry?.length).toEqual(1);
     }));
 
+  test.skip('Try to remove readonly choice-of-type property', () =>
+    withTestContext(async () => {
+      // Create a patient with an identifier
+      const patient1 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Identifier'], family: 'Test' }],
+        multipleBirthInteger: 2,
+      });
+
+      // AccessPolicy with Patient.identifier readonly
+      const accessPolicy: AccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          {
+            resourceType: 'Patient',
+            readonlyFields: ['multipleBirth[x]'],
+          },
+        ],
+      };
+
+      const repo = new Repository({
+        author: { reference: 'Practitioner/123' },
+        accessPolicy,
+      });
+
+      const { multipleBirthInteger, ...rest } = patient1;
+      expect(multipleBirthInteger).toEqual(2);
+      expect((rest as Patient).multipleBirthInteger).toBeUndefined();
+
+      // Try to update the patient without multipleBirth[x]
+      // Effectively, try to remove it
+      // This returns success, but multipleBirth[x] is still there
+      const patient2 = await repo.updateResource<Patient>(rest);
+      expect(patient2.multipleBirthInteger).toEqual(2);
+    }));
+
   test('Hidden fields on read', () =>
     withTestContext(async () => {
       const patient = await systemRepo.createResource<Patient>({
@@ -1158,6 +1271,34 @@ describe('AccessPolicy', () => {
       expect(historyBundle.entry?.[0]?.resource?.subject?.display).toBeUndefined();
     }));
 
+  test('Nested hidden fields on array element', () =>
+    withTestContext(async () => {
+      const patient = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'], family: 'Smith' }],
+      });
+
+      const accessPolicy: AccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [{ resourceType: 'Patient', hiddenFields: ['name.family'] }],
+      };
+
+      const repo2 = new Repository({
+        author: { reference: 'Practitioner/123' },
+        accessPolicy,
+      });
+
+      const readResource = await repo2.readResource<Patient>('Patient', patient.id as string);
+      expect(readResource).toMatchObject({
+        resourceType: 'Patient',
+        name: [{ given: ['Alice'] }],
+      });
+
+      expect(readResource.name?.[0]).toBeDefined();
+      expect(readResource.name?.[0].given).toEqual(['Alice']);
+      expect(readResource.name?.[0].family).toBeUndefined();
+    }));
+
   test('Hidden fields on possible missing values', () =>
     withTestContext(async () => {
       // Create an Observation with a valueQuantity
@@ -1179,7 +1320,7 @@ describe('AccessPolicy', () => {
         valueString: 'test',
       });
 
-      // AccessPolicy that hides ServiceRequest subject.display
+      // AccessPolicy that hides Observation valueQuantity.value
       const accessPolicy: AccessPolicy = {
         resourceType: 'AccessPolicy',
         resource: [
@@ -1277,6 +1418,59 @@ describe('AccessPolicy', () => {
       expect(historyBundle.entry?.[0]?.resource?.subject).toBeDefined();
       expect(historyBundle.entry?.[0]?.resource?.subject?.reference).toBeDefined();
       expect(historyBundle.entry?.[0]?.resource?.subject?.display).toBeUndefined();
+    }));
+
+  test.skip('Hidden choice-of-type field', () =>
+    withTestContext(async () => {
+      // Create an Observation with a valueQuantity
+      const obsQuantity = await systemRepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+        valueQuantity: {
+          value: 123,
+          unit: 'mmHg',
+        },
+      });
+
+      // Create an Observation with a valueString
+      const obsString = await systemRepo.createResource<Observation>({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+        valueString: 'test',
+      });
+
+      // AccessPolicy that hides Observation.value[x]
+      const accessPolicy: AccessPolicy = {
+        resourceType: 'AccessPolicy',
+        resource: [
+          {
+            resourceType: 'Observation',
+            hiddenFields: ['value[x]'],
+          },
+        ],
+      };
+
+      const repo2 = new Repository({ author: { reference: 'Practitioner/123' }, accessPolicy });
+
+      const readResource1 = await repo2.readResource<Observation>('Observation', obsQuantity.id as string);
+      expect(readResource1).toMatchObject({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+      });
+      expect(readResource1.valueQuantity).toBeUndefined();
+      expect(readResource1.valueString).toBeUndefined();
+
+      const readResource2 = await repo2.readResource<Observation>('Observation', obsString.id as string);
+      expect(readResource2).toMatchObject({
+        resourceType: 'Observation',
+        status: 'final',
+        code: { text: 'test' },
+      });
+      expect(readResource2.valueQuantity).toBeUndefined();
+      expect(readResource2.valueString).toBeDefined();
     }));
 
   test('Identifier criteria', () =>


### PR DESCRIPTION
`ResourceForm` can now consider the user's `AccessPolicy` and hide or show inputs in a disabled state for `AccessPolicy.resource.hiddenFields`  and `AccessPolicy.resource.readonlyFields` respectively.

For nested elements that have a custom input component, e.g. `<HumanNameInput/>`, we do not attempt to hide `hiddenFields` such as `name.given` since it would complicate managing the layout of the inputs. Instead, the fields are shown in a disabled state as an affordance to the user that they cannot edit/supply a value for those fields.

Note: choice-of-type elements, e.g. `value[x]`, are not technically supported since they are not valid values in `AccessPolicy.resource.readonlyFields`. A followup project to this PR is adding support for specifying choice-of-type elements in access policies at which point they should generally _just work_ in `<ResourceForm />`. Specifying explicitly typed choice-of-type like `valueBoolean` as is currently supported in `AccessPolicy.resource.{readonlyFields,hiddenFields}` will not be reflected correctly in `<ResourceForm />`.

#### Patient form with various fields in readonly
![Screenshot 2024-05-23 at 3 41 19 PM](https://github.com/medplum/medplum/assets/933303/c29cb9f8-47c6-4a79-bf75-6b9ea310ed76)

#### Patient form with various fields hidden, e.g. `'identifier', 'name.use', 'name.prefix', 'name.suffix', 'birthDate'`
![Screenshot 2024-05-23 at 3 52 12 PM](https://github.com/medplum/medplum/assets/933303/3a47ee1a-c7ed-4e66-8d0d-bd54e29d2d45)



Fixes #4469 #4470 