### PR TITLE
Update Refresh Token in Memory

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_ACCEPT,
   FetchLike,
   InviteRequest,
+  LoginState,
   MedplumClient,
   MedplumClientEventMap,
   NewPatientRequest,
@@ -2395,13 +2396,20 @@ describe('Client', () => {
     callback({
       key: 'activeLogin',
       oldValue: JSON.stringify({
-        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
-      }),
+        profile: { reference: `Practitioner/${practitioner1}` },
+        project: { reference: 'Project/123' },
+        accessToken: '12345',
+        refreshToken: 'abcde',
+      } satisfies LoginState),
       newValue: JSON.stringify({
-        profile: { reference: `Practitioner/${practitioner1}` } satisfies Reference<Practitioner>,
-      }),
+        profile: { reference: `Practitioner/${practitioner1}` },
+        project: { reference: 'Project/123' },
+        accessToken: '6789',
+        refreshToken: 'fghi',
+      } satisfies LoginState),
     } as StorageEvent);
     expect(mockReload).not.toHaveBeenCalled();
+    expect(client.getAccessToken()).toBe('6789');
 
     // Should refresh when we change to a new profile
     mockReload.mockReset();

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2472,7 +2472,7 @@ describe('Client', () => {
     } as StorageEvent);
     expect(mockReload).toHaveBeenCalled();
 
-    // Should NOT refresh if sessionDetails.profile.id is not the same as the ID of the profile in the newEvent
+    // Should NOT refresh if sessionDetails.profile.id IS the same as the ID of the profile in the newEvent
     mockReload.mockReset();
     // @ts-expect-error This is a no-no, overriding private field
     client.sessionDetails = { profile: { id: practitioner1 } as Practitioner };

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2450,6 +2450,48 @@ describe('Client', () => {
     mockReload.mockReset();
     callback({ key: null });
     expect(mockReload).toHaveBeenCalled();
+
+    // Should refresh if sessionDetails.profile.id is not the same as the ID of the profile in the newEvent
+    mockReload.mockReset();
+    // @ts-expect-error This is a no-no, overriding private field
+    client.sessionDetails = { profile: { id: randomUUID() } as Practitioner };
+    callback({
+      key: 'activeLogin',
+      oldValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` },
+        project: { reference: 'Project/123' },
+        accessToken: '12345',
+        refreshToken: 'abcde',
+      } satisfies LoginState),
+      newValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` },
+        project: { reference: 'Project/123' },
+        accessToken: '6789',
+        refreshToken: 'fghi',
+      } satisfies LoginState),
+    } as StorageEvent);
+    expect(mockReload).toHaveBeenCalled();
+
+    // Should NOT refresh if sessionDetails.profile.id is not the same as the ID of the profile in the newEvent
+    mockReload.mockReset();
+    // @ts-expect-error This is a no-no, overriding private field
+    client.sessionDetails = { profile: { id: practitioner1 } as Practitioner };
+    callback({
+      key: 'activeLogin',
+      oldValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` },
+        project: { reference: 'Project/123' },
+        accessToken: '12345',
+        refreshToken: 'abcde',
+      } satisfies LoginState),
+      newValue: JSON.stringify({
+        profile: { reference: `Practitioner/${practitioner1}` },
+        project: { reference: 'Project/123' },
+        accessToken: '6789',
+        refreshToken: 'fghi',
+      } satisfies LoginState),
+    } as StorageEvent);
+    expect(mockReload).not.toHaveBeenCalled();
   });
 
   test('setAccessToken', async () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3830,6 +3830,10 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
           const newState = (e.newValue ? JSON.parse(e.newValue) : undefined) as LoginState | undefined;
           if (oldState?.profile.reference !== newState?.profile.reference) {
             window.location.reload();
+          } else if (newState) {
+            this.setAccessToken(newState.accessToken, newState.refreshToken);
+          } else {
+            this.clear();
           }
         }
       });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3813,6 +3813,16 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     });
   }
 
+  private checkSessionDetailsMatchLogin(login?: LoginState): boolean {
+    // We only need to validate if we already have session details
+    if (!(this.sessionDetails && login)) {
+      return true;
+    }
+    // Make sure sessionDetails.profile.id matches the ID in the profile reference we are checking against
+    // Otherwise return false if no profile reference in login
+    return login.profile?.reference?.endsWith(this.sessionDetails.profile.id as string) ?? false;
+  }
+
   /**
    * Sets up a listener for window storage events.
    * This synchronizes state across browser windows and browser tabs.
@@ -3828,11 +3838,15 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         } else if (e.key === 'activeLogin') {
           const oldState = (e.oldValue ? JSON.parse(e.oldValue) : undefined) as LoginState | undefined;
           const newState = (e.newValue ? JSON.parse(e.newValue) : undefined) as LoginState | undefined;
-          if (oldState?.profile.reference !== newState?.profile.reference) {
+          if (
+            oldState?.profile.reference !== newState?.profile.reference ||
+            !this.checkSessionDetailsMatchLogin(newState)
+          ) {
             window.location.reload();
           } else if (newState) {
             this.setAccessToken(newState.accessToken, newState.refreshToken);
           } else {
+            // Theoretically this should never be called, but we might want to keep it here just in case
             this.clear();
           }
         }


### PR DESCRIPTION
Follow up to #5256 - The original PR modified the page refresh logic upon receiving an update to storage, but it didn't update the token state in the MedplumClient's memory

This is a continuation of the fix for #5255