### PR TITLE
types(generator): validate `fhirtypes` after generation

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf dist",
     "compare": "ts-node src/compare.ts",
     "docs": "ts-node src/docs.ts && cd ../.. && git apply packages/generator/src/ONC-compliance-text.patch",
-    "fhirtypes": "ts-node src/index.ts",
+    "fhirtypes": "ts-node src/index.ts && cd ../fhirtypes && tsc",
     "generate": "npm run valuesets && npm run fhirtypes && npm run jsonschema && npm run baseschema && npm run mockclient && npm run docs",
     "jsonschema": "ts-node src/jsonschema.ts && npx prettier ../definitions/dist/fhir/r4/fhir.schema.json --write",
     "lint": "eslint .",


### PR DESCRIPTION
This makes it so we get immediate feedback after `fhirtypes` runs, which is especially useful when running `npm run generate` since it short-circuits the whole 2 minute generator pipeline in a few seconds after a failure.