### PR TITLE
Use distroless base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,19 @@
 # Supported architectures:
 # linux/amd64, linux/arm64, linux/arm/v7
 # https://github.com/docker-library/official-images#architectures-other-than-amd64
-FROM gcr.io/distroless/nodejs20-debian12:nonroot
-WORKDIR /app
+FROM node:20-slim AS build
+WORKDIR /build
 
 # Add the application files: Docker handles extracting the tarball automatically
 ADD ./medplum-server.tar.gz ./
+# Install dependencies inside Docker container to handle multi-arch builds
+RUN npm ci --maxsockets 1
+
+
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
+WORKDIR /app
+
+COPY --from=build /build /app
 
 ENV PATH=/nodejs/bin:$PATH
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,25 +10,13 @@
 # Supported architectures:
 # linux/amd64, linux/arm64, linux/arm/v7
 # https://github.com/docker-library/official-images#architectures-other-than-amd64
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
+WORKDIR /app
 
-FROM node:20-slim
-
-ENV NODE_ENV=production
-
-WORKDIR /usr/src/medplum
-
-# Add the application files
+# Add the application files: Docker handles extracting the tarball automatically
 ADD ./medplum-server.tar.gz ./
 
-# Install dependencies, create non-root user, and set permissions in one layer
-RUN npm ci --maxsockets 1 && \
-  groupadd -r medplum && \
-  useradd -r -g medplum medplum && \
-  chown -R medplum:medplum /usr/src/medplum
-
-EXPOSE 5000 8103
-
-# Switch to the non-root user
-USER medplum
-
+ENV PATH=/nodejs/bin:$PATH
+ENV NODE_ENV=production
 ENTRYPOINT [ "node", "--require", "./packages/server/dist/otel/instrumentation.js", "packages/server/dist/index.js" ]
+EXPOSE 5000 8103

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -24,14 +24,17 @@ tar \
   -czf medplum-server.tar.gz \
   package.json \
   package-lock.json \
+  node_modules \
   packages/core/package.json \
   packages/core/dist \
   packages/definitions/package.json \
   packages/definitions/dist \
   packages/fhir-router/package.json \
   packages/fhir-router/dist \
+  packages/fhir-router/node_modules \
   packages/server/package.json \
-  packages/server/dist
+  packages/server/dist \
+  packages/server/node_modules
 
 # Supply chain attestations
 # See: https://docs.docker.com/scout/policy/#supply-chain-attestations

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -24,17 +24,14 @@ tar \
   -czf medplum-server.tar.gz \
   package.json \
   package-lock.json \
-  node_modules \
   packages/core/package.json \
   packages/core/dist \
   packages/definitions/package.json \
   packages/definitions/dist \
   packages/fhir-router/package.json \
   packages/fhir-router/dist \
-  packages/fhir-router/node_modules \
   packages/server/package.json \
-  packages/server/dist \
-  packages/server/node_modules
+  packages/server/dist
 
 # Supply chain attestations
 # See: https://docs.docker.com/scout/policy/#supply-chain-attestations


### PR DESCRIPTION
Two changes to the Docker build process to improve build times and harden/optimize the resulting image:
- Instead of running `npm ci` a second time inside the Docker container, include the `node_modules` from the original build step in the `medplum-server.tar.gz` artifact
- Use Google's [distroless](https://github.com/GoogleContainerTools/distroless) base image to shrink the final image, reduce security surface area, and automatically use a nonroot user to run the service