### PR TITLE
Update graphiql introspection url default

### DIFF
--- a/packages/graphiql/.env.defaults
+++ b/packages/graphiql/.env.defaults
@@ -1,1 +1,2 @@
 MEDPLUM_BASE_URL=http://localhost:8103/
+MEDPLUM_INTROSPECTION_URL=https://graphiql.medplum.com/schema/schema-latest.json

--- a/packages/graphiql/src/index.tsx
+++ b/packages/graphiql/src/index.tsx
@@ -61,11 +61,11 @@ const theme = createTheme({
   },
 });
 
-function fetcher(params: FetcherParams): Promise<SyncExecutionResult> {
+async function fetcher(params: FetcherParams): Promise<SyncExecutionResult> {
   if (params.operationName === 'IntrospectionQuery') {
     const config = getConfig().introspectionUrl;
     if (config) {
-      return fetch(config).then((res) => res.json());
+      return (await fetch(config)).json();
     }
   }
   return medplum.graphql(params.query, params.operationName, params.variables);

--- a/scripts/deploy-graphiql.sh
+++ b/scripts/deploy-graphiql.sh
@@ -2,17 +2,11 @@
 
 pushd packages/graphiql
 
-# No cache
-
-aws s3 cp dist/ s3://graphiql.medplum.com/ \
-  --region us-east-1 \
-  --recursive \
-  --content-type "text/html" \
-  --cache-control "no-cache" \
-  --exclude "*" \
-  --include "*.html"
-
-# Cache forever
+# First deploy hashed files that are cached forever
+# It is important to deploy these files first,
+# because they are referenced by the index.html file.
+# If a user attempts to download a hashed file that doesn't exist,
+# it can cause a bad cache entry in CloudFront.
 
 aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --region us-east-1 \
@@ -44,5 +38,18 @@ aws s3 cp dist/ s3://graphiql.medplum.com/ \
   --cache-control "public, max-age=31536000" \
   --exclude "*" \
   --include "*.txt"
+
+# Now deploy named files that are not cached.
+# These are small lightweight files that are not hashed.
+# It is important to deploy these files last,
+# because they reference the previously uploaded hashed files.
+
+aws s3 cp dist/ s3://graphiql.medplum.com/ \
+  --region us-east-1 \
+  --recursive \
+  --content-type "text/html" \
+  --cache-control "no-cache" \
+  --exclude "*" \
+  --include "*.html"
 
 popd


### PR DESCRIPTION
None of these changes should be required, so this is more of an experiment.

The `MEDPLUM_INTROSPECTION_URL` value should come from Github Actions Secrets, which is defined:

![image](https://github.com/user-attachments/assets/e8fe7d67-0668-480b-bc5f-f7ab89c7be81)

The `MEDPLUM_INTROSPECTION_URL` environment variable should be passed along:
* `deploy.yml`: https://github.com/medplum/medplum/blob/main/.github/workflows/deploy.yml#L65
* `cicd-deploy.sh`: uses `source deploy-graphiql.sh`, which should pass env vars
* `deploy-graphiql.sh`
