### PR TITLE
Update useSearch.ts

### DIFF
--- a/packages/react-hooks/src/useSearch/useSearch.ts
+++ b/packages/react-hooks/src/useSearch/useSearch.ts
@@ -60,7 +60,7 @@ function useSearchImpl<K extends ResourceType, ReturnType>(
 ): [ReturnType | undefined, boolean, OperationOutcome | undefined] {
   const medplum = useMedplum();
   const [searchKey, setSearchKey] = useState<string>();
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [result, setResult] = useState<ReturnType>();
   const [outcome, setOutcome] = useState<OperationOutcome>();
 


### PR DESCRIPTION
The `useSearchImpl` function never sets its `loading` state to true; it is initialized to `false` (likely the bug) and then set to `false` after a successful load or an error response. 

This commit initializes `loading` to `true` so the flag is true before any response is returned.