### PR TITLE
Update Coverage section to render a table in Foomedical example

### DIFF
--- a/examples/foomedical/src/pages/account/MembershipAndBilling.tsx
+++ b/examples/foomedical/src/pages/account/MembershipAndBilling.tsx
@@ -1,14 +1,41 @@
-import { Box, Stack, Title } from '@mantine/core';
-import { getReferenceString } from '@medplum/core';
-import { Patient } from '@medplum/fhirtypes';
+import { Box, Stack, Table, Title } from '@mantine/core';
+import { formatCoding, getReferenceString } from '@medplum/core';
+import { Coverage, Patient } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react';
 import { InfoButton } from '../../components/InfoButton';
 import { InfoSection } from '../../components/InfoSection';
 
+function CoverageTable({ coverages }: { coverages: Coverage[] }): JSX.Element {
+  return (
+    <Table>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Payor Name</Table.Th>
+          <Table.Th>Subscriber ID</Table.Th>
+          <Table.Th>Relationship to Subscriber</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {coverages.map((c) => (
+          <Table.Tr key={c.id}>
+            <Table.Td>{c.payor?.[0].display}</Table.Td>
+            <Table.Td>{c.subscriberId || '-'}</Table.Td>
+            <Table.Td>{formatCoding(c.relationship?.coding?.[0]) || '-'}</Table.Td>
+          </Table.Tr>
+        ))}
+      </Table.Tbody>
+    </Table>
+  );
+}
+
 export function MembershipAndBilling(): JSX.Element {
   const medplum = useMedplum();
   const patient = medplum.getProfile() as Patient;
-  const coverages = medplum.searchResources('Coverage', 'patient=' + getReferenceString(patient)).read();
+  const coverages = medplum
+    .searchResources('Coverage', {
+      beneficiary: getReferenceString(patient),
+    })
+    .read();
   const payments = medplum.searchResources('PaymentNotice').read();
 
   return (
@@ -19,9 +46,7 @@ export function MembershipAndBilling(): JSX.Element {
           <Box p="xl">No coverage</Box>
         ) : (
           <Stack gap={0}>
-            {coverages.map((c) => (
-              <InfoButton key={c.id}>{c.id}</InfoButton>
-            ))}
+            <CoverageTable coverages={coverages} />
           </Stack>
         )}
       </InfoSection>


### PR DESCRIPTION
## Description

- Resolves #4757
- Update the Coverage section to display a table with more information

## Steps to test

- [ ] Run the foomedical example
   ```bash
   examples/foomedical > npm install
   examples/foomedical > npm run dev  
    ```
- [x] Go to the `Membership & Billing` page http://localhost:3000/account/membership-and-billing
- [ ] If the current user has no coverage, it should display the empty state:

  ![image](https://github.com/medplum/medplum/assets/22326737/e0570653-3274-42e8-a3d6-0d3f010923c9)

- [ ] If the current user has coverages ([docs](https://www.medplum.com/docs/api/fhir/resources/coverage)), it should display a table with the following columns:
  - [ ] Payor Name (required field)
  - [ ] Subscriber ID (optional field)
  - [ ] Relationship to Subscriber (optional field)

  ![image](https://github.com/medplum/medplum/assets/22326737/0f314a04-72f2-4ba4-b0b4-6de0988e8ac8)

<details>
<summary>[Click to expand] Script to create coverages</summary>

```typescript
 medplum.createResource(
    // start-block exampleCoverage
    {
      resourceType: 'Coverage',

      // Member id
      identifier: [
        {
          type: {
            coding: [
              {
                system: 'http://terminology.hl7.org/CodeSystem/v2-0203',
                code: 'MB',
                display: 'Member Number',
              },
            ],
          },
          system: 'https://www.acmeinsurance.com/glossary/memberid',
          value: '102345672-01',
          assigner: {
            display: 'Acme Insurance Co',
          },
        },
      ],
      subscriberId: '102345672-01',
      status: 'active',

      // Subscriber & Beneficiary
      subscriber: createReference(patient),
      beneficiary: createReference(patient),
      relationship: {
        coding: [
          {
            system: 'http://terminology.hl7.org/CodeSystem/subscriber-relationship',
            code: 'spouse',
            display: 'Spouse',
          },
        ],
      },
      period: {
        start: '2024-01-01',
      },

      // Payor
      payor: [
        {
          display: 'Acme Insurance Co',
        },
      ],
    }
    // end-block exampleCoverage
  );
```
</details>

