### PR TITLE
Only include resolvable aliases

### DIFF
--- a/examples/medplum-health-gorilla-demo/vite.config.ts
+++ b/examples/medplum-health-gorilla-demo/vite.config.ts
@@ -6,11 +6,10 @@ import { defineConfig, UserConfig } from 'vite';
 // Resolve aliases to local packages when working within the monorepo
 const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
   Object.entries({
-    '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
-    '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
-    '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
-    '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),
-  }).filter(([, path]) => existsSync(path))
+    '@medplum/react': '../../packages/react/src',
+    '@medplum/health-gorilla-core': '../../packages/health-gorilla-core/src',
+    '@medplum/health-gorilla-react': '../../packages/health-gorilla-react/src',
+  }).filter(([, relPath]) => existsSync(path.resolve(__dirname, relPath)))
 );
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/examples/medplum-health-gorilla-demo/vite.config.ts
+++ b/examples/medplum-health-gorilla-demo/vite.config.ts
@@ -1,7 +1,17 @@
 import react from '@vitejs/plugin-react';
+import { existsSync } from 'fs';
 import path from 'path';
-import { defineConfig } from 'vite';
+import { defineConfig, UserConfig } from 'vite';
 
+// Resolve aliases to local packages when working within the monorepo
+const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
+  Object.entries({
+    '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
+    '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
+    '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
+    '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),
+  }).filter(([, path]) => existsSync(path))
+);
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -9,9 +19,6 @@ export default defineConfig({
     port: 3000,
   },
   resolve: {
-    alias: {
-      '@medplum/health-gorilla-core': path.resolve('../../packages/health-gorilla-core/src'),
-      '@medplum/health-gorilla-react': path.resolve('../../packages/health-gorilla-react/src'),
-    },
+    alias,
   },
 });

--- a/examples/medplum-health-gorilla-demo/vite.config.ts
+++ b/examples/medplum-health-gorilla-demo/vite.config.ts
@@ -6,10 +6,9 @@ import { defineConfig, UserConfig } from 'vite';
 // Resolve aliases to local packages when working within the monorepo
 const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
   Object.entries({
-    '@medplum/react': '../../packages/react/src',
-    '@medplum/health-gorilla-core': '../../packages/health-gorilla-core/src',
-    '@medplum/health-gorilla-react': '../../packages/health-gorilla-react/src',
-  }).filter(([, relPath]) => existsSync(path.resolve(__dirname, relPath)))
+    '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
+    '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),
+  }).filter(([, relPath]) => existsSync(relPath))
 );
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -1,9 +1,18 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, UserConfig } from 'vite';
 import dns from 'dns';
 import path from 'path';
+import { existsSync } from 'fs';
 
 dns.setDefaultResultOrder('verbatim');
+
+// Resolve aliases to local packages when working within the monorepo
+const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
+  Object.entries({
+    '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
+    '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
+  }).filter(([, path]) => existsSync(path))
+);
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -13,9 +22,6 @@ export default defineConfig({
     port: 3000,
   },
   resolve: {
-    alias: {
-      '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
-      '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
-    },
+    alias,
   },
 });

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -9,9 +9,9 @@ dns.setDefaultResultOrder('verbatim');
 // Resolve aliases to local packages when working within the monorepo
 const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
   Object.entries({
-    '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
-    '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
-  }).filter(([, path]) => existsSync(path))
+    '@medplum/core': '../../packages/core/src',
+    '@medplum/react': '../../packages/react/src',
+  }).filter(([, relPath]) => existsSync(path.resolve(__dirname, relPath)))
 );
 
 // https://vitejs.dev/config/

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -9,9 +9,9 @@ dns.setDefaultResultOrder('verbatim');
 // Resolve aliases to local packages when working within the monorepo
 const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
   Object.entries({
-    '@medplum/core': '../../packages/core/src',
-    '@medplum/react': '../../packages/react/src',
-  }).filter(([, relPath]) => existsSync(path.resolve(__dirname, relPath)))
+    '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
+    '@medplum/react': path.resolve(__dirname, '../../packages/react/src'),
+  }).filter(([, relPath]) => existsSync(relPath))
 );
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
These aliases are quite convenient when developing across packages and the example apps within the monorepo, but they break in the context of the individual git repos created for each example app.