### PR TITLE
[Patient Intake Sample] Observation and Consent tabs

### DIFF
--- a/examples/medplum-patient-intake-demo/src/components/PatientConsents.tsx
+++ b/examples/medplum-patient-intake-demo/src/components/PatientConsents.tsx
@@ -1,0 +1,30 @@
+import { formatSearchQuery, Operator, SearchRequest } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { SearchControl } from '@medplum/react';
+import { useNavigate } from 'react-router-dom';
+
+interface PatientConsentsProps {
+  patient: Patient;
+}
+
+export function PatientConsents(props: PatientConsentsProps): JSX.Element {
+  const navigate = useNavigate();
+
+  const search: SearchRequest = {
+    resourceType: 'Consent',
+    filters: [{ code: 'patient', operator: Operator.EQUALS, value: `Patient/${props.patient.id}` }],
+    fields: ['status', 'scope', 'category'],
+  };
+
+  return (
+    <SearchControl
+      search={search}
+      hideFilters={true}
+      hideToolbar={true}
+      onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
+      onChange={(e) => {
+        navigate(`/${search.resourceType}${formatSearchQuery(e.definition)}`);
+      }}
+    />
+  );
+}

--- a/examples/medplum-patient-intake-demo/src/components/PatientDetails.tsx
+++ b/examples/medplum-patient-intake-demo/src/components/PatientDetails.tsx
@@ -22,7 +22,7 @@ export function PatientDetails(props: PatientDetailsProps): JSX.Element {
     ['details', 'Details'],
     ['edit', 'Edit'],
     ['history', 'History'],
-    ['observations', 'SDOH Observations'],
+    ['observations', 'SDOH'],
     ['consents', 'Consents'],
   ];
   // Get the current tab

--- a/examples/medplum-patient-intake-demo/src/components/PatientDetails.tsx
+++ b/examples/medplum-patient-intake-demo/src/components/PatientDetails.tsx
@@ -5,6 +5,7 @@ import { Patient, Resource } from '@medplum/fhirtypes';
 import { Document, ResourceForm, ResourceHistoryTable, ResourceTable, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
+import { PatientObservations } from './PatientObservations';
 
 interface PatientDetailsProps {
   patient: Patient;
@@ -20,6 +21,7 @@ export function PatientDetails(props: PatientDetailsProps): JSX.Element {
     ['details', 'Details'],
     ['edit', 'Edit'],
     ['history', 'History'],
+    ['observations', 'SDOH Observations'],
   ];
   // Get the current tab
   const tab = window.location.pathname.split('/').pop();
@@ -71,6 +73,9 @@ export function PatientDetails(props: PatientDetailsProps): JSX.Element {
         </Tabs.Panel>
         <Tabs.Panel value="history">
           <ResourceHistoryTable resourceType="Patient" id={id} />
+        </Tabs.Panel>
+        <Tabs.Panel value="observations">
+          <PatientObservations patient={props.patient} />
         </Tabs.Panel>
       </Tabs>
     </Document>

--- a/examples/medplum-patient-intake-demo/src/components/PatientDetails.tsx
+++ b/examples/medplum-patient-intake-demo/src/components/PatientDetails.tsx
@@ -5,6 +5,7 @@ import { Patient, Resource } from '@medplum/fhirtypes';
 import { Document, ResourceForm, ResourceHistoryTable, ResourceTable, useMedplum } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 import { useNavigate } from 'react-router-dom';
+import { PatientConsents } from './PatientConsents';
 import { PatientObservations } from './PatientObservations';
 
 interface PatientDetailsProps {
@@ -22,6 +23,7 @@ export function PatientDetails(props: PatientDetailsProps): JSX.Element {
     ['edit', 'Edit'],
     ['history', 'History'],
     ['observations', 'SDOH Observations'],
+    ['consents', 'Consents'],
   ];
   // Get the current tab
   const tab = window.location.pathname.split('/').pop();
@@ -76,6 +78,9 @@ export function PatientDetails(props: PatientDetailsProps): JSX.Element {
         </Tabs.Panel>
         <Tabs.Panel value="observations">
           <PatientObservations patient={props.patient} />
+        </Tabs.Panel>
+        <Tabs.Panel value="consents">
+          <PatientConsents patient={props.patient} />
         </Tabs.Panel>
       </Tabs>
     </Document>

--- a/examples/medplum-patient-intake-demo/src/components/PatientObservations.tsx
+++ b/examples/medplum-patient-intake-demo/src/components/PatientObservations.tsx
@@ -1,0 +1,33 @@
+import { formatSearchQuery, Operator, SearchRequest } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { SearchControl } from '@medplum/react';
+import { useNavigate } from 'react-router-dom';
+
+interface PatientObservationsProps {
+  patient: Patient;
+}
+
+export function PatientObservations(props: PatientObservationsProps): JSX.Element {
+  const navigate = useNavigate();
+
+  const search: SearchRequest = {
+    resourceType: 'Observation',
+    filters: [
+      { code: 'patient', operator: Operator.EQUALS, value: `Patient/${props.patient.id}` },
+      { code: 'category', operator: Operator.EQUALS, value: 'sdoh' },
+    ],
+    fields: ['status', 'code', 'category'],
+  };
+
+  return (
+    <SearchControl
+      search={search}
+      hideFilters={true}
+      hideToolbar={true}
+      onClick={(e) => navigate(`/${e.resource.resourceType}/${e.resource.id}`)}
+      onChange={(e) => {
+        navigate(`/${search.resourceType}${formatSearchQuery(e.definition)}`);
+      }}
+    />
+  );
+}

--- a/examples/medplum-patient-intake-demo/src/components/PatientObservations.tsx
+++ b/examples/medplum-patient-intake-demo/src/components/PatientObservations.tsx
@@ -16,7 +16,7 @@ export function PatientObservations(props: PatientObservationsProps): JSX.Elemen
       { code: 'patient', operator: Operator.EQUALS, value: `Patient/${props.patient.id}` },
       { code: 'category', operator: Operator.EQUALS, value: 'sdoh' },
     ],
-    fields: ['status', 'code', 'category'],
+    fields: ['code', 'value[x]'],
   };
 
   return (


### PR DESCRIPTION
## Description 

- Resolves #4795 
- Add Observation and Consent tabs to the patient detail page

## Steps to test

> [!WARNING]
> Since the bot is a working-in-progress, you can manually create the observations and consent to test the tabs.

- [ ] Go to the patient detail page
- [ ] Check if the tabs are working properly
  - [ ] Observations
  - [ ] Consents

[Screencast from 09-07-2024 18:58:23.webm](https://github.com/medplum/medplum/assets/22326737/9d6871fc-dac1-43fc-ab3a-9ef5580cc3a7)

