### PR TITLE
Use StructureDefinition.type 

### DIFF
--- a/packages/app/src/resource/ProfilesPage.test.tsx
+++ b/packages/app/src/resource/ProfilesPage.test.tsx
@@ -22,7 +22,7 @@ describe('ProfilesPage', () => {
     }
     medplum.requestProfileSchema = jest.fn((profileUrl) => {
       if (loadedProfileUrls.includes(profileUrl)) {
-        return Promise.resolve([profileUrl]);
+        return Promise.resolve();
       } else {
         throw new Error('unexpected profileUrl');
       }

--- a/packages/app/src/resource/ProfilesPage.test.tsx
+++ b/packages/app/src/resource/ProfilesPage.test.tsx
@@ -18,7 +18,7 @@ describe('ProfilesPage', () => {
     for (const profile of [fishPatientProfile, FishPatientResources.getFishSpeciesExtensionSD()]) {
       const sd = await medplum.createResourceIfNoneExist<StructureDefinition>(profile, `url:${profile.url}`);
       loadedProfileUrls.push(sd.url);
-      loadDataType(sd, sd.url);
+      loadDataType(sd);
     }
     medplum.requestProfileSchema = jest.fn((profileUrl) => {
       if (loadedProfileUrls.includes(profileUrl)) {

--- a/packages/core/src/base-schema.ts
+++ b/packages/core/src/base-schema.ts
@@ -49,6 +49,7 @@ export function inflateBaseSchema(base: BaseSchema): DataTypesMap {
   for (const [key, schema] of Object.entries(base)) {
     output[key] = {
       name: key,
+      type: key,
       elements: Object.fromEntries(
         Object.entries(schema.elements).map(([property, partial]) => [property, inflateElement(property, partial)])
       ),

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -40,7 +40,7 @@ import { ProfileResource, createReference, sleep } from './utils';
 
 const patientStructureDefinition: StructureDefinition = {
   resourceType: 'StructureDefinition',
-  url: 'http://example.com/patient',
+  url: 'http://hl7.org/fhir/StructureDefinition/Patient',
   status: 'active',
   kind: 'resource',
   abstract: false,
@@ -89,6 +89,7 @@ const patientProfileExtensionUrl = 'http://example.com/patient-profile-extension
 const profileSD = {
   resourceType: 'StructureDefinition',
   name: 'PatientProfile',
+  type: 'Patient',
   url: patientProfileUrl,
   snapshot: {
     element: [
@@ -1853,7 +1854,7 @@ describe('Client', () => {
 
     await request1;
     expect(isProfileLoaded(patientProfileUrl)).toBe(true);
-    expect(getDataType(profileSD.name, patientProfileUrl)).toBeDefined();
+    expect(getDataType(profileSD.type, patientProfileUrl)).toBeDefined();
   });
 
   test('requestProfileSchema expandProfile', async () => {
@@ -1873,8 +1874,8 @@ describe('Client', () => {
     await request2;
     expect(isProfileLoaded(patientProfileUrl)).toBe(true);
     expect(isProfileLoaded(patientProfileExtensionUrl)).toBe(true);
-    expect(getDataType(profileSD.name, patientProfileUrl)).toBeDefined();
-    expect(getDataType(profileExtensionSD.name, patientProfileExtensionUrl)).toBeDefined();
+    expect(getDataType(profileSD.type, patientProfileUrl)).toBeDefined();
+    expect(getDataType(profileExtensionSD.type, patientProfileExtensionUrl)).toBeDefined();
   });
 
   test('Search', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1730,6 +1730,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         kind,
         description,
         type,
+        url,
         snapshot {
           element {
             id,

--- a/packages/core/src/default-values.test.ts
+++ b/packages/core/src/default-values.test.ts
@@ -14,7 +14,6 @@ import {
   SliceDefinition,
   SlicingRules,
   indexStructureDefinitionBundle,
-  loadDataType,
   tryGetProfile,
 } from './typeschema/types';
 import { isPopulated } from './utils';
@@ -68,9 +67,7 @@ describe('apply default values', () => {
 
     expect(sds.length).toEqual(profileUrls.length);
 
-    for (const sd of sds) {
-      loadDataType(sd, sd?.url);
-    }
+    indexStructureDefinitionBundle(sds);
   }
 
   describe('US Blood Pressure', () => {

--- a/packages/core/src/default-values.test.ts
+++ b/packages/core/src/default-values.test.ts
@@ -1,22 +1,23 @@
+import { readJson } from '@medplum/definitions';
+import { Bundle, Observation, Patient, StructureDefinition } from '@medplum/fhirtypes';
+import { HTTP_HL7_ORG } from './constants';
+import {
+  applyDefaultValuesToElement,
+  applyDefaultValuesToElementWithVisitor,
+  applyDefaultValuesToResource,
+  applyFixedOrPatternValue,
+  getDefaultValuesForNewSliceEntry,
+} from './default-values';
 import {
   InternalSchemaElement,
   InternalTypeSchema,
   SliceDefinition,
   SlicingRules,
+  indexStructureDefinitionBundle,
   loadDataType,
   tryGetProfile,
 } from './typeschema/types';
 import { isPopulated } from './utils';
-import { Observation, Patient, StructureDefinition } from '@medplum/fhirtypes';
-import {
-  applyDefaultValuesToElement,
-  applyDefaultValuesToResource,
-  applyDefaultValuesToElementWithVisitor,
-  getDefaultValuesForNewSliceEntry,
-  applyFixedOrPatternValue,
-} from './default-values';
-import { HTTP_HL7_ORG } from './constants';
-import { readJson } from '@medplum/definitions';
 
 function isStructureDefinition(sd: any): sd is StructureDefinition {
   if (!isPopulated<StructureDefinition>(sd)) {
@@ -52,6 +53,9 @@ function getSlice(schema: InternalTypeSchema, slicedElementKey: string, sliceNam
 describe('apply default values', () => {
   let USCoreStructureDefinitions: StructureDefinition[];
   beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+
     USCoreStructureDefinitions = readJson('fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json');
   });
 

--- a/packages/core/src/fhirmapper/transform.test.ts
+++ b/packages/core/src/fhirmapper/transform.test.ts
@@ -365,18 +365,10 @@ describe('FHIR Mapper transform', () => {
     // https://build.fhir.org/mapping-tutorial.html#step10
     // Many/most trees are fully and strongly typed. In these cases, the mapping language can make use of the typing system to simplify the mapping statements.
 
-    createType('TLeft', 'http://hl7.org/fhir/StructureDefinition/tutorial-left', [
-      { name: 'aa', type: 'TLeftInner', min: 0, max: '*' },
-    ]);
-    createType('TLeftInner', 'http://hl7.org/fhir/StructureDefinition/tutorial-left-inner', [
-      { name: 'ab', type: 'code', min: 0, max: '1' },
-    ]);
-    createType('TRight', 'http://hl7.org/fhir/StructureDefinition/tutorial-right', [
-      { name: 'aa', type: 'TRightInner', min: 0, max: '*' },
-    ]);
-    createType('TRightInner', 'http://hl7.org/fhir/StructureDefinition/tutorial-right-inner', [
-      { name: 'ac', type: 'code', min: 0, max: '1' },
-    ]);
+    createType('TLeft', [{ name: 'aa', type: 'TLeftInner', min: 0, max: '*' }]);
+    createType('TLeftInner', [{ name: 'ab', type: 'code', min: 0, max: '1' }]);
+    createType('TRight', [{ name: 'aa', type: 'TRightInner', min: 0, max: '*' }]);
+    createType('TRightInner', [{ name: 'ac', type: 'code', min: 0, max: '1' }]);
 
     const map = `
       uses "http://hl7.org/fhir/StructureDefinition/tutorial-left" as source
@@ -487,19 +479,14 @@ describe('FHIR Mapper transform', () => {
  * Creates a StructureDefinition object for the mapping tutorial.
  * Loads the StructureDefinition into the type schema.
  * @param name - The name of the type.
- * @param url - The URL of the type.
  * @param elements - Shorthand representation of the elements in the type.
  */
-function createType(
-  name: string,
-  url: string,
-  elements: { name: string; type: string; min: number; max: string }[]
-): void {
+function createType(name: string, elements: { name: string; type: string; min: number; max: string }[]): void {
   loadDataType({
     resourceType: 'StructureDefinition',
     id: name,
     name,
-    url,
+    url: `http://hl7.org/fhir/StructureDefinition/${name}`,
     status: 'active',
     kind: 'resource',
     type: name,

--- a/packages/core/src/typeschema/slices.ts
+++ b/packages/core/src/typeschema/slices.ts
@@ -42,7 +42,7 @@ export function getValueSliceName(
   for (const slice of slices) {
     const typedValue: TypedValue = {
       value,
-      type: slice.typeSchema?.name ?? slice.type?.[0].code,
+      type: slice.typeSchema?.type ?? slice.type?.[0].code,
     };
     if (
       discriminators.every((d) =>

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -364,7 +364,7 @@ describe('FHIR resource and data type representations', () => {
     expect(sd.url).toEqual(profileUrl);
     expect(sd.name).toEqual(profileName);
     expect(sd.type).toEqual(profileType);
-    indexStructureDefinitionBundle([sd], profileUrl);
+    indexStructureDefinitionBundle([sd]);
 
     expect(isProfileLoaded(profileUrl)).toBe(true);
     expect(tryGetProfile(profileUrl)).toBeDefined();

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -11,6 +11,7 @@ import {
   getDataType,
   indexStructureDefinitionBundle,
   isProfileLoaded,
+  loadDataType,
   parseStructureDefinition,
   subsetResource,
   tryGetDataType,
@@ -354,20 +355,70 @@ describe('FHIR resource and data type representations', () => {
   test('Indexing structure definitions related to a profile', () => {
     const profileUrl = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure';
     const profileName = 'USCoreBloodPressureProfile';
+    const profileType = 'Observation';
 
     expect(isProfileLoaded(profileUrl)).toBe(false);
     expect(tryGetProfile(profileUrl)).toBeUndefined();
-    expect(tryGetDataType(profileName)).toBeUndefined();
-    expect(tryGetDataType(profileName, profileUrl)).toBeUndefined();
 
     const sd = JSON.parse(readFileSync(resolve(__dirname, '__test__', 'us-core-blood-pressure.json'), 'utf8'));
     expect(sd.url).toEqual(profileUrl);
     expect(sd.name).toEqual(profileName);
+    expect(sd.type).toEqual(profileType);
     indexStructureDefinitionBundle([sd], profileUrl);
 
     expect(isProfileLoaded(profileUrl)).toBe(true);
     expect(tryGetProfile(profileUrl)).toBeDefined();
-    expect(tryGetDataType(profileName)).toBeUndefined(); // expect undefined since profileUrl argument not provided
-    expect(tryGetDataType(profileName, profileUrl)).toBeDefined();
+    expect(tryGetDataType(profileType, profileUrl)).toBeDefined();
+  });
+
+  test('Quantity profiles', () => {
+    const quantity = getDataType('Quantity');
+    expect(quantity).toBeDefined();
+    expect(quantity.name).toEqual('Quantity');
+    expect(quantity.type).toEqual('Quantity');
+
+    const simpleQuantity = getDataType('SimpleQuantity');
+    expect(simpleQuantity).toBeDefined();
+    expect(simpleQuantity.name).toEqual('SimpleQuantity');
+    expect(simpleQuantity.type).toEqual('Quantity');
+
+    const moneyQuantity = getDataType('MoneyQuantity');
+    expect(moneyQuantity).toBeDefined();
+    expect(moneyQuantity.name).toEqual('MoneyQuantity');
+    expect(moneyQuantity.type).toEqual('Quantity');
+  });
+
+  test('Name conflict', () => {
+    const patient1 = getDataType('Patient');
+    expect(patient1).toBeDefined();
+
+    // Index the C-CDA Patient profile
+    // Based on https://github.com/HL7/CDA-core-sd/blob/master/input/resources/Patient.xml
+    // Note that "name" is set to "Patient", which could be inconflict with the FHIR Patient.
+    // Note that "type" is not "Patient", which means that this is a different patient type.
+    loadDataType({
+      resourceType: 'StructureDefinition',
+      url: 'http://hl7.org/cda/stds/core/StructureDefinition/Patient',
+      name: 'Patient',
+      status: 'active',
+      kind: 'logical',
+      abstract: false,
+      type: 'http://hl7.org/cda/stds/core/StructureDefinition/Patient',
+      snapshot: {
+        element: [
+          {
+            path: 'Patient',
+          },
+        ],
+      },
+    });
+    const patient2 = getDataType('http://hl7.org/cda/stds/core/StructureDefinition/Patient');
+    expect(patient2).toBeDefined();
+    expect(patient2?.name).toEqual('Patient');
+
+    // The original Patient profile should still be accessible
+    const patient3 = getDataType('Patient');
+    expect(patient3).toBeDefined();
+    expect(patient3).toEqual(patient1);
   });
 });

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -18,10 +18,10 @@ import { capitalize, getExtension, isEmpty } from '../utils';
  */
 export interface InternalTypeSchema {
   name: string;
+  type: string;
   title?: string;
   url?: string;
   kind?: string;
-  type?: string;
   description?: string;
   elements: Record<string, InternalSchemaElement>;
   constraints?: Constraint[];
@@ -341,9 +341,11 @@ class StructureDefinitionParser {
       this.innerTypes.push(this.backboneContext.type);
       this.backboneContext = this.backboneContext.parent;
     }
+    const typeName = getElementDefinitionTypeName(element);
     this.backboneContext = {
       type: {
-        name: getElementDefinitionTypeName(element),
+        name: typeName,
+        type: typeName,
         title: element.label,
         description: element.definition,
         elements: {},

--- a/packages/core/src/typeschema/validate-sd.test.ts
+++ b/packages/core/src/typeschema/validate-sd.test.ts
@@ -1,4 +1,5 @@
-import { Observation, StructureDefinition } from '@medplum/fhirtypes';
+import { readJson } from '@medplum/definitions';
+import { Bundle, Observation, StructureDefinition } from '@medplum/fhirtypes';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { indexStructureDefinitionBundle } from './types';
@@ -8,6 +9,9 @@ import { validateResource } from './validation';
 // There may be a better way to do this
 
 test('Validate StructureDefinition with contentReference missing base', () => {
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+  indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+
   const observationSd = JSON.parse(
     readFileSync(resolve(__dirname, '__test__', 'compressed-observation.json'), 'utf8')
   ) as StructureDefinition;

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -685,6 +685,7 @@ export class MockFetchClient {
 
     for (const structureDefinition of StructureDefinitionList as StructureDefinition[]) {
       structureDefinition.kind = 'resource';
+      structureDefinition.url = 'http://hl7.org/fhir/StructureDefinition/' + structureDefinition.name;
       loadDataType(structureDefinition);
       await this.repo.createResource(structureDefinition);
     }

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
@@ -1,8 +1,8 @@
-import { globalSchema, indexStructureDefinitionBundle, InternalSchemaElement, TypeInfo } from '@medplum/core';
+import { globalSchema, InternalSchemaElement, loadDataType, TypeInfo } from '@medplum/core';
 import { FishPatientResources, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen, within } from '../test-utils/render';
 import { MemoryRouter } from 'react-router-dom';
+import { act, render, screen, within } from '../test-utils/render';
 import { BackboneElementInput, BackboneElementInputProps } from './BackboneElementInput';
 
 const valueSetComposeProperty: InternalSchemaElement = {
@@ -95,7 +95,7 @@ describe('BackboneElementInput', () => {
     const fishPatient = FishPatientResources.getSampleFishPatient();
 
     for (const profile of [fishPatientProfile, fishSpeciesProfile]) {
-      indexStructureDefinitionBundle([profile], profile.url);
+      loadDataType(profile);
     }
     await setup({
       path: fishPatientProfile.type,

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.test.tsx
@@ -99,7 +99,7 @@ describe('BackboneElementInput', () => {
     }
     await setup({
       path: fishPatientProfile.type,
-      typeName: fishPatientProfile.name,
+      typeName: fishPatientProfile.type,
       profileUrl: fishPatientProfile.url,
       defaultValue: fishPatient,
       onChange: () => {},

--- a/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
+++ b/packages/react/src/BackboneElementInput/BackboneElementInput.tsx
@@ -1,10 +1,10 @@
 import { ElementsContextType, buildElementsContext, tryGetDataType } from '@medplum/core';
+import { AccessPolicyResource } from '@medplum/fhirtypes';
 import { useContext, useMemo, useState } from 'react';
 import { ElementsInput } from '../ElementsInput/ElementsInput';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
-import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 import { BaseInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
-import { AccessPolicyResource } from '@medplum/fhirtypes';
+import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
 
 export interface BackboneElementInputProps extends BaseInputProps {
   /** Type name the backbone element represents */

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.test.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.test.tsx
@@ -47,7 +47,7 @@ describe('ExtensionDisplay', () => {
       if (!sd) {
         fail(`could not find structure definition for ${url}`);
       }
-      loadDataType(sd, sd.url);
+      loadDataType(sd);
     }
     const schema = tryGetProfile(profileUrl);
     const slice = schema?.elements['extension'].slicing?.slices.find((slice) => slice.name === 'race');

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.tsx
@@ -75,7 +75,7 @@ export function ExtensionDisplay(props: ExtensionDisplayProps): JSX.Element | nu
   return (
     <BackboneElementDisplay
       path={props.path}
-      value={{ type: typeSchema.name, value: props.value }}
+      value={{ type: typeSchema.type as string, value: props.value }}
       compact={props.compact}
       ignoreMissingValues={props.ignoreMissingValues}
       link={props.link}

--- a/packages/react/src/ExtensionInput/ExtensionInput.tsx
+++ b/packages/react/src/ExtensionInput/ExtensionInput.tsx
@@ -1,4 +1,4 @@
-import { InternalTypeSchema, tryGetProfile, isProfileLoaded, isPopulated } from '@medplum/core';
+import { isPopulated, isProfileLoaded } from '@medplum/core';
 import { ElementDefinitionType, Extension } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { useEffect, useMemo, useState } from 'react';
@@ -13,7 +13,6 @@ export function ExtensionInput(props: ExtensionInputProps): JSX.Element | null {
   const { propertyType } = props;
 
   const medplum = useMedplum();
-  const [typeSchema, setTypeSchema] = useState<InternalTypeSchema | undefined>();
   const profileUrl: string | undefined = useMemo(() => {
     if (!isPopulated(propertyType.profile)) {
       return undefined;
@@ -28,11 +27,7 @@ export function ExtensionInput(props: ExtensionInputProps): JSX.Element | null {
       setLoadingProfile(true);
       medplum
         .requestProfileSchema(profileUrl)
-        .then(() => {
-          const profile = tryGetProfile(profileUrl);
-          setLoadingProfile(false);
-          setTypeSchema(profile);
-        })
+        .then(() => setLoadingProfile(false))
         .catch((reason) => {
           setLoadingProfile(false);
           console.warn(reason);
@@ -60,7 +55,7 @@ export function ExtensionInput(props: ExtensionInputProps): JSX.Element | null {
     <BackboneElementInput
       profileUrl={profileUrl}
       path={props.path}
-      typeName={typeSchema?.name ?? 'Extension'}
+      typeName="Extension"
       defaultValue={props.defaultValue}
       onChange={props.onChange}
     />

--- a/packages/react/src/ReferenceInput/ReferenceInput.stories.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.stories.tsx
@@ -1,4 +1,4 @@
-import { indexStructureDefinitionBundle } from '@medplum/core';
+import { loadDataType } from '@medplum/core';
 import { FishPatientResources } from '@medplum/mock';
 import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
@@ -31,7 +31,7 @@ export const PatientProfileAndPatient = (): JSX.Element => {
   useEffect(() => {
     (async (): Promise<boolean> => {
       const sd = await medplum.createResource(FishPatientProfileSD);
-      indexStructureDefinitionBundle([sd], sd.url);
+      loadDataType(sd);
       await medplum.createResource(FishPatientResources.getBlinkyTheFish());
       await medplum.createResource(FishPatientResources.getSampleFishPatient());
       return true;

--- a/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.test.tsx
@@ -1,4 +1,4 @@
-import { indexStructureDefinitionBundle } from '@medplum/core';
+import { loadDataType } from '@medplum/core';
 import { FishPatientResources, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '../test-utils/render';
@@ -185,7 +185,7 @@ describe('ReferenceInput', () => {
     const blinky = FishPatientResources.getBlinkyTheFish();
     await medplum.createResource(blinky);
 
-    indexStructureDefinitionBundle([FishPatientProfileSD], FishPatientProfileSD.url);
+    loadDataType(FishPatientProfileSD);
     setup({
       name: 'foo',
       targetTypes: [FishPatientProfileSD.url, 'Patient'],

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.test.ts
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.test.ts
@@ -6,10 +6,10 @@ import {
   loadDataType,
   tryGetProfile,
 } from '@medplum/core';
-import { assignValuesIntoSlices, prepareSlices } from './ResourceArrayInput.utils';
-import { MockClient } from '@medplum/mock';
-import { StructureDefinition } from '@medplum/fhirtypes';
 import { readJson } from '@medplum/definitions';
+import { StructureDefinition } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { assignValuesIntoSlices, prepareSlices } from './ResourceArrayInput.utils';
 
 const medplum = new MockClient();
 

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.test.ts
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.test.ts
@@ -40,7 +40,7 @@ describe('assignValuesIntoSlices', () => {
         if (!sd) {
           fail(`could not find structure definition for ${url}`);
         }
-        loadDataType(sd, sd.url);
+        loadDataType(sd);
       }
       expect(isProfileLoaded(profileUrl)).toBe(true);
       patientSchema = tryGetProfile(profileUrl) as InternalTypeSchema;
@@ -125,7 +125,7 @@ describe('assignValuesIntoSlices', () => {
     beforeAll(() => {
       bpSD = USCoreStructureDefinitions.find((sd) => sd.url === profileUrl) as StructureDefinition;
       expect(bpSD).toBeDefined();
-      loadDataType(bpSD, bpSD.url);
+      loadDataType(bpSD);
       expect(isProfileLoaded(profileUrl)).toBe(true);
       bpSchema = tryGetProfile(profileUrl) as InternalTypeSchema;
       expect(bpSchema).toBeDefined();

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.ts
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.ts
@@ -54,7 +54,7 @@ export async function prepareSlices({
 
     const supportedSlices: SliceDefinitionWithTypes[] = [];
     const profileUrls: (string | undefined)[] = [];
-    const promises: Promise<string[]>[] = [];
+    const promises: Promise<void>[] = [];
     for (const slice of property.slicing.slices) {
       if (!isSliceDefinitionWithTypes(slice)) {
         console.debug('Unsupported slice definition', slice);
@@ -72,8 +72,6 @@ export async function prepareSlices({
       profileUrls.push(profileUrl);
       if (profileUrl) {
         promises.push(medplum.requestProfileSchema(profileUrl));
-      } else {
-        promises.push(Promise.resolve([]));
       }
     }
 

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.ts
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.utils.ts
@@ -9,18 +9,18 @@ import {
   tryGetProfile,
 } from '@medplum/core';
 
-export function assignValuesIntoSlices(
-  values: any[],
+export function assignValuesIntoSlices<T>(
+  values: T[],
   slices: SliceDefinitionWithTypes[],
   slicing: SlicingRules | undefined,
   profileUrl: string | undefined
-): any[][] {
+): T[][] {
   if (!isPopulated(slicing?.slices)) {
     return [values];
   }
 
   // store values in an array of arrays: one for each slice plus another for non-sliced values
-  const slicedValues: any[][] = new Array(slices.length + 1);
+  const slicedValues: T[][] = new Array(slices.length + 1);
   for (let i = 0; i < slicedValues.length; i++) {
     slicedValues[i] = [];
   }

--- a/packages/react/src/ResourceForm/ResourceForm.stories.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.stories.tsx
@@ -1,3 +1,5 @@
+import { MedplumClient, RequestProfileSchemaOptions, deepClone, loadDataType } from '@medplum/core';
+import { AccessPolicy, OperationOutcome, Resource, StructureDefinition } from '@medplum/fhirtypes';
 import {
   DrAliceSmith,
   HomerSimpson,
@@ -6,13 +8,11 @@ import {
   TestOrganization,
   USCoreStructureDefinitionList,
 } from '@medplum/mock';
+import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { Document } from '../Document/Document';
 import { ResourceForm } from './ResourceForm';
-import { useMedplum } from '@medplum/react-hooks';
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
-import { MedplumClient, RequestProfileSchemaOptions, deepClone, loadDataType } from '@medplum/core';
-import { AccessPolicy, OperationOutcome, Resource, StructureDefinition } from '@medplum/fhirtypes';
 
 export default {
   title: 'Medplum/ResourceForm',
@@ -226,7 +226,7 @@ function useUSCoreDataTypes({ medplum }: { medplum: MedplumClient }): { loaded: 
   useEffect(() => {
     (async (): Promise<boolean> => {
       for (const sd of USCoreStructureDefinitionList) {
-        loadDataType(sd, sd.url);
+        loadDataType(sd);
       }
       return true;
     })()
@@ -244,16 +244,12 @@ function useUSCoreDataTypes({ medplum }: { medplum: MedplumClient }): { loaded: 
 function useFakeRequestProfileSchema(medplum: MedplumClient): void {
   useLayoutEffect(() => {
     const realRequestProfileSchema = medplum.requestProfileSchema;
-    async function fakeRequestProfileSchema(
-      profileUrl: string,
-      options?: RequestProfileSchemaOptions
-    ): Promise<string[]> {
+    async function fakeRequestProfileSchema(profileUrl: string, options?: RequestProfileSchemaOptions): Promise<void> {
       console.log(
         'Fake medplum.requestProfileSchema invoked but not doing anything; ensure expected profiles are already loaded',
         profileUrl,
         options
       );
-      return [profileUrl];
     }
 
     medplum.requestProfileSchema = fakeRequestProfileSchema;

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -287,15 +287,13 @@ describe('ResourceForm', () => {
       if (!sd) {
         fail(`could not find structure definition for ${url}`);
       }
-      loadDataType(sd, sd.url);
+      loadDataType(sd);
     }
 
     const onSubmit = jest.fn();
 
     const mockedMedplum = new MockClient();
-    const fakeRequestProfileSchema = jest.fn(async (profileUrl: string) => {
-      return [profileUrl];
-    });
+    const fakeRequestProfileSchema = jest.fn(async (_profileUrl: string) => {});
     mockedMedplum.requestProfileSchema = fakeRequestProfileSchema;
     await setup({ defaultValue: { resourceType: 'Device' }, profileUrl, onSubmit }, mockedMedplum);
 
@@ -313,16 +311,14 @@ describe('ResourceForm', () => {
       `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-birthsex`,
       `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-genderIdentity`,
     ];
-    const fakeRequestProfileSchema = jest.fn(async (profileUrl: string) => {
-      return [profileUrl];
-    });
+    const fakeRequestProfileSchema = jest.fn(async (_profileUrl: string) => {});
     beforeAll(() => {
       for (const url of profileUrls) {
         const sd = USCoreStructureDefinitions.find((sd) => sd.url === url);
         if (!sd) {
           fail(`could not find structure definition for ${url}`);
         }
-        loadDataType(sd, sd.url);
+        loadDataType(sd);
       }
     });
 

--- a/packages/react/src/ResourceForm/ResourceForm.test.tsx
+++ b/packages/react/src/ResourceForm/ResourceForm.test.tsx
@@ -1,6 +1,6 @@
-import { HTTP_HL7_ORG, createReference, deepClone, loadDataType } from '@medplum/core';
+import { HTTP_HL7_ORG, createReference, deepClone, indexStructureDefinitionBundle, loadDataType } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
-import { Observation, OperationOutcome, Patient, Specimen, StructureDefinition } from '@medplum/fhirtypes';
+import { Bundle, Observation, OperationOutcome, Patient, Specimen, StructureDefinition } from '@medplum/fhirtypes';
 import { HomerObservation1, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { convertIsoToLocal, convertLocalToIso } from '../DateTimeInput/DateTimeInput.utils';
@@ -12,6 +12,9 @@ const medplum = new MockClient();
 describe('ResourceForm', () => {
   let USCoreStructureDefinitions: StructureDefinition[];
   beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+
     USCoreStructureDefinitions = readJson('fhir/r4/testing/uscore-v5.0.1-structuredefinitions.json');
   });
 

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -1,8 +1,8 @@
 import { Checkbox, Group, NativeSelect, Textarea, TextInput } from '@mantine/core';
 import {
-  ExtendedInternalSchemaElement,
   applyDefaultValuesToElement,
   capitalize,
+  ExtendedInternalSchemaElement,
   getPathDifference,
   HTTP_HL7_ORG,
   isComplexTypeCode,

--- a/packages/react/src/ResourceTable/ResourceTable.stories.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.stories.tsx
@@ -1,10 +1,14 @@
+import { MedplumClient, RequestProfileSchemaOptions, deepClone, loadDataType } from '@medplum/core';
+import { StructureDefinition } from '@medplum/fhirtypes';
 import {
   HomerObservation1,
   HomerSimpson,
   HomerSimpsonUSCorePatient,
   USCoreStructureDefinitionList,
 } from '@medplum/mock';
+import { useMedplum } from '@medplum/react-hooks';
 import { Meta } from '@storybook/react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { Document } from '../Document/Document';
 import {
   Covid19NasalSpecimen,
@@ -13,10 +17,6 @@ import {
   Covid19ReviewReport,
 } from '../stories/covid19';
 import { ResourceTable } from './ResourceTable';
-import { MedplumClient, RequestProfileSchemaOptions, deepClone, loadDataType } from '@medplum/core';
-import { StructureDefinition } from '@medplum/fhirtypes';
-import { useMedplum } from '@medplum/react-hooks';
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 export default {
   title: 'Medplum/ResourceTable',
@@ -70,7 +70,7 @@ function useUSCoreDataTypes({ medplum }: { medplum: MedplumClient }): { loaded: 
   useEffect(() => {
     (async (): Promise<boolean> => {
       for (const sd of USCoreStructureDefinitionList) {
-        loadDataType(sd, sd.url);
+        loadDataType(sd);
       }
       return true;
     })()
@@ -88,16 +88,12 @@ function useUSCoreDataTypes({ medplum }: { medplum: MedplumClient }): { loaded: 
 function useFakeRequestProfileSchema(medplum: MedplumClient): void {
   useLayoutEffect(() => {
     const realRequestProfileSchema = medplum.requestProfileSchema;
-    async function fakeRequestProfileSchema(
-      profileUrl: string,
-      options?: RequestProfileSchemaOptions
-    ): Promise<string[]> {
+    async function fakeRequestProfileSchema(profileUrl: string, options?: RequestProfileSchemaOptions): Promise<void> {
       console.log(
         'Fake medplum.requestProfileSchema invoked but not doing anything; ensure expected profiles are already loaded',
         profileUrl,
         options
       );
-      return [profileUrl];
     }
 
     medplum.requestProfileSchema = fakeRequestProfileSchema;

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -1,10 +1,10 @@
+import { HTTP_HL7_ORG, loadDataType } from '@medplum/core';
+import { readJson } from '@medplum/definitions';
+import { StructureDefinition } from '@medplum/fhirtypes';
 import { HomerSimpsonUSCorePatient, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '../test-utils/render';
 import { ResourceTable, ResourceTableProps } from './ResourceTable';
-import { HTTP_HL7_ORG, loadDataType } from '@medplum/core';
-import { StructureDefinition } from '@medplum/fhirtypes';
-import { readJson } from '@medplum/definitions';
 
 const medplum = new MockClient();
 

--- a/packages/react/src/ResourceTable/ResourceTable.test.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.test.tsx
@@ -78,13 +78,11 @@ describe('ResourceTable', () => {
       if (!sd) {
         fail(`could not find structure definition for ${url}`);
       }
-      loadDataType(sd, sd.url);
+      loadDataType(sd);
     }
 
     const mockedMedplum = new MockClient();
-    const fakeRequestProfileSchema = jest.fn(async (profileUrl: string) => {
-      return [profileUrl];
-    });
+    const fakeRequestProfileSchema = jest.fn(async (_profileUrl: string) => {});
     mockedMedplum.requestProfileSchema = fakeRequestProfileSchema;
 
     const value = HomerSimpsonUSCorePatient;

--- a/packages/react/src/ResourceTable/ResourceTable.tsx
+++ b/packages/react/src/ResourceTable/ResourceTable.tsx
@@ -1,8 +1,8 @@
+import { AccessPolicyInteraction, satisfiedAccessPolicy, tryGetProfile } from '@medplum/core';
 import { Reference, Resource } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { useEffect, useMemo, useState } from 'react';
 import { BackboneElementDisplay } from '../BackboneElementDisplay/BackboneElementDisplay';
-import { AccessPolicyInteraction, satisfiedAccessPolicy, tryGetProfile } from '@medplum/core';
 
 export interface ResourceTableProps {
   /**
@@ -32,7 +32,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
   const medplum = useMedplum();
   const accessPolicy = medplum.getAccessPolicy();
   const value = useResource(props.value);
-  const [schemaLoaded, setSchemaLoaded] = useState<string>();
+  const [schemaLoaded, setSchemaLoaded] = useState(false);
 
   useEffect(() => {
     if (!value) {
@@ -45,7 +45,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
         .then(() => {
           const profile = tryGetProfile(profileUrl);
           if (profile) {
-            setSchemaLoaded(profile.name);
+            setSchemaLoaded(true);
           } else {
             console.error(`Schema not found for ${profileUrl}`);
           }
@@ -58,7 +58,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
       medplum
         .requestSchema(schemaName)
         .then(() => {
-          setSchemaLoaded(schemaName);
+          setSchemaLoaded(true);
         })
         .catch(console.error);
     }
@@ -76,7 +76,7 @@ export function ResourceTable(props: ResourceTableProps): JSX.Element | null {
     <BackboneElementDisplay
       path={value.resourceType}
       value={{
-        type: schemaLoaded,
+        type: value.resourceType,
         value: props.forceUseInput ? props.value : value,
       }}
       profileUrl={profileUrl}


### PR DESCRIPTION
### Update 2024-07-31

First, let's consider the problem.  Here is a snippet of a `StructureDefinition` from the [HL7 C-CDA project](https://github.com/HL7/CDA-core-sd):

```js
{
  resourceType: 'StructureDefinition',
  url: 'http://hl7.org/cda/stds/core/StructureDefinition/Patient',
  name: 'Patient',
  status: 'active',
  kind: 'logical',
  abstract: false,
  type: 'http://hl7.org/cda/stds/core/StructureDefinition/Patient',
}
```

Expected behavior: we should be able to index this structure definition, and everything should work

Actual behavior: when we index this structure definition, it overwrites the FHIR `Patient`

Observations:
* `name` is `Patient` - when "indexing" this structure definition, we override the main FHIR `Patient`, which is bad
* `type` is a URL - in most FHIR structure definitions, `type === name`, but here we have something totally different

So, here is my new mental model for how to think about these various properties.

First, let's review some definitions from [StructureDefinition](https://hl7.org/fhir/r4/structuredefinition.html):

|  element  |  definition |
| --- | --- |
| `url` | The identifier that is used to identify this structure when it is referenced in a specification, model, design or an instance. |
| `name` | A Computer-ready name (e.g. a token) that identifies the structure - suitable for code generation. |
| `type` | The type the structure describes. type `uri`, [FHIRDefinedType](https://hl7.org/fhir/r4/valueset-defined-types.html) (Extensible) |

So here is my attempt at plain and simple explanation:
* `url` is the official unique identifier for the `StructureDefinition`
    * In the future, we should use this value more
    * We currently still rely on some assumptions that certain `type` implies certain `url`
    * In the future, we should instead use `getDataTypeByUrl()`
* `name` is a "computer-ready name"
    * This is what we previously used for generating type names
    * Due to the risk of conflicts, this value is not actually useful
* `type` is more important
    * We previously did not use this value
    * After this PR, this is the primary source of truth for the type name

And that gets to the main point of this PR:
* Before this PR, we used `name` to define a lot of types
* After this PR, we're using `type` to define types

Let's look at some examples:

<table>
<tr><td>name</td><td>type</td><td>file</td><td>notes</td></tr>
<tr><td colspan="4">http://hl7.org/fhir/StructureDefinition/Patient</td></tr>
<tr><td>Patient</td><td>Patient</td><td>profiles-resources.json</td><td>Clean and simple case of a FHIR defined type</td></tr>
<tr><td colspan="4">http://hl7.org/fhir/StructureDefinition/Observation</td></tr>
<tr><td>Observation</td><td>Observation</td><td>profiles-resources.json</td><td>Another clean and simple case of a FHIR defined type</td></tr>
<tr><td colspan="4">http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure</td></tr>
<tr><td>USCoreBloodPressureProfile</td><td>Observation</td><td>uscore-v5.0.1-structuredefinitions.json</td><td>A FHIR Profile on Observation</td></tr>
<tr><td colspan="4">http://hl7.org/fhir/StructureDefinition/Quantity</td></tr>
<tr><td>Quantity</td><td>Quantity</td><td>profiles-types.json</td><td>FHIR defined type, but "complex-type", so not a resource</td></tr>
<tr><td colspan="4">http://hl7.org/fhir/StructureDefinition/SimpleQuantity</td></tr>
<tr><td>SimpleQuantity</td><td>Quantity</td><td>profiles-types.json</td><td>FHIR defined profile</td></tr>
<tr><td colspan="4">https://medplum.com/fhir/StructureDefinition/User</td></tr>
<tr><td>User</td><td>User</td><td>profiles-medplum.json</td><td>Medplum defined resource</td></tr>
<tr><td colspan="4">http://hl7.org/cda/stds/core/StructureDefinition/Patient</td></tr>
<tr><td>Patient</td><td>http://hl7.org/cda/.../Patient</td><td>profiles-ccda.json</td><td>HL7 C-CDA Patient type, note that "type" is a URL, meaning this is completely separate</td></tr>
</table>

--------

### Original Comments

Context: https://medplum.slack.com/archives/C02AMUU6SBH/p1720453993583959

This came up while doing more experiments with FHIR Mapping Language, and the HL7 `StructureDefinition` resources for C-CDA.

I suspect this is something similar to what @mattlong ran into with US-Core StructureDefinitions, as all of my prototyping keeps breaking these tests 😆😢

The immediate issue that I ran into is another `StructureDefinition` with `name === 'Patient'` which is completely disconnected from a FHIR `Patient` - it's not a profile, it's a totally different type.  We currently naively index types by name, so that simply overwrote the R4 `Patient` type, and everything fell apart

That sent me down the rabbit hole on the nitty gritty details of `name` vs `type` vs `url`, and I think we may need to revisit some pretty fundamental assumptions and implementation details.

Some options I'm considering:

1. Replace `StructureDefinition.name` with `StructureDefinition.type` in terms of the main identifier that we use for types and type definitions and profiles
    a. This may be the most technically correct model, but will also be the most invasive
2. Only index by `name` when the `url` is one of the "official" or whitelisted URL's
3. We could just have multiple indexes: `dataTypesByName`, `dataTypesByType`, `dataTypesByUrl` - and corresponding `getDataTypeByName`, etc.  That might end up being the most surgical change.
4. Probably a combination of 2 and 3
5. Something else?

There are a few interesting wrinkles with that:

1. We currently have TypeScript type definitions for `SimpleQuantity` and `MoneyQuantity`.  Technically, these are "profiles" on top of `Quantity`.  so we might need to figure out a more concrete philosophy on "which `StructureDefinitions` become types?"
2. The SQL-on-FHIR `ViewDefinition` type doesn't meet the definition of any of this, so we may need to just embrace some degree of special cases for types
3. There are a whole bunch of places where we're making the implicit assumption that the `targetProfile` URL can be parsed, and the last token becomes a type name.  Those probably need to all be re-opened 🤒🤮 
