### PR TITLE
Document how userinfo values are generated

### DIFF
--- a/packages/docs/docs/api/oauth/userinfo.md
+++ b/packages/docs/docs/api/oauth/userinfo.md
@@ -49,6 +49,10 @@ Content-Type: application/json;charset=UTF-8
 
 For a list of OIDC claims, see [Standard Claims](http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims).
 
+:::note Contact Information
+The `email` and `phone` values of the `/userinfo` endpoint are generated from the user's [Profile resource](/docs/fhir-datastore/profiles).
+:::
+
 ## Sample negative responses
 
 #### Invalid request


### PR DESCRIPTION
Fixes #4885 Adds a note that email and phone values come from the user's profile resource