### PR TITLE
Fix token :not filter

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -1397,6 +1397,7 @@ describe('FHIR Search', () => {
           status: 'active',
           intent: 'order',
           subject: { reference: 'Patient/' + randomUUID() },
+          category: [{ coding: [{ code: randomUUID() }] }],
           code: { coding: [{ code }] },
         });
 


### PR DESCRIPTION
Corrects the matching semantics of the token `:not` filter: previously it was `NOT EXISTS(token = searchValue)`, when it should be `EXISTS(token != searchValue)`