### PR TITLE
Fixes broken links in example apps README

### DIFF
--- a/examples/medplum-chart-demo/README.md
+++ b/examples/medplum-chart-demo/README.md
@@ -51,7 +51,7 @@ The Encounter Chart has 3 distinct panels
 
 ### Getting Started
 
-If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/app/register) to register a Medplum project to store your data.
+If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
 [Fork](https://github.com/medplum/medplum-hello-world/fork) and clone the repo.
 
@@ -62,6 +62,7 @@ npm install
 ```
 
 Then, build the bots
+
 ```bash
 npm run build:bots
 ```

--- a/examples/medplum-patient-intake-demo/README.md
+++ b/examples/medplum-patient-intake-demo/README.md
@@ -33,7 +33,7 @@ The `data` directory contains data that can be uploaded for use in the demo. The
 
 ### Getting Started
 
-If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/app/register) to register a Medplum project to store your data.
+If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
 [Fork](https://github.com/medplum/medplum/) and clone the repo to your local machine.
 

--- a/examples/medplum-provider/README.md
+++ b/examples/medplum-provider/README.md
@@ -17,31 +17,33 @@ This example app demonstrates the following:
 The Patient Chart has 3 distinct panels
 
 1. Clinical Chart
-  The left panel shows the patient history and their status. Notable information in the clinical chart includes the following Resources:
-    - Patient Information
-    - Upcoming Appointments
-    - Documented Visits 
-    - List of Allergies
-    - List of Problems
-    - Medication Requests
-    - Smoking Status
-    - Vitals 
+   The left panel shows the patient history and their status. Notable information in the clinical chart includes the following Resources:
+
+   - Patient Information
+   - Upcoming Appointments
+   - Documented Visits
+   - List of Allergies
+   - List of Problems
+   - Medication Requests
+   - Smoking Status
+   - Vitals
 
 2. Tasks
-  The center panel shows list of the Task resource with a different focus resource. See our [Tasks Guide](https://www.medplum.com/docs/careplans/tasks) for more details.
-    - Each focus is interactive to either review or fill out
-    - This example project demonstrates interactions of the following resources:
-      - Questionnaire
-      - QuestionnaireResponse
-      - DiagnosticReport 
-      - CarePlan
+   The center panel shows list of the Task resource with a different focus resource. See our [Tasks Guide](https://www.medplum.com/docs/careplans/tasks) for more details.
+
+   - Each focus is interactive to either review or fill out
+   - This example project demonstrates interactions of the following resources:
+     - Questionnaire
+     - QuestionnaireResponse
+     - DiagnosticReport
+     - CarePlan
 
 3. SOAP Note
-  The right most panel documents an enounter with the patient through a questionnaire. Filling out and submitting the questionnaire automatically creates a task, with the response as the focus to be reviewed.
+   The right most panel documents an encounter with the patient through a questionnaire. Filling out and submitting the questionnaire automatically creates a task, with the response as the focus to be reviewed.
 
 ### Getting Started
 
-If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/app/register) to register a Medplum project to store your data.
+If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
 [Fork](https://github.com/medplum/medplum-hello-world/fork) and clone the repo.
 


### PR DESCRIPTION
Broken link: `https://www.medplum.com/docs/tutorials/app/register`
New link: `https://www.medplum.com/docs/tutorials/register`
