### PR TITLE
Disable S3 ACL in build-deb deb-s3 command

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -77,5 +77,6 @@ jobs:
             --sign=${{ secrets.MEDPLUM_GPG_KEY_ID }} \
             --gpg-options="--passphrase-fd 0 --pinentry-mode loopback" \
             --preserve-versions \
+            --acl-disabled \
             medplum_*.deb \
             < <(echo "${{ secrets.MEDPLUM_GPG_PASSPHRASE }}")


### PR DESCRIPTION
This PR adds the `--acl-disabled` flag to the `deb-s3` command. This is required because our S3 bucket was created with Object Ownership set to "Bucket owner enforced" (the default and more secure setting), which disables ACLs.

Rather than modifying the bucket to enable ACLs, using `--acl-disabled` allows us to work with the more secure default settings. This is the preferred approach since:

1. We're controlling access via CloudFront, not S3 ACLs
2. Keeping ACLs disabled is more secure and follows AWS best practices
3. No bucket configuration changes are required

Technical context:
- S3 bucket policies and CloudFront handle all necessary access controls
- ACLs are a legacy access control mechanism that AWS recommends disabling
- The deb-s3 tool supports working without ACLs via this flag