### PR TITLE
feat(fhirtypes): adding note to a diagnostic report resource

### DIFF
--- a/packages/fhirtypes/dist/DiagnosticReport.d.ts
+++ b/packages/fhirtypes/dist/DiagnosticReport.d.ts
@@ -3,6 +3,7 @@
  * Do not edit manually.
  */
 
+import { Annotation } from './Annotation';
 import { Attachment } from './Attachment';
 import { CarePlan } from './CarePlan';
 import { CareTeam } from './CareTeam';
@@ -236,6 +237,11 @@ export interface DiagnosticReport {
    * semantically equivalent.
    */
   presentedForm?: Attachment[];
+
+  /**
+   * General comments about the diagnostic report.
+   */
+  note?: Annotation[];
 }
 
 /**


### PR DESCRIPTION
According to 

https://build.fhir.org/diagnosticreport.html

Diagnostic Report has note section. 

This is is to add note field to the diagnostic report. 