### PR TITLE
fix(core): stop clearing `sessionDetails` while refreshing token

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2710,7 +2710,6 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   setAccessToken(accessToken: string, refreshToken?: string): void {
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
-    this.sessionDetails = undefined;
     this.accessTokenExpires = tryGetJwtExpiration(accessToken);
     this.medplumServer = isMedplumAccessToken(accessToken);
   }


### PR DESCRIPTION
Fixes #5027

The root of this regression was a new event `profileRefreshing` syncing the value of `medplum.getProfile()` to the `MedplumProvider` context and then triggering a re-render, which would lead to any guard checking against the result of `useMedplumProfile()` temporarily being triggered (this guard pattern is a common pattern we promote).

This is because the call to `medplum.setAccessToken()` in `setActiveLogin()` [via `verifyTokens()`] temporarily clears `sessionDetails`, which contain the profile information until the tokens / profile have been refreshed.

Previously this was not a problem because we would only re-sync the provider context on the change event, which would be fired after the profile is refreshed and not during. Now that `MedplumProvider` stays more in-sync, we caught this previously inconsequential clearing of the `sessionDetails` which we can easily remove without side effects.