### PR TITLE
Fix IAM policy resource strings

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -266,7 +266,7 @@ export class BackEnd extends Construct {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ['s3:ListBucket', 's3:GetObject', 's3:PutObject', 's3:DeleteObject'],
-          resources: [`arn:aws:s3:::${config.storageBucketName}`],
+          resources: ['arn:aws:s3:::*'],
         }),
 
         // IAM: Pass role to innvoke lambda functions
@@ -292,11 +292,17 @@ export class BackEnd extends Construct {
           resources: [`arn:aws:lambda:${region}:${accountNumber}:function:medplum-bot-lambda-*`],
         }),
 
-        // Lambda layers: List and get layer versions
-        // https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html
+        // Lambda layers: List layer versions
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ['lambda:ListLayerVersions', 'lambda:GetLayerVersion'],
+          actions: ['lambda:ListLayerVersions'],
+          resources: [`arn:aws:lambda:${region}:${accountNumber}:layer:medplum-bot-layer`],
+        }),
+
+        // Lambda layers: Get layer version
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['lambda:GetLayerVersion'],
           resources: [`arn:aws:lambda:${region}:${accountNumber}:layer:medplum-bot-layer:*`],
         }),
 

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -61,6 +61,8 @@ export class BackEnd extends Construct {
     super(scope, 'BackEnd');
 
     const name = config.name;
+    const accountNumber = config.accountNumber;
+    const region = config.region;
 
     // VPC
     if (config.vpcId) {
@@ -226,7 +228,7 @@ export class BackEnd extends Construct {
             'logs:DescribeLogGroups',
             'logs:PutRetentionPolicy',
           ],
-          resources: ['arn:aws:logs:*'],
+          resources: [`arn:aws:logs:${region}:${accountNumber}:log-group:/ecs/medplum/${name}/*`],
         }),
 
         // Secrets Manager: Read only access to secrets
@@ -240,7 +242,7 @@ export class BackEnd extends Construct {
             'secretsmanager:ListSecrets',
             'secretsmanager:ListSecretVersionIds',
           ],
-          resources: ['arn:aws:secretsmanager:*'],
+          resources: [`arn:aws:secretsmanager:${region}:${accountNumber}:secret:*`],
         }),
 
         // Parameter Store: Read only access
@@ -248,7 +250,7 @@ export class BackEnd extends Construct {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ['ssm:GetParametersByPath', 'ssm:GetParameters', 'ssm:GetParameter', 'ssm:DescribeParameters'],
-          resources: ['arn:aws:ssm:*'],
+          resources: [`arn:aws:ssm:${region}:${accountNumber}:parameter/medplum/${name}/*`],
         }),
 
         // SES: Send emails
@@ -256,7 +258,7 @@ export class BackEnd extends Construct {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ['ses:SendEmail', 'ses:SendRawEmail'],
-          resources: ['arn:aws:ses:*'],
+          resources: [`arn:aws:ses:${region}:${accountNumber}:identity/*`],
         }),
 
         // S3: Read and write access to buckets
@@ -264,7 +266,7 @@ export class BackEnd extends Construct {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ['s3:ListBucket', 's3:GetObject', 's3:PutObject', 's3:DeleteObject'],
-          resources: ['arn:aws:s3:::*'],
+          resources: [`arn:aws:s3:::${config.storageBucketName}`],
         }),
 
         // IAM: Pass role to innvoke lambda functions
@@ -285,11 +287,17 @@ export class BackEnd extends Construct {
             'lambda:GetFunctionConfiguration',
             'lambda:UpdateFunctionCode',
             'lambda:UpdateFunctionConfiguration',
-            'lambda:ListLayerVersions',
-            'lambda:GetLayerVersion',
             'lambda:InvokeFunction',
           ],
-          resources: ['arn:aws:lambda:*'],
+          resources: [`arn:aws:lambda:${region}:${accountNumber}:function:medplum-bot-lambda-*`],
+        }),
+
+        // Lambda layers: List and get layer versions
+        // https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['lambda:ListLayerVersions', 'lambda:GetLayerVersion'],
+          resources: [`arn:aws:lambda:${region}:${accountNumber}:layer:medplum-bot-layer:*`],
         }),
 
         // XRay: Write to segment store
@@ -338,7 +346,7 @@ export class BackEnd extends Construct {
     // Task Containers
     this.serviceContainer = this.taskDefinition.addContainer('MedplumTaskDefinition', {
       image: this.getContainerImage(config, config.serverImage),
-      command: [config.region === 'us-east-1' ? `aws:/medplum/${name}/` : `aws:${config.region}:/medplum/${name}/`],
+      command: [region === 'us-east-1' ? `aws:/medplum/${name}/` : `aws:${region}:/medplum/${name}/`],
       logging: this.logDriver,
       environment: config.environment,
     });

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -261,12 +261,20 @@ export class BackEnd extends Construct {
           resources: [`arn:aws:ses:${region}:${accountNumber}:identity/*`],
         }),
 
-        // S3: Read and write access to buckets
+        // S3: List storage bucket
         // https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ['s3:ListBucket', 's3:GetObject', 's3:PutObject', 's3:DeleteObject'],
-          resources: ['arn:aws:s3:::*'],
+          actions: ['s3:ListBucket'],
+          resources: [`arn:aws:s3:::${config.storageBucketName}`],
+        }),
+
+        // S3: Read, write, and delete access to storage bucket
+        // https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+          resources: [`arn:aws:s3:::${config.storageBucketName}/*`],
         }),
 
         // IAM: Pass role to innvoke lambda functions


### PR DESCRIPTION
AWS changed the validation for IAM policy resource strings.  Our old strings used trailing `*` to represent multiple segments, which is no longer allowed.  Now the resource strings must always have the correct number of segments.

For testing, I deployed a completely new cluster: https://app.iamtest.medplum.dev/

Before merging, I would still like to update staging with these changes.