### PR TITLE
chore(actions): auto-assign reviewers from list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,15 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set addAssignees to 'author' to set the PR creator as the assignee.
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - mattlong
+  - mattwiller
+  - ThatOneBro
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1

--- a/.github/workflows/assign-pull-request.yml
+++ b/.github/workflows/assign-pull-request.yml
@@ -1,8 +1,8 @@
 name: Assign pull request
 
 on:
-  pull_request:
-    types: [opened]
+  pull_request_target:
+    types: [opened, ready_for_review]
 
 jobs:
   assign-pull-request:
@@ -11,31 +11,4 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Assign pull request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-
-            if (pr.data.assignees.length === 0) {
-              try {
-                await github.rest.issues.checkUserCanBeAssigned({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  assignee: context.actor,
-                });
-
-                await github.rest.issues.addAssignees({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  assignees: [context.actor],
-                });
-              } catch (err) {
-                console.error(`Cannot assign PR #${context.issue.number} to ${context.actor}: ${err.message}`);
-              }
-            }
+      - uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
This PR adds [this action](https://github.com/kentaro-m/auto-assign-action), which enables auto-assigning reviewers from a pre-defined set of reviewers, as well as does the "assign author as assignee" functionality our existing auto-assign action did.

The thought behind this is to reduce siloing and spread the burden of reviewing all PRs among the core dev team. We're just going to try it out and see if it works for now