### PR TITLE
Fix recursive filter application in ValueSet expand

### DIFF
--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -724,6 +724,22 @@ describe('Updated implementation', () => {
     expect(abstractCode).toBeDefined();
   });
 
+  test('Recursive subsumption with filter', async () => {
+    const res = await request(app)
+      .get(
+        `/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype')}&filter=adopt&count=200`
+      )
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res.status).toEqual(200);
+    const expansion = res.body.expansion as ValueSetExpansion;
+
+    const expandedCodes = expansion.contains?.map((coding) => coding.code);
+    expect(expandedCodes).toHaveLength(6);
+    expect(expandedCodes).toEqual(
+      expect.arrayContaining(['ADOPTP', 'ADOPTF', 'ADOPTM', 'CHLDADOPT', 'DAUADOPT', 'SONADOPT'])
+    );
+  });
+
   test('Filter out abstract codes', async () => {
     const res = await request(app)
       .get(

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -289,9 +289,7 @@ async function includeInExpansion(
     .where('system', '=', codeSystem.id)
     .limit((count ?? MAX_EXPANSION_SIZE) + 1)
     .offset(offset ?? 0);
-  if (filter) {
-    query.where('display', '!=', null).where('display', 'TSVECTOR_ENGLISH', filterToTsvectorQuery(filter));
-  }
+
   if (include.filter?.length) {
     for (const condition of include.filter) {
       switch (condition.op) {
@@ -309,6 +307,9 @@ async function includeInExpansion(
           return; // Unknown filter type, don't make DB query with incorrect filters
       }
     }
+  }
+  if (filter) {
+    query.where('display', '!=', null).where('display', 'TSVECTOR_ENGLISH', filterToTsvectorQuery(filter));
   }
 
   if (params.excludeNotForUI) {


### PR DESCRIPTION
The logic for the `ValueSet/$expand` operation was applying the text filter at each level of recursion when expanding out a hierarchy; instead, the filter should only be applied at the end