### PR TITLE
[Scheduling Sample] Implement Set Availability Action

### DIFF
--- a/examples/medplum-scheduling-demo/src/bots/core/set-availability.test.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/set-availability.test.ts
@@ -1,0 +1,93 @@
+import { createReference, indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { readJson, SEARCH_PARAMETER_BUNDLE_FILES } from '@medplum/definitions';
+import { Bundle, Schedule, SearchParameter } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { handler, SetAvailabilityEvent } from './set-availability';
+
+describe('Set Availability', async () => {
+  let medplum: MockClient;
+  let schedule: Schedule;
+
+  const bot = { reference: 'Bot/123' };
+  const contentType = 'application/fhir+json';
+
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+    for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+      indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+    }
+  });
+
+  beforeEach(async () => {
+    medplum = new MockClient();
+    schedule = await medplum.createResource({
+      resourceType: 'Schedule',
+      active: true,
+      actor: [{ reference: 'Practitioner/dr-alice-smith' }],
+    });
+    // Delete all existing slots
+    const slots = await medplum.searchResources('Slot');
+    await Promise.all(slots.map((slot) => medplum.deleteResource('Slot', slot.id as string)));
+  });
+
+  test('Successfully create free slots', async () => {
+    const input: SetAvailabilityEvent = {
+      schedule: createReference(schedule as Schedule),
+      startDate: '2024-08-19',
+      endDate: '2024-08-21',
+      startTime: '09:00:00',
+      endTime: '17:00:00',
+      duration: 120,
+      daysOfWeek: ['mon', 'wed'],
+    };
+
+    let freeSlots = await medplum.searchResources('Slot', {
+      status: 'free',
+    });
+
+    expect(freeSlots.length).toBe(0);
+
+    await handler(medplum, { bot, input, contentType, secrets: {} });
+
+    freeSlots = await medplum.searchResources('Slot', {
+      status: 'free',
+    });
+
+    // 4 slots on Monday and 4 slots on Wednesday
+    expect(freeSlots.length).toBe(8);
+  });
+
+  test('Invalid duration', async () => {
+    const input: SetAvailabilityEvent = {
+      schedule: createReference(schedule as Schedule),
+      startDate: '2024-08-19',
+      endDate: '2024-08-21',
+      startTime: '09:00:00',
+      endTime: '17:00:00',
+      duration: 0,
+      daysOfWeek: ['mon', 'wed'],
+    };
+
+    await expect(handler(medplum, { bot, input, contentType, secrets: {} })).rejects.toThrow(
+      'Duration must be a positive number'
+    );
+  });
+
+  test('End date before start date', async () => {
+    const input: SetAvailabilityEvent = {
+      schedule: createReference(schedule as Schedule),
+      startDate: '2024-08-21',
+      endDate: '2024-08-19',
+      startTime: '09:00:00',
+      endTime: '17:00:00',
+      duration: 120,
+      daysOfWeek: ['mon', 'wed'],
+    };
+
+    await expect(handler(medplum, { bot, input, contentType, secrets: {} })).rejects.toThrow(
+      'End date must be after start date'
+    );
+  });
+});

--- a/examples/medplum-scheduling-demo/src/bots/core/set-availability.ts
+++ b/examples/medplum-scheduling-demo/src/bots/core/set-availability.ts
@@ -1,0 +1,103 @@
+import { BotEvent, MedplumClient } from '@medplum/core';
+import { Bundle, BundleEntry, Reference, Resource, Schedule, Slot } from '@medplum/fhirtypes';
+
+export interface SetAvailabilityEvent {
+  schedule: Reference<Schedule>;
+  startDate: string;
+  endDate: string;
+  startTime: string;
+  endTime: string;
+  duration: number;
+  daysOfWeek: string[];
+}
+
+export async function handler(medplum: MedplumClient, event: BotEvent<SetAvailabilityEvent>): Promise<Bundle> {
+  const { schedule, startDate, endDate, startTime, endTime, duration, daysOfWeek } = event.input;
+
+  // Basic data validation
+  if (duration <= 0) {
+    throw new Error('Duration must be a positive number');
+  }
+  if (new Date(endDate) < new Date(startDate)) {
+    throw new Error('End date must be after start date');
+  }
+
+  // Map daysOfWeek to their corresponding day numbers
+  const dayNumbers = daysOfWeek.map((day) => dayOfWeekMap[day.toLowerCase()]);
+
+  // Bulk create free slots
+  const entries: BundleEntry[] = [];
+
+  const end = new Date(endDate);
+  let currentDate = new Date(startDate);
+
+  while (currentDate <= end) {
+    if (dayNumbers.includes(currentDate.getUTCDay())) {
+      const dayStartTime = new Date(currentDate);
+      const dayEndTime = new Date(currentDate);
+
+      // Set the start and end times for the day
+      const [startHour, startMinute] = startTime.split(':').map(Number);
+      const [endHour, endMinute] = endTime.split(':').map(Number);
+
+      dayStartTime.setUTCHours(startHour, startMinute, 0, 0);
+      dayEndTime.setUTCHours(endHour, endMinute, 0, 0);
+
+      let currentSlotTime = new Date(dayStartTime);
+
+      // Create slots within the specified time window
+      while (currentSlotTime < dayEndTime) {
+        const slotEndTime = new Date(currentSlotTime.getTime() + duration * 60000);
+
+        // Ensure that the slot does not exceed the end time
+        if (slotEndTime <= dayEndTime) {
+          const slot = createFreeSlot(schedule, currentSlotTime, duration);
+          entries.push(createEntry(slot));
+        }
+
+        // Move to the next slot
+        currentSlotTime = new Date(currentSlotTime.getTime() + duration * 60000);
+      }
+    }
+    // Move to the next day
+    currentDate = new Date(currentDate.setUTCDate(currentDate.getUTCDate() + 1));
+  }
+
+  // Execute batch to create all slots at once
+  const responseBundle = await medplum.executeBatch({
+    resourceType: 'Bundle',
+    type: 'batch',
+    entry: entries,
+  });
+  return responseBundle;
+}
+
+const dayOfWeekMap: Record<string, number> = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+};
+
+function createEntry(resource: Resource): BundleEntry {
+  return {
+    resource,
+    request: {
+      url: resource.resourceType,
+      method: 'POST',
+    },
+  };
+}
+
+export function createFreeSlot(schedule: Reference<Schedule>, start: Date, duration: number): Slot {
+  return {
+    resourceType: 'Slot',
+    schedule: schedule,
+    start: start.toISOString(),
+    end: new Date(start.getTime() + duration * 60000).toISOString(),
+    status: 'free',
+  };
+}

--- a/examples/medplum-scheduling-demo/src/components/SetAvailability.tsx
+++ b/examples/medplum-scheduling-demo/src/components/SetAvailability.tsx
@@ -1,0 +1,155 @@
+import { Modal } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { createReference, getAllQuestionnaireAnswers, normalizeErrorString } from '@medplum/core';
+import {
+  Coding,
+  Questionnaire,
+  QuestionnaireItemAnswerOption,
+  QuestionnaireResponse,
+  Schedule,
+} from '@medplum/fhirtypes';
+import { Loading, QuestionnaireForm, useMedplum } from '@medplum/react';
+import { IconCircleCheck, IconCircleOff } from '@tabler/icons-react';
+import { useContext } from 'react';
+import { ScheduleContext } from '../Schedule.context';
+import { SetAvailabilityEvent } from '../bots/core/set-availability';
+
+interface SetAvailabilityProps {
+  readonly opened: boolean;
+  readonly handlers: {
+    readonly open: () => void;
+    readonly close: () => void;
+    readonly toggle: () => void;
+  };
+}
+
+export function SetAvailability(props: SetAvailabilityProps): JSX.Element {
+  const { opened, handlers } = props;
+
+  const medplum = useMedplum();
+
+  const { schedule } = useContext(ScheduleContext);
+
+  if (!schedule) {
+    return <Loading />;
+  }
+
+  async function handleQuestionnaireSubmit(formData: QuestionnaireResponse): Promise<void> {
+    const answers = getAllQuestionnaireAnswers(formData);
+
+    try {
+      // Call 'set-availability' bot to create slots
+      const input: SetAvailabilityEvent = {
+        schedule: createReference(schedule as Schedule),
+        startDate: answers['start-date'][0].valueDate as string,
+        endDate: answers['end-date'][0].valueDate as string,
+        startTime: answers['start-time'][0].valueTime as string,
+        endTime: answers['end-time'][0].valueTime as string,
+        duration: answers['duration'][0].valueInteger as number,
+        daysOfWeek: answers['days-of-week'].map(
+          (d: QuestionnaireItemAnswerOption) => (d.valueCoding as Coding).code as string
+        ),
+      };
+      await medplum.executeBot({ system: 'http://example.com', value: 'set-availability' }, input);
+
+      showNotification({
+        icon: <IconCircleCheck />,
+        title: 'Success',
+        message: 'Slots created',
+      });
+    } catch (err) {
+      showNotification({
+        color: 'red',
+        icon: <IconCircleOff />,
+        title: 'Error',
+        message: normalizeErrorString(err),
+      });
+    }
+
+    handlers.close();
+  }
+
+  return (
+    <Modal opened={opened} onClose={handlers.close}>
+      <QuestionnaireForm
+        questionnaire={setAvailabilityQuestionnaire}
+        subject={createReference(schedule)}
+        onSubmit={handleQuestionnaireSubmit}
+      />
+    </Modal>
+  );
+}
+
+const setAvailabilityQuestionnaire: Questionnaire = {
+  resourceType: 'Questionnaire',
+  status: 'active',
+  title: 'Set Availability',
+  id: 'set-availability',
+  item: [
+    {
+      linkId: 'start-date',
+      type: 'date',
+      text: 'Start date of availability',
+      required: true,
+      initial: [{ valueDate: new Date().toISOString().slice(0, 10) }],
+    },
+    {
+      linkId: 'end-date',
+      type: 'date',
+      text: 'End date of availability',
+      required: true,
+    },
+    {
+      linkId: 'start-time',
+      type: 'time',
+      text: 'Start time of availability (each day)',
+      required: true,
+      initial: [{ valueTime: '09:00:00' }],
+    },
+    {
+      linkId: 'end-time',
+      type: 'time',
+      text: 'End time of availability (each day)',
+      required: true,
+      initial: [{ valueTime: '17:00:00' }],
+    },
+    {
+      linkId: 'duration',
+      type: 'integer',
+      text: 'Duration of each slot (minutes)',
+      required: true,
+      initial: [{ valueInteger: 60 }],
+    },
+    {
+      linkId: 'days-of-week',
+      type: 'choice',
+      text: 'Repeat on days of the week',
+      required: true,
+      repeats: true,
+      answerOption: [
+        { valueCoding: { code: 'sun', display: 'Sunday', system: 'http://hl7.org/fhir/days-of-week' } },
+        { valueCoding: { code: 'mon', display: 'Monday', system: 'http://hl7.org/fhir/days-of-week' } },
+        { valueCoding: { code: 'tue', display: 'Tuesday', system: 'http://hl7.org/fhir/days-of-week' } },
+        { valueCoding: { code: 'wed', display: 'Wednesday', system: 'http://hl7.org/fhir/days-of-week' } },
+        { valueCoding: { code: 'thu', display: 'Thursday', system: 'http://hl7.org/fhir/days-of-week' } },
+        { valueCoding: { code: 'fri', display: 'Friday', system: 'http://hl7.org/fhir/days-of-week' } },
+        { valueCoding: { code: 'sat', display: 'Saturday', system: 'http://hl7.org/fhir/days-of-week' } },
+      ],
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system: 'http://hl7.org/fhir/questionnaire-item-control',
+                code: 'drop-down',
+                display: 'Drop down',
+              },
+            ],
+            text: 'Drop down',
+          },
+        },
+      ],
+    },
+  ],
+};

--- a/examples/medplum-scheduling-demo/src/pages/SchedulePage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/SchedulePage.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@mantine/core';
+import { Button, Group, Title } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { getReferenceString } from '@medplum/core';
 import { Practitioner, Schedule } from '@medplum/fhirtypes';
@@ -9,10 +9,12 @@ import { Calendar, dayjsLocalizer, Event } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useNavigate } from 'react-router-dom';
 import { ScheduleContext } from '../Schedule.context';
+import { SetAvailability } from '../components/SetAvailability';
 import { SlotDetails } from '../components/SlotDetails';
 
 export function SchedulePage(): JSX.Element {
   const navigate = useNavigate();
+  const [setAvailabilityOpened, setAvailabilityHandlers] = useDisclosure(false);
   const [slotDetailsOpened, slotDetailsHandlers] = useDisclosure(false);
   const [selectedEvent, setSelectedEvent] = useState<Event>();
   const { schedule } = useContext(ScheduleContext);
@@ -81,6 +83,12 @@ export function SchedulePage(): JSX.Element {
         My Schedule
       </Title>
 
+      <Group mb="lg">
+        <Button size="sm" onClick={() => setAvailabilityHandlers.open()}>
+          Set Availability
+        </Button>
+      </Group>
+
       <Calendar
         defaultView="week"
         views={['month', 'week', 'day', 'agenda']}
@@ -94,6 +102,8 @@ export function SchedulePage(): JSX.Element {
         selectable
       />
 
+      {/* Modals */}
+      <SetAvailability opened={setAvailabilityOpened} handlers={setAvailabilityHandlers} />
       <SlotDetails event={selectedEvent} opened={slotDetailsOpened} handlers={slotDetailsHandlers} />
     </Document>
   );

--- a/examples/medplum-scheduling-demo/src/pages/UploadDataPage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/UploadDataPage.tsx
@@ -132,9 +132,11 @@ async function uploadExampleBots(medplum: MedplumClient, profile: Practitioner):
 function checkBotsUploaded(medplum: MedplumClient): boolean {
   const bots = medplum.searchResources('Bot').read();
 
-  const exampleBots = bots.filter((bot) => bot.name === 'book-appointment' || bot.name === 'cancel-appointment');
+  const exampleBots = bots.filter(
+    (bot) => bot.name && ['book-appointment', 'cancel-appointment', 'set-availability'].includes(bot.name)
+  );
 
-  if (exampleBots.length === 2) {
+  if (exampleBots.length === 3) {
     return true;
   }
   return false;

--- a/examples/medplum-scheduling-demo/src/scripts/deploy-bots.ts
+++ b/examples/medplum-scheduling-demo/src/scripts/deploy-bots.ts
@@ -19,6 +19,10 @@ const Bots: BotDescription[] = [
     src: 'src/bots/core/cancel-appointment.ts',
     dist: 'dist/bots/core/cancel-appointment.js',
   },
+  {
+    src: 'src/bots/core/set-availability.ts',
+    dist: 'dist/bots/core/set-availability.js',
+  },
 ];
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## Description

- Resolves #4939
- Implement the feature to batch-create multiple available time slots using the bot, allowing users to set their availability in one action.
## Steps to test

- [ ] Build the bots: `npm run build:bots`
- [ ] Upload core data
- [ ] Upload example bots
- [ ] On My Schedule page, click on the `Set Availability` button, submit the form, and check if the free/available slots were created as expected.

[Screencast from 22-08-2024 16:50:48.webm](https://github.com/user-attachments/assets/d1f18cc3-17c7-414a-9014-6deb53bba112)

