### PR TITLE
fix(agent): harden reconnect logic

### DIFF
--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -176,6 +176,70 @@ describe('App', () => {
     mockServer2.stop();
   });
 
+  test('Attempt to reconnect after missed heartbeats', async () => {
+    const state = {
+      mySocket: undefined as Client | undefined,
+      heartbeatCount: 0,
+      connectRequestCount: 0,
+    };
+
+    function mockConnectionHandler(socket: Client): void {
+      state.mySocket = socket;
+      socket.on('message', (data) => {
+        const command = JSON.parse((data as Buffer).toString('utf8'));
+        if (command.type === 'agent:connect:request') {
+          state.connectRequestCount += 1;
+          socket.send(Buffer.from(JSON.stringify({ type: 'agent:connect:response' })));
+        } else if (command.type === 'agent:heartbeat:request') {
+          state.heartbeatCount += 1;
+        }
+      });
+    }
+
+    const mockServer = new Server('wss://example.com/ws/agent');
+    mockServer.on('connection', mockConnectionHandler);
+
+    const agent = await medplum.createResource<Agent>({
+      resourceType: 'Agent',
+      name: 'Test Agent',
+      status: 'active',
+    });
+
+    const app = new App(medplum, agent.id as string, LogLevel.INFO);
+
+    app.heartbeatPeriod = 200;
+    await app.start();
+
+    // Wait for the WebSocket to connect
+    while (!state.mySocket) {
+      await sleep(100);
+    }
+
+    while (state.connectRequestCount < 1) {
+      await sleep(100);
+    }
+
+    expect(state.connectRequestCount).toBe(1);
+
+    // Wait for 2 heartbeats to pass (we should disconnect)
+    while (state.heartbeatCount < 2) {
+      await sleep(100);
+    }
+
+    expect(state.connectRequestCount).toBe(1);
+
+    // Wait for another connect request (we reconnected)
+    while (state.connectRequestCount < 2) {
+      await sleep(100);
+    }
+
+    expect(state.connectRequestCount).toBe(2);
+
+    await app.stop();
+    await app.stop();
+    mockServer.stop();
+  });
+
   test('Empty endpoint URL', async () => {
     medplum.router.router.add('POST', ':resourceType/:id/$execute', async () => {
       return [allOk, {} as Resource];

--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -57,7 +57,7 @@ export class App {
   heartbeatPeriod = 10 * 1000;
   private heartbeatTimer?: NodeJS.Timeout;
   private outstandingHeartbeats = 0;
-  private webSocket?: ReconnectingWebSocket<WebSocket['binaryType']>;
+  private webSocket?: ReconnectingWebSocket<WebSocket>;
   private webSocketWorker?: Promise<void>;
   private live = false;
   private shutdown = false;
@@ -158,7 +158,7 @@ export class App {
     webSocketUrl.pathname = '/ws/agent';
     this.log.info(`Connecting to WebSocket: ${webSocketUrl.href}`);
 
-    this.webSocket = new ReconnectingWebSocket<WebSocket['binaryType']>(webSocketUrl.toString(), undefined, {
+    this.webSocket = new ReconnectingWebSocket<WebSocket>(webSocketUrl.toString(), undefined, {
       WebSocket,
       binaryType: 'nodebuffer',
     });

--- a/packages/core/src/websockets/reconnecting-websocket.ts
+++ b/packages/core/src/websockets/reconnecting-websocket.ts
@@ -477,7 +477,7 @@ export class ReconnectingWebSocket<WS extends IWebSocket = WebSocket>
         this._debug('connect', { url: this._url, protocols: this._protocols });
         this._ws = this._protocols ? new WS(this._url, this._protocols) : new WS(this._url);
 
-        this._ws.binaryType = this._binaryType as BinaryType;
+        this._ws.binaryType = this._binaryType;
         this._connectLock = false;
         this._addListeners();
 
@@ -524,7 +524,7 @@ export class ReconnectingWebSocket<WS extends IWebSocket = WebSocket>
 
     assert(this._ws, 'WebSocket is not defined');
 
-    this._ws.binaryType = this._binaryType as BinaryType;
+    this._ws.binaryType = this._binaryType;
 
     // send enqueued messages (messages sent before websocket open event)
     this._messageQueue.forEach((message) => this._ws?.send(message));

--- a/packages/core/src/websockets/reconnecting-websocket.ts
+++ b/packages/core/src/websockets/reconnecting-websocket.ts
@@ -39,6 +39,11 @@ export type WebSocketEventMap = {
   open: Event;
 };
 
+/**
+ * This map exists separately from `WebSocketEventMap`, which is the actual event map used for the `ReconnectingWebSocket` class itself,
+ * due to slight difference in the type between the events as we use them, and the events as they exist as global interfaces. We need the global interfaces
+ * to be generic enough to satisfy conformant implementations that don't exactly match the events we export and use in `ReconnectingWebSocket` itself.
+ */
 export type IWebSocketEventMap = {
   close: globalThis.CloseEvent;
   error: globalThis.ErrorEvent;
@@ -46,6 +51,13 @@ export type IWebSocketEventMap = {
   open: Event;
 };
 
+/**
+ * Generic interface that an implementation of `WebSocket` must satisfy to be used with `ReconnectingWebSocket`.
+ * This is a slightly modified fork of the `WebSocket` global type used in Node.
+ *
+ * The main key difference is making all the `onclose`, `onerror`, etc. functions have `any[]` args, making `data` in `send()` of type `any`, and making `binaryType` of type string,
+ * though the particular implementation should narrow each of these implementation-specific types.
+ */
 export interface IWebSocket {
   binaryType: string;
 


### PR DESCRIPTION
In this PR, we swap in the `ReconnectingWebSocket` implementation to the Agent's client-side WebSocket, and also add a force reconnect when we detect more than `MAX_MISSED_HEARTBEATS` have been missed. 

Fixes #5329