### PR TITLE
Use reader database instance for readonly graphql queries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
       postgres:
         image: postgres:${{ matrix.pg-version }}
         env:
-          POSTGRES_DB: medplum_test
+          POSTGRES_DB: medplum
           POSTGRES_USER: medplum
           POSTGRES_PASSWORD: medplum
         options: >-
@@ -220,6 +220,16 @@ jobs:
           echo "TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}" >> $GITHUB_ENV
           echo "TURBO_TEAM=${{ secrets.TURBO_TEAM }}" >> $GITHUB_ENV
           echo "TURBO_REMOTE_ONLY=${{ secrets.TURBO_REMOTE_ONLY }}" >> $GITHUB_ENV
+      - name: Wait for PostgreSQL
+        run: |
+          until pg_isready -h localhost -p 5432; do
+            echo "Waiting for postgres..."
+            sleep 2
+          done
+      - name: Run additional setup SQL
+        run: PGPASSWORD=medplum psql -h localhost -U medplum -d medplum -f ./postgres/init_test.sql
+        env:
+          PGPASSWORD: medplum
       - name: Test
         run: ./scripts/test.sh
         env:

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -35,7 +35,7 @@ import {
   ValidationContext,
 } from 'graphql';
 import { FhirRequest, FhirResponse, FhirRouter } from '../fhirrouter';
-import { FhirRepository } from '../repo';
+import { FhirRepository, RepositoryMode } from '../repo';
 import { getGraphQLInputType } from './input-types';
 import { buildGraphQLOutputType, getGraphQLOutputType, outputTypeCache } from './output-types';
 import {
@@ -111,6 +111,10 @@ export async function graphqlHandler(
     return [forbidden];
   }
 
+  if (includesMutations(query)) {
+    repo.setMode(RepositoryMode.WRITER);
+  }
+
   const dataLoader = new DataLoader<Reference, Resource>((keys) => repo.readReferences(keys));
 
   let result: any = introspection && introspectionResults.get(query);
@@ -138,6 +142,15 @@ export async function graphqlHandler(
  */
 function isIntrospectionQuery(query: string): boolean {
   return query.includes('query IntrospectionQuery') || query.includes('__schema');
+}
+
+/**
+ * Returns true if the query includes mutations.
+ * @param query - The GraphQL query.
+ * @returns True if the query includes mutations.
+ */
+function includesMutations(query: string): boolean {
+  return query.includes('mutation');
 }
 
 export function getRootSchema(): GraphQLSchema {

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -17,6 +17,11 @@ import {
 import { Bundle, BundleEntry, OperationOutcome, Reference, Resource } from '@medplum/fhirtypes';
 import { Operation, applyPatch } from 'rfc6902';
 
+export enum RepositoryMode {
+  READER = 'reader',
+  WRITER = 'writer',
+}
+
 /**
  * The FhirRepository interface defines the methods that are required to implement a FHIR repository.
  * A FHIR repository is responsible for storing and retrieving FHIR resources.
@@ -26,6 +31,16 @@ import { Operation, applyPatch } from 'rfc6902';
  *  2. Server Repository - A repository that stores resources in a relational database.
  */
 export interface FhirRepository<TClient = unknown> {
+  /**
+   * Sets the repository mode.
+   * In general, it is assumed that repositories will start in "reader" mode,
+   * and that the mode will be changed to "writer" as needed.
+   * It is recommended that the repository use "reader" opportunistically,
+   * but after using "writer" once it should use "writer" exclusively.
+   * @param mode - The repository mode.
+   */
+  setMode(mode: RepositoryMode): void;
+
   /**
    * Creates a FHIR resource.
    *
@@ -226,6 +241,10 @@ export class MemoryRepository extends BaseRepository implements FhirRepository {
   clear(): void {
     this.resources.clear();
     this.history.clear();
+  }
+
+  setMode(_mode: RepositoryMode): void {
+    // MockRepository ignores reader/writer mode
   }
 
   async createResource<T extends Resource>(resource: T): Promise<T> {

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -7,12 +7,14 @@ import {
   OperationOutcomeError,
   validateResourceType,
 } from '@medplum/core';
+import { ResourceType } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { body, validationResult } from 'express-validator';
 import { asyncWrap } from '../async';
 import { setPassword } from '../auth/setpassword';
+import { getConfig } from '../config';
 import { AuthenticatedRequestContext, getAuthenticatedContext } from '../context';
-import { getDatabasePool } from '../database';
+import { DatabaseMode, getDatabasePool } from '../database';
 import { AsyncJobExecutor, sendAsyncResponse } from '../fhir/operations/utils/asyncjobexecutor';
 import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 import { getSystemRepo } from '../fhir/repo';
@@ -23,9 +25,7 @@ import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { removeBullMQJobByKey } from '../workers/cron';
-import { ResourceType } from '@medplum/fhirtypes';
 import { addReindexJob } from '../workers/reindex';
-import { getConfig } from '../config';
 
 export const superAdminRouter = Router();
 superAdminRouter.use(authenticateRequest);
@@ -176,7 +176,7 @@ superAdminRouter.post(
     await sendAsyncResponse(req, res, async () => {
       const resourceTypes = getResourceTypes();
       for (const resourceType of resourceTypes) {
-        await getDatabasePool().query(
+        await getDatabasePool(DatabaseMode.WRITER).query(
           `UPDATE "${resourceType}" SET "projectId"="compartments"[1] WHERE "compartments" IS NOT NULL AND cardinality("compartments")>0`
         );
       }
@@ -196,7 +196,7 @@ superAdminRouter.post(
 
     await sendAsyncResponse(req, res, async () => {
       const systemRepo = getSystemRepo();
-      const client = getDatabasePool();
+      const client = getDatabasePool(DatabaseMode.WRITER);
       const result = await client.query('SELECT "dataVersion" FROM "DatabaseMigration"');
       const version = result.rows[0]?.dataVersion as number;
       const migrationKeys = Object.keys(dataMigrations);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from './app';
 import { getConfig, loadTestConfig } from './config';
-import { getDatabasePool } from './database';
+import { DatabaseMode, getDatabasePool } from './database';
 import { globalLogger } from './logger';
 import { getRedis } from './redis';
 
@@ -106,7 +106,7 @@ describe('App', () => {
 
     const loggerError = jest.spyOn(globalLogger, 'error').mockReturnValueOnce();
     const error = new Error('Mock database disconnect');
-    getDatabasePool().emit('error', error);
+    getDatabasePool(DatabaseMode.WRITER).emit('error', error);
     expect(loggerError).toHaveBeenCalledWith('Database connection error', error);
     expect(await shutdownApp()).toBeUndefined();
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -252,6 +252,7 @@ const loggingMiddleware = (req: Request, res: Response, next: NextFunction): voi
       receivedAt: start,
       status: res.statusCode,
       ua: req.get('User-Agent'),
+      mode: ctx instanceof AuthenticatedRequestContext ? ctx.repo.mode : undefined,
     });
   });
 

--- a/packages/server/src/cloud/aws/config.ts
+++ b/packages/server/src/cloud/aws/config.ts
@@ -40,6 +40,8 @@ export async function loadAwsConfig(path: string): Promise<MedplumServerConfig> 
     const value = param.Value as string;
     if (key === 'DatabaseSecrets') {
       config['database'] = await loadAwsSecrets(region, value);
+    } else if (key === 'ReaderDatabaseSecrets') {
+      config['readonlyDatabase'] = await loadAwsSecrets(region, value);
     } else if (key === 'RedisSecrets') {
       config['redis'] = await loadAwsSecrets(region, value);
     }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -26,6 +26,8 @@ export interface MedplumServerConfig {
   approvedSenderEmails?: string;
   database: MedplumDatabaseConfig;
   databaseProxyEndpoint?: string;
+  readonlyDatabase: MedplumDatabaseConfig;
+  readonlyDatabaseProxyEndpoint?: string;
   redis: MedplumRedisConfig;
   emailProvider?: 'none' | 'awsses' | 'smtp';
   smtp?: MedplumSmtpConfig;
@@ -187,6 +189,11 @@ export async function loadTestConfig(): Promise<MedplumServerConfig> {
   config.database.port = process.env['POSTGRES_PORT'] ? Number.parseInt(process.env['POSTGRES_PORT'], 10) : 5432;
   config.database.dbname = 'medplum_test';
   config.database.runMigrations = false;
+  config.readonlyDatabase = {
+    ...config.database,
+    username: 'medplum_test_readonly',
+    password: 'medplum_test_readonly',
+  };
   config.redis.db = 7; // Select logical DB `7` so we don't collide with existing dev Redis cache.
   config.redis.password = process.env['REDIS_PASSWORD_DISABLED_IN_TESTS'] ? undefined : config.redis.password;
   config.approvedSenderEmails = 'no-reply@example.com';

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1,14 +1,25 @@
 import { Pool, PoolClient } from 'pg';
-import { MedplumServerConfig } from './config';
+import { MedplumDatabaseConfig, MedplumServerConfig } from './config';
 import { globalLogger } from './logger';
 import * as migrations from './migrations/schema';
 
-let pool: Pool | undefined;
+export enum DatabaseMode {
+  READER = 'reader',
+  WRITER = 'writer',
+}
 
-export function getDatabasePool(): Pool {
+let pool: Pool | undefined;
+let readonlyPool: Pool | undefined;
+
+export function getDatabasePool(mode: DatabaseMode): Pool {
   if (!pool) {
     throw new Error('Database not setup');
   }
+
+  if (mode === DatabaseMode.READER && readonlyPool) {
+    return readonlyPool;
+  }
+
   return pool;
 }
 
@@ -17,8 +28,18 @@ export const locks = {
 };
 
 export async function initDatabase(serverConfig: MedplumServerConfig): Promise<void> {
-  const config = serverConfig.database;
+  pool = await initPool(serverConfig.database, serverConfig.databaseProxyEndpoint);
 
+  if (serverConfig.database.runMigrations !== false) {
+    await runMigrations(pool);
+  }
+
+  if (serverConfig.readonlyDatabase) {
+    readonlyPool = await initPool(serverConfig.readonlyDatabase, serverConfig.readonlyDatabaseProxyEndpoint);
+  }
+}
+
+async function initPool(config: MedplumDatabaseConfig, proxyEndpoint: string | undefined): Promise<Pool> {
   const poolConfig = {
     host: config.host,
     port: config.port,
@@ -29,13 +50,13 @@ export async function initDatabase(serverConfig: MedplumServerConfig): Promise<v
     max: 100,
   };
 
-  if (serverConfig.databaseProxyEndpoint) {
-    poolConfig.host = serverConfig.databaseProxyEndpoint;
+  if (proxyEndpoint) {
+    poolConfig.host = proxyEndpoint;
     poolConfig.ssl = poolConfig.ssl ?? {};
     poolConfig.ssl.require = true;
   }
 
-  pool = new Pool(poolConfig);
+  const pool = new Pool(poolConfig);
 
   pool.on('error', (err) => {
     globalLogger.error('Database connection error', err);
@@ -50,26 +71,32 @@ export async function initDatabase(serverConfig: MedplumServerConfig): Promise<v
     });
   });
 
-  let client: PoolClient | undefined;
-  // Run migrations by default
-  if (config.runMigrations !== false) {
-    try {
-      client = await pool.connect();
-      await client.query('SELECT pg_advisory_lock($1)', [locks.migration]);
-      await migrate(client);
-    } finally {
-      if (client) {
-        await client.query('SELECT pg_advisory_unlock($1)', [locks.migration]);
-        client.release();
-      }
-    }
-  }
+  return pool;
 }
 
 export async function closeDatabase(): Promise<void> {
   if (pool) {
     await pool.end();
     pool = undefined;
+  }
+
+  if (readonlyPool) {
+    await readonlyPool.end();
+    readonlyPool = undefined;
+  }
+}
+
+async function runMigrations(pool: Pool): Promise<void> {
+  let client: PoolClient | undefined;
+  try {
+    client = await pool.connect();
+    await client.query('SELECT pg_advisory_lock($1)', [locks.migration]);
+    await migrate(client);
+  } finally {
+    if (client) {
+      await client.query('SELECT pg_advisory_unlock($1)', [locks.migration]);
+      client.release();
+    }
   }
 }
 

--- a/packages/server/src/fhir/lookups/coding.test.ts
+++ b/packages/server/src/fhir/lookups/coding.test.ts
@@ -1,7 +1,7 @@
 import { CodeSystem } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { withTestContext } from '../../test.setup';
 import { getSystemRepo } from '../repo';
 
@@ -33,7 +33,7 @@ describe('Coding lookup table', () => {
 
       const systemResource = await systemRepo.createResource(codeSystem);
 
-      const db = getDatabasePool();
+      const db = getDatabasePool(DatabaseMode.READER);
       const results = await db.query('SELECT id, code, display FROM "Coding" WHERE system = $1', [systemResource.id]);
       expect(results.rows.map((r) => `${r.code} (${r.display})`).sort()).toEqual([
         'AB (Ambulance)',
@@ -68,7 +68,7 @@ describe('Coding lookup table', () => {
 
       const systemResource = await systemRepo.createResource(codeSystem);
 
-      const db = getDatabasePool();
+      const db = getDatabasePool(DatabaseMode.READER);
       const results = await db.query('SELECT code, display FROM "Coding" WHERE system = $1', [systemResource.id]);
       expect(results.rowCount).toEqual(0);
     }));

--- a/packages/server/src/fhir/operations/codesystemimport.test.ts
+++ b/packages/server/src/fhir/operations/codesystemimport.test.ts
@@ -4,7 +4,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { initTestAuth } from '../../test.setup';
 import { Column, Condition, SelectQuery } from '../sql';
 
@@ -241,7 +241,7 @@ describe('CodeSystem $import', () => {
 });
 
 async function assertCodeExists(system: string | undefined, code: string): Promise<any> {
-  const db = getDatabasePool();
+  const db = getDatabasePool(DatabaseMode.READER);
   const coding = await new SelectQuery('Coding')
     .column('id')
     .where('system', '=', system)
@@ -257,7 +257,7 @@ async function assertPropertyExists(
   property: string,
   value: string
 ): Promise<any> {
-  const db = getDatabasePool();
+  const db = getDatabasePool(DatabaseMode.READER);
   const query = new SelectQuery('Coding_Property');
   const codingTable = query.getNextJoinAlias();
   query.innerJoin(

--- a/packages/server/src/fhir/operations/codesystemlookup.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.ts
@@ -2,7 +2,7 @@ import { OperationOutcomeError, TypedValue, allOk, append, badRequest, notFound 
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { Column, Condition, SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -85,7 +85,7 @@ export async function lookupCoding(codeSystem: CodeSystem, coding: Coding): Prom
     .where(new Column(codeSystemTable, 'id'), '=', codeSystem.id)
     .where(new Column('Coding', 'code'), '=', coding.code);
 
-  const db = getDatabasePool();
+  const db = getDatabasePool(DatabaseMode.READER);
   const result = await lookup.execute(db);
   const resolved = result?.[0];
   if (!resolved) {

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.ts
@@ -2,7 +2,7 @@ import { allOk, badRequest } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { CodeSystem, Coding } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -88,7 +88,7 @@ export async function validateCodings(codeSystem: CodeSystem, codings: Coding[])
       .where('code', 'IN', codesToQuery)
       .where('system', '=', codeSystem.id);
 
-    const db = getDatabasePool();
+    const db = getDatabasePool(DatabaseMode.READER);
     result = await query.execute(db);
   }
 

--- a/packages/server/src/fhir/operations/dbstats.ts
+++ b/packages/server/src/fhir/operations/dbstats.ts
@@ -2,7 +2,7 @@ import { allOk } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { buildOutputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
@@ -21,7 +21,7 @@ const operation: OperationDefinition = {
 export async function dbStatsHandler(_req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();
 
-  const client = getDatabasePool();
+  const client = getDatabasePool(DatabaseMode.READER);
   const sql = `
       SELECT * FROM (
         SELECT table_schema, table_name, pg_relation_size('"'||table_schema||'"."'||table_name||'"') AS table_size

--- a/packages/server/src/fhir/operations/dbstats.ts
+++ b/packages/server/src/fhir/operations/dbstats.ts
@@ -21,7 +21,7 @@ const operation: OperationDefinition = {
 export async function dbStatsHandler(_req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();
 
-  const client = getDatabasePool(DatabaseMode.READER);
+  const client = getDatabasePool(DatabaseMode.WRITER);
   const sql = `
       SELECT * FROM (
         SELECT table_schema, table_name, pg_relation_size('"'||table_schema||'"."'||table_name||'"') AS table_size

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -2,7 +2,7 @@ import { allOk, badRequest, OperationOutcomeError } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { CodeSystem, Coding, ValueSet, ValueSetComposeInclude, ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { Column, Condition, Conjunction, Disjunction, Expression, SelectQuery, Union } from '../sql';
 import { validateCodings } from './codesystemvalidatecode';
 import { getOperationDefinition } from './definitions';
@@ -96,7 +96,7 @@ async function queryValueSetElements(
     throw new OperationOutcomeError(badRequest('No systems found'));
   }
 
-  const client = getDatabasePool();
+  const client = getDatabasePool(DatabaseMode.READER);
   const query = new SelectQuery('ValueSetElement')
     .distinctOn('system')
     .distinctOn('code')
@@ -319,7 +319,7 @@ async function includeInExpansion(
     query = addAbstractFilter(query, codeSystem);
   }
 
-  const results = await query.execute(ctx.repo.getDatabaseClient());
+  const results = await query.execute(ctx.repo.getDatabaseClient(DatabaseMode.READER));
   const system = codeSystem.url;
   for (const { code, display } of results) {
     expansion.push({ system, code, display });

--- a/packages/server/src/fhir/operations/expunge.test.ts
+++ b/packages/server/src/fhir/operations/expunge.test.ts
@@ -5,7 +5,7 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { getDatabasePool } from '../../database';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { getRedis } from '../../redis';
 import { createTestProject, initTestAuth, waitForAsyncJob, withTestContext } from '../../test.setup';
 import { getSystemRepo } from '../repo';
@@ -188,7 +188,10 @@ async function existsInCache(resourceType: string, id: string | undefined): Prom
 }
 
 async function existsInDatabase(tableName: string, id: string | undefined): Promise<boolean> {
-  const rows = await new SelectQuery(tableName).column('id').where('id', '=', id).execute(getDatabasePool());
+  const rows = await new SelectQuery(tableName)
+    .column('id')
+    .where('id', '=', id)
+    .execute(getDatabasePool(DatabaseMode.READER));
   return rows.length > 0;
 }
 
@@ -196,6 +199,6 @@ async function existsInLookupTable(tableName: string, id: string | undefined): P
   const rows = await new SelectQuery(tableName)
     .column('resourceId')
     .where('resourceId', '=', id)
-    .execute(getDatabasePool());
+    .execute(getDatabasePool(DatabaseMode.READER));
   return rows.length > 0;
 }

--- a/packages/server/src/fhir/operations/subsumes.ts
+++ b/packages/server/src/fhir/operations/subsumes.ts
@@ -2,6 +2,7 @@ import { allOk, badRequest } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { CodeSystem } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
+import { DatabaseMode } from '../../database';
 import { Column, SelectQuery } from '../sql';
 import { getOperationDefinition } from './definitions';
 import { buildOutputParameters, parseInputParameters } from './utils/parameters';
@@ -69,6 +70,6 @@ export async function isSubsumed(baseCode: string, ancestorCode: string, codeSys
     .where(new Column('Coding', 'code'), '=', baseCode);
 
   const query = findAncestor(base, codeSystem, ancestorCode);
-  const results = await query.execute(ctx.repo.getDatabaseClient());
+  const results = await query.execute(ctx.repo.getDatabaseClient(DatabaseMode.READER));
   return results.length > 0;
 }

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.ts
@@ -9,6 +9,7 @@ import {
   ValueSetComposeIncludeFilter,
 } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
+import { DatabaseMode } from '../../database';
 import { Column, SelectQuery } from '../sql';
 import { validateCoding } from './codesystemvalidatecode';
 import { getOperationDefinition } from './definitions';
@@ -138,6 +139,6 @@ async function satisfies(
       return false; // Unknown filter type, don't make DB query with incorrect filters
   }
 
-  const results = await query.execute(ctx.repo.getDatabaseClient());
+  const results = await query.execute(ctx.repo.getDatabaseClient(DatabaseMode.READER));
   return results.length > 0;
 }

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -32,7 +32,7 @@ import { resolve } from 'path';
 import { initAppServices, shutdownApp } from '../app';
 import { registerNew, RegisterRequest } from '../auth/register';
 import { loadTestConfig } from '../config';
-import { getDatabasePool } from '../database';
+import { DatabaseMode, getDatabasePool } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
 import { getSystemRepo, Repository, setTypedPropertyValue } from './repo';
@@ -802,7 +802,7 @@ describe('FHIR Repo', () => {
         subject: createReference(patient),
       });
 
-      const result = await getDatabasePool().query(
+      const result = await getDatabasePool(DatabaseMode.READER).query(
         'SELECT "code", "system", "value" FROM "Observation_Token" WHERE "resourceId"=$1',
         [obs1.id]
       );

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -1,5 +1,5 @@
 import { allOk, ContentType, isOk, OperationOutcomeError } from '@medplum/core';
-import { FhirRequest, FhirRouter, HttpMethod } from '@medplum/fhir-router';
+import { FhirRequest, FhirRouter, HttpMethod, RepositoryMode } from '@medplum/fhir-router';
 import { ResourceType } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
@@ -296,6 +296,13 @@ protectedRoutes.use(
       body: req.body,
       headers: req.headers,
     };
+
+    if (request.pathname.includes('$graphql')) {
+      // If this is a GraphQL request, mark the repository as eligible for "reader" mode.
+      // Inside the GraphQL handler, the repository will be set to "writer" mode if needed.
+      // At the time of this writing, the GraphQL handler is the only place where we consider "reader" mode.
+      ctx.repo.setMode(RepositoryMode.READER);
+    }
 
     const result = await getInternalFhirRouter().handleRequest(request, ctx.repo);
     if (result.length === 1) {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -42,6 +42,7 @@ import {
 } from '@medplum/fhirtypes';
 import validator from 'validator';
 import { getConfig } from '../config';
+import { DatabaseMode } from '../database';
 import { deriveIdentifierSearchParameter } from './lookups/util';
 import { getLookupTable, Repository } from './repo';
 import { getFullUrl } from './response';
@@ -162,7 +163,7 @@ async function getSearchEntries<T extends Resource>(
   builder.limit(count + 1); // Request one extra to test if there are more results
   builder.offset(searchRequest.offset || 0);
 
-  const rows = await builder.execute(repo.getDatabaseClient());
+  const rows = await builder.execute(repo.getDatabaseClient(DatabaseMode.READER));
   const rowCount = rows.length;
   const resources = rows.slice(0, count).map((row) => JSON.parse(row.content as string)) as T[];
   const entries = resources.map(
@@ -482,7 +483,7 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
     builder.raw('COUNT("id")::int AS "count"');
   }
 
-  const rows = await builder.execute(repo.getDatabaseClient());
+  const rows = await builder.execute(repo.getDatabaseClient(DatabaseMode.READER));
   return rows[0].count as number;
 }
 
@@ -505,7 +506,7 @@ async function getEstimateCount(
 
   // See: https://wiki.postgresql.org/wiki/Count_estimate
   // This parses the query plan to find the estimated number of rows.
-  const rows = await builder.execute(repo.getDatabaseClient());
+  const rows = await builder.execute(repo.getDatabaseClient(DatabaseMode.READER));
   let result = 0;
   for (const row of rows) {
     const queryPlan = row['QUERY PLAN'];

--- a/packages/server/src/healthcheck.ts
+++ b/packages/server/src/healthcheck.ts
@@ -2,18 +2,21 @@ import { MEDPLUM_VERSION } from '@medplum/core';
 import { Request, Response } from 'express';
 import os from 'node:os';
 import v8 from 'node:v8';
-import { getDatabasePool } from './database';
+import { Pool } from 'pg';
+import { DatabaseMode, getDatabasePool } from './database';
 import { setGauge } from './otel/otel';
 import { getRedis } from './redis';
 
 const hostname = os.hostname();
 
 export async function healthcheckHandler(_req: Request, res: Response): Promise<void> {
-  setGauge('medplum.db.idleConnections', getDatabasePool().idleCount, { hostname });
-  setGauge('medplum.db.queriesAwaitingClient', getDatabasePool().waitingCount, { hostname });
+  const pool = getDatabasePool(DatabaseMode.WRITER);
+
+  setGauge('medplum.db.idleConnections', pool.idleCount, { hostname });
+  setGauge('medplum.db.queriesAwaitingClient', pool.waitingCount, { hostname });
 
   let startTime = Date.now();
-  const postgresOk = await testPostgres();
+  const postgresOk = await testPostgres(pool);
   const dbRoundtripMs = Date.now() - startTime;
   setGauge('medplum.db.healthcheckRTT', dbRoundtripMs / 1000, { hostname });
 
@@ -45,8 +48,8 @@ export async function healthcheckHandler(_req: Request, res: Response): Promise<
   });
 }
 
-async function testPostgres(): Promise<boolean> {
-  return (await getDatabasePool().query(`SELECT 1 AS "status"`)).rows[0].status === 1;
+async function testPostgres(pool: Pool): Promise<boolean> {
+  return (await pool.query(`SELECT 1 AS "status"`)).rows[0].status === 1;
 }
 
 async function testRedis(): Promise<boolean> {

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -1,7 +1,7 @@
 import { Project } from '@medplum/fhirtypes';
 import { initAppServices, shutdownApp } from './app';
 import { loadTestConfig } from './config';
-import { getDatabasePool } from './database';
+import { DatabaseMode, getDatabasePool } from './database';
 import { SelectQuery } from './fhir/sql';
 import { seedDatabase } from './seed';
 import { withTestContext } from './test.setup';
@@ -13,7 +13,7 @@ describe('Seed', () => {
     const config = await loadTestConfig();
     config.database.runMigrations = true;
     return withTestContext(() => initAppServices(config));
-  });
+  }, 240000);
 
   afterAll(async () => {
     await shutdownApp();
@@ -24,7 +24,7 @@ describe('Seed', () => {
     await seedDatabase();
 
     // Make sure all database migrations have run
-    const pool = getDatabasePool();
+    const pool = getDatabasePool(DatabaseMode.WRITER);
     const result = await pool.query('SELECT "version" FROM "DatabaseMigration"');
     const version = result.rows[0]?.version ?? -1;
     expect(version).toBeGreaterThanOrEqual(67);

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,6 +1,6 @@
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import { BundleEntry, SearchParameter } from '@medplum/fhirtypes';
-import { getDatabasePool } from '../database';
+import { DatabaseMode, getDatabasePool } from '../database';
 import { Repository, getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { r4ProjectId } from '../seed';
@@ -9,7 +9,7 @@ import { r4ProjectId } from '../seed';
  * Creates all SearchParameter resources.
  */
 export async function rebuildR4SearchParameters(): Promise<void> {
-  const client = getDatabasePool();
+  const client = getDatabasePool(DatabaseMode.WRITER);
   await client.query('DELETE FROM "SearchParameter" WHERE "projectId" = $1', [r4ProjectId]);
 
   const systemRepo = getSystemRepo();

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,6 +1,6 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
-import { getDatabasePool } from '../database';
+import { DatabaseMode, getDatabasePool } from '../database';
 import { Repository, getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
 import { r4ProjectId } from '../seed';
@@ -9,7 +9,7 @@ import { r4ProjectId } from '../seed';
  * Creates all StructureDefinition resources.
  */
 export async function rebuildR4StructureDefinitions(): Promise<void> {
-  const client = getDatabasePool();
+  const client = getDatabasePool(DatabaseMode.WRITER);
   await client.query(`DELETE FROM "StructureDefinition" WHERE "projectId" = $1`, [r4ProjectId]);
 
   const systemRepo = getSystemRepo();

--- a/postgres/init_test.sql
+++ b/postgres/init_test.sql
@@ -1,2 +1,10 @@
 CREATE DATABASE medplum_test;
 GRANT ALL PRIVILEGES ON DATABASE medplum_test TO medplum;
+
+\c medplum_test
+
+CREATE USER medplum_test_readonly WITH PASSWORD 'medplum_test_readonly';
+GRANT CONNECT ON DATABASE medplum_test TO medplum_test_readonly;
+GRANT USAGE ON SCHEMA public TO medplum_test_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO medplum_test_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO medplum_test_readonly;


### PR DESCRIPTION
### Update 2024-07-03: Start with `$graphql` only

* Based on team discussions, we want to start using the reader instance only for readonly graphql queries
* This is a little tricky, due to the code split between `server` and `fhir-router`
* The `FhirRepository` interface now has a `setMode()` method which accepts `RepositoryMode.READER` or `RepositoryMode.WRITER`
* The server `Repository` starts in `RepositoryMode.WRITER`, and will therefore use the RDS writer instance by default for everything
* If the request is a `$graphql` request, we put the `Repository` in `RepositoryMode.READER`, meaning that it is eligible for the RDS reader instance
* Inside the graphql handler, we check for "mutations", and switch back to `RepositoryMode.WRITER` if necessary
* The net results is that we should only ever consider the reader instance under the following conditions:
   * Reader instance is configured in the server config settings
   * The request is a `$graphql` query
   * The GraphQL body does not include "mutation"

One slightly ugly part of this is there are now two enums, `RepositoryMode` and `DatabaseMode`, both with `READER` and `WRITER`.  These could be combined?

I don't love the flip-flopping between reader/writer modes, but I think it came out the most straightforward from API level.  Open to feedback.

The long term intent, as we gain confidence here, is that eventually server `Repository` could start in `READER` mode, and only switch to `WRITER` if the request makes any writes (as described below).  I think the current code is scaffolded nicely for that goal state.

--------

### Original remarks

How it works:
* During server startup, check for presence of a "reader" database config
* If there is a "reader" database config, setup a 2nd database pool for that instance
* Anytime the server requests a database client, it must specify "reader" or "writer"
* If the server requests a "reader" and the "reader" pool is available, then use a "reader" connection
* Database transactions always use "writer", including "reader" queries once inside a transaction

Needs more testing:
* We should be able to test this easily by creating a 2nd postgres user `medplum_readonly` or whatever
* I want to do some deeper testing on requests that potentially use a mix of "reader" and "writer"
   * The fear is the following situation:
      1. Create a resource using a "writer" connection
      2. Immediately search for a resource using a "reader" connection
      3. But the "reader" search executes during the brief window where "reader" and "writer" are out of sync
      4. Weird results follow
   * To resolve that, we may want to add some kind of logic such as: "once you use a writer connection, you have to use writer connections for the rest of the request"