### PR TITLE
fix(search): Log message when missing search parameter in `MockClient`, add tests

### DIFF
--- a/examples/medplum-demo-bots/src/hl7-bot.test.ts
+++ b/examples/medplum-demo-bots/src/hl7-bot.test.ts
@@ -1,9 +1,9 @@
 import { Hl7Message, indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import { Bot, Bundle, Reference, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { expect, test } from 'vitest';
 import { handler } from './hl7-bot';
-import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 
 //To run these tests from the command line
 //npm t src/hl7-bot.test.ts

--- a/examples/medplum-demo-bots/src/stripe-bots/stripe-create-invoice.test.ts
+++ b/examples/medplum-demo-bots/src/stripe-bots/stripe-create-invoice.test.ts
@@ -1,3 +1,6 @@
+import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
+import { Bundle, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { expect, test } from 'vitest';
 import { handler } from './stripe-create-invoice';
@@ -6,6 +9,11 @@ const medplum = new MockClient();
 // npm t src/examples/stripe-bots/stripe-create-invoice.test.ts
 
 test('Create Invoice', async () => {
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+  for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+    indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+  }
   // This input is a Stripe Event object from https://stripe.com/docs/webhooks/stripe-events
   const input = {
     id: 'evt_1MqItaDlo6kh7lYQKFQhFJ2J',

--- a/examples/medplum-patient-intake-demo/src/bots/core/intake-utils.ts
+++ b/examples/medplum-patient-intake-demo/src/bots/core/intake-utils.ts
@@ -463,7 +463,7 @@ export async function addFamilyMemberHistory(
     },
     {
       patient: getReferenceString(patient),
-      condition: `${condition.system}|${condition.code}`,
+      code: `${condition.system}|${condition.code}`,
       relationship: `${relationship.system}|${relationship.code}`,
     }
   );

--- a/packages/app/src/resource/ProfilesPage.test.tsx
+++ b/packages/app/src/resource/ProfilesPage.test.tsx
@@ -16,7 +16,7 @@ describe('ProfilesPage', () => {
   beforeAll(async () => {
     const loadedProfileUrls: string[] = [];
     for (const profile of [fishPatientProfile, FishPatientResources.getFishSpeciesExtensionSD()]) {
-      const sd = await medplum.createResourceIfNoneExist<StructureDefinition>(profile, `url:${profile.url}`);
+      const sd = await medplum.createResourceIfNoneExist<StructureDefinition>(profile, `url=${profile.url}`);
       loadedProfileUrls.push(sd.url);
       loadDataType(sd);
     }

--- a/packages/core/src/access.test.ts
+++ b/packages/core/src/access.test.ts
@@ -143,7 +143,27 @@ describe('Access', () => {
         },
       ],
     };
-    expect(matchesAccessPolicy(ap, { resourceType: 'Patient', meta: { compartment: [{ reference: '1' }] } }, true));
-    expect(matchesAccessPolicy(ap, { resourceType: 'Patient', meta: { compartment: [{ reference: '2' }] } }, false));
+    expect(
+      matchesAccessPolicy(ap, { resourceType: 'Patient', meta: { compartment: [{ reference: '1' }] } }, true)
+    ).toEqual(true);
+    expect(
+      matchesAccessPolicy(ap, { resourceType: 'Patient', meta: { compartment: [{ reference: '2' }] } }, false)
+    ).toEqual(false);
+  });
+
+  test('Invalid SearchParameter in criteria in AccessPolicy', () => {
+    const ap: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Patient',
+          criteria: 'Patient?invalid=invalid',
+        },
+      ],
+    };
+
+    expect(() =>
+      matchesAccessPolicy(ap, { resourceType: 'Patient', name: [{ given: ['John'], family: 'Doe' }] }, false)
+    ).toThrow(/Unknown search parameter: invalid/);
   });
 });

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -12,7 +12,7 @@ const universalAccessPolicy: AccessPolicyResource = {
  * Protected resource types are in the "medplum" project.
  * Reading and writing is limited to the system account.
  */
-export const protectedResourceTypes = ['DomainConfiguration', 'JsonWebKey', 'Login'];
+export const protectedResourceTypes = ['DomainConfiguration', 'JsonWebKey', 'Login'] as const;
 
 /**
  * Project admin resource types are special resources that are only

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -12,7 +12,7 @@ const universalAccessPolicy: AccessPolicyResource = {
  * Protected resource types are in the "medplum" project.
  * Reading and writing is limited to the system account.
  */
-export const protectedResourceTypes = ['DomainConfiguration', 'JsonWebKey', 'Login'] as const;
+export const protectedResourceTypes = ['DomainConfiguration', 'JsonWebKey', 'Login'];
 
 /**
  * Project admin resource types are special resources that are only

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -44,7 +44,7 @@ export function validateResourceType(resourceType: string): void {
     throw new OperationOutcomeError(validationError('Resource type is null'));
   }
   if (!isResourceType(resourceType)) {
-    throw new OperationOutcomeError(validationError('Unknown resource type'));
+    throw new OperationOutcomeError(validationError(`Unknown resource type: ${resourceType}`));
   }
 }
 

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -60,12 +60,12 @@ describe('Search matching', () => {
   });
 
   test('Unknown filter', () => {
-    expect(
+    expect(() =>
       matchesSearchRequest(
         { resourceType: 'Patient' },
         { resourceType: 'Patient', filters: [{ code: 'unknown', operator: Operator.EQUALS, value: 'xyz' }] }
       )
-    ).toBe(false);
+    ).toThrow('Unknown search parameter: unknown');
   });
 
   test('Token filter', () => {

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -65,7 +65,7 @@ describe('Search matching', () => {
         { resourceType: 'Patient' },
         { resourceType: 'Patient', filters: [{ code: 'unknown', operator: Operator.EQUALS, value: 'xyz' }] }
       )
-    ).toThrow('Unknown search parameter: unknown');
+    ).toThrow('Unknown search parameter: unknown for resource type Patient');
   });
 
   test('Token filter', () => {

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -34,7 +34,7 @@ export function matchesSearchRequest(resource: Resource, searchRequest: SearchRe
 function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, filter: Filter): boolean {
   const searchParam = globalSchema.types[searchRequest.resourceType]?.searchParams?.[filter.code];
   if (!searchParam) {
-    throw new Error(`Unknown search parameter: ${filter.code}`);
+    throw new Error(`Unknown search parameter: ${filter.code} for resource type ${searchRequest.resourceType}`);
   }
   if (filter.operator === Operator.MISSING && searchParam) {
     const values = evalFhirPath(searchParam.expression as string, resource);

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -36,10 +36,6 @@ function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, f
   if (!searchParam) {
     throw new Error(`Unknown search parameter: ${filter.code} for resource type ${searchRequest.resourceType}`);
   }
-  if (filter.operator === Operator.MISSING && searchParam) {
-    const values = evalFhirPath(searchParam.expression as string, resource);
-    return filter.value === 'true' ? !values.length : values.length > 0;
-  }
   if (filter.operator === Operator.MISSING || filter.operator === Operator.PRESENT) {
     return matchesMissingOrPresent(resource, filter, searchParam);
   }

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -1,9 +1,9 @@
 import { Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { evalFhirPathTyped } from '../fhirpath/parse';
+import { isDateTimeString } from '../fhirpath/utils';
 import { OperationOutcomeError, badRequest } from '../outcomes';
 import { TypedValue, globalSchema, stringifyTypedValue } from '../types';
 import { append, sortStringArray } from '../utils';
-import { isDateTimeString } from '../fhirpath/utils';
 
 export const DEFAULT_SEARCH_COUNT = 20;
 export const DEFAULT_MAX_SEARCH_COUNT = 1000;

--- a/packages/core/src/subscriptions/index.ts
+++ b/packages/core/src/subscriptions/index.ts
@@ -553,7 +553,16 @@ export async function resourceMatchesSubscriptionCriteria({
     return false;
   }
 
-  return matchesSearchRequest(resource, searchRequest);
+  // TODO(ThatOneBro 24 Oct 2024): Consider removing try-catch if we prevent invalid subscription criteria from being written
+  try {
+    const result = matchesSearchRequest(resource, searchRequest);
+    return result;
+  } catch (err: unknown) {
+    console.error(
+      `[Subscription]: Got error "${normalizeErrorString(err)}" while evaluating resource for ${getReferenceString(subscription)}`
+    );
+    return false;
+  }
 }
 
 /**

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -8,7 +8,6 @@ import {
   notFound,
   parseSearchRequest,
   singularize,
-  validateResourceType,
 } from '@medplum/core';
 import {
   CapabilityStatementRestInteraction,
@@ -74,7 +73,6 @@ async function batch(req: FhirRequest, repo: FhirRepository, router: FhirRouter)
 // Search
 async function search(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
   const { resourceType } = req.params;
-  validateResourceType(resourceType);
   const bundle = await repo.search(parseSearchRequest(resourceType as ResourceType, req.query));
   return [allOk, bundle];
 }

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -8,6 +8,7 @@ import {
   notFound,
   parseSearchRequest,
   singularize,
+  validateResourceType,
 } from '@medplum/core';
 import {
   CapabilityStatementRestInteraction,
@@ -73,6 +74,7 @@ async function batch(req: FhirRequest, repo: FhirRepository, router: FhirRouter)
 // Search
 async function search(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
   const { resourceType } = req.params;
+  validateResourceType(resourceType);
   const bundle = await repo.search(parseSearchRequest(resourceType as ResourceType, req.query));
   return [allOk, bundle];
 }

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -455,6 +455,9 @@ export class MemoryRepository extends FhirRepository<undefined> {
 
   async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>> {
     const { resourceType } = searchRequest;
+    if (!this.resources.has(resourceType)) {
+      throw new Error(`Unknown resource type: ${resourceType}`);
+    }
     const resources = this.resources.get(resourceType) ?? new Map();
     const result = [];
     for (const resource of resources.values()) {

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -456,6 +456,12 @@ export class MemoryRepository extends FhirRepository<undefined> {
   async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>> {
     const { resourceType } = searchRequest;
     const resources = this.resources.get(resourceType) ?? new Map();
+    if (resources.size === 0) {
+      // If there are no resources for this resource type,
+      // We still want to validate the search request and throw on any potentially invalid search params
+      // Instead of silently failing and returning an empty search set as if it was a valid search
+      matchesSearchRequest({ resourceType } as T, searchRequest);
+    }
     const result = [];
     for (const resource of resources.values()) {
       if (matchesSearchRequest(resource, searchRequest)) {

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -455,9 +455,6 @@ export class MemoryRepository extends FhirRepository<undefined> {
 
   async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>> {
     const { resourceType } = searchRequest;
-    if (!this.resources.has(resourceType)) {
-      throw new Error(`Unknown resource type: ${resourceType}`);
-    }
     const resources = this.resources.get(resourceType) ?? new Map();
     const result = [];
     for (const resource of resources.values()) {

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -745,10 +745,34 @@ export class MockFetchClient {
 
     const result = await this.router.handleRequest(request, this.repo);
     if (result.length === 1) {
+      this.logSearchParameterError(request);
       return result[0];
     } else {
       return result[1];
     }
+  }
+
+  private async logSearchParameterError(request: FhirRequest) {
+    const {
+      method,
+      params: { resourceType },
+      query,
+    } = request;
+    const codes = Object.keys(query);
+    if (method !== 'GET' || codes.length === 0) {
+      return;
+    }
+    const searchParameters = await this.repo.searchResources<SearchParameter>({
+      resourceType: 'SearchParameter',
+    });
+    codes.forEach((code) => {
+      const isMatch = searchParameters.some((searchParameter) => searchParameter.code === code);
+      if (!isMatch) {
+        console.error(
+          `Unknown search parameter ${code} for resource type ${resourceType}. Please check whether it is defined in searchparameters.json.`
+        );
+      }
+    });
   }
 }
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -728,7 +728,7 @@ export class MockFetchClient {
         url
       )
     ) {
-      return { resourceType: 'Bundle', type: 'searchset', entry: [] };
+      return { resourceType: 'Bundle', type: 'searchset', total: 0, entry: [] };
     }
 
     if (url.includes('fhir/R4')) {

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -759,7 +759,7 @@ export class MockFetchClient {
       const issueDetails = outcome.issue[0]?.details;
       const issueText = issueDetails?.text;
       if (!issueText) {
-        return result[0];
+        return outcome;
       }
       // Special case for unknown search parameters and resource types
       // We know it's common to forgot to index all search parameters and structure definitions in MockClient
@@ -777,10 +777,10 @@ export class MockFetchClient {
         console.error(errMsg);
         issueDetails.text = errMsg;
       }
-      return result[0];
+      return outcome;
     }
 
-    return result[1];
+    return resource;
   }
 }
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -745,15 +745,15 @@ export class MockFetchClient {
 
     const result = await this.router.handleRequest(request, this.repo);
     if (result.length === 1) {
-      this.logStructureDefinitionError(request.params.resourceType);
-      this.logSearchParameterError(request);
+      await this.logStructureDefinitionError(request.params.resourceType);
+      await this.logSearchParameterError(request);
       return result[0];
     } else {
       return result[1];
     }
   }
 
-  private async logStructureDefinitionError(resourceType: string) {
+  private async logStructureDefinitionError(resourceType: string): Promise<void> {
     const structureDefinitions = await this.repo.searchResources<StructureDefinition>({
       resourceType: 'StructureDefinition',
     });
@@ -765,7 +765,7 @@ export class MockFetchClient {
     }
   }
 
-  private async logSearchParameterError(request: FhirRequest) {
+  private async logSearchParameterError(request: FhirRequest): Promise<void> {
     const {
       method,
       params: { resourceType },

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -720,10 +720,6 @@ export class MockFetchClient {
       return exampleValueSet;
     }
 
-    if (url.startsWith('fhir/R4/Task')) {
-      console.log({ url });
-    }
-
     // Special case for ServiceRequestTimeline and DefaultResourceTimeline Task query
     // Since we don't support _filter yet
     // TODO(ThatOneBro 24 Oct 2024): Remove this once we support _filter in the in-memory search implementation

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -745,10 +745,23 @@ export class MockFetchClient {
 
     const result = await this.router.handleRequest(request, this.repo);
     if (result.length === 1) {
+      this.logStructureDefinitionError(request.params.resourceType);
       this.logSearchParameterError(request);
       return result[0];
     } else {
       return result[1];
+    }
+  }
+
+  private async logStructureDefinitionError(resourceType: string) {
+    const structureDefinitions = await this.repo.searchResources<StructureDefinition>({
+      resourceType: 'StructureDefinition',
+    });
+    const isMatch = structureDefinitions.some((sd) => sd.id === resourceType);
+    if (!isMatch) {
+      console.error(
+        `Unknown resource type: ${resourceType}. Please check whether it is defined in structuredefinitions.json.`
+      );
     }
   }
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -89,6 +89,13 @@ export interface MockClientOptions
   extends Pick<MedplumClientOptions, 'baseUrl' | 'clientId' | 'storage' | 'cacheTime' | 'fetch'> {
   readonly debug?: boolean;
   /**
+   * Determines whether this MockClient should operate in strict mode.
+   * In strict mode, unknown resource types and search parameters will cause searches to throw.
+   *
+   * Defaults to `true`.
+   */
+  readonly strictMode?: boolean;
+  /**
    * Override currently logged in user. Specifying null results in
    * MedplumContext.profile returning undefined as if no one were logged in.
    */
@@ -140,7 +147,7 @@ export class MockClient extends MedplumClient {
       client = clientOptions.mockFetchOverride.client;
     } else {
       router = new FhirRouter();
-      repo = new MemoryRepository();
+      repo = new MemoryRepository({ strictMode: clientOptions?.strictMode });
       client = new MockFetchClient(router, repo, baseUrl, clientOptions?.debug);
     }
 

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -779,10 +779,12 @@ export class MockFetchClient {
       resourceType: 'SearchParameter',
     });
     codes.forEach((code) => {
-      const isMatch = searchParameters.some((searchParameter) => searchParameter.code === code);
+      const isMatch = searchParameters.some(
+        (searchParameter) => searchParameter.code === code && searchParameter.base.some((r) => r === resourceType)
+      );
       if (!isMatch) {
         console.error(
-          `Unknown search parameter ${code} for resource type ${resourceType}. Please check whether it is defined in searchparameters.json.`
+          `Unknown search parameter '${code}' for resource type '${resourceType}'. Please check whether it is defined in searchparameters.json.`
         );
       }
     });

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -754,9 +754,9 @@ export class MockFetchClient {
       headers: toIncomingHttpHeaders(options.headers),
     };
 
-    const result = await this.router.handleRequest(request, this.repo);
-    if (result.length === 1) {
-      const issueDetails = result[0].issue[0]?.details;
+    const [outcome, resource] = await this.router.handleRequest(request, this.repo);
+    if (!resource) {
+      const issueDetails = outcome.issue[0]?.details;
       const issueText = issueDetails?.text;
       if (!issueText) {
         return result[0];

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.test.tsx
@@ -402,8 +402,8 @@ describe('MedplumProvider', () => {
       expect(screen.getByText('Loading...')).toBeInTheDocument();
       expect(medplum.isLoading()).toEqual(true);
 
-      await expect(screen.findByText('Parent count: 2')).resolves.toBeInTheDocument();
-      expect(screen.getByText('Child count: 1')).toBeInTheDocument();
+      await expect(screen.findByText('Child count: 1')).resolves.toBeInTheDocument();
+      expect(screen.getByText('Parent count: 2')).toBeInTheDocument();
       expect(medplum.isLoading()).toEqual(false);
       expect(mockFetchSpy).toHaveBeenCalledWith(`${baseUrl}auth/me`, expect.objectContaining({ method: 'GET' }));
       expect(dispatchEventSpy).toHaveBeenCalledWith({ type: 'profileRefreshed' });
@@ -432,8 +432,8 @@ describe('MedplumProvider', () => {
       expect(dispatchEventSpy).toHaveBeenCalledWith({ type: 'profileRefreshing' });
       expect(dispatchEventSpy).toHaveBeenCalledWith({ type: 'profileRefreshed' });
       expect(medplum.isLoading()).toEqual(false);
-      expect(screen.getByText('Parent count: 4')).toBeInTheDocument();
       expect(screen.getByText('Child count: 3')).toBeInTheDocument();
+      expect(screen.getByText('Parent count: 4')).toBeInTheDocument();
 
       expect(mockFetchSpy).toHaveBeenLastCalledWith(`${baseUrl}auth/me`, expect.objectContaining({ method: 'GET' }));
     });

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -21,7 +21,7 @@ export const parameters = {
 // so that resources created in MockFetchClient#initMockRepo have
 // consistent timestamps between storybook runs
 const clock = createGlobalTimer();
-const medplum = new MockClient();
+const medplum = new MockClient({ strictMode: false });
 medplum.get('/').then(() => {
   clock.restore();
 });

--- a/packages/react/src/PatientSummary/PatientSummary.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.tsx
@@ -14,6 +14,7 @@ import {
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { IconGenderFemale, IconGenderMale, IconStethoscope, IconUserSquare } from '@tabler/icons-react';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { Allergies } from './Allergies';
 import { Medications } from './Medications';
@@ -21,7 +22,6 @@ import { ProblemList } from './ProblemList';
 import { SexualOrientation } from './SexualOrientation';
 import { SmokingStatus } from './SmokingStatus';
 import { Vitals } from './Vitals';
-import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface PatientSummaryProps extends Omit<CardProps, 'children'> {
   readonly patient: Patient | Reference<Patient>;

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -103,8 +103,8 @@ describe('FHIR Repo', () => {
     }
   });
 
-  test('Read invalid resource with `checkCacheOnly` set', async () => {
-    await expect(systemRepo.readResource('Subscription', randomUUID(), { checkCacheOnly: true })).rejects.toThrow(
+  test('Read invalid resource with `allowReadFrom` only including `cache`', async () => {
+    await expect(systemRepo.readResource('Subscription', randomUUID(), { allowReadFrom: ['cache'] })).rejects.toThrow(
       new OperationOutcomeError(notFound)
     );
   });

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -103,8 +103,8 @@ describe('FHIR Repo', () => {
     }
   });
 
-  test('Read invalid resource with `allowReadFrom` only including `cache`', async () => {
-    await expect(systemRepo.readResource('Subscription', randomUUID(), { allowReadFrom: ['cache'] })).rejects.toThrow(
+  test('Read invalid resource with `checkCacheOnly` option', async () => {
+    await expect(systemRepo.readResource('Subscription', randomUUID(), { checkCacheOnly: true })).rejects.toThrow(
       new OperationOutcomeError(notFound)
     );
   });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -332,6 +332,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       }
     }
 
+    // Must be able to read from the database beyond this point, else throw a "not found" error
     if (!allowReadFrom.includes('database')) {
       throw new OperationOutcomeError(notFound);
     }
@@ -1180,7 +1181,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
     for (const policy of accessPolicy.resource) {
       if (policy.resourceType === resourceType) {
-        console.log({ policy });
         const policyCompartmentId = resolveId(policy.compartment);
         if (policyCompartmentId) {
           // Deprecated - to be removed
@@ -1197,7 +1197,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
           }
           // Add subquery for access policy criteria.
           const searchRequest = parseSearchRequest(policy.criteria);
-          console.log({ searchRequest });
           const accessPolicyExpression = buildSearchExpression(
             this,
             builder,

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -9,7 +9,6 @@ import {
   FhirFilterNegation,
   Filter,
   flatMapFilter,
-  forbidden,
   formatSearchQuery,
   getDataType,
   getReferenceString,
@@ -32,8 +31,8 @@ import {
   subsetResource,
   toPeriod,
   toTypedValue,
-  validateResourceType,
 } from '@medplum/core';
+import { validateSearchResourceTypes } from '@medplum/fhir-router';
 import {
   Bundle,
   BundleEntry,
@@ -200,38 +199,6 @@ function applyCountAndOffsetLimits<T extends Resource>(
         badRequest(`Search offset exceeds maximum (got ${searchRequest.offset}, max ${maxOffset})`)
       );
     }
-  }
-}
-
-/**
- * Validates that the resource type(s) are valid and that the user has permission to read them.
- * @param repo - The user's repository.
- * @param searchRequest - The incoming search request.
- */
-function validateSearchResourceTypes(repo: Repository, searchRequest: SearchRequest): void {
-  if (searchRequest.types) {
-    for (const resourceType of searchRequest.types) {
-      validateSearchResourceType(repo, resourceType);
-    }
-  } else {
-    validateSearchResourceType(repo, searchRequest.resourceType);
-  }
-}
-
-/**
- * Validates that the resource type is valid and that the user has permission to read it.
- * @param repo - The user's repository.
- * @param resourceType - The resource type to validate.
- */
-function validateSearchResourceType(repo: Repository, resourceType: ResourceType): void {
-  validateResourceType(resourceType);
-
-  if (resourceType === 'Binary') {
-    throw new OperationOutcomeError(badRequest('Cannot search on Binary resource type'));
-  }
-
-  if (!repo.canReadResourceType(resourceType)) {
-    throw new OperationOutcomeError(forbidden);
   }
 }
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -46,6 +46,11 @@ const MAX_JOB_ATTEMPTS = 18;
  */
 const DEFAULT_RETRIES = 3;
 
+/**
+ * The options to use for calls to `repo.readResource` for WebSocket subscriptions.
+ */
+const WS_SUB_READ_RESOURCE_OPTS = { checkCacheOnly: true } as const;
+
 /*
  * The subscription worker inspects every resource change,
  * and executes FHIR Subscription resources for those changes.
@@ -425,9 +430,11 @@ async function tryGetSubscription(
   channelType: SubscriptionJobData['channelType'] | undefined
 ): Promise<Subscription | undefined> {
   try {
-    return await systemRepo.readResource<Subscription>('Subscription', subscriptionId, {
-      allowReadFrom: channelType === 'websocket' ? ['cache'] : ['cache', 'database'],
-    });
+    return await systemRepo.readResource<Subscription>(
+      'Subscription',
+      subscriptionId,
+      channelType === 'websocket' ? WS_SUB_READ_RESOURCE_OPTS : undefined
+    );
   } catch (err) {
     const outcome = normalizeOperationOutcome(err);
     // If the Subscription was marked as deleted in the database, this will return "gone"

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -426,7 +426,7 @@ async function tryGetSubscription(
 ): Promise<Subscription | undefined> {
   try {
     return await systemRepo.readResource<Subscription>('Subscription', subscriptionId, {
-      checkCacheOnly: channelType === 'websocket',
+      allowReadFrom: channelType === 'websocket' ? ['cache'] : ['cache', 'database'],
     });
   } catch (err) {
     const outcome = normalizeOperationOutcome(err);


### PR DESCRIPTION
Working off of #4391

We need to ensure that no weird behavior comes from throwing from `matchesSearchRequest`
Adding some tests for that

In another PR:
- [ ] Link docs from error about how to index SearchParameters in `MockClient`