### PR TITLE
Fixes #4576 - Windows 1252 character encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20302,9 +20302,12 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
     },
     "node_modules/async-eventemitter": {
       "version": "0.2.4",
@@ -20312,14 +20315,6 @@
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "dependencies": {
         "async": "^2.4.0"
-      }
-    },
-    "node_modules/async-eventemitter/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
       }
     },
     "node_modules/async-limiter": {
@@ -21605,6 +21600,12 @@
         "pako": "~0.2.0"
       }
     },
+    "node_modules/browserify-zlib/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true
+    },
     "node_modules/browserslist": {
       "version": "4.23.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
@@ -22677,6 +22678,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/clsx": {
@@ -24638,11 +24648,6 @@
         "url": "https://github.com/PantelisGeorgiadis/dcmjs-dimse?sponsor=1"
       }
     },
-    "node_modules/dcmjs/node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -24699,18 +24704,6 @@
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -31921,6 +31914,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jake/node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "dev": true
+    },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -38870,12 +38869,15 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -41853,9 +41855,9 @@
       "dev": true
     },
     "node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -50361,6 +50363,11 @@
         "tiny-inflate": "^1.0.0"
       }
     },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
@@ -52270,6 +52277,11 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/winston/node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
     "node_modules/wonka": {
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-4.0.15.tgz",
@@ -52696,6 +52708,7 @@
         "@medplum/core": "3.1.6",
         "@medplum/hl7": "3.1.6",
         "dcmjs-dimse": "0.1.27",
+        "iconv-lite": "0.6.3",
         "node-windows": "1.0.0-beta.8",
         "ws": "8.17.0"
       },
@@ -52710,6 +52723,17 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/agent/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/app": {
@@ -53081,13 +53105,25 @@
       "version": "3.1.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@medplum/core": "3.1.6"
+        "@medplum/core": "3.1.6",
+        "iconv-lite": "0.6.3"
       },
       "devDependencies": {
         "@medplum/fhirtypes": "3.1.6"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/hl7/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/mock": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28636,6 +28636,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -28649,6 +28650,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -52833,6 +52835,7 @@
         "commander": "12.1.0",
         "dotenv": "16.4.5",
         "fast-glob": "3.3.2",
+        "iconv-lite": "0.6.3",
         "node-fetch": "2.7.0",
         "tar": "7.1.0"
       },
@@ -52854,6 +52857,17 @@
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/cli/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/core": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -26,6 +26,7 @@
     "@medplum/core": "3.1.6",
     "@medplum/hl7": "3.1.6",
     "dcmjs-dimse": "0.1.27",
+    "iconv-lite": "0.6.3",
     "node-windows": "1.0.0-beta.8",
     "ws": "8.17.0"
   },

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -521,6 +521,7 @@ export class App {
     const client = new Hl7Client({
       host: address.hostname,
       port: Number.parseInt(address.port, 10),
+      encoding: address.searchParams.get('encoding') ?? undefined,
     });
 
     client

--- a/packages/agent/src/hl7.ts
+++ b/packages/agent/src/hl7.ts
@@ -30,8 +30,9 @@ export class AgentHl7Channel extends BaseChannel {
     }
     this.started = true;
     const address = new URL(this.getEndpoint().address as string);
+    const encoding = address.searchParams.get('encoding') ?? undefined;
     this.log.info(`Channel starting on ${address}...`);
-    this.server.start(Number.parseInt(address.port, 10));
+    this.server.start(Number.parseInt(address.port, 10), encoding);
     this.log.info('Channel started successfully');
   }
 

--- a/packages/cli/esbuild.mjs
+++ b/packages/cli/esbuild.mjs
@@ -26,6 +26,7 @@ const options = {
     'commander',
     'dotenv',
     'fast-glob',
+    'iconv-lite',
     'node-fetch',
     'tar',
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "commander": "12.1.0",
     "dotenv": "16.4.5",
     "fast-glob": "3.3.2",
+    "iconv-lite": "0.6.3",
     "node-fetch": "2.7.0",
     "tar": "7.1.0"
   },

--- a/packages/cli/src/hl7.ts
+++ b/packages/cli/src/hl7.ts
@@ -11,6 +11,7 @@ const send = createMedplumCommand('send')
   .argument('[body]', 'Optional HL7 message body')
   .option('--generate-example', 'Generate a sample HL7 message')
   .option('--file <file>', 'Read the HL7 message from a file')
+  .option('--encoding <encoding>', 'The encoding to use')
   .action(async (host, port, body, options) => {
     if (options.generateExample) {
       body = generateSampleHl7Message();
@@ -25,6 +26,7 @@ const send = createMedplumCommand('send')
     const client = new Hl7Client({
       host,
       port: Number.parseInt(port, 10),
+      encoding: options.encoding,
     });
 
     try {
@@ -38,7 +40,8 @@ const send = createMedplumCommand('send')
 const listen = createMedplumCommand('listen')
   .description('Starts an HL7 v2 MLLP server')
   .argument('<port>')
-  .action(async (port) => {
+  .option('--encoding <encoding>', 'The encoding to use')
+  .action(async (port, options) => {
     const server = new Hl7Server((connection) => {
       connection.addEventListener('message', ({ message }) => {
         console.log(message.toString().replaceAll('\r', '\n'));
@@ -46,7 +49,7 @@ const listen = createMedplumCommand('listen')
       });
     });
 
-    server.start(Number.parseInt(port, 10));
+    server.start(Number.parseInt(port, 10), options.encoding);
     console.log('Listening on port ' + port);
   });
 

--- a/packages/hl7/README.md
+++ b/packages/hl7/README.md
@@ -2,6 +2,12 @@
 
 Server and client.
 
+## Character Encoding
+
+List of iconv-lite character encodings
+
+See: https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
+
 ## License
 
 Apache 2.0. Copyright &copy; Medplum 2023

--- a/packages/hl7/esbuild.mjs
+++ b/packages/hl7/esbuild.mjs
@@ -14,7 +14,7 @@ const options = {
   tsconfig: 'tsconfig.json',
   minify: true,
   sourcemap: true,
-  external: ['@medplum/core', 'dataloader', 'rfc6902'],
+  external: ['@medplum/core', 'iconv-lite'],
 };
 
 esbuild

--- a/packages/hl7/package.json
+++ b/packages/hl7/package.json
@@ -53,7 +53,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "@medplum/core": "3.1.6"
+    "@medplum/core": "3.1.6",
+    "iconv-lite": "0.6.3"
   },
   "devDependencies": {
     "@medplum/fhirtypes": "3.1.6"

--- a/packages/hl7/src/client.ts
+++ b/packages/hl7/src/client.ts
@@ -6,12 +6,14 @@ import { Hl7Connection } from './connection';
 export interface Hl7ClientOptions {
   host: string;
   port: number;
+  encoding?: string;
 }
 
 export class Hl7Client extends Hl7Base {
   options: Hl7ClientOptions;
   host: string;
   port: number;
+  encoding?: string;
   connection?: Hl7Connection;
 
   constructor(options: Hl7ClientOptions) {
@@ -19,6 +21,7 @@ export class Hl7Client extends Hl7Base {
     this.options = options;
     this.host = this.options.host;
     this.port = this.options.port;
+    this.encoding = this.options.encoding;
   }
 
   connect(): Promise<Hl7Connection> {
@@ -28,7 +31,7 @@ export class Hl7Client extends Hl7Base {
 
     return new Promise((resolve, reject) => {
       const socket = connect({ host: this.host, port: this.port }, () => {
-        this.connection = new Hl7Connection(socket);
+        this.connection = new Hl7Connection(socket, this.encoding);
         socket.off('error', reject);
         resolve(this.connection);
       });

--- a/packages/hl7/src/constants.ts
+++ b/packages/hl7/src/constants.ts
@@ -1,3 +1,20 @@
-export const VT = String.fromCharCode(0x0b);
-export const FS = String.fromCharCode(0x1c);
-export const CR = String.fromCharCode(0x0d);
+/**
+ * VT (Vertical Tab) character.
+ *
+ * In HL7 messages, this character is used to indicate the start of a message.
+ */
+export const VT = 0x0b;
+
+/**
+ * CR (Carriage Return) character.
+ *
+ * In HL7 messages, this character is used to indicate the end of a message.
+ */
+export const CR = 0x0d;
+
+/**
+ * FS (File Separator) character.
+ *
+ * In HL7 messages, this character is used to separate fields.
+ */
+export const FS = 0x1c;

--- a/packages/hl7/src/server.test.ts
+++ b/packages/hl7/src/server.test.ts
@@ -38,4 +38,65 @@ describe('HL7 Server', () => {
     client.close();
     await server.stop();
   });
+
+  test('Send and receive windows-1252', async () => {
+    // HL7 messages are typically encoded in ASCII or ISO-8859-1
+    // See: https://www.redoxengine.com/blog/everything-you-wanted-to-know-about-character-encoding-in-hl7-and-redox/
+    const encoding = 'windows-1252';
+
+    // Create a sample HL7 message with some special characters
+    // Windows-1252: https://en.wikipedia.org/wiki/Windows-1252
+    const patientName = 'Çödÿ';
+
+    const message = Hl7Message.parse(
+      'MSH|^~\\&|ADT1|MCM|LABADT|MCM|198808181126|SECURITY|ADT^A01|MSG00001|P|2.2\r' +
+        `PID|||PATID1234^5^M11||${patientName}||19610615|M-`
+    );
+
+    let receivedPatientName: string | undefined = undefined;
+
+    const server = new Hl7Server((connection) => {
+      connection.addEventListener('message', ({ message }) => {
+        receivedPatientName = message.getSegment('PID')?.getField(5)?.toString();
+        connection.send(message.buildAck());
+      });
+    });
+
+    server.start(1235, encoding);
+
+    // First, connect with a client correctly configured for windows-1252
+    // This should work correctly
+    const client1 = new Hl7Client({
+      host: 'localhost',
+      port: 1235,
+      encoding,
+    });
+
+    await client1.connect();
+
+    const response1 = await client1.sendAndWait(message);
+    expect(response1).toBeDefined();
+    expect(receivedPatientName).toBe(patientName);
+    client1.close();
+
+    // Next, connect with a client configured for utf-8
+    // This should produce invalid results due to the encoding mismatch
+    // The special characters will be garbled
+    // We add this test to demonstrate the importance of matching encodings
+    const client2 = new Hl7Client({
+      host: 'localhost',
+      port: 1235,
+      encoding: 'utf-8',
+    });
+
+    await client2.connect();
+
+    const response2 = await client2.sendAndWait(message);
+    expect(response2).toBeDefined();
+    expect(receivedPatientName).toBe('Ã‡Ã¶dÃ¿');
+    client2.close();
+
+    // Shut down
+    await server.stop();
+  });
 });

--- a/packages/hl7/src/server.ts
+++ b/packages/hl7/src/server.ts
@@ -6,7 +6,7 @@ export class Hl7Server {
 
   constructor(public readonly handler: (connection: Hl7Connection) => void) {}
 
-  start(port: number, encoding?: BufferEncoding): void {
+  start(port: number, encoding?: string): void {
     const server = net.createServer((socket) => {
       const connection = new Hl7Connection(socket, encoding);
       this.handler(connection);


### PR DESCRIPTION
- `packages/hl7`
    - Replaced the `encoding: BufferEncoding` param with `encoding: string`
    - Before, the `BufferEncoding` was passed to the Node.js socket `setEncoding` and defaulted to UTF-8
    - After, the Node.js socket never calls `setEncoding` and relies on `Buffer` for everything
    - We encode/decode all data with `iconv-lite`
    - We still default to UTF-8 if encoding is not specified
- `packages/agent`
    - For HL7 listener, we use the encoding from the `encoding` query param in `Endpoint.address`
    - For HL7 push, we use the encoding from the `encoding` query param in `Device.url`
    - For example, `mllp://localhost:2575?encoding=windows-1252`
- `packages/cli`
    - Added a new optional `--encoding` argument to `medplum hl7 listen`
    - Added a new optional `--encoding` argument to `medplum hl7 send`

![image](https://github.com/medplum/medplum/assets/749094/37d440f2-d052-459c-af64-f411ccbfe819)
