### PR TITLE
Fix typo in ValueSet expand docs

### DIFF
--- a/packages/docs/docs/api/fhir/operations/valueset-expand.mdx
+++ b/packages/docs/docs/api/fhir/operations/valueset-expand.mdx
@@ -97,7 +97,7 @@ curl 'https://api.medplum.com/fhir/R4/ValueSet/$expand?url=http%3A%2F%2Fhl7.org%
 }
 ```
 
-The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a `validateResource` convenience method:
+The [MedplumClient](/docs/sdk/core.medplumclient) TypeScript class provides a `searchValueSet` convenience method:
 
 <MedplumCodeBlock language="ts" selectBlocks="expand" showLineNumbers>
   {ExampleCode}


### PR DESCRIPTION
The's a typo in the ["ValueSet $expand Operation" documentation](https://www.medplum.com/docs/api/fhir/operations/valueset-expand) where `validateResource` is listed instead of `searchValueSet`.

**Current page:**

<img width="600" alt="image" src="https://github.com/medplum/medplum/assets/712727/d1c20595-91a2-434a-aa7e-613c52d1f018">

This PR fixes this.