### PR TITLE
Validate access policy criteria against stated resource type

### DIFF
--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -3635,7 +3635,7 @@
                 "key": "axp-3",
                 "severity": "error",
                 "human": "Criteria must be a valid FHIR search string on the correct resource type, e.g. Patient?identifier=123",
-                "expression": "criteria.exists() implies criteria.startsWith(resourceType + '?')"
+                "expression": "criteria.exists() implies criteria.startsWith(%context.resourceType & '?')"
               }
             ]
           },

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -3629,7 +3629,15 @@
               "path" : "AccessPolicy.resource",
               "min" : 0,
               "max" : "*"
-            }
+            },
+            "constraint": [
+              {
+                "key": "axp-3",
+                "severity": "error",
+                "human": "Criteria must be a valid FHIR search string on the correct resource type, e.g. Patient?identifier=123",
+                "expression": "criteria.exists() implies criteria.startsWith(resourceType + '?')"
+              }
+            ]
           },
           {
             "id" : "AccessPolicy.resource.resourceType",
@@ -3675,15 +3683,7 @@
               "path" : "AccessPolicy.resource.criteria",
               "min" : 0,
               "max" : "1"
-            },
-            "constraint": [
-              {
-                "key": "axp-2",
-                "severity": "error",
-                "human": "Criteria must be a valid FHIR search string, e.g. Patient?identifier=123",
-                "expression": "indexOf('?') > 0"
-              }
-            ]
+            }
           },
           {
             "id" : "AccessPolicy.resource.readonly",

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1178,7 +1178,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
           // Deprecated - to be removed
           // Add compartment restriction for the access policy.
           expressions.push(new Condition('compartments', 'ARRAY_CONTAINS', policyCompartmentId, 'UUID[]'));
-        } else if (policy.criteria) {
+        } else if (policy.criteria?.startsWith(policy.resourceType + '?')) {
           // Add subquery for access policy criteria.
           const searchRequest = parseSearchRequest(policy.criteria);
           const accessPolicyExpression = buildSearchExpression(

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1165,20 +1165,29 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * @param resourceType - The resource type being searched.
    */
   private addAccessPolicyFilters(builder: SelectQuery, resourceType: string): void {
-    if (!this.context.accessPolicy?.resource) {
+    const accessPolicy = this.context.accessPolicy;
+    if (!accessPolicy?.resource) {
       return;
     }
 
     const expressions: Expression[] = [];
 
-    for (const policy of this.context.accessPolicy.resource) {
+    for (const policy of accessPolicy.resource) {
       if (policy.resourceType === resourceType) {
         const policyCompartmentId = resolveId(policy.compartment);
         if (policyCompartmentId) {
           // Deprecated - to be removed
           // Add compartment restriction for the access policy.
           expressions.push(new Condition('compartments', 'ARRAY_CONTAINS', policyCompartmentId, 'UUID[]'));
-        } else if (policy.criteria?.startsWith(policy.resourceType + '?')) {
+        } else if (policy.criteria) {
+          if (!policy.criteria.startsWith(policy.resourceType + '?')) {
+            getLogger().warn('Invalid access policy criteria', {
+              accessPolicy: accessPolicy.id,
+              resourceType: policy.resourceType,
+              criteria: policy.criteria,
+            });
+            return; // Ignore invalid access policy criteria
+          }
           // Add subquery for access policy criteria.
           const searchRequest = parseSearchRequest(policy.criteria);
           const accessPolicyExpression = buildSearchExpression(


### PR DESCRIPTION
Ensure that `AccessPolicy` criteria are consistent: they must refer to the same resource type as the `AccessPolicy.resource.resourceType`, e.g.
```
{
  "resourceType": "Practitioner",
  "criteria": "Practitioner?identifier=http://hl7.org/fhir/sid/us-npi|9999999999"
}
```

This is checked in two places:
- When the `AccessPolicy` is modified, invalid `criteria` will trigger a 400 error
- When the access policy is applied, invalid `criteria` will be ignored