### PR TITLE
Fix Fork link in examples' README

### DIFF
--- a/examples/medplum-chart-demo/README.md
+++ b/examples/medplum-chart-demo/README.md
@@ -8,7 +8,7 @@
 
 This example app demonstrates the following:
 
-- Managing the lifecylce of an encounter and its corresponding notes.
+- Managing the lifecycle of an encounter and its corresponding notes.
 - Creating and displaying Encounter Notes using the [`ClinicalImpression`](/docs/api/fhir/resources/clinicalimpression) resource.
 - Converting notes into structured data ([`Observations`](/docs/api/fhir/resources/observation) and [`Conditions`](/docs/api/fhir/resources/condition)) for easy retrieval and longitudinal tracking.
 - Using [Medplum React Components](https://storybook.medplum.com/?path=/docs/medplum-introduction--docs) to display a chart that provides visibility on a patient and their medical encounters.
@@ -53,7 +53,7 @@ The Encounter Chart has 3 distinct panels
 
 If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
-[Fork](https://github.com/medplum/medplum-hello-world/fork) and clone the repo.
+[Fork](https://github.com/medplum/medplum-chart-demo/fork) and clone the repo.
 
 Next, install the dependencies.
 

--- a/examples/medplum-patient-intake-demo/README.md
+++ b/examples/medplum-patient-intake-demo/README.md
@@ -35,7 +35,7 @@ The `data` directory contains data that can be uploaded for use in the demo. The
 
 If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
-[Fork](https://github.com/medplum/medplum/) and clone the repo to your local machine.
+[Fork](https://github.com/medplum/medplum-patient-intake-demo/fork) and clone the repo to your local machine.
 
 Next, install the dependencies.
 

--- a/examples/medplum-provider/README.md
+++ b/examples/medplum-provider/README.md
@@ -45,7 +45,7 @@ The Patient Chart has 3 distinct panels
 
 If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
-[Fork](https://github.com/medplum/medplum-hello-world/fork) and clone the repo.
+[Fork](https://github.com/medplum/medplum-provider/fork) and clone the repo.
 
 Next, install the dependencies.
 

--- a/examples/medplum-scheduling-demo/README.md
+++ b/examples/medplum-scheduling-demo/README.md
@@ -37,7 +37,7 @@ The `data` directory contains data that can be uploaded for use in the demo. The
 
 If you haven't already done so, follow the instructions in [this tutorial](https://www.medplum.com/docs/tutorials/register) to register a Medplum project to store your data.
 
-[Fork](https://github.com/medplum/medplum/) and clone the repo to your local machine.
+[Fork](https://github.com/medplum/medplum-scheduling-demo/fork) and clone the repo to your local machine.
 
 Next, install the dependencies.
 


### PR DESCRIPTION
## Description

Some examples' README files had a _Fork_ link that pointed to another repository. This misled people when running the examples.