### PR TITLE
Enable chained search over canonical references

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1389,22 +1389,16 @@ function buildChainedSearchUsingReferenceTable(
 
 function linkCanonicalReference(selectQuery: SelectQuery, currentTable: string, link: ChainedSearchLink): string {
   const nextTableAlias = selectQuery.getNextJoinAlias();
-  let joinCondition: Condition;
+  const eq = link.details.array ? 'IN_SUBQUERY' : '=';
+
+  let join: Condition;
   if (link.reverse) {
-    joinCondition = new Condition(
-      new Column(currentTable, 'url'),
-      link.details.array ? 'IN_SUBQUERY' : '=',
-      new Column(nextTableAlias, link.details.columnName)
-    );
+    join = new Condition(new Column(currentTable, 'url'), eq, new Column(nextTableAlias, link.details.columnName));
   } else {
-    joinCondition = new Condition(
-      new Column(nextTableAlias, 'url'),
-      link.details.array ? 'IN_SUBQUERY' : '=',
-      new Column(currentTable, link.details.columnName)
-    );
+    join = new Condition(new Column(nextTableAlias, 'url'), eq, new Column(currentTable, link.details.columnName));
   }
 
-  selectQuery.join('INNER JOIN', link.resourceType, nextTableAlias, joinCondition);
+  selectQuery.join('INNER JOIN', link.resourceType, nextTableAlias, join);
   return nextTableAlias;
 }
 

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1389,19 +1389,22 @@ function buildChainedSearchUsingReferenceTable(
 
 function linkCanonicalReference(selectQuery: SelectQuery, currentTable: string, link: ChainedSearchLink): string {
   const nextTableAlias = selectQuery.getNextJoinAlias();
-  selectQuery.join(
-    'INNER JOIN',
-    link.resourceType,
-    nextTableAlias,
-    link.reverse
-      ? new Condition(
-          new Column(currentTable, 'url'),
-          link.details.array ? 'IN_SUBQUERY' : '=',
-          new Column(nextTableAlias, link.details.columnName)
-        )
-      : new Condition(new Column(currentTable, link.details.columnName), '=', new Column(nextTableAlias, 'url'))
-  );
+  let joinCondition: Condition;
+  if (link.reverse) {
+    joinCondition = new Condition(
+      new Column(currentTable, 'url'),
+      link.details.array ? 'IN_SUBQUERY' : '=',
+      new Column(nextTableAlias, link.details.columnName)
+    );
+  } else {
+    joinCondition = new Condition(
+      new Column(nextTableAlias, 'url'),
+      link.details.array ? 'IN_SUBQUERY' : '=',
+      new Column(currentTable, link.details.columnName)
+    );
+  }
 
+  selectQuery.join('INNER JOIN', link.resourceType, nextTableAlias, joinCondition);
   return nextTableAlias;
 }
 


### PR DESCRIPTION
Canonical references differ from regular `Reference` values: they are bare `string` values that must correspond with the `url` field of the target (referenced) resource.  Chained search over canonical references is handled in the database by a direct `JOIN` to the next resource table, using string equality on the `url` column