### PR TITLE
null-check-added@readResources

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1169,7 +1169,39 @@ describe('Client', () => {
     expect(result.resourceType).toBe('Patient');
     expect(result.id).toBe('123');
   });
-
+  test('Read resource with invalid id', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+  
+    try {
+      await client.readResource('Patient', '');
+      throw new Error('Test failed: Expected an error when calling readResource with an empty string id.');
+    } catch (err) {
+      expect((err as Error).message).toBe(
+        'The "id" parameter cannot be null, undefined, or an empty string.'
+      );
+    }
+  
+    try {
+      await client.readResource('Patient', undefined);
+      throw new Error('Test failed: Expected an error when calling readResource with an undefined id.');
+    } catch (err) {
+      expect((err as Error).message).toBe(
+        'The "id" parameter cannot be null, undefined, or an empty string.'
+      );
+    }
+  
+    try {
+      await client.readResource('Patient');
+      throw new Error('Test failed: Expected an error when calling readResource without an id.');
+    } catch (err) {
+      expect((err as Error).message).toBe(
+        'The "id" parameter cannot be null, undefined, or an empty string.'
+      );
+    }
+  });
+  
+  
   test('Read reference', async () => {
     const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
     const client = new MedplumClient({ fetch });

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1169,39 +1169,26 @@ describe('Client', () => {
     expect(result.resourceType).toBe('Patient');
     expect(result.id).toBe('123');
   });
+
   test('Read resource with invalid id', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
-  
+
     try {
       await client.readResource('Patient', '');
       throw new Error('Test failed: Expected an error when calling readResource with an empty string id.');
     } catch (err) {
-      expect((err as Error).message).toBe(
-        'The "id" parameter cannot be null, undefined, or an empty string.'
-      );
+      expect((err as Error).message).toBe('The "id" parameter cannot be null, undefined, or an empty string.');
     }
-  
+
     try {
-      await client.readResource('Patient', undefined);
+      await client.readResource('Patient', undefined as unknown as string);
       throw new Error('Test failed: Expected an error when calling readResource with an undefined id.');
     } catch (err) {
-      expect((err as Error).message).toBe(
-        'The "id" parameter cannot be null, undefined, or an empty string.'
-      );
-    }
-  
-    try {
-      await client.readResource('Patient');
-      throw new Error('Test failed: Expected an error when calling readResource without an id.');
-    } catch (err) {
-      expect((err as Error).message).toBe(
-        'The "id" parameter cannot be null, undefined, or an empty string.'
-      );
+      expect((err as Error).message).toBe('The "id" parameter cannot be null, undefined, or an empty string.');
     }
   });
-  
-  
+
   test('Read reference', async () => {
     const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
     const client = new MedplumClient({ fetch });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1662,7 +1662,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   readResource<K extends ResourceType>(
     resourceType: K,
-    id?: string,
+    id: string,
     options?: MedplumRequestOptions
   ): ReadablePromise<ExtractResource<K>> {
     if (!id) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1665,8 +1665,13 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     id: string,
     options?: MedplumRequestOptions
   ): ReadablePromise<ExtractResource<K>> {
+    if (id == null || id.trim() === '') {
+      throw new Error('The "id" parameter cannot be null, undefined, or an empty string.');
+    }
+  
     return this.get<ExtractResource<K>>(this.fhirUrl(resourceType, id), options);
   }
+  
 
   /**
    * Reads a resource by `Reference`.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1662,13 +1662,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   readResource<K extends ResourceType>(
     resourceType: K,
-    id: string,
+    id?: string,
     options?: MedplumRequestOptions
   ): ReadablePromise<ExtractResource<K>> {
-    if (id == null || id.trim() === '') {
+    if (!id) {
       throw new Error('The "id" parameter cannot be null, undefined, or an empty string.');
     }
-  
     return this.get<ExtractResource<K>>(this.fhirUrl(resourceType, id), options);
   }
   

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -120,7 +120,7 @@ export function getNameString(name: HumanName): string {
 }
 
 function getTokens(input: string): Set<string> {
-  if (!input) {
+  if (!input || typeof input !== 'string') {
     return new Set();
   }
 


### PR DESCRIPTION
Resolves #4873 

I have added a null check so that if the ID is null or an empty string, the readResource function will throw an error(I have also tested it locally).
```
if (id == null || id.trim() === '') {
      throw new Error('The "id" parameter cannot be null, undefined, or an empty string.');
    }
```

[screen-capture (17).webm](https://github.com/user-attachments/assets/0dcb7e13-22bc-4bb8-ac5c-2f33f2b04a91)
