### PR TITLE
test(cli): add refing config file names for cleanup

### DIFF
--- a/packages/cli/src/aws/init.test.ts
+++ b/packages/cli/src/aws/init.test.ts
@@ -41,6 +41,7 @@ describe('init command', () => {
     for (const file of configFiles.values()) {
       cleanupConfigFile(file);
     }
+    // We add a special case for `medplum.foo.config.server.json` since that is the output config file from these tests
     cleanupConfigFile('medplum.foo.config.server.json');
   });
 


### PR DESCRIPTION
This makes sure we cleanup config files created in `@medplum/cli` tests to prevent accidental commiting of those files and also just general less noise in working directory.