### PR TITLE
Actually fail esbuild in catch

### DIFF
--- a/packages/agent/esbuild.mjs
+++ b/packages/agent/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import esbuild from 'esbuild';
@@ -24,4 +25,7 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/cdk/esbuild.mjs
+++ b/packages/cdk/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import esbuild from 'esbuild';
@@ -35,7 +36,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -44,4 +48,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/cli/esbuild.mjs
+++ b/packages/cli/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import esbuild from 'esbuild';
@@ -40,7 +41,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -49,4 +53,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/cli/esbuild.mjs
+++ b/packages/cli/esbuild.mjs
@@ -10,7 +10,7 @@ const options = {
   bundle: true,
   platform: 'node',
   loader: { '.ts': 'ts' },
-  resolveExtensions: ['.ts'],
+  resolveExtensions: ['.ts', '.js'],
   target: 'es2021',
   tsconfig: 'tsconfig.json',
   minify: true,

--- a/packages/core/esbuild.mjs
+++ b/packages/core/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import { execSync } from 'child_process';
@@ -9,7 +10,7 @@ import packageJson from './package.json' with { type: 'json' };
 let gitHash;
 try {
   gitHash = execSync('git rev-parse --short HEAD').toString().trim();
-} catch (error) {
+} catch (_error) {
   gitHash = 'unknown'; // Default value when not in a git repository
 }
 
@@ -38,7 +39,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -47,4 +51,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/expo-polyfills/esbuild.mjs
+++ b/packages/expo-polyfills/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 import esbuild from 'esbuild';
 import { nodeExternalsPlugin } from 'esbuild-node-externals';
@@ -24,7 +25,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -33,4 +37,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/fhir-router/esbuild.mjs
+++ b/packages/fhir-router/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import esbuild from 'esbuild';
@@ -24,7 +25,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -33,4 +37,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/hl7/esbuild.mjs
+++ b/packages/hl7/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import esbuild from 'esbuild';
@@ -24,7 +25,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -33,4 +37,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/mock/esbuild.mjs
+++ b/packages/mock/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import esbuild from 'esbuild';
@@ -24,7 +25,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -33,4 +37,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/react-hooks/esbuild.mjs
+++ b/packages/react-hooks/esbuild.mjs
@@ -1,4 +1,5 @@
 /* global console */
+/* global process */
 /* eslint no-console: "off" */
 
 import dotenv from 'dotenv';
@@ -30,7 +31,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -39,4 +43,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/packages/react/esbuild.mjs
+++ b/packages/react/esbuild.mjs
@@ -47,7 +47,10 @@ esbuild
     outfile: './dist/cjs/index.cjs',
   })
   .then(() => writeFileSync('./dist/cjs/package.json', '{"type": "commonjs"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 
 esbuild
   .build({
@@ -56,4 +59,7 @@ esbuild
     outfile: './dist/esm/index.mjs',
   })
   .then(() => writeFileSync('./dist/esm/package.json', '{"type": "module"}'))
-  .catch(console.error);
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
@ianplunkett discovered that `@medplum/cli` was failing to build locally. That build failure was due to needing to change the esbuild config a bit. More importantly, this uncovered that our pattern of `.catch(console.error)` in esbuild scripts was effectively suppressing build failures.