### PR TITLE
Fixes #5378 - Handle multiple values in Timing.repeat.when

### DIFF
--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -311,7 +311,7 @@ export const functions: Record<string, FhirPathFunction> = {
    * @returns A collection containing only those elements in the input collection for which the stated criteria expression evaluates to true.
    */
   select: (context: AtomContext, input: TypedValue[], criteria: Atom): TypedValue[] => {
-    return input.map((e) => criteria.eval(context, [e])).flat();
+    return input.map((e) => criteria.eval({ parent: context, variables: { $this: e } }, [e])).flat();
   },
 
   /**

--- a/packages/definitions/dist/fhir/r4/profiles-types.json
+++ b/packages/definitions/dist/fhir/r4/profiles-types.json
@@ -28918,7 +28918,7 @@
             "key" : "tim-9",
             "severity" : "error",
             "human" : "If there's an offset, there must be a when (and not C, CM, CD, CV)",
-            "expression" : "offset.empty() or (when.exists() and ((when in ('C' | 'CM' | 'CD' | 'CV')).not()))",
+            "expression" : "offset.empty() or (when.exists() and when.select($this in ('C' | 'CM' | 'CD' | 'CV')).allFalse())",
             "xpath" : "not(exists(f:offset)) or exists(f:when)"
           },
           {


### PR DESCRIPTION
Timing constraint "tim-9" had a bug in R4 that prevents multiple codes in "when"

We are fixing by backporting the R5 constraint to R4

* R4 constraint: `offset.empty() or (when.exists() and ((when in ('C' | 'CM' | 'CD' | 'CV')).not()))`
* R5 constraint: `offset.empty() or (when.exists() and when.select($this in ('C' | 'CM' | 'CD' | 'CV')).allFalse())`

See https://github.com/medplum/medplum/issues/5378 for more details