### PR TITLE
Upgrade shawl to v1.5.0

### DIFF
--- a/packages/agent/installer.nsi
+++ b/packages/agent/installer.nsi
@@ -170,14 +170,14 @@ Function UpgradeApp
     DetailPrint "Exit code $1"
 
     # Copy the new files to the installation directory
-    File dist\shawl-v1.4.0-legal.txt
-    File dist\shawl-v1.4.0-win64.exe
+    File dist\shawl-v1.5.0-legal.txt
+    File dist\shawl-v1.5.0-win64.exe
     File dist\${SERVICE_FILE_NAME}
     File README.md
 
     # Create the service
     DetailPrint "Creating service..."
-    ExecWait "shawl-v1.4.0-win64.exe add --name $\"${SERVICE_NAME}$\" --log-as $\"${SERVICE_NAME}$\" --cwd $\"$INSTDIR$\" -- $\"$INSTDIR\${SERVICE_FILE_NAME}$\"" $1
+    ExecWait "shawl-v1.5.0-win64.exe add --name $\"${SERVICE_NAME}$\" --log-as $\"${SERVICE_NAME}$\" --cwd $\"$INSTDIR$\" -- $\"$INSTDIR\${SERVICE_FILE_NAME}$\"" $1
     DetailPrint "Exit code $1"
 
     # Set service display name
@@ -224,8 +224,8 @@ Function InstallApp
     DetailPrint "Agent ID: $agentId"
 
     # Copy the service files to the root directory
-    File dist\shawl-v1.4.0-legal.txt
-    File dist\shawl-v1.4.0-win64.exe
+    File dist\shawl-v1.5.0-legal.txt
+    File dist\shawl-v1.5.0-win64.exe
     File dist\${SERVICE_FILE_NAME}
     File README.md
 
@@ -239,7 +239,7 @@ Function InstallApp
 
     # Create the service
     DetailPrint "Creating service..."
-    ExecWait "shawl-v1.4.0-win64.exe add --name $\"${SERVICE_NAME}$\" --log-as $\"${SERVICE_NAME}$\" --cwd $\"$INSTDIR$\" -- $\"$INSTDIR\${SERVICE_FILE_NAME}$\"" $1
+    ExecWait "shawl-v1.5.0-win64.exe add --name $\"${SERVICE_NAME}$\" --log-as $\"${SERVICE_NAME}$\" --cwd $\"$INSTDIR$\" -- $\"$INSTDIR\${SERVICE_FILE_NAME}$\"" $1
     DetailPrint "Exit code $1"
 
     # Set service display name

--- a/scripts/build-agent-installer-win64.sh
+++ b/scripts/build-agent-installer-win64.sh
@@ -92,16 +92,16 @@ if [ ! SKIP_SIGNING ]; then
 fi
 
 # Download Shawl exe
-rm -f shawl-v1.4.0-win64.zip
-wget https://github.com/mtkennerly/shawl/releases/download/v1.4.0/shawl-v1.4.0-win64.zip
-unzip shawl-v1.4.0-win64.zip
-mv shawl.exe dist/shawl-v1.4.0-win64.exe
+rm -f shawl-v1.5.0-win64.zip
+wget https://github.com/mtkennerly/shawl/releases/download/v1.5.0/shawl-v1.5.0-win64.zip
+unzip shawl-v1.5.0-win64.zip
+mv shawl.exe dist/shawl-v1.5.0-win64.exe
 
 # Download Shawl legal
-rm -f shawl-v1.4.0-legal.zip
-wget https://github.com/mtkennerly/shawl/releases/download/v1.4.0/shawl-v1.4.0-legal.zip
-unzip shawl-v1.4.0-legal.zip
-mv shawl-v1.4.0-legal.txt dist
+rm -f shawl-v1.5.0-legal.zip
+wget https://github.com/mtkennerly/shawl/releases/download/v1.5.0/shawl-v1.5.0-legal.zip
+unzip shawl-v1.5.0-legal.zip
+mv shawl-v1.5.0-legal.txt dist
 
 if [ ! SKIP_SIGNING ]; then
   # Sign the Shawl executable
@@ -109,7 +109,7 @@ if [ ! SKIP_SIGNING ]; then
     --storetype DIGICERTONE \
     --storepass "$SM_API_KEY|$SM_CLIENT_CERT_FILE|$SM_CLIENT_CERT_PASSWORD" \
     --alias "$SM_CERT_ALIAS" \
-    dist/shawl-v1.4.0-win64.exe
+    dist/shawl-v1.5.0-win64.exe
 fi
 
 # Build the installer


### PR DESCRIPTION
Upgrade `shawl`, the tool that allows the Medplum agent to run as a Windows Service.

https://github.com/mtkennerly/shawl/releases/tag/v1.5.0

This is prework for #4497 and #4498 