### PR TITLE
Add build script to @medplum/fhirtypes

### DIFF
--- a/packages/fhirtypes/package.json
+++ b/packages/fhirtypes/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "",
+    "build": "tsc",
     "clean": "",
     "test": ""
   },

--- a/packages/fhirtypes/tsconfig.json
+++ b/packages/fhirtypes/tsconfig.json
@@ -3,5 +3,6 @@
     "noEmit": true,
     "skipLibCheck": false,
     "typeRoots": ["dist"]
-  }
+  },
+  "include": ["dist"]
 }

--- a/packages/fhirtypes/tsconfig.json
+++ b/packages/fhirtypes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false,
+    "typeRoots": ["dist"]
+  }
+}


### PR DESCRIPTION
As a follow up to #5537, adding `tsc` as the build step to `@medplum/fhirtypes`.

Big shoutout to @ThatOneBro for identifying `typeRoots` to avoid checking everything in various `node_modules/@types`!