### PR TITLE
[Scheduling Sample] Add bot to handle booking an appointment

### DIFF
--- a/examples/medplum-scheduling-demo/README.md
+++ b/examples/medplum-scheduling-demo/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Medplum Schedulingg Demo</h1>
+<h1 align="center">Medplum Scheduling Demo</h1>
 <p align="center">A starter application for building a scheduling app on Medplum.</p>
 <p align="center">
 <a href="https://github.com/medplum/medplum-hello-world/blob/main/LICENSE.txt">

--- a/examples/medplum-scheduling-demo/package.json
+++ b/examples/medplum-scheduling-demo/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "npm run build:bots && tsc && vite build",
     "build:bots": "npm run clean && tsc --project tsconfig-bots.json && node --no-warnings esbuild-script.mjs && node --loader ts-node/esm src/scripts/deploy-bots.ts",
     "clean": "rimraf dist",
     "dev": "vite",

--- a/examples/medplum-scheduling-demo/package.json
+++ b/examples/medplum-scheduling-demo/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
+    "build:bots": "npm run clean && tsc --project tsconfig-bots.json && node --no-warnings esbuild-script.mjs && node --loader ts-node/esm src/scripts/deploy-bots.ts",
     "clean": "rimraf dist",
     "dev": "vite",
     "lint": "eslint src/",
     "preview": "vite preview",
-    "test": "vitest run --passWithNoTests",
-    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch"
   },
   "prettier": {

--- a/examples/medplum-scheduling-demo/src/App.tsx
+++ b/examples/medplum-scheduling-demo/src/App.tsx
@@ -13,6 +13,7 @@ import { SchedulePage } from './pages/SchedulePage';
 import { Practitioner, Schedule } from '@medplum/fhirtypes';
 import { createReference, getReferenceString } from '@medplum/core';
 import { ScheduleContext } from './Schedule.context';
+import { UploadDataPage } from './pages/UploadDataPage';
 
 export function App(): JSX.Element | null {
   const medplum = useMedplum();
@@ -90,6 +91,7 @@ export function App(): JSX.Element | null {
               <Route path="/Appointment/upcoming" element={<AppointmentsPage />} />
               <Route path="/Appointment/past" element={<AppointmentsPage />} />
               <Route path="/Appointment/:id/*" element={<AppointmentDetailPage />} />
+              <Route path="/upload/:dataType" element={<UploadDataPage />} />
               <Route path="/:resourceType" element={<SearchPage />} />
               <Route path="/:resourceType/:id/*" element={<ResourcePage />} />
             </Routes>

--- a/examples/medplum-scheduling-demo/src/App.tsx
+++ b/examples/medplum-scheduling-demo/src/App.tsx
@@ -2,17 +2,18 @@ import { AppShell, ErrorBoundary, Loading, Logo, useMedplum, useMedplumProfile }
 import { IconUser, IconClipboard, IconCalendar, IconRobot } from '@tabler/icons-react';
 import { Suspense, useEffect, useState } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
+import { AppointmentDetailPage } from './pages/AppointmentDetailPage';
+import { AppointmentsPage } from './pages/AppointmentsPage';
+import { createReference, getReferenceString } from '@medplum/core';
 import { LandingPage } from './pages/LandingPage';
 import { PatientPage } from './pages/PatientPage';
-import { AppointmentsPage } from './pages/AppointmentsPage';
+import { PatientSchedulePage } from './pages/PatientSchedulePage';
+import { Practitioner, Schedule } from '@medplum/fhirtypes';
 import { ResourcePage } from './pages/ResourcePage';
+import { ScheduleContext } from './Schedule.context';
+import { SchedulePage } from './pages/SchedulePage';
 import { SearchPage } from './pages/SearchPage';
 import { SignInPage } from './pages/SignInPage';
-import { AppointmentDetailPage } from './pages/AppointmentDetailPage';
-import { SchedulePage } from './pages/SchedulePage';
-import { Practitioner, Schedule } from '@medplum/fhirtypes';
-import { createReference, getReferenceString } from '@medplum/core';
-import { ScheduleContext } from './Schedule.context';
 import { UploadDataPage } from './pages/UploadDataPage';
 
 export function App(): JSX.Element | null {
@@ -91,6 +92,10 @@ export function App(): JSX.Element | null {
               <Route path="/signin" element={<SignInPage />} />
               <Route path="/Schedule" element={schedule ? <Navigate to={`/Schedule/${schedule.id}`} /> : <Loading />} />
               <Route path="/Schedule/:id" element={schedule ? <SchedulePage /> : <Loading />} />
+              <Route
+                path="/Patient/:patientId/Schedule/:scheduleId"
+                element={schedule ? <PatientSchedulePage /> : <Loading />}
+              />
               <Route path="/Patient/:id/*" element={<PatientPage />} />
               <Route path="/Appointment/upcoming" element={<AppointmentsPage />} />
               <Route path="/Appointment/past" element={<AppointmentsPage />} />

--- a/examples/medplum-scheduling-demo/src/App.tsx
+++ b/examples/medplum-scheduling-demo/src/App.tsx
@@ -67,12 +67,12 @@ export function App(): JSX.Element | null {
           links: [
             {
               icon: <IconCalendar />,
-              label: 'Schedule',
+              label: 'My Schedule',
               href: '/Schedule',
             },
             {
               icon: <IconClipboard />,
-              label: 'Appointments',
+              label: 'My Appointments',
               href: '/Appointment/upcoming',
             },
           ],

--- a/examples/medplum-scheduling-demo/src/App.tsx
+++ b/examples/medplum-scheduling-demo/src/App.tsx
@@ -1,5 +1,5 @@
 import { AppShell, ErrorBoundary, Loading, Logo, useMedplum, useMedplumProfile } from '@medplum/react';
-import { IconUser, IconClipboard, IconCalendar } from '@tabler/icons-react';
+import { IconUser, IconClipboard, IconCalendar, IconRobot } from '@tabler/icons-react';
 import { Suspense, useEffect, useState } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { LandingPage } from './pages/LandingPage';
@@ -76,6 +76,10 @@ export function App(): JSX.Element | null {
               href: '/Appointment/upcoming',
             },
           ],
+        },
+        {
+          title: 'Upload Data',
+          links: [{ icon: <IconRobot />, label: 'Upload Example Bots', href: '/upload/bots' }],
         },
       ]}
     >

--- a/examples/medplum-scheduling-demo/src/bots/core/appointments.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/appointments.ts
@@ -1,0 +1,6 @@
+import { BotEvent, MedplumClient } from '@medplum/core';
+import { Appointment } from '@medplum/fhirtypes';
+
+export async function handler(medplum: MedplumClient, event: BotEvent<Appointment>): Promise<void> {
+  console.log('Appointment bot handler', event.input);
+}

--- a/examples/medplum-scheduling-demo/src/bots/core/appointments.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/appointments.ts
@@ -1,6 +1,0 @@
-import { BotEvent, MedplumClient } from '@medplum/core';
-import { Appointment } from '@medplum/fhirtypes';
-
-export async function handler(medplum: MedplumClient, event: BotEvent<Appointment>): Promise<void> {
-  console.log('Appointment bot handler', event.input);
-}

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.test.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.test.ts
@@ -1,1 +1,137 @@
-describe('Book Appointment', async () => {});
+import { createReference, indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { readJson, SEARCH_PARAMETER_BUNDLE_FILES } from '@medplum/definitions';
+import { Appointment, Bundle, Schedule, SearchParameter, Slot } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { handler } from './book-appointment';
+
+describe('Book Appointment', async () => {
+  let medplum: MockClient;
+
+  const bot = { reference: 'Bot/123' };
+  const contentType = 'application/fhir+json';
+
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+    for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+      indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+    }
+  });
+
+  beforeEach(async () => {
+    medplum = new MockClient();
+  });
+
+  test('Successfully create the appointment', async () => {
+    const schedule: Schedule = await medplum.createResource({
+      resourceType: 'Schedule',
+      active: true,
+      actor: [{ reference: 'Practitioner/dr-alice-smith' }],
+    });
+
+    let slot: Slot = await medplum.createResource({
+      resourceType: 'Slot',
+      status: 'free',
+      start: '2024-08-14T10:00:00.000Z',
+      end: '2024-08-14T11:00:00.000Z',
+      schedule: createReference(schedule),
+    });
+
+    const appointmentInput: Appointment = {
+      resourceType: 'Appointment',
+      status: 'booked',
+      slot: [createReference(slot)],
+      appointmentType: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/v2-0276',
+            code: 'FOLLOWUP',
+            display: 'A follow up visit from a previous appointment',
+          },
+        ],
+      },
+      participant: [
+        { actor: { reference: 'Patient/homer-simpson' }, status: 'accepted' },
+        { actor: { reference: 'Practitioner/dr-alice-smith' }, status: 'accepted' },
+      ],
+    };
+
+    const appointment = await handler(medplum, { bot, input: appointmentInput, contentType, secrets: {} });
+
+    slot = await medplum.readResource('Slot', slot.id as string);
+
+    // Check that the appointment was created
+    expect(appointment).toBeDefined();
+    expect(appointment.start).toBe(slot.start);
+    expect(appointment.end).toBe(slot.end);
+
+    // Check that the slot was updated
+    expect(slot.status).toBe('busy');
+  });
+
+  test('Missing slot', async () => {
+    const appointment: Appointment = {
+      resourceType: 'Appointment',
+      status: 'booked',
+      appointmentType: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/v2-0276',
+            code: 'FOLLOWUP',
+            display: 'A follow up visit from a previous appointment',
+          },
+        ],
+      },
+      participant: [
+        { actor: { reference: 'Patient/homer-simpson' }, status: 'accepted' },
+        { actor: { reference: 'Practitioner/dr-alice-smith' }, status: 'accepted' },
+      ],
+    };
+
+    await expect(handler(medplum, { bot, input: appointment, contentType, secrets: {} })).rejects.toThrow(
+      'Must provide a slot'
+    );
+  });
+
+  test('Missing appointment type', async () => {
+    const appointment: Appointment = {
+      resourceType: 'Appointment',
+      status: 'booked',
+      slot: [{ reference: 'Slot/123' }],
+      participant: [
+        { actor: { reference: 'Patient/homer-simpson' }, status: 'accepted' },
+        { actor: { reference: 'Practitioner/dr-alice-smith' }, status: 'accepted' },
+      ],
+    };
+
+    await expect(handler(medplum, { bot, input: appointment, contentType, secrets: {} })).rejects.toThrow(
+      'Must provide an appointment type'
+    );
+  });
+
+  test('Invalid status', async () => {
+    const appointment: Appointment = {
+      resourceType: 'Appointment',
+      status: 'cancelled',
+      slot: [{ reference: 'Slot/123' }],
+      appointmentType: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/v2-0276',
+            code: 'FOLLOWUP',
+            display: 'A follow up visit from a previous appointment',
+          },
+        ],
+      },
+      participant: [
+        { actor: { reference: 'Patient/homer-simpson' }, status: 'accepted' },
+        { actor: { reference: 'Practitioner/dr-alice-smith' }, status: 'accepted' },
+      ],
+    };
+
+    await expect(handler(medplum, { bot, input: appointment, contentType, secrets: {} })).rejects.toThrow(
+      'Appointment status must be "booked"'
+    );
+  });
+});

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.test.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.test.ts
@@ -1,0 +1,1 @@
+describe('Book Appointment', async () => {});

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.test.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.test.ts
@@ -55,6 +55,7 @@ describe('Book Appointment', async () => {
         { actor: { reference: 'Patient/homer-simpson' }, status: 'accepted' },
         { actor: { reference: 'Practitioner/dr-alice-smith' }, status: 'accepted' },
       ],
+      comment: 'The patient is feeling much better',
     };
 
     const appointment = await handler(medplum, { bot, input: appointmentInput, contentType, secrets: {} });
@@ -65,6 +66,7 @@ describe('Book Appointment', async () => {
     expect(appointment).toBeDefined();
     expect(appointment.start).toBe(slot.start);
     expect(appointment.end).toBe(slot.end);
+    expect(appointment.comment).toBe('The patient is feeling much better');
 
     // Check that the slot was updated
     expect(slot.status).toBe('busy');

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
@@ -1,11 +1,11 @@
-import { BotEvent, MedplumClient } from '@medplum/core';
+import { BotEvent, MedplumClient, resolveId } from '@medplum/core';
 import { Appointment } from '@medplum/fhirtypes';
 
 export async function handler(medplum: MedplumClient, event: BotEvent<Appointment>): Promise<Appointment> {
   let appointment = event.input;
 
   // Basic data validation
-  const slotId = appointment.slot?.[0].reference?.split('Slot/')[1];
+  const slotId = resolveId(appointment.slot?.[0]);
   if (!slotId) {
     throw new Error('Must provide a slot');
   }

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
@@ -1,0 +1,33 @@
+import { BotEvent, MedplumClient } from '@medplum/core';
+import { Appointment } from '@medplum/fhirtypes';
+
+export async function handler(medplum: MedplumClient, event: BotEvent<Appointment>): Promise<Appointment> {
+  let appointment = event.input;
+
+  // Basic validation
+  const slotId = appointment.slot?.[0].reference?.split('Slot/')[1];
+  if (!slotId) {
+    throw new Error('Must provide a slot');
+  }
+
+  if (appointment.serviceType?.length === 0) {
+    throw new Error('Must provide a  type');
+  }
+
+  if (appointment.participant?.length !== 2) {
+    throw new Error('Must provide a patient and a practitioner');
+  }
+
+  const slot = await medplum.readResource('Slot', slotId);
+
+  // Create the appointment
+  appointment.start = slot.start;
+  appointment.end = slot.end;
+  appointment = await medplum.createResource(appointment);
+
+  // Update the slot status to 'busy'
+  slot.status = 'busy';
+  await medplum.updateResource(slot);
+
+  return appointment;
+}

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
@@ -4,7 +4,7 @@ import { Appointment } from '@medplum/fhirtypes';
 export async function handler(medplum: MedplumClient, event: BotEvent<Appointment>): Promise<Appointment> {
   let appointment = event.input;
 
-  // Basic validation
+  // Basic data validation
   const slotId = appointment.slot?.[0].reference?.split('Slot/')[1];
   if (!slotId) {
     throw new Error('Must provide a slot');
@@ -12,10 +12,6 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Appointmen
 
   if (!appointment.appointmentType) {
     throw new Error('Must provide an appointment type');
-  }
-
-  if (appointment.participant?.length !== 2) {
-    throw new Error('Must provide a patient and a practitioner');
   }
 
   if (appointment.status !== 'booked') {

--- a/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/book-appointment.ts
@@ -10,12 +10,16 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Appointmen
     throw new Error('Must provide a slot');
   }
 
-  if (appointment.serviceType?.length === 0) {
-    throw new Error('Must provide a  type');
+  if (!appointment.appointmentType) {
+    throw new Error('Must provide an appointment type');
   }
 
   if (appointment.participant?.length !== 2) {
     throw new Error('Must provide a patient and a practitioner');
+  }
+
+  if (appointment.status !== 'booked') {
+    throw new Error('Appointment status must be "booked"');
   }
 
   const slot = await medplum.readResource('Slot', slotId);

--- a/examples/medplum-scheduling-demo/src/components/AppointmentActions.tsx
+++ b/examples/medplum-scheduling-demo/src/components/AppointmentActions.tsx
@@ -44,7 +44,17 @@ export function AppointmentActions(props: AppointmentActionsProps): JSX.Element 
       await medplum.updateResource({
         ...appointment,
         status: newStatus,
+        slot: undefined,
       });
+      // If the appointment is cancelled, update the slot status to free
+      if (newStatus === 'cancelled' && appointment.slot?.[0].reference) {
+        const slotId = appointment.slot[0].reference.split('Slot/')[1];
+        const slot = await medplum.readResource('Slot', slotId);
+        await medplum.updateResource({
+          ...slot,
+          status: 'free',
+        });
+      }
 
       navigate(`/Appointment/${appointment.id}/details`);
       showNotification({

--- a/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
+++ b/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
@@ -50,7 +50,7 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element {
         resourceType: 'Appointment',
         status: 'booked',
         slot: [createReference(slot)],
-        serviceType: [{ coding: [answers['service-type'].valueCoding as Coding] }],
+        appointmentType: { coding: [answers['service-type'].valueCoding as Coding] },
         participant: [
           {
             actor: appointmentPatient,
@@ -121,7 +121,7 @@ const appointmentQuestionnaire: Questionnaire = {
       linkId: 'service-type',
       type: 'choice',
       text: 'What is the appointment service type?',
-      answerValueSet: 'http://hl7.org/fhir/ValueSet/service-type',
+      answerValueSet: 'http://terminology.hl7.org/ValueSet/v2-0276',
       required: true,
     },
   ],

--- a/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
+++ b/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
@@ -1,7 +1,15 @@
 import { Modal } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { createReference, getQuestionnaireAnswers, normalizeErrorString } from '@medplum/core';
-import { Coding, Patient, Practitioner, Questionnaire, QuestionnaireResponse, Reference } from '@medplum/fhirtypes';
+import {
+  Appointment,
+  Coding,
+  Patient,
+  Practitioner,
+  Questionnaire,
+  QuestionnaireResponse,
+  Reference,
+} from '@medplum/fhirtypes';
 import { QuestionnaireForm, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
 
@@ -27,6 +35,8 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element {
 
   async function handleQuestionnaireSubmit(formData: QuestionnaireResponse): Promise<void> {
     const answers = getQuestionnaireAnswers(formData);
+
+    await medplum.executeBot('e63beaf0-60e8-4414-9392-a47787d210bd', { resourceType: 'Appointment' } as Appointment);
 
     // If a patient is provided to the component, use that patient, otherwise use the patient from the form
     const appointmentPatient = patient

--- a/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
+++ b/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
@@ -46,12 +46,9 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element {
       : (answers['patient'].valueReference as Reference<Patient>);
 
     try {
-      // Create the appointment
-      const appointment: Appointment = await medplum.createResource({
+      let appointment: Appointment = {
         resourceType: 'Appointment',
         status: 'booked',
-        start: slot.start,
-        end: slot.end,
         slot: [createReference(slot)],
         serviceType: [{ coding: [answers['service-type'].valueCoding as Coding] }],
         participant: [
@@ -64,13 +61,9 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element {
             status: 'accepted',
           },
         ],
-      });
-
-      // Update the slot status to busy
-      await medplum.updateResource({
-        ...slot,
-        status: 'busy',
-      });
+      };
+      // Call bot to create the appointment
+      appointment = await medplum.executeBot({ system: 'http://example.com', value: 'book-appointment' }, appointment);
 
       // Navigate to the appointment detail page
       navigate(`/Appointment/${appointment.id}`);

--- a/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
+++ b/examples/medplum-scheduling-demo/src/components/CreateAppointment.tsx
@@ -61,6 +61,7 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element {
             status: 'accepted',
           },
         ],
+        comment: answers['comment']?.valueString,
       };
       // Call bot to create the appointment
       appointment = await medplum.executeBot({ system: 'http://example.com', value: 'book-appointment' }, appointment);
@@ -123,6 +124,11 @@ const appointmentQuestionnaire: Questionnaire = {
       text: 'What is the appointment service type?',
       answerValueSet: 'http://terminology.hl7.org/ValueSet/v2-0276',
       required: true,
+    },
+    {
+      linkId: 'comment',
+      type: 'string',
+      text: 'Additional comments',
     },
   ],
 };

--- a/examples/medplum-scheduling-demo/src/components/PatientActions.tsx
+++ b/examples/medplum-scheduling-demo/src/components/PatientActions.tsx
@@ -1,8 +1,10 @@
 import { Button, Stack, Title } from '@mantine/core';
 import { IconClock } from '@tabler/icons-react';
-import { CreateAppointment } from './CreateAppointment';
-import { useDisclosure } from '@mantine/hooks';
 import { Patient } from '@medplum/fhirtypes';
+import { useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { ScheduleContext } from '../Schedule.context';
+import { Loading } from '@medplum/react';
 
 interface PatientActionsProps {
   patient: Patient;
@@ -10,13 +12,21 @@ interface PatientActionsProps {
 
 export function PatientActions(props: PatientActionsProps): JSX.Element {
   const { patient } = props;
-  const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
+  const navigate = useNavigate();
+  const { schedule } = useContext(ScheduleContext);
+
+  if (!schedule) {
+    return <Loading />;
+  }
 
   return (
     <Stack p="xs" m="xs">
       <Title>Patient Actions</Title>
-      <CreateAppointment patient={patient} opened={createAppointmentOpened} handlers={createAppointmentHandlers} />
-      <Button leftSection={<IconClock size={16} />} onClick={() => createAppointmentHandlers.open()}>
+
+      <Button
+        leftSection={<IconClock size={16} />}
+        onClick={() => navigate(`/Patient/${patient.id}/Schedule/${schedule.id}`)}
+      >
         Create Appointment
       </Button>
     </Stack>

--- a/examples/medplum-scheduling-demo/src/components/RescheduleAppointment.tsx
+++ b/examples/medplum-scheduling-demo/src/components/RescheduleAppointment.tsx
@@ -25,11 +25,24 @@ export function RescheduleAppointment(props: RescheduleAppointmentProps): JSX.El
     const answers = getQuestionnaireAnswers(formData);
 
     try {
-      // Update the appointment with the new start and end dates, and change the status to "booked"
+      const startDateTime = answers['start-date'].valueDateTime as string;
+      const endDateTime = answers['end-date'].valueDateTime as string;
+
+      // Update the appointment and the slot with the new start and end dates, and change the status
+      const slotId = appointment?.slot?.[0].reference?.split('Slot/')[1];
+      if (slotId) {
+        const slot = await medplum.readResource('Slot', slotId);
+        await medplum.updateResource({
+          ...slot,
+          start: startDateTime,
+          end: endDateTime,
+          status: 'busy',
+        });
+      }
       await medplum.updateResource({
         ...appointment,
-        start: answers['start-date'].valueDateTime,
-        end: answers['end-date'].valueDateTime,
+        start: startDateTime,
+        end: endDateTime,
         status: 'booked',
       });
 

--- a/examples/medplum-scheduling-demo/src/pages/AppointmentsPage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/AppointmentsPage.tsx
@@ -1,17 +1,14 @@
 import { Paper, Tabs } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
 import { Filter, getReferenceString, Operator, SearchRequest } from '@medplum/core';
 import { Practitioner } from '@medplum/fhirtypes';
 import { SearchControl, useMedplumProfile } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { CreateAppointment } from '../components/CreateAppointment';
 
 export function AppointmentsPage(): JSX.Element {
   const profile = useMedplumProfile() as Practitioner;
   const navigate = useNavigate();
   const location = useLocation();
-  const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
 
   const tab = location.pathname.split('/').pop() ?? '';
 
@@ -75,7 +72,6 @@ export function AppointmentsPage(): JSX.Element {
 
   return (
     <Paper shadow="xs" m="md" p="xs">
-      <CreateAppointment opened={createAppointmentOpened} handlers={createAppointmentHandlers} />
       <Tabs value={tab.toLowerCase()} onChange={changeTab}>
         <Tabs.List mb="xs">
           {tabs.map((tab) => (
@@ -92,7 +88,7 @@ export function AppointmentsPage(): JSX.Element {
         onChange={(e) => {
           setSearch(e.definition);
         }}
-        onNew={() => createAppointmentHandlers.open()}
+        onNew={() => navigate('/Schedule')} // Redirect to the Schedule page where the user can create a new appointment
         checkboxesEnabled={false}
         hideFilters
       />

--- a/examples/medplum-scheduling-demo/src/pages/PatientSchedulePage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/PatientSchedulePage.tsx
@@ -1,0 +1,72 @@
+import { useDisclosure } from '@mantine/hooks';
+import { getReferenceString } from '@medplum/core';
+import { Schedule } from '@medplum/fhirtypes';
+import { Document, Loading, useMedplum, useSearchResources } from '@medplum/react';
+import dayjs from 'dayjs';
+import { useCallback, useContext, useState } from 'react';
+import { Calendar, dayjsLocalizer, Event } from 'react-big-calendar';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import { useParams } from 'react-router-dom';
+import { ScheduleContext } from '../Schedule.context';
+import { Title } from '@mantine/core';
+import { CreateAppointment } from '../components/CreateAppointment';
+
+export function PatientSchedulePage(): JSX.Element {
+  const { patientId } = useParams();
+
+  const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
+  const [selectedEvent, setSelectedEvent] = useState<Event>();
+  const { schedule } = useContext(ScheduleContext);
+
+  const medplum = useMedplum();
+  const [slots] = useSearchResources('Slot', { schedule: getReferenceString(schedule as Schedule) });
+  const patient = patientId ? medplum.readResource('Patient', patientId).read() : undefined;
+
+  // Converts Slot resources to big-calendar Event objects
+  // Only show free slots (available for booking)
+  const slotEvents: Event[] = (slots ?? [])
+    .filter((slot) => slot.status === 'free')
+    .map((slot) => ({
+      title: slot.status === 'free' ? 'Available' : 'Blocked',
+      start: new Date(slot.start),
+      end: new Date(slot.end),
+      resource: slot,
+    }));
+
+  // When an exiting event (slot) is selected, set the event object and open the modal
+  const handleSelectEvent = useCallback(
+    (event: Event) => {
+      setSelectedEvent(event);
+      createAppointmentHandlers.open();
+    },
+    [createAppointmentHandlers]
+  );
+
+  if (!patientId) {
+    return <Loading />;
+  }
+
+  return (
+    <Document width={1000}>
+      <Title order={1} mb="lg">
+        Select a slot for the appointment
+      </Title>
+
+      <CreateAppointment
+        patient={patient}
+        slot={selectedEvent?.resource}
+        opened={createAppointmentOpened}
+        handlers={createAppointmentHandlers}
+      />
+
+      <Calendar
+        defaultView="week"
+        views={['week', 'day']}
+        localizer={dayjsLocalizer(dayjs)}
+        backgroundEvents={slotEvents} // Background events don't show in the month view
+        onSelectEvent={handleSelectEvent}
+        style={{ height: 600 }}
+      />
+    </Document>
+  );
+}

--- a/examples/medplum-scheduling-demo/src/pages/UploadDataPage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/UploadDataPage.tsx
@@ -1,0 +1,160 @@
+import { Button, LoadingOverlay } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { capitalize, getReferenceString, isOk, MedplumClient, normalizeErrorString } from '@medplum/core';
+import { Bot, Bundle, BundleEntry, Practitioner, Questionnaire, Resource } from '@medplum/fhirtypes';
+import { Document, useMedplum, useMedplumProfile } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+import { useCallback, useContext, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import exampleBotData from '../../data/core/example-bots.json';
+
+type UploadFunction = (medplum: MedplumClient, profile: Practitioner) => Promise<void>;
+
+export function UploadDataPage(): JSX.Element {
+  const medplum = useMedplum();
+  const profile = useMedplumProfile();
+  const navigate = useNavigate();
+  const [pageDisabled, setPageDisabled] = useState<boolean>(false);
+
+  const { dataType } = useParams();
+  const dataTypeDisplay = dataType ? capitalize(dataType) : '';
+  const buttonDisabled = dataType === 'bots' && checkBotsUploaded(medplum);
+
+  const handleUpload = useCallback(() => {
+    if (!profile) {
+      return;
+    }
+
+    setPageDisabled(true);
+    let uploadFunction: UploadFunction;
+    switch (dataType) {
+      // case 'core':
+      //   uploadFunction = uploadCoreData;
+      //   break;
+      // case 'example':
+      //   uploadFunction = uploadExampleData;
+      //   break;
+      case 'bots':
+        uploadFunction = uploadExampleBots;
+        break;
+      default:
+        throw new Error(`Invalid upload type: ${dataType}`);
+    }
+
+    uploadFunction(medplum, profile as Practitioner)
+      .then(() => navigate('/'))
+      .catch((error) => {
+        showNotification({
+          color: 'red',
+          icon: <IconCircleOff />,
+          title: 'Error',
+          message: normalizeErrorString(error),
+        });
+      })
+      .finally(() => setPageDisabled(false));
+  }, [medplum, profile, dataType, navigate]);
+
+  return (
+    <Document>
+      <LoadingOverlay visible={pageDisabled} />
+      <Button disabled={buttonDisabled} onClick={handleUpload}>
+        Upload {dataTypeDisplay} data
+      </Button>
+    </Document>
+  );
+}
+
+// async function uploadCoreData(medplum: MedplumClient): Promise<void> {
+//   const batch = coreData as Bundle;
+
+//   const result = await medplum.executeBatch(batch);
+
+//   if (result.entry?.every((entry) => entry.response?.outcome && isOk(entry.response?.outcome))) {
+//     await setTimeout(
+//       () =>
+//         showNotification({
+//           icon: <IconCircleCheck />,
+//           title: 'Success',
+//           message: 'Uploaded Core Data',
+//         }),
+//       1000
+//     );
+//   } else {
+//     throw new Error('Error uploading core data');
+//   }
+// }
+
+// async function uploadExampleData(medplum: MedplumClient): Promise<void> {
+//   const exampleDataBatch = exampleData as Bundle;
+//   const result = await medplum.executeBatch(exampleDataBatch);
+
+//   if (result.entry?.every((entry) => entry.response?.outcome && isOk(entry.response?.outcome))) {
+//     await setTimeout(
+//       () =>
+//         showNotification({
+//           icon: <IconCircleCheck />,
+//           title: 'Success',
+//           message: 'Uploaded Example Data',
+//         }),
+//       1000
+//     );
+//   } else {
+//     throw new Error('Error uploading example data');
+//   }
+// }
+
+async function uploadExampleBots(medplum: MedplumClient, profile: Practitioner): Promise<void> {
+  let transactionString = JSON.stringify(exampleBotData);
+  const botEntries: BundleEntry[] =
+    (exampleBotData as Bundle).entry?.filter((e: any) => (e.resource as Resource)?.resourceType === 'Bot') || [];
+  const botNames = botEntries.map((e) => (e.resource as Bot).name ?? '');
+  const botIds: Record<string, string> = {};
+
+  for (const botName of botNames) {
+    let existingBot = await medplum.searchOne('Bot', { name: botName });
+    // Create a new Bot if it doesn't already exist
+    if (!existingBot) {
+      const projectId = profile.meta?.project;
+      const createBotUrl = new URL('admin/projects/' + (projectId as string) + '/bot', medplum.getBaseUrl());
+      existingBot = (await medplum.post(createBotUrl, {
+        name: botName,
+      })) as Bot;
+    }
+
+    botIds[botName] = existingBot.id as string;
+
+    // Replace the Bot id placeholder in the bundle
+    transactionString = transactionString
+      .replaceAll(`$bot-${botName}-reference`, getReferenceString(existingBot))
+      .replaceAll(`$bot-${botName}-id`, existingBot.id as string);
+  }
+
+  // Execute the transaction to upload / update the bot
+  const transaction = JSON.parse(transactionString);
+  await medplum.executeBatch(transaction);
+
+  // Deploy the new bots
+  for (const entry of botEntries) {
+    const botName = (entry?.resource as Bot)?.name as string;
+    const distUrl = (entry.resource as Bot).executableCode?.url;
+    const distBinaryEntry = exampleBotData.entry.find((e: any) => e.fullUrl === distUrl);
+    // Decode the base64 encoded code and deploy
+    const code = atob(distBinaryEntry?.resource.data as string);
+    await medplum.post(medplum.fhirUrl('Bot', botIds[botName], '$deploy'), { code });
+  }
+
+  showNotification({
+    icon: <IconCircleCheck />,
+    title: 'Success',
+    message: 'Deployed Example Bots',
+  });
+}
+
+function checkBotsUploaded(medplum: MedplumClient): boolean {
+  const exampleBots = medplum.searchResources('Bot', { name: 'appointments' }).read();
+
+  if (exampleBots.length === 1) {
+    return true;
+  }
+  return false;
+}

--- a/examples/medplum-scheduling-demo/src/pages/UploadDataPage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/UploadDataPage.tsx
@@ -1,10 +1,10 @@
 import { Button, LoadingOverlay } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { capitalize, getReferenceString, isOk, MedplumClient, normalizeErrorString } from '@medplum/core';
-import { Bot, Bundle, BundleEntry, Practitioner, Questionnaire, Resource } from '@medplum/fhirtypes';
+import { capitalize, getReferenceString, MedplumClient, normalizeErrorString } from '@medplum/core';
+import { Bot, Bundle, BundleEntry, Practitioner, Resource } from '@medplum/fhirtypes';
 import { Document, useMedplum, useMedplumProfile } from '@medplum/react';
 import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import exampleBotData from '../../data/core/example-bots.json';
 
@@ -28,12 +28,6 @@ export function UploadDataPage(): JSX.Element {
     setPageDisabled(true);
     let uploadFunction: UploadFunction;
     switch (dataType) {
-      // case 'core':
-      //   uploadFunction = uploadCoreData;
-      //   break;
-      // case 'example':
-      //   uploadFunction = uploadExampleData;
-      //   break;
       case 'bots':
         uploadFunction = uploadExampleBots;
         break;
@@ -63,45 +57,6 @@ export function UploadDataPage(): JSX.Element {
     </Document>
   );
 }
-
-// async function uploadCoreData(medplum: MedplumClient): Promise<void> {
-//   const batch = coreData as Bundle;
-
-//   const result = await medplum.executeBatch(batch);
-
-//   if (result.entry?.every((entry) => entry.response?.outcome && isOk(entry.response?.outcome))) {
-//     await setTimeout(
-//       () =>
-//         showNotification({
-//           icon: <IconCircleCheck />,
-//           title: 'Success',
-//           message: 'Uploaded Core Data',
-//         }),
-//       1000
-//     );
-//   } else {
-//     throw new Error('Error uploading core data');
-//   }
-// }
-
-// async function uploadExampleData(medplum: MedplumClient): Promise<void> {
-//   const exampleDataBatch = exampleData as Bundle;
-//   const result = await medplum.executeBatch(exampleDataBatch);
-
-//   if (result.entry?.every((entry) => entry.response?.outcome && isOk(entry.response?.outcome))) {
-//     await setTimeout(
-//       () =>
-//         showNotification({
-//           icon: <IconCircleCheck />,
-//           title: 'Success',
-//           message: 'Uploaded Example Data',
-//         }),
-//       1000
-//     );
-//   } else {
-//     throw new Error('Error uploading example data');
-//   }
-// }
 
 async function uploadExampleBots(medplum: MedplumClient, profile: Practitioner): Promise<void> {
   let transactionString = JSON.stringify(exampleBotData);

--- a/examples/medplum-scheduling-demo/src/scripts/deploy-bots.ts
+++ b/examples/medplum-scheduling-demo/src/scripts/deploy-bots.ts
@@ -1,0 +1,100 @@
+import { ContentType } from '@medplum/core';
+import { Bundle, BundleEntry } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+interface BotDescription {
+  src: string;
+  dist: string;
+  criteria?: string;
+}
+
+const Bots: BotDescription[] = [
+  {
+    src: 'src/bots/core/appointments.ts',
+    dist: 'dist/bots/core/appointments.js',
+  },
+];
+
+async function main(): Promise<void> {
+  const bundle: Bundle = {
+    resourceType: 'Bundle',
+    type: 'transaction',
+    entry: Bots.flatMap((botDescription): BundleEntry[] => {
+      const botName = path.parse(botDescription.src).name;
+      const botUrlPlaceholder = `$bot-${botName}-reference`;
+      const botIdPlaceholder = `$bot-${botName}-id`;
+      const results: BundleEntry[] = [];
+      const { srcEntry, distEntry } = readBotFiles(botDescription);
+      results.push(srcEntry, distEntry);
+
+      results.push({
+        request: { method: 'PUT', url: botUrlPlaceholder },
+        resource: {
+          resourceType: 'Bot',
+          id: botIdPlaceholder,
+          name: botName,
+          runtimeVersion: 'awslambda',
+          sourceCode: {
+            contentType: ContentType.TYPESCRIPT,
+            url: srcEntry.fullUrl,
+          },
+          executableCode: {
+            contentType: ContentType.JAVASCRIPT,
+            url: distEntry.fullUrl,
+          },
+        },
+      });
+
+      if (botDescription.criteria) {
+        results.push({
+          request: {
+            url: 'Subscription',
+            method: 'POST',
+            ifNoneExist: `url=${botUrlPlaceholder}`,
+          },
+          resource: {
+            resourceType: 'Subscription',
+            status: 'active',
+            reason: botName,
+            channel: { endpoint: botUrlPlaceholder, type: 'rest-hook' },
+            criteria: botDescription.criteria,
+          },
+        });
+      }
+
+      return results;
+    }),
+  };
+
+  fs.writeFileSync('data/core/example-bots.json', JSON.stringify(bundle, null, 2));
+}
+
+function readBotFiles(description: BotDescription): Record<string, BundleEntry> {
+  const sourceFile = fs.readFileSync(description.src);
+  const distFile = fs.readFileSync(description.dist);
+
+  const srcEntry: BundleEntry = {
+    fullUrl: 'urn:uuid:' + randomUUID(),
+    request: { method: 'POST', url: 'Binary' },
+    resource: {
+      resourceType: 'Binary',
+      contentType: ContentType.TYPESCRIPT,
+      data: sourceFile.toString('base64'),
+    },
+  };
+  const distEntry: BundleEntry = {
+    fullUrl: 'urn:uuid:' + randomUUID(),
+    request: { method: 'POST', url: 'Binary' },
+    resource: {
+      resourceType: 'Binary',
+      contentType: ContentType.JAVASCRIPT,
+      data: distFile.toString('base64'),
+    },
+  };
+
+  return { srcEntry, distEntry };
+}
+
+main().catch(console.error);

--- a/examples/medplum-scheduling-demo/src/scripts/deploy-bots.ts
+++ b/examples/medplum-scheduling-demo/src/scripts/deploy-bots.ts
@@ -12,8 +12,8 @@ interface BotDescription {
 
 const Bots: BotDescription[] = [
   {
-    src: 'src/bots/core/appointments.ts',
-    dist: 'dist/bots/core/appointments.js',
+    src: 'src/bots/core/book-appointment.ts',
+    dist: 'dist/bots/core/book-appointment.js',
   },
 ];
 
@@ -34,6 +34,7 @@ async function main(): Promise<void> {
         resource: {
           resourceType: 'Bot',
           id: botIdPlaceholder,
+          identifier: [{ system: 'http://example.com', value: botName }],
           name: botName,
           runtimeVersion: 'awslambda',
           sourceCode: {


### PR DESCRIPTION
## Description


- Partial work of #4973 
- Update the scheduling flow that starts from My Schedule and Patient detail pages.

  | Starting Point | Flow |
  | -------------------- | ------- |
  | My Schedule | Click on an available slot -> Open appointment creation modal (slot field hidden) |
  | Patient detail | Click on create appointment action -> Redirect to a modified Scheduling page -> Select a slot -> Open appointment creation modal (slot and patient fields hidden)  |
  | My Appointments | Redirect to the My Schedule page (since it would be trickier to add the slots field to the create appointment modal questionnaire) |

- Add bot to handle booking an appointment
   - Move the logic from `CreateAppointment.handleQuestionnaireSubmit` to the `booking-appointment` bot.
   - Add tests for the bot code.

> [!NOTE]
> Other bots will be implemented in future PRs since this PR was already getting bigger due to the refactoring of the scheduling behavior flow.

## Steps to test

- [ ] Build the bots: `npm run build:bots`
- [ ] Upload example bots
- [ ] Create slots
  - [ ] Blocked
  - [ ] Available
- [ ] Create appointments
  - [ ] Starting from My Schedule page
  - [ ] Starting from Patient detail page
  - [ ] Starting from My Appointments page 

[Screencast from 15-08-2024 19:15:30.webm](https://github.com/user-attachments/assets/565d5928-0b55-405e-90f0-682efda0db59)
