### PR TITLE
Tighten up JSON vs FHIR JSON response formatting

### DIFF
--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -43,7 +43,13 @@ export type FhirRequestConfig = {
   transactions?: boolean;
 };
 
-export type FhirResponse = [OperationOutcome] | [OperationOutcome, Resource];
+export type ContentTypeOverride = string;
+
+// For v4, consider changing FhirResponse from an Array of variable length to an object with optional fields
+export type FhirResponse =
+  | [OperationOutcome]
+  | [OperationOutcome, Resource]
+  | [OperationOutcome, Resource, ContentTypeOverride];
 
 export type FhirRouteOptions = {
   batch?: boolean;

--- a/packages/fhir-router/src/fhirrouter.ts
+++ b/packages/fhir-router/src/fhirrouter.ts
@@ -43,13 +43,14 @@ export type FhirRequestConfig = {
   transactions?: boolean;
 };
 
-export type ContentTypeOverride = string;
+export type FhirResponseOptions = {
+  contentType?: string;
+};
 
-// For v4, consider changing FhirResponse from an Array of variable length to an object with optional fields
 export type FhirResponse =
   | [OperationOutcome]
   | [OperationOutcome, Resource]
-  | [OperationOutcome, Resource, ContentTypeOverride];
+  | [OperationOutcome, Resource, FhirResponseOptions];
 
 export type FhirRouteOptions = {
   batch?: boolean;

--- a/packages/fhir-router/src/graphql/graphql.test.ts
+++ b/packages/fhir-router/src/graphql/graphql.test.ts
@@ -170,14 +170,14 @@ describe('GraphQL', () => {
     });
     const fhirRouter = new FhirRouter();
     const result = await graphqlHandler(request, repo, fhirRouter);
-    expect(result).toBeDefined();
-    expect(result.length).toBe(2);
+    expect(result?.length).toBe(3);
     expect(result[0]).toMatchObject(allOk);
 
     const data = (result[1] as any).data;
     expect(data.Patient).toBeDefined();
     expect(data.Patient.id).toEqual(patient.id);
     expect(data.Patient.photo[0].url).toBeDefined();
+    expect(result[2]).toBe('application/json; charset=utf-8');
   });
 
   test('Read by ID not found', async () => {

--- a/packages/fhir-router/src/graphql/graphql.test.ts
+++ b/packages/fhir-router/src/graphql/graphql.test.ts
@@ -177,7 +177,7 @@ describe('GraphQL', () => {
     expect(data.Patient).toBeDefined();
     expect(data.Patient.id).toEqual(patient.id);
     expect(data.Patient.photo[0].url).toBeDefined();
-    expect(result[2]).toBe('application/json; charset=utf-8');
+    expect(result[2]).toBe('application/json');
   });
 
   test('Read by ID not found', async () => {
@@ -345,8 +345,7 @@ describe('GraphQL', () => {
 
     const fhirRouter = new FhirRouter();
     const result = await graphqlHandler(request, repo, fhirRouter);
-    expect(result).toBeDefined();
-    expect(result.length).toBe(2);
+    expect(result?.length).toBe(3);
     expect(result[0]).toMatchObject(allOk);
 
     const data = (result[1] as any).data;
@@ -354,6 +353,8 @@ describe('GraphQL', () => {
     expect(data.Encounter.subject.resource).toBeDefined();
     expect(data.Encounter.subject.resource.id).toEqual(patient.id);
     expect(data.Encounter.subject.resource.name[0].given[0]).toEqual('Alice');
+
+    expect(result[2]).toBe('application/json');
   });
 
   test('Read resource by reference not found', async () => {
@@ -1042,6 +1043,7 @@ describe('GraphQL', () => {
           PatientCreate: null,
         },
       },
+      'application/json',
     ]);
   });
 
@@ -1147,6 +1149,7 @@ describe('GraphQL', () => {
           PatientUpdate: null,
         },
       },
+      'application/json',
     ]);
   });
 
@@ -1189,6 +1192,7 @@ describe('GraphQL', () => {
           PatientUpdate: null,
         },
       },
+      'application/json',
     ]);
   });
 
@@ -1270,7 +1274,7 @@ describe('GraphQL', () => {
     const fhirRouter = new FhirRouter();
     const result = await graphqlHandler(request, repo, fhirRouter);
     expect(result).toBeDefined();
-    expect(result.length).toBe(2);
+    expect(result.length).toBe(3);
     expect(result[0]).toMatchObject(allOk);
 
     const data = (result[1] as any).data;
@@ -1278,5 +1282,7 @@ describe('GraphQL', () => {
     expect(data.Encounter.subject.resource).toBeDefined();
     expect(data.Encounter.subject.resource.id).toEqual(patient.id);
     expect(data.Encounter.subject.resource.name[0].given[0]).toEqual('Alice');
+
+    expect(result[2]).toBe('application/json');
   });
 });

--- a/packages/fhir-router/src/graphql/graphql.test.ts
+++ b/packages/fhir-router/src/graphql/graphql.test.ts
@@ -177,7 +177,7 @@ describe('GraphQL', () => {
     expect(data.Patient).toBeDefined();
     expect(data.Patient.id).toEqual(patient.id);
     expect(data.Patient.photo[0].url).toBeDefined();
-    expect(result[2]).toBe('application/json');
+    expect(result[2]?.contentType).toBe('application/json');
   });
 
   test('Read by ID not found', async () => {
@@ -354,7 +354,7 @@ describe('GraphQL', () => {
     expect(data.Encounter.subject.resource.id).toEqual(patient.id);
     expect(data.Encounter.subject.resource.name[0].given[0]).toEqual('Alice');
 
-    expect(result[2]).toBe('application/json');
+    expect(result[2]?.contentType).toBe('application/json');
   });
 
   test('Read resource by reference not found', async () => {
@@ -1043,7 +1043,7 @@ describe('GraphQL', () => {
           PatientCreate: null,
         },
       },
-      'application/json',
+      { contentType: 'application/json' },
     ]);
   });
 
@@ -1149,7 +1149,7 @@ describe('GraphQL', () => {
           PatientUpdate: null,
         },
       },
-      'application/json',
+      { contentType: 'application/json' },
     ]);
   });
 
@@ -1192,7 +1192,7 @@ describe('GraphQL', () => {
           PatientUpdate: null,
         },
       },
-      'application/json',
+      { contentType: 'application/json' },
     ]);
   });
 
@@ -1283,6 +1283,6 @@ describe('GraphQL', () => {
     expect(data.Encounter.subject.resource.id).toEqual(patient.id);
     expect(data.Encounter.subject.resource.name[0].given[0]).toEqual('Alice');
 
-    expect(result[2]).toBe('application/json');
+    expect(result[2]?.contentType).toBe('application/json');
   });
 });

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -143,7 +143,7 @@ export async function graphqlHandler(
     });
   }
 
-  return [allOk, result, ContentType.JSON];
+  return [allOk, result, { contentType: ContentType.JSON }];
 }
 
 /**

--- a/packages/fhir-router/src/graphql/graphql.ts
+++ b/packages/fhir-router/src/graphql/graphql.ts
@@ -1,6 +1,7 @@
 import {
   allOk,
   badRequest,
+  ContentType,
   DEFAULT_SEARCH_COUNT,
   forbidden,
   getResourceTypes,
@@ -142,7 +143,7 @@ export async function graphqlHandler(
     });
   }
 
-  return [allOk, result];
+  return [allOk, result, ContentType.JSON];
 }
 
 /**

--- a/packages/health-gorilla-react/src/autocomplete-endpoint.ts
+++ b/packages/health-gorilla-react/src/autocomplete-endpoint.ts
@@ -1,4 +1,4 @@
-import { MedplumClient, isCoding, isResource } from '@medplum/core';
+import { ContentType, MedplumClient, isCoding, isResource } from '@medplum/core';
 import { Identifier, Questionnaire } from '@medplum/fhirtypes';
 import { HGAutocompleteBotResponse, LabOrganization, TestCoding } from '@medplum/health-gorilla-core';
 
@@ -22,7 +22,7 @@ export function getAutocompleteSearchFunction(
   autocompleteBot: string | Identifier
 ): HGSearchFunction {
   return async (params) => {
-    const botResponse: HGAutocompleteBotResponse = await medplum.executeBot(autocompleteBot, params);
+    const botResponse: HGAutocompleteBotResponse = await medplum.executeBot(autocompleteBot, params, ContentType.JSON);
     if (botResponse.type === 'error') {
       throw new Error('Error executing autocomplete bot', { cause: botResponse });
     }

--- a/packages/server/src/admin/invite.ts
+++ b/packages/server/src/admin/invite.ts
@@ -21,7 +21,7 @@ import { getConfig } from '../config';
 import { getAuthenticatedContext, getLogger } from '../context';
 import { sendEmail } from '../email/email';
 import { getSystemRepo, Repository } from '../fhir/repo';
-import { sendResponse } from '../fhir/response';
+import { sendFhirResponse } from '../fhir/response';
 import { generateSecret } from '../oauth/keys';
 import { getUserByEmailInProject, getUserByEmailWithoutProject } from '../oauth/utils';
 import { makeValidationMiddleware } from '../util/validator';
@@ -52,7 +52,7 @@ export async function inviteHandler(req: Request, res: Response): Promise<void> 
   }
 
   const { membership } = await inviteUser(inviteRequest);
-  return sendResponse(req, res, allOk, membership);
+  return sendFhirResponse(req, res, allOk, membership);
 }
 
 export interface ServerInviteRequest extends InviteRequest {

--- a/packages/server/src/cloud/aws/execute.test.ts
+++ b/packages/server/src/cloud/aws/execute.test.ts
@@ -96,7 +96,7 @@ describe('Execute', () => {
         name: [{ given: ['John'], family: ['Doe'] }],
       });
     expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
   });
 
   test('Submit FHIR without content type', async () => {

--- a/packages/server/src/fhir/binary.ts
+++ b/packages/server/src/fhir/binary.ts
@@ -7,7 +7,7 @@ import { asyncWrap } from '../async';
 import { getAuthenticatedContext, getLogger } from '../context';
 import { authenticateRequest } from '../oauth/middleware';
 import { sendOutcome } from './outcomes';
-import { sendResponse } from './response';
+import { sendFhirResponse } from './response';
 import { BinarySource, getBinaryStorage } from './storage';
 import { Repository } from './repo';
 
@@ -28,7 +28,7 @@ binaryRouter.get(
     const ctx = getAuthenticatedContext();
     const { id } = req.params;
     const binary = await ctx.repo.readResource<Binary>('Binary', id);
-    await sendResponse(req, res, allOk, binary);
+    await sendFhirResponse(req, res, allOk, binary);
   })
 );
 
@@ -71,7 +71,7 @@ async function handleBinaryWriteRequest(req: Request, res: Response): Promise<vo
       // """
       const resource = body as Binary;
       const binary = await (create ? repo.createResource<Binary>(resource) : repo.updateResource<Binary>(resource));
-      await sendResponse(req, res, create ? created : allOk, binary);
+      await sendFhirResponse(req, res, create ? created : allOk, binary);
       return;
     }
   }
@@ -83,7 +83,7 @@ async function handleBinaryWriteRequest(req: Request, res: Response): Promise<vo
     securityContext: req.get('X-Security-Context'),
   });
 
-  await sendResponse(req, res, create ? created : allOk, binary);
+  await sendFhirResponse(req, res, create ? created : allOk, binary);
 }
 
 /**

--- a/packages/server/src/fhir/job.ts
+++ b/packages/server/src/fhir/job.ts
@@ -3,7 +3,7 @@ import { AsyncJob } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
 import { getAuthenticatedContext } from '../context';
-import { sendResponse } from './response';
+import { sendFhirResponse } from './response';
 
 // Asychronous Job Status API
 // https://hl7.org/fhir/async-bundle.html
@@ -24,7 +24,7 @@ jobRouter.get(
       return;
     }
 
-    await sendResponse(req, res, allOk, asyncJob);
+    sendFhirResponse(req, res, allOk, asyncJob);
   })
 );
 

--- a/packages/server/src/fhir/job.ts
+++ b/packages/server/src/fhir/job.ts
@@ -1,8 +1,10 @@
-import { allOk } from '@medplum/core';
-import { AsyncJob } from '@medplum/fhirtypes';
+import { accepted, allOk } from '@medplum/core';
+import { AsyncJob, OperationOutcome } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
+import { getConfig } from '../config';
 import { getAuthenticatedContext } from '../context';
+import { AsyncJobExecutor } from './operations/utils/asyncjobexecutor';
 import { sendFhirResponse } from './response';
 
 // Asychronous Job Status API
@@ -19,12 +21,15 @@ jobRouter.get(
     const { id } = req.params;
     const asyncJob = await ctx.repo.readResource<AsyncJob>('AsyncJob', id);
 
+    let outcome: OperationOutcome;
     if (!finalJobStatusCodes.includes(asyncJob.status as string)) {
-      res.status(202).send(asyncJob).end();
-      return;
+      const exec = new AsyncJobExecutor(ctx.repo, asyncJob);
+      outcome = accepted(exec.getContentLocation(getConfig().baseUrl));
+    } else {
+      outcome = allOk;
     }
 
-    sendFhirResponse(req, res, allOk, asyncJob);
+    return sendFhirResponse(req, res, outcome, asyncJob);
   })
 );
 

--- a/packages/server/src/fhir/operations/execute.test.ts
+++ b/packages/server/src/fhir/operations/execute.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, Operator, allOk, badRequest, createReference, getReferenceString } from '@medplum/core';
+import { ContentType, Operator, badRequest, createReference, getReferenceString } from '@medplum/core';
 import {
   AsyncJob,
   AuditEvent,
@@ -150,7 +150,7 @@ exports.handler = async function (medplum, event) {
     expect(res.text).toEqual('input');
   });
 
-  test('Submit FHIR with content type returns FHIR content', async () => {
+  test('Submit FHIR with content type returns non-FHIR JSON', async () => {
     const res = await request(app)
       .post(`/fhir/R4/Bot/${bots[0].id}/$execute`)
       .set('Content-Type', ContentType.FHIR_JSON)
@@ -161,8 +161,8 @@ exports.handler = async function (medplum, event) {
         identifier: [],
       });
     expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
-    expect(res.body.identifier).toBeUndefined();
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(res.body.identifier).toEqual([]);
   });
 
   test('Submit FHIR without content type return JSON content', async () => {
@@ -449,13 +449,12 @@ exports.handler = async function (medplum, event) {
 
   test('OperationOutcome response', async () => {
     const res = await request(app)
-      .post(`/fhir/R4/Bot/${bots[0].id}/$execute`)
-      .set('Content-Type', ContentType.FHIR_JSON)
+      .post(`/fhir/R4/Bot/$execute?identifier=invalid-identifier`)
       .set('Authorization', 'Bearer ' + accessToken)
-      .send(allOk);
-    expect(res.status).toBe(200);
+      .send('');
+    expect(res.status).toBe(400);
     expect(res.headers['content-type']).toBe('application/fhir+json; charset=utf-8');
-    expect(res.body).toMatchObject(allOk);
+    expect(res.body).toMatchObject(badRequest('Must specify bot ID or identifier.'));
   });
 
   test('Binary response', async () => {

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -47,7 +47,7 @@ import { readStreamToString } from '../../util/streams';
 import { createAuditEventEntities, findProjectMembership } from '../../workers/utils';
 import { sendOutcome } from '../outcomes';
 import { getSystemRepo, Repository } from '../repo';
-import { sendResponse } from '../response';
+import { sendFhirResponse } from '../response';
 import { getBinaryStorage } from '../storage';
 import { sendAsyncResponse } from './utils/asyncjobexecutor';
 
@@ -105,7 +105,7 @@ export const executeHandler = asyncWrap(async (req: Request, res: Response) => {
     const outcome = result.success ? allOk : badRequest(result.logResult);
 
     if (isResource(responseBody) && responseBody.resourceType === 'Binary') {
-      await sendResponse(req, res, outcome, responseBody);
+      await sendFhirResponse(req, res, outcome, responseBody);
       return;
     }
 

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -51,8 +51,6 @@ import { sendFhirResponse } from '../response';
 import { getBinaryStorage } from '../storage';
 import { sendAsyncResponse } from './utils/asyncjobexecutor';
 
-export const EXECUTE_CONTENT_TYPES = [ContentType.JSON, ContentType.FHIR_JSON, ContentType.TEXT, ContentType.HL7_V2];
-
 export interface BotExecutionRequest {
   readonly bot: Bot;
   readonly runAs: ProjectMembership;
@@ -534,14 +532,16 @@ async function addBotSecrets(
   }
 }
 
+const MIRRORED_CONTENT_TYPES: string[] = [ContentType.FHIR_JSON, ContentType.TEXT, ContentType.HL7_V2];
+
 function getResponseContentType(req: Request): string {
   const requestContentType = req.get('Content-Type');
-  if (requestContentType && (EXECUTE_CONTENT_TYPES as string[]).includes(requestContentType)) {
+  if (requestContentType && MIRRORED_CONTENT_TYPES.includes(requestContentType)) {
     return requestContentType;
   }
 
-  // Default to FHIR
-  return ContentType.FHIR_JSON;
+  // Default to JSON
+  return ContentType.JSON;
 }
 
 /**

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -532,7 +532,7 @@ async function addBotSecrets(
   }
 }
 
-const MIRRORED_CONTENT_TYPES: string[] = [ContentType.FHIR_JSON, ContentType.TEXT, ContentType.HL7_V2];
+const MIRRORED_CONTENT_TYPES: string[] = [ContentType.TEXT, ContentType.HL7_V2];
 
 function getResponseContentType(req: Request): string {
   const requestContentType = req.get('Content-Type');

--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -1,4 +1,4 @@
-import { getStatus, isAccepted } from '@medplum/core';
+import { ContentType, getStatus, isAccepted } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Response } from 'express';
 import { Result, ValidationError } from 'express-validator';
@@ -38,8 +38,11 @@ export function sendOutcome(res: Response, outcome: OperationOutcome): Response 
   if (isAccepted(outcome) && outcome.issue?.[0].diagnostics) {
     res.set('Content-Location', outcome.issue[0].diagnostics);
   }
-  return res.status(getStatus(outcome)).json({
-    ...outcome,
-    extension: buildTracingExtension(),
-  } as OperationOutcome);
+  return res
+    .status(getStatus(outcome))
+    .type(ContentType.FHIR_JSON)
+    .json({
+      ...outcome,
+      extension: buildTracingExtension(),
+    } as OperationOutcome);
 }

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -28,7 +28,7 @@ export function sendResponseHeaders(_req: Request, res: Response, outcome: Opera
   res.status(getStatus(outcome));
 }
 
-export async function sendResponse(
+export async function sendFhirResponse(
   req: Request,
   res: Response,
   outcome: OperationOutcome,

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -5,7 +5,7 @@ import { getConfig } from '../config';
 import { getAuthenticatedContext } from '../context';
 import { RewriteMode, rewriteAttachments } from './rewrite';
 import { getBinaryStorage } from './storage';
-import { ContentTypeOverride } from '@medplum/fhir-router';
+import { FhirResponseOptions } from '@medplum/fhir-router';
 
 export function isFhirJsonContentType(req: Request): boolean {
   return !!(req.is(ContentType.JSON) || req.is(ContentType.FHIR_JSON));
@@ -34,7 +34,7 @@ export async function sendFhirResponse(
   res: Response,
   outcome: OperationOutcome,
   body: Resource,
-  contentTypeOverride?: ContentTypeOverride
+  options?: FhirResponseOptions
 ): Promise<void> {
   sendResponseHeaders(req, res, outcome, body);
 
@@ -55,6 +55,6 @@ export async function sendFhirResponse(
   const ctx = getAuthenticatedContext();
   const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, body);
 
-  res.set('Content-Type', contentTypeOverride ?? ContentType.FHIR_JSON);
+  res.set('Content-Type', options?.contentType ?? ContentType.FHIR_JSON);
   res.json(result);
 }

--- a/packages/server/src/fhir/response.ts
+++ b/packages/server/src/fhir/response.ts
@@ -1,10 +1,11 @@
-import { ContentType, concatUrls, getStatus, isCreated, isResource } from '@medplum/core';
+import { ContentType, concatUrls, getStatus, isCreated } from '@medplum/core';
 import { OperationOutcome, Resource } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
 import { getConfig } from '../config';
 import { getAuthenticatedContext } from '../context';
 import { RewriteMode, rewriteAttachments } from './rewrite';
 import { getBinaryStorage } from './storage';
+import { ContentTypeOverride } from '@medplum/fhir-router';
 
 export function isFhirJsonContentType(req: Request): boolean {
   return !!(req.is(ContentType.JSON) || req.is(ContentType.FHIR_JSON));
@@ -32,7 +33,8 @@ export async function sendFhirResponse(
   req: Request,
   res: Response,
   outcome: OperationOutcome,
-  body: Resource
+  body: Resource,
+  contentTypeOverride?: ContentTypeOverride
 ): Promise<void> {
   sendResponseHeaders(req, res, outcome, body);
 
@@ -53,6 +55,6 @@ export async function sendFhirResponse(
   const ctx = getAuthenticatedContext();
   const result = await rewriteAttachments(RewriteMode.PRESIGNED_URL, ctx.repo, body);
 
-  res.set('Content-Type', ContentType.FHIR_JSON);
+  res.set('Content-Type', contentTypeOverride ?? ContentType.FHIR_JSON);
   res.json(result);
 }

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -40,7 +40,7 @@ import { codeSystemSubsumesOperation } from './operations/subsumes';
 import { valueSetValidateOperation } from './operations/valuesetvalidatecode';
 import { sendOutcome } from './outcomes';
 import { ResendSubscriptionsOptions } from './repo';
-import { sendResponse } from './response';
+import { sendFhirResponse } from './response';
 import { smartConfigurationHandler, smartStylingHandler } from './smart';
 
 export const fhirRouter = Router();
@@ -342,7 +342,7 @@ protectedRoutes.use(
       }
       sendOutcome(res, result[0]);
     } else {
-      await sendResponse(req, res, result[0], result[1]);
+      await sendFhirResponse(req, res, result[0], result[1]);
     }
   })
 );

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -66,28 +66,30 @@ fhirRouter.use((req: Request, res: Response, next: NextFunction) => {
       return res.send();
     }
 
-    // Unless already set, use the FHIR content type
     if (!res.get('Content-Type')) {
-      res.contentType(ContentType.FHIR_JSON);
-    }
-
-    let legacyFhirJsonResponseFormat: boolean | undefined;
-    try {
-      const ctx = getAuthenticatedContext();
-      legacyFhirJsonResponseFormat = ctx.project.systemSetting?.find(
-        (s) => s.name === 'legacyFhirJsonResponseFormat'
-      )?.valueBoolean;
-    } catch (_err) {
-      // Ignore errors since unauthenticated requests also use this middleware
+      res.contentType(ContentType.JSON);
     }
 
     const pretty = req.query._pretty === 'true';
 
-    if (legacyFhirJsonResponseFormat) {
-      return res.send(JSON.stringify(data, undefined, pretty ? 2 : undefined));
-    } else {
-      return res.send(stringify(data, pretty));
+    if (res.get('Content-Type')?.startsWith(ContentType.FHIR_JSON)) {
+      let legacyFhirJsonResponseFormat: boolean | undefined;
+      try {
+        const ctx = getAuthenticatedContext();
+        legacyFhirJsonResponseFormat = ctx.project.systemSetting?.find(
+          (s) => s.name === 'legacyFhirJsonResponseFormat'
+        )?.valueBoolean;
+      } catch (_err) {
+        // Ignore errors since unauthenticated requests also use this middleware
+      }
+
+      if (!legacyFhirJsonResponseFormat) {
+        return res.send(stringify(data, pretty));
+      }
     }
+
+    // Default JSON response
+    return res.send(JSON.stringify(data, undefined, pretty ? 2 : undefined));
   };
   next();
 });
@@ -341,8 +343,9 @@ protectedRoutes.use(
         throw new OperationOutcomeError(result[0]);
       }
       sendOutcome(res, result[0]);
-    } else {
-      await sendFhirResponse(req, res, result[0], result[1]);
+      return;
     }
+
+    await sendFhirResponse(req, res, result[0], result[1], result[2]);
   })
 );


### PR DESCRIPTION
The issue that prompted this further cleanup was that Bot execution responses had been getting the FHIR JSON treatment even when they do not return a FHIR resource.

For backwards compatibility, we still assume a FHIR response if the *input* to the bot execution was FHIR JSON. For the future, we should consider having a more explicit way to specify the content types.

Fixes #5502 