### PR TITLE
`useResource` compatible with a disabled MedplumClient cache

### DIFF
--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -85,7 +85,8 @@ import {
 } from './mocks/workflow';
 import { MockSubscriptionManager } from './subscription-manager';
 
-export interface MockClientOptions extends MedplumClientOptions {
+export interface MockClientOptions
+  extends Pick<MedplumClientOptions, 'baseUrl' | 'clientId' | 'storage' | 'cacheTime'> {
   readonly debug?: boolean;
   /**
    * Override currently logged in user. Specifying null results in
@@ -147,6 +148,7 @@ export class MockClient extends MedplumClient {
       baseUrl,
       clientId: clientOptions?.clientId,
       storage: clientOptions?.storage,
+      cacheTime: clientOptions?.cacheTime,
       createPdf: (
         docDefinition: TDocumentDefinitions,
         tableLayouts?: { [name: string]: CustomTableLayout },

--- a/packages/react-hooks/src/useResource/useResource.test.tsx
+++ b/packages/react-hooks/src/useResource/useResource.test.tsx
@@ -2,7 +2,7 @@ import { createReference } from '@medplum/core';
 import { OperationOutcome, Reference, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useRef, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { MedplumProvider } from '../MedplumProvider/MedplumProvider';
 import { useResource } from './useResource';
@@ -10,10 +10,19 @@ import { useResource } from './useResource';
 interface TestComponentProps {
   value?: Reference | Resource;
   setOutcome?: (outcome: OperationOutcome) => void;
+  /** Optional max render count before failing the test. Defaults to 5 */
+  maxRenders?: number;
 }
 
 function TestComponent(props: TestComponentProps): JSX.Element {
   const resource = useResource(props.value, props.setOutcome);
+  const renderCount = useRef(0);
+  const maxRenders = props.maxRenders ?? 5;
+  if (typeof maxRenders === 'number' && maxRenders > 0) {
+    if (renderCount.current++ >= maxRenders) {
+      throw new Error(`Rendered too many times: ${renderCount.current}`);
+    }
+  }
   return <div data-testid="test-component">{JSON.stringify(resource)}</div>;
 }
 
@@ -22,176 +31,180 @@ describe('useResource', () => {
     console.error = jest.fn();
   });
 
-  async function setup(children: ReactNode): Promise<void> {
-    const medplum = new MockClient();
-    await act(async () => {
-      render(
-        <MemoryRouter>
-          <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
-        </MemoryRouter>
-      );
-    });
-  }
-
-  test('Renders null', async () => {
-    await setup(<TestComponent value={null as unknown as Reference} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).toBe('');
-  });
-
-  test('Renders undefined', async () => {
-    await setup(<TestComponent value={undefined as unknown as Reference} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).toBe('');
-  });
-
-  test('Handles invalid value', async () => {
-    await setup(<TestComponent value={{} as unknown as Reference} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).toBe('');
-  });
-
-  test('Renders resource', async () => {
-    await setup(<TestComponent value={HomerSimpson} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).not.toBe('');
-  });
-
-  test('Renders reference', async () => {
-    await setup(<TestComponent value={createReference(HomerSimpson)} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-
-    await waitFor(() => expect(screen.getByTestId('test-component').innerHTML).not.toBe(''));
-    expect(screen.getByTestId('test-component').innerHTML).not.toBe('');
-  });
-
-  test('Renders system', async () => {
-    await setup(<TestComponent value={{ reference: 'system' }} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).not.toBe('');
-  });
-
-  test('Handles 404 not found', async () => {
-    await setup(<TestComponent value={{ reference: 'Patient/not-found' }} />);
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).toBe('');
-  });
-
-  test('Set outcome on error', async () => {
-    const setOutcome = jest.fn();
-    await setup(<TestComponent value={{ reference: 'Patient/not-found' }} setOutcome={setOutcome} />);
-    await waitFor(() => expect(setOutcome).toHaveBeenCalled());
-  });
-
-  test('Responds to value change', async () => {
-    function TestComponentWrapper(): JSX.Element {
-      const [id, setId] = useState('123');
-      return (
-        <>
-          <button onClick={() => setId('456')}>Click</button>
-          <TestComponent value={{ id, resourceType: 'ServiceRequest' }} />
-        </>
-      );
-    }
-
-    await setup(<TestComponentWrapper />);
-
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).toContain('123');
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Click'));
-    });
-
-    expect(el.innerHTML).toContain('456');
-  });
-
-  test('Responds to value edit', async () => {
-    function TestComponentWrapper(): JSX.Element {
-      const [resource, setResource] = useState<ServiceRequest>({
-        resourceType: 'ServiceRequest',
-        id: '123',
-        status: 'draft',
-        intent: 'order',
-        code: { text: 'test' },
-        subject: { reference: 'Patient/123' },
+  describe.each([undefined, 0])('MedplumClient.cacheTime=%j', (cacheTime: number | undefined) => {
+    async function setup(children: ReactNode): Promise<void> {
+      const medplum = new MockClient({ cacheTime });
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <MedplumProvider medplum={medplum}>{children}</MedplumProvider>
+          </MemoryRouter>
+        );
       });
-      return (
-        <>
-          <button onClick={() => setResource((sr) => ({ ...sr, status: sr.status === 'active' ? 'draft' : 'active' }))}>
-            Click
-          </button>
-          <TestComponent value={resource} />
-        </>
-      );
     }
 
-    await setup(<TestComponentWrapper />);
-
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).not.toContain('active');
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Click'));
+    test('Renders null', async () => {
+      await setup(<TestComponent value={null as unknown as Reference} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).toBe('');
     });
-    expect(el.innerHTML).toContain('active');
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Click'));
+    test('Renders undefined', async () => {
+      await setup(<TestComponent value={undefined as unknown as Reference} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).toBe('');
     });
-    expect(el.innerHTML).not.toContain('active');
-  });
 
-  test('Responds to value edit after cache', async () => {
-    function TestComponentWrapper(): JSX.Element {
-      // Call useResource with a reference to fill the cache
-      useResource({ reference: 'ServiceRequest/123' });
-      const [resource, setResource] = useState<ServiceRequest>({
-        resourceType: 'ServiceRequest',
-        id: '123',
-        status: 'draft',
-        intent: 'order',
-        code: { text: 'test' },
-        subject: { reference: 'Patient/123' },
+    test('Handles invalid value', async () => {
+      await setup(<TestComponent value={{} as unknown as Reference} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).toBe('');
+    });
+
+    test('Renders resource', async () => {
+      await setup(<TestComponent value={HomerSimpson} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).not.toBe('');
+    });
+
+    test('Renders reference', async () => {
+      await setup(<TestComponent value={createReference(HomerSimpson)} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+
+      await waitFor(() => expect(screen.getByTestId('test-component').innerHTML).not.toBe(''));
+      expect(screen.getByTestId('test-component').innerHTML).not.toBe('');
+    });
+
+    test('Renders system', async () => {
+      await setup(<TestComponent value={{ reference: 'system' }} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).not.toBe('');
+    });
+
+    test('Handles 404 not found', async () => {
+      await setup(<TestComponent value={{ reference: 'Patient/not-found' }} />);
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).toBe('');
+    });
+
+    test('Set outcome on error', async () => {
+      const setOutcome = jest.fn();
+      await setup(<TestComponent value={{ reference: 'Patient/not-found' }} setOutcome={setOutcome} />);
+      await waitFor(() => expect(setOutcome).toHaveBeenCalled());
+    });
+
+    test('Responds to value change', async () => {
+      function TestComponentWrapper(): JSX.Element {
+        const [id, setId] = useState('123');
+        return (
+          <>
+            <button onClick={() => setId('456')}>Click</button>
+            <TestComponent value={{ id, resourceType: 'ServiceRequest' }} />
+          </>
+        );
+      }
+
+      await setup(<TestComponentWrapper />);
+
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).toContain('123');
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Click'));
       });
 
-      return (
-        <>
-          <button
-            onClick={() => {
-              setResource((sr) => ({ ...sr, status: sr.status === 'active' ? 'draft' : 'active' }));
-            }}
-          >
-            Click
-          </button>
-          <TestComponent value={resource} />
-        </>
-      );
-    }
-
-    await setup(<TestComponentWrapper />);
-
-    const el = screen.getByTestId('test-component');
-    expect(el).toBeInTheDocument();
-    expect(el.innerHTML).not.toContain('active');
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Click'));
+      expect(el.innerHTML).toContain('456');
     });
-    expect(el.innerHTML).toContain('active');
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Click'));
+    test('Responds to value edit', async () => {
+      function TestComponentWrapper(): JSX.Element {
+        const [resource, setResource] = useState<ServiceRequest>({
+          resourceType: 'ServiceRequest',
+          id: '123',
+          status: 'draft',
+          intent: 'order',
+          code: { text: 'test' },
+          subject: { reference: 'Patient/123' },
+        });
+        return (
+          <>
+            <button
+              onClick={() => setResource((sr) => ({ ...sr, status: sr.status === 'active' ? 'draft' : 'active' }))}
+            >
+              Click
+            </button>
+            <TestComponent value={resource} />
+          </>
+        );
+      }
+
+      await setup(<TestComponentWrapper />);
+
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).not.toContain('active');
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Click'));
+      });
+      expect(el.innerHTML).toContain('active');
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Click'));
+      });
+      expect(el.innerHTML).not.toContain('active');
     });
-    expect(el.innerHTML).not.toContain('active');
+
+    test('Responds to value edit after cache', async () => {
+      function TestComponentWrapper(): JSX.Element {
+        // Call useResource with a reference to fill the cache
+        useResource({ reference: 'ServiceRequest/123' });
+        const [resource, setResource] = useState<ServiceRequest>({
+          resourceType: 'ServiceRequest',
+          id: '123',
+          status: 'draft',
+          intent: 'order',
+          code: { text: 'test' },
+          subject: { reference: 'Patient/123' },
+        });
+
+        return (
+          <>
+            <button
+              onClick={() => {
+                setResource((sr) => ({ ...sr, status: sr.status === 'active' ? 'draft' : 'active' }));
+              }}
+            >
+              Click
+            </button>
+            <TestComponent value={resource} maxRenders={6} />
+          </>
+        );
+      }
+
+      await setup(<TestComponentWrapper />);
+
+      const el = screen.getByTestId('test-component');
+      expect(el).toBeInTheDocument();
+      expect(el.innerHTML).not.toContain('active');
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Click'));
+      });
+      expect(el.innerHTML).toContain('active');
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Click'));
+      });
+      expect(el.innerHTML).not.toContain('active');
+    });
   });
 });

--- a/packages/react-hooks/src/useResource/useResource.ts
+++ b/packages/react-hooks/src/useResource/useResource.ts
@@ -15,7 +15,9 @@ export function useResource<T extends Resource>(
   setOutcome?: (outcome: OperationOutcome) => void
 ): T | undefined {
   const medplum = useMedplum();
-  const [resource, setResource] = useState<T | undefined>(getInitialResource(medplum, value));
+  const [resource, setResource] = useState<T | undefined>(() => {
+    return getInitialResource(medplum, value);
+  });
 
   const setResourceIfChanged = useCallback(
     (r: T | undefined) => {
@@ -27,13 +29,10 @@ export function useResource<T extends Resource>(
   );
 
   useEffect(() => {
-    setResourceIfChanged(getInitialResource(medplum, value));
-  }, [medplum, value, setResourceIfChanged]);
-
-  useEffect(() => {
     let subscribed = true;
 
-    if (isReference(value)) {
+    const newValue = getInitialResource(medplum, value);
+    if (!newValue && isReference(value)) {
       medplum
         .readReference(value as Reference<T>)
         .then((r) => {
@@ -49,6 +48,8 @@ export function useResource<T extends Resource>(
             }
           }
         });
+    } else {
+      setResourceIfChanged(newValue);
     }
 
     return (() => (subscribed = false)) as () => void;


### PR DESCRIPTION
Previously `useResource` with a reference, e.g. `useResrouce({reference: 'Patient/some-id'})`, in conjunction with a `MedplumClient` configured with a very low TTL or disabled cache would result in an infinite render loop due to the way `useReference` interacts with the cache and competing calls to `setResource`.