### PR TITLE
Add opt-in `Project.systemSetting` to perform searches on readers when available

### DIFF
--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -72,8 +72,13 @@ async function batch(req: FhirRequest, repo: FhirRepository, router: FhirRouter)
 }
 
 // Search
-async function search(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
-  setSearchRepositoryMode(req, repo);
+async function search(
+  req: FhirRequest,
+  repo: FhirRepository,
+  _router: FhirRouter,
+  options?: FhirRouteOptions
+): Promise<FhirResponse> {
+  setSearchRepositoryMode(req, repo, options);
 
   const { resourceType } = req.params;
   const bundle = await repo.search(parseSearchRequest(resourceType as ResourceType, req.query));
@@ -81,8 +86,13 @@ async function search(req: FhirRequest, repo: FhirRepository): Promise<FhirRespo
 }
 
 // Search multiple types
-async function searchMultipleTypes(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
-  setSearchRepositoryMode(req, repo);
+async function searchMultipleTypes(
+  req: FhirRequest,
+  repo: FhirRepository,
+  _router: FhirRouter,
+  options?: FhirRouteOptions
+): Promise<FhirResponse> {
+  setSearchRepositoryMode(req, repo, options);
 
   const searchRequest = parseSearchRequest('MultipleTypes' as ResourceType, req.query);
   if (!searchRequest.types || searchRequest.types.length === 0) {
@@ -93,8 +103,13 @@ async function searchMultipleTypes(req: FhirRequest, repo: FhirRepository): Prom
 }
 
 // Search by POST
-async function searchByPost(req: FhirRequest, repo: FhirRepository): Promise<FhirResponse> {
-  setSearchRepositoryMode(req, repo);
+async function searchByPost(
+  req: FhirRequest,
+  repo: FhirRepository,
+  _router: FhirRouter,
+  options?: FhirRouteOptions
+): Promise<FhirResponse> {
+  setSearchRepositoryMode(req, repo, options);
 
   const { resourceType } = req.params;
   const query = req.body as Record<string, string[] | string | undefined>;
@@ -102,8 +117,8 @@ async function searchByPost(req: FhirRequest, repo: FhirRepository): Promise<Fhi
   return [allOk, bundle];
 }
 
-function setSearchRepositoryMode(req: FhirRequest, repo: FhirRepository): void {
-  if (req.config?.searchOnReader) {
+function setSearchRepositoryMode(req: FhirRequest, repo: FhirRepository, options?: FhirRouteOptions): void {
+  if (!options?.batch && req.config?.searchOnReader) {
     repo.setMode(RepositoryMode.READER);
   }
 }

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -104,7 +104,6 @@ async function searchByPost(req: FhirRequest, repo: FhirRepository): Promise<Fhi
 
 function setSearchRepositoryMode(req: FhirRequest, repo: FhirRepository): void {
   if (req.config?.searchOnReader) {
-    console.log('Setting search mode to READER');
     repo.setMode(RepositoryMode.READER);
   }
 }

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -117,6 +117,8 @@ export async function graphqlHandler(
 
   if (includesMutations(query)) {
     repo.setMode(RepositoryMode.WRITER);
+  } else {
+    repo.setMode(RepositoryMode.READER);
   }
 
   const dataLoader = new DataLoader<Reference, Resource>((keys) => repo.readReferences(keys));

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -38,7 +38,7 @@ import {
   validate,
   ValidationContext,
 } from 'graphql';
-import { FhirRequest, FhirResponse, FhirRouter } from '../fhirrouter';
+import { FhirRequest, FhirResponse, FhirRouteOptions, FhirRouter } from '../fhirrouter';
 import { FhirRepository, RepositoryMode } from '../repo';
 import { getGraphQLInputType } from './input-types';
 import { buildGraphQLOutputType, getGraphQLOutputType, outputTypeCache } from './output-types';
@@ -84,12 +84,14 @@ interface ConnectionEdge {
  * @param req - The request details.
  * @param repo - The current user FHIR repository.
  * @param router - The router for router options.
+ * @param options - Additional route options.
  * @returns The response.
  */
 export async function graphqlHandler(
   req: FhirRequest,
   repo: FhirRepository,
-  router: FhirRouter
+  router: FhirRouter,
+  options?: FhirRouteOptions
 ): Promise<FhirResponse> {
   const { query, operationName, variables } = req.body;
   if (!query) {
@@ -115,9 +117,7 @@ export async function graphqlHandler(
     return [forbidden];
   }
 
-  if (includesMutations(query)) {
-    repo.setMode(RepositoryMode.WRITER);
-  } else {
+  if (!options?.batch && !includesMutations(query)) {
     repo.setMode(RepositoryMode.READER);
   }
 

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -1,5 +1,5 @@
 import { ContentType, createReference, getReferenceString, isPopulated } from '@medplum/core';
-import { Binary, Encounter, Patient, Practitioner, Resource, ServiceRequest } from '@medplum/fhirtypes';
+import { Binary, Bundle, Encounter, Patient, Practitioner, Resource, ServiceRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -1075,10 +1075,8 @@ describe('GraphQL', () => {
   });
 
   test('Uses reader instance when available', async () => {
-    const reader = getDatabasePool(DatabaseMode.READER);
-    const readerSpy = jest.spyOn(reader, 'query');
-    const writer = getDatabasePool(DatabaseMode.WRITER);
-    const writerSpy = jest.spyOn(writer, 'query');
+    const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
+    const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
 
     const res = await request(app)
       .post('/fhir/R4/$graphql')
@@ -1088,6 +1086,39 @@ describe('GraphQL', () => {
     expect(res.status).toBe(200);
     expect(readerSpy).toHaveBeenCalledTimes(1);
     expect(writerSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('GraphQL in batch users writer', async () => {
+    const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
+    const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
+
+    const batch: Bundle = {
+      resourceType: 'Bundle',
+      type: 'batch',
+      entry: [
+        {
+          request: {
+            method: 'POST',
+            url: '$graphql',
+          },
+          resource: {
+            query: `{ PatientList(_id: "${patient.id}") { id } }`,
+          } as unknown as Resource,
+        },
+      ],
+    };
+    const res = await request(app)
+      .post(`/fhir/R4/`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send(batch);
+    expect(res.status).toBe(200);
+    expect(res.body.resourceType).toEqual('Bundle');
+    expect(res.body.entry[0].resource.data.PatientList).toHaveLength(1);
+    expect(res.body.entry[0].resource.data.PatientList[0].id).toBe(patient.id);
+
+    expect(readerSpy).toHaveBeenCalledTimes(0);
+    expect(writerSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/server/src/fhir/operations/graphql.test.ts
+++ b/packages/server/src/fhir/operations/graphql.test.ts
@@ -123,6 +123,10 @@ describe('GraphQL', () => {
     })
   );
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   afterAll(async () => {
     await shutdownApp();
   });

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -44,9 +44,11 @@ describe('FHIR Routes', () => {
           ],
         });
       expect(res.status).toBe(201);
-      testPatient = res.body as Patient;
-      patientId = testPatient.id as string;
-      patientVersionId = (testPatient.meta as Meta).versionId as string;
+      if (token === accessToken) {
+        testPatient = res.body as Patient;
+        patientId = testPatient.id as string;
+        patientVersionId = (testPatient.meta as Meta).versionId as string;
+      }
     }
   });
 

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -467,7 +467,7 @@ describe('FHIR Routes', () => {
     expect(res.status).toBe(200);
   });
 
-  test.only.each<['writer' | 'reader']>([['writer'], ['reader']])('Search on %s', async (repoMode) => {
+  test.each<['writer' | 'reader']>([['writer'], ['reader']])('Search on %s', async (repoMode) => {
     const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
     const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
     const token = repoMode === 'writer' ? accessToken : searchOnReaderAccessToken;
@@ -501,7 +501,7 @@ describe('FHIR Routes', () => {
     expect(res.body.issue[0].details.text).toEqual('Unknown search parameter: basedOn');
   });
 
-  test.only.each<['writer' | 'reader']>([['writer'], ['reader']])('Search by POST on %s', async (repoMode) => {
+  test.each<['writer' | 'reader']>([['writer'], ['reader']])('Search by POST on %s', async (repoMode) => {
     const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
     const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
     const token = repoMode === 'writer' ? accessToken : searchOnReaderAccessToken;
@@ -628,7 +628,7 @@ describe('FHIR Routes', () => {
       expect(res3.status).toBe(403);
     }));
 
-  test.only.each<['writer' | 'reader']>([['writer'], ['reader']])(
+  test.each<['writer' | 'reader']>([['writer'], ['reader']])(
     'Search multiple resource types with _type on %s',
     async (repoMode) =>
       withTestContext(async () => {

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -7,10 +7,12 @@ import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { addTestUser, bundleContains, createTestProject, initTestAuth, withTestContext } from '../test.setup';
+import { DatabaseMode, getDatabasePool } from '../database';
 
 const app = express();
 let accessToken: string;
 let legacyJsonResponseAccessToken: string;
+let searchOnReaderAccessToken: string;
 let testPatient: Patient;
 let patientId: string;
 let patientVersionId: string;
@@ -23,24 +25,33 @@ describe('FHIR Routes', () => {
     legacyJsonResponseAccessToken = await initTestAuth({
       project: { systemSetting: [{ name: 'legacyFhirJsonResponseFormat', valueBoolean: true }] },
     });
+    searchOnReaderAccessToken = await initTestAuth({
+      project: { systemSetting: [{ name: 'searchOnReader', valueBoolean: true }] },
+    });
 
-    const res = await request(app)
-      .post(`/fhir/R4/Patient`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Content-Type', ContentType.FHIR_JSON)
-      .send({
-        resourceType: 'Patient',
-        name: [
-          {
-            given: ['Alice'],
-            family: 'Smith',
-          },
-        ],
-      });
-    expect(res.status).toBe(201);
-    testPatient = res.body as Patient;
-    patientId = testPatient.id as string;
-    patientVersionId = (testPatient.meta as Meta).versionId as string;
+    for (const token of [accessToken, searchOnReaderAccessToken]) {
+      const res = await request(app)
+        .post(`/fhir/R4/Patient`)
+        .set('Authorization', 'Bearer ' + token)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send({
+          resourceType: 'Patient',
+          name: [
+            {
+              given: ['Alice'],
+              family: 'Smith',
+            },
+          ],
+        });
+      expect(res.status).toBe(201);
+      testPatient = res.body as Patient;
+      patientId = testPatient.id as string;
+      patientVersionId = (testPatient.meta as Meta).versionId as string;
+    }
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   afterAll(async () => {
@@ -456,11 +467,23 @@ describe('FHIR Routes', () => {
     expect(res.status).toBe(200);
   });
 
-  test('Search', async () => {
+  test.only.each<['writer' | 'reader']>([['writer'], ['reader']])('Search on %s', async (repoMode) => {
+    const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
+    const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
+    const token = repoMode === 'writer' ? accessToken : searchOnReaderAccessToken;
+
     const res = await request(app)
       .get(`/fhir/R4/Patient`)
-      .set('Authorization', 'Bearer ' + accessToken);
+      .set('Authorization', 'Bearer ' + token);
     expect(res.status).toBe(200);
+
+    if (repoMode === 'writer') {
+      expect(writerSpy).toHaveBeenCalledTimes(1);
+      expect(readerSpy).toHaveBeenCalledTimes(0);
+    } else {
+      expect(writerSpy).toHaveBeenCalledTimes(0);
+      expect(readerSpy).toHaveBeenCalledTimes(1);
+    }
   });
 
   test('Search invalid resource', async () => {
@@ -478,15 +501,27 @@ describe('FHIR Routes', () => {
     expect(res.body.issue[0].details.text).toEqual('Unknown search parameter: basedOn');
   });
 
-  test('Search by POST', async () => {
+  test.only.each<['writer' | 'reader']>([['writer'], ['reader']])('Search by POST on %s', async (repoMode) => {
+    const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
+    const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
+    const token = repoMode === 'writer' ? accessToken : searchOnReaderAccessToken;
+
     const res = await request(app)
       .post(`/fhir/R4/Patient/_search`)
-      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Authorization', 'Bearer ' + token)
       .type('form');
     expect(res.status).toBe(200);
     const result = res.body as Bundle;
     expect(result.type).toEqual('searchset');
     expect(result.entry?.length).toBeGreaterThan(0);
+
+    if (repoMode === 'writer') {
+      expect(writerSpy).toHaveBeenCalledTimes(1);
+      expect(readerSpy).toHaveBeenCalledTimes(0);
+    } else {
+      expect(writerSpy).toHaveBeenCalledTimes(0);
+      expect(readerSpy).toHaveBeenCalledTimes(1);
+    }
   });
 
   test('Validate create success', async () => {
@@ -593,50 +628,68 @@ describe('FHIR Routes', () => {
       expect(res3.status).toBe(403);
     }));
 
-  test('Search multiple resource types with _type', async () =>
-    withTestContext(async () => {
-      const { accessToken } = await createTestProject({ withAccessToken: true });
-
-      const res1 = await request(app)
-        .post('/fhir/R4/Patient')
-        .set('Authorization', 'Bearer ' + accessToken)
-        .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(201);
-
-      const res2 = await request(app)
-        .post('/fhir/R4/Observation')
-        .set('Authorization', 'Bearer ' + accessToken)
-        .send({
-          resourceType: 'Observation',
-          status: 'final',
-          code: { text: 'test' },
-          subject: { reference: `Patient/${res1.body.id}` },
+  test.only.each<['writer' | 'reader']>([['writer'], ['reader']])(
+    'Search multiple resource types with _type on %s',
+    async (repoMode) =>
+      withTestContext(async () => {
+        const { accessToken } = await createTestProject({
+          withAccessToken: true,
+          project:
+            repoMode === 'reader' ? { systemSetting: [{ name: 'searchOnReader', valueBoolean: true }] } : undefined,
         });
-      expect(res2.status).toBe(201);
 
-      const res3 = await request(app)
-        .get('/fhir/R4?_type=Patient,Observation')
-        .set('Authorization', 'Bearer ' + accessToken);
-      expect(res3.status).toBe(200);
+        const res1 = await request(app)
+          .post('/fhir/R4/Patient')
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send({ resourceType: 'Patient' });
+        expect(res1.status).toBe(201);
 
-      const patient = res1.body;
-      const obs = res2.body;
-      const bundle = res3.body;
+        const res2 = await request(app)
+          .post('/fhir/R4/Observation')
+          .set('Authorization', 'Bearer ' + accessToken)
+          .send({
+            resourceType: 'Observation',
+            status: 'final',
+            code: { text: 'test' },
+            subject: { reference: `Patient/${res1.body.id}` },
+          });
+        expect(res2.status).toBe(201);
 
-      expect(bundle.entry?.length).toBe(2);
-      expect(bundleContains(bundle, patient)).toBeTruthy();
-      expect(bundleContains(bundle, obs)).toBeTruthy();
+        const readerSpy = jest.spyOn(getDatabasePool(DatabaseMode.READER), 'query');
+        const writerSpy = jest.spyOn(getDatabasePool(DatabaseMode.WRITER), 'query');
 
-      // Also verify that trailing slash works
-      const res4 = await request(app)
-        .get('/fhir/R4/?_type=Patient,Observation')
-        .set('Authorization', 'Bearer ' + accessToken);
-      expect(res4.status).toBe(200);
-      const bundle2 = res4.body;
-      expect(bundle2.entry?.length).toBe(2);
-      expect(bundleContains(bundle2, patient)).toBeTruthy();
-      expect(bundleContains(bundle2, obs)).toBeTruthy();
-    }));
+        const res3 = await request(app)
+          .get('/fhir/R4?_type=Patient,Observation')
+          .set('Authorization', 'Bearer ' + accessToken);
+        expect(res3.status).toBe(200);
+
+        const patient = res1.body;
+        const obs = res2.body;
+        const bundle = res3.body;
+
+        expect(bundle.entry?.length).toBe(2);
+        expect(bundleContains(bundle, patient)).toBeTruthy();
+        expect(bundleContains(bundle, obs)).toBeTruthy();
+
+        if (repoMode === 'writer') {
+          expect(writerSpy).toHaveBeenCalledTimes(1);
+          expect(readerSpy).toHaveBeenCalledTimes(0);
+        } else {
+          expect(writerSpy).toHaveBeenCalledTimes(0);
+          expect(readerSpy).toHaveBeenCalledTimes(1);
+        }
+
+        // Also verify that trailing slash works
+        const res4 = await request(app)
+          .get('/fhir/R4/?_type=Patient,Observation')
+          .set('Authorization', 'Bearer ' + accessToken);
+        expect(res4.status).toBe(200);
+        const bundle2 = res4.body;
+        expect(bundle2.entry?.length).toBe(2);
+        expect(bundleContains(bundle2, patient)).toBeTruthy();
+        expect(bundleContains(bundle2, obs)).toBeTruthy();
+      })
+  );
 
   test('Set accounts on create', async () => {
     const { project, accessToken } = await createTestProject({ withAccessToken: true });

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -1,5 +1,5 @@
 import { allOk, ContentType, isOk, OperationOutcomeError, stringify } from '@medplum/core';
-import { BatchEvent, FhirRequest, FhirRouter, HttpMethod, RepositoryMode } from '@medplum/fhir-router';
+import { BatchEvent, FhirRequest, FhirRouter, HttpMethod } from '@medplum/fhir-router';
 import { ResourceType } from '@medplum/fhirtypes';
 import { NextFunction, Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
@@ -330,16 +330,10 @@ protectedRoutes.use(
         graphqlMaxDepth: ctx.project.systemSetting?.find((s) => s.name === 'graphqlMaxDepth')?.valueInteger,
         graphqlMaxPageSize: ctx.project.systemSetting?.find((s) => s.name === 'graphqlMaxPageSize')?.valueInteger,
         graphqlMaxSearches: ctx.project.systemSetting?.find((s) => s.name === 'graphqlMaxSearches')?.valueInteger,
+        searchOnReader: ctx.project.systemSetting?.find((s) => s.name === 'searchOnReader')?.valueBoolean,
         transactions: ctx.project.features?.includes('transaction-bundles'),
       },
     };
-
-    if (request.url.includes('$graphql')) {
-      // If this is a GraphQL request, mark the repository as eligible for "reader" mode.
-      // Inside the GraphQL handler, the repository will be set to "writer" mode if needed.
-      // At the time of this writing, the GraphQL handler is the only place where we consider "reader" mode.
-      ctx.repo.setMode(RepositoryMode.READER);
-    }
 
     const result = await getInternalFhirRouter().handleRequest(request, ctx.repo);
     if (result.length === 1) {


### PR DESCRIPTION
Previously, only GraphQL queries (except mutations) would be sent to readers. With this, searches can also be sent to readers if configured that way by a super-admin.