### PR TITLE
tweak(repo): each repo can only do one query at a time

### DIFF
--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -319,7 +319,8 @@ async function includeInExpansion(
     query = addAbstractFilter(query, codeSystem);
   }
 
-  const results = await query.execute(ctx.repo.getDatabaseClient());
+  const results = await query.execute(await ctx.repo.getDatabaseClient());
+  ctx.repo.setQuerying(false);
   const system = codeSystem.url;
   for (const { code, display } of results) {
     expansion.push({ system, code, display });

--- a/packages/server/src/fhir/operations/subsumes.ts
+++ b/packages/server/src/fhir/operations/subsumes.ts
@@ -69,6 +69,7 @@ export async function isSubsumed(baseCode: string, ancestorCode: string, codeSys
     .where(new Column('Coding', 'code'), '=', baseCode);
 
   const query = findAncestor(base, codeSystem, ancestorCode);
-  const results = await query.execute(ctx.repo.getDatabaseClient());
+  const results = await query.execute(await ctx.repo.getDatabaseClient());
+  ctx.repo.setQuerying(false);
   return results.length > 0;
 }

--- a/packages/server/src/fhir/operations/valuesetvalidatecode.ts
+++ b/packages/server/src/fhir/operations/valuesetvalidatecode.ts
@@ -138,6 +138,7 @@ async function satisfies(
       return false; // Unknown filter type, don't make DB query with incorrect filters
   }
 
-  const results = await query.execute(ctx.repo.getDatabaseClient());
+  const results = await query.execute(await ctx.repo.getDatabaseClient());
+  ctx.repo.setQuerying(false);
   return results.length > 0;
 }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -162,7 +162,8 @@ async function getSearchEntries<T extends Resource>(
   builder.limit(count + 1); // Request one extra to test if there are more results
   builder.offset(searchRequest.offset || 0);
 
-  const rows = await builder.execute(repo.getDatabaseClient());
+  const rows = await builder.execute(await repo.getDatabaseClient());
+  repo.setQuerying(false);
   const rowCount = rows.length;
   const resources = rows.slice(0, count).map((row) => JSON.parse(row.content as string)) as T[];
   const entries = resources.map(
@@ -482,7 +483,8 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
     builder.raw('COUNT("id")::int AS "count"');
   }
 
-  const rows = await builder.execute(repo.getDatabaseClient());
+  const rows = await builder.execute(await repo.getDatabaseClient());
+  repo.setQuerying(false);
   return rows[0].count as number;
 }
 
@@ -505,7 +507,8 @@ async function getEstimateCount(
 
   // See: https://wiki.postgresql.org/wiki/Count_estimate
   // This parses the query plan to find the estimated number of rows.
-  const rows = await builder.execute(repo.getDatabaseClient());
+  const rows = await builder.execute(await repo.getDatabaseClient());
+  repo.setQuerying(false);
   let result = 0;
   for (const row of rows) {
     const queryPlan = row['QUERY PLAN'];


### PR DESCRIPTION
This is just testing what it would be like if each `Repository` could only issue one query at a time