### PR TITLE
Revert "Add request ID to Postgres transaction error logs (#5038)"

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -64,7 +64,7 @@ import { Pool, PoolClient } from 'pg';
 import { Operation, applyPatch } from 'rfc6902';
 import validator from 'validator';
 import { getConfig } from '../config';
-import { getLogger, getRequestContext, tryGetRequestContext } from '../context';
+import { getLogger, getRequestContext } from '../context';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { getRedis } from '../redis';
 import { r4ProjectId } from '../seed';
@@ -2066,7 +2066,6 @@ export class Repository extends BaseRepository implements FhirRepository<PoolCli
     this.transactionDepth++;
     const conn = await this.getConnection(DatabaseMode.WRITER);
     if (this.transactionDepth === 1) {
-      await conn.query(`SET application_name TO '${tryGetRequestContext()?.requestId ?? ''}'`);
       await conn.query('BEGIN ISOLATION LEVEL ' + isolationLevel);
     } else {
       await conn.query('SAVEPOINT sp' + this.transactionDepth);

--- a/postgres/postgres.conf
+++ b/postgres/postgres.conf
@@ -1,2 +1,1 @@
 listen_addresses = '*'
-log_line_prefix = '%m [%p %a] '


### PR DESCRIPTION
This change is no longer necessary, since it is not possible to change the `log_line_prefix` setting in AWS Aurora RDS

This reverts commit 1b7026bb91b6f3c1924ab7b010be3056e42d5d54