### PR TITLE
Implements FHIRPath string join (stu)

### DIFF
--- a/packages/core/src/fhirpath/atoms.ts
+++ b/packages/core/src/fhirpath/atoms.ts
@@ -32,7 +32,7 @@ export class FhirPathAtom implements Atom {
         return this.child.eval(context, []);
       }
     } catch (error) {
-      throw new Error(`FhirPathError on "${this.original}": ${error}`);
+      throw new Error(`FhirPathError on "${this.original}": ${error}`, { cause: error });
     }
   }
 

--- a/packages/core/src/fhirpath/functions.test.ts
+++ b/packages/core/src/fhirpath/functions.test.ts
@@ -571,6 +571,26 @@ describe('FHIRPath functions', () => {
     expect(functions.toChars(context, [toTypedValue('xyz')])).toEqual([TYPED_X, TYPED_Y, TYPED_Z]);
   });
 
+  // Additional string functions
+  // STU Note: the contents of this section are Standard for Trial Use (STU)
+
+  test('join', () => {
+    expect(functions.join(context, [toTypedValue('')])).toEqual([toTypedValue('')]);
+    expect(functions.join(context, [toTypedValue('a'), toTypedValue('b'), toTypedValue('c')])).toEqual([
+      toTypedValue('abc'),
+    ]);
+    expect(
+      functions.join(
+        context,
+        [toTypedValue('a'), toTypedValue('b'), toTypedValue('c')],
+        new LiteralAtom(toTypedValue(','))
+      )
+    ).toEqual([toTypedValue('a,b,c')]);
+    expect(() => functions.join(context, [toTypedValue('')], new LiteralAtom(toTypedValue(1)))).toThrow(
+      'Separator must be a string'
+    );
+  });
+
   // 5.7. Math
 
   test('abs', () => {

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1355,7 +1355,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns The joined string.
    */
   join: (context: AtomContext, input: TypedValue[], separatorAtom: Atom): TypedValue[] => {
-    const separator = separatorAtom?.eval(context, input)[0]?.value ?? '';
+    const separator = separatorAtom?.eval(context, getRootInput(context))[0]?.value ?? '';
     if (typeof separator !== 'string') {
       throw new Error('Separator must be a string.');
     }

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1328,6 +1328,41 @@ export const functions: Record<string, FhirPathFunction> = {
   },
 
   /*
+   * Additional string functions
+   * See: https://build.fhir.org/ig/HL7/FHIRPath/#additional-string-functions
+   * STU Note: the contents of this section are Standard for Trial Use (STU)
+   */
+
+  encode: stub,
+  decode: stub,
+  escape: stub,
+  unescape: stub,
+  trim: stub,
+  split: stub,
+
+  /**
+   * The join function takes a collection of strings and joins them into a single string, optionally using the given separator.
+   *
+   * If the input is empty, the result is empty.
+   *
+   * If no separator is specified, the strings are directly concatenated.
+   *
+   * See: https://build.fhir.org/ig/HL7/FHIRPath/#joinseparator-string--string
+   *
+   * @param context - The evaluation context.
+   * @param input - The input collection.
+   * @param separatorAtom - Optional separator atom.
+   * @returns The joined string.
+   */
+  join: (context: AtomContext, input: TypedValue[], separatorAtom: Atom): TypedValue[] => {
+    const separator = separatorAtom?.eval(context, input)[0]?.value ?? '';
+    if (typeof separator !== 'string') {
+      throw new Error('Separator must be a string.');
+    }
+    return [{ type: PropertyType.string, value: input.map((i) => i.value?.toString() ?? '').join(separator) }];
+  },
+
+  /*
    * 5.7. Math
    */
 


### PR DESCRIPTION
Note that `join` is not in the published version: https://hl7.org/fhirpath/

It is in the current STU version: https://build.fhir.org/ig/HL7/FHIRPath/#joinseparator-string--string

For better or worse, it is referenced by the SQL-on-FHIR test suite