### PR TITLE
Update search docs to highlight _offset limits

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1558,7 +1558,8 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * Creates an
    * [async generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator)
    * over a series of FHIR search requests for paginated search results. Each iteration of the generator yields
-   * the array of resources on each page.
+   * the array of resources on each page. Searches using _offset based pagination are limited to 10,000 records.
+   * For larger result sets, _cursor based pagination should be used instead.
    *
    * @example
    *

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1560,6 +1560,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * over a series of FHIR search requests for paginated search results. Each iteration of the generator yields
    * the array of resources on each page. Searches using _offset based pagination are limited to 10,000 records.
    * For larger result sets, _cursor based pagination should be used instead.
+   * See: https://www.medplum.com/docs/search/paginated-search#cursor-based-pagination
    *
    * @example
    *

--- a/packages/docs/docs/search/paginated-search.mdx
+++ b/packages/docs/docs/search/paginated-search.mdx
@@ -38,10 +38,10 @@ GET /Patient?_offset=20
 
 This request would return results starting from the 21st matching Patient resource.
 
-#### Limitations:
-
+:::caution Limitations:
 - Our server supports `_offset` values up to 10,000.
 - Offset-based pagination can lead to performance issues with very large datasets.
+:::
 
 #### Implementation Details:
 


### PR DESCRIPTION
This PR updates the search pagination documentation to highlight that `_offset` based pagination is limited to 10,000 records. 
#5252 

<img width="1840" alt="Screenshot 2024-09-24 at 8 45 32 AM" src="https://github.com/user-attachments/assets/ea31ebc0-3edd-483b-bfa0-64e71528374d">
