### PR TITLE
Gracefully handle no major dep upgrades

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -49,6 +49,12 @@ gh pr ready
 # "latest" - Upgrade to whatever the package's "latest" git tag points to.
 npx npm-check-updates --workspaces --root --upgrade --reject "$EXCLUDE" --target latest
 
+# Check for changes in the working directory
+if git diff --quiet; then
+  echo "No active changes. Exiting the script."
+  exit 0
+fi
+
 # Commit and push before running NPM install
 git add -u .
 git commit -m "Dependency upgrades - step 3"


### PR DESCRIPTION
The most recent dependency upgrade action "failed" because there were no major version upgrades and then `nothing to commit, working tree clean`

This PR gracefully exits the action rather than letting it fail. 