### PR TITLE
Index default search parameters for all resources

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,7 +156,7 @@ export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): voi
 export function indexDefaultSearchParameters(bundle: StructureDefinition[] | Bundle): void {
   const sds = Array.isArray(bundle) ? bundle : (bundle.entry?.map((e) => e.resource as StructureDefinition) ?? []);
   for (const sd of sds) {
-    if(sd.resourceType === 'StructureDefinition'){
+    if (sd.resourceType === 'StructureDefinition') {
       getOrInitTypeSchema(sd.type);
     }
   }
@@ -164,61 +164,61 @@ export function indexDefaultSearchParameters(bundle: StructureDefinition[] | Bun
 
 export function getOrInitTypeSchema(resourceType: string): TypeInfo {
   let typeSchema = globalSchema.types[resourceType];
-    if (!typeSchema) {
-      typeSchema = {
-        searchParamsDetails: {},
-      } as TypeInfo;
-      globalSchema.types[resourceType] = typeSchema;
-    }
+  if (!typeSchema) {
+    typeSchema = {
+      searchParamsDetails: {},
+    } as TypeInfo;
+    globalSchema.types[resourceType] = typeSchema;
+  }
 
-    if (!typeSchema.searchParams) {
-      typeSchema.searchParams = {
-        _id: {
-          base: [resourceType],
-          code: '_id',
-          type: 'token',
-          expression: resourceType + '.id',
-        } as SearchParameter,
-        _lastUpdated: {
-          base: [resourceType],
-          code: '_lastUpdated',
-          type: 'date',
-          expression: resourceType + '.meta.lastUpdated',
-        } as SearchParameter,
-        _compartment: {
-          base: [resourceType],
-          code: '_compartment',
-          type: 'reference',
-          expression: resourceType + '.meta.compartment',
-        } as SearchParameter,
-        _profile: {
-          base: [resourceType],
-          code: '_profile',
-          type: 'uri',
-          expression: resourceType + '.meta.profile',
-        } as SearchParameter,
-        _security: {
-          base: [resourceType],
-          code: '_security',
-          type: 'token',
-          expression: resourceType + '.meta.security',
-        } as SearchParameter,
-        _source: {
-          base: [resourceType],
-          code: '_source',
-          type: 'uri',
-          expression: resourceType + '.meta.source',
-        } as SearchParameter,
-        _tag: {
-          base: [resourceType],
-          code: '_tag',
-          type: 'token',
-          expression: resourceType + '.meta.tag',
-        } as SearchParameter,
-      };
-    }
+  if (!typeSchema.searchParams) {
+    typeSchema.searchParams = {
+      _id: {
+        base: [resourceType],
+        code: '_id',
+        type: 'token',
+        expression: resourceType + '.id',
+      } as SearchParameter,
+      _lastUpdated: {
+        base: [resourceType],
+        code: '_lastUpdated',
+        type: 'date',
+        expression: resourceType + '.meta.lastUpdated',
+      } as SearchParameter,
+      _compartment: {
+        base: [resourceType],
+        code: '_compartment',
+        type: 'reference',
+        expression: resourceType + '.meta.compartment',
+      } as SearchParameter,
+      _profile: {
+        base: [resourceType],
+        code: '_profile',
+        type: 'uri',
+        expression: resourceType + '.meta.profile',
+      } as SearchParameter,
+      _security: {
+        base: [resourceType],
+        code: '_security',
+        type: 'token',
+        expression: resourceType + '.meta.security',
+      } as SearchParameter,
+      _source: {
+        base: [resourceType],
+        code: '_source',
+        type: 'uri',
+        expression: resourceType + '.meta.source',
+      } as SearchParameter,
+      _tag: {
+        base: [resourceType],
+        code: '_tag',
+        type: 'token',
+        expression: resourceType + '.meta.tag',
+      } as SearchParameter,
+    };
+  }
 
-    return typeSchema;
+  return typeSchema;
 }
 
 /**
@@ -231,7 +231,7 @@ export function indexSearchParameter(searchParam: SearchParameter): void {
   for (const resourceType of searchParam.base ?? []) {
     const typeSchema = getOrInitTypeSchema(resourceType);
 
-    if(!typeSchema.searchParams){
+    if (!typeSchema.searchParams) {
       typeSchema.searchParams = {};
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -162,7 +162,7 @@ export function indexDefaultSearchParameters(bundle: StructureDefinition[] | Bun
   }
 }
 
-export function getOrInitTypeSchema(resourceType: string): TypeInfo {
+function getOrInitTypeSchema(resourceType: string): TypeInfo {
   let typeSchema = globalSchema.types[resourceType];
   if (!typeSchema) {
     typeSchema = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -153,7 +153,9 @@ export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): voi
 }
 
 export function indexDefaultSearchParameters(bundle: Bundle): void {
-  const sds = flatMapFilter(bundle.entry, (e) => e.resource?.resourceType === 'StructureDefinition' ? e.resource : undefined) ?? [];
+  const sds =
+    flatMapFilter(bundle.entry, (e) => (e.resource?.resourceType === 'StructureDefinition' ? e.resource : undefined)) ??
+    [];
   for (const sd of sds) {
     getOrInitTypeSchema(sd.type);
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,12 +8,11 @@ import {
   Resource,
   ResourceType,
   SearchParameter,
-  StructureDefinition,
 } from '@medplum/fhirtypes';
 import { formatHumanName } from './format';
 import { SearchParameterDetails } from './search/details';
 import { InternalSchemaElement, InternalTypeSchema, getAllDataTypes, tryGetDataType } from './typeschema/types';
-import { capitalize, createReference } from './utils';
+import { capitalize, createReference, flatMapFilter } from './utils';
 
 export type TypeName<T> = T extends string
   ? 'string'
@@ -153,12 +152,10 @@ export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): voi
   }
 }
 
-export function indexDefaultSearchParameters(bundle: StructureDefinition[] | Bundle): void {
-  const sds = Array.isArray(bundle) ? bundle : (bundle.entry?.map((e) => e.resource as StructureDefinition) ?? []);
+export function indexDefaultSearchParameters(bundle: Bundle): void {
+  const sds = flatMapFilter(bundle.entry, (e) => e.resource?.resourceType === 'StructureDefinition' ? e.resource : undefined) ?? [];
   for (const sd of sds) {
-    if (sd.resourceType === 'StructureDefinition') {
-      getOrInitTypeSchema(sd.type);
-    }
+    getOrInitTypeSchema(sd.type);
   }
 }
 

--- a/packages/server/src/fhir/structure.test.ts
+++ b/packages/server/src/fhir/structure.test.ts
@@ -1,0 +1,18 @@
+import { getSearchParameter } from "@medplum/core";
+import { loadStructureDefinitions } from "./structure";
+
+describe('FHIR structure', () => {
+    beforeAll(async () => {
+      loadStructureDefinitions();
+    });
+
+    test('Can search Organization on _profile', async () =>{
+        const param = getSearchParameter('Organization', '_profile');
+        expect(param).toBeDefined();
+    });
+
+    test('Can search MedicinalProductManufactured on _profile', async () =>{
+        const param = getSearchParameter('MedicinalProductManufactured', '_profile');
+        expect(param).toBeDefined();
+    });
+});

--- a/packages/server/src/fhir/structure.test.ts
+++ b/packages/server/src/fhir/structure.test.ts
@@ -1,18 +1,18 @@
-import { getSearchParameter } from "@medplum/core";
-import { loadStructureDefinitions } from "./structure";
+import { getSearchParameter } from '@medplum/core';
+import { loadStructureDefinitions } from './structure';
 
 describe('FHIR structure', () => {
-    beforeAll(async () => {
-      loadStructureDefinitions();
-    });
+  beforeAll(async () => {
+    loadStructureDefinitions();
+  });
 
-    test('Can search Organization on _profile', async () =>{
-        const param = getSearchParameter('Organization', '_profile');
-        expect(param).toBeDefined();
-    });
+  test('Can search Organization on _profile', async () => {
+    const param = getSearchParameter('Organization', '_profile');
+    expect(param).toBeDefined();
+  });
 
-    test('Can search MedicinalProductManufactured on _profile', async () =>{
-        const param = getSearchParameter('MedicinalProductManufactured', '_profile');
-        expect(param).toBeDefined();
-    });
+  test('Can search MedicinalProductManufactured on _profile', async () => {
+    const param = getSearchParameter('MedicinalProductManufactured', '_profile');
+    expect(param).toBeDefined();
+  });
 });

--- a/packages/server/src/fhir/structure.ts
+++ b/packages/server/src/fhir/structure.ts
@@ -1,4 +1,8 @@
-import { indexSearchParameterBundle, indexStructureDefinitionBundle, indexDefaultSearchParameters } from '@medplum/core';
+import {
+  indexSearchParameterBundle,
+  indexStructureDefinitionBundle,
+  indexDefaultSearchParameters,
+} from '@medplum/core';
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import { Bundle, SearchParameter } from '@medplum/fhirtypes';
 

--- a/packages/server/src/fhir/structure.ts
+++ b/packages/server/src/fhir/structure.ts
@@ -1,4 +1,4 @@
-import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { indexSearchParameterBundle, indexStructureDefinitionBundle, indexDefaultSearchParameters } from '@medplum/core';
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import { Bundle, SearchParameter } from '@medplum/fhirtypes';
 
@@ -7,8 +7,11 @@ let loaded = false;
 export function loadStructureDefinitions(): void {
   if (!loaded) {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
-    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    const resourcesBundle = readJson('fhir/r4/profiles-resources.json') as Bundle;
+    indexStructureDefinitionBundle(resourcesBundle);
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
+
+    indexDefaultSearchParameters(resourcesBundle);
     for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
       indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
     }


### PR DESCRIPTION
Greetings,

We're running into an issue while using the UI to create a MedicinalProductPacked. We've linked our own profile to this resource, tying the packageItem.manufacturedItem to our (other) own profile.

This causes the UI to execute following call to the server, searching for viable MedicinalProductManufactured items:
`https://{fhir server url}/fhir/R4/MedicinalProductManufactured?_id=&_count=10&_profile={profile url}`
This call fails with the error message `Unknown search parameter: _profile`.

It seems that the default search parameters are only populated if there also exists another, custom, search parameter. Which is not the case for MedicinalProductManufactured: https://www.medplum.com/docs/api/fhir/resources/medicinalproductmanufactured#search-parameters

I believe the following changes fix this issue. I've written a unit test which failed before these changes "Can search MedicinalProductManufactured on _profile"

Thoughts and remarks are welcome.

Kind regards