### PR TITLE
fix(subscriptions): don't log if AP not satisfied for WS subs

### DIFF
--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -1711,7 +1711,7 @@ describe('Subscription Worker', () => {
 
         await assertPromise;
 
-        expect(console.log).toHaveBeenCalledWith(
+        expect(console.log).not.toHaveBeenCalledWith(
           expect.stringContaining('[Subscription Access Policy]: Access Policy not satisfied on')
         );
         console.log = originalConsoleLog;

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -158,7 +158,7 @@ async function satisfiesAccessPolicy(
     if (membership) {
       const accessPolicy = await buildAccessPolicy(membership);
       satisfied = !!satisfiedAccessPolicy(resource, AccessPolicyInteraction.READ, accessPolicy);
-      if (!satisfied) {
+      if (!satisfied && subscription.channel.type !== 'websocket') {
         const resourceReference = getReferenceString(resource);
         const subReference = getReferenceString(subscription);
         const projectReference = getReferenceString(project);


### PR DESCRIPTION
Since we already enforce `AccessPolicy`s for WebSocket Subscriptions, we don't really need to log when an `AccessPolicy` is not satisfied since the Subscription does not create a notification when `subscription.channel.type === 'websocket'`