### PR TITLE
Use FHIR stringify in server responses

### DIFF
--- a/packages/server/src/auth/newproject.test.ts
+++ b/packages/server/src/auth/newproject.test.ts
@@ -193,7 +193,7 @@ describe('New project', () => {
       .get(`/fhir/R4/Patient`)
       .set('Authorization', 'Bearer ' + res6.body.access_token);
     expect(res8.status).toBe(200);
-    expect(res8.body.entry.length).toEqual(0);
+    expect(res8.body.entry).toBeUndefined();
   });
 
   test('GraphQL is restricted to project', async () => {

--- a/packages/server/src/fhir/batch.test.ts
+++ b/packages/server/src/fhir/batch.test.ts
@@ -136,8 +136,8 @@ describe('Batch and Transaction processing', () => {
     expect(results.entry?.[1]?.resource).toMatchObject<Partial<Bundle>>({
       resourceType: 'Bundle',
       type: 'searchset',
-      entry: [],
     });
+    expect((results.entry?.[1]?.resource as Partial<Bundle>).entry).toBeUndefined();
 
     expect(results.entry?.[2]?.response?.status).toEqual('201');
     expect(results.entry?.[2]?.resource).toMatchObject<Partial<Patient>>({
@@ -279,8 +279,8 @@ describe('Batch and Transaction processing', () => {
     expect(results.entry?.[1]?.resource).toMatchObject<Partial<Bundle>>({
       resourceType: 'Bundle',
       type: 'searchset',
-      entry: [],
     });
+    expect((results.entry?.[1]?.resource as Partial<Bundle>).entry).toBeUndefined();
 
     expect(results.entry?.[2]?.response?.status).toEqual('201');
     expect(results.entry?.[2]?.resource).toMatchObject<Patient>({
@@ -819,7 +819,7 @@ describe('Batch and Transaction processing', () => {
       .set('Content-Type', ContentType.FHIR_JSON)
       .send();
     expect(res2.status).toBe(200);
-    expect(res2.body.entry).toHaveLength(0);
+    expect(res2.body.entry).toBeUndefined();
   });
 
   test('Conditional reference resolution', async () => {

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -964,7 +964,7 @@ describe('Updated implementation', () => {
 
     expect(res.status).toEqual(200);
     const expansion = res.body.expansion as ValueSetExpansion;
-    expect(expansion.contains).toHaveLength(0);
+    expect(expansion.contains).toBeUndefined();
   });
 
   test('Exact code match', async () => {

--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -944,8 +944,7 @@ describe('Updated implementation', () => {
     expect(res.status).toEqual(200);
     const expansion = res.body.expansion as ValueSetExpansion;
 
-    const expandedCodes = expansion.contains?.map((coding) => coding.code);
-    expect(expandedCodes).toHaveLength(0);
+    expect(expansion.contains).toBeUndefined();
   });
 
   test('Expand with empty filter', async () => {

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -276,6 +276,7 @@ describe('GraphQL', () => {
         }`,
       });
     expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
     expect(res.headers['cache-control']).toBe('no-store, no-cache, must-revalidate');
   });
 

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -310,9 +310,14 @@ describe('FHIR Repo', () => {
       const patient = await repo.createResource<Patient>({
         resourceType: 'Patient',
         name: [{ given: ['Alice'], family: 'Smith' }],
+        identifier: [],
       });
 
       expect(patient.meta?.author?.reference).toEqual(getReferenceString(client));
+
+      // empty identifier array should removed when read from cache
+      const readPatient = await repo.readResource<Patient>('Patient', patient.id as string, { checkCacheOnly: true });
+      expect(readPatient.identifier).toBeUndefined();
     }));
 
   test('Create Patient as Practitioner with no author', () =>

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2241,7 +2241,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     const projectId = resource.meta?.project;
     await getRedis().set(
       getCacheKey(resource.resourceType, resource.id as string),
-      JSON.stringify({ resource, projectId }),
+      stringify({ resource, projectId }),
       'EX',
       REDIS_CACHE_EX_SECONDS
     );

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -1,4 +1,4 @@
-import { allOk, ContentType, isOk, OperationOutcomeError } from '@medplum/core';
+import { allOk, ContentType, isOk, OperationOutcomeError, stringify } from '@medplum/core';
 import { BatchEvent, FhirRequest, FhirRouter, HttpMethod, RepositoryMode } from '@medplum/fhir-router';
 import { ResourceType } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response, Router } from 'express';
@@ -71,7 +71,7 @@ fhirRouter.use((req: Request, res: Response, next: NextFunction) => {
       res.contentType(ContentType.FHIR_JSON);
     }
 
-    return res.json(data);
+    return res.send(stringify(data, req.query._pretty === 'true'));
   };
   next();
 });

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -78,7 +78,7 @@ fhirRouter.use((req: Request, res: Response, next: NextFunction) => {
         (s) => s.name === 'legacyFhirJsonResponseFormat'
       )?.valueBoolean;
     } catch (_err) {
-      // Ignore errors
+      // Ignore errors since unauthenticated requests also use this middleware
     }
 
     const pretty = req.query._pretty === 'true';


### PR DESCRIPTION
Previously, there were cases in which empty text/array fields were not being properly removed from FHIR server responses due to the particulars of the caching logic. This is a more robust fix that ensures all FHIR responses use the appropriate JSON-serialization method.

To revert to the legacy `JSON.stringify`, a super admin can include the following entry in `Project.systemSetting`:

```js
{ name: 'legacyFhirJsonResponseFormat', valueBoolean: true }
```

