### PR TITLE
fix(react/app): don't cast `Bundle.entry` to `BundleEntry[]`

### DIFF
--- a/packages/app/src/components/QuickServiceRequests.tsx
+++ b/packages/app/src/components/QuickServiceRequests.tsx
@@ -28,7 +28,7 @@ export function QuickServiceRequests(props: QuickServiceRequestsProps): JSX.Elem
     medplum
       .search('ServiceRequest', 'subject=' + patientRefStr)
       .then((bundle) => {
-        const entries = bundle.entry as BundleEntry<ServiceRequest>[];
+        const entries = (bundle.entry ?? []) as BundleEntry<ServiceRequest>[];
         const resources = entries.map((e) => e.resource as ServiceRequest);
         sortByDateAndPriority(resources);
         resources.reverse();

--- a/packages/app/src/resource/ResourceVersionPage.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.tsx
@@ -1,5 +1,5 @@
 import { Paper, Tabs, Text, Title } from '@mantine/core';
-import { Bundle, BundleEntry, OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
+import { Bundle, OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
 import { Container, Document, Loading, MedplumLink, ResourceDiff, useMedplum } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -43,7 +43,7 @@ export function ResourceVersionPage(): JSX.Element {
     );
   }
 
-  const entries = historyBundle.entry as BundleEntry[];
+  const entries = historyBundle.entry ?? [];
   const index = entries.findIndex((entry) => entry.resource?.meta?.versionId === versionId);
   if (index === -1) {
     return (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,5 @@
 import {
   Bundle,
-  BundleEntry,
   CodeableConcept,
   Coding,
   ElementDefinition,
@@ -144,7 +143,7 @@ export interface TypeInfo {
  * @see {@link IndexedStructureDefinition} for more details on indexed StructureDefinitions.
  */
 export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): void {
-  for (const entry of bundle.entry as BundleEntry[]) {
+  for (const entry of bundle.entry ?? []) {
     const resource = entry.resource as SearchParameter;
     if (resource.resourceType === 'SearchParameter') {
       indexSearchParameter(resource);

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.tsx
@@ -84,7 +84,7 @@ export function RequestGroupDisplay(props: RequestGroupDisplayProps): JSX.Elemen
   }
 
   function findBundleEntry<T extends Resource>(reference: Reference<T>): T | undefined {
-    for (const entry of responseBundle?.entry as BundleEntry[]) {
+    for (const entry of responseBundle?.entry ?? []) {
       if (entry.resource && reference.reference === getReferenceString(entry.resource)) {
         return entry.resource as T;
       }

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -5,7 +5,6 @@ import {
   Attachment,
   AuditEvent,
   Bundle,
-  BundleEntry,
   Communication,
   DiagnosticReport,
   Media,
@@ -335,8 +334,9 @@ function HistoryTimelineItem(props: HistoryTimelineItemProps): JSX.Element {
 }
 
 function getPrevious(history: Bundle, version: Resource): Resource | undefined {
-  const entries = history.entry as BundleEntry[];
+  const entries = history.entry ?? [];
   const index = entries.findIndex((entry) => entry.resource?.meta?.versionId === version.meta?.versionId);
+  // If not found this is -1, -1 === 0 -1 so this returns undefined
   if (index >= entries.length - 1) {
     return undefined;
   }

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -336,7 +336,7 @@ function HistoryTimelineItem(props: HistoryTimelineItemProps): JSX.Element {
 function getPrevious(history: Bundle, version: Resource): Resource | undefined {
   const entries = history.entry ?? [];
   const index = entries.findIndex((entry) => entry.resource?.meta?.versionId === version.meta?.versionId);
-  // If not found this is -1, -1 === 0 -1 so this returns undefined
+  // If not found index is -1, -1 === 0 - 1 so this returns undefined
   if (index >= entries.length - 1) {
     return undefined;
   }

--- a/packages/react/src/utils/blame.ts
+++ b/packages/react/src/utils/blame.ts
@@ -1,5 +1,5 @@
 import { stringify } from '@medplum/core';
-import { Bundle, BundleEntry, Meta } from '@medplum/fhirtypes';
+import { Bundle, Meta } from '@medplum/fhirtypes';
 import { diff } from './diff';
 
 export interface BlameRow {
@@ -11,13 +11,17 @@ export interface BlameRow {
 
 export function blame(history: Bundle): BlameRow[] {
   // Convert to array of array of lines
-  const versions = (history.entry as BundleEntry[])
+  const versions = (history.entry ?? [])
     .filter((entry) => !!entry.resource)
     .map((entry) => ({
       meta: entry.resource?.meta as Meta,
       lines: stringify(entry.resource, true).match(/[^\r\n]+/g) as string[],
     }))
     .sort((a, b) => (a.meta.lastUpdated as string).localeCompare(b.meta.lastUpdated as string));
+
+  if (!versions.length) {
+    return [];
+  }
 
   // Start with array of lines from the first version
   const table: BlameRow[] = versions[0].lines.map((line) => ({


### PR DESCRIPTION
Casting `Bundle.entry` in a lot of places used to work for us because we were not stripping out the empty array from outgoing JSON in many places. After #5437, this broke some of our components where we were casting `Bundle.entry` to `BundleEntry[]` naively. 

Adding the nullish-coalescing operator (`??`) in places where we access `Bundle.entry` should fix this