### PR TITLE
Improve observability of reindex job

### DIFF
--- a/packages/server/src/fhir/job.ts
+++ b/packages/server/src/fhir/job.ts
@@ -20,7 +20,7 @@ jobRouter.get(
     const asyncJob = await ctx.repo.readResource<AsyncJob>('AsyncJob', id);
 
     if (!finalJobStatusCodes.includes(asyncJob.status as string)) {
-      res.status(202).end();
+      res.status(202).send(asyncJob).end();
       return;
     }
 

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -94,6 +94,16 @@ export class AsyncJobExecutor {
     });
   }
 
+  async updateJobProgress(repo: Repository, output: Parameters): Promise<AsyncJob | undefined> {
+    if (!this.resource) {
+      return undefined;
+    }
+    return repo.updateResource<AsyncJob>({
+      ...this.resource,
+      output,
+    });
+  }
+
   async failJob(repo: Repository, err: Error): Promise<AsyncJob | undefined> {
     if (!this.resource) {
       return undefined;
@@ -102,10 +112,14 @@ export class AsyncJobExecutor {
       ...this.resource,
       status: 'error',
       transactionTime: new Date().toISOString(),
-      output:
-        err instanceof OperationOutcomeError
-          ? { resourceType: 'Parameters', parameter: [{ name: 'outcome', resource: err.outcome }] }
-          : undefined,
+      output: {
+        resourceType: 'Parameters',
+        parameter: [
+          err instanceof OperationOutcomeError
+            ? { name: 'outcome', resource: err.outcome }
+            : { name: 'error', valueString: err.message },
+        ],
+      },
     });
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -894,7 +894,6 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
    * When doing a bulk reindex, this will be more efficient because it avoids unnecessary reads.
    * @param conn - Database client to use for reindex operations.
    * @param resources - The resource(s) to reindex.
-   * @returns The reindexed resource.
    */
   async reindexResources<T extends Resource>(conn: PoolClient, ...resources: T[]): Promise<void> {
     let resource: Resource;

--- a/packages/server/src/workers/reindex.test.ts
+++ b/packages/server/src/workers/reindex.test.ts
@@ -1,4 +1,4 @@
-import { AsyncJob, Parameters, Patient, Practitioner, ResourceType } from '@medplum/fhirtypes';
+import { AsyncJob, Parameters, ParametersParameter, Patient, Practitioner, ResourceType } from '@medplum/fhirtypes';
 import { Job } from 'bullmq';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
@@ -145,6 +145,42 @@ describe('Reindex Worker', () => {
 
       asyncJob = await repo.readResource('AsyncJob', asyncJob.id as string);
       expect(asyncJob.status).toEqual('accepted');
+    }));
+
+  test('Updates in-progress status on AsyncJob resource', () =>
+    withTestContext(async () => {
+      const queue = getReindexQueue() as any;
+      queue.add.mockClear();
+
+      let asyncJob = await repo.createResource<AsyncJob>({
+        resourceType: 'AsyncJob',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: '/admin/super/reindex',
+      });
+
+      const resourceTypes = ['MedicinalProductManufactured', 'BiologicallyDerivedProduct'] as ResourceType[];
+
+      await addReindexJob(resourceTypes, asyncJob);
+      expect(queue.add).toHaveBeenCalledWith(
+        'ReindexJobData',
+        expect.objectContaining<Partial<ReindexJobData>>({
+          resourceTypes,
+          asyncJob,
+        })
+      );
+
+      const job = { id: 1, data: queue.add.mock.calls[0][1] } as unknown as Job;
+      queue.add.mockClear();
+      await execReindexJob(job);
+
+      asyncJob = await repo.readResource('AsyncJob', asyncJob.id as string);
+      expect(asyncJob.status).toEqual('accepted');
+      const outputParam = asyncJob.output?.parameter?.[0];
+      expect(outputParam).toMatchObject<ParametersParameter>({
+        name: 'result',
+        part: expect.arrayContaining([{ name: 'resourceType', valueCode: 'MedicinalProductManufactured' }]),
+      });
     }));
 
   test('Fails job on error', () =>

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -245,10 +245,6 @@ export async function addReindexJob(
   const currentTimestamp = new Date(0).toISOString(); // Beginning of epoch time
   const endTimestamp = new Date(Date.now() + 1000 * 60 * 5).toISOString(); // Five minutes in the future
 
-  if (searchFilter) {
-    searchFilter.filters = searchFilter.filters?.filter((f) => f.code !== '_lastUpdated');
-  }
-
   return addReindexJobData({
     resourceTypes,
     currentTimestamp,


### PR DESCRIPTION
Enhances the reindex async job to enable better observability as the job runs:
- Return the full `AsyncJob` resource when the job status endpoint returns a `202 Accepted` to indicate that the job is in progress
- Periodically (every 50k resources) update the `AsyncJob` resource with the latest results
- For in-progress resource types, the next timestamp is emitted; this allows the reindex process to be restarted from that checkpoint if it fails partway through