### PR TITLE
tweak(cli): make `medplum token` more cli consumer friendly

### DIFF
--- a/packages/cli/src/auth.test.ts
+++ b/packages/cli/src/auth.test.ts
@@ -178,7 +178,7 @@ describe('CLI auth', () => {
     );
 
     await main(['node', 'index.js', 'token']);
-    expect((console.log as unknown as jest.Mock).mock.calls).toEqual([['Access token:'], [], [expect.any(String)]]);
+    expect((console.log as unknown as jest.Mock).mock.calls).toEqual([[expect.any(String)]]);
   });
 
   test('Get access token -- needs auth (expired or not logged in)', async () => {

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -41,8 +41,6 @@ token.action(async (options) => {
   if (!token) {
     throw new Error('Not logged in');
   }
-  console.log('Access token:');
-  console.log();
   console.log(token);
 });
 


### PR DESCRIPTION
Allows use of `npx medplum token` directly in scripts, eg:
`export ACCESS_TOKEN=$(npx medplum token)`