### PR TITLE
Fix Permissions-Policy HTTP header

### DIFF
--- a/packages/cdk/src/frontend.ts
+++ b/packages/cdk/src/frontend.ts
@@ -59,7 +59,7 @@ export class FrontEnd extends Construct {
         customHeadersBehavior: {
           customHeaders: [
             {
-              header: 'Permission-Policy',
+              header: 'Permissions-Policy',
               value:
                 'accelerometer=(), camera=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()',
               override: true,

--- a/packages/cdk/src/storage.ts
+++ b/packages/cdk/src/storage.ts
@@ -81,7 +81,7 @@ export class Storage extends Construct {
         customHeadersBehavior: {
           customHeaders: [
             {
-              header: 'Permission-Policy',
+              header: 'Permissions-Policy',
               value:
                 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()',
               override: true,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -74,7 +74,7 @@ function standardHeaders(_req: Request, res: Response, next: NextFunction): void
 
   // Disable browser features
   res.set(
-    'Permission-Policy',
+    'Permissions-Policy',
     'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()'
   );
 


### PR DESCRIPTION
It's `Permissions-Policy`, not `Permission-Policy` 🤦 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy