### PR TITLE
Fix AWS stub generic params

### DIFF
--- a/packages/cli/src/aws/update-app.test.ts
+++ b/packages/cli/src/aws/update-app.test.ts
@@ -1,18 +1,26 @@
 import {
   CloudFormationClient,
   CloudFormationClientResolvedConfig,
+  ServiceInputTypes as CloudFormationServiceInputTypes,
+  ServiceOutputTypes as CloudFormationServiceOutputTypes,
   DescribeStackResourcesCommand,
   DescribeStacksCommand,
   ListStacksCommand,
-  ServiceInputTypes,
-  ServiceOutputTypes,
 } from '@aws-sdk/client-cloudformation';
 import {
   CloudFrontClient,
   CloudFrontClientResolvedConfig,
+  ServiceInputTypes as CloudFrontServiceInputTypes,
+  ServiceOutputTypes as CloudFrontServiceOutputTypes,
   CreateInvalidationCommand,
 } from '@aws-sdk/client-cloudfront';
-import { PutObjectCommand, S3Client, S3ClientResolvedConfig } from '@aws-sdk/client-s3';
+import {
+  PutObjectCommand,
+  S3Client,
+  S3ClientResolvedConfig,
+  ServiceInputTypes as S3ServiceInputTypes,
+  ServiceOutputTypes as S3ServiceOutputTypes,
+} from '@aws-sdk/client-s3';
 import { AwsStub, mockClient } from 'aws-sdk-client-mock';
 import fastGlob from 'fast-glob';
 import fetch from 'node-fetch';
@@ -49,9 +57,13 @@ jest.mock('tar', () => ({
 
 const { Response: NodeFetchResponse } = jest.requireActual('node-fetch');
 
-let cfMock: AwsStub<ServiceInputTypes, ServiceOutputTypes, CloudFormationClientResolvedConfig>;
-let s3Mock: AwsStub<ServiceInputTypes, ServiceOutputTypes, S3ClientResolvedConfig>;
-let cloudFrontMock: AwsStub<ServiceInputTypes, ServiceOutputTypes, CloudFrontClientResolvedConfig>;
+let cfMock: AwsStub<
+  CloudFormationServiceInputTypes,
+  CloudFormationServiceOutputTypes,
+  CloudFormationClientResolvedConfig
+>;
+let s3Mock: AwsStub<S3ServiceInputTypes, S3ServiceOutputTypes, S3ClientResolvedConfig>;
+let cloudFrontMock: AwsStub<CloudFrontServiceInputTypes, CloudFrontServiceOutputTypes, CloudFrontClientResolvedConfig>;
 
 describe('update-app command', () => {
   let processError: jest.SpyInstance;
@@ -144,11 +156,7 @@ describe('update-app command', () => {
     s3Mock = mockClient(S3Client);
     s3Mock.on(PutObjectCommand).resolves({});
 
-    cloudFrontMock = mockClient(CloudFrontClient) as AwsStub<
-      ServiceInputTypes,
-      ServiceOutputTypes,
-      CloudFrontClientResolvedConfig
-    >;
+    cloudFrontMock = mockClient(CloudFrontClient);
     cloudFrontMock.on(CreateInvalidationCommand).resolves({});
   });
 

--- a/packages/cli/src/aws/update-bucket-policies.test.ts
+++ b/packages/cli/src/aws/update-bucket-policies.test.ts
@@ -1,19 +1,28 @@
 import {
   CloudFormationClient,
   CloudFormationClientResolvedConfig,
+  ServiceInputTypes as CloudFormationServiceInputTypes,
+  ServiceOutputTypes as CloudFormationServiceOutputTypes,
   DescribeStackResourcesCommand,
   DescribeStacksCommand,
   ListStacksCommand,
-  ServiceInputTypes,
-  ServiceOutputTypes,
   StackResource,
 } from '@aws-sdk/client-cloudformation';
 import {
   CloudFrontClient,
   CloudFrontClientResolvedConfig,
+  ServiceInputTypes as CloudFrontServiceInputTypes,
+  ServiceOutputTypes as CloudFrontServiceOutputTypes,
   CreateInvalidationCommand,
 } from '@aws-sdk/client-cloudfront';
-import { GetBucketPolicyCommand, PutBucketPolicyCommand, S3Client, S3ClientResolvedConfig } from '@aws-sdk/client-s3';
+import {
+  GetBucketPolicyCommand,
+  PutBucketPolicyCommand,
+  S3Client,
+  S3ClientResolvedConfig,
+  ServiceInputTypes as S3ServiceInputTypes,
+  ServiceOutputTypes as S3ServiceOutputTypes,
+} from '@aws-sdk/client-s3';
 import { AwsStub, mockClient } from 'aws-sdk-client-mock';
 import fs from 'node:fs';
 import { main } from '../index';
@@ -35,9 +44,13 @@ jest.mock('node:fs', () => ({
   },
 }));
 
-let cfMock: AwsStub<ServiceInputTypes, ServiceOutputTypes, CloudFormationClientResolvedConfig>;
-let s3Mock: AwsStub<ServiceInputTypes, ServiceOutputTypes, S3ClientResolvedConfig>;
-let cloudFrontMock: AwsStub<ServiceInputTypes, ServiceOutputTypes, CloudFrontClientResolvedConfig>;
+let cfMock: AwsStub<
+  CloudFormationServiceInputTypes,
+  CloudFormationServiceOutputTypes,
+  CloudFormationClientResolvedConfig
+>;
+let s3Mock: AwsStub<S3ServiceInputTypes, S3ServiceOutputTypes, S3ClientResolvedConfig>;
+let cloudFrontMock: AwsStub<CloudFrontServiceInputTypes, CloudFrontServiceOutputTypes, CloudFrontClientResolvedConfig>;
 
 describe('update-bucket-policies command', () => {
   let processError: jest.SpyInstance;
@@ -129,11 +142,7 @@ describe('update-bucket-policies command', () => {
     s3Mock.on(GetBucketPolicyCommand).resolves({ Policy: '{}' });
     s3Mock.on(PutBucketPolicyCommand).resolves({});
 
-    cloudFrontMock = mockClient(CloudFrontClient) as AwsStub<
-      ServiceInputTypes,
-      ServiceOutputTypes,
-      CloudFrontClientResolvedConfig
-    >;
+    cloudFrontMock = mockClient(CloudFrontClient);
     cloudFrontMock.on(CreateInvalidationCommand).resolves({});
   });
 


### PR DESCRIPTION
I originally wrote this as part of the dependency upgrade PR: https://github.com/medplum/medplum/pull/5108

We aborted those dependency upgrades for unrelated reasons.  This is still a good fix though.

Context:  We use the official AWS SDK's for AWS stuff.  We use a library called `aws-sdk-mock-client` for AWS mocks in tests.

The `aws-sdk-mock-client` uses some really clever TypeScript types to make it all work elegantly.  Great library.

It turns out that we were abusing the fact that `ServiceInputTypes` and `ServiceOutputTypes` are exported from multiple AWS SDK packages, and just happened to compatible historically.

In one of the more recent versions, that changed, and those types with the same names are no longer compatible, which leads to build errors.

Pretty straightforward fix.

This is tests only, low risk.