### PR TITLE
feat(AsyncJob): add `$cancel` operation for `AsyncJob`s

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
   },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "never"
-  }
+  },
+  "cSpell.words": ["Medplum", "FHIR"]
 }

--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -60782,7 +60782,7 @@
         },
         "status": {
           "description": "The status of the request.",
-          "enum": ["accepted", "active", "completed", "error"]
+          "enum": ["accepted", "active", "completed", "error", "cancelled"]
         },
         "requestTime": {
           "description": "Indicates the server\u0027s time when the query is requested.",
@@ -61059,7 +61059,7 @@
         },
         "status": {
           "description": "The status of the request.",
-          "enum": ["accepted", "active", "completed", "error"]
+          "enum": ["accepted", "active", "completed", "error", "cancelled"]
         },
         "requestTime": {
           "description": "Indicates the server\u0027s time when the query is requested.",

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -5250,7 +5250,7 @@
           {
             "id" : "AsyncJob.status",
             "path" : "AsyncJob.status",
-            "short" : "accepted | error | completed",
+            "short" : "accepted | error | completed | cancelled",
             "definition" : "The status of the request.",
             "min" : 1,
             "max" : "1",

--- a/packages/definitions/dist/fhir/r4/valuesets-medplum.json
+++ b/packages/definitions/dist/fhir/r4/valuesets-medplum.json
@@ -496,6 +496,11 @@
             "code": "error",
             "display": "Error",
             "definition": "Error"
+          },
+          {
+            "code": "cancelled",
+            "display": "Cancelled",
+            "definition": "Cancelled"
           }
         ]
       }

--- a/packages/docs/static/data/medplumDefinitions/asyncjob.json
+++ b/packages/docs/static/data/medplumDefinitions/asyncjob.json
@@ -170,7 +170,7 @@
       "path": "AsyncJob.status",
       "min": 1,
       "max": "1",
-      "short": "accepted | error | completed",
+      "short": "accepted | error | completed | cancelled",
       "definition": "The status of the request.",
       "comment": "",
       "inherited": false

--- a/packages/fhirtypes/dist/AsyncJob.d.ts
+++ b/packages/fhirtypes/dist/AsyncJob.d.ts
@@ -93,7 +93,7 @@ export interface AsyncJob {
   /**
    * The status of the request.
    */
-  status: 'accepted' | 'active' | 'completed' | 'error';
+  status: 'accepted' | 'active' | 'completed' | 'error' | 'cancelled';
 
   /**
    * Indicates the server's time when the query is requested.

--- a/packages/fhirtypes/dist/BulkDataExport.d.ts
+++ b/packages/fhirtypes/dist/BulkDataExport.d.ts
@@ -93,7 +93,7 @@ export interface BulkDataExport {
   /**
    * The status of the request.
    */
-  status: 'accepted' | 'active' | 'completed' | 'error';
+  status: 'accepted' | 'active' | 'completed' | 'error' | 'cancelled';
 
   /**
    * Indicates the server's time when the query is requested.

--- a/packages/server/src/fhir/operations/asyncjobcancel.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.test.ts
@@ -135,34 +135,4 @@ describe('AsyncJob/$cancel', () => {
     }
     expect(next).toHaveBeenCalledWith(new Error('This operation can only be executed on an instance'));
   });
-
-  test('Responds with bad request outcome if error thrown', async () => {
-    const next = jest.fn();
-
-    class MockResponse {
-      type = jest.fn().mockImplementation(() => this);
-      status = jest.fn().mockImplementation(() => this);
-      json = jest.fn().mockImplementation(() => this);
-    }
-
-    const mockResponse = new MockResponse();
-
-    expect(() =>
-      asyncJobCancelHandler(
-        { params: { id: 'fake-id' } as Record<string, string> } as express.Request,
-        mockResponse as unknown as express.Response,
-        next
-      )
-    ).not.toThrow();
-
-    while (mockResponse.json.mock.calls.length === 0) {
-      await sleep(100);
-    }
-
-    expect(mockResponse.type).toHaveBeenCalledWith(ContentType.FHIR_JSON);
-    expect(mockResponse.status).toHaveBeenCalledWith(400);
-    expect(mockResponse.json).toHaveBeenCalledWith(
-      expect.objectContaining<OperationOutcome>(badRequest('No request context available'))
-    );
-  });
 });

--- a/packages/server/src/fhir/operations/asyncjobcancel.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.test.ts
@@ -122,7 +122,9 @@ describe('AsyncJob/$cancel', () => {
     expect(res2.status).toEqual(400);
 
     const outcome = res2.body as OperationOutcome;
-    expect(outcome).toMatchObject<OperationOutcome>(badRequest(`Test failed: ${status} != accepted`));
+    expect(outcome).toMatchObject<OperationOutcome>(
+      badRequest(`AsyncJob cannot be cancelled if status is not 'accepted', job had status '${status}'`)
+    );
   });
 
   test('Fails if not executed on an instance (no ID given)', async () => {

--- a/packages/server/src/fhir/operations/asyncjobcancel.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.test.ts
@@ -1,0 +1,129 @@
+import { allOk, badRequest, ContentType, sleep } from '@medplum/core';
+import { AsyncJob, OperationOutcome } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config';
+import { initTestAuth } from '../../test.setup';
+import { asyncJobCancelHandler } from './asyncjobcancel';
+
+const app = express();
+
+describe('AsyncJob/$cancel', () => {
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+  });
+
+  beforeEach(async () => {
+    accessToken = await initTestAuth({ superAdmin: true });
+    expect(accessToken).toBeDefined();
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Sets AsyncJob.status to `cancelled`', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/AsyncJob')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'AsyncJob',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+      } satisfies AsyncJob);
+    expect(res.status).toEqual(201);
+    expect(res.body).toBeDefined();
+
+    const asyncJob = res.body as AsyncJob;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$cancel`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toEqual(200);
+    expect(res2.body).toMatchObject<OperationOutcome>(allOk);
+
+    const res3 = await request(app)
+      .get(`/fhir/R4/AsyncJob/${asyncJob.id as string}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON);
+
+    expect(res3.status).toEqual(200);
+    expect(res3.body).toMatchObject<AsyncJob>({
+      id: asyncJob.id,
+      resourceType: 'AsyncJob',
+      status: 'cancelled',
+      requestTime: asyncJob.requestTime,
+      request: 'random-request',
+    });
+  });
+
+  test.each(['completed', 'cancelled', 'error'] as const)('Fails if AsyncJob.status is `%s`', async (status) => {
+    const res = await request(app)
+      .post('/fhir/R4/AsyncJob')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'AsyncJob',
+        status,
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+      } satisfies AsyncJob);
+    expect(res.status).toEqual(201);
+    expect(res.body).toBeDefined();
+
+    const asyncJob = res.body as AsyncJob;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$cancel`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toEqual(400);
+
+    const outcome = res2.body as OperationOutcome;
+    expect(outcome).toMatchObject<OperationOutcome>(badRequest(`Test failed: ${status} != accepted`));
+  });
+
+  test('Fails if not executed on an instance (no ID given)', async () => {
+    const next = jest.fn();
+    expect(() => asyncJobCancelHandler({ params: {} } as express.Request, {} as express.Response, next)).not.toThrow();
+    while (next.mock.calls.length === 0) {
+      await sleep(100);
+    }
+    expect(next).toHaveBeenCalledWith(new Error('This operation can only be executed on an instance'));
+  });
+
+  test('Responds with bad request outcome if error thrown', async () => {
+    const next = jest.fn();
+
+    class MockResponse {
+      type = jest.fn().mockImplementation(() => this);
+      status = jest.fn().mockImplementation(() => this);
+      json = jest.fn().mockImplementation(() => this);
+    }
+
+    const mockResponse = new MockResponse();
+
+    expect(() =>
+      asyncJobCancelHandler(
+        { params: { id: 'fake-id' } as Record<string, string> } as express.Request,
+        mockResponse as unknown as express.Response,
+        next
+      )
+    ).not.toThrow();
+
+    while (mockResponse.json.mock.calls.length === 0) {
+      await sleep(100);
+    }
+
+    expect(mockResponse.type).toHaveBeenCalledWith(ContentType.FHIR_JSON);
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining<OperationOutcome>(badRequest('No request context available'))
+    );
+  });
+});

--- a/packages/server/src/fhir/operations/asyncjobcancel.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.ts
@@ -1,0 +1,41 @@
+import { allOk, assert, badRequest, OperationOutcomeError } from '@medplum/core';
+import { OperationDefinition } from '@medplum/fhirtypes';
+import { Request, Response } from 'express';
+import { asyncWrap } from '../../async';
+import { getAuthenticatedContext } from '../../context';
+import { sendOutcome } from '../outcomes';
+
+export const operation: OperationDefinition = {
+  id: 'AsyncJob-cancel',
+  resourceType: 'OperationDefinition',
+  name: 'asyncjob-cancel',
+  status: 'active',
+  kind: 'operation',
+  code: 'cancel',
+  experimental: true,
+  resource: ['AsyncJob'],
+  system: false,
+  type: false,
+  instance: true,
+  parameter: [{ use: 'out', name: 'return', type: 'OperationOutcome', min: 1, max: '1' }],
+};
+
+/**
+ * Handles HTTP requests for the AsyncJob $cancel operation.
+ * Sets the status of the `AsyncJob` to `cancelled`.
+ */
+export const asyncJobCancelHandler = asyncWrap(async (req: Request, res: Response) => {
+  assert(req.params.id, 'This operation can only be executed on an instance');
+  // Update status of async job
+  try {
+    const { repo } = getAuthenticatedContext();
+    await repo.patchResource('AsyncJob', req.params.id, [{ op: 'add', path: '/status', value: 'cancelled' }]);
+    sendOutcome(res, allOk);
+  } catch (err) {
+    if (err instanceof OperationOutcomeError) {
+      sendOutcome(res, err.outcome);
+    } else {
+      sendOutcome(res, badRequest((err as Error).message));
+    }
+  }
+});

--- a/packages/server/src/fhir/operations/asyncjobcancel.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.ts
@@ -29,10 +29,13 @@ export const asyncJobCancelHandler = asyncWrap(async (req: Request, res: Respons
   // Update status of async job
   try {
     const { repo } = getAuthenticatedContext();
-    await repo.patchResource('AsyncJob', req.params.id, [
-      { op: 'test', path: '/status', value: 'accepted' },
-      { op: 'add', path: '/status', value: 'cancelled' },
-    ]);
+    const job = await repo.readResource('AsyncJob', req.params.id);
+    if (job.status !== 'cancelled') {
+      await repo.patchResource('AsyncJob', req.params.id, [
+        { op: 'test', path: '/status', value: 'accepted' },
+        { op: 'add', path: '/status', value: 'cancelled' },
+      ]);
+    }
     sendOutcome(res, allOk);
   } catch (err) {
     if (err instanceof OperationOutcomeError) {

--- a/packages/server/src/fhir/operations/asyncjobcancel.ts
+++ b/packages/server/src/fhir/operations/asyncjobcancel.ts
@@ -29,7 +29,10 @@ export const asyncJobCancelHandler = asyncWrap(async (req: Request, res: Respons
   // Update status of async job
   try {
     const { repo } = getAuthenticatedContext();
-    await repo.patchResource('AsyncJob', req.params.id, [{ op: 'add', path: '/status', value: 'cancelled' }]);
+    await repo.patchResource('AsyncJob', req.params.id, [
+      { op: 'test', path: '/status', value: 'accepted' },
+      { op: 'add', path: '/status', value: 'cancelled' },
+    ]);
     sendOutcome(res, allOk);
   } catch (err) {
     if (err instanceof OperationOutcomeError) {

--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -38,12 +38,11 @@ export function sendOutcome(res: Response, outcome: OperationOutcome): Response 
   if (isAccepted(outcome) && outcome.issue?.[0].diagnostics) {
     res.set('Content-Location', outcome.issue[0].diagnostics);
   }
-  const extension = buildTracingExtension();
   return res
     .status(getStatus(outcome))
     .type(ContentType.FHIR_JSON)
     .json({
       ...outcome,
-      ...(extension ? extension : undefined),
+      extension: buildTracingExtension(),
     } as OperationOutcome);
 }

--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -38,11 +38,12 @@ export function sendOutcome(res: Response, outcome: OperationOutcome): Response 
   if (isAccepted(outcome) && outcome.issue?.[0].diagnostics) {
     res.set('Content-Location', outcome.issue[0].diagnostics);
   }
+  const extension = buildTracingExtension();
   return res
     .status(getStatus(outcome))
     .type(ContentType.FHIR_JSON)
     .json({
       ...outcome,
-      extension: buildTracingExtension(),
+      ...(extension ? extension : undefined),
     } as OperationOutcome);
 }

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -16,6 +16,7 @@ import { agentPushHandler } from './operations/agentpush';
 import { agentReloadConfigHandler } from './operations/agentreloadconfig';
 import { agentStatusHandler } from './operations/agentstatus';
 import { agentUpgradeHandler } from './operations/agentupgrade';
+import { asyncJobCancelHandler } from './operations/asyncjobcancel';
 import { codeSystemImportHandler } from './operations/codesystemimport';
 import { codeSystemLookupHandler } from './operations/codesystemlookup';
 import { codeSystemValidateCodeHandler } from './operations/codesystemvalidatecode';
@@ -122,6 +123,9 @@ protectedRoutes.get('/:resourceType/([$]|%24)csv', asyncWrap(csvHandler));
 // Agent $push operation (cannot use FhirRouter due to HL7 and DICOM output)
 protectedRoutes.post('/Agent/([$]|%24)push', agentPushHandler);
 protectedRoutes.post('/Agent/:id/([$]|%24)push', agentPushHandler);
+
+// AsyncJob $cancel operation
+protectedRoutes.post('/AsyncJob/:id/([$]|%24)cancel', asyncJobCancelHandler);
 
 // Bot $execute operation
 // Allow extra path content after the "$execute" to support external callers who append path info


### PR DESCRIPTION
EDIT:

This PR adds a `$cancel` operation to the `AsyncJob` resource, which allows for cancellation of a job by setting the `status` to `cancelled`, which should trigger the job worker to stop the processing of long-running jobs.

 The current prospective case is for the future data migration jobs, which will often be very long running jobs. In particular, reindex will be a job we want to be able to cancel in an emergency, which is probably the type of job most of our data migrations will be.