### PR TITLE
Fixes #4343 - ONC service base url

### DIFF
--- a/packages/docs/static/onc-service-base-url.json
+++ b/packages/docs/static/onc-service-base-url.json
@@ -1,0 +1,90 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Endpoint",
+        "id": "medplum",
+        "status": "active",
+        "connectionType": {
+          "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+          "code": "hl7-fhir-rest",
+          "display": "HL7 FHIR"
+        },
+        "name": "Medplum Endpoint",
+        "managingOrganization": {
+          "reference": "Organization/medplum",
+          "display": "Medplum"
+        },
+        "payloadType": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/endpoint-payload-type",
+                "code": "any",
+                "display": "Any"
+              }
+            ]
+          }
+        ],
+        "payloadMimeType": ["application/fhir+json"],
+        "address": "https://api.medplum.com/fhir/R4"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "medplum",
+        "name": "Medplum",
+        "telecom": [
+          {
+            "system": "phone",
+            "use": "work",
+            "value": "+1-415-900-9122"
+          }
+        ],
+        "address": [
+          {
+            "use": "work",
+            "type": "both",
+            "line": ["2477 Sutter St"],
+            "city": "San Francisco",
+            "state": "California",
+            "postalCode": "94115"
+          }
+        ],
+        "contact": [
+          {
+            "purpose": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/contactentity-type",
+                  "code": "ADMIN",
+                  "display": "Administrative"
+                }
+              ]
+            },
+            "name": {
+              "use": "official",
+              "given": ["Cody"],
+              "family": "Ebberson"
+            },
+            "address": {
+              "city": "San Francisco",
+              "state": "California",
+              "postalCode": "94115",
+              "line": ["2477 Sutter St"]
+            }
+          }
+        ],
+        "endpoint": [
+          {
+            "reference": "Endpoint/medplum",
+            "display": "Medplum Endpoint"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/docs/static/onc/base.json
+++ b/packages/docs/static/onc/base.json
@@ -1,11 +1,23 @@
 {
   "resourceType": "Bundle",
   "type": "searchset",
+  "total": 2,
+  "link": [
+    {
+      "relation": "self",
+      "url": "https://www.medplum.com/onc/base.json"
+    }
+  ],
   "entry": [
     {
+      "fullUrl": "https://www.medplum.com/Endpoint/medplum",
       "resource": {
         "resourceType": "Endpoint",
         "id": "medplum",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p></div>"
+        },
         "status": "active",
         "connectionType": {
           "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
@@ -30,12 +42,21 @@
         ],
         "payloadMimeType": ["application/fhir+json"],
         "address": "https://api.medplum.com/fhir/R4"
+      },
+      "search": {
+        "mode": "match",
+        "score": 1
       }
     },
     {
+      "fullUrl": "https://www.medplum.com/Organization/medplum",
       "resource": {
         "resourceType": "Organization",
         "id": "medplum",
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: example</p></div>"
+        },
         "name": "Medplum",
         "telecom": [
           {
@@ -84,6 +105,10 @@
             "display": "Medplum Endpoint"
           }
         ]
+      },
+      "search": {
+        "mode": "match",
+        "score": 1
       }
     }
   ]


### PR DESCRIPTION
Replaces https://github.com/medplum/medplum/pull/4352

The old PR was stuck on auth refactoring.  Serving this content from the API server would require some pretty deep changes to how auth works for the FHIR base URL (i.e., `/fhir/R4`) because the ONC service base URL must be public.

I was reading through the requirements, and realized that the ONC service base URL does not need to be the same as the FHIR base URL.  So we can do the really simple thing, and just host it on www.medplum.com 🙃 

Basic FHIR validator: https://inferno.healthit.gov/validator/

Service Base URL test kit: https://inferno.healthit.gov/test-kits/service-base-url/