### PR TITLE
S3 Native Presigned URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2706,6 +2706,25 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.705.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.705.0.tgz",
+      "integrity": "sha512-dAQiXv/TqjEUCoEeiKqQGI8LJ3g8Xv+XJL4W9CwsB6ZHHDq0Q05ulpDSkhhCf52ySXf5dJ33e1o/VeUDY3q0pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.696.0",
+        "@aws-sdk/types": "3.696.0",
+        "@aws-sdk/util-format-url": "3.696.0",
+        "@smithy/middleware-endpoint": "^3.2.3",
+        "@smithy/protocol-http": "^4.1.7",
+        "@smithy/smithy-client": "^3.4.4",
+        "@smithy/types": "^3.7.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.696.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.696.0.tgz",
@@ -2776,6 +2795,21 @@
         "@aws-sdk/types": "3.696.0",
         "@smithy/types": "^3.7.1",
         "@smithy/util-endpoints": "^2.1.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.696.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.696.0.tgz",
+      "integrity": "sha512-R6yK1LozUD1GdAZRPhNsIow6VNFJUTyyoIar1OCWaknlucBMcq7musF3DN3TlORBwfFMj5buHc2ET9OtMtzvuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.696.0",
+        "@smithy/querystring-builder": "^3.0.10",
+        "@smithy/types": "^3.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9361,9 +9395,9 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "8.0.22",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.0.22.tgz",
-      "integrity": "sha512-Kwlf3ymHH37W2nuNA9FzYgZvrImJScLA98939kapnOxfNGAPhmhEw26sfIGmBWAa8ymdL6p+HXQ3+b/xJ74bOg==",
+      "version": "8.0.23",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.0.23.tgz",
+      "integrity": "sha512-Zf01kFiN2PISmLb0DhIAJh76v3J2oYUKSjiAtGZLOH0HUz59by/qdyU4mGHWdeyRdCCrLUA21Rct2MBykvRMsg==",
       "license": "MIT",
       "dependencies": {
         "@expo/config": "~10.0.4",
@@ -9371,7 +9405,7 @@
         "@expo/config-types": "^52.0.0",
         "@expo/image-utils": "^0.6.0",
         "@expo/json-file": "^9.0.0",
-        "@react-native/normalize-colors": "0.76.3",
+        "@react-native/normalize-colors": "0.76.5",
         "debug": "^4.3.1",
         "fs-extra": "^9.0.0",
         "resolve-from": "^5.0.0",
@@ -14433,21 +14467,21 @@
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.76.3",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.3.tgz",
-      "integrity": "sha512-mZ7jmIIg4bUnxCqY3yTOkoHvvzsDyrZgfnIKiTGm5QACrsIGa5eT3pMFpMm2OpxGXRDrTMsYdPXE2rCyDX52VQ==",
+      "version": "0.76.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.5.tgz",
+      "integrity": "sha512-xe7HSQGop4bnOLMaXt0aU+rIatMNEQbz242SDl8V9vx5oOTI0VbZV9yLy6yBc6poUlYbcboF20YVjoRsxX4yww==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/codegen": "0.76.3"
+        "@react-native/codegen": "0.76.5"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.76.3",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.3.tgz",
-      "integrity": "sha512-zi2nPlQf9q2fmfPyzwWEj6DU96v8ziWtEfG7CTAX2PG/Vjfsr94vn/wWrCdhBVvLRQ6Kvd/MFAuDYpxmQwIiVQ==",
+      "version": "0.76.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.5.tgz",
+      "integrity": "sha512-1Nu5Um4EogOdppBLI4pfupkteTjWfmI0hqW8ezWTg7Bezw0FtBj8yS8UYVd3wTnDFT9A5mA2VNoNUqomJnvj2A==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -14491,7 +14525,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.76.3",
+        "@react-native/babel-plugin-codegen": "0.76.5",
         "babel-plugin-syntax-hermes-parser": "^0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -14504,9 +14538,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.76.3",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.3.tgz",
-      "integrity": "sha512-oJCH/jbYeGmFJql8/y76gqWCCd74pyug41yzYAjREso1Z7xL88JhDyKMvxEnfhSdMOZYVl479N80xFiXPy3ZYA==",
+      "version": "0.76.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.5.tgz",
+      "integrity": "sha512-FoZ9VRQ5MpgtDAnVo1rT9nNRfjnWpE40o1GeJSDlpUMttd36bVXvsDm8W/NhX8BKTWXSX+CPQJsRcvN1UPYGKg==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.3",
@@ -14893,9 +14927,9 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.76.3",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.3.tgz",
-      "integrity": "sha512-Yrpmrh4IDEupUUM/dqVxhAN8QW1VEUR3Qrk2lzJC1jB2s46hDe0hrMP2vs12YJqlzshteOthjwXQlY0TgIzgbg==",
+      "version": "0.76.5",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.5.tgz",
+      "integrity": "sha512-6QRLEok1r55gLqj+94mEWUENuU5A6wsr2OoXpyq/CgQ7THWowbHtru/kRGRr6o3AQXrVnZheR60JNgFcpNYIug==",
       "license": "MIT"
     },
     "node_modules/@react-native/virtualized-lists": {
@@ -21303,9 +21337,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-12.0.3.tgz",
-      "integrity": "sha512-1695e8y3U/HjifKx33vcNnFMSUSXwPWwhFxRlL6NRx2TENN6gySH82gPOWgxcra6gi+EJgXx52xG3PcqTjwW6w==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-12.0.4.tgz",
+      "integrity": "sha512-SAzAwqpyjA+/OFrU95OOioj6oTeCv4+rRfrNmBTy5S/gJswrZKBSPJioFudIaJBy43W+BL7HA5AspBIF6tO/aA==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.12.9",
@@ -21314,7 +21348,7 @@
         "@babel/plugin-transform-parameters": "^7.22.15",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.76.3",
+        "@react-native/babel-preset": "0.76.5",
         "babel-plugin-react-native-web": "~0.19.13",
         "react-refresh": "^0.14.2"
       },
@@ -26390,9 +26424,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.71.tgz",
-      "integrity": "sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA==",
+      "version": "1.5.72",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
+      "integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
       "license": "ISC"
     },
     "node_modules/emitter-component": {
@@ -28043,9 +28077,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.4.tgz",
-      "integrity": "sha512-aAWEDwnu0XHOBYvQ9Q0+QIa+483vYJaC4IDsXyWQ73Rtsg273NZh5kYowY+cAocvoSmA99G6htrLBn11ax2bTQ==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.5.tgz",
+      "integrity": "sha512-vm7gA+PB7j99hfvBBFMRiti8OeazFK3AZWtDmCi6WQCXDxngXkAJViXhkHyF3xwDKljzlP8+4BIGrKCzbfoObg==",
       "license": "MIT",
       "dependencies": {
         "web-streams-polyfill": "^3.3.2"
@@ -35886,9 +35920,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.14",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.14.tgz",
-      "integrity": "sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==",
+      "version": "0.30.15",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.15.tgz",
+      "integrity": "sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -39798,9 +39832,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "license": "MIT"
     },
     "node_modules/node-stream-zip": {
@@ -53819,6 +53853,7 @@
         "@aws-sdk/client-textract": "3.699.0",
         "@aws-sdk/cloudfront-signer": "3.696.0",
         "@aws-sdk/lib-storage": "3.705.0",
+        "@aws-sdk/s3-request-presigner": "3.705.0",
         "@aws-sdk/types": "3.696.0",
         "@google-cloud/secret-manager": "5.6.0",
         "@medplum/core": "3.2.24",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/cloudfront-signer": "3.696.0",
     "@aws-sdk/lib-storage": "3.705.0",
     "@aws-sdk/types": "3.696.0",
+    "@aws-sdk/s3-request-presigner": "3.705.0",
     "@google-cloud/secret-manager": "5.6.0",
     "@medplum/core": "3.2.24",
     "@medplum/definitions": "3.2.24",

--- a/packages/server/src/cloud/aws/signer.ts
+++ b/packages/server/src/cloud/aws/signer.ts
@@ -1,6 +1,5 @@
-import { badRequest, OperationOutcomeError } from '@medplum/core';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
-import { concatUrls } from '@medplum/core';
+import { badRequest, concatUrls, OperationOutcomeError } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { getConfig } from '../../config';
 

--- a/packages/server/src/cloud/aws/signer.ts
+++ b/packages/server/src/cloud/aws/signer.ts
@@ -1,3 +1,4 @@
+import { badRequest, OperationOutcomeError } from '@medplum/core';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { concatUrls } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
@@ -13,6 +14,9 @@ import { getConfig } from '../../config';
  */
 export function getPresignedUrl(binary: Binary): string {
   const config = getConfig();
+  if (!config.signingKeyId || !config.signingKey) {
+    throw new OperationOutcomeError(badRequest('Need to provide signingKeyId and signingKey in config file'));
+  }
   const storageBaseUrl = config.storageBaseUrl;
   const unsignedUrl = concatUrls(storageBaseUrl, `${binary.id}/${binary.meta?.versionId}`);
   const dateLessThan = new Date();

--- a/packages/server/src/cloud/aws/storage.ts
+++ b/packages/server/src/cloud/aws/storage.ts
@@ -1,4 +1,5 @@
 import { CopyObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl as s3GetSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { Upload } from '@aws-sdk/lib-storage';
 import { concatUrls } from '@medplum/core';
@@ -113,8 +114,14 @@ export class S3Storage implements BinaryStorage {
    * @param binary - Binary resource.
    * @returns Presigned URL to access the binary data.
    */
-  getPresignedUrl(binary: Binary): string {
+  async getPresignedUrl(binary: Binary): Promise<string> {
     const config = getConfig();
+
+    if (!config.signingKey || !config.signingKeyId) {
+      const Key = this.getKey(binary);
+      return s3GetSignedUrl(this.client, new GetObjectCommand({ Bucket: this.bucket, Key }), { expiresIn: 3600 });
+    }
+
     const storageBaseUrl = config.storageBaseUrl;
     const unsignedUrl = concatUrls(storageBaseUrl, `${binary.id}/${binary.meta?.versionId}`);
     const dateLessThan = new Date();

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -20,9 +20,9 @@ export interface MedplumServerConfig {
   logLevel?: string;
   binaryStorage?: string;
   storageBaseUrl: string;
-  signingKey: string;
-  signingKeyId: string;
-  signingKeyPassphrase: string;
+  signingKey?: string;
+  signingKeyId?: string;
+  signingKeyPassphrase?: string;
   supportEmail: string;
   approvedSenderEmails?: string;
   database: MedplumDatabaseConfig;

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -155,6 +155,6 @@ export async function uploadBinaryData(
   const contentType = options?.contentType ?? DEFAULT_CONTENT_TYPE;
   await getBinaryStorage().writeBinary(binary, options?.filename, contentType, source);
 
-  binary.url = getBinaryStorage().getPresignedUrl(binary);
+  binary.url = await getBinaryStorage().getPresignedUrl(binary);
   return binary;
 }


### PR DESCRIPTION
Adding pre-signed URLs implementation using s3 native functionality so that alternative (non AWS) deployments can be achieved

Medplum is nodejs server + postgres + redis plus s3, with a CDN in front. 
But you can deploy all of that not just on AWS but on other clouds.
Lots of clouds offer postgres/redis/s3-compatible offerings, notably GCP.
With this small change we allow the usage of native pre-signed s3 functionality so that it can be deployed in many more arrangements than just AWS

This is the implementation we envision for the issue #4815

We're using this change in production with our deployment in GCP (we've forked medplum with only this specific change) and we keep it in sync with upstream.
