### PR TITLE
Case-insensitive search on ContactPoint

### DIFF
--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -58,10 +58,17 @@ export abstract class LookupTable {
    * @param _selectQuery - The select query builder.
    * @param resourceType - The FHIR resource type.
    * @param table - The resource table.
+   * @param _param - The search parameter.
    * @param filter - The search filter details.
    * @returns The select query where expression.
    */
-  buildWhere(_selectQuery: SelectQuery, resourceType: ResourceType, table: string, filter: Filter): Expression {
+  buildWhere(
+    _selectQuery: SelectQuery,
+    resourceType: ResourceType,
+    table: string,
+    _param: SearchParameter,
+    filter: Filter
+  ): Expression {
     const lookupTableName = this.getTableName(resourceType);
     const columnName = this.getColumnName(filter.code);
 

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3436,6 +3436,27 @@ describe('FHIR Search', () => {
         expect(result.entry?.length).toBe(0);
       }));
 
+    test('Practitioner by email case insensitive', () =>
+      withTestContext(async () => {
+        const email = 'UPPER@EXAMPLE.COM';
+        const practitioner = await repo.createResource<Practitioner>({
+          resourceType: 'Practitioner',
+          telecom: [{ system: 'email', value: email }],
+        });
+        const result = await repo.search({
+          resourceType: 'Practitioner',
+          filters: [
+            {
+              code: 'telecom',
+              operator: Operator.EQUALS,
+              value: 'uPpeR@ExAmPlE.CoM',
+            },
+          ],
+        });
+        expect(result.entry?.length).toBe(1);
+        expect(bundleContains(result, practitioner)).toBeDefined();
+      }));
+
     test('Patient by name with stop word', () =>
       withTestContext(async () => {
         const seed = randomUUID();

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -880,7 +880,7 @@ function buildSearchFilterExpression(
 
   const lookupTable = getLookupTable(resourceType, param);
   if (lookupTable) {
-    return lookupTable.buildWhere(selectQuery, resourceType, table, filter);
+    return lookupTable.buildWhere(selectQuery, resourceType, table, param, filter);
   }
 
   // Not any special cases, just a normal search parameter.


### PR DESCRIPTION
`ContactPoint` token search parameters are now treated as case-insensitive so that searching for `upper@example.com` matches against an email address entered as `UPPER@example.com` in a resource.

Reindexing all objects is required to take full advantage of this change, but it is backwards compatible such that the previous/current case-sensitive search is still supported.

Fixes #5424 