### PR TITLE
Deploy bot layer on staging deploys

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -72,3 +72,5 @@ jobs:
           AWS_REGION: ${{ secrets.STAGING_AWS_REGION }}
           ECS_CLUSTER: ${{ secrets.STAGING_ECS_CLUSTER }}
           ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
+      - name: Deploy bot layer
+        run: ./scripts/deploy-bot-layer.sh

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -74,3 +74,5 @@ jobs:
           ECS_SERVICE: ${{ secrets.STAGING_ECS_SERVICE }}
       - name: Deploy bot layer
         run: ./scripts/deploy-bot-layer.sh
+        env:
+          AWS_REGION: ${{ secrets.STAGING_AWS_REGION }}


### PR DESCRIPTION
Creating a new version of the bot layer has worked as expected in [this action](https://github.com/medplum/medplum/actions/runs/9748437164/job/26903420527); it created a new version of our [AWS Lambda layer](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/layers/medplum-bot-layer/versions/3?tab=versions).