### PR TITLE
Fix documentation links

### DIFF
--- a/examples/foomedical/README.md
+++ b/examples/foomedical/README.md
@@ -78,7 +78,7 @@ Contact the medplum team ([support@medplum.com](mailto:support@medplum.com) or [
 
 ### Data Setup
 
-When you log into Foo Medical a set of sample FHIR records is created on your behalf. The ability to run automations is part of the Medplum platform using a framework called [Bots](https://docs.medplum.com/app/bots). For reference, Bot that created the records in Foo Medical can be found [here](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/sample-account-setup.ts).
+When you log into Foo Medical a set of sample FHIR records is created on your behalf. The ability to run automations is part of the Medplum platform using a framework called [Bots](https://docs.medplum.com/app/bots). For reference, Bot that created the records in Foo Medical can be found [here](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts).
 
 ### Compliance
 

--- a/examples/foomedical/README.md
+++ b/examples/foomedical/README.md
@@ -65,7 +65,7 @@ You can deploy this application by [clicking here](https://vercel.com/new/clone?
 
 By default, your locally running Foo Medical app is pointing to the hosted Medplum service. Foo Medical registers signups to a test project.
 
-To send patients to your own organization you will need to [register a new Project on Medplum](https://docs.medplum.com/tutorials/app/register) and configure your environment variables to point to your own project (see [config.ts](https://github.com/medplum/foomedical/blob/main/src/config.ts) for an example).
+To send patients to your own organization you will need to [register a new Project on Medplum](https://www.medplum.com/docs/tutorials/register) and configure your environment variables to point to your own project (see [config.ts](https://github.com/medplum/foomedical/blob/main/src/config.ts) for an example).
 
 If you are using the Medplum Hosted service, you can login to your Medplum Instance and add the following identifiers to your [Project Site Settings](https://app.medplum.com/admin/sites)
 
@@ -78,7 +78,7 @@ Contact the medplum team ([support@medplum.com](mailto:support@medplum.com) or [
 
 ### Data Setup
 
-When you log into Foo Medical a set of sample FHIR records is created on your behalf. The ability to run automations is part of the Medplum platform using a framework called [Bots](https://docs.medplum.com/app/bots). For reference, Bot that created the records in Foo Medical can be found [here](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts).
+When you log into Foo Medical a set of sample FHIR records is created on your behalf. The ability to run automations is part of the Medplum platform using a framework called [Bots](https://www.medplum.com/docs/bots). For reference, Bot that created the records in Foo Medical can be found [here](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts).
 
 ### Compliance
 
@@ -90,6 +90,7 @@ Medplum backend is HIPAA compliant and SOC 2 certified. Getting an account set u
 
 Medplum supports self-hosting and provides a [hosted service](https://app.medplum.com/). [Foo Medical](https://foomedical.com/) uses the hosted service as a backend.
 
-- Read our [documentation](https://docs.medplum.com/)
-- Browse our [React component library](https://docs.medplum.com/storybook/index.html?)
+<!-- fix me: -->
+- Read our [documentation](https://www.medplum.com/docs/)
+- Browse our [React component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/foomedical/README.md
+++ b/examples/foomedical/README.md
@@ -90,7 +90,6 @@ Medplum backend is HIPAA compliant and SOC 2 certified. Getting an account set u
 
 Medplum supports self-hosting and provides a [hosted service](https://app.medplum.com/). [Foo Medical](https://foomedical.com/) uses the hosted service as a backend.
 
-<!-- fix me: -->
 - Read our [documentation](https://www.medplum.com/docs/)
 - Browse our [React component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-chart-demo/README.md
+++ b/examples/medplum-chart-demo/README.md
@@ -82,5 +82,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-chat-demo/README.md
+++ b/examples/medplum-chat-demo/README.md
@@ -59,5 +59,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-client-external-idp-demo/README.md
+++ b/examples/medplum-client-external-idp-demo/README.md
@@ -18,7 +18,7 @@ Setup your external authentication provider (Auth0, AWS Cognito, Okta, etc).  Us
 
 Setup your Medplum account:
 
-- [Register for a Medplum account](https://docs.medplum.com/tutorials/app/register)
+- [Register for a Medplum account](https://www.medplum.com/docs/tutorials/register)
 - Create a `ClientApplication`
 - Set the "Redirect URI" to "http://localhost:8000/"
 - Add an external identity provider with the details from above

--- a/examples/medplum-demo-bots/README.md
+++ b/examples/medplum-demo-bots/README.md
@@ -1,8 +1,8 @@
 # Medplum Demo Bots
 
-This repo contains code for [Medplum Bots](https://docs.medplum.com/app/bots). Bots power many of the integrations you see in Medplum apps. You can view your deployed bots online on the [Medplum App](https://app.medplum.com).
+This repo contains code for [Medplum Bots](https://www.medplum.com/docs/bots). Bots power many of the integrations you see in Medplum apps. You can view your deployed bots online on the [Medplum App](https://app.medplum.com).
 
-Bots make heavy use of the [Medplum JS Client Library](https://docs.medplum.com/typedoc/core/index.html).
+Bots make heavy use of the [Medplum JS Client Library](https://www.medplum.com/docs/sdk/core).
 
 ## Setup
 

--- a/examples/medplum-demo-bots/src/sample-account-setup.ts
+++ b/examples/medplum-demo-bots/src/sample-account-setup.ts
@@ -162,7 +162,7 @@ async function getPractitioner(medplum: MedplumClient): Promise<Practitioner> {
       photo: [
         {
           contentType: 'image/png',
-          url: 'https://docs.medplum.com/img/cdc-femaledoc.png',
+          url: 'https://www.medplum.com/img/cdc-femaledoc.png',
         },
       ],
     },

--- a/examples/medplum-eligibility-demo/README.md
+++ b/examples/medplum-eligibility-demo/README.md
@@ -61,5 +61,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-hello-world/README.md
+++ b/examples/medplum-hello-world/README.md
@@ -42,5 +42,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-live-chat-demo/README.md
+++ b/examples/medplum-live-chat-demo/README.md
@@ -50,5 +50,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-patient-intake-demo/README.md
+++ b/examples/medplum-patient-intake-demo/README.md
@@ -73,5 +73,5 @@ Click `Upload Example Bots` in the app navigation menu and then click the upload
 Medplum supports self-hosting and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-photon-integration/README.md
+++ b/examples/medplum-photon-integration/README.md
@@ -98,5 +98,5 @@ In the events section, select `Let me select specific events.` This demo impleme
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-provider/README.md
+++ b/examples/medplum-provider/README.md
@@ -68,5 +68,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-scheduling-demo/README.md
+++ b/examples/medplum-scheduling-demo/README.md
@@ -75,5 +75,5 @@ Click `Upload Example Bots` in the app navigation menu and then click the upload
 Medplum supports self-hosting and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-task-demo/README.md
+++ b/examples/medplum-task-demo/README.md
@@ -57,5 +57,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/examples/medplum-websocket-subscriptions-demo/README.md
+++ b/examples/medplum-websocket-subscriptions-demo/README.md
@@ -42,5 +42,5 @@ This app should run on `http://localhost:3000/`
 Medplum supports self-hosting, and provides a [hosted service](https://app.medplum.com/). Medplum Hello World uses the hosted service as a backend.
 
 - Read our [documentation](https://www.medplum.com/docs)
-- Browse our [react component library](https://docs.medplum.com/storybook/index.html?)
+- Browse our [react component library](https://storybook.medplum.com/)
 - Join our [Discord](https://discord.gg/medplum)

--- a/packages/docs/blog/2023-06-19-ensage-case-study.md
+++ b/packages/docs/blog/2023-06-19-ensage-case-study.md
@@ -50,7 +50,7 @@ EnSage leveraged a suite of Medplum features to create a comprehensive and effic
 4. [Subscriptions](/docs/subscriptions): In this implementation, in response to [questionnaires](/docs/questionnaires/basic-tutorial), subscriptions are triggered, setting off automated workflows like notifications, data synchronization and more.
 5. [Scheduling](/docs/scheduling): Integration between [Acuity](https://www.acuityscheduling.com/) and [FHIR Schedule](/docs/api/fhir/resources/schedule) provided a robust solution for managing appointments and optimizing healthcare service delivery.
 6. [Charting](/docs/charting): A system for documenting encounters, including details like CPT and diagnosis codes, was created. This facilitated a comprehensive and precise record-keeping process.
-7. [Billing and Revenue Cycle](/docs/billing): An automated integration with [Candid Health](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/candid-health) enabled Medicare (CMS) billing for providers on the platform.
+7. [Billing and Revenue Cycle](/docs/billing): An automated integration with [Candid Health](https://github.com/medplum/medplum-demo-bots/tree/main/src/candid-health) enabled Medicare (CMS) billing for providers on the platform.
 8. [Open source](https://github.com/medplum/medplum): The development team used Typescript for the entire stack. The Medplum open source code, [issue tracking](https://github.com/medplum/medplum/issues) and community features helped streamline development and speed learning.
 
 Below is an architecture diagram showing how the different components fit together.

--- a/packages/docs/docs/bots/consuming-webhooks.md
+++ b/packages/docs/docs/bots/consuming-webhooks.md
@@ -9,7 +9,7 @@ Many SaaS products including popular services like Stripe and Okta support Webho
 
 Medplum [bots](/docs/bots) can be used to listen for webhooks and so keep records synchronized between systems. When another application fires a webhook, it can trigger a Medplum bot using the [$execute](/docs/bots/bot-basics#using-the-execute-endpoint) endpoint.
 
-For an example of a Bot that consumes webhooks, see the [Stripe demo bot](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/stripe-bots).
+For an example of a Bot that consumes webhooks, see the [Stripe demo bot](https://github.com/medplum/medplum-demo-bots/tree/main/src/stripe-bots).
 
 ## Planning your integration
 
@@ -25,7 +25,7 @@ We recommend writing some [unit tests](/docs/bots/unit-testing-bots) as well, an
 
 If the SaaS application that sends webhooks publishes a TypeScript SDK, it's straightforward to add it to your bot, to streamline development. Add the package to the `devDependencies` in the `package.json` of your bot repository and install the dependency, and [example from demo bots repo](https://github.com/medplum/medplum-demo-bots/blob/main/package.json) is available. You can then use the TypeScript SDK when developing your bot.
 
-The [Stripe demo bot](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/stripe-bots) uses the Stripe TypeScript SDK.
+The [Stripe demo bot](https://github.com/medplum/medplum-demo-bots/tree/main/src/stripe-bots) uses the Stripe TypeScript SDK.
 
 ## Creating Access Policies
 

--- a/packages/docs/docs/bots/file-uploads.md
+++ b/packages/docs/docs/bots/file-uploads.md
@@ -58,7 +58,7 @@ const response = await fetch('https://httpbin.org/post', {
 });
 ```
 
-This is what it looks like all put together. You can also see this example in our [Medplum Demo Bots](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/form-data-upload.ts) repo.
+This is what it looks like all put together. You can also see this example in our [Medplum Demo Bots](https://github.com/medplum/medplum-demo-bots/blob/main/src/form-data-upload.ts) repo.
 
 ```ts
 import { BotEvent, MedplumClient } from '@medplum/core';

--- a/packages/docs/docs/bots/index.md
+++ b/packages/docs/docs/bots/index.md
@@ -29,11 +29,11 @@ Super administrators can enable bots via the Medplum App:
 1. [Consuming Webhooks](consuming-webhooks.md)
 2. [Consuming HL7 Feeds and Converting to FHIR](hl7-into-fhir.md)
 3. Coming Soon: Consuming Lab Results from a lab instrument or LIS
-4. [Receive payment and accounts data](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/stripe-bots)
+4. [Receive payment and accounts data](https://github.com/medplum/medplum-demo-bots/tree/main/src/stripe-bots)
 
 ## Export data to other systems
 
-1. [Exporting data to a billing service](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/candid-health)
+1. [Exporting data to a billing service](https://github.com/medplum/medplum-demo-bots/tree/main/src/candid-health)
 2. [Exporting a PDF Report for human consumption](creating-a-pdf.md)
 3. [File Uploads](file-uploads.md)
 

--- a/packages/docs/docs/bots/index.md
+++ b/packages/docs/docs/bots/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 0
 ---
 
-# Intro
+# Bots
 
 If you have never heard of Medplum Bots, we encourage you to read the intro material in the [**Bot Guide**](./bots/bot-basics).
 

--- a/packages/docs/docs/bots/unit-testing-bots.mdx
+++ b/packages/docs/docs/bots/unit-testing-bots.mdx
@@ -45,7 +45,7 @@ Most bot unit tests follow a common pattern:
 3. Invoke the handler function
 4. Query mock resources and assert test your test criteria
 
-The [finalize-report tests](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/finalize-report.ts) are a great example of this pattern.
+The [finalize-report tests](https://github.com/medplum/medplum-demo-bots/blob/main/src/finalize-report.ts) are a great example of this pattern.
 
 ### Create a `MockClient`
 
@@ -72,7 +72,7 @@ The Medplum team is working on bringing these features to parity as soon as poss
 
 Most tests require setting up some resources in the mock environment before running the Bot. You can use `createResource()` and `updateResource()` to add resources to your mock server, just as you would with a regular `MedplumClient` instance.
 
-The [finalize-report bot](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/finalize-reports.test.ts) from [Medplum Demo Bots](https://github.com/medplum/medplum-demo-bots/) provides a good example. Each test sets up a [Patient](/docs/api/fhir/resources/patient), an [Observation](/docs/api/fhir/resources/observation), and a [DiagnosticReport](/docs/api/fhir/resources/diagnosticreport) before invoking the bot.
+The [finalize-report bot](https://github.com/medplum/medplum-demo-bots/blob/main/src/finalize-reports.test.ts) from [Medplum Demo Bots](https://github.com/medplum/medplum-demo-bots/) provides a good example. Each test sets up a [Patient](/docs/api/fhir/resources/patient), an [Observation](/docs/api/fhir/resources/observation), and a [DiagnosticReport](/docs/api/fhir/resources/diagnosticreport) before invoking the bot.
 
 <details>
   <summary>Example: Create Resources</summary>
@@ -135,7 +135,7 @@ Most of the time, Bots will create or modify resources on the Medplum server. To
 
 To check the bot's response, simply check the return value of your `handler` function.
 
-The after running the Bot, the [finalize-report bot's tests](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/finalize-reports.test.ts) read the updated `DiagnosticReport` and `Observation` resources to confirm their status.
+The after running the Bot, the [finalize-report bot's tests](https://github.com/medplum/medplum-demo-bots/blob/main/src/finalize-reports.test.ts) read the updated `DiagnosticReport` and `Observation` resources to confirm their status.
 
 <details>
   <summary>Example: Query the results</summary>

--- a/packages/docs/docs/fhir-datastore/patient-deduplication/ingestion.md
+++ b/packages/docs/docs/fhir-datastore/patient-deduplication/ingestion.md
@@ -30,6 +30,6 @@ Incremental pipelines can often be implemented using [Medplum Bots](/docs/bots),
 
 - Update the `Patient.active` and `Patient.link` elements for all relevant records.
 
-Check out [this blog post](/blog/patient-deduplication) for more details on event-driven pipelines. The medplum-demo-bots repo also contains an [example](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/patient-deduplication.ts) of an incremental deduplication bot.
+Check out [this blog post](/blog/patient-deduplication) for more details on event-driven pipelines. The medplum-demo-bots repo also contains an [example](https://github.com/medplum/medplum-demo-bots/tree/main/src/deduplication) of an incremental deduplication bot.
 
 The next section will discuss **matching** potential duplicate records.

--- a/packages/docs/docs/questionnaires/basic-tutorial.md
+++ b/packages/docs/docs/questionnaires/basic-tutorial.md
@@ -36,7 +36,7 @@ The [QuestionnaireResponse](/docs/api/fhir/resources/questionnaireresponse) reso
 
 Questionnaires are very powerful when embedded in custom applications and [paired with Bots](/docs/bots/bot-for-questionnaire-response). The Medplum App is a good example of use of a Questionnaire in an application and [related commits](https://github.com/medplum/medplum/pulls?q=is%3Apr+is%3Aclosed+label%3Aquestionnaires) can be useful for context.
 
-There are bots in the [medplum-demo-bot repository](https://github.com/medplum/medplum-demo-bots/tree/main/src/examples/questionnaire-bots) that show examples of how to create common FHIR resources like `Observation` or `Condition` from QuestionnaireResponse resources.
+There are bots in the [medplum-demo-bot repository](https://github.com/medplum/medplum-demo-bots/tree/main/src/questionnaire-bots) that show examples of how to create common FHIR resources like `Observation` or `Condition` from QuestionnaireResponse resources.
 
 ## Related Resources
 

--- a/packages/docs/src/pages/products/careplans.md
+++ b/packages/docs/src/pages/products/careplans.md
@@ -27,7 +27,7 @@ One way to think of a Care Plan protocol is an "order-able service" off of a ser
 Once care plans are designed, the next step is to create all the relevant resources when a care plan is instantiated for a specific patient. The FHIR [CarePlan](https://app.medplum.com/CarePlan) object serves as a high level object that refers to related resources. Items that belong to that instantiation of the CarePlan are linked in a [RequestGroup](https://app.medplum.com/RequestGroup). The care plan should refer to a specific patient, and the appropriate responsible party such as practitioner or care team should be appropriately tracked. The correct creation of the CarePlan and RequestGroup is referred to in FHIR terms as the **apply** operation.
 
 - **Simple Care Plans**: are relatively straightforward to create, and we have provided sample implementations for your convenience. [RequestGroup sample in storybook](https://storybook.medplum.com/?path=/docs/medplum-requestgroupdisplay--simple).
-- **Linking objects**: a CarePlan should have a RequestGroup, and the RequestGroup can have one or more actions in an implementation. Commonly, each of the actions in the RequestGroup can drive automations or integrations. Sample code for [creating care plans](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/sample-account-setup.ts).
+- **Linking objects**: a CarePlan should have a RequestGroup, and the RequestGroup can have one or more actions in an implementation. Commonly, each of the actions in the RequestGroup can drive automations or integrations. Sample code for [creating care plans](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts).
 
 ## Care Plans and Care Teams
 
@@ -60,6 +60,6 @@ These are a common subset of objects that can be linked to CarePlans. Complex Ca
 
 - [Foo Medical Care Plan](https://foomedical.com/care-plan): sample patient portal with sample patient care plan.
 - [Provider Demo Care Plans](https://provider.medplum.com/): sample simple EHR with a menu of available care plans.
-- [Sample Code from for creating care plans](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/sample-account-setup.ts).
+- [Sample Code from for creating care plans](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts).
 - [Care Plan sample React Component](https://storybook.medplum.com/?path=/docs/medplum-requestgroupdisplay--simple) is one example of a care plan visualization.
 - [PlanDefinition Apply documentation](https://hl7.org/fhir/plandefinition-operation-apply.html), this is the process by which a PlanDefinition is converted to a CarePlan.

--- a/packages/docs/src/pages/products/scheduling.md
+++ b/packages/docs/src/pages/products/scheduling.md
@@ -45,4 +45,4 @@ In general one Schedule has many Slots, one Appointment takes one or more Slots.
 - [Storybook Scheduler React Component](https://storybook.medplum.com/?path=/docs/medplum-scheduler--basic)
 - [Foo Medical Scheduling](https://foomedical.com/get-care) sample patient portal with appointment booking experience.
 - [Provider Demo](https://provider.medplum.com/) sample simple EHR with provider calendar and slot creation.
-- [Sample Code](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/sample-account-setup.ts) sample code for searching for and creating schedules and slots.
+- [Sample Code](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts) sample code for searching for and creating schedules and slots.

--- a/packages/docs/src/pages/solutions/patient-portal.md
+++ b/packages/docs/src/pages/solutions/patient-portal.md
@@ -46,5 +46,5 @@ Giving patients access to only their data can be enabled via [access controls](/
 
 - Sample app [Foo Medical](https://www.foomedical.com) live for testing
 - [Foo Medical Source Code](https://github.com/medplum/foomedical)
-- [Sample data generation script](https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/sample-account-setup.ts)
+- [Sample data generation script](https://github.com/medplum/medplum-demo-bots/blob/main/src/sample-account-setup.ts)
 - [UI components on Storybook](https://storybook.medplum.com)

--- a/packages/react/.env.defaults
+++ b/packages/react/.env.defaults
@@ -1,2 +1,2 @@
 GOOGLE_CLIENT_ID=921088377005-3j1sa10vr6hj86jgmdfh2l53v3mp7lfi.apps.googleusercontent.com
-GOOGLE_AUTH_ORIGINS=http://localhost:3000,https://app.medplum.com,https://docs.medplum.com
+GOOGLE_AUTH_ORIGINS=http://localhost:3000,https://app.medplum.com


### PR DESCRIPTION
Fixes a number of dead links.

| Before | After |
|--------|--------|
| `https://docs.medplum.com/` | `https://www.medplum.com/docs/` |
| `https://github.com/medplum/medplum-demo-bots/blob/main/src/examples/*` | `https://github.com/medplum/medplum-demo-bots/blob/main/src/*` |
| `https://docs.medplum.com/storybook/index.html?` | `https://storybook.medplum.com/` | 

I also changed the header of the Bots index page from `Intro` to `Bots`.
This was to align it with the other index pages, and I also personally felt that it read odd to have the first sentence of an Intro section talking about reading the intro on another page 🙂 