### PR TITLE
Rewrite simple chained search for efficiency

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -935,6 +935,21 @@ describe('FHIR Search', () => {
         expect(searchResult2.entry?.length).toEqual(0);
       }));
 
+    test('Filter by chained _id', () =>
+      withTestContext(async () => {
+        const organizationId = randomUUID();
+
+        const patient = await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          managingOrganization: { reference: 'Organization/' + organizationId },
+        });
+
+        const searchResult1 = await repo.search(parseSearchRequest('Patient?organization._id=' + organizationId));
+
+        expect(searchResult1.entry?.length).toEqual(1);
+        expect(bundleContains(searchResult1 as Bundle, patient as Patient)).toBeDefined();
+      }));
+
     test('Empty _id', async () =>
       withTestContext(async () => {
         const searchResult1 = await repo.search({

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1292,6 +1292,17 @@ function buildChainedSearch(
     throw new OperationOutcomeError(badRequest('Search chains longer than three links are not currently supported'));
   }
 
+  // Special case: single-link chain of the form param._id=<id> can be rewritten as param=ResourceType/<id>
+  if (param.chain.length === 1 && param.chain[0].filter?.code === '_id') {
+    const searchParam = param.chain[0];
+    const targetId = searchParam.filter?.value;
+    return buildSearchFilterExpression(repo, selectQuery, resourceType as ResourceType, resourceType, {
+      code: searchParam.code,
+      operator: Operator.EQUALS,
+      value: `${searchParam.resourceType}/${targetId}`,
+    });
+  }
+
   if (usesReferenceLookupTable(repo)) {
     return buildChainedSearchUsingReferenceTable(repo, selectQuery, resourceType, param);
   } else {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1293,13 +1293,15 @@ function buildChainedSearch(
   }
 
   // Special case: single-link chain of the form param._id=<id> can be rewritten as param=ResourceType/<id>
+  // Note that this does slightly change the behavior of the search query: true chained search would require the
+  // reference to point to an existing resource, while the rewritten query just matches the reference string
   if (param.chain.length === 1 && param.chain[0].filter?.code === '_id') {
-    const searchParam = param.chain[0];
-    const targetId = searchParam.filter?.value;
+    const { resourceType: targetType, code, filter } = param.chain[0];
+    const targetId = filter.value;
     return buildSearchFilterExpression(repo, selectQuery, resourceType as ResourceType, resourceType, {
-      code: searchParam.code,
+      code,
       operator: Operator.EQUALS,
-      value: `${searchParam.resourceType}/${targetId}`,
+      value: `${targetType}/${targetId}`,
     });
   }
 


### PR DESCRIPTION
Special cased handling of a single-link chained search to rewrite e.g. `param._id=<id>` as `param=ResourceType/<id>`.  This results in a much more efficient search query that does not need to join multiple extra tables.  Note that this does slightly change the behavior of the search query: true chained search would require the reference to point to an existing resource, while the rewritten query just matches the reference string