### PR TITLE
fix(searchparams): `Location.physicalType` -> `Location.physical-type`

### DIFF
--- a/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
@@ -713,17 +713,17 @@
       }
     },
     {
-      "fullUrl": "https://medplum.com/fhir/SearchParameter/Location-physicalType",
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/Location-physical-type",
       "resource": {
         "resourceType": "SearchParameter",
-        "id": "Location-physicalType",
-        "url": "https://medplum.com/fhir/SearchParameter/Location-physicalType",
+        "id": "Location-physical-type",
+        "url": "https://medplum.com/fhir/SearchParameter/Location-physical-type",
         "version": "4.0.1",
-        "name": "physicalType",
+        "name": "physical-type",
         "status": "draft",
         "publisher": "Medplum",
-        "description": "The physicalType of the Location resource",
-        "code": "physicalType",
+        "description": "The physical type of the Location resource",
+        "code": "physical-type",
         "base": ["Location"],
         "type": "token",
         "expression": "Location.physicalType"


### PR DESCRIPTION
Made a mistake when getting out this new `SearchParameter` quickly. This PR fixes the casing of the `SearchParameter` name, code, etc. from camelCase to kebab-case