### PR TITLE
Centralize token index type determination logic

### DIFF
--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -227,7 +227,6 @@ function getTokenIndexType(searchParam: SearchParameter, resourceType: string): 
 }
 
 const TokenIndexTypes = {
-  // NOT_INDEXED: 'NOT_INDEXED',
   CASE_SENSITIVE: 'CASE_SENSITIVE',
   CASE_INSENSITIVE: 'CASE_INSENSITIVE',
 } as const;


### PR DESCRIPTION
In particular, to handle the `:identifier` modifier correctly