### PR TITLE
fix(fhircast): associate topic with separate random connection endpoint

### DIFF
--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -140,6 +140,35 @@ describe('FHIRCast routes', () => {
     }
   });
 
+  test('Subscribing twice to the same topic yields the same url', async () => {
+    const res1 = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': 'topic',
+        'hub.events': 'Patient-open',
+      });
+    expect(res1.status).toBe(202);
+    expect(res1.body['hub.channel.endpoint']).toMatch(/ws:\/\/localhost:8103\/ws\/fhircast\/*/);
+    expect(res1.body['hub.channel.endpoint']).not.toContain('topic');
+
+    const res2 = await request(server)
+      .post(STU3_BASE_ROUTE)
+      .set('Content-Type', ContentType.JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        'hub.channel.type': 'websocket',
+        'hub.mode': 'subscribe',
+        'hub.topic': 'topic',
+        'hub.events': 'Patient-open',
+      });
+    expect(res2.status).toBe(202);
+    expect(res2.body['hub.channel.endpoint']).toEqual(res1.body['hub.channel.endpoint']);
+  });
+
   test('Unsubscribe', async () => {
     for (const route of [STU2_BASE_ROUTE, STU3_BASE_ROUTE]) {
       const subRes = await request(server)

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -151,9 +151,13 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
   let subscriptionEndpoint: string;
   try {
     const results = await getRedis()
+      // Multi allows for multiple commands to be executed in a transaction
       .multi()
+      // Sets the endpoint key for this topic if it doesn't exist
       .setnx(`medplum:fhircast:topic:${topic}:endpoint`, generateId())
+      // Gets the endpoint, either previously generated endpoint secret or the newly generated key if a previous one did not exist
       .get(`medplum:fhircast:topic:${topic}:endpoint`)
+      // Executes the transaction
       .exec();
 
     if (!results) {

--- a/packages/server/src/fhircast/routes.ts
+++ b/packages/server/src/fhircast/routes.ts
@@ -152,14 +152,14 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
   const topic = req.body['hub.topic'];
   let subscriptionEndpoint: string;
   try {
-    const topicKey = `medplum:fhircast:project:${ctx.project.id as string}:topic:${topic}:endpoint`;
+    const topicEndpointKey = `medplum:fhircast:project:${ctx.project.id as string}:topic:${topic}:endpoint`;
     const results = await getRedis()
       // Multi allows for multiple commands to be executed in a transaction
       .multi()
       // Sets the endpoint key for this topic if it doesn't exist
-      .setnx(topicKey, generateId())
+      .setnx(topicEndpointKey, generateId())
       // Gets the endpoint, either previously generated endpoint secret or the newly generated key if a previous one did not exist
-      .get(topicKey)
+      .get(topicEndpointKey)
       // Executes the transaction
       .exec();
 
@@ -215,8 +215,10 @@ async function handleSubscriptionRequest(req: Request, res: Response): Promise<v
 }
 
 async function handleContextChangeRequest(req: Request, res: Response): Promise<void> {
+  const ctx = getAuthenticatedContext();
   const { event } = req.body as FhircastMessagePayload;
   let stringifiedBody = JSON.stringify(req.body);
+  const topicContextKey = `medplum:fhircast:project:${ctx.project.id as string}:topic:${event['hub.topic']}:latest`;
   // Check if this an open event
   if (event['hub.event'].endsWith('-open')) {
     // TODO: Support this as a param for event type: "versionable"?
@@ -224,18 +226,17 @@ async function handleContextChangeRequest(req: Request, res: Response): Promise<
       event['context.versionId'] = generateId();
       stringifiedBody = JSON.stringify(req.body);
     }
-    // TODO: we need to get topic from event and not route param since per spec, the topic shouldn't be the slug like we have it
-    await getRedis().set(`medplum:fhircast:topic:${event['hub.topic']}:latest`, stringifiedBody);
+    await getRedis().set(topicContextKey, stringifiedBody);
   } else if (event['hub.event'].endsWith('-close')) {
     // We always close the current context, even if the event is not for the original resource... There isn't any mention of checking to see it's the right resource, so it seems it may be assumed to be always valid to do any arbitrary close as long as there is an existing context...
-    await getRedis().del(`medplum:fhircast:topic:${event['hub.topic']}:latest`);
+    await getRedis().del(topicContextKey);
   } else if (event['hub.event'] === 'DiagnosticReport-update') {
     // See: https://build.fhir.org/ig/HL7/fhircast-docs/3-6-3-DiagnosticReport-update.html#:~:text=The%20Hub%20SHALL,the%20new%20updates.
     event['context.priorVersionId'] = event['context.versionId'];
     event['context.versionId'] = generateId();
     stringifiedBody = JSON.stringify(req.body);
     // TODO: Make sure this is actually supposed to be stored / overwrite open context? (ambiguous from docs, see: https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html)
-    await getRedis().set(`medplum:fhircast:topic:${event['hub.topic']}:latest`, stringifiedBody);
+    await getRedis().set(topicContextKey, stringifiedBody);
   }
   await getRedis().publish(event['hub.topic'], stringifiedBody);
   res.status(201).json({ success: true, event: body });
@@ -245,7 +246,10 @@ async function handleContextChangeRequest(req: Request, res: Response): Promise<
 protectedSTU2Routes.get(
   '/:topic',
   asyncWrap(async (req: Request, res: Response) => {
-    const latestEventStr = await getRedis().get(`medplum:fhircast:topic:${req.params.topic}:latest`);
+    const ctx = getAuthenticatedContext();
+    const latestEventStr = await getRedis().get(
+      `medplum:fhircast:project:${ctx.project.id as string}:topic:${req.params.topic}:latest`
+    );
     // Non-standard FHIRCast extension to support Nuance PowerCast Hub
     if (!latestEventStr) {
       res.status(200).json([]);
@@ -258,7 +262,10 @@ protectedSTU2Routes.get(
 protectedSTU3Routes.get(
   '/:topic',
   asyncWrap(async (req: Request, res: Response) => {
-    const latestEventStr = await getRedis().get(`medplum:fhircast:topic:${req.params.topic}:latest`);
+    const ctx = getAuthenticatedContext();
+    const latestEventStr = await getRedis().get(
+      `medplum:fhircast:project:${ctx.project.id as string}:topic:${req.params.topic}:latest`
+    );
     if (!latestEventStr) {
       // Source: https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html#:~:text=The%20following%20example%20shows%20the%20returned%20structure%20when%20no%20context%20is%20established%3A
       res.status(200).json({


### PR DESCRIPTION
This makes `FHIRcast` connections slightly more secure since knowing the secret `topic` will no longer be enough to connect to the topic WebSocket endpoint URL, and all users will need to POST a subscription request in order to receive the proper endpoint URL, which requires authentication to a protected route first.

This also makes the implementation more in line with the spec: https://fhircast.org/specification/STU2/#:~:text=When%20using%20WebSockets%2C%20the%20HTTP%20body%20of%20the%20response%20SHALL%20consist%20of%20a%20JSON%20object%20containing%20an%20element%20name%20of%20hub.channel.endpoint%20and%20a%20value%20of%20the%20WSS%20URL.%20The%20WebSocket%20WSS%20URL%20SHALL%20be%20cryptographically%20random%2C%20unique%2C%20and%20unguessable.