### PR TITLE
test(agent): attempt to fix test flakiness

### DIFF
--- a/packages/agent/jest.config.json
+++ b/packages/agent/jest.config.json
@@ -1,5 +1,6 @@
 {
   "testEnvironment": "node",
+  "testTimeout": 30000,
   "transform": {
     "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
   },

--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -159,6 +159,8 @@ describe('App', () => {
     state.mySocket = undefined;
     mockServer1.stop();
 
+    console.log('Busting Turbo cache');
+
     // Start a new server
     const mockServer2 = new Server('wss://example.com/ws/agent');
     mockServer2.on('connection', mockConnectionHandler);

--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -159,8 +159,6 @@ describe('App', () => {
     state.mySocket = undefined;
     mockServer1.stop();
 
-    console.log('Busting Turbo cache');
-
     // Start a new server
     const mockServer2 = new Server('wss://example.com/ws/agent');
     mockServer2.on('connection', mockConnectionHandler);

--- a/packages/agent/src/app.test.ts
+++ b/packages/agent/src/app.test.ts
@@ -159,9 +159,6 @@ describe('App', () => {
     state.mySocket = undefined;
     mockServer1.stop();
 
-    // Sleep for a bit to allow healthchecks while disconnected
-    await sleep(1000);
-
     // Start a new server
     const mockServer2 = new Server('wss://example.com/ws/agent');
     mockServer2.on('connection', mockConnectionHandler);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3326,6 +3326,8 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       this.setRequestHeader(options, 'Content-Type', ContentType.FHIR_JSON, true);
     }
 
+    console.log('Busting cache');
+
     if (this.accessToken) {
       this.setRequestHeader(options, 'Authorization', 'Bearer ' + this.accessToken);
     } else if (this.basicAuth) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3326,7 +3326,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       this.setRequestHeader(options, 'Content-Type', ContentType.FHIR_JSON, true);
     }
 
-    console.log('Busting cache');
+    console.log('Busting cache again');
 
     if (this.accessToken) {
       this.setRequestHeader(options, 'Authorization', 'Bearer ' + this.accessToken);

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -3326,8 +3326,6 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       this.setRequestHeader(options, 'Content-Type', ContentType.FHIR_JSON, true);
     }
 
-    console.log('Busting cache again');
-
     if (this.accessToken) {
       this.setRequestHeader(options, 'Authorization', 'Bearer ' + this.accessToken);
     } else if (this.basicAuth) {


### PR DESCRIPTION
This is an attempt to fix some of the flakiness in one of the older tests "Reconnect after connection closed" in `packages/agent/src/app.test.ts` that seems to have emerged after #5476

My guess is that now attempting to wait further after adding `ReconnectingWebSocket` is unnecessary and the sleep seems to be causing more problems than it previously solved.

If removing it makes the test fail less often in CI, then I think we should remove this.

Going to run the CI for this branch a few times to see if I can get it to fail anywhere near as often as it has been.

EDIT: Looks like extending the `jest` timeout on the `agent` package was required. Set it to `30000` ms like the other packages with an explicit `testTimeout` in `jest.config.json`.