### PR TITLE
Fixes #4531 - choice-of-type definitions and getExtensionValue()

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -4,6 +4,7 @@ import {
   Coding,
   Device,
   Extension,
+  ExtensionValue,
   Identifier,
   ObservationDefinition,
   ObservationDefinitionQualifiedInterval,
@@ -421,7 +422,7 @@ export function setIdentifier(resource: Resource & { identifier?: Identifier[] }
  * @param urls - Array of extension URLs.  Each entry represents a nested extension.
  * @returns The extension value if found; undefined otherwise.
  */
-export function getExtensionValue(resource: any, ...urls: string[]): string | undefined {
+export function getExtensionValue(resource: any, ...urls: string[]): ExtensionValue | undefined {
   const extension = getExtension(resource, ...urls);
   if (!extension) {
     return undefined;

--- a/packages/fhirtypes/dist/ActivityDefinition.d.ts
+++ b/packages/fhirtypes/dist/ActivityDefinition.d.ts
@@ -467,6 +467,24 @@ export interface ActivityDefinition {
 }
 
 /**
+ * A code or group definition that describes the intended subject of the
+ * activity being defined.
+ */
+export type ActivityDefinitionSubject = CodeableConcept | Reference<Group>;
+
+/**
+ * The period, timing or frequency upon which the described activity is
+ * to occur.
+ */
+export type ActivityDefinitionTiming = Age | Duration | Period | Range | string | Timing;
+
+/**
+ * Identifies the food, drug or other product being consumed or supplied
+ * in the activity.
+ */
+export type ActivityDefinitionProduct = CodeableConcept | Reference<Medication | Substance>;
+
+/**
  * Dynamic values that will be evaluated to produce values for elements
  * of the resulting resource. For example, if the dosage of a medication
  * must be computed based on the patient's weight, a dynamic value would

--- a/packages/fhirtypes/dist/Agent.d.ts
+++ b/packages/fhirtypes/dist/Agent.d.ts
@@ -156,6 +156,11 @@ export interface AgentChannel {
 }
 
 /**
+ * The target resource where channel messages will be delivered.
+ */
+export type AgentChannelTarget = Reference<Bot> | string;
+
+/**
  * The settings for the agent.
  */
 export interface AgentSetting {
@@ -185,3 +190,8 @@ export interface AgentSetting {
    */
   valueInteger?: number;
 }
+
+/**
+ * The setting value.
+ */
+export type AgentSettingValue = boolean | number | string;

--- a/packages/fhirtypes/dist/AllergyIntolerance.d.ts
+++ b/packages/fhirtypes/dist/AllergyIntolerance.d.ts
@@ -237,6 +237,12 @@ export interface AllergyIntolerance {
 }
 
 /**
+ * Estimated or actual date,  date-time, or age when allergy or
+ * intolerance was identified.
+ */
+export type AllergyIntoleranceOnset = Age | Period | Range | string;
+
+/**
  * Details about each adverse reaction event linked to exposure to the
  * identified substance.
  */

--- a/packages/fhirtypes/dist/Annotation.d.ts
+++ b/packages/fhirtypes/dist/Annotation.d.ts
@@ -52,3 +52,8 @@ export interface Annotation {
    */
   text: string;
 }
+
+/**
+ * The individual responsible for making the annotation.
+ */
+export type AnnotationAuthor = Reference<Practitioner | Patient | RelatedPerson | Organization> | string;

--- a/packages/fhirtypes/dist/AuditEvent.d.ts
+++ b/packages/fhirtypes/dist/AuditEvent.d.ts
@@ -476,6 +476,11 @@ export interface AuditEventEntityDetail {
 }
 
 /**
+ * The  value of the extra detail.
+ */
+export type AuditEventEntityDetailValue = string;
+
+/**
  * The system that is reporting the event.
  */
 export interface AuditEventSource {

--- a/packages/fhirtypes/dist/BiologicallyDerivedProduct.d.ts
+++ b/packages/fhirtypes/dist/BiologicallyDerivedProduct.d.ts
@@ -229,6 +229,11 @@ export interface BiologicallyDerivedProductCollection {
 }
 
 /**
+ * Time of product collection.
+ */
+export type BiologicallyDerivedProductCollectionCollected = Period | string;
+
+/**
  * Any manipulation of product post-collection that is intended to alter
  * the product.  For example a buffy-coat enrichment or CD8 reduction of
  * Peripheral Blood Stem Cells to make it more suitable for infusion.
@@ -285,6 +290,11 @@ export interface BiologicallyDerivedProductManipulation {
    */
   timePeriod?: Period;
 }
+
+/**
+ * Time of manipulation.
+ */
+export type BiologicallyDerivedProductManipulationTime = Period | string;
 
 /**
  * Any processing of the product during collection that does not change
@@ -353,6 +363,11 @@ export interface BiologicallyDerivedProductProcessing {
    */
   timePeriod?: Period;
 }
+
+/**
+ * Time of processing.
+ */
+export type BiologicallyDerivedProductProcessingTime = Period | string;
 
 /**
  * Product storage.

--- a/packages/fhirtypes/dist/Bot.d.ts
+++ b/packages/fhirtypes/dist/Bot.d.ts
@@ -170,3 +170,8 @@ export interface Bot {
    */
   code?: string;
 }
+
+/**
+ * A schedule for the bot to be executed.
+ */
+export type BotCron = string | Timing;

--- a/packages/fhirtypes/dist/CarePlan.d.ts
+++ b/packages/fhirtypes/dist/CarePlan.d.ts
@@ -516,3 +516,15 @@ export interface CarePlanActivityDetail {
    */
   description?: string;
 }
+
+/**
+ * The period, timing or frequency upon which the described activity is
+ * to occur.
+ */
+export type CarePlanActivityDetailScheduled = Period | string | Timing;
+
+/**
+ * Identifies the food, drug or other product to be consumed or supplied
+ * in the activity.
+ */
+export type CarePlanActivityDetailProduct = CodeableConcept | Reference<Medication | Substance>;

--- a/packages/fhirtypes/dist/ChargeItem.d.ts
+++ b/packages/fhirtypes/dist/ChargeItem.d.ts
@@ -284,6 +284,17 @@ export interface ChargeItem {
 }
 
 /**
+ * Date/time(s) or duration when the charged service was applied.
+ */
+export type ChargeItemOccurrence = Period | string | Timing;
+
+/**
+ * Identifies the device, food, drug or other product being charged
+ * either by type code or reference to an instance.
+ */
+export type ChargeItemProduct = CodeableConcept | Reference<Device | Medication | Substance>;
+
+/**
  * Indicates who or what performed or participated in the charged
  * service.
  */

--- a/packages/fhirtypes/dist/Claim.d.ts
+++ b/packages/fhirtypes/dist/Claim.d.ts
@@ -340,6 +340,11 @@ export interface ClaimAccident {
 }
 
 /**
+ * The physical location of the accident event.
+ */
+export type ClaimAccidentLocation = Address | Reference<Location>;
+
+/**
  * The members of the team who provided the products and services.
  */
 export interface ClaimCareTeam {
@@ -483,6 +488,12 @@ export interface ClaimDiagnosis {
    */
   packageCode?: CodeableConcept;
 }
+
+/**
+ * The nature of illness or problem in a coded form or as a reference to
+ * an external defined Condition.
+ */
+export type ClaimDiagnosisDiagnosis = CodeableConcept | Reference<Condition>;
 
 /**
  * Financial instruments for reimbursement for the health care products
@@ -749,6 +760,17 @@ export interface ClaimItem {
    */
   detail?: ClaimItemDetail[];
 }
+
+/**
+ * The date or dates when the service or product was supplied, performed
+ * or completed.
+ */
+export type ClaimItemServiced = Period | string;
+
+/**
+ * Where the product or service was provided.
+ */
+export type ClaimItemLocation = Address | CodeableConcept | Reference<Location>;
 
 /**
  * A claim detail line. Either a simple (a product or service) or a
@@ -1100,6 +1122,12 @@ export interface ClaimProcedure {
 }
 
 /**
+ * The code or reference to a Procedure resource which identifies the
+ * clinical intervention performed.
+ */
+export type ClaimProcedureProcedure = CodeableConcept | Reference<Procedure>;
+
+/**
  * Other claims which are related to this claim such as prior submissions
  * or claims for related services or for the same event.
  */
@@ -1267,3 +1295,15 @@ export interface ClaimSupportingInfo {
    */
   reason?: CodeableConcept;
 }
+
+/**
+ * The date when or period to which this information refers.
+ */
+export type ClaimSupportingInfoTiming = Period | string;
+
+/**
+ * Additional data or information such as resources, documents, images
+ * etc. including references to the data or the actual inclusion of the
+ * data.
+ */
+export type ClaimSupportingInfoValue = Attachment | boolean | Quantity | Reference<Resource> | string;

--- a/packages/fhirtypes/dist/ClaimResponse.d.ts
+++ b/packages/fhirtypes/dist/ClaimResponse.d.ts
@@ -427,6 +427,17 @@ export interface ClaimResponseAddItem {
 }
 
 /**
+ * The date or dates when the service or product was supplied, performed
+ * or completed.
+ */
+export type ClaimResponseAddItemServiced = Period | string;
+
+/**
+ * Where the product or service was provided.
+ */
+export type ClaimResponseAddItemLocation = Address | CodeableConcept | Reference<Location>;
+
+/**
  * The second-tier service adjudications for payor added services.
  */
 export interface ClaimResponseAddItemDetail {

--- a/packages/fhirtypes/dist/ClinicalImpression.d.ts
+++ b/packages/fhirtypes/dist/ClinicalImpression.d.ts
@@ -238,6 +238,11 @@ export interface ClinicalImpression {
 }
 
 /**
+ * The point in time or period over which the subject was assessed.
+ */
+export type ClinicalImpressionEffective = Period | string;
+
+/**
  * Specific findings or diagnoses that were considered likely or relevant
  * to ongoing treatment.
  */

--- a/packages/fhirtypes/dist/CodeSystem.d.ts
+++ b/packages/fhirtypes/dist/CodeSystem.d.ts
@@ -495,6 +495,11 @@ export interface CodeSystemConceptProperty {
 }
 
 /**
+ * The value of this property.
+ */
+export type CodeSystemConceptPropertyValue = boolean | Coding | number | string;
+
+/**
  * A filter that can be used in a value set compose statement when
  * selecting concepts using a filter.
  */

--- a/packages/fhirtypes/dist/Communication.d.ts
+++ b/packages/fhirtypes/dist/Communication.d.ts
@@ -307,3 +307,9 @@ export interface CommunicationPayload {
    */
   contentReference?: Reference<Resource>;
 }
+
+/**
+ * A communicated content (or for multi-part communications, one portion
+ * of the communication).
+ */
+export type CommunicationPayloadContent = Attachment | Reference<Resource> | string;

--- a/packages/fhirtypes/dist/CommunicationRequest.d.ts
+++ b/packages/fhirtypes/dist/CommunicationRequest.d.ts
@@ -246,6 +246,11 @@ export interface CommunicationRequest {
 }
 
 /**
+ * The time when this communication is to occur.
+ */
+export type CommunicationRequestOccurrence = Period | string;
+
+/**
  * Text, attachment(s), or resource(s) to be communicated to the
  * recipient.
  */
@@ -304,3 +309,9 @@ export interface CommunicationRequestPayload {
    */
   contentReference?: Reference<Resource>;
 }
+
+/**
+ * The communicated content (or for multi-part communications, one
+ * portion of the communication).
+ */
+export type CommunicationRequestPayloadContent = Attachment | Reference<Resource> | string;

--- a/packages/fhirtypes/dist/Composition.d.ts
+++ b/packages/fhirtypes/dist/Composition.d.ts
@@ -382,6 +382,11 @@ export interface CompositionRelatesTo {
 }
 
 /**
+ * The target composition/document of this relationship.
+ */
+export type CompositionRelatesToTarget = Identifier | Reference<Composition>;
+
+/**
  * The root of the sections that make up the composition.
  */
 export interface CompositionSection {

--- a/packages/fhirtypes/dist/ConceptMap.d.ts
+++ b/packages/fhirtypes/dist/ConceptMap.d.ts
@@ -238,6 +238,20 @@ export interface ConceptMap {
 }
 
 /**
+ * Identifier for the source value set that contains the concepts that
+ * are being mapped and provides context for the mappings.
+ */
+export type ConceptMapSource = string;
+
+/**
+ * The target value set provides context for the mappings. Note that the
+ * mapping is made between concepts, not between value sets, but the
+ * value set provides important context about how the concept mapping
+ * choices are made.
+ */
+export type ConceptMapTarget = string;
+
+/**
  * A group of mappings that all have the same source and target system.
  */
 export interface ConceptMapGroup {

--- a/packages/fhirtypes/dist/Condition.d.ts
+++ b/packages/fhirtypes/dist/Condition.d.ts
@@ -266,6 +266,20 @@ export interface Condition {
 }
 
 /**
+ * Estimated or actual date or date-time  the condition began, in the
+ * opinion of the clinician.
+ */
+export type ConditionOnset = Age | Period | Range | string;
+
+/**
+ * The date or estimated date that the condition resolved or went into
+ * remission. This is called &quot;abatement&quot; because of the many overloaded
+ * connotations associated with &quot;remission&quot; or &quot;resolution&quot; - Conditions
+ * are never really resolved, but they can abate.
+ */
+export type ConditionAbatement = Age | Period | Range | string;
+
+/**
  * Supporting evidence / manifestations that are the basis of the
  * Condition's verification status, such as evidence that confirmed or
  * refuted the condition.

--- a/packages/fhirtypes/dist/Consent.d.ts
+++ b/packages/fhirtypes/dist/Consent.d.ts
@@ -199,6 +199,14 @@ export interface Consent {
 }
 
 /**
+ * The source on which this consent statement is based. The source might
+ * be a scanned original paper form, or a reference to a consent that
+ * links back to such a source, a reference to a document repository
+ * (e.g. XDS) that stores the original consent document.
+ */
+export type ConsentSource = Attachment | Reference<Consent | DocumentReference | Contract | QuestionnaireResponse>;
+
+/**
  * The references to the policies that are included in this consent
  * scope. Policies may be organizational, but are often defined
  * jurisdictionally, or in law.

--- a/packages/fhirtypes/dist/Contract.d.ts
+++ b/packages/fhirtypes/dist/Contract.d.ts
@@ -362,6 +362,20 @@ export interface Contract {
 }
 
 /**
+ * Narrows the range of legal concerns to focus on the achievement of
+ * specific contractual objectives.
+ */
+export type ContractTopic = CodeableConcept | Reference<Resource>;
+
+/**
+ * Legally binding Contract: This is the signed and legally recognized
+ * representation of the Contract, which is considered the &quot;source of
+ * truth&quot; and which would be the basis for legal action related to
+ * enforcement of this Contract.
+ */
+export type ContractLegallyBinding = Attachment | Reference<Composition | DocumentReference | QuestionnaireResponse | Contract>;
+
+/**
  * Precusory content developed with a focus and intent of supporting the
  * formation a Contract instance, which may be associated with and
  * transformable into a Contract.
@@ -507,6 +521,13 @@ export interface ContractFriendly {
 }
 
 /**
+ * Human readable rendering of this Contract in a format and
+ * representation intended to enhance comprehension and ensure
+ * understandability.
+ */
+export type ContractFriendlyContent = Attachment | Reference<Composition | DocumentReference | QuestionnaireResponse>;
+
+/**
  * List of Legal expressions or representations of this Contract.
  */
 export interface ContractLegal {
@@ -556,6 +577,11 @@ export interface ContractLegal {
    */
   contentReference?: Reference<Composition | DocumentReference | QuestionnaireResponse>;
 }
+
+/**
+ * Contract legal text in human renderable form.
+ */
+export type ContractLegalContent = Attachment | Reference<Composition | DocumentReference | QuestionnaireResponse>;
 
 /**
  * List of Computable Policy Rule Language Representations of this
@@ -610,6 +636,12 @@ export interface ContractRule {
    */
   contentReference?: Reference<DocumentReference>;
 }
+
+/**
+ * Computable Contract conveyed using a policy rule language (e.g. XACML,
+ * DKAL, SecPal).
+ */
+export type ContractRuleContent = Attachment | Reference<DocumentReference>;
 
 /**
  * Parties with legal standing in the Contract, including the principal
@@ -784,6 +816,11 @@ export interface ContractTerm {
    */
   group?: ContractTerm[];
 }
+
+/**
+ * The entity that the term applies to.
+ */
+export type ContractTermTopic = CodeableConcept | Reference<Resource>;
 
 /**
  * An actor taking a role in an activity for which it can be assigned
@@ -961,6 +998,11 @@ export interface ContractTermAction {
    */
   securityLabelNumber?: number[];
 }
+
+/**
+ * When action happens.
+ */
+export type ContractTermActionOccurrence = Period | string | Timing;
 
 /**
  * Entity of the action.
@@ -1326,6 +1368,11 @@ export interface ContractTermAssetValuedItem {
 }
 
 /**
+ * Specific type of Contract Valued Item that may be priced.
+ */
+export type ContractTermAssetValuedItemEntity = CodeableConcept | Reference<Resource>;
+
+/**
  * The matter of concern in the context of this provision of the
  * agrement.
  */
@@ -1559,6 +1606,14 @@ export interface ContractTermOfferAnswer {
    */
   valueReference?: Reference<Resource>;
 }
+
+/**
+ * Response to an offer clause or question text,  which enables selection
+ * of values to be agreed to, e.g., the period of participation, the date
+ * of occupancy of a rental, warrently duration, or whether biospecimen
+ * may be used for further research.
+ */
+export type ContractTermOfferAnswerValue = Attachment | boolean | Coding | number | Quantity | Reference<Resource> | string;
 
 /**
  * Offer Recipient.

--- a/packages/fhirtypes/dist/Coverage.d.ts
+++ b/packages/fhirtypes/dist/Coverage.d.ts
@@ -328,6 +328,11 @@ export interface CoverageCostToBeneficiary {
 }
 
 /**
+ * The amount due from the patient for the cost category.
+ */
+export type CoverageCostToBeneficiaryValue = Money | Quantity;
+
+/**
  * A suite of codes indicating exceptions or reductions to patient costs
  * and their effective periods.
  */

--- a/packages/fhirtypes/dist/CoverageEligibilityRequest.d.ts
+++ b/packages/fhirtypes/dist/CoverageEligibilityRequest.d.ts
@@ -195,6 +195,12 @@ export interface CoverageEligibilityRequest {
 }
 
 /**
+ * The date or dates when the enclosed suite of services were performed
+ * or completed.
+ */
+export type CoverageEligibilityRequestServiced = Period | string;
+
+/**
  * Financial instruments for reimbursement for the health care products
  * and services.
  */
@@ -406,6 +412,12 @@ export interface CoverageEligibilityRequestItemDiagnosis {
    */
   diagnosisReference?: Reference<Condition>;
 }
+
+/**
+ * The nature of illness or problem in a coded form or as a reference to
+ * an external defined Condition.
+ */
+export type CoverageEligibilityRequestItemDiagnosisDiagnosis = CodeableConcept | Reference<Condition>;
 
 /**
  * Additional information codes regarding exceptions, special

--- a/packages/fhirtypes/dist/CoverageEligibilityResponse.d.ts
+++ b/packages/fhirtypes/dist/CoverageEligibilityResponse.d.ts
@@ -193,6 +193,12 @@ export interface CoverageEligibilityResponse {
 }
 
 /**
+ * The date or dates when the enclosed suite of services were performed
+ * or completed.
+ */
+export type CoverageEligibilityResponseServiced = Period | string;
+
+/**
  * Errors encountered during the processing of the request.
  */
 export interface CoverageEligibilityResponseError {
@@ -505,3 +511,13 @@ export interface CoverageEligibilityResponseInsuranceItemBenefit {
    */
   usedMoney?: Money;
 }
+
+/**
+ * The quantity of the benefit which is permitted under the coverage.
+ */
+export type CoverageEligibilityResponseInsuranceItemBenefitAllowed = Money | number | string;
+
+/**
+ * The quantity of the benefit which have been consumed to date.
+ */
+export type CoverageEligibilityResponseInsuranceItemBenefitUsed = Money | number | string;

--- a/packages/fhirtypes/dist/DataRequirement.d.ts
+++ b/packages/fhirtypes/dist/DataRequirement.d.ts
@@ -102,6 +102,12 @@ export interface DataRequirement {
 }
 
 /**
+ * The intended subjects of the data requirement. If this element is not
+ * provided, a Patient subject is assumed.
+ */
+export type DataRequirementSubject = CodeableConcept | Reference<Group>;
+
+/**
  * Code filters specify additional constraints on the data, specifying
  * the value set of interest for a particular element of the data. Each
  * code filter defines an additional constraint on the data, i.e. code
@@ -237,6 +243,16 @@ export interface DataRequirementDateFilter {
    */
   valueDuration?: Duration;
 }
+
+/**
+ * The value of the filter. If period is specified, the filter will
+ * return only those data items that fall within the bounds determined by
+ * the Period, inclusive of the period boundaries. If dateTime is
+ * specified, the filter will return only those data items that are equal
+ * to the specified dateTime. If a Duration is specified, the filter will
+ * return only those data items that fall within Duration before now.
+ */
+export type DataRequirementDateFilterValue = Duration | Period | string;
 
 /**
  * Specifies the order of the results to be returned.

--- a/packages/fhirtypes/dist/DetectedIssue.d.ts
+++ b/packages/fhirtypes/dist/DetectedIssue.d.ts
@@ -178,6 +178,11 @@ export interface DetectedIssue {
 }
 
 /**
+ * The date or period when the detected issue was initially identified.
+ */
+export type DetectedIssueIdentified = Period | string;
+
+/**
  * Supporting evidence or manifestations that provide the basis for
  * identifying the detected issue such as a GuidanceResponse or
  * MeasureReport.

--- a/packages/fhirtypes/dist/DeviceDefinition.d.ts
+++ b/packages/fhirtypes/dist/DeviceDefinition.d.ts
@@ -242,6 +242,11 @@ export interface DeviceDefinition {
 }
 
 /**
+ * A name of the manufacturer.
+ */
+export type DeviceDefinitionManufacturer = Reference<Organization> | string;
+
+/**
  * Device capabilities.
  */
 export interface DeviceDefinitionCapability {

--- a/packages/fhirtypes/dist/DeviceRequest.d.ts
+++ b/packages/fhirtypes/dist/DeviceRequest.d.ts
@@ -280,6 +280,19 @@ export interface DeviceRequest {
 }
 
 /**
+ * The details of the device to be used.
+ */
+export type DeviceRequestCode = CodeableConcept | Reference<Device>;
+
+/**
+ * The timing schedule for the use of the device. The Schedule data type
+ * allows many different expressions, for example. &quot;Every 8 hours&quot;;
+ * &quot;Three times a day&quot;; &quot;1/2 an hour before breakfast for 10 days from
+ * 23-Dec 2011:&quot;; &quot;15 Oct 2013, 17 Oct 2013 and 1 Nov 2013&quot;.
+ */
+export type DeviceRequestOccurrence = Period | string | Timing;
+
+/**
  * Specific parameters for the ordered item.  For example, the prism
  * value for lenses.
  */
@@ -345,3 +358,8 @@ export interface DeviceRequestParameter {
    */
   valueBoolean?: boolean;
 }
+
+/**
+ * The value of the device detail.
+ */
+export type DeviceRequestParameterValue = boolean | CodeableConcept | Quantity | Range;

--- a/packages/fhirtypes/dist/DeviceUseStatement.d.ts
+++ b/packages/fhirtypes/dist/DeviceUseStatement.d.ts
@@ -196,3 +196,8 @@ export interface DeviceUseStatement {
    */
   note?: Annotation[];
 }
+
+/**
+ * How often the device was used.
+ */
+export type DeviceUseStatementTiming = Period | string | Timing;

--- a/packages/fhirtypes/dist/DiagnosticReport.d.ts
+++ b/packages/fhirtypes/dist/DiagnosticReport.d.ts
@@ -239,6 +239,14 @@ export interface DiagnosticReport {
 }
 
 /**
+ * The time or time-period the observed values are related to. When the
+ * subject of the report is a patient, this is usually either the time of
+ * the procedure or of specimen collection(s), but very often the source
+ * of the date/time is not known, only the date/time itself.
+ */
+export type DiagnosticReportEffective = Period | string;
+
+/**
  * A list of key images associated with this report. The images are
  * generally created during the diagnostic process, and may be directly
  * of the patient, or of treated specimens (i.e. slides of interest).

--- a/packages/fhirtypes/dist/Dosage.d.ts
+++ b/packages/fhirtypes/dist/Dosage.d.ts
@@ -131,6 +131,13 @@ export interface Dosage {
 }
 
 /**
+ * Indicates whether the Medication is only taken when needed within a
+ * specific dosing schedule (Boolean option), or it indicates the
+ * precondition for taking the Medication (CodeableConcept).
+ */
+export type DosageAsNeeded = boolean | CodeableConcept;
+
+/**
  * The amount of medication administered.
  */
 export interface DosageDoseAndRate {
@@ -182,3 +189,13 @@ export interface DosageDoseAndRate {
    */
   rateQuantity?: Quantity;
 }
+
+/**
+ * Amount of medication per dose.
+ */
+export type DosageDoseAndRateDose = Quantity | Range;
+
+/**
+ * Amount of medication per unit of time.
+ */
+export type DosageDoseAndRateRate = Quantity | Range | Ratio;

--- a/packages/fhirtypes/dist/ElementDefinition.d.ts
+++ b/packages/fhirtypes/dist/ElementDefinition.d.ts
@@ -2317,6 +2317,67 @@ export interface ElementDefinition {
 }
 
 /**
+ * The value that should be used if there is no value stated in the
+ * instance (e.g. 'if not otherwise specified, the abstract is false').
+ */
+export type ElementDefinitionDefaultValue = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding
+    | ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
+
+/**
+ * Specifies a value that SHALL be exactly the value  for this element in
+ * the instance. For purposes of comparison, non-significant whitespace
+ * is ignored, and all values must be an exact match (case and accent
+ * sensitive). Missing elements/attributes must also be missing.
+ */
+export type ElementDefinitionFixed = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding |
+    ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
+
+/**
+ * Specifies a value that the value in the instance SHALL follow - that
+ * is, any value in the pattern must be found in the instance. Other
+ * additional values may be found too. This is effectively constraint by
+ * example.
+ *
+ * When pattern[x] is used to constrain a primitive, it means that the
+ * value provided in the pattern[x] must match the instance value
+ * exactly.
+ *
+ * When pattern[x] is used to constrain an array, it means that each
+ * element provided in the pattern[x] array must (recursively) match at
+ * least one element from the instance array.
+ *
+ * When pattern[x] is used to constrain a complex object, it means that
+ * each property in the pattern must be present in the complex object,
+ * and its value must recursively match -- i.e.,
+ *
+ * 1. If primitive: it must match exactly the pattern value
+ * 2. If a complex object: it must match (recursively) the pattern value
+ * 3. If an array: it must match (recursively) the pattern value.
+ */
+export type ElementDefinitionPattern = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding |
+    ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
+
+/**
+ * The minimum allowed value for the element. The value is inclusive.
+ * This is allowed for the types date, dateTime, instant, time, decimal,
+ * integer, and Quantity.
+ */
+export type ElementDefinitionMinValue = number | Quantity | string;
+
+/**
+ * The maximum allowed value for the element. The value is inclusive.
+ * This is allowed for the types date, dateTime, instant, time, decimal,
+ * integer, and Quantity.
+ */
+export type ElementDefinitionMaxValue = number | Quantity | string;
+
+/**
  * Information about the base definition of the element, provided to make
  * it unnecessary for tools to trace the deviation of the element through
  * the derived and related profiles. When the element definition is not
@@ -2797,6 +2858,15 @@ export interface ElementDefinitionExample {
    */
   valueMeta?: Meta;
 }
+
+/**
+ * The actual value for the element, which must be one of the types
+ * allowed for this element.
+ */
+export type ElementDefinitionExampleValue = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding
+    | ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
 
 /**
  * Identifies a concept from an external specification that roughly

--- a/packages/fhirtypes/dist/EventDefinition.d.ts
+++ b/packages/fhirtypes/dist/EventDefinition.d.ts
@@ -295,3 +295,9 @@ export interface EventDefinition {
    */
   trigger: TriggerDefinition[];
 }
+
+/**
+ * A code or group definition that describes the intended subject of the
+ * event definition.
+ */
+export type EventDefinitionSubject = CodeableConcept | Reference<Group>;

--- a/packages/fhirtypes/dist/EvidenceVariable.d.ts
+++ b/packages/fhirtypes/dist/EvidenceVariable.d.ts
@@ -429,3 +429,16 @@ export interface EvidenceVariableCharacteristic {
    */
   groupMeasure?: 'mean' | 'median' | 'mean-of-mean' | 'mean-of-median' | 'median-of-mean' | 'median-of-median';
 }
+
+/**
+ * Define members of the evidence element using Codes (such as condition,
+ * medication, or observation), Expressions ( using an expression
+ * language such as FHIRPath or CQL) or DataRequirements (such as
+ * Diabetes diagnosis onset in the last year).
+ */
+export type EvidenceVariableCharacteristicDefinition = CodeableConcept | DataRequirement | Expression | Reference<Group> | string | TriggerDefinition;
+
+/**
+ * Indicates what effective period the study covers.
+ */
+export type EvidenceVariableCharacteristicParticipantEffective = Duration | Period | string | Timing;

--- a/packages/fhirtypes/dist/ExplanationOfBenefit.d.ts
+++ b/packages/fhirtypes/dist/ExplanationOfBenefit.d.ts
@@ -433,6 +433,11 @@ export interface ExplanationOfBenefitAccident {
 }
 
 /**
+ * The physical location of the accident event.
+ */
+export type ExplanationOfBenefitAccidentLocation = Address | Reference<Location>;
+
+/**
  * The first-tier service adjudications for payor added product or
  * service lines.
  */
@@ -594,6 +599,17 @@ export interface ExplanationOfBenefitAddItem {
    */
   detail?: ExplanationOfBenefitAddItemDetail[];
 }
+
+/**
+ * The date or dates when the service or product was supplied, performed
+ * or completed.
+ */
+export type ExplanationOfBenefitAddItemServiced = Period | string;
+
+/**
+ * Where the product or service was provided.
+ */
+export type ExplanationOfBenefitAddItemLocation = Address | CodeableConcept | Reference<Location>;
 
 /**
  * The second-tier service adjudications for payor added services.
@@ -940,6 +956,16 @@ export interface ExplanationOfBenefitBenefitBalanceFinancial {
 }
 
 /**
+ * The quantity of the benefit which is permitted under the coverage.
+ */
+export type ExplanationOfBenefitBenefitBalanceFinancialAllowed = Money | number | string;
+
+/**
+ * The quantity of the benefit which have been consumed to date.
+ */
+export type ExplanationOfBenefitBenefitBalanceFinancialUsed = Money | number;
+
+/**
  * The members of the team who provided the products and services.
  */
 export interface ExplanationOfBenefitCareTeam {
@@ -1083,6 +1109,12 @@ export interface ExplanationOfBenefitDiagnosis {
    */
   packageCode?: CodeableConcept;
 }
+
+/**
+ * The nature of illness or problem in a coded form or as a reference to
+ * an external defined Condition.
+ */
+export type ExplanationOfBenefitDiagnosisDiagnosis = CodeableConcept | Reference<Condition>;
 
 /**
  * Financial instruments for reimbursement for the health care products
@@ -1337,6 +1369,17 @@ export interface ExplanationOfBenefitItem {
    */
   detail?: ExplanationOfBenefitItemDetail[];
 }
+
+/**
+ * The date or dates when the service or product was supplied, performed
+ * or completed.
+ */
+export type ExplanationOfBenefitItemServiced = Period | string;
+
+/**
+ * Where the product or service was provided.
+ */
+export type ExplanationOfBenefitItemLocation = Address | CodeableConcept | Reference<Location>;
 
 /**
  * If this item is a group then the values here are a summary of the
@@ -1853,6 +1896,12 @@ export interface ExplanationOfBenefitProcedure {
 }
 
 /**
+ * The code or reference to a Procedure resource which identifies the
+ * clinical intervention performed.
+ */
+export type ExplanationOfBenefitProcedureProcedure = CodeableConcept | Reference<Procedure>;
+
+/**
  * A note that describes or explains adjudication results in a human
  * readable form.
  */
@@ -2082,6 +2131,18 @@ export interface ExplanationOfBenefitSupportingInfo {
    */
   reason?: Coding;
 }
+
+/**
+ * The date when or period to which this information refers.
+ */
+export type ExplanationOfBenefitSupportingInfoTiming = Period | string;
+
+/**
+ * Additional data or information such as resources, documents, images
+ * etc. including references to the data or the actual inclusion of the
+ * data.
+ */
+export type ExplanationOfBenefitSupportingInfoValue = Attachment | boolean | Quantity | Reference<Resource> | string;
 
 /**
  * Categorized monetary totals for the adjudication.

--- a/packages/fhirtypes/dist/Extension.d.ts
+++ b/packages/fhirtypes/dist/Extension.d.ts
@@ -362,3 +362,12 @@ export interface Extension {
    */
   valueMeta?: Meta;
 }
+
+/**
+ * Value of extension - must be one of a constrained set of the data
+ * types (see [Extensibility](extensibility.html) for a list).
+ */
+export type ExtensionValue = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding |
+    ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;

--- a/packages/fhirtypes/dist/FamilyMemberHistory.d.ts
+++ b/packages/fhirtypes/dist/FamilyMemberHistory.d.ts
@@ -261,6 +261,23 @@ export interface FamilyMemberHistory {
 }
 
 /**
+ * The actual or approximate date of birth of the relative.
+ */
+export type FamilyMemberHistoryBorn = Period | string;
+
+/**
+ * The age of the relative at the time the family member history is
+ * recorded.
+ */
+export type FamilyMemberHistoryAge = Age | Range | string;
+
+/**
+ * Deceased flag or the actual or approximate age of the relative at the
+ * time of death for the family member history record.
+ */
+export type FamilyMemberHistoryDeceased = Age | boolean | Range | string;
+
+/**
  * The significant Conditions (or condition) that the family member had.
  * This is a repeating section to allow a system to represent more than
  * one condition per resource, though there is nothing stopping multiple
@@ -357,3 +374,10 @@ export interface FamilyMemberHistoryCondition {
    */
   note?: Annotation[];
 }
+
+/**
+ * Either the age of onset, range of approximate age or descriptive
+ * string can be recorded.  For conditions with multiple occurrences,
+ * this describes the first known occurrence.
+ */
+export type FamilyMemberHistoryConditionOnset = Age | Period | Range | string;

--- a/packages/fhirtypes/dist/Goal.d.ts
+++ b/packages/fhirtypes/dist/Goal.d.ts
@@ -209,6 +209,11 @@ export interface Goal {
 }
 
 /**
+ * The date or event after which the goal should begin being pursued.
+ */
+export type GoalStart = CodeableConcept | string;
+
+/**
  * Indicates what should be done by when.
  */
 export interface GoalTarget {
@@ -343,3 +348,20 @@ export interface GoalTarget {
    */
   dueDuration?: Duration;
 }
+
+/**
+ * The target value of the focus to be achieved to signify the
+ * fulfillment of the goal, e.g. 150 pounds, 7.0%. Either the high or low
+ * or both values of the range can be specified. When a low value is
+ * missing, it indicates that the goal is achieved at any focus value at
+ * or below the high value. Similarly, if the high value is missing, it
+ * indicates that the goal is achieved at any focus value at or above the
+ * low value.
+ */
+export type GoalTargetDetail = boolean | CodeableConcept | number | Quantity | Range | Ratio | string;
+
+/**
+ * Indicates either the date or the duration after start by which the
+ * goal should be met.
+ */
+export type GoalTargetDue = Duration | string;

--- a/packages/fhirtypes/dist/Group.d.ts
+++ b/packages/fhirtypes/dist/Group.d.ts
@@ -256,6 +256,12 @@ export interface GroupCharacteristic {
 }
 
 /**
+ * The value of the trait that holds (or does not hold - see 'exclude')
+ * for members of the group.
+ */
+export type GroupCharacteristicValue = boolean | CodeableConcept | Quantity | Range | Reference;
+
+/**
  * Identifies the resource instances that are members of the group.
  */
 export interface GroupMember {

--- a/packages/fhirtypes/dist/GuidanceResponse.d.ts
+++ b/packages/fhirtypes/dist/GuidanceResponse.d.ts
@@ -226,3 +226,9 @@ export interface GuidanceResponse {
    */
   dataRequirement?: DataRequirement[];
 }
+
+/**
+ * An identifier, CodeableConcept or canonical reference to the guidance
+ * that was requested.
+ */
+export type GuidanceResponseModule = CodeableConcept | string;

--- a/packages/fhirtypes/dist/Immunization.d.ts
+++ b/packages/fhirtypes/dist/Immunization.d.ts
@@ -268,6 +268,11 @@ export interface Immunization {
 }
 
 /**
+ * Date vaccine administered or was to be administered.
+ */
+export type ImmunizationOccurrence = string;
+
+/**
  * Educational material presented to the patient (or guardian) at the
  * time of vaccine administration.
  */
@@ -461,6 +466,16 @@ export interface ImmunizationProtocolApplied {
    */
   seriesDosesString?: string;
 }
+
+/**
+ * Nominal position in a series.
+ */
+export type ImmunizationProtocolAppliedDoseNumber = number | string;
+
+/**
+ * The recommended number of doses to achieve immunity.
+ */
+export type ImmunizationProtocolAppliedSeriesDoses = number | string;
 
 /**
  * Categorical data indicating that an adverse event is associated in

--- a/packages/fhirtypes/dist/ImmunizationEvaluation.d.ts
+++ b/packages/fhirtypes/dist/ImmunizationEvaluation.d.ts
@@ -177,3 +177,13 @@ export interface ImmunizationEvaluation {
    */
   seriesDosesString?: string;
 }
+
+/**
+ * Nominal position in a series.
+ */
+export type ImmunizationEvaluationDoseNumber = number | string;
+
+/**
+ * The recommended number of doses to achieve immunity.
+ */
+export type ImmunizationEvaluationSeriesDoses = number | string;

--- a/packages/fhirtypes/dist/ImmunizationRecommendation.d.ts
+++ b/packages/fhirtypes/dist/ImmunizationRecommendation.d.ts
@@ -245,6 +245,17 @@ export interface ImmunizationRecommendationRecommendation {
 }
 
 /**
+ * Nominal position of the recommended dose in a series (e.g. dose 2 is
+ * the next recommended dose).
+ */
+export type ImmunizationRecommendationRecommendationDoseNumber = number | string;
+
+/**
+ * The recommended number of doses to achieve immunity.
+ */
+export type ImmunizationRecommendationRecommendationSeriesDoses = number | string;
+
+/**
  * Vaccine date recommendations.  For example, earliest date to
  * administer, latest date to administer, etc.
  */

--- a/packages/fhirtypes/dist/ImplementationGuide.d.ts
+++ b/packages/fhirtypes/dist/ImplementationGuide.d.ts
@@ -484,6 +484,11 @@ export interface ImplementationGuideDefinitionPage {
 }
 
 /**
+ * The source address for the page.
+ */
+export type ImplementationGuideDefinitionPageName = Reference<Binary> | string;
+
+/**
  * Defines how IG is built by tools.
  */
 export interface ImplementationGuideDefinitionParameter {
@@ -626,6 +631,13 @@ export interface ImplementationGuideDefinitionResource {
    */
   groupingId?: string;
 }
+
+/**
+ * If true or a reference, indicates the resource is an example instance.
+ * If a reference is present, indicates that the example is an example
+ * of the specified profile.
+ */
+export type ImplementationGuideDefinitionResourceExample = boolean | string;
 
 /**
  * A template for building resources.
@@ -991,3 +1003,10 @@ export interface ImplementationGuideManifestResource {
    */
   relativePath?: string;
 }
+
+/**
+ * If true or a reference, indicates the resource is an example instance.
+ * If a reference is present, indicates that the example is an example
+ * of the specified profile.
+ */
+export type ImplementationGuideManifestResourceExample = boolean | string;

--- a/packages/fhirtypes/dist/Invoice.d.ts
+++ b/packages/fhirtypes/dist/Invoice.d.ts
@@ -275,6 +275,14 @@ export interface InvoiceLineItem {
 }
 
 /**
+ * The ChargeItem contains information such as the billing code, date,
+ * amount etc. If no further details are required for the lineItem,
+ * inline billing codes can be added using the CodeableConcept data type
+ * instead of the Reference.
+ */
+export type InvoiceLineItemChargeItem = CodeableConcept | Reference<ChargeItem>;
+
+/**
  * The price for a ChargeItem may be calculated as a base price with
  * surcharges/deductions that apply in certain conditions. A
  * ChargeItemDefinition resource that defines the prices, factors and

--- a/packages/fhirtypes/dist/Library.d.ts
+++ b/packages/fhirtypes/dist/Library.d.ts
@@ -322,3 +322,9 @@ export interface Library {
    */
   content?: Attachment[];
 }
+
+/**
+ * A code or group definition that describes the intended subject of the
+ * contents of the library.
+ */
+export type LibrarySubject = CodeableConcept | Reference<Group>;

--- a/packages/fhirtypes/dist/Measure.d.ts
+++ b/packages/fhirtypes/dist/Measure.d.ts
@@ -384,6 +384,13 @@ export interface Measure {
 }
 
 /**
+ * The intended subjects for the measure. If this element is not
+ * provided, a Patient subject is assumed, but the subject of the measure
+ * can be anything.
+ */
+export type MeasureSubject = CodeableConcept | Reference<Group>;
+
+/**
  * A group of population criteria for the measure.
  */
 export interface MeasureGroup {

--- a/packages/fhirtypes/dist/Media.d.ts
+++ b/packages/fhirtypes/dist/Media.d.ts
@@ -241,3 +241,8 @@ export interface Media {
    */
   note?: Annotation[];
 }
+
+/**
+ * The date and time(s) at which the media was collected.
+ */
+export type MediaCreated = Period | string;

--- a/packages/fhirtypes/dist/Medication.d.ts
+++ b/packages/fhirtypes/dist/Medication.d.ts
@@ -265,3 +265,9 @@ export interface MedicationIngredient {
    */
   strength?: Ratio;
 }
+
+/**
+ * The actual ingredient - either a substance (simple ingredient) or
+ * another medication of a medication.
+ */
+export type MedicationIngredientItem = CodeableConcept | Reference<Substance | Medication>;

--- a/packages/fhirtypes/dist/MedicationAdministration.d.ts
+++ b/packages/fhirtypes/dist/MedicationAdministration.d.ts
@@ -253,6 +253,22 @@ export interface MedicationAdministration {
 }
 
 /**
+ * Identifies the medication that was administered. This is either a link
+ * to a resource representing the details of the medication or a simple
+ * attribute carrying a code that identifies the medication from a known
+ * list of medications.
+ */
+export type MedicationAdministrationMedication = CodeableConcept | Reference<Medication>;
+
+/**
+ * A specific date/time or interval of time during which the
+ * administration took place (or did not take place, when the 'notGiven'
+ * attribute is true). For many administrations, such as swallowing a
+ * tablet the use of dateTime is more appropriate.
+ */
+export type MedicationAdministrationEffective = Period | string;
+
+/**
  * Describes the medication dosage information details e.g. dose, rate,
  * site, route, etc.
  */
@@ -348,6 +364,15 @@ export interface MedicationAdministrationDosage {
    */
   rateQuantity?: Quantity;
 }
+
+/**
+ * Identifies the speed with which the medication was or will be
+ * introduced into the patient.  Typically, the rate for an infusion e.g.
+ * 100 ml per 1 hour or 100 ml/hr.  May also be expressed as a rate per
+ * unit of time, e.g. 500 ml per 2 hours.  Other examples:  200 mcg/min
+ * or 200 mcg/1 minute; 1 liter/8 hours.
+ */
+export type MedicationAdministrationDosageRate = Quantity | Ratio;
 
 /**
  * Indicates who or what performed the medication administration and how

--- a/packages/fhirtypes/dist/MedicationDispense.d.ts
+++ b/packages/fhirtypes/dist/MedicationDispense.d.ts
@@ -276,6 +276,19 @@ export interface MedicationDispense {
 }
 
 /**
+ * Indicates the reason why a dispense was not performed.
+ */
+export type MedicationDispenseStatusReason = CodeableConcept | Reference<DetectedIssue>;
+
+/**
+ * Identifies the medication being administered. This is either a link to
+ * a resource representing the details of the medication or a simple
+ * attribute carrying a code that identifies the medication from a known
+ * list of medications.
+ */
+export type MedicationDispenseMedication = CodeableConcept | Reference<Medication>;
+
+/**
  * Indicates who or what performed the event.
  */
 export interface MedicationDispensePerformer {

--- a/packages/fhirtypes/dist/MedicationKnowledge.d.ts
+++ b/packages/fhirtypes/dist/MedicationKnowledge.d.ts
@@ -302,6 +302,12 @@ export interface MedicationKnowledgeAdministrationGuidelines {
 }
 
 /**
+ * Indication for use that apply to the specific administration
+ * guidelines.
+ */
+export type MedicationKnowledgeAdministrationGuidelinesIndication = CodeableConcept | Reference<ObservationDefinition>;
+
+/**
  * Dosage for the medication for the specific guidelines.
  */
 export interface MedicationKnowledgeAdministrationGuidelinesDosage {
@@ -411,6 +417,12 @@ export interface MedicationKnowledgeAdministrationGuidelinesPatientCharacteristi
    */
   value?: string[];
 }
+
+/**
+ * Specific characteristic that is relevant to the administration
+ * guideline (e.g. height, weight, gender).
+ */
+export type MedicationKnowledgeAdministrationGuidelinesPatientCharacteristicsCharacteristic = CodeableConcept | Quantity;
 
 /**
  * The price of the medication.
@@ -538,6 +550,11 @@ export interface MedicationKnowledgeDrugCharacteristic {
 }
 
 /**
+ * Description of the characteristic.
+ */
+export type MedicationKnowledgeDrugCharacteristicValue = CodeableConcept | Quantity | string;
+
+/**
  * Identifies a particular constituent of interest in the product.
  */
 export interface MedicationKnowledgeIngredient {
@@ -602,6 +619,12 @@ export interface MedicationKnowledgeIngredient {
    */
   strength?: Ratio;
 }
+
+/**
+ * The actual ingredient - either a substance (simple ingredient) or
+ * another medication.
+ */
+export type MedicationKnowledgeIngredientItem = CodeableConcept | Reference<Substance>;
 
 /**
  * The time course of drug absorption, distribution, metabolism and

--- a/packages/fhirtypes/dist/MedicationRequest.d.ts
+++ b/packages/fhirtypes/dist/MedicationRequest.d.ts
@@ -347,6 +347,21 @@ export interface MedicationRequest {
 }
 
 /**
+ * Indicates if this record was captured as a secondary 'reported' record
+ * rather than as an original primary source-of-truth record.  It may
+ * also indicate the source of the report.
+ */
+export type MedicationRequestReported = boolean | Reference<Patient | Practitioner | PractitionerRole | RelatedPerson | Organization>;
+
+/**
+ * Identifies the medication being requested. This is a link to a
+ * resource that represents the medication which may be the details of
+ * the medication or simply an attribute carrying a code that identifies
+ * the medication from a known list of medications.
+ */
+export type MedicationRequestMedication = CodeableConcept | Reference<Medication>;
+
+/**
  * Indicates the specific details for the dispense or medication supply
  * part of a medication request (also known as a Medication Prescription
  * or Medication Order).  Note that this information is not always sent
@@ -552,3 +567,9 @@ export interface MedicationRequestSubstitution {
    */
   reason?: CodeableConcept;
 }
+
+/**
+ * True if the prescriber allows a different drug to be dispensed from
+ * what was prescribed.
+ */
+export type MedicationRequestSubstitutionAllowed = boolean | CodeableConcept;

--- a/packages/fhirtypes/dist/MedicationStatement.d.ts
+++ b/packages/fhirtypes/dist/MedicationStatement.d.ts
@@ -260,3 +260,18 @@ export interface MedicationStatement {
    */
   dosage?: Dosage[];
 }
+
+/**
+ * Identifies the medication being administered. This is either a link to
+ * a resource representing the details of the medication or a simple
+ * attribute carrying a code that identifies the medication from a known
+ * list of medications.
+ */
+export type MedicationStatementMedication = CodeableConcept | Reference<Medication>;
+
+/**
+ * The interval of time during which it is being asserted that the
+ * patient is/was/will be taking the medication (or was not taking, when
+ * the MedicationStatement.taken element is No).
+ */
+export type MedicationStatementEffective = Period | string;

--- a/packages/fhirtypes/dist/MedicinalProduct.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProduct.d.ts
@@ -528,3 +528,8 @@ export interface MedicinalProductSpecialDesignation {
    */
   species?: CodeableConcept;
 }
+
+/**
+ * Condition for which the medicinal use applies.
+ */
+export type MedicinalProductSpecialDesignationIndication = CodeableConcept | Reference<MedicinalProductIndication>;

--- a/packages/fhirtypes/dist/MedicinalProductAuthorization.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductAuthorization.d.ts
@@ -318,3 +318,8 @@ export interface MedicinalProductAuthorizationProcedure {
    */
   application?: MedicinalProductAuthorizationProcedure[];
 }
+
+/**
+ * Date of procedure.
+ */
+export type MedicinalProductAuthorizationProcedureDate = Period | string;

--- a/packages/fhirtypes/dist/MedicinalProductContraindication.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductContraindication.d.ts
@@ -197,3 +197,11 @@ export interface MedicinalProductContraindicationOtherTherapy {
    */
   medicationReference?: Reference<MedicinalProduct | Medication | Substance | SubstanceSpecification>;
 }
+
+/**
+ * Reference to a specific medication (active substance, medicinal
+ * product or class of products) as part of an indication or
+ * contraindication.
+ */
+export type MedicinalProductContraindicationOtherTherapyMedication = CodeableConcept | Reference<MedicinalProduct |
+    Medication | Substance | SubstanceSpecification>;

--- a/packages/fhirtypes/dist/MedicinalProductIndication.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductIndication.d.ts
@@ -208,3 +208,10 @@ export interface MedicinalProductIndicationOtherTherapy {
    */
   medicationReference?: Reference<MedicinalProduct | Medication | Substance | SubstanceSpecification>;
 }
+
+/**
+ * Reference to a specific medication (active substance, medicinal
+ * product or class of products) as part of an indication or
+ * contraindication.
+ */
+export type MedicinalProductIndicationOtherTherapyMedication = CodeableConcept | Reference<MedicinalProduct | Medication | Substance | SubstanceSpecification>;

--- a/packages/fhirtypes/dist/MedicinalProductInteraction.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductInteraction.d.ts
@@ -184,3 +184,8 @@ export interface MedicinalProductInteractionInteractant {
    */
   itemCodeableConcept?: CodeableConcept;
 }
+
+/**
+ * The specific medication, food or laboratory test that interacts.
+ */
+export type MedicinalProductInteractionInteractantItem = CodeableConcept | Reference<MedicinalProduct | Medication | Substance | ObservationDefinition>;

--- a/packages/fhirtypes/dist/MessageDefinition.d.ts
+++ b/packages/fhirtypes/dist/MessageDefinition.d.ts
@@ -263,6 +263,11 @@ export interface MessageDefinition {
 }
 
 /**
+ * Event code or link to the EventDefinition.
+ */
+export type MessageDefinitionEvent = Coding | string;
+
+/**
  * Indicates what types of messages may be sent as an application-level
  * response to this message.
  */

--- a/packages/fhirtypes/dist/MessageHeader.d.ts
+++ b/packages/fhirtypes/dist/MessageHeader.d.ts
@@ -183,6 +183,15 @@ export interface MessageHeader {
 }
 
 /**
+ * Code that identifies the event this message represents and connects it
+ * with its definition. Events defined as part of the FHIR specification
+ * have the system value
+ * &quot;http://terminology.hl7.org/CodeSystem/message-events&quot;.  Alternatively
+ * uri to the EventDefinition.
+ */
+export type MessageHeaderEvent = Coding | string;
+
+/**
  * The destination application which the message is intended for.
  */
 export interface MessageHeaderDestination {

--- a/packages/fhirtypes/dist/NutritionOrder.d.ts
+++ b/packages/fhirtypes/dist/NutritionOrder.d.ts
@@ -392,6 +392,12 @@ export interface NutritionOrderEnteralFormulaAdministration {
 }
 
 /**
+ * The rate of administration of formula via a feeding pump, e.g. 60 mL
+ * per hour, according to the specified schedule.
+ */
+export type NutritionOrderEnteralFormulaAdministrationRate = Quantity | Ratio;
+
+/**
  * Diet given orally in contrast to enteral (tube) feeding.
  */
 export interface NutritionOrderOralDiet {

--- a/packages/fhirtypes/dist/Observation.d.ts
+++ b/packages/fhirtypes/dist/Observation.d.ts
@@ -376,6 +376,21 @@ export interface Observation {
 }
 
 /**
+ * The time or time-period the observed value is asserted as being true.
+ * For biological subjects - e.g. human patients - this is usually called
+ * the &quot;physiologically relevant time&quot;. This is usually either the time
+ * of the procedure or of specimen collection, but very often the source
+ * of the date/time is not known, only the date/time itself.
+ */
+export type ObservationEffective = Period | string | Timing;
+
+/**
+ * The information determined as a result of making the observation, if
+ * the information has a simple value.
+ */
+export type ObservationValue = boolean | CodeableConcept | number | Period | Quantity | Range | Ratio | SampledData | string;
+
+/**
  * Some observations have multiple component observations.  These
  * component observations are expressed as separate code value pairs that
  * share the same attributes.  Examples include systolic and diastolic
@@ -509,6 +524,12 @@ export interface ObservationComponent {
    */
   referenceRange?: ObservationReferenceRange[];
 }
+
+/**
+ * The information determined as a result of making the observation, if
+ * the information has a simple value.
+ */
+export type ObservationComponentValue = boolean | CodeableConcept | number | Period | Quantity | Range | Ratio | SampledData | string;
 
 /**
  * Guidance on how to interpret the value by comparison to a normal or

--- a/packages/fhirtypes/dist/Parameters.d.ts
+++ b/packages/fhirtypes/dist/Parameters.d.ts
@@ -386,3 +386,11 @@ export interface ParametersParameter {
    */
   part?: ParametersParameter[];
 }
+
+/**
+ * If the parameter is a data type.
+ */
+export type ParametersParameterValue = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding |
+    ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;

--- a/packages/fhirtypes/dist/Patient.d.ts
+++ b/packages/fhirtypes/dist/Patient.d.ts
@@ -208,6 +208,17 @@ export interface Patient {
 }
 
 /**
+ * Indicates if the individual is deceased or not.
+ */
+export type PatientDeceased = boolean | string;
+
+/**
+ * Indicates whether the patient is part of a multiple (boolean) or
+ * indicates the actual birth order (integer).
+ */
+export type PatientMultipleBirth = boolean | number;
+
+/**
  * A language which may be used to communicate with the patient about his
  * or her health.
  */

--- a/packages/fhirtypes/dist/PlanDefinition.d.ts
+++ b/packages/fhirtypes/dist/PlanDefinition.d.ts
@@ -329,6 +329,12 @@ export interface PlanDefinition {
 }
 
 /**
+ * A code or group definition that describes the intended subject of the
+ * plan definition.
+ */
+export type PlanDefinitionSubject = CodeableConcept | Reference<Group>;
+
+/**
  * An action or group of actions to be taken as part of the plan.
  */
 export interface PlanDefinitionAction {
@@ -567,6 +573,24 @@ export interface PlanDefinitionAction {
 }
 
 /**
+ * A code or group definition that describes the intended subject of the
+ * action and its children, if any.
+ */
+export type PlanDefinitionActionSubject = CodeableConcept | Reference<Group>;
+
+/**
+ * An optional value describing when the action should be performed.
+ */
+export type PlanDefinitionActionTiming = Age | Duration | Period | Range | string | Timing;
+
+/**
+ * A reference to an ActivityDefinition that describes the action to be
+ * taken in detail, or a PlanDefinition that describes a series of
+ * actions to be taken.
+ */
+export type PlanDefinitionActionDefinition = string;
+
+/**
  * An expression that describes applicability criteria or start/stop
  * conditions for the action.
  */
@@ -800,6 +824,12 @@ export interface PlanDefinitionActionRelatedAction {
 }
 
 /**
+ * A duration or range of durations to apply to the relationship. For
+ * example, 30-60 minutes before.
+ */
+export type PlanDefinitionActionRelatedActionOffset = Duration | Range;
+
+/**
  * Goals that describe what the activities within the plan are intended
  * to achieve. For example, weight loss, restoring an activity of daily
  * living, obtaining herd immunity via immunization, meeting a process
@@ -967,3 +997,13 @@ export interface PlanDefinitionGoalTarget {
    */
   due?: Duration;
 }
+
+/**
+ * The target value of the measure to be achieved to signify fulfillment
+ * of the goal, e.g. 150 pounds or 7.0%. Either the high or low or both
+ * values of the range can be specified. When a low value is missing, it
+ * indicates that the goal is achieved at any value at or below the high
+ * value. Similarly, if the high value is missing, it indicates that the
+ * goal is achieved at any value at or above the low value.
+ */
+export type PlanDefinitionGoalTargetDetail = CodeableConcept | Quantity | Range;

--- a/packages/fhirtypes/dist/Population.d.ts
+++ b/packages/fhirtypes/dist/Population.d.ts
@@ -73,3 +73,8 @@ export interface Population {
    */
   physiologicalCondition?: CodeableConcept;
 }
+
+/**
+ * The age of the specific population.
+ */
+export type PopulationAge = CodeableConcept | Range;

--- a/packages/fhirtypes/dist/Procedure.d.ts
+++ b/packages/fhirtypes/dist/Procedure.d.ts
@@ -322,6 +322,14 @@ export interface Procedure {
 }
 
 /**
+ * Estimated or actual date, date-time, period, or age when the procedure
+ * was performed.  Allows a period to support complex procedures that
+ * span more than one date, and also allows for the length of the
+ * procedure to be captured.
+ */
+export type ProcedurePerformed = Age | Period | Range | string;
+
+/**
  * A device that is implanted, removed or otherwise manipulated
  * (calibration, battery replacement, fitting a prosthesis, attaching a
  * wound-vac, etc.) as a focal portion of the Procedure.

--- a/packages/fhirtypes/dist/Project.d.ts
+++ b/packages/fhirtypes/dist/Project.d.ts
@@ -220,6 +220,11 @@ export interface ProjectSetting {
 }
 
 /**
+ * The secret value.
+ */
+export type ProjectSettingValue = boolean | number | string;
+
+/**
  * Web application or web site that is associated with the project.
  */
 export interface ProjectSite {

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -210,3 +210,9 @@ export interface ProjectMembershipAccessParameter {
    */
   valueReference?: Reference;
 }
+
+/**
+ * Value of the parameter - must be one of a constrained set of the data
+ * types (see [Extensibility](extensibility.html) for a list).
+ */
+export type ProjectMembershipAccessParameterValue = Reference | string;

--- a/packages/fhirtypes/dist/Provenance.d.ts
+++ b/packages/fhirtypes/dist/Provenance.d.ts
@@ -176,6 +176,11 @@ export interface Provenance {
 }
 
 /**
+ * The period during which the activity occurred.
+ */
+export type ProvenanceOccurred = Period | string;
+
+/**
  * An actor taking a role in an activity  for which it can be assigned
  * some degree of responsibility for the activity taking place.
  */

--- a/packages/fhirtypes/dist/Questionnaire.d.ts
+++ b/packages/fhirtypes/dist/Questionnaire.d.ts
@@ -489,6 +489,11 @@ export interface QuestionnaireItemAnswerOption {
 }
 
 /**
+ * A potential answer that's allowed as the answer to this question.
+ */
+export type QuestionnaireItemAnswerOptionValue = Coding | number | Reference<Resource> | string;
+
+/**
  * A constraint indicating that this item should only be enabled
  * (displayed/allow answers to be captured) when the specified condition
  * is true.
@@ -603,6 +608,12 @@ export interface QuestionnaireItemEnableWhen {
 }
 
 /**
+ * A value that the referenced question is tested using the specified
+ * operator in order for the item to be enabled.
+ */
+export type QuestionnaireItemEnableWhenAnswer = boolean | Coding | number | Quantity | Reference<Resource> | string;
+
+/**
  * One or more values that should be pre-populated in the answer when
  * initially rendering the questionnaire for user input.
  */
@@ -703,3 +714,8 @@ export interface QuestionnaireItemInitial {
    */
   valueReference?: Reference<Resource>;
 }
+
+/**
+ * The actual value to for an initial answer.
+ */
+export type QuestionnaireItemInitialValue = Attachment | boolean | Coding | number | Quantity | Reference<Resource> | string;

--- a/packages/fhirtypes/dist/QuestionnaireResponse.d.ts
+++ b/packages/fhirtypes/dist/QuestionnaireResponse.d.ts
@@ -363,3 +363,9 @@ export interface QuestionnaireResponseItemAnswer {
    */
   item?: QuestionnaireResponseItem[];
 }
+
+/**
+ * The answer (or one of the answers) provided by the respondent to the
+ * question.
+ */
+export type QuestionnaireResponseItemAnswerValue = Attachment | boolean | Coding | number | Quantity | Reference<Resource> | string;

--- a/packages/fhirtypes/dist/RequestGroup.d.ts
+++ b/packages/fhirtypes/dist/RequestGroup.d.ts
@@ -392,6 +392,11 @@ export interface RequestGroupAction {
 }
 
 /**
+ * An optional value describing when the action should be performed.
+ */
+export type RequestGroupActionTiming = Age | Duration | Period | Range | string | Timing;
+
+/**
  * An expression that describes applicability criteria, or start/stop
  * conditions for the action.
  */
@@ -508,3 +513,9 @@ export interface RequestGroupActionRelatedAction {
    */
   offsetRange?: Range;
 }
+
+/**
+ * A duration or range of durations to apply to the relationship. For
+ * example, 30-60 minutes before.
+ */
+export type RequestGroupActionRelatedActionOffset = Duration | Range;

--- a/packages/fhirtypes/dist/ResearchDefinition.d.ts
+++ b/packages/fhirtypes/dist/ResearchDefinition.d.ts
@@ -339,3 +339,10 @@ export interface ResearchDefinition {
    */
   outcome?: Reference<ResearchElementDefinition>;
 }
+
+/**
+ * The intended subjects for the ResearchDefinition. If this element is
+ * not provided, a Patient subject is assumed, but the subject of the
+ * ResearchDefinition can be anything.
+ */
+export type ResearchDefinitionSubject = CodeableConcept | Reference<Group>;

--- a/packages/fhirtypes/dist/ResearchElementDefinition.d.ts
+++ b/packages/fhirtypes/dist/ResearchElementDefinition.d.ts
@@ -342,6 +342,13 @@ export interface ResearchElementDefinition {
 }
 
 /**
+ * The intended subjects for the ResearchElementDefinition. If this
+ * element is not provided, a Patient subject is assumed, but the subject
+ * of the ResearchElementDefinition can be anything.
+ */
+export type ResearchElementDefinitionSubject = CodeableConcept | Reference<Group>;
+
+/**
  * A characteristic that defines the members of the research element.
  * Multiple characteristics are applied with &quot;and&quot; semantics.
  */
@@ -503,3 +510,21 @@ export interface ResearchElementDefinitionCharacteristic {
    */
   participantEffectiveGroupMeasure?: 'mean' | 'median' | 'mean-of-mean' | 'mean-of-median' | 'median-of-mean' | 'median-of-median';
 }
+
+/**
+ * Define members of the research element using Codes (such as condition,
+ * medication, or observation), Expressions ( using an expression
+ * language such as FHIRPath or CQL) or DataRequirements (such as
+ * Diabetes diagnosis onset in the last year).
+ */
+export type ResearchElementDefinitionCharacteristicDefinition = CodeableConcept | DataRequirement | Expression | string;
+
+/**
+ * Indicates what effective period the study covers.
+ */
+export type ResearchElementDefinitionCharacteristicStudyEffective = Duration | Period | string | Timing;
+
+/**
+ * Indicates what effective period the study covers.
+ */
+export type ResearchElementDefinitionCharacteristicParticipantEffective = Duration | Period | string | Timing;

--- a/packages/fhirtypes/dist/RiskAssessment.d.ts
+++ b/packages/fhirtypes/dist/RiskAssessment.d.ts
@@ -203,6 +203,11 @@ export interface RiskAssessment {
 }
 
 /**
+ * The date (and possibly time) the risk assessment was performed.
+ */
+export type RiskAssessmentOccurrence = Period | string;
+
+/**
  * Describes the expected outcome for the subject.
  */
 export interface RiskAssessmentPrediction {
@@ -289,3 +294,14 @@ export interface RiskAssessmentPrediction {
    */
   rationale?: string;
 }
+
+/**
+ * Indicates how likely the outcome is (in the specified timeframe).
+ */
+export type RiskAssessmentPredictionProbability = number | Range;
+
+/**
+ * Indicates the period of time or age range of the subject to which the
+ * specified probability applies.
+ */
+export type RiskAssessmentPredictionWhen = Period | Range;

--- a/packages/fhirtypes/dist/ServiceRequest.d.ts
+++ b/packages/fhirtypes/dist/ServiceRequest.d.ts
@@ -360,3 +360,21 @@ export interface ServiceRequest {
    */
   relevantHistory?: Reference<Provenance>[];
 }
+
+/**
+ * An amount of service being requested which can be a quantity ( for
+ * example $1,500 home modification), a ratio ( for example, 20 half day
+ * visits per month), or a range (2.0 to 1.8 Gy per fraction).
+ */
+export type ServiceRequestQuantity = Quantity | Range | Ratio;
+
+/**
+ * The date/time at which the requested service should occur.
+ */
+export type ServiceRequestOccurrence = Period | string | Timing;
+
+/**
+ * If a CodeableConcept is present, it indicates the pre-condition for
+ * performing the service.  For example &quot;pain&quot;, &quot;on flare-up&quot;, etc.
+ */
+export type ServiceRequestAsNeeded = boolean | CodeableConcept;

--- a/packages/fhirtypes/dist/Specimen.d.ts
+++ b/packages/fhirtypes/dist/Specimen.d.ts
@@ -274,6 +274,18 @@ export interface SpecimenCollection {
 }
 
 /**
+ * Time when specimen was collected from subject - the physiologically
+ * relevant time.
+ */
+export type SpecimenCollectionCollected = Period | string;
+
+/**
+ * Abstinence or reduction from some or all food, drink, or both, for a
+ * period of time prior to sample collection.
+ */
+export type SpecimenCollectionFastingStatus = CodeableConcept | Duration;
+
+/**
  * The container holding the specimen.  The recursive nature of
  * containers; i.e. blood in tube in tray in rack is not addressed here.
  */
@@ -357,6 +369,12 @@ export interface SpecimenContainer {
 }
 
 /**
+ * Introduced substance to preserve, maintain or enhance the specimen.
+ * Examples: Formalin, Citrate, EDTA.
+ */
+export type SpecimenContainerAdditive = CodeableConcept | Reference<Substance>;
+
+/**
  * Details concerning processing and processing steps for the specimen.
  */
 export interface SpecimenProcessing {
@@ -425,3 +443,10 @@ export interface SpecimenProcessing {
    */
   timePeriod?: Period;
 }
+
+/**
+ * A record of the time or period when the specimen processing occurred.
+ * For example the time of sample fixation or the period of time the
+ * sample was in formalin.
+ */
+export type SpecimenProcessingTime = Period | string;

--- a/packages/fhirtypes/dist/SpecimenDefinition.d.ts
+++ b/packages/fhirtypes/dist/SpecimenDefinition.d.ts
@@ -303,6 +303,11 @@ export interface SpecimenDefinitionTypeTestedContainer {
 }
 
 /**
+ * The minimum volume to be conditioned in the container.
+ */
+export type SpecimenDefinitionTypeTestedContainerMinimumVolume = Quantity | string;
+
+/**
  * Substance introduced in the kind of container to preserve, maintain or
  * enhance the specimen. Examples: Formalin, Citrate, EDTA.
  */
@@ -355,6 +360,12 @@ export interface SpecimenDefinitionTypeTestedContainerAdditive {
    */
   additiveReference?: Reference<Substance>;
 }
+
+/**
+ * Substance introduced in the kind of container to preserve, maintain or
+ * enhance the specimen. Examples: Formalin, Citrate, EDTA.
+ */
+export type SpecimenDefinitionTypeTestedContainerAdditiveAdditive = CodeableConcept | Reference<Substance>;
 
 /**
  * Set of instructions for preservation/transport of the specimen at a

--- a/packages/fhirtypes/dist/StructureMap.d.ts
+++ b/packages/fhirtypes/dist/StructureMap.d.ts
@@ -854,6 +854,14 @@ export interface StructureMapGroupRuleSource {
 }
 
 /**
+ * A value to use if there is no existing value in the source object.
+ */
+export type StructureMapGroupRuleSourceDefaultValue = Address | Age | Annotation | Attachment | boolean |
+    CodeableConcept | Coding | ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage |
+    Duration | Expression | HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range
+    | Ratio | Reference | RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
+
+/**
  * Content to create because of this mapping rule.
  */
 export interface StructureMapGroupRuleTarget {
@@ -1000,6 +1008,11 @@ export interface StructureMapGroupRuleTargetParameter {
    */
   valueDecimal?: number;
 }
+
+/**
+ * Parameter value - variable or literal.
+ */
+export type StructureMapGroupRuleTargetParameterValue = boolean | number | string;
 
 /**
  * A structure definition used by this map. The structure definition may

--- a/packages/fhirtypes/dist/Substance.d.ts
+++ b/packages/fhirtypes/dist/Substance.d.ts
@@ -190,6 +190,11 @@ export interface SubstanceIngredient {
 }
 
 /**
+ * Another substance that is a component of this substance.
+ */
+export type SubstanceIngredientSubstance = CodeableConcept | Reference<Substance>;
+
+/**
  * Substance may be used to describe a kind of substance, or a specific
  * package/container of the substance: an instance.
  */

--- a/packages/fhirtypes/dist/SubstanceAmount.d.ts
+++ b/packages/fhirtypes/dist/SubstanceAmount.d.ts
@@ -102,6 +102,14 @@ export interface SubstanceAmount {
 }
 
 /**
+ * Used to capture quantitative values for a variety of elements. If only
+ * limits are given, the arithmetic mean would be the average. If only a
+ * single definite value for a given element is given, it would be
+ * captured in this field.
+ */
+export type SubstanceAmountAmount = Quantity | Range | string;
+
+/**
  * Reference range of possible or expected values.
  */
 export interface SubstanceAmountReferenceRange {

--- a/packages/fhirtypes/dist/SubstanceReferenceInformation.d.ts
+++ b/packages/fhirtypes/dist/SubstanceReferenceInformation.d.ts
@@ -384,3 +384,8 @@ export interface SubstanceReferenceInformationTarget {
    */
   source?: Reference<DocumentReference>[];
 }
+
+/**
+ * Todo.
+ */
+export type SubstanceReferenceInformationTargetAmount = Quantity | Range | string;

--- a/packages/fhirtypes/dist/SubstanceSpecification.d.ts
+++ b/packages/fhirtypes/dist/SubstanceSpecification.d.ts
@@ -352,6 +352,11 @@ export interface SubstanceSpecificationMoiety {
 }
 
 /**
+ * Quantitative value for this moiety.
+ */
+export type SubstanceSpecificationMoietyAmount = Quantity | string;
+
+/**
  * Names applicable to this substance.
  */
 export interface SubstanceSpecificationName {
@@ -585,6 +590,17 @@ export interface SubstanceSpecificationProperty {
 }
 
 /**
+ * A substance upon which a defining property depends (e.g. for
+ * solubility: in water, in alcohol).
+ */
+export type SubstanceSpecificationPropertyDefiningSubstance = CodeableConcept | Reference<SubstanceSpecification | Substance>;
+
+/**
+ * Quantitative value for this property.
+ */
+export type SubstanceSpecificationPropertyAmount = Quantity | string;
+
+/**
  * A link between this substance and another, with details of the
  * relationship.
  */
@@ -693,6 +709,19 @@ export interface SubstanceSpecificationRelationship {
    */
   source?: Reference<DocumentReference>[];
 }
+
+/**
+ * A pointer to another substance, as a resource or just a
+ * representational code.
+ */
+export type SubstanceSpecificationRelationshipSubstance = CodeableConcept | Reference<SubstanceSpecification>;
+
+/**
+ * A numeric factor for the relationship, for instance to express that
+ * the salt of a substance has some percentage of the active substance in
+ * relation to some other.
+ */
+export type SubstanceSpecificationRelationshipAmount = Quantity | Range | Ratio | string;
 
 /**
  * Structural information.

--- a/packages/fhirtypes/dist/SupplyDelivery.d.ts
+++ b/packages/fhirtypes/dist/SupplyDelivery.d.ts
@@ -179,6 +179,11 @@ export interface SupplyDelivery {
 }
 
 /**
+ * The date or time(s) the activity occurred.
+ */
+export type SupplyDeliveryOccurrence = Period | string | Timing;
+
+/**
  * The item that is being delivered or has been supplied.
  */
 export interface SupplyDeliverySuppliedItem {
@@ -238,3 +243,10 @@ export interface SupplyDeliverySuppliedItem {
    */
   itemReference?: Reference<Medication | Substance | Device>;
 }
+
+/**
+ * Identifies the medication, substance or device being dispensed. This
+ * is either a link to a resource representing the details of the item or
+ * a code that identifies the item from a known list.
+ */
+export type SupplyDeliverySuppliedItemItem = CodeableConcept | Reference<Medication | Substance | Device>;

--- a/packages/fhirtypes/dist/SupplyRequest.d.ts
+++ b/packages/fhirtypes/dist/SupplyRequest.d.ts
@@ -212,6 +212,18 @@ export interface SupplyRequest {
 }
 
 /**
+ * The item that is requested to be supplied. This is either a link to a
+ * resource representing the details of the item or a code that
+ * identifies the item from a known list.
+ */
+export type SupplyRequestItem = CodeableConcept | Reference<Medication | Substance | Device>;
+
+/**
+ * When the request should be fulfilled.
+ */
+export type SupplyRequestOccurrence = Period | string | Timing;
+
+/**
  * Specific parameters for the ordered item.  For example, the size of
  * the indicated item.
  */
@@ -277,3 +289,8 @@ export interface SupplyRequestParameter {
    */
   valueBoolean?: boolean;
 }
+
+/**
+ * The value of the device detail.
+ */
+export type SupplyRequestParameterValue = boolean | CodeableConcept | Quantity | Range;

--- a/packages/fhirtypes/dist/Task.d.ts
+++ b/packages/fhirtypes/dist/Task.d.ts
@@ -615,6 +615,14 @@ export interface TaskInput {
 }
 
 /**
+ * The value of the input parameter as a basic type.
+ */
+export type TaskInputValue = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding |
+    ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
+
+/**
  * Outputs produced by the Task.
  */
 export interface TaskOutput {
@@ -909,6 +917,14 @@ export interface TaskOutput {
    */
   valueMeta?: Meta;
 }
+
+/**
+ * The value of the Output parameter as a basic type.
+ */
+export type TaskOutputValue = Address | Age | Annotation | Attachment | boolean | CodeableConcept | Coding |
+    ContactDetail | ContactPoint | Contributor | Count | DataRequirement | Distance | Dosage | Duration | Expression |
+    HumanName | Identifier | Meta | Money | number | ParameterDefinition | Period | Quantity | Range | Ratio | Reference |
+    RelatedArtifact | SampledData | Signature | string | Timing | TriggerDefinition | UsageContext;
 
 /**
  * If the Task.focus is a request resource and the task is seeking

--- a/packages/fhirtypes/dist/Timing.d.ts
+++ b/packages/fhirtypes/dist/Timing.d.ts
@@ -210,3 +210,10 @@ export interface TimingRepeat {
    */
   offset?: number;
 }
+
+/**
+ * Either a duration for the length of the timing schedule, a range of
+ * possible length, or outer bounds for start and/or end limits of the
+ * timing schedule.
+ */
+export type TimingRepeatBounds = Duration | Period | Range;

--- a/packages/fhirtypes/dist/TriggerDefinition.d.ts
+++ b/packages/fhirtypes/dist/TriggerDefinition.d.ts
@@ -78,3 +78,8 @@ export interface TriggerDefinition {
    */
   condition?: Expression;
 }
+
+/**
+ * The timing of the event (if this is a periodic trigger).
+ */
+export type TriggerDefinitionTiming = Reference<Schedule> | string | Timing;

--- a/packages/fhirtypes/dist/UsageContext.d.ts
+++ b/packages/fhirtypes/dist/UsageContext.d.ts
@@ -72,3 +72,10 @@ export interface UsageContext {
    */
   valueReference?: Reference<PlanDefinition | ResearchStudy | InsurancePlan | HealthcareService | Group | Location | Organization>;
 }
+
+/**
+ * A value that defines the context specified in this context of use. The
+ * interpretation of the value is defined by the code.
+ */
+export type UsageContextValue = CodeableConcept | Quantity | Range | Reference<PlanDefinition | ResearchStudy |
+    InsurancePlan | HealthcareService | Group | Location | Organization>;

--- a/packages/fhirtypes/dist/UserConfiguration.d.ts
+++ b/packages/fhirtypes/dist/UserConfiguration.d.ts
@@ -184,6 +184,12 @@ export interface UserConfigurationOption {
 }
 
 /**
+ * Value of option - must be one of a constrained set of the data types
+ * (see [Extensibility](extensibility.html) for a list).
+ */
+export type UserConfigurationOptionValue = boolean | number | string;
+
+/**
  * Shortcut links to URLs.
  */
 export interface UserConfigurationSearch {

--- a/packages/fhirtypes/dist/ValueSet.d.ts
+++ b/packages/fhirtypes/dist/ValueSet.d.ts
@@ -828,3 +828,8 @@ export interface ValueSetExpansionParameter {
    */
   valueDateTime?: string;
 }
+
+/**
+ * The value of the parameter.
+ */
+export type ValueSetExpansionParameterValue = boolean | number | string;

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -11,6 +11,7 @@ import {
   getReferenceString,
   isGone,
   isNotFound,
+  isString,
   normalizeOperationOutcome,
   resourceMatchesSubscriptionCriteria,
   satisfiedAccessPolicy,
@@ -529,7 +530,7 @@ function buildRestHookHeaders(subscription: Subscription, resource: Resource): H
   const secret =
     getExtensionValue(subscription, 'https://www.medplum.com/fhir/StructureDefinition/subscription-secret') ||
     getExtensionValue(subscription, 'https://www.medplum.com/fhir/StructureDefinition-subscriptionSecret');
-  if (secret) {
+  if (secret && isString(secret)) {
     const body = stringify(resource);
     headers['X-Signature'] = createHmac('sha256', secret).update(body).digest('hex');
   }


### PR DESCRIPTION
PR is big, but it's mostly autogenerated.

I recommend collapsing `packages/fhirtypes` first, and then scanning them second.

The main relevant parts:

* `packages/generator/src/index.ts` - add TypeScript `type` definitions for all `[x]` choice-of-type properties
* `packages/core/src/utils.ts` - use the new `ExtensionValue` type for the correct return type