### PR TITLE
Fix several fhirpath functions taking `other` Atom and implement subsetOf & supersetOf

### DIFF
--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -59,6 +59,9 @@ export class LiteralAtom implements Atom {
 export class SymbolAtom implements Atom {
   constructor(public readonly name: string) {}
   eval(context: AtomContext, input: TypedValue[]): TypedValue[] {
+    if (this.name === '$this') {
+      return input;
+    }
     const variableValue = this.getVariable(context);
     if (variableValue) {
       return [variableValue];

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -1385,7 +1385,7 @@ describe('FHIRPath Test Suite', () => {
     });
   });
 
-  describe.skip('testAll', () => {
+  describe('testAll', () => {
     test('testAllTrue1', () => {
       expect(evalFhirPath('Patient.name.select(given.exists()).allTrue()', patient)).toEqual([true]);
     });
@@ -1403,7 +1403,7 @@ describe('FHIRPath Test Suite', () => {
     });
   });
 
-  describe.skip('testSubSetOf', () => {
+  describe('testSubSetOf', () => {
     test('testSubSetOf1', () => {
       expect(evalFhirPath('Patient.name.first().subsetOf($this.name)', patient)).toEqual([true]);
     });
@@ -1413,7 +1413,7 @@ describe('FHIRPath Test Suite', () => {
     });
   });
 
-  describe.skip('testSuperSetOf', () => {
+  describe('testSuperSetOf', () => {
     test('testSuperSetOf1', () => {
       expect(evalFhirPath('Patient.name.first().supersetOf($this.name).not()', patient)).toEqual([true]);
     });
@@ -2864,6 +2864,29 @@ describe('FHIRPath Test Suite', () => {
     test('testUnion8', () => {
       expect(evalFhirPath('1.combine(1).union(2).count() = 2', patient)).toEqual([true]);
     });
+    test('testUnion9', () => {
+      expect(evalFhirPath('Patient.name.family.union(Patient.name.given)', patient)).toEqual([
+        'Chalmers',
+        'Windsor',
+        'Peter',
+        'James',
+        'Jim',
+      ]);
+    });
+  });
+
+  describe('testCombine', () => {
+    test('testCombine1', () => {
+      expect(evalFhirPath('Patient.name.family.combine(Patient.name.given)', patient)).toEqual([
+        'Chalmers',
+        'Windsor',
+        'Peter',
+        'James',
+        'Jim',
+        'Peter',
+        'James',
+      ]);
+    });
   });
 
   describe('testIntersect', () => {
@@ -2903,6 +2926,11 @@ describe('FHIRPath Test Suite', () => {
 
     test('testExclude4', () => {
       expect(evalFhirPath('1.combine(1).exclude(2).count() = 2', patient)).toEqual([true]);
+    });
+    test('testExclude5', () => {
+      expect(
+        evalFhirPath("Patient.name.given.exclude(Patient.name.given.where(startsWith('J').not())).distinct()", patient)
+      ).toEqual(['James', 'Jim']);
     });
   });
 

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -1411,6 +1411,14 @@ describe('FHIRPath Test Suite', () => {
     test('testSubSetOf2', () => {
       expect(evalFhirPath('Patient.name.subsetOf($this.name.first()).not()', patient)).toEqual([true]);
     });
+
+    test('testSubSetOf3', () => {
+      expect(evalFhirPath('{}.subsetOf(Patient.name)', patient)).toEqual([true]);
+    });
+
+    test('testSubSetOf4', () => {
+      expect(evalFhirPath('Patient.name.subsetOf({})', patient)).toEqual([false]);
+    });
   });
 
   describe('testSuperSetOf', () => {
@@ -1420,6 +1428,13 @@ describe('FHIRPath Test Suite', () => {
 
     test('testSuperSetOf2', () => {
       expect(evalFhirPath('Patient.name.supersetOf($this.name.first())', patient)).toEqual([true]);
+    });
+    test('testSuperSetOf3', () => {
+      expect(evalFhirPath('{}.supersetOf(Patient.name)', patient)).toEqual([false]);
+    });
+
+    test('testSuperSetOf4', () => {
+      expect(evalFhirPath('Patient.name.supersetOf({})', patient)).toEqual([true]);
     });
   });
 

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -173,7 +173,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * See: http://hl7.org/fhirpath/#subsetofother-collection-boolean
    * @param context - The evaluation context.
    * @param input - The input collection.
-   * @param other - The atom representing the collection of elements to check for membership.
+   * @param other - The atom representing the collection of elements.
    * @returns True if all items in the input collection are members of the other collection.
    */
   subsetOf: (context: AtomContext, input: TypedValue[], other: Atom): TypedValue[] => {
@@ -199,8 +199,23 @@ export const functions: Record<string, FhirPathFunction> = {
    * is empty ({ }), the result is false.
    *
    * See: http://hl7.org/fhirpath/#supersetofother-collection-boolean
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param other - The atom representing the collection of elements.
+   * @returns True if all items in the other collection are members of the input collection.
    */
-  supersetOf: stub,
+  supersetOf: (context: AtomContext, input: TypedValue[], other: Atom): TypedValue[] => {
+    const otherArray = other.eval(context, getRootInput(context));
+    if (otherArray.length === 0) {
+      return booleanToTypedValue(true);
+    }
+
+    if (input.length === 0) {
+      return booleanToTypedValue(false);
+    }
+
+    return booleanToTypedValue(otherArray.every((e) => input.some((o) => o.value === e.value)));
+  },
 
   /**
    * Returns the integer count of the number of items in the input collection.
@@ -479,7 +494,7 @@ export const functions: Record<string, FhirPathFunction> = {
     if (!other) {
       return input;
     }
-    const otherArray = other.eval(context, input);
+    const otherArray = other.eval(context, getRootInput(context));
     const result: TypedValue[] = [];
     for (const value of input) {
       if (!otherArray.some((e) => e.value === value.value)) {
@@ -512,7 +527,7 @@ export const functions: Record<string, FhirPathFunction> = {
     if (!other) {
       return input;
     }
-    const otherArray = other.eval(context, input);
+    const otherArray = other.eval(context, getRootInput(context));
     return removeDuplicates([...input, ...otherArray]);
   },
 
@@ -533,7 +548,7 @@ export const functions: Record<string, FhirPathFunction> = {
     if (!other) {
       return input;
     }
-    const otherArray = other.eval(context, input);
+    const otherArray = other.eval(context, getRootInput(context));
     return [...input, ...otherArray];
   },
 


### PR DESCRIPTION
While working on a tangentially related project, I discovered that the fhirpath function implementation taking an `other` collection parameter were implemented incorrectly: evaluating the other expression against the current `input` value rather than the original/"root" input.

This PR undoes some of the changes in https://github.com/medplum/medplum/pull/4189 to get proper resolution of `$this` without having to explicitly modify the context before each call to `.eval(...)` which would be rather tedious. @codyebberson, was there a reason for those changes that I'm missing?