### PR TITLE
Add opt-out config to not configure database connections to avoid session pinning

### DIFF
--- a/packages/server/src/cloud/aws/config.ts
+++ b/packages/server/src/cloud/aws/config.ts
@@ -1,7 +1,7 @@
 import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { GetParametersByPathCommand, Parameter, SSMClient } from '@aws-sdk/client-ssm';
 import { splitN } from '@medplum/core';
-import { MedplumServerConfig } from '../../config';
+import { isBooleanConfig, isIntegerConfig, isObjectConfig, MedplumServerConfig } from '../../config';
 
 const DEFAULT_AWS_REGION = 'us-east-1';
 
@@ -96,25 +96,4 @@ function setValue(config: Record<string, unknown>, key: string, value: string): 
   }
 
   obj[keySegments[0]] = parsedValue;
-}
-
-function isIntegerConfig(key: string): boolean {
-  return key === 'port' || key === 'accurateCountThreshold';
-}
-
-function isBooleanConfig(key: string): boolean {
-  return (
-    key === 'botCustomFunctionsEnabled' ||
-    key === 'database.ssl.rejectUnauthorized' ||
-    key === 'database.ssl.require' ||
-    key === 'logRequests' ||
-    key === 'logAuditEvents' ||
-    key === 'registerEnabled' ||
-    key === 'require' ||
-    key === 'rejectUnauthorized'
-  );
-}
-
-function isObjectConfig(key: string): boolean {
-  return key === 'tls';
 }

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -111,6 +111,7 @@ export interface MedplumDatabaseConfig {
   queryTimeout?: number;
   runMigrations?: boolean;
   maxConnections?: number;
+  disableConnectionConfiguration?: boolean;
 }
 
 export interface MedplumRedisConfig {
@@ -287,7 +288,7 @@ function addDefaults(config: MedplumServerConfig): MedplumServerConfig {
 }
 
 const integerKeys = ['port', 'accurateCountThreshold'];
-function isIntegerConfig(key: string): boolean {
+export function isIntegerConfig(key: string): boolean {
   return integerKeys.includes(key);
 }
 
@@ -299,16 +300,20 @@ const booleanKeys = [
   'botCustomFunctionsEnabled',
   'database.ssl.rejectUnauthorized',
   'database.ssl.require',
+  'database.disableConnectionConfiguration',
+  'readonlyDatabase.ssl.rejectUnauthorized',
+  'readonlyDatabase.ssl.require',
+  'readonlyDatabase.disableConnectionConfiguration',
   'logRequests',
   'logAuditEvents',
   'registerEnabled',
   'require',
   'rejectUnauthorized',
 ];
-function isBooleanConfig(key: string): boolean {
+export function isBooleanConfig(key: string): boolean {
   return booleanKeys.includes(key);
 }
 
-function isObjectConfig(key: string): boolean {
+export function isObjectConfig(key: string): boolean {
   return key === 'tls' || key === 'ssl';
 }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -62,14 +62,16 @@ async function initPool(config: MedplumDatabaseConfig, proxyEndpoint: string | u
     globalLogger.error('Database connection error', err);
   });
 
-  pool.on('connect', (client) => {
-    client.query(`SET statement_timeout TO ${config.queryTimeout ?? 60000}`).catch((err) => {
-      globalLogger.warn('Failed to set query timeout', err);
+  if (!config.disableConnectionConfiguration) {
+    pool.on('connect', (client) => {
+      client.query(`SET statement_timeout TO ${config.queryTimeout ?? 60000}`).catch((err) => {
+        globalLogger.warn('Failed to set query timeout', err);
+      });
+      client.query(`SET default_transaction_isolation TO 'REPEATABLE READ'`).catch((err) => {
+        globalLogger.warn('Failed to set default transaction isolation', err);
+      });
     });
-    client.query(`SET default_transaction_isolation TO 'REPEATABLE READ'`).catch((err) => {
-      globalLogger.warn('Failed to set default transaction isolation', err);
-    });
-  });
+  }
 
   return pool;
 }


### PR DESCRIPTION
This is useful/necessary if using a database proxy like RDS Proxy and you want to avoid connection pinning or if using PgBouncer with `pool_mode` set to `transaction` or `statement`