### PR TITLE
Update function signatures for crawlResource

### DIFF
--- a/packages/core/src/typeschema/crawler.test.ts
+++ b/packages/core/src/typeschema/crawler.test.ts
@@ -131,7 +131,7 @@ describe('ResourceCrawler', () => {
             if (propertyValue) {
               for (const value of arrayify(propertyValue) as TypedValue[]) {
                 if (value.type === 'Coding') {
-                  resultCodes.push(value.value as Attachment);
+                  resultCodes.push(value.value);
                 }
               }
             }
@@ -181,7 +181,7 @@ describe('ResourceCrawler', () => {
             for (const value of arrayify(propertyValue) as TypedValue[]) {
               if (value.type === 'Coding') {
                 await sleep(1); // Simulate validating the coding
-                resultCodes.push(value.value as Attachment);
+                resultCodes.push(value.value);
               }
             }
           }

--- a/packages/core/src/typeschema/crawler.test.ts
+++ b/packages/core/src/typeschema/crawler.test.ts
@@ -1,9 +1,10 @@
 import { readJson } from '@medplum/definitions';
-import { Attachment, Bundle, Patient } from '@medplum/fhirtypes';
+import { Attachment, Bundle, Coding, Observation, Patient } from '@medplum/fhirtypes';
 import { TypedValue } from '../types';
 import { arrayify, sleep } from '../utils';
-import { crawlResource } from './crawler';
+import { crawlResource, crawlResourceAsync } from './crawler';
 import { indexStructureDefinitionBundle } from './types';
+import { LOINC } from '../constants';
 
 describe('ResourceCrawler', () => {
   beforeAll(() => {
@@ -96,5 +97,104 @@ describe('ResourceCrawler', () => {
 
     expect(paths).toContain('Patient.photo.contentType');
     expect(paths).not.toContain('Patient.gender');
+  });
+
+  test('New sync signature', () => {
+    const obs: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: {
+        coding: [{ system: LOINC, code: '85354-9' }],
+      },
+      component: [
+        {
+          code: {
+            coding: [{ system: LOINC, code: '8480-6' }],
+          },
+          valueQuantity: { value: 120, code: 'mm[Hg]' },
+        },
+        {
+          code: {
+            coding: [{ system: LOINC, code: '8462-4' }],
+          },
+          valueQuantity: { value: 80, code: 'mm[Hg]' },
+        },
+      ],
+    };
+
+    const resultCodes: Coding[] = [];
+    crawlResource(
+      obs,
+      {
+        visitProperty: (_parent, _key, _path, propertyValues) => {
+          for (const propertyValue of propertyValues) {
+            if (propertyValue) {
+              for (const value of arrayify(propertyValue) as TypedValue[]) {
+                if (value.type === 'Coding') {
+                  resultCodes.push(value.value as Attachment);
+                }
+              }
+            }
+          }
+        },
+      },
+      { initialPath: 'component' }
+    );
+
+    expect(resultCodes).toEqual(
+      expect.arrayContaining<Coding>([
+        { system: LOINC, code: '8480-6' },
+        { system: LOINC, code: '8462-4' },
+      ])
+    );
+  });
+
+  test('New async signature', async () => {
+    const obs: Observation = {
+      resourceType: 'Observation',
+      status: 'final',
+      code: {
+        coding: [{ system: LOINC, code: '85354-9' }],
+      },
+      component: [
+        {
+          code: {
+            coding: [{ system: LOINC, code: '8480-6' }],
+          },
+          valueQuantity: { value: 120, code: 'mm[Hg]' },
+        },
+        {
+          code: {
+            coding: [{ system: LOINC, code: '8462-4' }],
+          },
+          valueQuantity: { value: 80, code: 'mm[Hg]' },
+        },
+      ],
+    };
+
+    const resultCodes: Coding[] = [];
+    await crawlResourceAsync(
+      obs,
+      {
+        visitPropertyAsync: async (_parent, _key, _path, propertyValue) => {
+          if (propertyValue) {
+            for (const value of arrayify(propertyValue) as TypedValue[]) {
+              if (value.type === 'Coding') {
+                await sleep(1); // Simulate validating the coding
+                resultCodes.push(value.value as Attachment);
+              }
+            }
+          }
+        },
+      },
+      { initialPath: 'component' }
+    );
+
+    expect(resultCodes).toEqual(
+      expect.arrayContaining<Coding>([
+        { system: LOINC, code: '8480-6' },
+        { system: LOINC, code: '8462-4' },
+      ])
+    );
   });
 });

--- a/packages/core/src/typeschema/crawler.ts
+++ b/packages/core/src/typeschema/crawler.ts
@@ -40,17 +40,40 @@ function isAsync(visitor: ResourceVisitor | AsyncResourceVisitor): visitor is As
   return Boolean((visitor as AsyncResourceVisitor).visitPropertyAsync);
 }
 
+/**
+ * Crawls the resource synchronously.
+ * @param resource - The resource to crawl.
+ * @param visitor - The visitor functions to apply while crawling.
+ * @param schema - The schema to use for the resource.
+ * @param initialPath - The path within the resource form which to start crawling.
+ * @deprecated
+ */
 export function crawlResource(
   resource: Resource,
   visitor: ResourceVisitor,
   schema?: InternalTypeSchema,
   initialPath?: string
 ): void;
+/**
+ * Crawls the resource asynchronously.
+ * @param resource - The resource to crawl.
+ * @param visitor - The visitor functions to apply while crawling.
+ * @param options - Options for how to crawl the resource.
+ * @returns void
+ * @deprecated
+ */
 export function crawlResource(
   resource: Resource,
   visitor: AsyncResourceVisitor,
   options: ResourceCrawlerOptions
 ): Promise<void>;
+/**
+ * Crawls the resource synchronously.
+ * @param resource - The resource to crawl.
+ * @param visitor - The visitor functions to apply while crawling.
+ * @param options - Options for how to crawl the resource.
+ */
+export function crawlResource(resource: Resource, visitor: ResourceVisitor, options?: ResourceCrawlerOptions): void;
 export function crawlResource(
   resource: Resource,
   visitor: ResourceVisitor | AsyncResourceVisitor,
@@ -70,6 +93,20 @@ export function crawlResource(
     new ResourceCrawler(resource, visitor, options).crawl();
     return undefined;
   }
+}
+
+/**
+ * Crawls the resource asynchronously.
+ * @param resource - The resource to crawl.
+ * @param visitor - The visitor functions to apply while crawling.
+ * @param options - Options for how to crawl the resource.
+ */
+export async function crawlResourceAsync(
+  resource: Resource,
+  visitor: AsyncResourceVisitor,
+  options: ResourceCrawlerOptions
+): Promise<void> {
+  await new AsyncResourceCrawler(resource, visitor, options).crawl();
 }
 
 export type ResourceCrawlerOptions = {


### PR DESCRIPTION
Per a conversation with @codyebberson, creating separate sync and async versions of the `crawlResource` utility function and deprecating the legacy function signatures.  The old versions of the function can be removed later, in the next major version of `@medplum/core`