### PR TITLE
Support string values in batch PATCH requests

### DIFF
--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -615,7 +615,7 @@ describe('Batch', () => {
                 name: 'operation',
                 part: [
                   { name: 'op', valueCode: 'replace' },
-                  { name: 'path', valueString: '/gender', },
+                  { name: 'path', valueString: '/gender' },
                   { name: 'value', valueString: 'female' },
                 ],
               },

--- a/packages/fhir-router/src/batch.test.ts
+++ b/packages/fhir-router/src/batch.test.ts
@@ -578,6 +578,7 @@ describe('Batch', () => {
   test('Process batch patch Parameters', async () => {
     const patient = await repo.createResource<Patient>({
       resourceType: 'Patient',
+      birthDate: '2000-01-01',
       gender: 'unknown',
     });
 
@@ -613,8 +614,16 @@ describe('Batch', () => {
               {
                 name: 'operation',
                 part: [
+                  { name: 'op', valueCode: 'replace' },
+                  { name: 'path', valueString: '/gender', },
+                  { name: 'value', valueString: 'female' },
+                ],
+              },
+              {
+                name: 'operation',
+                part: [
                   { name: 'op', valueCode: 'remove' },
-                  { name: 'path', valueString: '/gender' },
+                  { name: 'path', valueString: '/birthDate' },
                 ],
               },
             ],
@@ -640,7 +649,8 @@ describe('Batch', () => {
     expect(results[0].response?.status).toEqual('200');
     const updatedPatient = results[0].resource as Patient;
     expect(updatedPatient.name?.[0]?.given).toEqual(['Dave', 'Smith']);
-    expect(updatedPatient.gender).toBeUndefined();
+    expect(updatedPatient.gender).toEqual('female');
+    expect(updatedPatient.birthDate).toBeUndefined();
     expect(results[1].response?.status).toEqual('400');
     expect(results[1].response?.outcome?.issue?.[0]?.details?.text).toEqual('Decoded PATCH body must be an array');
   });

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -512,12 +512,12 @@ class BatchProcessor {
           if (part.name === 'path') {
             op.path = part.valueString;
           } else if (part.name === 'value') {
-              try {
-                op.value = JSON.parse(part.valueString ?? '');
-              } catch {
-                op.value = part.valueString ?? '';
-              }
-              break;
+            try {
+              op.value = JSON.parse(part.valueString ?? '');
+            } catch {
+              op.value = part.valueString ?? '';
+            }
+            break;
           }
         }
         break;

--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -512,7 +512,12 @@ class BatchProcessor {
           if (part.name === 'path') {
             op.path = part.valueString;
           } else if (part.name === 'value') {
-            op.value = JSON.parse(part.valueString ?? '');
+              try {
+                op.value = JSON.parse(part.valueString ?? '');
+              } catch {
+                op.value = part.valueString ?? '';
+              }
+              break;
           }
         }
         break;


### PR DESCRIPTION
Running into an issue where we're trying to update the `status` of a `Communication` in a batch request, but the handler at present is only accepting objects/arrays due to the `JSON.stringify` always being applied

## Example request

```json
{
  "resourceType": "Bundle",
  "type": "transaction",
  "entry": [
    {
      "resource": {
        "resourceType": "Parameters",
        "parameter": [
          {
            "name": "operation",
            "part": [
              { "name": "op", "valueCode": "replace" },
              { "name": "path", "valueString": "/status" },
              { "name": "value", "valueString": "completed" }
            ]
          }
        ]
      },
      "fullUrl": "Communication/d33411f7-3370-4efa-a7ad-a8a7d1ecb3a5",
      "request": {
        "method": "PATCH",
        "url": "Communication/d33411f7-3370-4efa-a7ad-a8a7d1ecb3a5"
      }
    },
    // ... other operations
  ]
}
```

## Expected

200 on the PATCH

## Actual

```json
{
    "resourceType": "Bundle",
    "type": "transaction-response",
    "entry": [
        {
            "response": {
                "outcome": {
                    "resourceType": "OperationOutcome",
                    "issue": [
                        {
                            "severity": "error",
                            "code": "invalid",
                            "details": {
                                "text": "Unexpected token 'c', \"completed\" is not valid JSON"
                            }
                        }
                    ]
                },
                "status": "400"
            }
        }
    ]
}
```


