### PR TITLE
[Patient Intake Sample] Create `RelatedPerson` resource when necessary

### DIFF
--- a/examples/medplum-patient-intake-demo/data/core/patient-intake-questionnaire.json
+++ b/examples/medplum-patient-intake-demo/data/core/patient-intake-questionnaire.json
@@ -262,7 +262,7 @@
               },
               {
                 "linkId": "related-person",
-                "text": "Related Person Information",
+                "text": "Subscriber Information",
                 "type": "group",
                 "enableBehavior": "all",
                 "enableWhen": [

--- a/examples/medplum-patient-intake-demo/data/core/patient-intake-questionnaire.json
+++ b/examples/medplum-patient-intake-demo/data/core/patient-intake-questionnaire.json
@@ -257,8 +257,71 @@
                 "linkId": "relationship-to-subscriber",
                 "text": "Relationship to Subscriber",
                 "type": "choice",
-                "answerValueSet": "http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype",
+                "answerValueSet": "http://hl7.org/fhir/ValueSet/subscriber-relationship",
                 "required": true
+              },
+              {
+                "linkId": "related-person",
+                "text": "Related Person Information",
+                "type": "group",
+                "enableBehavior": "all",
+                "enableWhen": [
+                  {
+                    "question": "relationship-to-subscriber",
+                    "operator": "!=",
+                    "answerCoding": {
+                      "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
+                      "code": "other",
+                      "display": "Other"
+                    }
+                  },
+                  {
+                    "question": "relationship-to-subscriber",
+                    "operator": "!=",
+                    "answerCoding": {
+                      "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
+                      "code": "self",
+                      "display": "Self"
+                    }
+                  },
+                  {
+                    "question": "relationship-to-subscriber",
+                    "operator": "!=",
+                    "answerCoding": {
+                      "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
+                      "code": "injured",
+                      "display": "Injured Party"
+                    }
+                  }
+                ],
+                "item": [
+                  {
+                    "linkId": "related-person-first-name",
+                    "text": "First Name",
+                    "type": "string"
+                  },
+                  {
+                    "linkId": "related-person-middle-name",
+                    "text": "Middle Name",
+                    "type": "string"
+                  },
+                  {
+                    "linkId": "related-person-last-name",
+                    "text": "Last Name",
+                    "type": "string"
+                  },
+                  {
+                    "linkId": "related-person-dob",
+                    "text": "Date of Birth",
+                    "type": "date"
+                  },
+                  {
+                    "linkId": "related-person-gender-identity",
+                    "text": "Gender Identity",
+                    "type": "choice",
+                    "answerValueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1021.32"
+                  }
+                ]
               }
             ]
           },

--- a/examples/medplum-patient-intake-demo/src/bots/core/intake-form.ts
+++ b/examples/medplum-patient-intake-demo/src/bots/core/intake-form.ts
@@ -193,8 +193,6 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
   }
 
   const familyMemberHistory = getGroupRepeatedAnswers(questionnaire, response, 'family-member-history');
-  // const relatedPerson = getGroupRepeatedAnswers(questionnaire, response, 'related-person');
-  // console.log(JSON.stringify(response, null, 2));
   for (const history of familyMemberHistory) {
     await addFamilyMemberHistory(medplum, patient, history);
   }

--- a/examples/medplum-patient-intake-demo/src/bots/core/intake-form.ts
+++ b/examples/medplum-patient-intake-demo/src/bots/core/intake-form.ts
@@ -1,12 +1,5 @@
 import { BotEvent, createReference, getQuestionnaireAnswers, MedplumClient } from '@medplum/core';
-import {
-  Address,
-  HumanName,
-  Patient,
-  Questionnaire,
-  QuestionnaireResponse,
-  QuestionnaireResponseItemAnswer,
-} from '@medplum/fhirtypes';
+import { Patient, Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import {
   addAllergy,
   addCondition,
@@ -21,6 +14,8 @@ import {
   convertDateToDateTime,
   extensionURLMapping,
   getGroupRepeatedAnswers,
+  getHumanName,
+  getPatientAddress,
   observationCategoryMapping,
   observationCodeMapping,
   setExtension,
@@ -198,6 +193,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
   }
 
   const familyMemberHistory = getGroupRepeatedAnswers(questionnaire, response, 'family-member-history');
+  // const relatedPerson = getGroupRepeatedAnswers(questionnaire, response, 'related-person');
+  // console.log(JSON.stringify(response, null, 2));
   for (const history of familyMemberHistory) {
     await addFamilyMemberHistory(medplum, patient, history);
   }
@@ -250,52 +247,4 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
     consentPolicyRuleMapping.adr,
     convertDateToDateTime(answers['acknowledgement-for-advance-directives-date']?.valueDate)
   );
-}
-
-function getHumanName(
-  answers: Record<string, QuestionnaireResponseItemAnswer>,
-  prefix: string = ''
-): HumanName | undefined {
-  const patientName: HumanName = {};
-
-  const givenName = [];
-  if (answers[`${prefix}first-name`]?.valueString) {
-    givenName.push(answers[`${prefix}first-name`].valueString as string);
-  }
-  if (answers[`${prefix}middle-name`]?.valueString) {
-    givenName.push(answers[`${prefix}middle-name`].valueString as string);
-  }
-
-  if (givenName.length > 0) {
-    patientName.given = givenName;
-  }
-
-  if (answers[`${prefix}last-name`]?.valueString) {
-    patientName.family = answers[`${prefix}last-name`].valueString;
-  }
-
-  return Object.keys(patientName).length > 0 ? patientName : undefined;
-}
-
-function getPatientAddress(answers: Record<string, QuestionnaireResponseItemAnswer>): Address | undefined {
-  const patientAddress: Address = {};
-
-  if (answers['street']?.valueString) {
-    patientAddress.line = [answers['street'].valueString];
-  }
-
-  if (answers['city']?.valueString) {
-    patientAddress.city = answers['city'].valueString;
-  }
-
-  if (answers['state']?.valueCoding?.code) {
-    patientAddress.state = answers['state'].valueCoding.code;
-  }
-
-  if (answers['zip']?.valueString) {
-    patientAddress.postalCode = answers['zip'].valueString;
-  }
-
-  // To simplify the demo, we're assuming the address is always a home address
-  return Object.keys(patientAddress).length > 0 ? { use: 'home', type: 'physical', ...patientAddress } : undefined;
 }

--- a/examples/medplum-patient-intake-demo/src/bots/core/intake-utils.test.ts
+++ b/examples/medplum-patient-intake-demo/src/bots/core/intake-utils.test.ts
@@ -32,9 +32,16 @@ describe('getAnswers', async () => {
   test('answer objects have the correct keys', async () => {
     const repeatedAnswers = getGroupRepeatedAnswers(questionnaire, response, 'coverage-information');
 
-    const linkedIds = ['insurance-provider', 'subscriber-id', 'relationship-to-subscriber'];
-
-    expect(Object.keys(repeatedAnswers[0])).toEqual(linkedIds);
-    expect(Object.keys(repeatedAnswers[1])).toEqual(linkedIds);
+    expect(Object.keys(repeatedAnswers[0])).toEqual([
+      'insurance-provider',
+      'subscriber-id',
+      'relationship-to-subscriber',
+    ]);
+    expect(Object.keys(repeatedAnswers[1])).toEqual([
+      'insurance-provider',
+      'subscriber-id',
+      'relationship-to-subscriber',
+      'related-person',
+    ]);
   });
 });

--- a/examples/medplum-patient-intake-demo/src/bots/core/test-data/intake-form-test-data.ts
+++ b/examples/medplum-patient-intake-demo/src/bots/core/test-data/intake-form-test-data.ts
@@ -642,7 +642,7 @@ export const intakeResponse: QuestionnaireResponse = {
         {
           id: 'id-108',
           linkId: 'related-person',
-          text: 'Related Person Information',
+          text: 'Subscriber Information',
           item: [
             {
               id: 'id-109',

--- a/examples/medplum-patient-intake-demo/src/bots/core/test-data/intake-form-test-data.ts
+++ b/examples/medplum-patient-intake-demo/src/bots/core/test-data/intake-form-test-data.ts
@@ -589,9 +589,9 @@ export const intakeResponse: QuestionnaireResponse = {
           answer: [
             {
               valueCoding: {
-                system: 'http://terminology.hl7.org/CodeSystem/v2-0131',
-                code: 'BP',
-                display: 'Billing contact person',
+                system: 'http://terminology.hl7.org/CodeSystem/subscriber-relationship',
+                code: 'self',
+                display: 'Self',
               },
             },
           ],
@@ -632,10 +632,66 @@ export const intakeResponse: QuestionnaireResponse = {
           answer: [
             {
               valueCoding: {
-                system: 'http://terminology.hl7.org/CodeSystem/v2-0131',
-                code: 'BP',
-                display: 'Billing contact person',
+                system: 'http://terminology.hl7.org/CodeSystem/subscriber-relationship',
+                code: 'child',
+                display: 'Child',
               },
+            },
+          ],
+        },
+        {
+          id: 'id-108',
+          linkId: 'related-person',
+          text: 'Related Person Information',
+          item: [
+            {
+              id: 'id-109',
+              linkId: 'related-person-first-name',
+              text: 'First Name',
+              answer: [
+                {
+                  valueString: 'Marge',
+                },
+              ],
+            },
+            {
+              id: 'id-110',
+              linkId: 'related-person-middle-name',
+              text: 'Middle Name',
+            },
+            {
+              id: 'id-111',
+              linkId: 'related-person-last-name',
+              text: 'Last Name',
+              answer: [
+                {
+                  valueString: 'Simpson',
+                },
+              ],
+            },
+            {
+              id: 'id-112',
+              linkId: 'related-person-dob',
+              text: 'Date of Birth',
+              answer: [
+                {
+                  valueDate: '1958-03-19',
+                },
+              ],
+            },
+            {
+              id: 'id-113',
+              linkId: 'related-person-gender-identity',
+              text: 'Gender Identity',
+              answer: [
+                {
+                  valueCoding: {
+                    system: 'http://snomed.info/sct',
+                    code: '446141000124107',
+                    display: 'Identifies as female gender (finding)',
+                  },
+                },
+              ],
             },
           ],
         },


### PR DESCRIPTION
## Description

- Resolves #5161
- Create a `RelatedPerson` resource for the `Patient` depending on the `Coverage.relationship`

## Steps to test

- [ ] Build the bots: `npm run build:bots`
- [ ] Upload data
  ![image](https://github.com/user-attachments/assets/3aef804a-c148-40a0-b4f6-24d561f1421e)
- [ ] Set up patient coverage with a subscriber relationship (e.g., spouse, child, parent) to automatically create a `RelatedPerson` resource.

[Screencast from 02-09-2024 17:33:03.webm](https://github.com/user-attachments/assets/983a45db-75e7-40ca-be74-6ede02e87a6a)



