### PR TITLE
Replace some example.com URLS with data URLS

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,4 +27,4 @@ jobs:
           autoAcceptChanges: 'main'
           exitOnceUploaded: true
           exitZeroOnChanges: true
-          onlyChanged: true
+          onlyChanged: false

--- a/packages/mock/src/mocks/simpsons.ts
+++ b/packages/mock/src/mocks/simpsons.ts
@@ -346,7 +346,7 @@ export const HomerMedia: Media = {
   encounter: createReference(HomerEncounter),
   content: {
     contentType: ContentType.TEXT,
-    url: 'https://example.com/test.txt',
+    url: 'data:text/plain,This%20is%20a%20text/plain%20data%20URL',
   },
 };
 

--- a/packages/react/src/AttachmentDisplay/AttachmentDisplay.test.tsx
+++ b/packages/react/src/AttachmentDisplay/AttachmentDisplay.test.tsx
@@ -77,7 +77,9 @@ describe('AttachmentDisplay', () => {
   });
 
   test('Renders plain text', async () => {
-    await setup({ value: { contentType: 'text/plain', url: 'https://example.com/test.txt' } });
+    await setup({
+      value: { contentType: 'text/plain', url: 'data:text/plain,This%20is%20a%20text/plain%20data%20URL' },
+    });
     expect(await screen.findByTestId('attachment-iframe')).toBeInTheDocument();
     expect(screen.getByText('Download')).toBeInTheDocument();
   });
@@ -92,7 +94,7 @@ describe('AttachmentDisplay', () => {
     await setup({
       value: {
         contentType: 'text/plain',
-        url: 'https://example.com/test.txt',
+        url: 'data:text/plain,This%20is%20a%20text/plain%20data%20URL',
         title: 'test.txt',
       },
     });
@@ -104,7 +106,7 @@ describe('AttachmentDisplay', () => {
     await setup({
       value: {
         contentType: 'text/plain',
-        url: 'https://example.com/test.txt',
+        url: 'data:text/plain,This%20is%20a%20text/plain%20data%20URL',
       },
     });
     expect(await screen.findByTestId('attachment-details')).toBeInTheDocument();


### PR DESCRIPTION
We use example.com liberally in tests, but it turns out there is a server hosting that site that seems to have recently changed it's behavior leading to inconsistent rendering, so let's start using data URLs instead.