### PR TITLE
Revert "Revert "fixed the matchesStringValue doesn't match exactly on token...""

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -9,6 +9,7 @@ import {
   QuestionnaireResponse,
   SearchParameter,
   ServiceRequest,
+  Task,
 } from '@medplum/fhirtypes';
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
@@ -807,5 +808,17 @@ describe('Search matching', () => {
       filters: [{ code: 'organization', operator: Operator.PRESENT, value: 'false' }],
     };
     expect(matchesSearchRequest(resource, search2)).toBe(false);
+  });
+
+  test('Tags', () => {
+    const task: Task = {
+      resourceType: 'Task',
+      meta: { tag: [{ system: 'http://example.com', code: 'foo' }] },
+      status: 'draft',
+      intent: 'proposal',
+    };
+
+    expect(matchesSearchRequest(task, parseSearchRequest('Task?_tag=foo'))).toBe(true);
+    expect(matchesSearchRequest(task, parseSearchRequest('Task?_tag=bar'))).toBe(false);
   });
 });

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -101,7 +101,7 @@ function matchesTokenFilter(resource: Resource, filter: Filter, searchParam: Sea
   if (details.type === SearchParameterType.BOOLEAN) {
     return matchesBooleanFilter(resource, filter, searchParam);
   } else {
-    return matchesStringFilter(resource, filter, searchParam, true);
+    return matchesStringFilter(resource, filter, searchParam, true, true);
   }
 }
 
@@ -116,7 +116,8 @@ function matchesStringFilter(
   resource: Resource,
   filter: Filter,
   searchParam: SearchParameter,
-  asToken?: boolean
+  asToken?: boolean,
+  exactMatch?: boolean
 ): boolean {
   const details = getSearchParameterDetails(resource.resourceType, searchParam);
   const searchParamElementType = details.elementDefinitions?.[0]?.type?.[0]?.code;
@@ -131,7 +132,7 @@ function matchesStringFilter(
       } else if (searchParamElementType === PropertyType.CodeableConcept) {
         match = matchesTokenCodeableConceptValue(resourceValue as Coding, filter.operator, filterValue);
       } else {
-        match = matchesStringValue(resourceValue, filter.operator, filterValue, asToken);
+        match = matchesStringValue(resourceValue, filter.operator, filterValue, asToken, exactMatch);
       }
       if (match) {
         return !negated;
@@ -147,7 +148,8 @@ function matchesStringValue(
   resourceValue: unknown,
   operator: Operator,
   filterValue: string,
-  asToken?: boolean
+  asToken?: boolean,
+  exactMatch?: boolean
 ): boolean {
   if (asToken && filterValue.includes('|')) {
     const [system, code] = filterValue.split('|');
@@ -164,6 +166,11 @@ function matchesStringValue(
       str = JSON.stringify(resourceValue);
     }
   }
+
+  if (exactMatch) {
+    return str === filterValue;
+  }
+
   return str.toLowerCase().includes(filterValue.toLowerCase());
 }
 

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -168,7 +168,7 @@ function matchesStringValue(
   }
 
   if (exactMatch) {
-    return str === filterValue;
+    return str === filterValue || str.includes(`"${filterValue}"`);
   }
 
   return str.toLowerCase().includes(filterValue.toLowerCase());


### PR DESCRIPTION
Reverts medplum/medplum#4855

This is a "revert of the revert".  The [original PR](https://github.com/medplum/medplum/commit/ba1cdfd95eebcb56d764954a846f0b06ae912fc0) did not handle `SearchParameter.type='token'` on `Coding` values.  That led to a production issue of `Subscription` webhooks not firing that depended on `token` and `Coding` (such as `Task?_tag=x`.  

This PR "fixes" the issue and adds tests.  If we want to merge, we can.

However, the `matchesStringValue` implementation overall is brittle, and probably needs an overhaul.  It relies on a series of heuristics and special cases rather than a concrete system of handling all possible combinations of `SearchParameter.type` and `ElementDefinition.type`.