### PR TITLE
Fix ResearchStudy type by removing Citation reference

### DIFF
--- a/packages/docs/static/data/resourceDefinitions/researchstudy.json
+++ b/packages/docs/static/data/resourceDefinitions/researchstudy.json
@@ -1788,9 +1788,6 @@
           "datatype": "EvidenceReport"
         },
         {
-          "datatype": "Citation"
-        },
-        {
           "datatype": "DiagnosticReport",
           "documentLocation": "resource"
         }

--- a/packages/docs/static/data/resourceDefinitions/researchstudy.json
+++ b/packages/docs/static/data/resourceDefinitions/researchstudy.json
@@ -1785,9 +1785,6 @@
       ],
       "referenceTypes": [
         {
-          "datatype": "EvidenceReport"
-        },
-        {
           "datatype": "DiagnosticReport",
           "documentLocation": "resource"
         }

--- a/packages/fhirtypes/dist/ResearchStudy.d.ts
+++ b/packages/fhirtypes/dist/ResearchStudy.d.ts
@@ -4,7 +4,6 @@
  */
 
 import { Annotation } from './Annotation';
-import { Citation } from './Citation';
 import { CodeableConcept } from './CodeableConcept';
 import { ContactDetail } from './ContactDetail';
 import { DiagnosticReport } from './DiagnosticReport';
@@ -347,7 +346,7 @@ export interface ResearchStudy {
    * also link to a research registry holding the results such as
    * ClinicalTrials.gov.
    */
-  result?: Reference<EvidenceReport | Citation | DiagnosticReport>[];
+  result?: Reference<EvidenceReport | DiagnosticReport>[];
 }
 
 /**

--- a/packages/fhirtypes/dist/ResearchStudy.d.ts
+++ b/packages/fhirtypes/dist/ResearchStudy.d.ts
@@ -7,7 +7,6 @@ import { Annotation } from './Annotation';
 import { CodeableConcept } from './CodeableConcept';
 import { ContactDetail } from './ContactDetail';
 import { DiagnosticReport } from './DiagnosticReport';
-import { EvidenceReport } from './EvidenceReport';
 import { EvidenceVariable } from './EvidenceVariable';
 import { Extension } from './Extension';
 import { Group } from './Group';
@@ -346,7 +345,7 @@ export interface ResearchStudy {
    * also link to a research registry holding the results such as
    * ClinicalTrials.gov.
    */
-  result?: Reference<EvidenceReport | DiagnosticReport>[];
+  result?: Reference<DiagnosticReport>[];
 }
 
 /**


### PR DESCRIPTION
Context:
* We backported some R5 features of the `ResearchStudy` type to support https://clinicaltrials.gov/
   * See https://github.com/medplum/medplum/pull/5394 and https://github.com/medplum/medplum/pull/5428
* Backporting R5 is always risky, due to the sprawling nature of new data types
* Despite knowing that, we missed this one, where `ResearchStudy` can refer to `Citation`, which does not exist in R4 at all
* Our automation did not catch this
   * The `@medplum/fhirtypes` package is autogenerated by some custom code, not `api-generator`
   * All of our projects use `"skipLibCheck": true` in `tsconfig.json`, which silently ignores this type of error

In the future, we will explore using `api-generator`, or having at least one test project which uses `"skipLibCheck": false`.