### PR TITLE
Fix build-deb import GPG key step

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -67,8 +67,9 @@ jobs:
 
       - name: Import GPG key
         run: |
-          echo "${{ secrets.MEDPLUM_GPG_KEY }}" | gpg --import
-          echo "${{ secrets.MEDPLUM_GPG_PASSPHRASE }}" | gpg --passphrase-fd 0 --pinentry-mode loopback -u ${{ secrets.MEDPLUM_GPG_KEY_ID }} --yes --sign test.txt
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          echo "${{ secrets.MEDPLUM_GPG_KEY }}" | gpg --batch --no-tty --import
 
       - name: Upload to APT repository
         run: |

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -66,10 +66,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Import GPG key
-        run: |
-          mkdir -p ~/.gnupg
-          chmod 700 ~/.gnupg
-          echo "${{ secrets.MEDPLUM_GPG_KEY }}" | gpg --batch --no-tty --import
+        run: echo "${{ secrets.MEDPLUM_GPG_KEY }}" | gpg --batch --no-tty --import
 
       - name: Upload to APT repository
         run: |


### PR DESCRIPTION
Broken build: https://github.com/medplum/medplum/actions/runs/11671760007/job/32498881295

```
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key F9975ECD11AE1DDE: public key "Medplum APT Repository <dev@***.com>" imported
gpg: key F9975ECD11AE1DDE/F9975ECD11AE1DDE: error sending to agent: Inappropriate ioctl for device
gpg: error building skey array: Inappropriate ioctl for device
gpg: error reading '[stdin]': Inappropriate ioctl for device
gpg: import from '[stdin]' failed: Inappropriate ioctl for device
gpg: Total number processed: 0
gpg:               imported: 1
gpg:       secret keys read: 1
Error: Process completed with exit code 2.
```