### PR TITLE
Default additional containers to non-essential

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -19,8 +19,8 @@ import {
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { ClusterInstance, ParameterGroup } from 'aws-cdk-lib/aws-rds';
 import { Construct } from 'constructs';
-import { buildWafConfig } from './waf';
 import hashObject from 'object-hash';
+import { buildWafConfig } from './waf';
 
 /**
  * Based on: https://github.com/aws-samples/http-api-aws-fargate-cdk/blob/master/cdk/singleAccount/lib/fargate-vpclink-stack.ts
@@ -424,6 +424,7 @@ export class BackEnd extends Construct {
           command: container.command,
           environment: container.environment,
           logging: this.logDriver,
+          essential: container.essential ?? false, // Default to false
         });
       }
     }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,14 +21,8 @@ export async function main(configName: string): Promise<void> {
     }
 
     if (err.message && typeof err.message === 'string' && err.message.includes('Unexpected end of input')) {
-      // The otel library can throw this error on bad connections (?)
-      // ParseError: Unexpected end of input
-      // at parse (/usr/src/medplum/node_modules/forwarded-parse/index.js:146:11)
-      // at getServerAddress (/usr/src/medplum/node_modules/@opentelemetry/instrumentation-http/build/src/utils.js:419:29)
-      // at getIncomingRequestAttributes (/usr/src/medplum/node_modules/@opentelemetry/instrumentation-http/build/src/utils.js:497:27)
-      // at Server.incomingRequest (/usr/src/medplum/node_modules/@opentelemetry/instrumentation-http/build/src/http.js:363:77)
-      // at parserOnIncoming (node:_http_server:1141:12)
-      // at HTTPParser.parserOnHeadersComplete (node:_http_common:118:17)
+      // Workaround for OpenTelemetry bug: https://github.com/open-telemetry/opentelemetry-js/issues/5095
+      // The otel library can throw this error on malformed X-Forwarded-For headers.
       // We do *not* want to exit the process in this case.
       return;
     }


### PR DESCRIPTION
Follow-up to: https://github.com/medplum/medplum/pull/5477

Workaround for: https://github.com/open-telemetry/opentelemetry-js/issues/5095

One of the other unfortunate discoveries was that the AWS ECS Task "additional containers" defaults to "essential":

```ts
/**
 * Specifies whether the container is marked essential.
 *
 * If the essential parameter of a container is marked as true, and that container fails
 * or stops for any reason, all other containers that are part of the task are stopped.
 * If the essential parameter of a container is marked as false, then its failure does not
 * affect the rest of the containers in a task. All tasks must have at least one essential container.
 *
 * If this parameter is omitted, a container is assumed to be essential.
 *
 * @default true
 */
readonly essential?: boolean;
```

So, with some unfortunate irony, here's what happened:
* The otel SDK has a bug that throws an unhandled error in a background task
* That crashed the Medplum nodejs process
* The otel collector sidecar was marked as "essential"
* So the otel collector kept the AWS ECS task alive, even though the node process was dead