### PR TITLE
Add and set AccessPolicy.basedOn

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -60253,6 +60253,13 @@
           "description": "A name associated with the AccessPolicy.",
           "$ref": "#/definitions/string"
         },
+        "basedOn": {
+          "description": "Other access policies used to derive this access policy.",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          },
+          "type": "array"
+        },
         "compartment": {
           "description": "Optional compartment for newly created resources.  If this field is set, any resources created by a user with this access policy will automatically be included in the specified compartment.",
           "$ref": "#/definitions/Reference"

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -3509,6 +3509,22 @@
             }
           },
           {
+            "id" : "AccessPolicy.basedOn",
+            "path" : "AccessPolicy.basedOn",
+            "definition" : "Other access policies used to derive this access policy.",
+            "min" : 0,
+            "max" : "*",
+            "base" : {
+              "path" : "AccessPolicy.basedOn",
+              "min" : 0,
+              "max" : "*"
+            },
+            "type" : [{
+              "code" : "Reference",
+              "targetProfile" : ["https://medplum.com/fhir/StructureDefinition/AccessPolicy"]
+            }]
+          },
+          {
             "id" : "AccessPolicy.compartment",
             "path" : "AccessPolicy.compartment",
             "definition" : "Optional compartment for newly created resources.  If this field is set, any resources created by a user with this access policy will automatically be included in the specified compartment.",

--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -98,6 +98,11 @@ export interface AccessPolicy {
   name?: string;
 
   /**
+   * Other access policies used to derive this access policy.
+   */
+  basedOn?: Reference<AccessPolicy>[];
+
+  /**
    * Optional compartment for newly created resources.  If this field is
    * set, any resources created by a user with this access policy will
    * automatically be included in the specified compartment.

--- a/packages/fhirtypes/dist/Meta.d.ts
+++ b/packages/fhirtypes/dist/Meta.d.ts
@@ -84,7 +84,8 @@ export interface Meta {
   author?: Reference;
 
   /**
-   * The individual, device, or organization for whom the change was made.
+   * Optional individual, device, or organization for whom the change was
+   * made.
    */
   onBehalfOf?: Reference;
 

--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -117,6 +117,7 @@ export async function buildAccessPolicy(membership: ProjectMembership): Promise<
 
   return {
     resourceType: 'AccessPolicy',
+    basedOn: access.map((a) => a.policy),
     compartment,
     resource: resourcePolicies,
     ipAccessRule: ipAccessRules,


### PR DESCRIPTION
Context: Users can optionally have one or more `AccessPolicy` resources attached to their `ProjectMembership`.  Those `AccessPolicy` resources can be parameterized.  At runtime, Medplum server gathers everything and "resolves" them into a single ready-to-use `AccessPolicy`, which is used for actual enforcement.

A user requested having some kind of linkage in that "derived" or "resolved" `AccessPolicy` back to the originals.

This PR adds new `AccessPolicy.basedOn` element, and populates it during the resolution step.

User requested: https://medplum.slack.com/archives/C0720R0KVTQ/p1721025520098469