### PR TITLE
chore(core): `createReference` narrow `reference` to `string`

### DIFF
--- a/examples/medplum-demo-bots/src/candid-health/sync-candid-tasks.ts
+++ b/examples/medplum-demo-bots/src/candid-health/sync-candid-tasks.ts
@@ -76,9 +76,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent): Promise<
           authorString: note.author_name,
           time: note.created_at,
         })),
-        encounter: {
-          reference: createReference(encounter) as string,
-        },
+        encounter: createReference(encounter),
       },
       'identifier=' + candidTask.task_id
     );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -493,7 +493,7 @@ export function stringifyTypedValue(v: TypedValue): string {
       return v.value.reference;
     default:
       if (isResource(v.value)) {
-        return createReference(v.value).reference as string;
+        return createReference(v.value).reference;
       }
       return JSON.stringify(v);
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -59,7 +59,7 @@ export type ResourceWithCode = Resource & Code;
  * @param resource - The FHIR resource.
  * @returns A reference resource.
  */
-export function createReference<T extends Resource>(resource: T): Reference<T> {
+export function createReference<T extends Resource>(resource: T): Reference<T> & { reference: string } {
   const reference = getReferenceString(resource);
   const display = getDisplayString(resource);
   return display === reference ? { reference } : { reference, display };


### PR DESCRIPTION
`reference` is guaranteed to be set on the returned `Reference` object from `createReference`. We should narrow it to prevent unnecessary type assertions in calling code.