### PR TITLE
fix(react-hooks): make `loading` track `MedplumClient#isLoading()`

### DIFF
--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -2,6 +2,7 @@ import {
   BinarySource,
   ContentType,
   CreateBinaryOptions,
+  IClientStorage,
   LoginState,
   MedplumClient,
   MedplumClientOptions,
@@ -91,6 +92,7 @@ export interface MockClientOptions extends MedplumClientOptions {
    * MedplumContext.profile returning undefined as if no one were logged in.
    */
   readonly profile?: ReturnType<MedplumClient['getProfile']> | null;
+  readonly storage?: IClientStorage;
 }
 
 export class MockClient extends MedplumClient {

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
@@ -23,7 +23,7 @@ export function MedplumProvider(props: MedplumProviderProps): JSX.Element {
 
   const [state, setState] = useState({
     profile: medplum.getProfile(),
-    loading: !medplum.isInitialized,
+    loading: medplum.isLoading(),
   });
 
   useEffect(() => {


### PR DESCRIPTION
This aligns `useMedplumContext().loading` and `MedplumClient#isLoading()` so that it should be less confusing and more useful for users who want to be able use `loading` as a dependency to other hooks