### PR TITLE
fix(build) Update deprecated import assertion into import attribute

### DIFF
--- a/examples/medplum-chart-demo/esbuild-script.mjs
+++ b/examples/medplum-chart-demo/esbuild-script.mjs
@@ -5,7 +5,7 @@
 
 import esbuild from 'esbuild';
 import { glob } from 'glob';
-import botLayer from '@medplum/bot-layer/package.json' assert { type: 'json' };
+import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };
 
 // Find all TypeScript files in your source directory
 const entryPoints = glob.sync('./src/**/*.ts').filter((file) => !file.endsWith('test.ts'));

--- a/examples/medplum-demo-bots/esbuild-script.mjs
+++ b/examples/medplum-demo-bots/esbuild-script.mjs
@@ -5,7 +5,7 @@
 
 import esbuild from 'esbuild';
 import { glob } from 'glob';
-import botLayer from '@medplum/bot-layer/package.json' assert { type: 'json' };
+import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };
 
 // Find all TypeScript files in your source directory
 const entryPoints = glob.sync('./src/**/*.ts').filter((file) => !file.endsWith('test.ts'));

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -4,7 +4,7 @@ import { execSync } from 'child_process';
 import { copyFileSync, existsSync } from 'fs';
 import path from 'path';
 import { defineConfig } from 'vite';
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 if (!existsSync('.env')) {
   copyFileSync('.env.defaults', '.env');

--- a/packages/core/esbuild.mjs
+++ b/packages/core/esbuild.mjs
@@ -4,7 +4,7 @@
 import { execSync } from 'child_process';
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 let gitHash;
 try {


### PR DESCRIPTION
It looks like "assert" was deprecated. 
![image](https://github.com/medplum/medplum/assets/6597168/73443a66-46f6-487d-91fa-0bb63809ea90)
https://nodejs.org/docs/latest-v20.x/api/esm.html#json-modules

I'm not sure if this is a problem for others but building fails for me because of assert:
![image](https://github.com/medplum/medplum/assets/6597168/e8aa6292-0648-4f76-b1a1-d53de693829a)

Found 4 occurrences. 
![image](https://github.com/medplum/medplum/assets/6597168/1d7e599f-8bfd-4b3d-bd0a-aa65d86f2975)
