### PR TITLE
Fix QuesitonnaireForm dependency on requestSchema

### DIFF
--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -193,7 +193,7 @@ function toTypedValueWithType(value: any, type: string): TypedValue {
  * @param path - The property path.
  * @returns The value of the property and the property type.
  */
-function getTypedPropertyValueWithoutSchema(
+export function getTypedPropertyValueWithoutSchema(
   typedValue: TypedValue,
   path: string
 ): TypedValue[] | TypedValue | undefined {


### PR DESCRIPTION
Fixed regression created here: https://github.com/medplum/medplum/pull/5381

There are a handful of cases where we called `getTypedPropertyValue` on a `Questionnaire` to get choice-of-type values, such as `Questionnaire.item.answerOption.value[x]` and `Questionnaire.item.initial.value[x]`.

In those cases, we did need the schema to be loaded.  This error stayed hidden for a long time, because in `app` we loaded it elsewhere, and in `react` tests we load it in `test.setup.ts`.

Under the covers `getTypedPropertyValue` can call either `getTypedPropertyValueWithSchema` (to properly use the `StructureDefinition` for detailed type values) or `getTypedPropertyValueWithoutSchema` (for quick cases, where the type information is implicit in the property name).  We can fix this case by just using the "without schema" variant.