### PR TITLE
Protect version-conditional updates with transactions

### DIFF
--- a/packages/fhir-router/src/batch.ts
+++ b/packages/fhir-router/src/batch.ts
@@ -172,12 +172,17 @@ class BatchProcessor {
         // guarantee uniqueness of created resource
         requiresStrongTransaction = true;
       } else if (interaction === 'update') {
-        if (entry.request?.url.includes('?')) {
+        if (entry.request?.url.includes('?') || entry.request?.ifMatch) {
           // Conditional update requires strong (serializable) transaction to
           // guarantee uniqueness of possibly-created resource
           requiresStrongTransaction = true;
         }
         updates++;
+      } else if (interaction === 'patch') {
+        updates++;
+        if (entry.request?.ifMatch) {
+          requiresStrongTransaction = true;
+        }
       } else if (interaction === 'delete' && entry.request?.url.includes('?')) {
         // Conditional delete requires strong (serializable) transaction
         requiresStrongTransaction = true;

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -25,6 +25,7 @@ export type CreateResourceOptions = {
 };
 
 export type UpdateResourceOptions = {
+  /** The specific version intended to be updated. */
   ifMatch?: string;
 };
 
@@ -146,9 +147,15 @@ export abstract class FhirRepository<TClient = unknown> {
    * @param resourceType - The FHIR resource type.
    * @param id - The FHIR resource ID.
    * @param patch - The JSONPatch operations.
+   * @param options - Options for the update operation.
    * @returns The patched resource.
    */
-  abstract patchResource(resourceType: string, id: string, patch: Operation[]): Promise<Resource>;
+  abstract patchResource(
+    resourceType: string,
+    id: string,
+    patch: Operation[],
+    options?: UpdateResourceOptions
+  ): Promise<Resource>;
 
   /**
    * Searches for FHIR resources.
@@ -396,7 +403,12 @@ export class MemoryRepository extends FhirRepository<undefined> {
     return this.createResource(result);
   }
 
-  async patchResource(resourceType: string, id: string, patch: Operation[]): Promise<Resource> {
+  async patchResource(
+    resourceType: string,
+    id: string,
+    patch: Operation[],
+    options?: UpdateResourceOptions
+  ): Promise<Resource> {
     const resource = await this.readResource(resourceType, id);
 
     try {
@@ -408,7 +420,7 @@ export class MemoryRepository extends FhirRepository<undefined> {
       throw new OperationOutcomeError(normalizeOperationOutcome(err));
     }
 
-    return this.updateResource(resource);
+    return this.updateResource(resource, options);
   }
 
   async readResource<T extends Resource>(resourceType: string, id: string): Promise<T> {

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -560,7 +560,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       let result: T;
       if (options?.ifMatch) {
         // Ensure transactional processing for version-specific conditional update
-        result = await this.ensureInTransaction(() => this.updateResourceImpl(resource, false, options?.ifMatch));
+        result = await this.withTransaction(() => this.updateResourceImpl(resource, false, options?.ifMatch), {
+          serializable: true,
+        });
       } else {
         result = await this.updateResourceImpl(resource, false, options?.ifMatch);
       }
@@ -1072,7 +1074,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       let result: T;
       if (options?.ifMatch) {
         // Ensure transactional processing for version-specific conditional update
-        result = await this.ensureInTransaction(() => this.updateResourceImpl(resource, false, options?.ifMatch));
+        result = await this.withTransaction(() => this.updateResourceImpl(resource, false, options?.ifMatch), {
+          serializable: true,
+        });
       } else {
         result = await this.updateResourceImpl(resource, false, options?.ifMatch);
       }


### PR DESCRIPTION
In an effort to reduce transaction conflicts around PATCH interactions in the general case, the situations where transactions are used are narrowed to only conditional updates (using `If-Match`).  This is applied to normal `PUT` updates with `If-Match` as well.  By reducing the scope of cases using a transaction, fewer conflicts should be generated and users receiving them should largely be opting into that behavior by using conditional update semantics.

Conceptually, this unifies the handling of query-based conditional updates (e.g. `PUT ResourceType?parameter=value`) and version-conditional updates (i.e. using the `If-Match` header).  This guarantees that when a user specifies that they want to ensure they are updating the latest version, it is impossible for anyone else to write a new conflicting version underneath them without an error.