### PR TITLE
fix(ci): update node to 20 for agent build, move linux -> `node:sea`

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: '18'
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: ${{ secrets.TURBO_REMOTE_ONLY }}
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: '18'
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: ${{ secrets.TURBO_REMOTE_ONLY }}
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -81,9 +81,10 @@ jobs:
                 }
                 
                 console.log(fileName);
+                return fileName;
             }
 
-            await getSigntoolLocation();
+            return await getSigntoolLocation();
 
       - name: Build Agent installer
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -84,7 +84,8 @@ jobs:
                 return fileName;
             }
 
-            return await getSigntoolLocation().replace(' ', '\ ');
+            const path = await getSigntoolLocation();
+            return path.replace(' ', '\ ');
 
       - name: Build Agent installer
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -40,11 +40,58 @@ jobs:
       - name: Build
         run: npm run build -- --filter=@medplum/agent
 
+      - name: Find signtool
+        uses: actions/github-script@v6
+        id: find-signtool
+        with:
+          result-encoding: string
+          script: |
+            /**
+            * Searches the installed Windows SDKs for the most recent signtool.exe version
+            * Taken from https://github.com/dlemstra/code-sign-action
+            * @returns Path to most recent signtool.exe (x86 version)
+            */
+            async function getSigntoolLocation() {
+                const windowsKitsFolder = 'C:/Program Files (x86)/Windows Kits/10/bin/';
+                const folders = await fs.readdir(windowsKitsFolder);
+                let fileName = '';
+                let maxVersion = 0;
+                for (const folder of folders) {
+                    if (!folder.endsWith('.0')) {
+                        continue;
+                    }
+                    const folderVersion = parseInt(folder.replace(/\./g,''));
+                    if (folderVersion > maxVersion) {
+                        const signtoolFilename = `${windowsKitsFolder}${folder}/x64/signtool.exe`;
+                        try {
+                            const stat = await fs.stat(signtoolFilename);
+                            if (stat.isFile()) {
+                                fileName = signtoolFilename;
+                                maxVersion = folderVersion;
+                            }
+                        } catch {
+                            console.warn('Skipping %s due to error.', signtoolFilename);
+                        }
+                    }
+                }
+                if(fileName == '') {
+                    throw new Error('Unable to find signtool.exe in ' + windowsKitsFolder);
+                }
+                
+                console.log(fileName);
+            }
+
+            getSigntoolLocation().catch((err) => {
+              console.error(err);
+              process.exit(1);
+            });
+
       - name: Build Agent installer
         shell: bash
         run: ./scripts/build-agent-installer-win64.sh
         env:
           SKIP_SIGNING: 1
+          SIGNTOOL_PATH: ${{steps.find-signtool.outputs.result}}
 
       - name: Set Medplum version
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -85,7 +85,7 @@ jobs:
             }
 
             const path = await getSigntoolLocation();
-            return path.replace('/', '\\')
+            return path.replace('C:/', '/mnt/c/').replace(' ', '\ ');
 
       - name: Build Agent installer
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -85,14 +85,14 @@ jobs:
             }
 
             const path = await getSigntoolLocation();
-            return path.replace('C:/', '/mnt/c/').replace(' ', '\ ');
+            return path.replace(' ', '\ ');
 
       - name: Build Agent installer
         shell: bash
         run: ./scripts/build-agent-installer-win64.sh
         env:
-          SKIP_SIGNING: 1
           SIGNTOOL_PATH: ${{steps.find-signtool.outputs.result}}
+          SKIP_SIGNING: 1
 
       - name: Set Medplum version
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           result-encoding: string
           script: |
+            const fs = require('node:fs');
+
             /**
             * Searches the installed Windows SDKs for the most recent signtool.exe version
             * Taken from https://github.com/dlemstra/code-sign-action
@@ -81,10 +83,7 @@ jobs:
                 console.log(fileName);
             }
 
-            getSigntoolLocation().catch((err) => {
-              console.error(err);
-              process.exit(1);
-            });
+            await getSigntoolLocation();
 
       - name: Build Agent installer
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -85,7 +85,7 @@ jobs:
             }
 
             const path = await getSigntoolLocation();
-            return path.replace(' ', '\ ');
+            return path.replace('/', '\\')
 
       - name: Build Agent installer
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -84,7 +84,7 @@ jobs:
                 return fileName;
             }
 
-            return await getSigntoolLocation();
+            return await getSigntoolLocation().replace(' ', '\ ');
 
       - name: Build Agent installer
         shell: bash

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const fs = require('node:fs');
+            const fs = require('node:fs/promises');
 
             /**
             * Searches the installed Windows SDKs for the most recent signtool.exe version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: '18'
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: ${{ secrets.TURBO_REMOTE_ONLY }}
@@ -122,7 +122,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: '18'
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: ${{ secrets.TURBO_REMOTE_ONLY }}
@@ -186,7 +186,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,10 +131,58 @@ jobs:
       - name: Build
         run: npm run build -- --filter=@medplum/agent
 
+      - name: Find signtool
+        uses: actions/github-script@v6
+        id: find-signtool
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('node:fs/promises');
+
+            /**
+            * Searches the installed Windows SDKs for the most recent signtool.exe version
+            * Taken from https://github.com/dlemstra/code-sign-action
+            * @returns Path to most recent signtool.exe (x86 version)
+            */
+            async function getSigntoolLocation() {
+                const windowsKitsFolder = 'C:/Program Files (x86)/Windows Kits/10/bin/';
+                const folders = await fs.readdir(windowsKitsFolder);
+                let fileName = '';
+                let maxVersion = 0;
+                for (const folder of folders) {
+                    if (!folder.endsWith('.0')) {
+                        continue;
+                    }
+                    const folderVersion = parseInt(folder.replace(/\./g,''));
+                    if (folderVersion > maxVersion) {
+                        const signtoolFilename = `${windowsKitsFolder}${folder}/x64/signtool.exe`;
+                        try {
+                            const stat = await fs.stat(signtoolFilename);
+                            if (stat.isFile()) {
+                                fileName = signtoolFilename;
+                                maxVersion = folderVersion;
+                            }
+                        } catch {
+                            console.warn('Skipping %s due to error.', signtoolFilename);
+                        }
+                    }
+                }
+                if(fileName == '') {
+                    throw new Error('Unable to find signtool.exe in ' + windowsKitsFolder);
+                }
+                
+                console.log(fileName);
+                return fileName;
+            }
+
+            const path = await getSigntoolLocation();
+            return path.replace(' ', '\ ');
+
       - name: Build Agent installer
         shell: bash
         run: ./scripts/build-agent-installer-win64.sh
         env:
+          SIGNTOOL_PATH: ${{steps.find-signtool.outputs.result}}
           SM_HOST: ${{ secrets.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
           SM_CLIENT_CERT_FILE_BASE64: ${{ secrets.SM_CLIENT_CERT_FILE_BASE64 }}

--- a/scripts/build-agent-installer-linux.sh
+++ b/scripts/build-agent-installer-linux.sh
@@ -14,8 +14,12 @@ pushd packages/agent
 # Build the agent
 npm run build
 
+pushd ../..
+
 # Build the executable
-npx pkg ./dist/cjs/index.cjs --targets node18-linux --output "medplum-agent-$MEDPLUM_VERSION-linux" --options no-warnings
+./scripts/build-agent-sea-linux.sh
+
+popd
 
 # Generate the installer checksum
 sha256sum "medplum-agent-$MEDPLUM_VERSION-linux" > "medplum-agent-$MEDPLUM_VERSION-linux.sha256"

--- a/scripts/build-agent-sea-linux.sh
+++ b/scripts/build-agent-sea-linux.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Fail on error
+set -e
+
+# Get the current version number
+export MEDPLUM_VERSION=$(node -p "require('./package.json').version")
+
+# Move into packages/agent
+pushd packages/agent
+
+# Build the agent
+npm run build
+
+# Check Node version
+# If not the expected default version, then warn
+node_version=$(node -v)
+major_version=$(echo "$node_version" | cut -d '.' -f 1)
+if [ "$major_version" != "v20" ]; then
+  echo "WARNING: Expected to be on v20.x.x but on $node_version"
+fi
+
+# Generate blob to inject into node executable
+node --experimental-sea-config sea-config.json
+
+# Copy the local node binary
+cp $(command -v node) medplum-agent-$MEDPLUM_VERSION-linux
+
+# Inject blob into binary
+npx postject medplum-agent-$MEDPLUM_VERSION-linux NODE_SEA_BLOB sea-prep.blob \
+    --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+
+popd

--- a/scripts/build-agent-sea-win64.sh
+++ b/scripts/build-agent-sea-win64.sh
@@ -28,11 +28,11 @@ node -e "require('fs').copyFileSync(process.execPath, 'dist/medplum-agent-$MEDPL
 # Remove signature from binary
 
 # If no defined signtool path, try to find it in PATH
-if [[ -z "${SIGNTOOL_PATH}" ]]; then
+if [[ -z "$SIGNTOOL_PATH" ]]; then
   signtool remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
 else 
   # Otherwise use the defined path from the env var
-  $SIGNTOOL_PATH remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
+  "$SIGNTOOL_PATH" remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
 fi
 
 # NOTE: If the above step fails, you likely need to install Windows 10 SDK

--- a/scripts/build-agent-sea-win64.sh
+++ b/scripts/build-agent-sea-win64.sh
@@ -27,13 +27,17 @@ node -e "require('fs').copyFileSync(process.execPath, 'dist/medplum-agent-$MEDPL
 
 # Remove signature from binary
 
+echo "Removing signature from Node binary..."
 # If no defined signtool path, try to find it in PATH
 if [[ -z "$SIGNTOOL_PATH" ]]; then
+  echo "Using signtool from PATH"
   signtool remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
-else 
+else
+  echo "Using signtool located at $SIGNTOOL_PATH"
   # Otherwise use the defined path from the env var
   "$SIGNTOOL_PATH" remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
 fi
+echo "Signature successfully removed."
 
 # NOTE: If the above step fails, you likely need to install Windows 10 SDK
 #

--- a/scripts/build-agent-sea-win64.sh
+++ b/scripts/build-agent-sea-win64.sh
@@ -26,7 +26,14 @@ node --experimental-sea-config sea-config.json
 node -e "require('fs').copyFileSync(process.execPath, 'dist/medplum-agent-$MEDPLUM_VERSION-win64.exe')" 
 
 # Remove signature from binary
-signtool remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
+
+# If no defined signtool path, try to find it in PATH
+if [[ -z "${SIGNTOOL_PATH}" ]]; then
+  signtool remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
+else 
+  # Otherwise use the defined path from the env var
+  $SIGNTOOL_PATH remove -s dist/medplum-agent-$MEDPLUM_VERSION-win64.exe
+fi
 
 # NOTE: If the above step fails, you likely need to install Windows 10 SDK
 #


### PR DESCRIPTION
Fixes agent build failing in CI since SEA was not available until v20

Also fixes Linux build since it wasn't properly ported to `node:sea` in #4613