### PR TITLE
fix(docs): fix broken `auth/methods/client-credentials` page

### DIFF
--- a/packages/docs/docs/auth/methods/client-credentials.md
+++ b/packages/docs/docs/auth/methods/client-credentials.md
@@ -30,9 +30,8 @@ curl -X POST https://api.medplum.com/oauth2/token \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "grant_type=client_credentials&client_id=$MY_CLIENT_ID&client_secret=$MY_CLIENT_SECRET"
 ```
+
   </TabItem>
-  
-  Note: If you are hosting this on localhost, without editing the configuration file, the URL will be http:<nolink></nolink>//localhost:8103/oauth2/token .
 
   <TabItem value="python" label="Python">
 
@@ -55,6 +54,8 @@ def get_auth_token(url, client_id, client_secret):
 
   </TabItem>
 </BrowserOnlyTabs>
+
+**Note:** If you are hosting this on localhost, without editing the configuration file, the URL will be `http://localhost:8103/oauth2/token`
 
 On success, the response will be a JSON object with the following properties:
 


### PR DESCRIPTION
Fixes #5295

The page was broken because all children of `Tabs` have to be `TabItem`s and the free-floating text becomes a `p` element.