### PR TITLE
fix(core): on `activeLogin` change, check against `profile.reference` instead of `profile.id`

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2425,7 +2425,7 @@ describe('Client', () => {
         profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
       }),
     } as StorageEvent);
-    expect(mockReload).not.toHaveBeenCalled();
+    expect(mockReload).toHaveBeenCalled();
 
     // Should refresh when going from a profile to no profile (logged out)
     mockReload.mockReset();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2362,7 +2362,7 @@ describe('Client', () => {
     );
   });
 
-  test.only('Storage events', async () => {
+  test('Storage events', async () => {
     // Make window.location writeable
     Object.defineProperty(window, 'location', {
       value: { assign: {} },

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -4,6 +4,8 @@ import {
   Identifier,
   OperationOutcome,
   Patient,
+  Practitioner,
+  Reference,
   SearchParameter,
   StructureDefinition,
 } from '@medplum/fhirtypes';
@@ -2360,7 +2362,7 @@ describe('Client', () => {
     );
   });
 
-  test('Storage events', async () => {
+  test.only('Storage events', async () => {
     // Make window.location writeable
     Object.defineProperty(window, 'location', {
       value: { assign: {} },
@@ -2392,8 +2394,12 @@ describe('Client', () => {
     mockReload.mockReset();
     callback({
       key: 'activeLogin',
-      oldValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: practitioner1 } }),
-      newValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: practitioner1 } }),
+      oldValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
+      }),
+      newValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
+      }),
     } as StorageEvent);
     expect(mockReload).not.toHaveBeenCalled();
 
@@ -2401,26 +2407,34 @@ describe('Client', () => {
     mockReload.mockReset();
     callback({
       key: 'activeLogin',
-      oldValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: practitioner1 } }),
-      newValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: practitioner2 } }),
+      oldValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
+      }),
+      newValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner2}` } satisfies Reference<Practitioner>,
+      }),
     } as StorageEvent);
     expect(mockReload).toHaveBeenCalled();
 
-    // Should refresh when going to a new profile from no profile
+    // Should refresh when going from no profile to a new profile
     mockReload.mockReset();
     callback({
       key: 'activeLogin',
-      oldValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: null } }),
-      newValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: practitioner1 } }),
+      oldValue: null,
+      newValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
+      }),
     } as StorageEvent);
-    expect(mockReload).toHaveBeenCalled();
+    expect(mockReload).not.toHaveBeenCalled();
 
     // Should refresh when going from a profile to no profile (logged out)
     mockReload.mockReset();
     callback({
       key: 'activeLogin',
-      oldValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: practitioner1 } }),
-      newValue: JSON.stringify({ profile: { resourceType: 'Practitioner', id: null } }),
+      oldValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
+      }),
+      newValue: null,
     } as StorageEvent);
     expect(mockReload).toHaveBeenCalled();
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3824,7 +3824,6 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         // On storage clear (key === null) or profile change (key === 'activeLogin', and profile in 'activeLogin' is different)
         // Refresh the page to ensure the active login is up to date.
         if (e.key === null) {
-          console.log('HERE');
           window.location.reload();
         } else if (e.key === 'activeLogin') {
           const oldState = (e.oldValue ? JSON.parse(e.oldValue) : undefined) as LoginState | undefined;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3824,11 +3824,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         // On storage clear (key === null) or profile change (key === 'activeLogin', and profile in 'activeLogin' is different)
         // Refresh the page to ensure the active login is up to date.
         if (e.key === null) {
+          console.log('HERE');
           window.location.reload();
         } else if (e.key === 'activeLogin') {
           const oldState = (e.oldValue ? JSON.parse(e.oldValue) : undefined) as LoginState | undefined;
           const newState = (e.newValue ? JSON.parse(e.newValue) : undefined) as LoginState | undefined;
-          if (oldState?.profile.id !== newState?.profile.id) {
+          if (oldState?.profile.reference !== newState?.profile.reference) {
             window.location.reload();
           }
         }


### PR DESCRIPTION
[Original PR](https://github.com/medplum/medplum/pull/5256) missed that `ActiveLogin.profile` is a `Reference<ProfileResource>` and not a `ProfileResource` like `profile` in `MedplumClient` is. However, `Reference` types have an optional `id` field and so types didn't catch this bug.

This should actually fix #5255