### PR TITLE
Pre-signed urls using native s3 presigner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2105,6 +2105,20 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.598.0.tgz",
+      "integrity": "sha512-1X0PlREk5K6tQg8rFZOjoKVtDyI1WgbKJNCymHhMye6STryY6fhuuayKstiDThkqDYxqahjUJz/Tl2p5W3rbcw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/querystring-builder": "^3.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.568.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
@@ -52604,6 +52618,7 @@
         "@aws-sdk/client-textract": "3.606.0",
         "@aws-sdk/cloudfront-signer": "3.598.0",
         "@aws-sdk/lib-storage": "3.606.0",
+        "@aws-sdk/s3-request-presigner": "3.598.0",
         "@aws-sdk/types": "3.598.0",
         "@medplum/core": "3.2.0",
         "@medplum/definitions": "3.2.0",
@@ -52693,6 +52708,24 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "packages/server/node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.606.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.606.0.tgz",
+      "integrity": "sha512-ErxArdCk73MVOh5xiTWZkk76kZWCHZqCCdMnSJTD0lzTpfGbwL/eEjHIjKLJO+EsRtDKYmS8vN+qijyMvMqruw==",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-format-url": "3.598.0",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "packages/server/node_modules/uuid": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
     "@aws-sdk/client-textract": "3.606.0",
     "@aws-sdk/cloudfront-signer": "3.598.0",
     "@aws-sdk/lib-storage": "3.606.0",
+    "@aws-sdk/s3-request-presigner": "3.598.0",
     "@aws-sdk/types": "3.598.0",
     "@medplum/core": "3.2.0",
     "@medplum/definitions": "3.2.0",

--- a/packages/server/src/cloud/aws/signer.ts
+++ b/packages/server/src/cloud/aws/signer.ts
@@ -1,3 +1,4 @@
+import { badRequest, OperationOutcomeError } from '@medplum/core';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { Binary } from '@medplum/fhirtypes';
 import { getConfig } from '../../config';
@@ -12,6 +13,9 @@ import { getConfig } from '../../config';
  */
 export function getPresignedUrl(binary: Binary): string {
   const config = getConfig();
+  if (!config.signingKeyId || !config.signingKey) {
+    throw new OperationOutcomeError(badRequest('Need to provide signingKeyId and signingKey in config file'));
+  }
   const storageBaseUrl = config.storageBaseUrl;
   const unsignedUrl = `${storageBaseUrl}${binary.id}/${binary.meta?.versionId}`;
   const dateLessThan = new Date();

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -19,9 +19,9 @@ export interface MedplumServerConfig {
   logLevel?: string;
   binaryStorage?: string;
   storageBaseUrl: string;
-  signingKey: string;
-  signingKeyId: string;
-  signingKeyPassphrase: string;
+  signingKey?: string;
+  signingKeyId?: string;
+  signingKeyPassphrase?: string;
   supportEmail: string;
   approvedSenderEmails?: string;
   database: MedplumDatabaseConfig;

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -103,7 +103,7 @@ async function handleBinaryWriteRequest(req: Request, res: Response): Promise<vo
 
   await sendResponse(req, res, outcome, {
     ...binary,
-    url: getBinaryStorage().getPresignedUrl(binary),
+    url: await getBinaryStorage().getPresignedUrl(binary),
   });
 }
 

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -60,7 +60,7 @@ export interface BinaryStorage {
 
   copyFile(sourceKey: string, destinationKey: string): Promise<void>;
 
-  getPresignedUrl(binary: Binary): string;
+  getPresignedUrl(binary: Binary): Promise<string>;
 }
 
 /**
@@ -126,7 +126,7 @@ class FileSystemStorage implements BinaryStorage {
     copyFileSync(resolve(this.baseDir, sourceKey), resolve(this.baseDir, destinationKey));
   }
 
-  getPresignedUrl(binary: Binary): string {
+  async getPresignedUrl(binary: Binary): Promise<string> {
     const config = getConfig();
     const storageBaseUrl = config.storageBaseUrl;
     const result = new URL(`${storageBaseUrl}${binary.id}/${binary.meta?.versionId}`);
@@ -135,9 +135,11 @@ class FileSystemStorage implements BinaryStorage {
     dateLessThan.setHours(dateLessThan.getHours() + 1);
     result.searchParams.set('Expires', dateLessThan.getTime().toString());
 
-    const privateKey = { key: config.signingKey, passphrase: config.signingKeyPassphrase };
-    const signature = createSign('sha256').update(result.toString()).sign(privateKey, 'base64');
-    result.searchParams.set('Signature', signature);
+    if (config.signingKey) {
+      const privateKey = { key: config.signingKey, passphrase: config.signingKeyPassphrase };
+      const signature = createSign('sha256').update(result.toString()).sign(privateKey, 'base64');
+      result.searchParams.set('Signature', signature);
+    }
 
     return result.toString();
   }


### PR DESCRIPTION
This is implements medplum/medplum#4815

Instead of a flag, we can make `signingKey` and `signingKeyId` optional, thus relying on AWS config directly.

- Since the original presigner doesn't have test, I didn't add any, but could try to figure out a way how to test it properly.
- Docs not yet updated

I can address those points but wanted to get a sense if the general direction is acceptable to the team.

---

I tested it locally and it the code does construct URLs for Binary that are signed correctly, (can be opened in incognito mode)