### PR TITLE
Remove Literal in favor of Parameter

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -58,8 +58,8 @@ import {
   Disjunction,
   escapeLikeString,
   Expression,
-  Literal,
   Negation,
+  Parameter,
   periodToRangeString,
   SelectQuery,
   Operator as SQL,
@@ -161,7 +161,7 @@ export async function searchByReferenceImpl<T extends Resource>(
       referenceValues.map((r) => [r])
     )
   );
-  builder.join('INNER JOIN LATERAL', searchQuery, 'results', new Literal('true'));
+  builder.join('INNER JOIN LATERAL', searchQuery, 'results', new Parameter('true'));
   builder.column(new Column('results', 'id')).column(new Column('results', 'content')).column(referenceColumn);
 
   const rows: {

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -186,14 +186,6 @@ export class Column implements Expression {
   }
 }
 
-export class Literal implements Expression {
-  constructor(readonly value: string) {}
-
-  buildSql(sql: SqlBuilder): void {
-    sql.append(this.value);
-  }
-}
-
 export class Parameter implements Expression {
   constructor(readonly value: string) {}
 
@@ -503,7 +495,7 @@ interface CTE {
 export class SelectQuery extends BaseQuery implements Expression {
   readonly innerQuery?: SelectQuery | Union | ValuesQuery;
   readonly distinctOns: Column[];
-  readonly columns: (Column | Literal)[];
+  readonly columns: Column[];
   readonly joins: Join[];
   readonly groupBys: GroupBy[];
   readonly orderBys: OrderBy[];
@@ -539,8 +531,8 @@ export class SelectQuery extends BaseQuery implements Expression {
     return this;
   }
 
-  column(column: Column | string | Literal): this {
-    this.columns.push(column instanceof Literal ? column : getColumn(column, this.tableName));
+  column(column: Column | string): this {
+    this.columns.push(getColumn(column, this.tableName));
     return this;
   }
 
@@ -650,11 +642,7 @@ export class SelectQuery extends BaseQuery implements Expression {
       if (!first) {
         sql.append(', ');
       }
-      if (column instanceof Literal) {
-        sql.appendParameters(column.value, false);
-      } else {
-        sql.appendColumn(column);
-      }
+      sql.appendColumn(column);
       first = false;
     }
   }


### PR DESCRIPTION
Followup to #5444 

We can simplify a bit and just use `Parameter` in the other place we were using `Literal`.