### PR TITLE
Fix wrong pipe character in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ medplum/
 │   ├── definitions     # Data definitions
 │   ├── docs            # Documentation
 │   ├── examples        # Example code used in documentation
-|   ├── expo-polyfills  # Expo polyfills for MedplumClient compatability
+│   ├── expo-polyfills  # Expo polyfills for MedplumClient compatability
 │   ├── fhir-router     # FHIR URL router
 │   ├── fhirtypes       # FHIR TypeScript definitions
 │   ├── generator       # Code generator utilities


### PR DESCRIPTION
Oops
<img width="831" alt="Screenshot 2024-06-14 at 9 59 38 AM" src="https://github.com/medplum/medplum/assets/1592008/5482b1ae-60cb-4791-af53-8ce99b029daa">
This PR makes sure everything matches again
