### PR TITLE
Make QuestionnaireForm change event handling pure

### DIFF
--- a/examples/medplum-health-gorilla-demo/src/components/TestMetadataCardInput.tsx
+++ b/examples/medplum-health-gorilla-demo/src/components/TestMetadataCardInput.tsx
@@ -53,7 +53,7 @@ export function TestMetadataCardInput({ test, metadata, error }: TestMetadataCar
 
             <TextInput
               label="Notes"
-              value={metadata.notes}
+              value={metadata.notes ?? ''}
               onChange={(event) => {
                 updateTestMetadata(test, { notes: event.currentTarget.value });
               }}

--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -169,6 +169,9 @@ describe('FHIRPath utils', () => {
     expect(getTypedPropertyValueWithoutSchema({ type: 'Foo', value: { x: 1 } }, 'x')).toEqual(TYPED_1);
     expect(getTypedPropertyValueWithoutSchema({ type: 'Foo', value: { x: [1] } }, 'x')).toEqual([TYPED_1]);
     expect(getTypedPropertyValueWithoutSchema({ type: 'Foo', value: { valueInteger: 1 } }, 'value')).toEqual(TYPED_1);
+    expect(getTypedPropertyValueWithoutSchema({ type: 'Foo', value: { valueInteger: 1 } }, 'value[x]')).toEqual(
+      TYPED_1
+    );
 
     // Only use valid property types
     expect(
@@ -296,6 +299,10 @@ describe('FHIRPath utils', () => {
       type: [{ code: 'boolean' }],
     };
     expect(getTypedPropertyValueWithSchema(choiceOfTypeTypedValue, 'value[x]', extensionValueX)).toEqual({
+      type: 'boolean',
+      value: true,
+    });
+    expect(getTypedPropertyValueWithSchema(choiceOfTypeTypedValue, 'value', extensionValueX)).toEqual({
       type: 'boolean',
       value: true,
     });

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -223,8 +223,9 @@ export function getTypedPropertyValueWithoutSchema(
     // id + identifier = not ok, because "entifier" is not a valid type
     // resource + resourceType = not ok, because "type" is not a valid type
     //eslint-disable-next-line guard-for-in
-    for (const propertyType in PropertyType) {
-      const propertyName = path + capitalize(propertyType);
+    const trimmedPath = path.endsWith('[x]') ? path.substring(0, path.length - 3) : path;
+    for (const propertyType of Object.values(PropertyType)) {
+      const propertyName = trimmedPath + capitalize(propertyType);
       if (propertyName in input) {
         const propertyValue = (input as { [key: string]: unknown })[propertyName];
         if (Array.isArray(propertyValue)) {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -44,6 +44,16 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
     setResponse(questionnaire ? buildInitialResponse(questionnaire) : undefined);
   }, [questionnaire]);
 
+  useEffect(() => {
+    if (response && onChangeRef.current) {
+      try {
+        onChangeRef.current(response);
+      } catch (e) {
+        console.error('Error invoking QuestionnaireForm.onChange callback', e);
+      }
+    }
+  }, [response]);
+
   const setItems = useCallback((newResponseItems: QuestionnaireResponseItem | QuestionnaireResponseItem[]): void => {
     setResponse((prevResponse) => {
       const currentItems = prevResponse?.item ?? [];
@@ -57,16 +67,6 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
         status: 'in-progress',
         item: mergedItems,
       };
-
-      const onChange = onChangeRef.current;
-      if (onChange) {
-        try {
-          onChange(newResponse);
-        } catch (e) {
-          console.error('Error invoking QuestionnaireForm.onChange callback', e);
-        }
-      }
-
       return newResponse;
     });
   }, []);

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -41,7 +41,12 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
   onSubmitRef.current = props.onSubmit;
 
   useEffect(() => {
-    setResponse(questionnaire ? buildInitialResponse(questionnaire) : undefined);
+    setResponse((prevResponse) => {
+      if (prevResponse) {
+        return prevResponse;
+      }
+      return questionnaire ? buildInitialResponse(questionnaire) : undefined;
+    });
   }, [questionnaire]);
 
   useEffect(() => {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -43,7 +43,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
 
   useEffect(() => {
     // If the Questionnaire remains "the same", keep the existing response
-    if (questionnaire && getQuestionnaireIdenity(prevQuestionnaire) === getQuestionnaireIdenity(questionnaire)) {
+    if (questionnaire && getQuestionnaireIdentity(prevQuestionnaire) === getQuestionnaireIdentity(questionnaire)) {
       return;
     }
 
@@ -176,6 +176,6 @@ function mergeItems(
   return result;
 }
 
-function getQuestionnaireIdenity(questionnaire: Questionnaire | undefined): Questionnaire | string | undefined {
+function getQuestionnaireIdentity(questionnaire: Questionnaire | undefined): Questionnaire | string | undefined {
   return questionnaire?.id || questionnaire;
 }


### PR DESCRIPTION
Also made a small change in behavior to `QuestionnaireForm` such that receiving a new `questionnaire` does not erase all existing answers.

It might arguably be better to make `QuestionnaireForm` more of a controlled component that takes `response` as a property; right now it's halfway-controlled ; it fires on changes with responses but has no way to specify the response.