### PR TITLE
Fixes #3892 - "On Behalf Of" header

### DIFF
--- a/packages/core/src/base-schema.json
+++ b/packages/core/src/base-schema.json
@@ -2180,6 +2180,13 @@
           }
         ]
       },
+      "onBehalfOf": {
+        "type": [
+          {
+            "code": "Reference"
+          }
+        ]
+      },
       "account": {
         "type": [
           {

--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -1,7 +1,7 @@
 import { Bundle, BundleEntry, DiagnosticReport, Patient, Resource, Specimen } from '@medplum/fhirtypes';
 import { convertContainedResourcesToBundle, convertToTransactionBundle } from './bundle';
-import { deepClone, isUUID } from './utils';
 import { getDataType } from './typeschema/types';
+import { deepClone, isUUID } from './utils';
 
 let jsonFile: any;
 
@@ -225,6 +225,10 @@ describe('Bundle tests', () => {
             display: 'Organization #3',
           },
           author: {
+            reference: 'Practitioner/22222222-2222-2222-2222-222222222222',
+            display: 'Doctor',
+          },
+          onBehalfOf: {
             reference: 'Practitioner/22222222-2222-2222-2222-222222222222',
             display: 'Doctor',
           },

--- a/packages/definitions/dist/fhir/r4/profiles-types.json
+++ b/packages/definitions/dist/fhir/r4/profiles-types.json
@@ -21953,11 +21953,26 @@
           "path" : "Meta.author",
           "short" : "The individual, device or organization who initiated the last change.",
           "definition" : "The individual, device or organization who initiated the last change.",
-          "comment" : "The individual, device or organization who initiated the last change.",
           "min" : 0,
           "max" : "1",
           "base" : {
             "path" : "Meta.author",
+            "min" : 0,
+            "max" : "1"
+          },
+          "type" : [{
+            "code" : "Reference"
+          }]
+        },
+        {
+          "id" : "Meta.onBehalfOf",
+          "path" : "Meta.onBehalfOf",
+          "short" : "Optional individual, device, or organization for whom the change was made.",
+          "definition" : "Optional individual, device, or organization for whom the change was made.",
+          "min" : 0,
+          "max" : "1",
+          "base" : {
+            "path" : "Meta.onBehalfOf",
             "min" : 0,
             "max" : "1"
           },

--- a/packages/fhirtypes/dist/Meta.d.ts
+++ b/packages/fhirtypes/dist/Meta.d.ts
@@ -84,6 +84,11 @@ export interface Meta {
   author?: Reference;
 
   /**
+   * The individual, device, or organization for whom the change was made.
+   */
+  onBehalfOf?: Reference;
+
+  /**
    * Optional account reference that can be used for sub-project
    * compartments.
    */

--- a/packages/server/src/agent/websockets.ts
+++ b/packages/server/src/agent/websockets.ts
@@ -129,8 +129,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
       return;
     }
 
-    const { login, project, membership } = authState;
-    const repo = await getRepoForLogin(login, membership, project, true);
+    const repo = await getRepoForLogin(authState, true);
     const agent = await repo.readResource<Agent>('Agent', agentId);
 
     // Connect to Redis
@@ -183,8 +182,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
       return;
     }
 
-    const { login, project, membership } = authState;
-    const repo = await getRepoForLogin(login, membership, project, true);
+    const repo = await getRepoForLogin(authState, true);
     const agent = await repo.readResource<Agent>('Agent', agentId);
     const channel = agent?.channel?.find((c) => c.name === command.channel);
     if (!channel) {
@@ -204,7 +202,7 @@ export async function handleAgentConnection(socket: ws.WebSocket, request: Incom
     const result = await executeBot({
       agent,
       bot,
-      runAs: membership,
+      runAs: authState.membership,
       contentType: command.contentType,
       input,
       remoteAddress,

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -23,11 +23,12 @@ interface UserSecurity {
 
 export async function meHandler(req: Request, res: Response): Promise<void> {
   const systemRepo = getSystemRepo();
-
-  const { login, project, membership, profile: profileRef } = getAuthenticatedContext();
+  const { authState } = getAuthenticatedContext();
+  const { project, membership } = authState;
+  const profileRef = membership.profile as Reference<ProfileResource>;
   const profile = await systemRepo.readReference<ProfileResource>(profileRef);
   const config = await getUserConfiguration(systemRepo, project, membership);
-  const accessPolicy = await getAccessPolicyForLogin(project, login, membership);
+  const accessPolicy = await getAccessPolicyForLogin(authState);
 
   let security: UserSecurity | undefined = undefined;
   if (membership.user?.reference?.startsWith('User/')) {

--- a/packages/server/src/cloud/aws/deploy.test.ts
+++ b/packages/server/src/cloud/aws/deploy.test.ts
@@ -1,5 +1,6 @@
 import {
   CreateFunctionCommand,
+  CreateFunctionRequest,
   GetFunctionCommand,
   GetFunctionConfigurationCommand,
   LambdaClient,
@@ -139,7 +140,7 @@ describe('Deploy', () => {
     });
     expect(mockLambdaClient).toHaveReceivedCommandWith(CreateFunctionCommand, {
       FunctionName: name,
-    });
+    } as CreateFunctionRequest);
     mockLambdaClient.resetHistory();
 
     // Step 3: Deploy again to trigger the update path
@@ -215,7 +216,7 @@ describe('Deploy', () => {
     });
     expect(mockLambdaClient).toHaveReceivedCommandWith(CreateFunctionCommand, {
       FunctionName: name,
-    });
+    } as CreateFunctionRequest);
     mockLambdaClient.resetHistory();
 
     // Step 3: Simulate releasing a new version of the lambda layer

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -6,7 +6,7 @@ import { NextFunction, Request, Response } from 'express';
 import { getConfig } from './config';
 import { getRepoForLogin } from './fhir/accesspolicy';
 import { Repository, getSystemRepo } from './fhir/repo';
-import { authenticateTokenImpl, isExtendedMode } from './oauth/middleware';
+import { AuthState, authenticateTokenImpl, isExtendedMode } from './oauth/middleware';
 import { parseTraceparent } from './traceparent';
 
 export class RequestContext {
@@ -32,29 +32,28 @@ export class RequestContext {
 const systemLogger = new Logger(write, undefined, LogLevel.ERROR);
 
 export class AuthenticatedRequestContext extends RequestContext {
-  readonly repo: Repository;
-  readonly project: Project;
-  readonly membership: ProjectMembership;
-  readonly login: Login;
-  readonly profile: Reference<ProfileResource>;
-  readonly accessToken?: string;
-
   constructor(
     ctx: RequestContext,
-    login: Login,
-    project: Project,
-    membership: ProjectMembership,
-    repo: Repository,
-    accessToken?: string
+    readonly authState: Readonly<AuthState>,
+    readonly repo: Repository
   ) {
     super(ctx.requestId, ctx.traceId, ctx.logger);
+  }
 
-    this.repo = repo;
-    this.project = project;
-    this.membership = membership;
-    this.login = login;
-    this.profile = membership.profile as Reference<ProfileResource>;
-    this.accessToken = accessToken;
+  get project(): Project {
+    return this.authState.project;
+  }
+
+  get membership(): ProjectMembership {
+    return this.authState.membership;
+  }
+
+  get login(): Login {
+    return this.authState.login;
+  }
+
+  get profile(): Reference<ProfileResource> {
+    return this.authState.membership.profile as Reference<ProfileResource>;
   }
 
   close(): void {
@@ -64,9 +63,7 @@ export class AuthenticatedRequestContext extends RequestContext {
   static system(ctx?: { requestId?: string; traceId?: string }): AuthenticatedRequestContext {
     return new AuthenticatedRequestContext(
       new RequestContext(ctx?.requestId ?? '', ctx?.traceId ?? '', systemLogger),
-      {} as unknown as Login,
-      {} as unknown as Project,
-      {} as unknown as ProjectMembership,
+      {} as unknown as AuthState,
       getSystemRepo()
     );
   }
@@ -95,18 +92,21 @@ export function getAuthenticatedContext(): AuthenticatedRequestContext {
 }
 
 export async function attachRequestContext(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const { requestId, traceId } = requestIds(req);
+  try {
+    const { requestId, traceId } = requestIds(req);
 
-  let ctx = new RequestContext(requestId, traceId);
+    let ctx = new RequestContext(requestId, traceId);
 
-  const authState = await authenticateTokenImpl(req);
-  if (authState) {
-    const { login, membership, project, accessToken } = authState;
-    const repo = await getRepoForLogin(login, membership, project, isExtendedMode(req));
-    ctx = new AuthenticatedRequestContext(ctx, login, project, membership, repo, accessToken);
+    const authState = await authenticateTokenImpl(req);
+    if (authState) {
+      const repo = await getRepoForLogin(authState, isExtendedMode(req));
+      ctx = new AuthenticatedRequestContext(ctx, authState, repo);
+    }
+
+    requestContextStore.run(ctx, () => next());
+  } catch (err) {
+    next(err);
   }
-
-  requestContextStore.run(ctx, () => next());
 }
 
 export function closeRequestContext(): void {

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -697,14 +697,14 @@ describe('AccessPolicy', () => {
 
       // Create a repo for the ClientApplication
       // Use getRepoForLogin to generate the synthetic access policy
-      const clientRepo = await getRepoForLogin(
-        {
+      const clientRepo = await getRepoForLogin({
+        login: {
           resourceType: 'Login',
           user: createReference(clientApplication),
           authMethod: 'client',
           authTime: new Date().toISOString(),
         },
-        {
+        membership: {
           resourceType: 'ProjectMembership',
           project: {
             reference: 'Project/' + testProject.id,
@@ -713,8 +713,8 @@ describe('AccessPolicy', () => {
           accessPolicy: createReference(accessPolicy),
           user: createReference(clientApplication),
         },
-        testProject
-      );
+        project: testProject,
+      });
 
       // Create a Patient using the ClientApplication
       const patient = await clientRepo.createResource<Patient>({
@@ -802,14 +802,14 @@ describe('AccessPolicy', () => {
       expect(clientApplication).toBeDefined();
 
       // Create a repo for the ClientApplication
-      const clientRepo = await getRepoForLogin(
-        {
+      const clientRepo = await getRepoForLogin({
+        login: {
           resourceType: 'Login',
           user: createReference(clientApplication),
           authMethod: 'client',
           authTime: new Date().toISOString(),
         },
-        {
+        membership: {
           resourceType: 'ProjectMembership',
           project: {
             reference: 'Project/' + testProject.id,
@@ -818,8 +818,8 @@ describe('AccessPolicy', () => {
           accessPolicy: createReference(accessPolicy),
           user: createReference(clientApplication),
         },
-        testProject
-      );
+        project: testProject,
+      });
 
       // Create a Patient using the ClientApplication
       const patient = await clientRepo.createResource<Patient>({
@@ -1676,7 +1676,11 @@ describe('AccessPolicy', () => {
         ],
       });
 
-      const repo2 = await getRepoForLogin({ resourceType: 'Login' } as Login, membership, testProject);
+      const repo2 = await getRepoForLogin({
+        login: { resourceType: 'Login' } as Login,
+        membership,
+        project: testProject,
+      });
 
       const check1 = await repo2.readResource<Patient>('Patient', p1.id as string);
       expect(check1.id).toBe(p1.id);
@@ -1728,7 +1732,11 @@ describe('AccessPolicy', () => {
         ],
       });
 
-      const repo2 = await getRepoForLogin({ resourceType: 'Login' } as Login, membership, testProject);
+      const repo2 = await getRepoForLogin({
+        login: { resourceType: 'Login' } as Login,
+        membership,
+        project: testProject,
+      });
 
       const check1 = await repo2.readResource<Task>('Task', t1.id as string);
       expect(check1.id).toBe(t1.id);
@@ -1790,7 +1798,7 @@ describe('AccessPolicy', () => {
         sendEmail: false,
       });
 
-      const repo2 = await getRepoForLogin({ resourceType: 'Login' } as Login, membership, project, true);
+      const repo2 = await getRepoForLogin({ login: { resourceType: 'Login' } as Login, membership, project });
 
       const check1 = await repo2.readResource<Patient>('Patient', patient.id as string);
       expect(check1.id).toBe(patient.id);
@@ -1834,7 +1842,7 @@ describe('AccessPolicy', () => {
         admin: true,
       });
 
-      const repo2 = await getRepoForLogin({ resourceType: 'Login' } as Login, membership, project, true);
+      const repo2 = await getRepoForLogin({ login: { resourceType: 'Login' } as Login, membership, project }, true);
 
       const check1 = await repo2.readResource<Project>('Project', project.id as string);
       expect(check1.id).toEqual(project.id);
@@ -1916,8 +1924,14 @@ describe('AccessPolicy', () => {
         admin: false,
       });
 
-      const adminRepo = await getRepoForLogin({ resourceType: 'Login' } as Login, adminMembership, project, true);
-      const nonAdminRepo = await getRepoForLogin({ resourceType: 'Login' } as Login, nonAdminMembership, project, true);
+      const adminRepo = await getRepoForLogin(
+        { login: { resourceType: 'Login' } as Login, membership: adminMembership, project },
+        true
+      );
+      const nonAdminRepo = await getRepoForLogin(
+        { login: { resourceType: 'Login' } as Login, membership: nonAdminMembership, project },
+        true
+      );
       const account1 = randomUUID();
       const account2 = randomUUID();
 
@@ -2114,7 +2128,7 @@ describe('AccessPolicy', () => {
       });
 
       // Get a repo for the user
-      const repo = await getRepoForLogin(login, updatedMembership, project, true);
+      const repo = await getRepoForLogin({ login, membership: updatedMembership, project }, true);
 
       // Try to search for StructureDefinitions, should succeed
       const bundle1 = await repo.search<StructureDefinition>({ resourceType: 'StructureDefinition' });
@@ -2224,7 +2238,7 @@ describe('AccessPolicy', () => {
         password: randomUUID(),
       });
       expect(project.link).toBeUndefined();
-      const repo = await getRepoForLogin(login, membership, project, true);
+      const repo = await getRepoForLogin({ login, membership, project }, true);
 
       project.link = [{ project: { reference: 'Project/foo' } }, { project: { reference: 'Project/bar' } }];
 
@@ -2276,7 +2290,7 @@ describe('AccessPolicy', () => {
       });
 
       // Repo for project admin
-      const projAdminRepo = await getRepoForLogin(login, membership, project, true);
+      const projAdminRepo = await getRepoForLogin({ login, membership, project }, true);
 
       // Repos for the test user
 

--- a/packages/server/src/fhir/onbehalfof.test.ts
+++ b/packages/server/src/fhir/onbehalfof.test.ts
@@ -1,0 +1,191 @@
+import { ContentType, getReferenceString, unauthorized } from '@medplum/core';
+import { randomUUID } from 'crypto';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config';
+import { addTestUser, createTestProject, withTestContext } from '../test.setup';
+
+describe('On Behalf Of', () => {
+  const app = express();
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Set meta onBehalfOf', () =>
+    withTestContext(async () => {
+      // Create a single project and single admin client
+      const adminAccount = await createTestProject({
+        withClient: true,
+        withAccessToken: true,
+        membership: { admin: true },
+      });
+
+      const { client, project } = adminAccount;
+
+      // Setup basic auth for the admin client
+      // This client will be the "primary" user for all HTTP requests
+      const basicAuth = 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64');
+
+      // Create two test accounts
+      // These represent 2 "normal" users
+      // They will be the "onBehalfOf" users for all HTTP requests
+
+      const org1 = 'Organization/' + randomUUID();
+      const testAccount1 = await addTestUser(project, {
+        resourceType: 'AccessPolicy',
+        compartment: { reference: org1 },
+        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org1 }],
+      });
+
+      const org2 = 'Organization/' + randomUUID();
+      const testAccount2 = await addTestUser(project, {
+        resourceType: 'AccessPolicy',
+        compartment: { reference: org2 },
+        resource: [{ resourceType: 'Patient', criteria: 'Patient?_compartment=' + org2 }],
+      });
+
+      // Create a patient on behalf of test account 1
+      const res1 = await request(app)
+        .post(`/fhir/R4/Patient`)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile))
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({ resourceType: 'Patient' });
+      expect(res1.status).toBe(201);
+      expect(res1.body.resourceType).toEqual('Patient');
+      expect(res1.headers.location).toContain('Patient');
+      expect(res1.headers.location).toContain(res1.body.id);
+
+      const patient1 = res1.body;
+      expect(patient1.resourceType).toBe('Patient');
+      expect(patient1.meta.author.reference).toEqual(getReferenceString(adminAccount.client));
+      expect(patient1.meta.onBehalfOf.reference).toEqual(getReferenceString(testAccount1.profile));
+
+      // Read the patient on behalf of test account 1
+      const res2 = await request(app)
+        .get(`/fhir/R4/Patient/` + patient1.id)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile));
+      expect(res2.status).toBe(200);
+
+      const patient2 = res2.body;
+      expect(patient2.resourceType).toBe('Patient');
+      expect(patient2.id).toBe(patient1.id);
+      expect(patient2.meta.author.reference).toEqual(getReferenceString(adminAccount.client));
+      expect(patient2.meta.onBehalfOf.reference).toEqual(getReferenceString(testAccount1.profile));
+
+      // Create a patient on behalf of test account 2
+      const res3 = await request(app)
+        .post(`/fhir/R4/Patient`)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile))
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({ resourceType: 'Patient' });
+      expect(res3.status).toBe(201);
+      expect(res3.body.resourceType).toEqual('Patient');
+      expect(res3.headers.location).toContain('Patient');
+      expect(res3.headers.location).toContain(res3.body.id);
+
+      const patient3 = res3.body;
+      expect(patient3.resourceType).toBe('Patient');
+      expect(patient3.meta.author.reference).toEqual(getReferenceString(adminAccount.client));
+      expect(patient3.meta.onBehalfOf.reference).toEqual(getReferenceString(testAccount2.profile));
+
+      // Read the patient on behalf of test account 2
+      const res4 = await request(app)
+        .get(`/fhir/R4/Patient/` + patient3.id)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile));
+      expect(res4.status).toBe(200);
+
+      const patient4 = res4.body;
+      expect(patient4.resourceType).toBe('Patient');
+      expect(patient4.id).toBe(patient3.id);
+      expect(patient4.meta.author.reference).toEqual(getReferenceString(adminAccount.client));
+      expect(patient4.meta.onBehalfOf.reference).toEqual(getReferenceString(testAccount2.profile));
+
+      // Try to read the first patient on behalf of test account 2
+      // This should fail because the patient was created on behalf of test account 1
+      const res5 = await request(app)
+        .get(`/fhir/R4/Patient/` + patient1.id)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile));
+      expect(res5.status).toBe(404);
+
+      // Try to read the second patient on behalf of test account 1
+      // This should fail because the patient was created on behalf of test account 2
+      const res6 = await request(app)
+        .get(`/fhir/R4/Patient/` + patient3.id)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile));
+      expect(res6.status).toBe(404);
+    }));
+
+  test('Unauthorized for non-admin', () =>
+    withTestContext(async () => {
+      // Create a project with a non-admin user
+      const testAccount1 = await createTestProject({
+        withClient: true,
+        withAccessToken: true,
+      });
+
+      const { client, project } = testAccount1;
+      const basicAuth = 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64');
+      const testAccount2 = await addTestUser(project);
+
+      // Try to use onBehalfOf without admin rights
+      // This should fail
+      const res1 = await request(app)
+        .post(`/fhir/R4/Patient`)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile))
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({ resourceType: 'Patient' });
+      expect(res1.status).toBe(401);
+      expect(res1.body).toMatchObject(unauthorized);
+    }));
+
+  test('Unauthorized for cross project', () =>
+    withTestContext(async () => {
+      const adminAccount1 = await createTestProject({
+        withClient: true,
+        withAccessToken: true,
+        membership: { admin: true },
+      });
+
+      const adminAccount2 = await createTestProject({
+        withClient: true,
+        withAccessToken: true,
+        membership: { admin: true },
+      });
+
+      const { client } = adminAccount1;
+      const basicAuth = 'Basic ' + Buffer.from(client.id + ':' + client.secret).toString('base64');
+
+      // Try to use onBehalfOf for a different project
+      // This should fail
+      const res1 = await request(app)
+        .post(`/fhir/R4/Patient`)
+        .set('Authorization', basicAuth)
+        .set('X-Medplum', 'extended')
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(adminAccount2.client))
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({ resourceType: 'Patient' });
+      expect(res1.status).toBe(401);
+      expect(res1.body).toMatchObject(unauthorized);
+    }));
+});

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -62,11 +62,11 @@ describe('FHIR Repo', () => {
 
   test('getRepoForLogin', async () => {
     await expect(() =>
-      getRepoForLogin(
-        { resourceType: 'Login' } as Login,
-        { resourceType: 'ProjectMembership' } as ProjectMembership,
-        testProject
-      )
+      getRepoForLogin({
+        login: { resourceType: 'Login' } as Login,
+        membership: { resourceType: 'ProjectMembership' } as ProjectMembership,
+        project: testProject,
+      })
     ).rejects.toThrow('Invalid author reference');
   });
 
@@ -490,7 +490,7 @@ describe('FHIR Repo', () => {
       const result1 = await registerNew(registration1);
       expect(result1.profile).toBeDefined();
 
-      const repo1 = await getRepoForLogin({ resourceType: 'Login' } as Login, result1.membership, result1.project);
+      const repo1 = await getRepoForLogin(result1);
       const patient1 = await repo1.createResource<Patient>({
         resourceType: 'Patient',
       });
@@ -513,7 +513,7 @@ describe('FHIR Repo', () => {
       const result2 = await registerNew(registration2);
       expect(result2.profile).toBeDefined();
 
-      const repo2 = await getRepoForLogin({ resourceType: 'Login' } as Login, result2.membership, result2.project);
+      const repo2 = await getRepoForLogin(result2);
       try {
         await repo2.readResource('Patient', patient1.id as string);
         fail('Should have thrown');

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -120,6 +120,12 @@ export interface RepositoryContext {
    */
   author: Reference;
 
+  /**
+   * Optional individual, device, or organization for whom the change was made.
+   * This value will be included in every resource as meta.onBehalfOf.
+   */
+  onBehalfOf?: Reference;
+
   remoteAddress?: string;
 
   /**
@@ -573,12 +579,17 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     });
     updated = await replaceConditionalReferences(this, updated);
 
-    const resultMeta = {
+    const resultMeta: Meta = {
       ...updated.meta,
       versionId: randomUUID(),
       lastUpdated: this.getLastUpdated(existing, resource),
       author: this.getAuthor(resource),
     };
+
+    if (this.context.onBehalfOf) {
+      resultMeta.onBehalfOf = this.context.onBehalfOf;
+    }
+
     const result: T = { ...updated, meta: resultMeta };
 
     const project = this.getProjectId(existing, updated);

--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -1,8 +1,17 @@
-import { OperationOutcomeError, createReference, unauthorized } from '@medplum/core';
+import {
+  OperationOutcomeError,
+  Operator,
+  ProfileResource,
+  createReference,
+  getReferenceString,
+  isString,
+  unauthorized,
+} from '@medplum/core';
 import { ClientApplication, Login, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response } from 'express';
 import { IncomingMessage } from 'http';
 import { AuthenticatedRequestContext, getRequestContext } from '../context';
+import { getRepoForLogin } from '../fhir/accesspolicy';
 import { getSystemRepo } from '../fhir/repo';
 import { getClientApplicationMembership, getLoginForAccessToken, timingSafeEqualStr } from './utils';
 
@@ -11,6 +20,9 @@ export interface AuthState {
   project: Project;
   membership: ProjectMembership;
   accessToken?: string;
+
+  onBehalfOf?: ProfileResource;
+  onBehalfOfMembership?: ProjectMembership;
 }
 
 export function authenticateRequest(req: Request, res: Response, next: NextFunction): void {
@@ -76,7 +88,36 @@ async function authenticateBasicAuth(req: IncomingMessage, token: string): Promi
     authTime: new Date().toISOString(),
   };
 
-  return { login, project, membership };
+  const onBehalfOfHeader = req.headers['x-medplum-on-behalf-of'];
+  let onBehalfOf: ProfileResource | undefined = undefined;
+  let onBehalfOfMembership: ProjectMembership | undefined = undefined;
+
+  if (onBehalfOfHeader && isString(onBehalfOfHeader)) {
+    if (!membership.admin) {
+      throw new OperationOutcomeError(unauthorized);
+    }
+
+    const adminRepo = await getRepoForLogin({ login, project, membership });
+
+    if (onBehalfOfHeader.startsWith('ProjectMembership/')) {
+      onBehalfOfMembership = await adminRepo.readReference<ProjectMembership>({ reference: onBehalfOfHeader });
+    } else {
+      onBehalfOfMembership = await adminRepo.searchOne({
+        resourceType: 'ProjectMembership',
+        filters: [
+          { code: 'profile', operator: Operator.EQUALS, value: onBehalfOfHeader },
+          { code: 'project', operator: Operator.EQUALS, value: getReferenceString(project) },
+        ],
+      });
+      if (!onBehalfOfMembership) {
+        return undefined;
+      }
+    }
+
+    onBehalfOf = await adminRepo.readReference(onBehalfOfMembership.profile as Reference<ProfileResource>);
+  }
+
+  return { login, project, membership, onBehalfOf, onBehalfOfMembership };
 }
 
 export function isExtendedMode(req: Request): boolean {

--- a/packages/server/src/oauth/token.ts
+++ b/packages/server/src/oauth/token.ts
@@ -142,8 +142,10 @@ async function handleClientCredentials(req: Request, res: Response): Promise<voi
     userAgent: req.get('User-Agent'),
   });
 
+  // TODO: build full AuthState object, including on-behalf-of
+
   try {
-    const accessPolicy = await getAccessPolicyForLogin(project, login, membership);
+    const accessPolicy = await getAccessPolicyForLogin({ project, login, membership });
     await checkIpAccessRules(login, accessPolicy);
   } catch (err) {
     sendTokenError(res, 'invalid_request', normalizeErrorString(err));

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -403,8 +403,12 @@ export async function setLoginMembership(login: Login, membershipId: string): Pr
     throw new OperationOutcomeError(badRequest('Google authentication is required'));
   }
 
+  // TODO: Do we really need to check IP access rules inside this method?
+  // Or could this be done closer to call site?
+  // This method is used internally in a bunch of places that do not need to check IP access rules
+
   // Get the access policy
-  const accessPolicy = await getAccessPolicyForLogin(project, login, membership);
+  const accessPolicy = await getAccessPolicyForLogin({ project, login, membership });
 
   // Check IP Access Rules
   await checkIpAccessRules(login, accessPolicy);


### PR DESCRIPTION
Implements "On-Behalf-Of" for Basic Auth

Context: https://github.com/medplum/medplum/issues/3892

Design doc: https://docs.google.com/document/d/118LLwHJ75aPCjXA6QI1j6j3mqlmCJ3-5FXO7v6a5_QQ/edit#heading=h.a3j2r6dlljij

## What is `On-Behalf-Of`?

An emerging pattern we have observed with customers is using Medplum as a backing store, and putting an additional API server or web server in front.

Consider this common Medplum architectural pattern:

![image](https://github.com/medplum/medplum/assets/749094/e8100222-6566-45c9-a1b7-b8da9aa99721)

Here, the Medplum "Customer" has a custom End User App and a Server Side App to enable their business requirements.

In this model, the Customer Server Side App is the only system component that interacts with Medplum Server. In this model, the Medplum Server is more like an internal data store.

The challenge with this model is that it is difficult to take advantage of many Medplum features related to Medplum authentication (author tracking, access policies, etc).

### Option 1: Try to use Medplum Authentication

The Customer Server Side App can attempt to link its "native" authentication method (which can be virtually anything, depending on the technology stack and auth services) and Medplum authentication.  The result would typically be a Medplum access token stored in the Server Side App's "session storage".  Then, when making API requests, the Server Side App would use the Medplum access token.

This has a number of challenges:

* Medplum user authentication was not really designed for this use case (PKCE, etc)
* The Server Side App must manage short lived JWT access tokens and/or refresh tokens
* General anti pattern of trying to managing auth state in two places

### Option 2: Do not use Medplum Authentication

Instead, the Customer Server Side App can simply skip Medplum Authentication and do everything as a single ClientApplication.  This dramatically simplifies the the setup and management of the integration, but then loses out on many key Medplum features:

* No author tracking
* No access control checks

### Option 3: Medplum "On-Behalf-Of"

1. The Customer Server Side App uses a single ClientApplication
   a. Similar to how a web server would use a single database credential
   b. The ClientApplication must be provisioned with "project admin" rights
2. When the Customer Server Side App sends a request, it includes a ProjectMembership id
   a. This ID represents a Medplum ProjectMembership id
   b. It would presumably be stored in the Customer Server Side App database
3. Medplum server would first authenticate the ClientApplication as normal
4. Medplum server would then check for the X-Medplum-On-Behalf-Of header
5. If present, it sets up the Repository instance accordingly
   a. Sets onBehalfOf
   b. Uses the ProjectMembership access policy

## How do you use `On-Behalf-Of`?

When making requests, as a project admin, you can now pass in an extra `X-Medplum-On-Behalf-Of` header.  The value of this header should be a FHIR reference string.  It can be a reference to either:

1. A `ProjectMembership` resource, specifying an exact `ProjectMembership`, including `Project`, profile, and access policy
2. A profile resource such as `Patient` or `Practitioner`.  The server will then search for the `ProjectMembership` accordingly.

Check out the new tests in [onbehalfof.test.ts
](https://github.com/medplum/medplum/pull/4740/files#diff-f200b32443cd02e0edb209e65d41ec838a8b57c9a3eb83187c01f5d02058e1bc)

For example:

```ts
      // Create a patient on behalf of test account 1
      const res1 = await request(app)
        .post(`/fhir/R4/Patient`)
        .set('Authorization', basicAuth)
        .set('X-Medplum', 'extended')
        .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount1.profile))
        .set('Content-Type', ContentType.FHIR_JSON)
        .send({ resourceType: 'Patient' });
      expect(res1.status).toBe(201);
      expect(res1.body.resourceType).toEqual('Patient');
      expect(res1.headers.location).toContain('Patient');
      expect(res1.headers.location).toContain(res1.body.id);

      const patient1 = res1.body;
      expect(patient1.resourceType).toBe('Patient');
      expect(patient1.meta.author.reference).toEqual(getReferenceString(adminAccount.client));
      expect(patient1.meta.onBehalfOf.reference).toEqual(getReferenceString(testAccount1.profile));
```

## Why implement it with Basic Auth first?

We will add support for `On-Behalf-Of` with access tokens in a future PR.

Based on initial customer interviews, we anticipate that the most common usage will be with Basic Auth, to avoid the complexity of managing expiring access tokens.

Basic Auth sends the Client ID and Client Secret in the `Authorization` header on every request.

## Limitations

* Does not implement "On-Behalf-of" for Bearer tokens / Access tokens.
* Not supported for `/admin/*` APIs
* Not supported for `/auth/*` APIs
* Not supported for `/oauth2/*` APIs

## Implementation Notes

In the PR, you'll notice that we're formalizing the notion of `AuthState`.  There were a bunch of internal helper utilities that took `login`, `project`, and `membership` as parameters.  This PR would have required adding `onBehalfOf` and `onBehalfOfMembership` to those utility methods.  Instead, it seemed that the `AuthState` type already represented all of that.

In the future, I'd like to submit a cleanup PR that fully embraces `AuthState`, and centralizes all of the related utility methods into a single file in `server`.  Open for feedback on that.
