### PR TITLE
Handle non-resource types in crawler and validator

### DIFF
--- a/packages/core/src/base-schema.ts
+++ b/packages/core/src/base-schema.ts
@@ -50,6 +50,7 @@ export function inflateBaseSchema(base: BaseSchema): DataTypesMap {
     output[key] = {
       name: key,
       type: key,
+      path: key,
       elements: Object.fromEntries(
         Object.entries(schema.elements).map(([property, partial]) => [property, inflateElement(property, partial)])
       ),

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -137,22 +137,16 @@ export function getTypedPropertyValueWithSchema(
   let resultType = 'undefined';
   let primitiveExtension: Extension[] | undefined = undefined;
 
-  if (element.path.endsWith('[x]')) {
-    const elementBasePath = (element.path.split('.').pop() as string).replace('[x]', '');
-    for (const type of types) {
-      const candidatePath = elementBasePath + capitalize(type.code);
-      resultValue = value[candidatePath];
-      primitiveExtension = value['_' + candidatePath];
-      if (resultValue !== undefined || primitiveExtension !== undefined) {
-        resultType = type.code;
-        break;
-      }
+  const lastPathSegmentIndex = element.path.lastIndexOf('.');
+  const lastPathSegment = element.path.substring(lastPathSegmentIndex + 1);
+  for (const type of types) {
+    const candidatePath = lastPathSegment.replace('[x]', capitalize(type.code));
+    resultValue = value[candidatePath];
+    primitiveExtension = value['_' + candidatePath];
+    if (resultValue !== undefined || primitiveExtension !== undefined) {
+      resultType = type.code;
+      break;
     }
-  } else {
-    console.assert(types.length === 1, 'Expected single type', element.path);
-    resultValue = value[path];
-    resultType = types[0].code;
-    primitiveExtension = value['_' + path];
   }
 
   // When checking for primitive extensions, we must use the "resolved" path.

--- a/packages/core/src/typeschema/crawler.ts
+++ b/packages/core/src/typeschema/crawler.ts
@@ -39,12 +39,12 @@ export interface AsyncCrawlerVisitor {
 /** @deprecated - Use AsyncCrawlerVisitor instead */
 export type AsyncResourceVisitor = AsyncCrawlerVisitor;
 
-function isSchema(obj: InternalTypeSchema | ResourceCrawlerOptions): obj is InternalTypeSchema {
+function isSchema(obj: InternalTypeSchema | CrawlerOptions): obj is InternalTypeSchema {
   return 'elements' in obj;
 }
 
-function isAsync(visitor: ResourceVisitor | AsyncResourceVisitor): visitor is AsyncResourceVisitor {
-  return Boolean((visitor as AsyncResourceVisitor).visitPropertyAsync);
+function isAsync(visitor: CrawlerVisitor | AsyncCrawlerVisitor): visitor is AsyncCrawlerVisitor {
+  return Boolean((visitor as AsyncCrawlerVisitor).visitPropertyAsync);
 }
 
 /**
@@ -57,7 +57,7 @@ function isAsync(visitor: ResourceVisitor | AsyncResourceVisitor): visitor is As
  */
 export function crawlResource(
   resource: Resource,
-  visitor: ResourceVisitor,
+  visitor: CrawlerVisitor,
   schema?: InternalTypeSchema,
   initialPath?: string
 ): void;
@@ -69,11 +69,7 @@ export function crawlResource(
  * @returns void
  * @deprecated - Use crawlTypedValueAsync instead
  */
-export function crawlResource(
-  resource: Resource,
-  visitor: AsyncResourceVisitor,
-  options: ResourceCrawlerOptions
-): Promise<void>;
+export function crawlResource(resource: Resource, visitor: AsyncCrawlerVisitor, options: CrawlerOptions): Promise<void>;
 /**
  * Crawls the resource synchronously.
  * @param resource - The resource to crawl.
@@ -81,7 +77,7 @@ export function crawlResource(
  * @param options - Options for how to crawl the resource.
  * @deprecated - Use crawlTypedValue instead
  */
-export function crawlResource(resource: Resource, visitor: ResourceVisitor, options?: ResourceCrawlerOptions): void;
+export function crawlResource(resource: Resource, visitor: CrawlerVisitor, options?: CrawlerOptions): void;
 
 /**
  * Crawls the resource synchronously.
@@ -94,11 +90,11 @@ export function crawlResource(resource: Resource, visitor: ResourceVisitor, opti
  */
 export function crawlResource(
   resource: Resource,
-  visitor: ResourceVisitor | AsyncResourceVisitor,
-  schema?: InternalTypeSchema | ResourceCrawlerOptions,
+  visitor: CrawlerVisitor | AsyncCrawlerVisitor,
+  schema?: InternalTypeSchema | CrawlerOptions,
   initialPath?: string
 ): Promise<void> | void {
-  let options: ResourceCrawlerOptions | undefined;
+  let options: CrawlerOptions | undefined;
   if (schema && isSchema(schema)) {
     options = { schema, initialPath };
   } else {
@@ -122,8 +118,8 @@ export function crawlResource(
  */
 export async function crawlResourceAsync(
   resource: Resource,
-  visitor: AsyncResourceVisitor,
-  options: ResourceCrawlerOptions
+  visitor: AsyncCrawlerVisitor,
+  options: CrawlerOptions
 ): Promise<void> {
   return crawlTypedValueAsync(toTypedValue(resource), visitor, options);
 }

--- a/packages/core/src/typeschema/types.test.ts
+++ b/packages/core/src/typeschema/types.test.ts
@@ -5,14 +5,14 @@ import { resolve } from 'path';
 import { LOINC } from '../constants';
 import { TypedValue } from '../types';
 import {
-  InternalSchemaElement,
-  InternalTypeSchema,
-  SlicingRules,
   getDataType,
   indexStructureDefinitionBundle,
+  InternalSchemaElement,
+  InternalTypeSchema,
   isProfileLoaded,
   loadDataType,
   parseStructureDefinition,
+  SlicingRules,
   subsetResource,
   tryGetDataType,
   tryGetProfile,

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -19,6 +19,7 @@ import { capitalize, getExtension, isEmpty } from '../utils';
 export interface InternalTypeSchema {
   name: string;
   type: string;
+  path: string;
   title?: string;
   url?: string;
   kind?: string;
@@ -255,6 +256,7 @@ class StructureDefinitionParser {
     this.index = 0;
     this.resourceSchema = {
       name: sd.name as string,
+      path: this.root.path,
       title: sd.title,
       type: sd.type,
       url: sd.url as string,
@@ -346,13 +348,14 @@ class StructureDefinitionParser {
       type: {
         name: typeName,
         type: typeName,
+        path: element.path,
         title: element.label,
         description: element.definition,
         elements: {},
         constraints: this.parseElementDefinition(element).constraints,
         innerTypes: [],
       },
-      path: element.path ?? '',
+      path: element.path,
       parent: pathsCompatible(this.backboneContext?.path, element.path)
         ? this.backboneContext
         : this.backboneContext?.parent,

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -36,7 +36,7 @@ import { HTTP_HL7_ORG, LOINC, RXNORM, SNOMED, UCUM } from '../constants';
 import { ContentType } from '../contenttype';
 import { OperationOutcomeError } from '../outcomes';
 import { createReference, deepClone } from '../utils';
-import { indexStructureDefinitionBundle } from './types';
+import { indexStructureDefinitionBundle, loadDataType } from './types';
 import { validateResource, validateTypedValue } from './validation';
 
 describe('FHIR resource validation', () => {
@@ -1534,6 +1534,115 @@ describe('FHIR resource validation', () => {
     expect(() => validateTypedValue({ type: 'Address', value: { foo: 'bar' } })).toThrow(
       'Invalid additional property "foo" (Address.foo)'
     );
+  });
+
+  test('Element type code different than path', () => {
+    // ClinicalDocument.realmCode
+    // Source: https://github.com/HL7/CDA-core-sd/blob/master/input/resources/ClinicalDocument.xml
+    // Note that the type code is disconnected from the path
+    const csSd: StructureDefinition = {
+      resourceType: 'StructureDefinition',
+      url: 'http://hl7.org/cda/stds/core/StructureDefinition/CS',
+      name: 'ClinicalDocument',
+      status: 'active',
+      kind: 'logical',
+      abstract: false,
+      type: 'http://hl7.org/cda/stds/core/StructureDefinition/CS',
+      snapshot: {
+        element: [
+          {
+            path: 'CS',
+          },
+          {
+            path: 'CS.code',
+            min: 0,
+            max: '1',
+            base: {
+              path: 'CD.code',
+              min: 0,
+              max: '1',
+            },
+            type: [{ code: 'code' }],
+          },
+        ],
+      },
+    };
+    loadDataType(csSd);
+
+    const clinicalDocumentSd: StructureDefinition = {
+      resourceType: 'StructureDefinition',
+      url: 'http://hl7.org/cda/stds/core/StructureDefinition/ClinicalDocument',
+      name: 'ClinicalDocument',
+      status: 'active',
+      kind: 'logical',
+      abstract: false,
+      type: 'http://hl7.org/cda/stds/core/StructureDefinition/ClinicalDocument',
+      snapshot: {
+        element: [
+          {
+            path: 'ClinicalDocument',
+          },
+          {
+            path: 'ClinicalDocument.realmCode',
+            min: 0,
+            max: '*',
+            base: {
+              path: 'ClinicalDocument.realmCode',
+              min: 0,
+              max: '*',
+            },
+            type: [
+              {
+                code: 'http://hl7.org/cda/stds/core/StructureDefinition/CS',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    loadDataType(clinicalDocumentSd);
+
+    const value = { realmCode: [{ code: 'foo' }] };
+    const typedValue = { type: clinicalDocumentSd.type, value };
+    expect(() => validateTypedValue(typedValue)).not.toThrow();
+  });
+
+  test('Choice-of-type without [x]', () => {
+    // SubstanceAdministration.effectiveTime
+    // Source: https://github.com/HL7/CDA-core-sd/blob/master/input/resources/SubstanceAdministration.xml
+    // Note that there are multiple types for this property, but it does not have a [x] suffix
+    const sd: StructureDefinition = {
+      resourceType: 'StructureDefinition',
+      url: 'http://hl7.org/cda/stds/core/StructureDefinition/SubstanceAdministration',
+      name: 'SubstanceAdministration',
+      status: 'active',
+      kind: 'logical',
+      abstract: false,
+      type: 'http://hl7.org/cda/stds/core/StructureDefinition/SubstanceAdministration',
+      snapshot: {
+        element: [
+          {
+            path: 'SubstanceAdministration',
+          },
+          {
+            path: 'SubstanceAdministration.effectiveTime',
+            min: 0,
+            max: '*',
+            base: {
+              path: 'SubstanceAdministration.effectiveTime',
+              min: 0,
+              max: '*',
+            },
+            type: [{ code: 'dateTime' }, { code: 'time' }],
+          },
+        ],
+      },
+    };
+    loadDataType(sd);
+
+    const value = { effectiveTime: ['2022-02-02T12:00:00Z'] };
+    const typedValue = { type: sd.type, value };
+    expect(() => validateTypedValue(typedValue)).not.toThrow();
   });
 });
 

--- a/packages/core/src/typeschema/validation.test.ts
+++ b/packages/core/src/typeschema/validation.test.ts
@@ -1602,9 +1602,19 @@ describe('FHIR resource validation', () => {
     };
     loadDataType(clinicalDocumentSd);
 
-    const value = { realmCode: [{ code: 'foo' }] };
-    const typedValue = { type: clinicalDocumentSd.type, value };
-    expect(() => validateTypedValue(typedValue)).not.toThrow();
+    const typedValue1 = {
+      type: clinicalDocumentSd.type,
+      value: { realmCode: [{ code: 'foo' }] },
+    };
+    expect(() => validateTypedValue(typedValue1)).not.toThrow();
+
+    const typedValue2 = {
+      type: clinicalDocumentSd.type,
+      value: { realmCode: [{ foo: 'bar' }] },
+    };
+    expect(() => validateTypedValue(typedValue2)).toThrow(
+      'Invalid additional property "foo" (ClinicalDocument.realmCode.foo)'
+    );
   });
 
   test('Choice-of-type without [x]', () => {
@@ -1640,9 +1650,19 @@ describe('FHIR resource validation', () => {
     };
     loadDataType(sd);
 
-    const value = { effectiveTime: ['2022-02-02T12:00:00Z'] };
-    const typedValue = { type: sd.type, value };
-    expect(() => validateTypedValue(typedValue)).not.toThrow();
+    const typedValue1 = {
+      type: sd.type,
+      value: { effectiveTime: ['2022-02-02T12:00:00Z'] },
+    };
+    expect(() => validateTypedValue(typedValue1)).not.toThrow();
+
+    const typedValue2 = {
+      type: sd.type,
+      value: { effectiveTime: ['foo'] },
+    };
+    expect(() => validateTypedValue(typedValue2)).toThrow(
+      'Invalid dateTime format (SubstanceAdministration.effectiveTime)'
+    );
   });
 });
 


### PR DESCRIPTION
In service of https://github.com/medplum/medplum/issues/3005 and https://github.com/medplum/medplum/issues/4726

I've been experimenting with the HL7 FHIR Mapping Language maps for C-CDA to/from FHIR: https://github.com/hl7ch/cda-fhir-maps

One of the challenging parts is reading the XML files to the necessary JSON structure (i.e., when to treat XML elements as singletons vs arrays, when to parse attributes as numbers vs strings, etc).

Thankfully, HL7 publishes `StructureDefinition` resources for the C-CDA types, so we can validate the input: https://github.com/HL7/CDA-core-sd

This uncovered a couple bugs/limitations of our resource validation and "crawler" utilities, because they relied on assumptions of conventions in the FHIR R4 `StructureDefinition` resources.

The main two fixes here:

1. We cannot assume any implicit relationship between `StructureDefinition.name`, `StructureDefinition.type`, and `StructureDefinition.snapshot.element[0].path`.
    * We fixed most of the `name` vs `type` issues in https://github.com/medplum/medplum/pull/4993
    * The jump from `path` back to `type` was still lingering in `crawler`, which is used by `validate`
    * This is fixed by using `TypedValue` everywhere, and not relying on `toTypedValue(myObj)`
2. We cannot assume that choice-of-type elements have the `[x]` path suffix.
    * This assumption was really only in `getTypedPropertyValueWithSchema`
    * To be clear, this isn't 100% fixed, because we now cannot know the type of the property value
    * For example, with `Observation.value[x]`, you know `valueString` is a `string` and `valueInteger` is an `integer`, etc
    * But for these C-CDA types, the property names don't give any information, so currently we just take the first match
    * You could try to be clever and look for the first value that validates (gross)
    * For now, I'm doing the simple thing, which is good enough for the C-CDA types, and does not affect the R4 types at all

Then two additional drive-by fixes:

3. I renamed `crawlResource`/`crawlResourceAsync` to `crawlTypedValue`/`crawlTypedValueAsync`
    * This is perhaps a minor point, but it is more technically correct
    * We need to preserve the `TypedValue.type` information
    * Rather than adding a whole new set of methods and overloads, I went ahead and marked the old ones as deprecated
    * So now `crawlTypedValue`/`crawlTypedValueAsync` are the final methods to rule them all
4. Replaced `isLowerCase(value.type.charAt(0))` with a proper `isPrimitiveType(value.type)`
    * There appears to be a convention of using full HTTP URL's for `StructureDefinition.type` values
    * Obviously `http://...` starts with a lower case letter, and those values are not primitives
    * So now, we check against the known list of primitive types, which we already have in the code
