### PR TITLE
tweak(core): align `.isLoading()` to what was previously perceived in React

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2771,12 +2771,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   /**
-   * Returns true if the client is waiting for authentication.
-   * @returns True if the client is waiting for authentication.
+   * Returns true if the client is waiting for initial authentication.
+   * @returns True if the client is waiting for initial authentication.
    * @category Authentication
    */
   isLoading(): boolean {
-    return !this.isInitialized || !!this.profilePromise;
+    return !this.isInitialized || (!!this.profilePromise && !this.sessionDetails?.profile);
   }
 
   /**


### PR DESCRIPTION
`MedplumClient.isLoading()` is currently used in examples to prevent render before being authed, but with our new events that keep the `MedplumProvider` more in sync with `MedplumClient`, we read `.isLoading()` more frequently, and in many cases it is now evaluating to true, ie. when a profile is just being refreshed. This causes unmounting in many cases and is probably not the behavior that most users would expect, and in many cases it is an unintentional downstream breaking change.

This PR would bring `isLoading()` in line with the behavior previously observed from the perspective of users of the `useMedplum` hook. It is technically a breaking change from the previous explicit contract, though it fixes a "regression" from the perspective of React.