### PR TITLE
Use default max search results for _(rev)include circuit breaker

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -424,7 +424,7 @@ async function getExtraEntries<T extends Resource>(
   let depth = 0;
   while (base.length > 0) {
     // Circuit breaker / load limit
-    if (depth >= 5 || entries.length > 1000) {
+    if (depth >= 5 || entries.length > maxSearchResults) {
       throw new Error(`Search with _(rev)include reached query scope limit: depth=${depth}, results=${entries.length}`);
     }
 


### PR DESCRIPTION
Hey team- ran into this in our self-hosted instance. We had increased [that value](https://github.com/medplum/medplum/blob/cd10c14c048b16077f92c7081f8df5ca34c1e524/packages/core/src/search/search.ts#L8) for our use case but hit this on a request using `_include`. Is this circuit breaker fundamentally different from the max search results?