### PR TITLE
Note that referential integrity is not supported for deletes

### DIFF
--- a/packages/docs/docs/fhir-datastore/deleting-data.md
+++ b/packages/docs/docs/fhir-datastore/deleting-data.md
@@ -29,7 +29,7 @@ However, the original content of the resource is not destroyed. It can still be 
 
 :::caution Referential Integrity on Deletes
 
-Referential integrity is **not** supported for deletes at this time as it would require checking every resource in a project for inbound references to the deleted resource. Unfortunately, performance tradeoffs forbid Medplum from implementing this.
+Referential integrity is **not** supported for deletes at this time.
 
 :::
 

--- a/packages/docs/docs/fhir-datastore/deleting-data.md
+++ b/packages/docs/docs/fhir-datastore/deleting-data.md
@@ -27,6 +27,12 @@ However, the original content of the resource is not destroyed. It can still be 
 - Reading resource history: `GET Patient/123/_history`
 - Reading a resource version: `GET Patient/123/_history/1`
 
+:::caution Referential Integrity on Deletes
+
+Referential integrity is **not** supported for deletes at this time as it would require checking every resource in a project for inbound references to the deleted resource. Unfortunately, performance tradeoffs forbid Medplum from implementing this.
+
+:::
+
 ## Expunge Operation
 
 The Medplum `$expunge` operation performs a "hard" or "physical" delete. This means that the data is permanently removed from the database, including all resource history.


### PR DESCRIPTION
Fixes #5446 Adds a note to the deleting data docs that referential integrity is not supported when deleting data.