### PR TITLE
fix(MedplumProvider): stop clearing profile from context while refreshing

### DIFF
--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -203,9 +203,11 @@ export class MockClient extends MedplumClient {
     this.activeLoginOverride = activeLoginOverride;
   }
 
-  setProfile(profile: ProfileResource | undefined): void {
+  setProfile(profile: ProfileResource | undefined, emitEvent = true): void {
     this.profile = profile;
-    this.dispatchEvent({ type: 'change' });
+    if (emitEvent) {
+      this.dispatchEvent({ type: 'change' });
+    }
   }
 
   getActiveLogin(): LoginState | undefined {

--- a/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
+++ b/packages/react-hooks/src/MedplumProvider/MedplumProvider.tsx
@@ -35,7 +35,14 @@ export function MedplumProvider(props: MedplumProviderProps): JSX.Element {
   });
 
   useEffect(() => {
-    function eventListener(): void {
+    function eventListener(event: MedplumClientEventMap[keyof MedplumClientEventMap]): void {
+      if (event.type === 'profileRefreshing') {
+        setState((s) => ({
+          ...s,
+          loading: medplum.isLoading(),
+        }));
+        return;
+      }
       setState((s) => ({
         ...s,
         profile: medplum.getProfile(),


### PR DESCRIPTION
Fixes #5027

The root of this regression was a new event `profileRefreshing` syncing the value of `medplum.getProfile()` to the `MedplumProvider` context and then triggering a re-render, which would lead to any guard checking against the result of  `useMedplumProfile` temporarily being triggered (this guard pattern is a common pattern we promote). 

This is because the call to `medplum.setAccessToken()` in `setActiveLogin()` [via `verifyTokens()`] temporarily clears `sessionDetails`, which contain the profile information until the tokens / profile have been refreshed. 

Previously this was not a problem because we would only re-sync the provider context on the `change` event, which would be fired after the profile is refreshed and not during. Now that `MedplumProvider` stays more in-sync, we have to special case the `profileRefreshing` event and let `profileRefreshed` trigger the resyncing of `profile`.

