### PR TITLE
Defensive check in async resource crawler

### DIFF
--- a/packages/core/src/typeschema/crawler.ts
+++ b/packages/core/src/typeschema/crawler.ts
@@ -263,7 +263,7 @@ class AsyncCrawler {
       await this.visitor.onEnterObject(path, obj, schema);
     }
 
-    if (this.excludeMissingProperties) {
+    if (this.excludeMissingProperties && obj.value) {
       for (const key of Object.keys(obj.value)) {
         await this.crawlProperty(obj, key, schema, `${path}.${key}`);
       }


### PR DESCRIPTION
Noticed a `TypeError: Cannot convert undefined or null to object` coming from this part of the code, adding a defensive check here to prevent trying to recurse on an empty value