### PR TITLE
[Chart demo] Fixes bots handler function signature

### DIFF
--- a/examples/medplum-chart-demo/src/bots/core/general-encounter-note.ts
+++ b/examples/medplum-chart-demo/src/bots/core/general-encounter-note.ts
@@ -14,7 +14,7 @@ import {
 import { createBundle, createClinicalImpression, createConditions, createObservations } from './charting-utils';
 import { calculateBMI } from './observation-utils';
 
-export async function handler(event: BotEvent<QuestionnaireResponse>, medplum: MedplumClient): Promise<Bundle> {
+export async function handler(medplum: MedplumClient, event: BotEvent<QuestionnaireResponse>): Promise<Bundle> {
   // Parse the answers from the QuestionnaireResponse
   const response = event.input;
   const answers = getQuestionnaireAnswers(response);

--- a/examples/medplum-chart-demo/src/bots/core/general-encounter.test.ts
+++ b/examples/medplum-chart-demo/src/bots/core/general-encounter.test.ts
@@ -38,7 +38,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     fullResponse.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler({ bot, contentType, input: fullResponse, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, contentType, input: fullResponse, secrets: {} });
     const observations = await medplum.searchResources('Observation', {
       encounter: encounterRef,
     });
@@ -59,7 +59,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     fullResponseNoProblemList.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler({ bot, contentType, input: fullResponseNoProblemList, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, contentType, input: fullResponseNoProblemList, secrets: {} });
     const observations = await medplum.searchResources('Observation', {
       encounter: encounterRef,
     });
@@ -80,7 +80,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     noReasonForVisit.encounter = { reference: encounterRef };
 
-    await expect(handler({ bot, contentType, input: noReasonForVisit, secrets: {} }, medplum)).rejects.toThrow(
+    await expect(handler(medplum, { bot, contentType, input: noReasonForVisit, secrets: {} })).rejects.toThrow(
       /^Must provide a reason for the visit$/
     );
   });
@@ -91,7 +91,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     onlyCondition.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler({ bot, contentType, input: onlyCondition, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, contentType, input: onlyCondition, secrets: {} });
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
     });
@@ -112,10 +112,12 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     oneBloodPressureMeasurement.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler(
-      { bot, contentType, input: oneBloodPressureMeasurement, secrets: {} },
-      medplum
-    );
+    const responseBundle = await handler(medplum, {
+      bot,
+      contentType,
+      input: oneBloodPressureMeasurement,
+      secrets: {},
+    });
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
     });
@@ -141,7 +143,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     selfReportedHistoryBmi.encounter = { reference: encounterRef };
 
-    await handler({ bot, contentType, input: selfReportedHistoryBmi, secrets: {} }, medplum);
+    await handler(medplum, { bot, contentType, input: selfReportedHistoryBmi, secrets: {} });
 
     const highBmiObservation = await medplum.searchOne('Observation', {
       code: 'E66.9',
@@ -156,7 +158,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     selfReportedHistoryBreastCancer.encounter = { reference: encounterRef };
 
-    await handler({ bot, contentType, input: selfReportedHistoryBreastCancer, secrets: {} }, medplum);
+    await handler(medplum, { bot, contentType, input: selfReportedHistoryBreastCancer, secrets: {} });
 
     const breastCancerObservatoin = await medplum.searchOne('Observation', {
       code: 'D05.10',
@@ -171,7 +173,7 @@ describe('General Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     selfReportedHistoryEndometrialCancer.encounter = { reference: encounterRef };
 
-    await handler({ bot, contentType, input: selfReportedHistoryEndometrialCancer, secrets: {} }, medplum);
+    await handler(medplum, { bot, contentType, input: selfReportedHistoryEndometrialCancer, secrets: {} });
 
     const endometrialCancerObservatoin = await medplum.searchOne('Observation', {
       code: 'C54.1',

--- a/examples/medplum-chart-demo/src/bots/core/gynecology-encounter-note.ts
+++ b/examples/medplum-chart-demo/src/bots/core/gynecology-encounter-note.ts
@@ -14,7 +14,7 @@ import {
 import { createBundle, createClinicalImpression, createConditions, createObservations } from './charting-utils';
 import { calculateBMI } from './observation-utils';
 
-export async function handler(event: BotEvent<QuestionnaireResponse>, medplum: MedplumClient): Promise<Bundle> {
+export async function handler(medplum: MedplumClient, event: BotEvent<QuestionnaireResponse>): Promise<Bundle> {
   // Parse the answers from the QuestionnaireResponse
   const response = event.input;
   const answers = getQuestionnaireAnswers(response);

--- a/examples/medplum-chart-demo/src/bots/core/gynecology-encounter.test.ts
+++ b/examples/medplum-chart-demo/src/bots/core/gynecology-encounter.test.ts
@@ -31,7 +31,7 @@ describe('Gynecology Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     fullResponse.encounter = { reference: getReferenceString(testEncounter) };
 
-    const responseBundle = await handler({ bot, input: fullResponse, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: fullResponse, contentType, secrets: {} });
     const clinicalImpression = await medplum.searchResources('ClinicalImpression');
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
@@ -52,7 +52,7 @@ describe('Gynecology Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     fullResponseNoProblemList.encounter = { reference: getReferenceString(testEncounter) };
 
-    const responseBundle = await handler({ bot, input: fullResponseNoProblemList, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: fullResponseNoProblemList, contentType, secrets: {} });
     const clinicalImpression = await medplum.searchResources('ClinicalImpression');
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
@@ -72,7 +72,7 @@ describe('Gynecology Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     noAssessment.encounter = { reference: getReferenceString(testEncounter) };
 
-    const responseBundle = await handler({ bot, input: noAssessment, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: noAssessment, contentType, secrets: {} });
     const clinicalImpression = await medplum.searchResources('ClinicalImpression');
 
     expect(responseBundle.entry?.length).toBe(12);
@@ -84,7 +84,7 @@ describe('Gynecology Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     noCondition.encounter = { reference: getReferenceString(testEncounter) };
 
-    await expect(handler({ bot, input: noCondition, contentType, secrets: {} }, medplum)).rejects.toThrow(
+    await expect(handler(medplum, { bot, input: noCondition, contentType, secrets: {} })).rejects.toThrow(
       /^Must provide a reason for the visit$/
     );
   });
@@ -94,7 +94,7 @@ describe('Gynecology Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     onlyCondition.encounter = { reference: getReferenceString(testEncounter) };
 
-    const responseBundle = await handler({ bot, input: onlyCondition, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: onlyCondition, contentType, secrets: {} });
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
     });
@@ -115,10 +115,12 @@ describe('Gynecology Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     oneBloodPressureMeasurement.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler(
-      { bot, contentType, input: oneBloodPressureMeasurement, secrets: {} },
-      medplum
-    );
+    const responseBundle = await handler(medplum, {
+      bot,
+      contentType,
+      input: oneBloodPressureMeasurement,
+      secrets: {},
+    });
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
     });

--- a/examples/medplum-chart-demo/src/bots/core/obstetric-encounter-note.ts
+++ b/examples/medplum-chart-demo/src/bots/core/obstetric-encounter-note.ts
@@ -14,7 +14,7 @@ import {
 import { createBundle, createClinicalImpression, createConditions, createObservations } from './charting-utils';
 import { calculateBMI } from './observation-utils';
 
-export async function handler(event: BotEvent<QuestionnaireResponse>, medplum: MedplumClient): Promise<Bundle> {
+export async function handler(medplum: MedplumClient, event: BotEvent<QuestionnaireResponse>): Promise<Bundle> {
   // Parse the answers from the QuestionnaireResponse
   const response = event.input;
   const answers = getQuestionnaireAnswers(response);

--- a/examples/medplum-chart-demo/src/bots/core/obstetric-encounter.test.ts
+++ b/examples/medplum-chart-demo/src/bots/core/obstetric-encounter.test.ts
@@ -35,7 +35,7 @@ describe('Obstetric Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     fullResponse.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler({ bot, input: fullResponse, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: fullResponse, contentType, secrets: {} });
     const observations = await medplum.searchResources('Observation', {
       encounter: encounterRef,
     });
@@ -56,7 +56,7 @@ describe('Obstetric Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     responseWithNoAssessment.encounter = { reference: getReferenceString(testEncounter) };
 
-    const responseBundle = await handler({ bot, input: responseWithNoAssessment, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: responseWithNoAssessment, contentType, secrets: {} });
 
     const clinicalImpression = await medplum.searchResources('ClinicalImpression');
 
@@ -70,7 +70,7 @@ describe('Obstetric Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     noCondition.encounter = { reference: getReferenceString(testEncounter) };
 
-    await expect(handler({ bot, input: noCondition, contentType, secrets: {} }, medplum)).rejects.toThrow(
+    await expect(handler(medplum, { bot, input: noCondition, contentType, secrets: {} })).rejects.toThrow(
       /^Must provide a reason for the visit$/
     );
   });
@@ -81,7 +81,7 @@ describe('Obstetric Encounter Note', async () => {
     const testEncounter = await medplum.createResource(encounter);
     onlyCondition.encounter = { reference: getReferenceString(testEncounter) };
 
-    const responseBundle = await handler({ bot, input: onlyCondition, contentType, secrets: {} }, medplum);
+    const responseBundle = await handler(medplum, { bot, input: onlyCondition, contentType, secrets: {} });
 
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(encounter),
@@ -101,10 +101,12 @@ describe('Obstetric Encounter Note', async () => {
     const encounterRef = getReferenceString(testEncounter);
     oneBloodPressureMeasurement.encounter = { reference: encounterRef };
 
-    const responseBundle = await handler(
-      { bot, contentType, input: oneBloodPressureMeasurement, secrets: {} },
-      medplum
-    );
+    const responseBundle = await handler(medplum, {
+      bot,
+      contentType,
+      input: oneBloodPressureMeasurement,
+      secrets: {},
+    });
     const observations = await medplum.searchResources('Observation', {
       encounter: getReferenceString(testEncounter),
     });


### PR DESCRIPTION
# Description
While working at he Patient Intake demo bots I noticed that the handler parameters from the Charts demo were reversed, `handler(event, medplum)` instead of `handler(medplum, event)`, this PR fixes this issue.