### PR TITLE
Support Database SSL config from Env

### DIFF
--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -22,12 +22,14 @@ describe('Config', () => {
     process.env.MEDPLUM_PORT = '3000';
     process.env.MEDPLUM_DATABASE_PORT = '5432';
     process.env.MEDPLUM_REDIS_TLS = '{}';
+    process.env.MEDPLUM_DATABASE_SSL = '{"require":true}'
     const config = await loadConfig('env');
     expect(config).toBeDefined();
     expect(config.baseUrl).toEqual('http://localhost:3000');
     expect(config.port).toEqual(3000);
     expect(config.database.port).toEqual(5432);
     expect(config.redis.tls).toEqual({});
+    expect(config.database.ssl).toEqual({ require: true });
     expect(getConfig()).toBe(config);
   });
 });

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -286,5 +286,5 @@ function isBooleanConfig(key: string): boolean {
 }
 
 function isObjectConfig(key: string): boolean {
-  return key === 'tls';
+  return key === 'tls' || key === 'ssl';
 }


### PR DESCRIPTION
## Why
- Similar to #3787, it would be nice to be able to configure Database SSL from ENV values

## What
- Implemented the same way, the key we do an object check on is `ssl` - when the key is `ssl` we JSON.parse() before setting the value
