### PR TITLE
Exclude extended attrs in Docker build

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -5,6 +5,11 @@ if [[ -z "${DOCKERHUB_REPOSITORY}" ]]; then
   exit 1
 fi
 
+if [[ -z "${GITHUB_SHA}" ]]; then
+  echo "GITHUB_SHA is missing"
+  exit 1
+fi
+
 # Fail on error
 set -e
 
@@ -13,6 +18,7 @@ set -x
 
 # Build server tarball
 tar \
+  --no-xattrs \
   --exclude='*.ts' \
   --exclude='*.tsbuildinfo' \
   -czf medplum-server.tar.gz \


### PR DESCRIPTION
We don't rely on extended attributes (please correct me if I'm wrong) and this makes our Docker build process more compatible with MacOS. Without this, running `scripts/build-docker.sh` on MacOS yields this error:

```
 => ERROR [linux/amd64 3/4] ADD ./medplum-server.tar.gz ./
 => CANCELED [linux/arm/v7 2/4] WORKDIR /usr/src/medplum
 => CANCELED [linux/arm64 2/4] WORKDIR /usr/src/medplum
------
 > [linux/amd64 3/4] ADD ./medplum-server.tar.gz ./:
------
Dockerfile:21
--------------------
  19 |
  20 |     # Add the application files
  21 | >>> ADD ./medplum-server.tar.gz ./
  22 |
  23 |     # Install dependencies, create non-root user, and set permissions in one layer
--------------------
ERROR: failed to solve: lsetxattr /package.json: operation not supported
```