### PR TITLE
fix(scheduling-demo): search after updating calendar

### DIFF
--- a/examples/medplum-scheduling-demo/src/components/SlotDetails.tsx
+++ b/examples/medplum-scheduling-demo/src/components/SlotDetails.tsx
@@ -16,6 +16,7 @@ interface SlotDetailsProps {
     readonly close: () => void;
     readonly toggle: () => void;
   };
+  readonly onSlotsUpdated: () => void;
 }
 
 /**
@@ -25,7 +26,7 @@ interface SlotDetailsProps {
  * @returns A React component that displays the modal.
  */
 export function SlotDetails(props: SlotDetailsProps): JSX.Element | null {
-  const { event, opened, handlers } = props;
+  const { event, opened, handlers, onSlotsUpdated } = props;
   const slot: Slot | undefined = event?.resource;
 
   const [updateSlotOpened, updateSlotHandlers] = useDisclosure(false, { onClose: handlers.close });
@@ -35,6 +36,7 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element | null {
   async function handleDeleteSlot(slotId: string): Promise<void> {
     try {
       await medplum.deleteResource('Slot', slotId);
+      onSlotsUpdated();
       showNotification({
         icon: <IconCircleCheck />,
         title: 'Success',
@@ -97,7 +99,12 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element | null {
         </Stack>
       </Modal>
 
-      <CreateUpdateSlot event={event} opened={updateSlotOpened} handlers={updateSlotHandlers} />
+      <CreateUpdateSlot
+        event={event}
+        opened={updateSlotOpened}
+        handlers={updateSlotHandlers}
+        onSlotsUpdated={onSlotsUpdated}
+      />
     </>
   );
 }

--- a/examples/medplum-scheduling-demo/src/components/actions/CreateAppointment.tsx
+++ b/examples/medplum-scheduling-demo/src/components/actions/CreateAppointment.tsx
@@ -27,6 +27,7 @@ interface CreateAppointmentProps {
     readonly close: () => void;
     readonly toggle: () => void;
   };
+  readonly onAppointmentsUpdated: () => void;
 }
 
 /**
@@ -35,7 +36,7 @@ interface CreateAppointmentProps {
  * @returns A React component that displays the modal.
  */
 export function CreateAppointment(props: CreateAppointmentProps): JSX.Element | null {
-  const { patient, event, opened, handlers } = props;
+  const { patient, event, opened, handlers, onAppointmentsUpdated } = props;
   const slot: Slot | undefined = event?.resource;
 
   const [updateSlotOpened, updateSlotHandlers] = useDisclosure(false, { onClose: handlers.close });
@@ -51,6 +52,7 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element | 
   async function handleDeleteSlot(slotId: string): Promise<void> {
     try {
       await medplum.deleteResource('Slot', slotId);
+      onAppointmentsUpdated();
       showNotification({
         icon: <IconCircleCheck />,
         title: 'Success',
@@ -100,6 +102,7 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element | 
 
       // Navigate to the appointment detail page
       navigate(`/Appointment/${appointment.id}`);
+      onAppointmentsUpdated();
       showNotification({
         icon: <IconCircleCheck />,
         title: 'Success',
@@ -154,7 +157,12 @@ export function CreateAppointment(props: CreateAppointmentProps): JSX.Element | 
         <QuestionnaireForm questionnaire={createAppointmentQuestionnaire} onSubmit={handleQuestionnaireSubmit} />
       </Modal>
 
-      <CreateUpdateSlot event={event} opened={updateSlotOpened} handlers={updateSlotHandlers} />
+      <CreateUpdateSlot
+        event={event}
+        opened={updateSlotOpened}
+        handlers={updateSlotHandlers}
+        onSlotsUpdated={onAppointmentsUpdated}
+      />
     </>
   );
 }

--- a/examples/medplum-scheduling-demo/src/components/actions/CreateUpdateSlot.tsx
+++ b/examples/medplum-scheduling-demo/src/components/actions/CreateUpdateSlot.tsx
@@ -17,6 +17,7 @@ interface CreateUpdateSlotProps {
     readonly close: () => void;
     readonly toggle: () => void;
   };
+  readonly onSlotsUpdated: () => void;
 }
 
 /**
@@ -25,7 +26,7 @@ interface CreateUpdateSlotProps {
  * @returns A React component that displays the modal.
  */
 export function CreateUpdateSlot(props: CreateUpdateSlotProps): JSX.Element {
-  const { event, opened, handlers } = props;
+  const { event, opened, handlers, onSlotsUpdated } = props;
   const medplum = useMedplum();
   const { schedule } = useContext(ScheduleContext);
 
@@ -70,6 +71,7 @@ export function CreateUpdateSlot(props: CreateUpdateSlotProps): JSX.Element {
         });
       }
 
+      onSlotsUpdated();
       showNotification({
         icon: <IconCircleCheck />,
         title: 'Success',

--- a/examples/medplum-scheduling-demo/src/pages/PatientSchedulePage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/PatientSchedulePage.tsx
@@ -1,15 +1,15 @@
+import { Title } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { getReferenceString } from '@medplum/core';
-import { Schedule } from '@medplum/fhirtypes';
-import { Document, Loading, useMedplum, useSearchResources } from '@medplum/react';
+import { Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import { Document, Loading, useMedplum, useMedplumProfile, usePrevious } from '@medplum/react';
 import dayjs from 'dayjs';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { Calendar, dayjsLocalizer, Event } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useParams } from 'react-router-dom';
-import { ScheduleContext } from '../Schedule.context';
-import { Title } from '@mantine/core';
 import { CreateAppointment } from '../components/actions/CreateAppointment';
+import { ScheduleContext } from '../Schedule.context';
 
 /**
  * PatientSchedulePage component that displays the practitioner's schedule as part of the
@@ -22,11 +22,45 @@ export function PatientSchedulePage(): JSX.Element {
 
   const [createAppointmentOpened, createAppointmentHandlers] = useDisclosure(false);
   const [selectedEvent, setSelectedEvent] = useState<Event>();
-  const { schedule } = useContext(ScheduleContext);
 
   const medplum = useMedplum();
-  const [slots] = useSearchResources('Slot', { schedule: getReferenceString(schedule as Schedule), _count: '100' });
   const patient = patientId ? medplum.readResource('Patient', patientId).read() : undefined;
+
+  const { schedule } = useContext(ScheduleContext);
+  const profile = useMedplumProfile() as Practitioner;
+
+  const prevSchedule = usePrevious(schedule);
+  const prevProfile = usePrevious(profile);
+
+  const [shouldRefreshCalender, setShouldRefreshCalender] = useState(true);
+
+  const [slots, setSlots] = useState<Slot[]>();
+
+  useEffect(() => {
+    if ((schedule && prevSchedule?.id !== schedule?.id) || (profile && prevProfile?.id !== profile?.id)) {
+      setShouldRefreshCalender(true);
+    }
+  }, [schedule, profile, prevSchedule?.id, prevProfile?.id]);
+
+  useEffect(() => {
+    async function searchSlots(): Promise<void> {
+      const slots = await medplum.searchResources(
+        'Slot',
+        {
+          schedule: getReferenceString(schedule as Schedule),
+          _count: '100',
+        },
+        { cache: 'no-cache' }
+      );
+      setSlots(slots);
+    }
+
+    if (shouldRefreshCalender) {
+      searchSlots()
+        .then(() => setShouldRefreshCalender(false))
+        .catch(console.error);
+    }
+  }, [medplum, schedule, shouldRefreshCalender]);
 
   // Converts Slot resources to big-calendar Event objects
   // Only show free slots (available for booking)
@@ -76,6 +110,7 @@ export function PatientSchedulePage(): JSX.Element {
         event={selectedEvent}
         opened={createAppointmentOpened}
         handlers={createAppointmentHandlers}
+        onAppointmentsUpdated={() => setShouldRefreshCalender(true)}
       />
     </Document>
   );

--- a/examples/medplum-scheduling-demo/src/pages/SchedulePage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/SchedulePage.tsx
@@ -1,10 +1,10 @@
 import { Button, Group, Title } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure, usePrevious } from '@mantine/hooks';
 import { getReferenceString } from '@medplum/core';
-import { Practitioner, Schedule } from '@medplum/fhirtypes';
-import { Document, useMedplumProfile, useSearchResources } from '@medplum/react';
+import { Appointment, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
+import { Document, useMedplum, useMedplumProfile } from '@medplum/react';
 import dayjs from 'dayjs';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { Calendar, dayjsLocalizer, Event } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useNavigate } from 'react-router-dom';
@@ -23,6 +23,7 @@ import { ScheduleContext } from '../Schedule.context';
  */
 export function SchedulePage(): JSX.Element {
   const navigate = useNavigate();
+  const medplum = useMedplum();
 
   const [blockAvailabilityOpened, blockAvailabilityHandlers] = useDisclosure(false);
   const [setAvailabilityOpened, setAvailabilityHandlers] = useDisclosure(false);
@@ -32,10 +33,52 @@ export function SchedulePage(): JSX.Element {
 
   const [selectedEvent, setSelectedEvent] = useState<Event>();
   const { schedule } = useContext(ScheduleContext);
-
   const profile = useMedplumProfile() as Practitioner;
-  const [slots] = useSearchResources('Slot', { schedule: getReferenceString(schedule as Schedule), _count: '100' });
-  const [appointments] = useSearchResources('Appointment', { actor: getReferenceString(profile as Practitioner) });
+
+  const prevSchedule = usePrevious(schedule);
+  const prevProfile = usePrevious(profile);
+
+  const [shouldRefreshCalender, setShouldRefreshCalender] = useState(true);
+
+  const [slots, setSlots] = useState<Slot[]>();
+  const [appointments, setAppointments] = useState<Appointment[]>();
+
+  useEffect(() => {
+    if ((schedule && prevSchedule?.id !== schedule?.id) || (profile && prevProfile?.id !== profile?.id)) {
+      setShouldRefreshCalender(true);
+    }
+  }, [schedule, profile, prevSchedule?.id, prevProfile?.id]);
+
+  useEffect(() => {
+    async function searchSlots(): Promise<void> {
+      const slots = await medplum.searchResources(
+        'Slot',
+        {
+          schedule: getReferenceString(schedule as Schedule),
+          _count: '100',
+        },
+        { cache: 'no-cache' }
+      );
+      setSlots(slots);
+    }
+
+    async function searchAppointments(): Promise<void> {
+      const appointments = await medplum.searchResources(
+        'Appointment',
+        {
+          actor: getReferenceString(profile as Practitioner),
+        },
+        { cache: 'no-cache' }
+      );
+      setAppointments(appointments);
+    }
+
+    if (shouldRefreshCalender) {
+      Promise.allSettled([searchSlots(), searchAppointments()])
+        .then(() => setShouldRefreshCalender(false))
+        .catch(console.error);
+    }
+  }, [medplum, schedule, profile, shouldRefreshCalender]);
 
   // Converts Slot resources to big-calendar Event objects
   // Only show free and busy-unavailable slots
@@ -82,7 +125,7 @@ export function SchedulePage(): JSX.Element {
   );
 
   /**
-   * When an exiting event (slot/appointment) is selected, set the event object and open the
+   * When an existing event (slot/appointment) is selected, set the event object and open the
    * appropriate modal.
    * - If the event is a free slot, open the create appointment modal.
    * - If the event is a busy-unavailable slot, open the slot details modal.
@@ -148,9 +191,19 @@ export function SchedulePage(): JSX.Element {
       {/* Modals */}
       <SetAvailability opened={setAvailabilityOpened} handlers={setAvailabilityHandlers} />
       <BlockAvailability opened={blockAvailabilityOpened} handlers={blockAvailabilityHandlers} />
-      <CreateUpdateSlot event={selectedEvent} opened={createUpdateSlotOpened} handlers={createUpdateSlotHandlers} />
+      <CreateUpdateSlot
+        event={selectedEvent}
+        opened={createUpdateSlotOpened}
+        handlers={createUpdateSlotHandlers}
+        onSlotsUpdated={() => setShouldRefreshCalender(true)}
+      />
       <SlotDetails event={selectedEvent} opened={slotDetailsOpened} handlers={slotDetailsHandlers} />
-      <CreateAppointment event={selectedEvent} opened={createAppointmentOpened} handlers={createAppointmentHandlers} />
+      <CreateAppointment
+        event={selectedEvent}
+        opened={createAppointmentOpened}
+        handlers={createAppointmentHandlers}
+        onAppointmentsUpdated={() => setShouldRefreshCalender(true)}
+      />
     </Document>
   );
 }

--- a/examples/medplum-scheduling-demo/src/pages/SchedulePage.tsx
+++ b/examples/medplum-scheduling-demo/src/pages/SchedulePage.tsx
@@ -197,7 +197,12 @@ export function SchedulePage(): JSX.Element {
         handlers={createUpdateSlotHandlers}
         onSlotsUpdated={() => setShouldRefreshCalender(true)}
       />
-      <SlotDetails event={selectedEvent} opened={slotDetailsOpened} handlers={slotDetailsHandlers} />
+      <SlotDetails
+        event={selectedEvent}
+        opened={slotDetailsOpened}
+        handlers={slotDetailsHandlers}
+        onSlotsUpdated={() => setShouldRefreshCalender(true)}
+      />
       <CreateAppointment
         event={selectedEvent}
         opened={createAppointmentOpened}


### PR DESCRIPTION
Fixes #5534.

Instead of using `useSearch` which only refetch when the query params of the search changes, we instead use a state variable to drive the refetching via `medplum.searchResources`