### PR TITLE
Close BullMQ worker before queue

### DIFF
--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -73,14 +73,14 @@ export function initCronWorker(config: MedplumServerConfig): void {
  * Closes the BullMQ worker.
  */
 export async function closeCronWorker(): Promise<void> {
-  if (queue) {
-    await queue.close();
-    queue = undefined;
-  }
-
   if (worker) {
     await worker.close();
     worker = undefined;
+  }
+
+  if (queue) {
+    await queue.close();
+    queue = undefined;
   }
 }
 

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -74,14 +74,14 @@ export function initDownloadWorker(config: MedplumServerConfig): void {
  * Closes the BullMQ worker.
  */
 export async function closeDownloadWorker(): Promise<void> {
-  if (queue) {
-    await queue.close();
-    queue = undefined;
-  }
-
   if (worker) {
     await worker.close();
     worker = undefined;
+  }
+
+  if (queue) {
+    await queue.close();
+    queue = undefined;
   }
 }
 

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -66,14 +66,15 @@ export function initReindexWorker(config: MedplumServerConfig): void {
  * Closes the BullMQ worker.
  */
 export async function closeReindexWorker(): Promise<void> {
-  if (queue) {
-    await queue.close();
-    queue = undefined;
-  }
-
+  // Close worker first, so any jobs that need to finish can enqueue the next job before exiting
   if (worker) {
     await worker.close();
     worker = undefined;
+  }
+
+  if (queue) {
+    await queue.close();
+    queue = undefined;
   }
 }
 

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -112,14 +112,14 @@ export function initSubscriptionWorker(config: MedplumServerConfig): void {
  * Clsoes the BullMQ worker.
  */
 export async function closeSubscriptionWorker(): Promise<void> {
-  if (queue) {
-    await queue.close();
-    queue = undefined;
-  }
-
   if (worker) {
     await worker.close();
     worker = undefined;
+  }
+
+  if (queue) {
+    await queue.close();
+    queue = undefined;
   }
 }
 


### PR DESCRIPTION
Changing the order of closing BullMQ resources when shutting down the server allows in-progress jobs to enqueue continuation jobs before exiting