### PR TITLE
Emit performance metrics for Repository interactions

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -108,6 +108,7 @@ import {
   periodToRangeString,
 } from './sql';
 import { getBinaryStorage } from './storage';
+import { recordHistogramValue } from '../otel/otel';
 
 /**
  * The RepositoryContext interface defines standard metadata for repository actions.
@@ -266,14 +267,18 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       ...resource,
       id: options?.assignedId && resource.id ? resource.id : this.generateId(),
     };
+    const startTime = Date.now();
     try {
       const result = await this.updateResourceImpl(resourceWithId, true);
+      const durationMs = Date.now() - startTime;
+
       await this.postCommit(async () => {
-        this.logEvent(CreateInteraction, AuditEventOutcome.Success, undefined, result);
+        this.logEvent(CreateInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
       });
       return result;
     } catch (err) {
-      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, resourceWithId);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, { resource: resourceWithId, durationMs });
       throw err;
     }
   }
@@ -287,12 +292,15 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     id: string,
     options?: ReadResourceOptions
   ): Promise<T> {
+    const startTime = Date.now();
     try {
       const result = this.removeHiddenFields(await this.readResourceImpl<T>(resourceType, id, options));
-      this.logEvent(ReadInteraction, AuditEventOutcome.Success, undefined, result);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(ReadInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
       return result;
     } catch (err) {
-      this.logEvent(ReadInteraction, AuditEventOutcome.MinorFailure, err);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(ReadInteraction, AuditEventOutcome.MinorFailure, err, { durationMs });
       throw err;
     }
   }
@@ -374,14 +382,17 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     const result: (Resource | Error)[] = new Array(references.length);
 
     for (let i = 0; i < result.length; i++) {
+      const startTime = Date.now();
       const reference = references[i];
       const cacheEntry = cacheEntries[i];
       let entryResult = await this.processReadReferenceEntry(reference, cacheEntry);
+      const durationMs = Date.now() - startTime;
+
       if (entryResult instanceof Error) {
-        this.logEvent(ReadInteraction, AuditEventOutcome.MinorFailure, entryResult);
+        this.logEvent(ReadInteraction, AuditEventOutcome.MinorFailure, entryResult, { durationMs });
       } else {
         entryResult = this.removeHiddenFields(entryResult);
-        this.logEvent(ReadInteraction, AuditEventOutcome.Success, undefined, entryResult);
+        this.logEvent(ReadInteraction, AuditEventOutcome.Success, undefined, { resource: entryResult, durationMs });
       }
       result[i] = entryResult;
     }
@@ -438,6 +449,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * @returns Operation outcome and a history bundle.
    */
   async readHistory<T extends Resource>(resourceType: T['resourceType'], id: string, limit = 100): Promise<Bundle<T>> {
+    const startTime = Date.now();
     try {
       let resource: T | undefined = undefined;
       try {
@@ -491,19 +503,22 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         });
       }
 
-      this.logEvent(HistoryInteraction, AuditEventOutcome.Success, undefined, resource);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(HistoryInteraction, AuditEventOutcome.Success, undefined, { resource, durationMs });
       return {
         resourceType: 'Bundle',
         type: 'history',
         entry: entries,
       };
     } catch (err) {
-      this.logEvent(HistoryInteraction, AuditEventOutcome.MinorFailure, err);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(HistoryInteraction, AuditEventOutcome.MinorFailure, err, { durationMs });
       throw err;
     }
   }
 
   async readVersion<T extends Resource>(resourceType: T['resourceType'], id: string, vid: string): Promise<T> {
+    const startTime = Date.now();
     try {
       if (!validator.isUUID(id) || !validator.isUUID(vid)) {
         throw new OperationOutcomeError(notFound);
@@ -528,23 +543,28 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       }
 
       const result = this.removeHiddenFields(JSON.parse(rows[0].content as string));
-      this.logEvent(VreadInteraction, AuditEventOutcome.Success, undefined, result);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(VreadInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
       return result;
     } catch (err) {
-      this.logEvent(VreadInteraction, AuditEventOutcome.MinorFailure, err);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(VreadInteraction, AuditEventOutcome.MinorFailure, err, { durationMs });
       throw err;
     }
   }
 
   async updateResource<T extends Resource>(resource: T, options?: UpdateResourceOptions): Promise<T> {
+    const startTime = Date.now();
     try {
       const result = await this.updateResourceImpl(resource, false, options?.ifMatch);
+      const durationMs = Date.now() - startTime;
       await this.postCommit(async () => {
-        this.logEvent(UpdateInteraction, AuditEventOutcome.Success, undefined, result);
+        this.logEvent(UpdateInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
       });
       return result;
     } catch (err) {
-      this.logEvent(UpdateInteraction, AuditEventOutcome.MinorFailure, err, resource);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(UpdateInteraction, AuditEventOutcome.MinorFailure, err, { resource, durationMs });
       throw err;
     }
   }
@@ -953,6 +973,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
   }
 
   async deleteResource<T extends Resource = Resource>(resourceType: T['resourceType'], id: string): Promise<void> {
+    const startTime = Date.now();
     let resource: Resource;
     try {
       resource = await this.readResourceImpl<T>(resourceType, id);
@@ -1002,15 +1023,17 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         ]).execute(conn);
 
         await this.deleteFromLookupTables(conn, resource);
+        const durationMs = Date.now() - startTime;
 
         await this.postCommit(async () => {
-          this.logEvent(DeleteInteraction, AuditEventOutcome.Success, undefined, resource);
+          this.logEvent(DeleteInteraction, AuditEventOutcome.Success, undefined, { resource, durationMs });
         });
       });
 
       await addSubscriptionJobs(resource, resource, { interaction: 'delete' });
     } catch (err) {
-      this.logEvent(DeleteInteraction, AuditEventOutcome.MinorFailure, err);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(DeleteInteraction, AuditEventOutcome.MinorFailure, err, { durationMs });
       throw err;
     }
   }
@@ -1020,6 +1043,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     id: string,
     patch: Operation[]
   ): Promise<T> {
+    const startTime = Date.now();
     try {
       return await this.withTransaction(async () => {
         const resource = await this.readResourceFromDatabase<T>(resourceType, id);
@@ -1034,13 +1058,15 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         patchObject(resource, patch);
 
         const result = await this.updateResourceImpl(resource, false);
+        const durationMs = Date.now() - startTime;
         await this.postCommit(async () => {
-          this.logEvent(PatchInteraction, AuditEventOutcome.Success, undefined, result);
+          this.logEvent(PatchInteraction, AuditEventOutcome.Success, undefined, { resource: result, durationMs });
         });
         return result;
       });
     } catch (err) {
-      this.logEvent(PatchInteraction, AuditEventOutcome.MinorFailure, err);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(PatchInteraction, AuditEventOutcome.MinorFailure, err, { durationMs });
       throw err;
     }
   }
@@ -1100,13 +1126,16 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
   }
 
   async search<T extends Resource>(searchRequest: SearchRequest<T>): Promise<Bundle<T>> {
+    const startTime = Date.now();
     try {
       // Resource type validation is performed in the searchImpl function
       const result = await searchImpl(this, searchRequest);
-      this.logEvent(SearchInteraction, AuditEventOutcome.Success, undefined, undefined, searchRequest);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(SearchInteraction, AuditEventOutcome.Success, undefined, { searchRequest, durationMs });
       return result;
     } catch (err) {
-      this.logEvent(SearchInteraction, AuditEventOutcome.MinorFailure, err, undefined, searchRequest);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(SearchInteraction, AuditEventOutcome.MinorFailure, err, { searchRequest, durationMs });
       throw err;
     }
   }
@@ -1116,12 +1145,15 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     referenceField: string,
     references: string[]
   ): Promise<Record<string, T[]>> {
+    const startTime = Date.now();
     try {
       const result = await searchByReferenceImpl<T>(this, searchRequest, referenceField, references);
-      this.logEvent(SearchInteraction, AuditEventOutcome.Success, undefined, undefined, searchRequest);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(SearchInteraction, AuditEventOutcome.Success, undefined, { searchRequest, durationMs });
       return result;
     } catch (err) {
-      this.logEvent(SearchInteraction, AuditEventOutcome.MinorFailure, err, undefined, searchRequest);
+      const durationMs = Date.now() - startTime;
+      this.logEvent(SearchInteraction, AuditEventOutcome.MinorFailure, err, { searchRequest, durationMs });
       throw err;
     }
   }
@@ -2004,15 +2036,20 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * @param subtype - The AuditEvent subtype.
    * @param outcome - The AuditEvent outcome.
    * @param description - The description.  Can be a string, object, or Error.  Will be normalized to a string.
-   * @param resource - Optional resource to associate with the AuditEvent.
-   * @param search - Optional search parameters to associate with the AuditEvent.
+   * @param options -
+   * @param options.resource - Optional resource to associate with the AuditEvent.
+   * @param options.searchRequest - Optional search parameters to associate with the AuditEvent.
+   * @param options.durationMs - Duration of the operation, used for generating metrics.
    */
   private logEvent(
     subtype: AuditEventSubtype,
     outcome: AuditEventOutcome,
     description?: unknown,
-    resource?: Resource,
-    search?: SearchRequest
+    options?: {
+      resource?: Resource;
+      searchRequest?: SearchRequest;
+      durationMs?: number;
+    }
   ): void {
     if (this.context.author.reference === 'system') {
       // Don't log system events.
@@ -2023,9 +2060,11 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       outcomeDesc = normalizeErrorString(description);
     }
     let query: string | undefined = undefined;
-    if (search) {
-      query = search.resourceType + formatSearchQuery(search);
+    if (options?.searchRequest) {
+      query = options.searchRequest.resourceType + formatSearchQuery(options.searchRequest);
     }
+    const resource = options?.resource;
+
     const auditEvent = logRestfulEvent(
       subtype,
       this.context.projects?.[0] as string,
@@ -2036,6 +2075,16 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       resource,
       query
     );
+
+    if (options?.durationMs) {
+      const duration = options.durationMs / 1e6; // Report duration in whole seconds
+      recordHistogramValue('medplum.fhir.interaction.' + subtype.code, duration, {
+        attributes: {
+          resourceType: resource?.resourceType,
+          result: outcome === AuditEventOutcome.Success ? 'success' : 'failure',
+        },
+      });
+    }
 
     if (getConfig().saveAuditEvents && resource?.resourceType !== 'AuditEvent') {
       auditEvent.id = this.generateId();

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2077,7 +2077,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     );
 
     if (options?.durationMs) {
-      const duration = options.durationMs / 1e6; // Report duration in whole seconds
+      const duration = options.durationMs / 1000; // Report duration in whole seconds
       recordHistogramValue('medplum.fhir.interaction.' + subtype.code, duration, {
         attributes: {
           resourceType: resource?.resourceType,


### PR DESCRIPTION
Adds new OpenTelemetry metrics for FHIR Repository interactions, e.g. `medplum.fhir.interaction.search` or `medplum.fhir.interaction.vread`