### PR TITLE
Include the URL for OAUTH on localhost.

### DIFF
--- a/packages/docs/docs/auth/methods/client-credentials.md
+++ b/packages/docs/docs/auth/methods/client-credentials.md
@@ -32,7 +32,7 @@ curl -X POST https://api.medplum.com/oauth2/token \
 ```
   </TabItem>
   
-  Note: If you are hosting this on localhost, without editing the configuration file, the URL will be http:<nolink>//localhost:8103/oauth2/token .
+  Note: If you are hosting this on localhost, without editing the configuration file, the URL will be http:<nolink></nolink>//localhost:8103/oauth2/token .
 
   <TabItem value="python" label="Python">
 

--- a/packages/docs/docs/auth/methods/client-credentials.md
+++ b/packages/docs/docs/auth/methods/client-credentials.md
@@ -30,8 +30,10 @@ curl -X POST https://api.medplum.com/oauth2/token \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "grant_type=client_credentials&client_id=$MY_CLIENT_ID&client_secret=$MY_CLIENT_SECRET"
 ```
-
   </TabItem>
+  
+  Note: If you are hosting this on localhost, without editing the configuration file, the URL will be http:<nolink>//localhost:8103/oauth2/token .
+
   <TabItem value="python" label="Python">
 
 ```py


### PR DESCRIPTION
The instructions indicate how to get an OAUTH token on the medplum server, but not self-hosted on localhost.