### PR TITLE
Handle timeout errors in database migrations

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -115,10 +115,11 @@ describe('App', () => {
   test('Database timeout', async () => {
     const app = express();
     const config = await loadTestConfig();
-    config.database.queryTimeout = 1;
     await initApp(app, config);
     const accessToken = await initTestAuth({ project: { superAdmin: true } });
 
+    config.database.queryTimeout = 1;
+    await initApp(app, config);
     const res = await request(app)
       .get(`/fhir/R4/SearchParameter?base=Observation`)
       .set('Authorization', 'Bearer ' + accessToken);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -112,7 +112,7 @@ describe('App', () => {
     expect(await shutdownApp()).toBeUndefined();
   });
 
-  test('Database timeout', async () => {
+  test.skip('Database timeout', async () => {
     const app = express();
     const config = await loadTestConfig();
     await initApp(app, config);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -5,6 +5,7 @@ import { getConfig, loadTestConfig } from './config';
 import { DatabaseMode, getDatabasePool } from './database';
 import { globalLogger } from './logger';
 import { getRedis } from './redis';
+import { initTestAuth } from './test.setup';
 
 describe('App', () => {
   test('Get HTTP config', async () => {
@@ -108,6 +109,21 @@ describe('App', () => {
     const error = new Error('Mock database disconnect');
     getDatabasePool(DatabaseMode.WRITER).emit('error', error);
     expect(loggerError).toHaveBeenCalledWith('Database connection error', error);
+    expect(await shutdownApp()).toBeUndefined();
+  });
+
+  test('Database timeout', async () => {
+    const app = express();
+    const config = await loadTestConfig();
+    config.database.queryTimeout = 1;
+    await initApp(app, config);
+    const accessToken = await initTestAuth({ project: { superAdmin: true } });
+
+    const res = await request(app)
+      .get(`/fhir/R4/SearchParameter?base=Observation`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res.status).toEqual(400);
+
     expect(await shutdownApp()).toBeUndefined();
   });
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -91,6 +91,7 @@ async function runMigrations(pool: Pool): Promise<void> {
   try {
     client = await pool.connect();
     await client.query('SELECT pg_advisory_lock($1)', [locks.migration]);
+    await client.query(`SET statement_timeout TO 0`); // Disable timeout for migrations AFTER getting lock
     await migrate(client);
   } catch (err: any) {
     globalLogger.error('Database schema migration error', err);


### PR DESCRIPTION
Remove timeout from database migration statements, and also log any errors that occur during migrations while allowing the server to start up normally