### PR TITLE
Update docs to reflect default config location

### DIFF
--- a/packages/cli/src/aws/index.ts
+++ b/packages/cli/src/aws/index.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { createMedplumCommand } from '../util/command';
+import { color, createMedplumCommand, processDescription } from '../util/command';
 import { describeStacksCommand } from './describe';
 import { initStackCommand } from './init';
 import { listStacksCommand } from './list';
@@ -7,7 +7,6 @@ import { updateAppCommand } from './update-app';
 import { updateBucketPoliciesCommand } from './update-bucket-policies';
 import { updateConfigCommand } from './update-config';
 import { updateServerCommand } from './update-server';
-import { processDescription } from '../util/command';
 
 export function buildAwsCommand(): Command {
   const aws = new Command('aws').description('Commands to manage AWS resources');
@@ -25,9 +24,11 @@ export function buildAwsCommand(): Command {
   aws
     .command('update-config')
     .alias('deploy-config')
+    .summary('Update the AWS Parameter Store config values.')
     .description(
       processDescription(
-        'Update the AWS Parameter Store config values.\n\nConfiguration values come from a file named **medplum.<tag>.config.server.json** where **<tag>** is the Medplum stack tag.\n\n**Services must be restarted to apply changes.**'
+        'Update the AWS Parameter Store config values.\n\nConfiguration values come from a file named **medplum.<tag>.config.server.json** where **<tag>** is the Medplum stack tag.\n\n' +
+          color.yellow('**Services must be restarted to apply changes.**')
       )
     )
     .argument('<tag>', 'The Medplum stack tag')

--- a/packages/cli/src/aws/index.ts
+++ b/packages/cli/src/aws/index.ts
@@ -7,6 +7,7 @@ import { updateAppCommand } from './update-app';
 import { updateBucketPoliciesCommand } from './update-bucket-policies';
 import { updateConfigCommand } from './update-config';
 import { updateServerCommand } from './update-server';
+import { processDescription } from '../util/command';
 
 export function buildAwsCommand(): Command {
   const aws = new Command('aws').description('Commands to manage AWS resources');
@@ -24,9 +25,18 @@ export function buildAwsCommand(): Command {
   aws
     .command('update-config')
     .alias('deploy-config')
-    .description('Update the AWS Parameter Store config values')
+    .description(
+      processDescription(
+        'Update the AWS Parameter Store config values.\n\nConfiguration values come from a file named **medplum.<tag>.config.server.json** where **<tag>** is the Medplum stack tag.\n\n**Services must be restarted to apply changes.**'
+      )
+    )
     .argument('<tag>', 'The Medplum stack tag')
-    .option('--file [file]', 'Specifies the config file to use. If not specified, the file is based on the tag.')
+    .option(
+      '--file [file]',
+      processDescription(
+        'File to provide overrides for **apiPort**, **baseUrl**, **appDomainName** and **storageDomainName** values that appear in the config file.'
+      )
+    )
     .option(
       '--dryrun',
       'Displays the operations that would be performed using the specified command without actually running them.'

--- a/packages/cli/src/aws/update-config.test.ts
+++ b/packages/cli/src/aws/update-config.test.ts
@@ -73,11 +73,8 @@ describe('update-config command', () => {
       'utf8'
     );
 
-    readline.createInterface = jest.fn(() =>
-      mockReadline(
-        'y' // Yes, write to Parameter Store
-      )
-    );
+    // Mock readline.createInterface for two calls
+    (readline.createInterface as jest.Mock).mockImplementation(() => mockReadline('y', 'y'));
 
     await main(['node', 'index.js', 'aws', 'update-config', tag]);
     unlinkSync(infraFileName);

--- a/packages/cli/src/aws/update-config.ts
+++ b/packages/cli/src/aws/update-config.ts
@@ -1,7 +1,8 @@
 import { MedplumInfraConfig } from '@medplum/core';
-import { readConfig, readServerConfig } from '../utils';
+import { readConfig, readServerConfig, getConfigFileName } from '../utils';
 import { closeTerminal, initTerminal, print, yesOrNo } from './terminal';
 import { printConfigNotFound, writeParameters } from './utils';
+import { color } from '../util/command';
 
 export interface UpdateConfigOptions {
   file?: string;
@@ -26,6 +27,16 @@ export async function updateConfigCommand(tag: string, options: UpdateConfigOpti
 
     const serverConfig = readServerConfig(tag) ?? {};
 
+    // If the server config is empty, prompt the user to proceed
+    if (!options.yes && Object.keys(serverConfig).length === 0) {
+      const serverConfigFileName = getConfigFileName(tag, { server: true });
+      console.log(color.yellow(`Config file ${serverConfigFileName} not found!`));
+      if (!(await yesOrNo('Do you want to proceed?'))) {
+        console.log(color.red(`Run Aborted, please ensure ${serverConfigFileName} is present and try again.`));
+        return;
+      }
+    }
+
     checkConfigConflicts(infraConfig, serverConfig);
     mergeConfigs(infraConfig, serverConfig);
 
@@ -45,7 +56,9 @@ export async function updateConfigCommand(tag: string, options: UpdateConfigOpti
       )
     );
 
-    if (options.yes || (await yesOrNo('Do you want to store these values in AWS Parameter Store?'))) {
+    if (options.dryrun) {
+      console.log(color.yellow('Dry run - skipping updates!'));
+    } else if (options.yes || (await yesOrNo('Do you want to store these values in AWS Parameter Store?'))) {
       await writeParameters(
         infraConfig.region,
         `/medplum/${infraConfig.name}/`,

--- a/packages/cli/src/util/command.test.ts
+++ b/packages/cli/src/util/command.test.ts
@@ -1,0 +1,56 @@
+import { color, processDescription } from './command';
+
+describe('CLI Color Utilities', () => {
+  // Tests for color object
+  describe('color object', () => {
+    test('red function adds red color codes', () => {
+      expect(color.red('test')).toBe('\x1b[31mtest\x1b[0m');
+    });
+
+    test('green function adds green color codes', () => {
+      expect(color.green('test')).toBe('\x1b[32mtest\x1b[0m');
+    });
+
+    test('yellow function adds yellow color codes', () => {
+      expect(color.yellow('test')).toBe('\x1b[33mtest\x1b[0m');
+    });
+
+    test('blue function adds blue color codes', () => {
+      expect(color.blue('test')).toBe('\x1b[34mtest\x1b[0m');
+    });
+
+    test('bold function adds bold formatting codes', () => {
+      expect(color.bold('test')).toBe('\x1b[1mtest\x1b[0m');
+    });
+  });
+
+  // Tests for processDescription function
+  describe('processDescription function', () => {
+    test('replaces **text** with bold formatting', () => {
+      const input = 'This is a **bold** text';
+      const expected = `This is a ${color.bold('bold')} text`;
+      expect(processDescription(input)).toBe(expected);
+    });
+
+    test('handles multiple bold sections', () => {
+      const input = '**Hello** world, this is **important**';
+      const expected = `${color.bold('Hello')} world, this is ${color.bold('important')}`;
+      expect(processDescription(input)).toBe(expected);
+    });
+
+    test('returns original string if no bold markers are present', () => {
+      const input = 'No bold text here';
+      expect(processDescription(input)).toBe(input);
+    });
+
+    test('handles empty string', () => {
+      expect(processDescription('')).toBe('');
+    });
+
+    test('handles string with only bold markers', () => {
+      const input = '**bold**';
+      const expected = color.bold('bold');
+      expect(processDescription(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -17,7 +17,7 @@ export const color = {
 };
 
 // Bold text wrapped in ** **
-export const processDescription = (desc: string) => {
+export const processDescription = (desc: string): string => {
   return desc.replace(/\*\*(.*?)\*\*/g, (_, text) => color.bold(text));
 };
 

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -1,5 +1,26 @@
 import { Command, Option } from 'commander';
 
+// CLI color highlighting
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const BLUE = '\x1b[34m';
+
+export const color = {
+  red: (text: string) => `${RED}${text}${RESET}`,
+  green: (text: string) => `${GREEN}${text}${RESET}`,
+  yellow: (text: string) => `${YELLOW}${text}${RESET}`,
+  blue: (text: string) => `${BLUE}${text}${RESET}`,
+  bold: (text: string) => `${BOLD}${text}${RESET}`,
+};
+
+// Bold text wrapped in ** **
+export const processDescription = (desc: string) => {
+  return desc.replace(/\*\*(.*?)\*\*/g, (_, text) => color.bold(text));
+};
+
 export function createMedplumCommand(name: string): Command {
   return new Command(name)
     .option('--client-id <clientId>', 'FHIR server client id')


### PR DESCRIPTION
## Relates to #5275 

This PR does a few things

1. Updates the help documentation to indicated the naming of the default configuration file
2. Prompt the user to kill the command if the default configuration file is not present
3. Honor the `--dryrun` flag.  Previously we weren't checking that. 

Additionally, some color and bolding formatting utility functions were added. I purposely didn't add in something like [chalk](https://www.npmjs.com/package/chalk) because I didn't want to introduce new dependencies. 

## New Help Messaging
<img width="682" alt="Screenshot 2024-10-01 at 4 18 21 PM" src="https://github.com/user-attachments/assets/362528e9-0893-455e-b7bb-a6704379a4fb">

## New invocation with missing config file and `dryrun` flag applied
<img width="682" alt="Screenshot 2024-10-01 at 4 05 22 PM" src="https://github.com/user-attachments/assets/04dda9d2-86f6-4ea5-8347-4c620debbd6f">



