### PR TITLE
Improve docs on running bots on localhost

### DIFF
--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -14,7 +14,7 @@ Bots are disabled by default for accounts. Contact info@medplum.com if you'd lik
 
 :::note Bots in Local Development
 
-If you want to run bots locally, you should use a VM Context. For more details see the [VM Context Bots docs](/docs/bots/vm-context-bots).
+If you want to run bots locally, you should use a VM Context. For more details see the [Running Bots Locally docs](/docs/bots/running-bots-locally).
 
 :::
 

--- a/packages/docs/docs/bots/bots-in-production.md
+++ b/packages/docs/docs/bots/bots-in-production.md
@@ -13,7 +13,7 @@ Editing bots in the web editor is good for getting started quickly, but as Bots 
 
 :::note Bots in Local Development
 
-If you want to run bots locally, you should use a VM Context. For more details see the [VM Context Bots docs](/docs/bots/vm-context-bots).
+If you want to run bots locally, you should use a VM Context. For more details see the [Running Bots Locally docs](/docs/bots/running-bots-locally).
 
 :::
 

--- a/packages/docs/docs/bots/running-bots-locally.md
+++ b/packages/docs/docs/bots/running-bots-locally.md
@@ -1,8 +1,19 @@
-# VM Context Bots
+# Running Bots Locally
 
 To set up the Medplum [`Bot`](/docs/api/fhir/medplum/bot) framework locally, Medplum offers VM Context [`Bots`](/docs/api/fhir/medplum/bot). VM Context allows bots to spin up a local thread inside your server, rather than using an isolated lambda.
 
-There are two steps to set up VM context bots:
+Before enabling VM Context [Bots](/docs/api/fhir/medplum/bot), you must first enable bots on your project. To do so, follow thse steps:
+
+1. Log in to your [Super Admin Project](/docs/self-hosting/super-admin-guide).
+2. Access your [Project](/docs/api/fhir/medplum/project) resource.
+3. Go to the `Edit` tab.
+4. In the `Features` section, add the `bot` feature.
+
+:::note
+The `defaultProjectFeatures` server config setting is used for default features when your project is being set up. Editing this config setting will not update your project to enable bots.
+:::
+
+Once this is done, you can enable VM Context bots. There are two steps to set up VM context bots:
 
 1. Enable VM Context [`Bots`](/docs/api/fhir/medplum/bot) on your server config.
 2. Set your [`Bot's`](/docs/api/fhir/medplum/bot) runtime version to VM Context.


### PR DESCRIPTION
Rename the VM context bots docs to make them more clear and add instructions for enabling bots on your project. Fixes #4920 