### PR TITLE
[Photon Health] Handle prescription webhooks

### DIFF
--- a/examples/medplum-photon-integration/package.json
+++ b/examples/medplum-photon-integration/package.json
@@ -42,6 +42,7 @@
     "react-dom": "18.2.0",
     "react-router-dom": "6.25.1",
     "typescript": "5.5.4",
-    "vite": "5.3.5"
+    "vite": "5.3.5",
+    "vitest": "^2.0.5"
   }
 }

--- a/examples/medplum-photon-integration/src/bots/handle-order-event.test.ts
+++ b/examples/medplum-photon-integration/src/bots/handle-order-event.test.ts
@@ -1,5 +1,5 @@
 import { PhotonWebhook } from '../photon-types';
-import { verifyEvent } from './handle-webhooks';
+import { verifyEvent } from './handle-order-event';
 
 test.skip('Verify photon signature', async () => {
   const result = verifyEvent(exampleWebhookEvent, 'example-secret');

--- a/examples/medplum-photon-integration/src/bots/handle-order-event.ts
+++ b/examples/medplum-photon-integration/src/bots/handle-order-event.ts
@@ -1,6 +1,6 @@
 import { BotEvent, MedplumClient } from '@medplum/core';
 import { createHmac } from 'crypto';
-import { PhotonWebhook } from './../photon-types';
+import { PhotonWebhook } from '../photon-types';
 
 export async function handler(_medplum: MedplumClient, event: BotEvent<PhotonWebhook>): Promise<void> {
   const webhook = event.input;

--- a/examples/medplum-photon-integration/src/bots/handle-prescription-event.test.ts
+++ b/examples/medplum-photon-integration/src/bots/handle-prescription-event.test.ts
@@ -1,0 +1,135 @@
+import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { readJson, SEARCH_PARAMETER_BUNDLE_FILES } from '@medplum/definitions';
+import { Bundle, MedicationRequest, SearchParameter } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { PrescriptionCreatedEvent, PrescriptionData, PrescriptionDepletedEvent } from '../photon-types';
+import {
+  getExistingPrescription,
+  handleCreatePrescription,
+  handleUpdatePrescription,
+} from './handle-prescription-event';
+
+describe('Prescription webhooks', async () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+      indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+    }
+  });
+
+  test.skip('Check for existing prescription', async () => {
+    const medplum = new MockClient();
+    await medplum.createResource({
+      resourceType: 'MedicationRequest',
+      status: 'active',
+      intent: 'order',
+      subject: { reference: 'Patient/123' },
+      identifier: [{ system: 'https://neutron.health', value: 'example-id' }],
+    });
+
+    const prescription = await medplum.searchOne('MedicationRequest', {
+      identifier: 'https://neutron.health|example-id',
+    });
+
+    const prescriptionData: PrescriptionData = {
+      id: 'example-id',
+      externalId: prescription?.id ?? '',
+      patient: {
+        id: 'example',
+        externalId: 'example',
+      },
+    };
+
+    const existingRequest = await getExistingPrescription(prescriptionData, medplum);
+    expect(existingRequest).toBeDefined();
+  });
+
+  test.skip('Create prescription', async () => {
+    const medplum = new MockClient();
+
+    await medplum.createResource({
+      resourceType: 'Practitioner',
+      identifier: [{ system: 'https://neutron.health', value: 'example-prescriber' }],
+    });
+
+    await medplum.createResource({
+      resourceType: 'Medication',
+      identifier: [{ system: 'https://neutron.health', value: 'example-med' }],
+      code: {
+        coding: [
+          {
+            system: 'http://www.nlm.nih.gov/research/umls/rxnorm',
+            value: '197365',
+            display: 'amoxapine 25 MG Oral Tablet',
+          },
+        ],
+      },
+    });
+
+    const event: PrescriptionCreatedEvent = {
+      id: '01G8C1TNGH2F03021F23C95261',
+      type: 'photon:prescription:created',
+      specversion: 1.0,
+      datacontenttype: 'application/json',
+      time: '2022-01-01T01:00:00.000Z',
+      subject: 'rx_01G8C1TNF8TZ5N9DAJN66H9KSH',
+      source: 'org:org_KzSVZBQixLRkqj5d',
+      data: {
+        id: 'rx_01G8C1TNF8TZ5N9DAJN66H9KSH',
+        externalId: '1234',
+        dispenseQuantity: 30,
+        dispenseAsWritten: true,
+        dispenseUnit: 'EA',
+        refillsAllowed: 12,
+        daysSupply: 30,
+        instructions: 'Take once daily',
+        notes: 'Very good',
+        effectiveDate: '2022-01-01',
+        expirationDate: '2023-01-01',
+        prescriberId: 'example-prescriber',
+        medicationId: 'example-med',
+        patient: {
+          id: 'pat_ieUv67viS0lG18JN',
+          externalId: '1234',
+        },
+      },
+    };
+
+    const medicationRequest = await handleCreatePrescription(event, medplum, 'auth-token');
+    expect(medicationRequest).toBeDefined();
+  });
+
+  test('Update Prescription', async () => {
+    const medplum = new MockClient();
+
+    const existingPrescription = (await medplum.createResource({
+      resourceType: 'MedicationRequest',
+      status: 'active',
+      intent: 'order',
+      subject: { reference: 'Patient/123' },
+    })) as MedicationRequest;
+
+    const depletedEvent: PrescriptionDepletedEvent = {
+      id: '01G8AHJBT081QQWM89X3SVV31F',
+      type: 'photon:prescription:depleted',
+      specversion: 1.0,
+      datacontenttype: 'application/json',
+      time: '2022-01-01T01:00:00.000Z',
+      subject: 'rx_01G8AGBC91W1042CDRB19545EC',
+      source: 'org:org_KzSVZBQixLRkqj5d',
+      data: {
+        id: 'rx_01G8AGBC91W1042CDRB19545EC',
+        externalId: existingPrescription.id as string,
+        patient: {
+          id: 'pat_ieUv67viS0lG18JN',
+          externalId: '1234',
+        },
+      },
+    };
+
+    const result = await handleUpdatePrescription(depletedEvent, medplum, existingPrescription);
+    expect(result).toBeDefined();
+    expect(result.status).toBe('completed');
+  });
+});

--- a/examples/medplum-photon-integration/src/bots/handle-prescription-event.ts
+++ b/examples/medplum-photon-integration/src/bots/handle-prescription-event.ts
@@ -1,0 +1,238 @@
+import { BotEvent, getReferenceString, MedplumClient, normalizeErrorString, PatchOperation } from '@medplum/core';
+import { Medication, MedicationRequest, Practitioner } from '@medplum/fhirtypes';
+import { createHmac } from 'crypto';
+import {
+  PhotonEvent,
+  PhotonWebhook,
+  PrescriptionCreatedData,
+  PrescriptionDepletedEvent,
+  PrescriptionExpiredEvent,
+} from '../photon-types';
+import { handlePhotonAuth, photonGraphqlFetch } from './utils';
+
+export async function handler(medplum: MedplumClient, event: BotEvent<PhotonWebhook>): Promise<MedicationRequest> {
+  const webhook = event.input;
+  const PHOTON_WEBHOOK_SECRET = event.secrets['PHOTON_PRESCRIPTION_WEBHOOK_SECRET']?.valueString ?? '';
+  const isValid = verifyEvent(webhook, PHOTON_WEBHOOK_SECRET);
+  if (!isValid) {
+    throw new Error('Not a valid Photon Webhook Event');
+  }
+
+  const body = webhook.body;
+
+  if (!body.type.includes('prescription')) {
+    throw new Error('Not a prescription event');
+  }
+
+  const existingPrescription = await getExistingPrescription(body.data, medplum);
+  if (!existingPrescription && body.type !== 'photon:prescription:created') {
+    throw new Error('Prescription does not exist');
+  }
+
+  const PHOTON_CLIENT_ID = event.secrets['PHOTON_CLIENT_ID']?.valueString;
+  const PHOTON_CLIENT_SECRET = event.secrets['PHOTON_CLIENT_SECRET']?.valueString;
+  const PHOTON_AUTH_TOKEN = await handlePhotonAuth(PHOTON_CLIENT_ID, PHOTON_CLIENT_SECRET);
+
+  let prescription: MedicationRequest;
+  if (body.type === 'photon:prescription:created') {
+    prescription = await handleCreatePrescription(body, medplum, PHOTON_AUTH_TOKEN);
+  } else if (body.type === 'photon:prescription:depleted' || body.type === 'photon:prescription:expired') {
+    prescription = await handleUpdatePrescription(body, medplum, existingPrescription);
+  } else {
+    throw new Error('Invalid prescription type');
+  }
+
+  return prescription;
+}
+
+function verifyEvent(photonEvent: PhotonWebhook, secret: string): boolean {
+  const signature = photonEvent.headers['X-Photon-Signature'];
+  const body = photonEvent.body;
+
+  const hmac = createHmac('sha256', secret);
+  const digest = hmac.update(JSON.stringify(body)).digest('hex');
+
+  return digest === signature;
+}
+
+export async function getExistingPrescription(
+  data: PhotonEvent['data'],
+  medplum: MedplumClient
+): Promise<MedicationRequest | undefined> {
+  const id = data.externalId;
+  const photonId = data.id;
+
+  let existingPrescription = await medplum.searchOne('MedicationRequest', {
+    _id: id,
+  });
+
+  if (existingPrescription) {
+    return existingPrescription;
+  }
+
+  existingPrescription = await medplum.searchOne('MedicationRequest', {
+    identifier: `https://neutron.health|${photonId}`,
+  });
+
+  return existingPrescription;
+}
+
+export async function handleUpdatePrescription(
+  body: PrescriptionDepletedEvent | PrescriptionExpiredEvent,
+  medplum: MedplumClient,
+  existingPrescription?: MedicationRequest
+): Promise<MedicationRequest> {
+  if (!existingPrescription) {
+    throw new Error('No prescription to update');
+  }
+
+  const updatedStatus = body.type === 'photon:prescription:depleted' ? 'completed' : 'stopped';
+
+  const id = body.data.externalId;
+  const ops: PatchOperation[] = [
+    { op: 'test', path: '/meta/versionId', value: existingPrescription.meta?.versionId },
+    { op: 'replace', path: '/status', value: updatedStatus },
+  ];
+
+  try {
+    const result = await medplum.patchResource('MedicationRequest', id, ops);
+    return result;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
+}
+
+export async function handleCreatePrescription(
+  event: PhotonEvent,
+  medplum: MedplumClient,
+  authToken: string
+): Promise<MedicationRequest> {
+  const data = event.data as PrescriptionCreatedData;
+  // Get the prescribing practitioner and the medication from Medplum
+  const prescriber = await getPrescriber(data, medplum, authToken);
+  const medication = await getMedication(data.medicationId, medplum, authToken);
+
+  const medicationRequest: MedicationRequest = {
+    resourceType: 'MedicationRequest',
+    status: 'active',
+    intent: 'order',
+    subject: { reference: `Patient/${data.patient.externalId}` },
+    dispenseRequest: {
+      quantity: {
+        value: data.dispenseQuantity,
+        unit: data.dispenseUnit,
+      },
+      numberOfRepeatsAllowed: data.refillsAllowed,
+      expectedSupplyDuration: { value: data.daysSupply, unit: 'days' },
+      validityPeriod: {
+        start: data.effectiveDate,
+        end: data.expirationDate,
+      },
+    },
+    substitution: { allowedBoolean: data.dispenseAsWritten },
+    dosageInstruction: [{ patientInstruction: data.instructions }],
+    note: [{ text: data.notes }],
+  };
+
+  if (medication) {
+    medicationRequest.medicationCodeableConcept = medication.code;
+  }
+
+  if (prescriber) {
+    medicationRequest.requester = { reference: getReferenceString(prescriber) };
+  }
+
+  try {
+    const result = await medplum.createResource(medicationRequest);
+    return result;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
+}
+
+async function getPrescriber(
+  prescriptionData: PrescriptionCreatedData,
+  medplum: MedplumClient,
+  authToken: string
+): Promise<Practitioner | undefined> {
+  const prescriberId = prescriptionData.prescriberId;
+  // Search for an existing practitioner with a photon identifier
+  const trackedPractitioner = await medplum.searchOne('Practitioner', {
+    identifier: `https://neutron.health|${prescriberId}`,
+  });
+
+  // Return the practitioner if they are already tracked in Medplum
+  if (trackedPractitioner) {
+    return trackedPractitioner;
+  }
+
+  // Otherwise query for the practitioner in Photon to get additional details to search on
+  // We will get the external ID (Medplum ID) and the email
+  const query = `
+    query prescription($id: ID!) {
+      prescription(id: $id) {
+        prescriber {
+          externalId
+          email
+        }
+      }
+    }
+  `;
+
+  const variables = { id: prescriptionData.id };
+  const body = JSON.stringify({ query, variables });
+
+  try {
+    const result = await photonGraphqlFetch(body, authToken);
+
+    const practitionerId = result.data.prescriber.externalId;
+    const practitionerEmail = result.data.prescriber.email;
+
+    const practitioner = await medplum.searchOne('Practitioner', {
+      _filter: `(_id eq ${practitionerId} or email eq ${practitionerEmail})`,
+    });
+
+    return practitioner;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
+}
+async function getMedication(
+  photonMedicationId: string,
+  medplum: MedplumClient,
+  authToken: string
+): Promise<Medication | undefined> {
+  const trackedMedication = await medplum.searchOne('Medication', {
+    identifier: `https://neutron.health|${photonMedicationId}`,
+  });
+
+  if (trackedMedication) {
+    return trackedMedication;
+  }
+
+  const query = `
+    query medicationProducts($id: string) {
+      medicationProducts(id: $id) {
+        codes {
+          rxcui
+        }
+      }
+    }
+  `;
+
+  const variables = { id: photonMedicationId };
+  const body = JSON.stringify({ query, variables });
+
+  try {
+    const result = await photonGraphqlFetch(body, authToken);
+    const rxcui = result.data.medicationProducts?.[0].codes?.rxcui ?? '';
+
+    const medication = await medplum.searchOne('Medication', {
+      code: rxcui,
+    });
+
+    return medication;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
+}

--- a/examples/medplum-photon-integration/src/bots/utils.ts
+++ b/examples/medplum-photon-integration/src/bots/utils.ts
@@ -2,6 +2,28 @@ import { normalizeErrorString } from '@medplum/core';
 import { Address, ContactPoint, Patient } from '@medplum/fhirtypes';
 import { PhotonAddress } from '../photon-types';
 
+export async function photonGraphqlFetch(body: string, authToken: string): Promise<any> {
+  try {
+    const response = await fetch('https://api.neutron.health/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + authToken,
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP Error! Status: ${response.status} ${response.statusText}`);
+    }
+
+    const result = await response.json();
+    return result;
+  } catch (err) {
+    throw new Error(normalizeErrorString(err));
+  }
+}
+
 export function formatAWSDate(date?: string): string {
   if (!date) {
     return '1970-01-01';

--- a/examples/medplum-photon-integration/src/photon-types.d.ts
+++ b/examples/medplum-photon-integration/src/photon-types.d.ts
@@ -347,7 +347,7 @@ interface PrescriptionCreatedEvent extends BasePhotonEvent {
   data: PrescriptionCreatedData;
 }
 
-interface PrescriptionDepletedEvent extends BasePhotonEvent {
+export interface PrescriptionDepletedEvent extends BasePhotonEvent {
   type: 'photon:prescription:depleted';
   data: PrescriptionData;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,7 +392,368 @@
         "react-dom": "18.2.0",
         "react-router-dom": "6.25.1",
         "typescript": "5.5.4",
-        "vite": "5.3.5"
+        "vite": "5.3.5",
+        "vitest": "^2.0.5"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/expect": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
+      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
+        "chai": "^5.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/pretty-format": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
+      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/runner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
+      "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.0.5",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/snapshot": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
+      "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.5",
+        "magic-string": "^0.30.10",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/spy": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
+      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/ui": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.0.5.tgz",
+      "integrity": "sha512-m+ZpVt/PVi/nbeRKEjdiYeoh0aOfI9zr3Ria9LO7V2PlMETtAXJS3uETEZkc8Be2oOl8mhd7Ew+5SRBXRYncNw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "2.0.5",
+        "fast-glob": "^3.3.2",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.1",
+        "pathe": "^1.1.2",
+        "sirv": "^2.0.4",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "2.0.5"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/@vitest/utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.5",
+        "estree-walker": "^3.0.3",
+        "loupe": "^3.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/vite-node": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+      "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.5",
+        "pathe": "^1.1.2",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "examples/medplum-photon-integration/node_modules/vitest": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
+      "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@vitest/expect": "2.0.5",
+        "@vitest/pretty-format": "^2.0.5",
+        "@vitest/runner": "2.0.5",
+        "@vitest/snapshot": "2.0.5",
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
+        "chai": "^5.1.1",
+        "debug": "^4.3.5",
+        "execa": "^8.0.1",
+        "magic-string": "^0.30.10",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.8.0",
+        "tinypool": "^1.0.0",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.0.5",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.0.5",
+        "@vitest/ui": "2.0.5",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "examples/medplum-provider": {


### PR DESCRIPTION
This creates a bot to handle prescription event webhooks from Photon Health. It separates the previous webhook bot into two bots, one for prescription events and one for order events, but only adds functionality for prescriptions. It also installs vitest into the Photon integration example to allow for testing.