### PR TITLE
Add search mode to search results Bundle

### DIFF
--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -90,9 +90,9 @@ describe('HumanName Lookup Table', () => {
         ],
       });
       expect(searchResult.entry?.length).toEqual(2);
-      expect(bundleContains(searchResult, patients[0])).toBe(true);
-      expect(bundleContains(searchResult, patients[1])).toBe(true);
-      expect(bundleContains(searchResult, patients[2])).toBe(false);
+      expect(bundleContains(searchResult, patients[0])).toBeDefined();
+      expect(bundleContains(searchResult, patients[1])).toBeDefined();
+      expect(bundleContains(searchResult, patients[2])).toBeUndefined();
     }));
 
   test('Search with blank name', async () => {

--- a/packages/server/src/fhir/lookups/token.test.ts
+++ b/packages/server/src/fhir/lookups/token.test.ts
@@ -178,8 +178,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult1, patient1)).toBe(true);
-      expect(bundleContains(searchResult1, patient2)).toBe(false);
+      expect(bundleContains(searchResult1, patient1)).toBeDefined();
+      expect(bundleContains(searchResult1, patient2)).toBeUndefined();
     }));
 
   test('Explicit exact', () =>
@@ -209,8 +209,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult1, patient1)).toBe(true);
-      expect(bundleContains(searchResult1, patient2)).toBe(false);
+      expect(bundleContains(searchResult1, patient1)).toBeDefined();
+      expect(bundleContains(searchResult1, patient2)).toBeUndefined();
     }));
 
   test('Contains', () =>
@@ -240,8 +240,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(2);
-      expect(bundleContains(searchResult1, patient1)).toBe(true);
-      expect(bundleContains(searchResult1, patient2)).toBe(true);
+      expect(bundleContains(searchResult1, patient1)).toBeDefined();
+      expect(bundleContains(searchResult1, patient2)).toBeDefined();
     }));
 
   test('Not equals', () =>
@@ -277,8 +277,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult1, patient1)).toBe(false);
-      expect(bundleContains(searchResult1, patient2)).toBe(true);
+      expect(bundleContains(searchResult1, patient1)).toBeUndefined();
+      expect(bundleContains(searchResult1, patient2)).toBeDefined();
     }));
 
   test('Missing', () =>
@@ -313,8 +313,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult1, patient1)).toBe(true);
-      expect(bundleContains(searchResult1, patient2)).toBe(false);
+      expect(bundleContains(searchResult1, patient1)).toBeDefined();
+      expect(bundleContains(searchResult1, patient2)).toBeUndefined();
     }));
 
   test('Search comma separated identifier exact', () =>
@@ -345,8 +345,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(2);
-      expect(bundleContains(searchResult1, patient1)).toBe(true);
-      expect(bundleContains(searchResult1, patient2)).toBe(true);
+      expect(bundleContains(searchResult1, patient1)).toBeDefined();
+      expect(bundleContains(searchResult1, patient2)).toBeDefined();
     }));
 
   test('Search on system', () =>
@@ -378,8 +378,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult1, patient1)).toBe(true);
-      expect(bundleContains(searchResult1, patient2)).toBe(false);
+      expect(bundleContains(searchResult1, patient1)).toBeDefined();
+      expect(bundleContains(searchResult1, patient2)).toBeUndefined();
 
       const searchResult2 = await systemRepo.search({
         resourceType: 'Patient',
@@ -392,8 +392,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult2.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult2, patient1)).toBe(false);
-      expect(bundleContains(searchResult2, patient2)).toBe(true);
+      expect(bundleContains(searchResult2, patient1)).toBeUndefined();
+      expect(bundleContains(searchResult2, patient2)).toBeDefined();
     }));
 
   test('Non-array identifier', () =>
@@ -471,8 +471,8 @@ describe('Identifier Lookup Table', () => {
         ],
       });
       expect(searchResult1.entry?.length).toEqual(1);
-      expect(bundleContains(searchResult1, sr1)).toBe(true);
-      expect(bundleContains(searchResult1, sr2)).toBe(false);
+      expect(bundleContains(searchResult1, sr1)).toBeDefined();
+      expect(bundleContains(searchResult1, sr2)).toBeUndefined();
     }));
 
   test('Identifier value with pipe', () =>

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -17,6 +17,7 @@ import {
   AuditEvent,
   Binary,
   Bundle,
+  BundleEntry,
   CareTeam,
   Coding,
   Communication,
@@ -859,7 +860,7 @@ describe('FHIR Search', () => {
           ],
         });
         expect(bundle.entry?.length).toEqual(1);
-        expect(bundleContains(bundle, location)).toBe(true);
+        expect(bundleContains(bundle, location)).toBeDefined();
       }));
 
     test('Filter by _id', () =>
@@ -885,7 +886,7 @@ describe('FHIR Search', () => {
         });
 
         expect(searchResult1.entry?.length).toEqual(1);
-        expect(bundleContains(searchResult1 as Bundle, patient as Patient)).toEqual(true);
+        expect(bundleContains(searchResult1 as Bundle, patient as Patient)).toBeDefined();
 
         const searchResult2 = await repo.search({
           resourceType: 'Patient',
@@ -970,7 +971,7 @@ describe('FHIR Search', () => {
         });
 
         expect(searchResult1.entry?.length).toEqual(1);
-        expect(bundleContains(searchResult1 as Bundle, patient as Patient)).toEqual(true);
+        expect(bundleContains(searchResult1 as Bundle, patient as Patient)).toBeDefined();
       }));
 
     test('Handle malformed _lastUpdated', async () =>
@@ -1079,9 +1080,9 @@ describe('FHIR Search', () => {
           ],
         });
         expect(bundle1.entry?.length).toEqual(1);
-        expect(bundleContains(bundle1, serviceRequest1)).toEqual(true);
-        expect(bundleContains(bundle1, serviceRequest2)).toEqual(false);
-        expect(bundleContains(bundle1, serviceRequest3)).toEqual(false);
+        expect(bundleContains(bundle1, serviceRequest1)).toBeDefined();
+        expect(bundleContains(bundle1, serviceRequest2)).toBeUndefined();
+        expect(bundleContains(bundle1, serviceRequest3)).toBeUndefined();
 
         const bundle2 = await repo.search({
           resourceType: 'ServiceRequest',
@@ -1094,9 +1095,9 @@ describe('FHIR Search', () => {
           ],
         });
         expect(bundle2.entry?.length).toEqual(1);
-        expect(bundleContains(bundle2, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle2, serviceRequest2)).toEqual(true);
-        expect(bundleContains(bundle2, serviceRequest3)).toEqual(false);
+        expect(bundleContains(bundle2, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle2, serviceRequest2)).toBeDefined();
+        expect(bundleContains(bundle2, serviceRequest3)).toBeUndefined();
 
         const bundle3 = await repo.search({
           resourceType: 'ServiceRequest',
@@ -1109,9 +1110,9 @@ describe('FHIR Search', () => {
           ],
         });
         expect(bundle3.entry?.length).toEqual(1);
-        expect(bundleContains(bundle3, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle3, serviceRequest2)).toEqual(false);
-        expect(bundleContains(bundle3, serviceRequest3)).toEqual(true);
+        expect(bundleContains(bundle3, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle3, serviceRequest2)).toBeUndefined();
+        expect(bundleContains(bundle3, serviceRequest3)).toBeDefined();
       }));
 
     test('Filter by Quantity.value', () =>
@@ -1246,8 +1247,8 @@ describe('FHIR Search', () => {
           parseSearchRequest('ServiceRequest', { category, code: `${codes[0]},${codes[1]}` })
         );
         expect(bundle1.entry?.length).toEqual(2);
-        expect(bundleContains(bundle1, serviceRequests[0])).toEqual(true);
-        expect(bundleContains(bundle1, serviceRequests[1])).toEqual(true);
+        expect(bundleContains(bundle1, serviceRequests[0])).toBeDefined();
+        expect(bundleContains(bundle1, serviceRequests[1])).toBeDefined();
       }));
 
     test('Token not equals', () =>
@@ -1276,8 +1277,8 @@ describe('FHIR Search', () => {
 
         const bundle1 = await repo.search(parseSearchRequest('ServiceRequest', { category, 'code:not': code1 }));
         expect(bundle1.entry?.length).toEqual(1);
-        expect(bundleContains(bundle1, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle1, serviceRequest2)).toEqual(true);
+        expect(bundleContains(bundle1, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle1, serviceRequest2)).toBeDefined();
       }));
 
     test('Token array not equals', () =>
@@ -1306,8 +1307,8 @@ describe('FHIR Search', () => {
 
         const bundle1 = await repo.search(parseSearchRequest('ServiceRequest', { code, 'category:not': category1 }));
         expect(bundle1.entry?.length).toEqual(1);
-        expect(bundleContains(bundle1, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle1, serviceRequest2)).toEqual(true);
+        expect(bundleContains(bundle1, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle1, serviceRequest2)).toBeDefined();
       }));
 
     test('Null token array not equals', () =>
@@ -1334,8 +1335,8 @@ describe('FHIR Search', () => {
 
         const bundle1 = await repo.search(parseSearchRequest('ServiceRequest', { code, 'category:not': category1 }));
         expect(bundle1.entry?.length).toEqual(1);
-        expect(bundleContains(bundle1, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle1, serviceRequest2)).toEqual(true);
+        expect(bundleContains(bundle1, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle1, serviceRequest2)).toBeDefined();
       }));
 
     test('Missing', () =>
@@ -1365,23 +1366,23 @@ describe('FHIR Search', () => {
 
         const bundle1 = await repo.search(parseSearchRequest('ServiceRequest', { code, 'specimen:missing': 'true' }));
         expect(bundle1.entry?.length).toEqual(1);
-        expect(bundleContains(bundle1, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle1, serviceRequest2)).toEqual(true);
+        expect(bundleContains(bundle1, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle1, serviceRequest2)).toBeDefined();
 
         const bundle2 = await repo.search(parseSearchRequest('ServiceRequest', { code, 'specimen:missing': 'false' }));
         expect(bundle2.entry?.length).toEqual(1);
-        expect(bundleContains(bundle2, serviceRequest1)).toEqual(true);
-        expect(bundleContains(bundle2, serviceRequest2)).toEqual(false);
+        expect(bundleContains(bundle2, serviceRequest1)).toBeDefined();
+        expect(bundleContains(bundle2, serviceRequest2)).toBeUndefined();
 
         const bundle3 = await repo.search(parseSearchRequest('ServiceRequest', { code, 'encounter:missing': 'true' }));
         expect(bundle3.entry?.length).toEqual(1);
-        expect(bundleContains(bundle3, serviceRequest1)).toEqual(false);
-        expect(bundleContains(bundle3, serviceRequest2)).toEqual(true);
+        expect(bundleContains(bundle3, serviceRequest1)).toBeUndefined();
+        expect(bundleContains(bundle3, serviceRequest2)).toBeDefined();
 
         const bundle4 = await repo.search(parseSearchRequest('ServiceRequest', { code, 'encounter:missing': 'false' }));
         expect(bundle4.entry?.length).toEqual(1);
-        expect(bundleContains(bundle4, serviceRequest1)).toEqual(true);
-        expect(bundleContains(bundle4, serviceRequest2)).toEqual(false);
+        expect(bundleContains(bundle4, serviceRequest1)).toBeDefined();
+        expect(bundleContains(bundle4, serviceRequest2)).toBeUndefined();
       }));
 
     test('Missing with logical (identifier) references', () =>
@@ -1475,8 +1476,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult1 as Bundle, appt1 as Appointment)).toEqual(true);
-        expect(bundleContains(searchResult1 as Bundle, appt2 as Appointment)).toEqual(false);
+        expect(bundleContains(searchResult1 as Bundle, appt1 as Appointment)).toBeDefined();
+        expect(bundleContains(searchResult1 as Bundle, appt2 as Appointment)).toBeUndefined();
 
         // Greater than (newer than) or equal to 2 seconds ago should return both appts
         const searchResult2 = await repo.search({
@@ -1495,8 +1496,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult2 as Bundle, appt1 as Appointment)).toEqual(true);
-        expect(bundleContains(searchResult2 as Bundle, appt2 as Appointment)).toEqual(true);
+        expect(bundleContains(searchResult2 as Bundle, appt1 as Appointment)).toBeDefined();
+        expect(bundleContains(searchResult2 as Bundle, appt2 as Appointment)).toBeDefined();
 
         // Less than (older than) to 1 seconds ago should only return appt 2
         const searchResult3 = await repo.search({
@@ -1520,8 +1521,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult3 as Bundle, appt1 as Appointment)).toEqual(false);
-        expect(bundleContains(searchResult3 as Bundle, appt2 as Appointment)).toEqual(true);
+        expect(bundleContains(searchResult3 as Bundle, appt1 as Appointment)).toBeUndefined();
+        expect(bundleContains(searchResult3 as Bundle, appt2 as Appointment)).toBeDefined();
 
         // Less than (older than) or equal to 1 seconds ago should return both appts
         const searchResult4 = await repo.search({
@@ -1545,8 +1546,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult4 as Bundle, appt1 as Appointment)).toEqual(true);
-        expect(bundleContains(searchResult4 as Bundle, appt2 as Appointment)).toEqual(true);
+        expect(bundleContains(searchResult4 as Bundle, appt1 as Appointment)).toBeDefined();
+        expect(bundleContains(searchResult4 as Bundle, appt2 as Appointment)).toBeDefined();
       }));
 
     test('Boolean search', () =>
@@ -1957,8 +1958,8 @@ describe('FHIR Search', () => {
           filters: [{ code: '_id', operator: Operator.EQUALS, value: order.id as string }],
         });
         expect(bundle.total).toEqual(1);
-        expect(bundleContains(bundle, order)).toBeTruthy();
-        expect(bundleContains(bundle, patient)).toBeTruthy();
+        expect(bundleContains(bundle, order)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+        expect(bundleContains(bundle, patient)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
       }));
 
     test('Include canonical success', () =>
@@ -1986,8 +1987,8 @@ describe('FHIR Search', () => {
           filters: [{ code: '_id', operator: Operator.EQUALS, value: response.id as string }],
         });
         expect(bundle.total).toEqual(1);
-        expect(bundleContains(bundle, response)).toBeTruthy();
-        expect(bundleContains(bundle, questionnaire)).toBeTruthy();
+        expect(bundleContains(bundle, response)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+        expect(bundleContains(bundle, questionnaire)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
       }));
 
     test('Include PlanDefinition mixed types', () =>
@@ -2021,9 +2022,9 @@ describe('FHIR Search', () => {
           filters: [{ code: '_id', operator: Operator.EQUALS, value: plan.id as string }],
         });
         expect(bundle.total).toEqual(1);
-        expect(bundleContains(bundle, plan)).toBeTruthy();
-        expect(bundleContains(bundle, activity1)).toBeTruthy();
-        expect(bundleContains(bundle, activity2)).toBeTruthy();
+        expect(bundleContains(bundle, plan)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+        expect(bundleContains(bundle, activity1)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+        expect(bundleContains(bundle, activity2)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
       }));
 
     test('Include references invalid search param', async () =>
@@ -2090,10 +2091,10 @@ describe('FHIR Search', () => {
 
         const searchResult2 = await repo.search(searchRequest);
         expect(searchResult2.entry).toHaveLength(4);
-        expect(bundleContains(searchResult2, practitioner1)).toBeTruthy();
-        expect(bundleContains(searchResult2, practitioner2)).toBeTruthy();
-        expect(bundleContains(searchResult2, provenance1)).toBeTruthy();
-        expect(bundleContains(searchResult2, provenance2)).toBeTruthy();
+        expect(bundleContains(searchResult2, practitioner1)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+        expect(bundleContains(searchResult2, practitioner2)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+        expect(bundleContains(searchResult2, provenance1)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
+        expect(bundleContains(searchResult2, provenance2)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
       }));
 
     test('Reverse include canonical', () =>
@@ -2121,8 +2122,8 @@ describe('FHIR Search', () => {
           filters: [{ code: '_id', operator: Operator.EQUALS, value: questionnaire.id as string }],
         });
         expect(bundle.total).toEqual(1);
-        expect(bundleContains(bundle, response)).toBeTruthy();
-        expect(bundleContains(bundle, questionnaire)).toBeTruthy();
+        expect(bundleContains(bundle, questionnaire)).toMatchObject<BundleEntry>({ search: { mode: 'match' } });
+        expect(bundleContains(bundle, response)).toMatchObject<BundleEntry>({ search: { mode: 'include' } });
       }));
 
     test('_include:iterate', () =>
@@ -2237,16 +2238,18 @@ describe('FHIR Search', () => {
         });
 
         const expected = [
-          `Patient/${patient.id}`,
-          `Patient/${linked1.id}`,
-          `Patient/${linked2.id}`,
-          `Patient/${linked3.id}`,
-          `Organization/${organization1.id}`,
-          `Practitioner/${practitioner1.id}`,
-          `Practitioner/${practitioner2.id}`,
+          `match:Patient/${patient.id}`,
+          `include:Patient/${linked1.id}`,
+          `include:Patient/${linked2.id}`,
+          `include:Patient/${linked3.id}`,
+          `include:Organization/${organization1.id}`,
+          `include:Practitioner/${practitioner1.id}`,
+          `include:Practitioner/${practitioner2.id}`,
         ].sort();
 
-        expect(bundle.entry?.map((e) => `${e.resource?.resourceType}/${e.resource?.id}`).sort()).toEqual(expected);
+        expect(
+          bundle.entry?.map((e) => `${e.search?.mode}:${e.resource?.resourceType}/${e.resource?.id}`).sort()
+        ).toEqual(expected);
       }));
 
     test('_revinclude:iterate', () =>
@@ -2379,16 +2382,18 @@ describe('FHIR Search', () => {
         });
 
         const expected = [
-          `Patient/${patient.id}`,
-          `Patient/${linked1.id}`,
-          `Patient/${linked2.id}`,
-          `Observation/${observation1.id}`,
-          `Observation/${observation2.id}`,
-          `Observation/${observation3.id}`,
-          `Observation/${observation4.id}`,
+          `match:Patient/${patient.id}`,
+          `include:Patient/${linked1.id}`,
+          `include:Patient/${linked2.id}`,
+          `include:Observation/${observation1.id}`,
+          `include:Observation/${observation2.id}`,
+          `include:Observation/${observation3.id}`,
+          `include:Observation/${observation4.id}`,
         ].sort();
 
-        expect(bundle.entry?.map((e) => `${e.resource?.resourceType}/${e.resource?.id}`).sort()).toEqual(expected);
+        expect(
+          bundle.entry?.map((e) => `${e.search?.mode}:${e.resource?.resourceType}/${e.resource?.id}`).sort()
+        ).toEqual(expected);
       }));
 
     test('_include depth limit', () =>
@@ -3311,8 +3316,8 @@ describe('FHIR Search', () => {
         });
 
         expect(result.entry).toHaveLength(2);
-        expect(bundleContains(result, p1)).toBe(true);
-        expect(bundleContains(result, p2)).toBe(true);
+        expect(bundleContains(result, p1)).toBeDefined();
+        expect(bundleContains(result, p2)).toBeDefined();
       }));
 
     test('Sort by unknown search parameter', async () =>
@@ -4071,8 +4076,8 @@ describe('FHIR Search', () => {
           ],
         });
         expect(bundle.entry?.length).toEqual(1);
-        expect(bundleContains(bundle as Bundle, patient1 as Patient)).toEqual(true);
-        expect(bundleContains(bundle as Bundle, patient2 as Patient)).toEqual(false);
+        expect(bundleContains(bundle as Bundle, patient1 as Patient)).toBeDefined();
+        expect(bundleContains(bundle as Bundle, patient2 as Patient)).toBeUndefined();
       }));
 
     test('Filter by _lastUpdated', () =>
@@ -4121,8 +4126,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult1 as Bundle, patient1 as Patient)).toEqual(true);
-        expect(bundleContains(searchResult1 as Bundle, patient2 as Patient)).toEqual(false);
+        expect(bundleContains(searchResult1 as Bundle, patient1 as Patient)).toBeDefined();
+        expect(bundleContains(searchResult1 as Bundle, patient2 as Patient)).toBeUndefined();
 
         // Greater than (newer than) or equal to 2 seconds ago should return both patients
         const searchResult2 = await systemRepo.search({
@@ -4141,8 +4146,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult2 as Bundle, patient1 as Patient)).toEqual(true);
-        expect(bundleContains(searchResult2 as Bundle, patient2 as Patient)).toEqual(true);
+        expect(bundleContains(searchResult2 as Bundle, patient1 as Patient)).toBeDefined();
+        expect(bundleContains(searchResult2 as Bundle, patient2 as Patient)).toBeDefined();
 
         // Less than (older than) to 1 seconds ago should only return patient 2
         const searchResult3 = await systemRepo.search({
@@ -4166,8 +4171,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult3 as Bundle, patient1 as Patient)).toEqual(false);
-        expect(bundleContains(searchResult3 as Bundle, patient2 as Patient)).toEqual(true);
+        expect(bundleContains(searchResult3 as Bundle, patient1 as Patient)).toBeUndefined();
+        expect(bundleContains(searchResult3 as Bundle, patient2 as Patient)).toBeDefined();
 
         // Less than (older than) or equal to 1 seconds ago should return both patients
         const searchResult4 = await systemRepo.search({
@@ -4191,8 +4196,8 @@ describe('FHIR Search', () => {
           ],
         });
 
-        expect(bundleContains(searchResult4 as Bundle, patient1 as Patient)).toEqual(true);
-        expect(bundleContains(searchResult4 as Bundle, patient2 as Patient)).toEqual(true);
+        expect(bundleContains(searchResult4 as Bundle, patient1 as Patient)).toBeDefined();
+        expect(bundleContains(searchResult4 as Bundle, patient2 as Patient)).toBeDefined();
       }));
 
     test('Sort by _lastUpdated', () =>

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -250,6 +250,7 @@ async function getSearchEntries<T extends Resource>(
     (resource) =>
       ({
         fullUrl: getFullUrl(resource.resourceType, resource.id as string),
+        search: { mode: 'match' },
         resource,
       }) as BundleEntry
   );
@@ -463,6 +464,7 @@ async function getSearchIncludeEntries(
 
   return includedResources.map((resource) => ({
     fullUrl: getFullUrl(resource.resourceType, resource.id as string),
+    search: { mode: 'include' },
     resource,
   }));
 }
@@ -512,7 +514,11 @@ async function getSearchRevIncludeEntries(
   };
   const builder = getSelectQueryForSearch(repo, searchRequest);
 
-  return (await getSearchEntries(repo, searchRequest, builder)).entry;
+  const entries = (await getSearchEntries(repo, searchRequest, builder)).entry;
+  for (const entry of entries) {
+    entry.search = { mode: 'include' };
+  }
+  return entries;
 }
 
 /**

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -3,6 +3,7 @@ import {
   AccessPolicy,
   AsyncJob,
   Bundle,
+  BundleEntry,
   ClientApplication,
   Login,
   Project,
@@ -235,8 +236,8 @@ export function setupRecaptchaMock(fetch: jest.Mock, success: boolean): void {
  * @param resource - The resource to search for.
  * @returns True if the resource is in the bundle.
  */
-export function bundleContains(bundle: Bundle, resource: Resource): boolean {
-  return !!bundle.entry?.some((entry) => entry.resource?.id === resource.id);
+export function bundleContains(bundle: Bundle, resource: Resource): BundleEntry | undefined {
+  return bundle.entry?.find((entry) => entry.resource?.id === resource.id);
 }
 
 /**

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -234,7 +234,7 @@ export function setupRecaptchaMock(fetch: jest.Mock, success: boolean): void {
  * Returns true if the resource is in an entry in the bundle.
  * @param bundle - A bundle of resources.
  * @param resource - The resource to search for.
- * @returns True if the resource is in the bundle.
+ * @returns The matching bundle entry, or undefined if not found
  */
 export function bundleContains(bundle: Bundle, resource: Resource): BundleEntry | undefined {
   return bundle.entry?.find((entry) => entry.resource?.id === resource.id);


### PR DESCRIPTION
Adding the `Bundle.entry.search.mode` property to search results to differentiate between direct `match` results and ones added via an `include`

Fixes #5062 