### PR TITLE
Fix simple chained search to account for reverse chaining

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1327,11 +1327,13 @@ function buildChainedSearch(
   if (param.chain.length === 1 && param.chain[0].filter?.code === '_id' && !param.chain[0].reverse) {
     const { resourceType: targetType, code, filter } = param.chain[0];
     const targetId = filter.value;
-    return buildSearchFilterExpression(repo, selectQuery, resourceType as ResourceType, resourceType, {
-      code,
-      operator: Operator.EQUALS,
-      value: `${targetType}/${targetId}`,
-    });
+    if (resourceType === targetType) {
+      return buildSearchFilterExpression(repo, selectQuery, resourceType as ResourceType, resourceType, {
+        code,
+        operator: Operator.EQUALS,
+        value: `${targetType}/${targetId}`,
+      });
+    }
   }
 
   if (usesReferenceLookupTable(repo)) {


### PR DESCRIPTION
Feel free to make this better. Don't 100% understand the query building implementation yet but this seems to resolve the issue. Copying message from discord below.

After upgrading to 3.2.17, it seems I've started to get 400's on some requests with reverse references beginning with [this commit](https://github.com/medplum/medplum/commit/9b57ce6744acfbe1afabee06a9ae88f114c457f3#diff-7dae6f2aae2e65e707358949198c13cf800c8795900cfc1a9f3f67d9d9e388f1R1298)

example request- `/Patient?_count=1&_has:Encounter:patient:_id=[uuid]`

I believe it's trying to lookup `'patient'` search parameter from `Patient` resource type instead of `Encounter`.

The same request has worked up to 3.2.16 and each commit up until the linked one. Is that intended? Can open an issue on Github if helpful.