### PR TITLE
Use turbo for linting

### DIFF
--- a/examples/foomedical/tsconfig.json
+++ b/examples/foomedical/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/foomedical/tsconfig.json
+++ b/examples/foomedical/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-chart-demo/tsconfig.json
+++ b/examples/medplum-chart-demo/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["dist"]
 }

--- a/examples/medplum-chat-demo/package.json
+++ b/examples/medplum-chat-demo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "prettier": {

--- a/examples/medplum-chat-demo/tsconfig.json
+++ b/examples/medplum-chat-demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-chat-demo/tsconfig.json
+++ b/examples/medplum-chat-demo/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-client-external-idp-demo/package.json
+++ b/examples/medplum-client-external-idp-demo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "prettier": {

--- a/examples/medplum-client-external-idp-demo/tsconfig.json
+++ b/examples/medplum-client-external-idp-demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-client-external-idp-demo/tsconfig.json
+++ b/examples/medplum-client-external-idp-demo/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-demo-bots/tsconfig.json
+++ b/examples/medplum-demo-bots/tsconfig.json
@@ -30,5 +30,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/examples/medplum-eligibility-demo/tsconfig.json
+++ b/examples/medplum-eligibility-demo/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "data/example/request-data.ts"]
+  "include": ["src", "data/example/request-data.ts"],
+  "exclude": ["dist"]
 }

--- a/examples/medplum-fhircast-demo/package.json
+++ b/examples/medplum-fhircast-demo/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "eslintConfig": {

--- a/examples/medplum-fhircast-demo/tsconfig.json
+++ b/examples/medplum-fhircast-demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -16,5 +15,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-fhircast-demo/tsconfig.json
+++ b/examples/medplum-fhircast-demo/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,6 +16,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-hello-world/package.json
+++ b/examples/medplum-hello-world/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "prettier": {

--- a/examples/medplum-hello-world/tsconfig.json
+++ b/examples/medplum-hello-world/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-hello-world/tsconfig.json
+++ b/examples/medplum-hello-world/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-live-chat-demo/package.json
+++ b/examples/medplum-live-chat-demo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "prettier": {

--- a/examples/medplum-live-chat-demo/tsconfig.json
+++ b/examples/medplum-live-chat-demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-live-chat-demo/tsconfig.json
+++ b/examples/medplum-live-chat-demo/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-nextauth-demo/tsconfig.json
+++ b/examples/medplum-nextauth-demo/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/examples/medplum-nextjs-demo/.eslintrc.json
+++ b/examples/medplum-nextjs-demo/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/examples/medplum-nextjs-demo/tsconfig.json
+++ b/examples/medplum-nextjs-demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -21,5 +20,6 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/examples/medplum-nextjs-demo/tsconfig.json
+++ b/examples/medplum-nextjs-demo/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
@@ -20,6 +21,5 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
 }

--- a/examples/medplum-patient-intake-demo/tsconfig.json
+++ b/examples/medplum-patient-intake-demo/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["dist"]
 }

--- a/examples/medplum-photon-integration/tsconfig.json
+++ b/examples/medplum-photon-integration/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "src/custom.d.ts"]
+  "include": ["src", "src/custom.d.ts"],
+  "exclude": ["dist"]
 }

--- a/examples/medplum-provider/package.json
+++ b/examples/medplum-provider/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "prettier": {

--- a/examples/medplum-provider/tsconfig.json
+++ b/examples/medplum-provider/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-provider/tsconfig.json
+++ b/examples/medplum-provider/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/examples/medplum-react-native-example/package.json
+++ b/examples/medplum-react-native-example/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "android": "expo start --android",
     "ios": "expo start --ios",
+    "lint": "eslint .",
     "start": "expo start",
     "web": "expo start --web"
   },

--- a/examples/medplum-react-native-example/tsconfig.json
+++ b/examples/medplum-react-native-example/tsconfig.json
@@ -15,5 +15,6 @@
     "jsx": "react-jsx"
   },
   "include": ["src"],
-  "extends": "expo/tsconfig.base"
+  "extends": "expo/tsconfig.base",
+  "exclude": ["dist"]
 }

--- a/examples/medplum-scheduling-demo/tsconfig.json
+++ b/examples/medplum-scheduling-demo/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["dist"]
 }

--- a/examples/medplum-task-demo/tsconfig.json
+++ b/examples/medplum-task-demo/tsconfig.json
@@ -15,5 +15,6 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["dist"]
 }

--- a/examples/medplum-websocket-subscriptions-demo/package.json
+++ b/examples/medplum-websocket-subscriptions-demo/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",
+    "lint": "eslint .",
     "preview": "vite preview"
   },
   "prettier": {

--- a/examples/medplum-websocket-subscriptions-demo/tsconfig.json
+++ b/examples/medplum-websocket-subscriptions-demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -15,5 +14,6 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/examples/medplum-websocket-subscriptions-demo/tsconfig.json
+++ b/examples/medplum-websocket-subscriptions-demo/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
@@ -14,6 +15,5 @@
     "resolveJsonModule": true,
     "noEmit": true,
     "jsx": "react-jsx"
-  },
-  "include": ["src"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:fast": "turbo run build --filter=@medplum/app --filter=@medplum/server",
     "clean": "turbo run clean",
     "cyclonedx": "cyclonedx-npm --omit dev --omit optional --omit peer",
-    "lint": "cross-env NODE_OPTIONS='--max-old-space-size=8192' eslint .",
+    "lint": "turbo run lint --filter=!@medplum/docs",
     "prettier": "prettier --write \"**/*.{ts,tsx,cts,mts,js,jsx,cjs,mjs,json}\"",
     "sort-package-json": "sort-package-json package.json \"packages/*/package.json\" \"examples/*/package.json\"",
     "test": "turbo run test --filter=!@medplum/docs"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -20,6 +20,7 @@
     "agent": "ts-node src/main.ts",
     "build": "npm run clean && tsc && node esbuild.mjs",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,7 @@
     "build": "npm run clean && tsc && vite build",
     "clean": "rimraf dist",
     "dev": "vite",
+    "lint": "eslint .",
     "source-map-explorer": "source-map-explorer dist/**/*.js --gzip",
     "test": "jest"
   },

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -9,5 +9,5 @@
       "@medplum/react": ["../react/src"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "./jest.setup.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "jest.setup.ts", "vite.config.ts"]
 }

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -20,6 +20,7 @@
     "build": "npm run clean && tsc --project tsconfig.build.json && node esbuild.mjs",
     "cdk": "cdk",
     "clean": "rimraf dist cdk.out",
+    "lint": "eslint .",
     "test": "jest --runInBand"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "build": "npm run clean && tsc && node esbuild.mjs",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "medplum": "ts-node src/index.ts",
     "test": "jest"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor && npm run api-documenter",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "clean": "rimraf dist/index.js dist/index.d.ts",
+    "lint": "eslint .",
     "test": "jest"
   },
   "engines": {

--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -149,9 +149,8 @@ module.exports = {
   },
   ignorePatterns: [
     'coverage',
-    'dist',
-    'node_modules',
-    'packages/**/dist/',
+    '**/node_modules/',
+    '**/dist/',
     'packages/docs/build/',
     'packages/docs/markdown-to-mdx.cjs',
     'packages/docs/docusaurus.config.js',

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,7 +15,8 @@
   "author": "Medplum <hello@medplum.com>",
   "scripts": {
     "build": "npm run clean && tsc",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",

--- a/packages/expo-polyfills/package.json
+++ b/packages/expo-polyfills/package.json
@@ -39,6 +39,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf ./build",
+    "lint": "eslint .",
     "test": "jest --runInBand"
   },
   "dependencies": {

--- a/packages/fhir-router/package.json
+++ b/packages/fhir-router/package.json
@@ -50,6 +50,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -20,6 +20,7 @@
     "fhirtypes": "ts-node src/index.ts",
     "generate": "npm run fhirtypes && npm run jsonschema && npm run baseschema && npm run mockclient",
     "jsonschema": "ts-node src/jsonschema.ts && npx prettier ../definitions/dist/fhir/r4/fhir.schema.json --write",
+    "lint": "eslint .",
     "migrate": "ts-node src/migrate.ts",
     "mockclient": "ts-node src/mockclient.ts && npx prettier ../mock/src/mocks/*.json --write",
     "test": "jest"

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "npm run clean && tsc && vite build",
     "clean": "rimraf dist",
-    "dev": "vite"
+    "dev": "vite",
+    "lint": "eslint ."
   },
   "browserslist": [
     "last 1 Chrome versions"

--- a/packages/graphiql/tsconfig.json
+++ b/packages/graphiql/tsconfig.json
@@ -4,6 +4,5 @@
     "module": "esnext",
     "lib": ["esnext", "dom", "dom.iterable"],
     "types": ["vite/client"]
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "./jest.setup.ts"]
+  }
 }

--- a/packages/health-gorilla/package.json
+++ b/packages/health-gorilla/package.json
@@ -36,6 +36,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/hl7/package.json
+++ b/packages/hl7/package.json
@@ -50,6 +50,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -50,6 +50,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -54,6 +54,7 @@
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node esbuild.mjs && npm run api-extractor",
     "clean": "rimraf dist",
+    "lint": "eslint .",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
     "chromatic": "chromatic --exit-zero-on-changes --build-script-name=storybook --exit-once-uploaded",
     "clean": "rimraf dist storybook-static",
     "dev": "storybook dev -p 6006",
+    "lint": "eslint .",
     "storybook": "storybook build",
     "test": "jest"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "clean": "rimraf dist",
     "dev": "ts-node-dev --poll --respawn --transpile-only --require ./src/otel/instrumentation.ts src/index.ts",
+    "lint": "eslint .",
     "start": "node --require ./dist/otel/instrumentation.js dist/index.js",
     "test": "jest",
     "test:seed": "jest seed.test.ts --testTimeout=400000"

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,7 @@
       "dependsOn": ["build"],
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"]
-    }
+    },
+    "lint": {}
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,8 @@
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts"]
     },
-    "lint": {}
+    "lint": {
+      "dependsOn": ["build"]
+    }
   }
 }


### PR DESCRIPTION
Previously we ran eslint against the entire repo which seems to be hitting some scaling issues and surfacing errors unrelated to the diffs of PRs/commits such as [this build](https://github.com/medplum/medplum/actions/runs/10391113203/job/28774368521?pr=5093).