### PR TITLE
Validate certain references with systemRepo

### DIFF
--- a/packages/server/src/fhir/references.test.ts
+++ b/packages/server/src/fhir/references.test.ts
@@ -142,6 +142,9 @@ describe('Reference checks', () => {
 
       const repo = await getRepoForLogin({ resourceType: 'Login' } as Login, membership, project1, true);
       let project = await repo.readResource<Project>('Project', project1.id as string);
+
+      // Checking the name change is ancillary; mostly confirming that the update
+      // doesn't throw due to reference validation failure
       expect(project.name).not.toEqual('new name');
       project.name = 'new name';
       project = await repo.updateResource(project);


### PR DESCRIPTION
With `Project.checkReferencesOnWrite` is true, when a project admin attempts to update their project resource in any way, e.g. specify secrets, the update would fail due to `Project.owner` and `Project.link.project` (assuming the project has linked projects) failing reference validation. Arguably, these references shouldn't be validated at all since the user (i.e. a project admin) has no ability to fix the references to begin with. This is the less extreme option of falling back to use the system repo rather than the project repo when validating the references.