### PR TITLE
Allow cancellation of reindex job

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -13,7 +13,7 @@ import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../test.setup';
-import { ReindexJobData, execReindexJob, getReindexQueue } from '../workers/reindex';
+import { ReindexJob, ReindexJobData, getReindexQueue } from '../workers/reindex';
 import { Job } from 'bullmq';
 
 jest.mock('../seeds/valuesets');
@@ -318,7 +318,7 @@ describe('Super Admin routes', () => {
         resourceTypes: ['PaymentNotice'],
       })
     );
-    await withTestContext(() => execReindexJob({ data: queue.add.mock.calls[0][1] } as Job));
+    await withTestContext(() => new ReindexJob().execute({ data: queue.add.mock.calls[0][1] } as Job));
     await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken);
   });
 
@@ -346,7 +346,7 @@ describe('Super Admin routes', () => {
     let job = { data: queue.add.mock.calls[0][1] } as Job;
     queue.add.mockClear();
 
-    await withTestContext(() => execReindexJob(job));
+    await withTestContext(() => new ReindexJob().execute(job));
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
       expect.objectContaining<Partial<ReindexJobData>>({
@@ -356,7 +356,7 @@ describe('Super Admin routes', () => {
     job = { data: queue.add.mock.calls[0][1] } as Job;
     queue.add.mockClear();
 
-    await withTestContext(() => execReindexJob(job));
+    await withTestContext(() => new ReindexJob().execute(job));
     expect(queue.add).toHaveBeenCalledWith(
       'ReindexJobData',
       expect.objectContaining<Partial<ReindexJobData>>({
@@ -366,7 +366,7 @@ describe('Super Admin routes', () => {
     job = { data: queue.add.mock.calls[0][1] } as Job;
     queue.add.mockClear();
 
-    await withTestContext(() => execReindexJob(job));
+    await withTestContext(() => new ReindexJob().execute(job));
     expect(queue.add).not.toHaveBeenCalled();
 
     await waitForAsyncJob(res.headers['content-location'], app, adminAccessToken);

--- a/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
+++ b/packages/server/src/fhir/operations/utils/asyncjobexecutor.ts
@@ -7,6 +7,7 @@ import { getAuthenticatedContext } from '../../../context';
 import { sendOutcome } from '../../outcomes';
 import { Repository, getSystemRepo } from '../../repo';
 import { getLogger } from 'nodemailer/lib/shared';
+import { UpdateResourceOptions } from '@medplum/fhir-router';
 
 export class AsyncJobExecutor {
   readonly repo: Repository;
@@ -95,14 +96,21 @@ export class AsyncJobExecutor {
     });
   }
 
-  async updateJobProgress(repo: Repository, output: Parameters): Promise<AsyncJob | undefined> {
+  async updateJobProgress(
+    repo: Repository,
+    output: Parameters,
+    options?: UpdateResourceOptions
+  ): Promise<AsyncJob | undefined> {
     if (!this.resource) {
       return undefined;
     }
-    return repo.updateResource<AsyncJob>({
-      ...this.resource,
-      output,
-    });
+    return repo.updateResource<AsyncJob>(
+      {
+        ...this.resource,
+        output,
+      },
+      options
+    );
   }
 
   async failJob(repo: Repository, err?: Error): Promise<AsyncJob | undefined> {

--- a/packages/server/src/workers/long-job.ts
+++ b/packages/server/src/workers/long-job.ts
@@ -4,13 +4,13 @@ import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import { getSystemRepo, Repository } from '../fhir/repo';
 import { getStatus, OperationOutcomeError } from '@medplum/core';
 
-export interface LongTermJobData {
+export interface LongJobData {
   asyncJob: AsyncJob;
 }
 
 const inProgressJobStatus: AsyncJob['status'][] = ['accepted', 'active'];
 
-export abstract class LongTermJob<TResult extends {}, TData extends LongTermJobData> {
+export abstract class LongJob<TResult extends {}, TData extends LongJobData> {
   private systemRepo: Repository;
 
   constructor(systemRepo?: Repository) {
@@ -97,8 +97,8 @@ export abstract class LongTermJob<TResult extends {}, TData extends LongTermJobD
         // at the beginning of the next iteration
         await this.enqueueJob(nextIteration);
       }
-    } catch (err: any) {
-      await this.failJob(job, err);
+    } catch (err: unknown) {
+      await this.failJob(job, err as Error);
     }
   }
 

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -5,7 +5,6 @@ import { MedplumServerConfig } from '../config';
 import { getLogger, getRequestContext, tryRunInRequestContext } from '../context';
 import { getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
-import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import { LongTermJob } from './longterm-job';
 
 /*
@@ -46,7 +45,7 @@ export function initReindexWorker(config: MedplumServerConfig): void {
   queue = new Queue<ReindexJobData>(queueName, {
     ...defaultOptions,
     defaultJobOptions: {
-      attempts: 3,
+      attempts: 1,
       backoff: {
         type: 'exponential',
         delay: 1000,
@@ -54,10 +53,9 @@ export function initReindexWorker(config: MedplumServerConfig): void {
     },
   });
 
-  const jobImpl = new ReindexJob();
   worker = new Worker<ReindexJobData>(
     queueName,
-    (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, () => jobImpl.execute(job)),
+    (job) => tryRunInRequestContext(job.data.requestId, job.data.traceId, () => new ReindexJob().execute(job)),
     {
       ...defaultOptions,
       ...config.bullmq,
@@ -82,238 +80,6 @@ export async function closeReindexWorker(): Promise<void> {
     await queue.close();
     queue = undefined;
   }
-}
-
-export async function execReindexJob(job: Job<ReindexJobData>): Promise<void> {
-  let resourceTypes = job.data.resourceTypes;
-  const resourceType = job.data.resourceTypes[0];
-  if (!job.data.count) {
-    getLogger().info('Reindex started', { resourceType });
-  }
-  let asyncJob = job.data.asyncJob;
-
-  try {
-    const result = await processPage(job);
-    job.data.results[resourceType] = result;
-
-    if ('duration' in result || 'err' in result) {
-      asyncJob = await updateStatus(job);
-      resourceTypes = resourceTypes.slice(1);
-    }
-
-    if ('cursor' in result && !('err' in result)) {
-      const count = result.count;
-      // Log progress and update status in the AsyncJob resource periodically
-      if (Math.floor(count / progressLogThreshold) !== Math.floor((count - batchSize) / progressLogThreshold)) {
-        globalLogger.info('Reindex in progress', {
-          resourceType,
-          latestJobId: job.id,
-          cursor: result.cursor,
-          currentCount: count,
-          elapsedTime: `${Date.now() - job.data.startTime} ms`,
-        });
-        asyncJob = await updateStatus(job);
-      }
-
-      // Enqueue job to handle next page of the current resource type
-      await addReindexJobData({
-        ...job.data,
-        asyncJob,
-        cursor: result.cursor,
-        count,
-      });
-    } else if (resourceTypes.length) {
-      // Enqueue job to start reindexing the next resource type
-      await addReindexJobData({
-        ...job.data,
-        asyncJob,
-        resourceTypes: resourceTypes,
-        count: 0,
-        cursor: undefined,
-        startTime: Date.now(),
-      });
-    } else {
-      await finishReindex(job, asyncJob);
-    }
-  } catch (err) {
-    const systemRepo = getSystemRepo();
-    const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
-    await exec.failJob(systemRepo, err as Error);
-  }
-}
-
-/**
- * Reindex one page of resources in the database, determined by the job data and search filter.
- * @param job - The current job.
- * @returns The result of reindexing the next page of results.
- */
-async function processPage(job: Job<ReindexJobData>): Promise<ReindexResult> {
-  const { resourceTypes, count } = job.data;
-  const resourceType = resourceTypes[0];
-
-  const searchRequest = searchRequestForNextPage(job);
-  let newCount = count ?? 0;
-  let cursor = '';
-  let nextTimestamp = new Date(0).toISOString();
-  try {
-    const systemRepo = getSystemRepo();
-    await systemRepo.withTransaction(async (conn) => {
-      const bundle = await systemRepo.search(searchRequest);
-      if (bundle.entry?.length) {
-        const resources = bundle.entry.map((e) => e.resource as Resource);
-        await systemRepo.reindexResources(conn, resources);
-        newCount += resources.length;
-        nextTimestamp = bundle.entry[bundle.entry.length - 1].resource?.meta?.lastUpdated ?? nextTimestamp;
-      }
-
-      const nextLink = bundle.link?.find((link) => link.relation === 'next');
-      if (nextLink) {
-        cursor = parseSearchRequest(nextLink.url).cursor ?? '';
-      }
-    });
-  } catch (err: any) {
-    return { count: newCount, cursor, nextTimestamp, err };
-  }
-
-  if (cursor) {
-    return { cursor, count: newCount, nextTimestamp };
-  } else if (resourceTypes.length > 1) {
-    // Completed reindex for this resource type
-    const elapsedTime = Date.now() - job.data.startTime;
-    getLogger().info('Reindex completed', {
-      resourceType,
-      count: newCount,
-      duration: `${elapsedTime} ms`,
-    });
-
-    return { count: newCount, duration: elapsedTime };
-  } else {
-    const elapsedTime = Date.now() - job.data.startTime;
-    getLogger().info('Reindex completed', { resourceType, count, duration: `${elapsedTime} ms` });
-    return { count: newCount, duration: elapsedTime };
-  }
-}
-
-function searchRequestForNextPage(job: Job<ReindexJobData>): SearchRequest {
-  const { resourceTypes, cursor, endTimestamp, searchFilter } = job.data;
-  const resourceType = resourceTypes[0];
-  const searchRequest: SearchRequest = {
-    resourceType,
-    count: batchSize,
-    sortRules: [{ code: '_lastUpdated', descending: false }],
-    filters: [{ code: '_lastUpdated', operator: Operator.LESS_THAN, value: endTimestamp }],
-  };
-  if (cursor) {
-    searchRequest.cursor = cursor;
-  }
-  if (searchFilter?.filters) {
-    searchRequest.filters?.push(...searchFilter.filters);
-  }
-
-  return searchRequest;
-}
-
-async function updateStatus(job: Job<ReindexJobData>): Promise<AsyncJob> {
-  const systemRepo = getSystemRepo();
-  const exec = new AsyncJobExecutor(systemRepo, job.data.asyncJob);
-  const output = formatResults(job.data.results);
-  return (await exec.updateJobProgress(systemRepo, output)) ?? job.data.asyncJob;
-}
-
-async function finishReindex(job: Job<ReindexJobData>, asyncJob: AsyncJob): Promise<void> {
-  const systemRepo = getSystemRepo();
-  const exec = new AsyncJobExecutor(systemRepo, asyncJob);
-  if (Object.values(job.data.results).some((r) => 'err' in r)) {
-    await exec.failJob(systemRepo);
-  } else {
-    const output = formatResults(job.data.results);
-    await exec.completeJob(systemRepo, output);
-  }
-}
-
-/**
- * Format the current job result status for inclusion in the AsyncJob resource.
- * @param results - The current results from the job
- * @returns The formatted output parameters
- */
-function formatResults(results: ReindexJobData['results']): Parameters {
-  return {
-    resourceType: 'Parameters',
-    parameter: Object.keys(results).map((resourceType) => formatReindexResult(results[resourceType], resourceType)),
-  };
-}
-
-function formatReindexResult(result: ReindexResult, resourceType: string): ParametersParameter {
-  if ('err' in result && result.err) {
-    // Resource types that encountered an error report the error,
-    // and a timestamp to allow restarting from previous checkpoint
-    const parts: ParametersParameter[] = [
-      { name: 'resourceType', valueCode: resourceType },
-      { name: 'error', valueString: normalizeErrorString(result.err) },
-    ];
-    if (result.nextTimestamp) {
-      parts.push({ name: 'nextTimestamp', valueDateTime: result.nextTimestamp });
-    }
-    return {
-      name: 'result',
-      part: parts,
-    };
-  } else if ('cursor' in result) {
-    // In-progress resource types log the next timestamp, which could be used to restart the job
-    return {
-      name: 'result',
-      part: [
-        { name: 'resourceType', valueCode: resourceType },
-        { name: 'nextTimestamp', valueDateTime: result.nextTimestamp },
-      ],
-    };
-  } else {
-    // Completed resource types report the number of indexed resources and wall time for the reindex job(s)
-    return {
-      name: 'result',
-      part: [
-        { name: 'resourceType', valueCode: resourceType },
-        { name: 'count', valueInteger: result.count },
-        { name: 'elapsedTime', valueQuantity: { value: result.duration, code: 'ms' } },
-      ],
-    };
-  }
-}
-
-/**
- * Returns the reindex queue instance.
- * This is used by the unit tests.
- * @returns The reindex queue (if available).
- */
-export function getReindexQueue(): Queue<ReindexJobData> | undefined {
-  return queue;
-}
-
-async function addReindexJobData(job: ReindexJobData): Promise<Job<ReindexJobData>> {
-  if (!queue) {
-    throw new Error('Job queue not available');
-  }
-  return queue.add(jobName, job);
-}
-
-export async function addReindexJob(
-  resourceTypes: ResourceType[],
-  job: AsyncJob,
-  searchFilter?: SearchRequest
-): Promise<Job<ReindexJobData>> {
-  const { requestId, traceId } = getRequestContext();
-  const endTimestamp = new Date(Date.now() + 1000 * 60 * 5).toISOString(); // Five minutes in the future
-
-  return addReindexJobData({
-    resourceTypes,
-    endTimestamp,
-    asyncJob: job,
-    startTime: Date.now(),
-    searchFilter,
-    results: Object.create(null),
-    requestId,
-    traceId,
-  });
 }
 
 export class ReindexJob extends LongTermJob<ReindexResult, ReindexJobData> {
@@ -403,4 +169,160 @@ function isResultInProgress(
 function shouldLogProgress(result: ReindexResult): boolean {
   const count = result.count;
   return Math.floor(count / progressLogThreshold) !== Math.floor((count - batchSize) / progressLogThreshold);
+}
+
+/**
+ * Reindex one page of resources in the database, determined by the job data and search filter.
+ * @param job - The current job.
+ * @returns The result of reindexing the next page of results.
+ */
+async function processPage(job: Job<ReindexJobData>): Promise<ReindexResult> {
+  const { resourceTypes, count } = job.data;
+  const resourceType = resourceTypes[0];
+
+  const searchRequest = searchRequestForNextPage(job);
+  let newCount = count ?? 0;
+  let cursor = '';
+  let nextTimestamp = new Date(0).toISOString();
+  try {
+    const systemRepo = getSystemRepo();
+    await systemRepo.withTransaction(async (conn) => {
+      const bundle = await systemRepo.search(searchRequest);
+      if (bundle.entry?.length) {
+        const resources = bundle.entry.map((e) => e.resource as Resource);
+        await systemRepo.reindexResources(conn, resources);
+        newCount += resources.length;
+        nextTimestamp = bundle.entry[bundle.entry.length - 1].resource?.meta?.lastUpdated ?? nextTimestamp;
+      }
+
+      const nextLink = bundle.link?.find((link) => link.relation === 'next');
+      if (nextLink) {
+        cursor = parseSearchRequest(nextLink.url).cursor ?? '';
+      }
+    });
+  } catch (err: any) {
+    return { count: newCount, cursor, nextTimestamp, err };
+  }
+
+  if (cursor) {
+    return { cursor, count: newCount, nextTimestamp };
+  } else if (resourceTypes.length > 1) {
+    // Completed reindex for this resource type
+    const elapsedTime = Date.now() - job.data.startTime;
+    getLogger().info('Reindex completed', {
+      resourceType,
+      count: newCount,
+      duration: `${elapsedTime} ms`,
+    });
+
+    return { count: newCount, duration: elapsedTime };
+  } else {
+    const elapsedTime = Date.now() - job.data.startTime;
+    getLogger().info('Reindex completed', { resourceType, count, duration: `${elapsedTime} ms` });
+    return { count: newCount, duration: elapsedTime };
+  }
+}
+
+function searchRequestForNextPage(job: Job<ReindexJobData>): SearchRequest {
+  const { resourceTypes, cursor, endTimestamp, searchFilter } = job.data;
+  const resourceType = resourceTypes[0];
+  const searchRequest: SearchRequest = {
+    resourceType,
+    count: batchSize,
+    sortRules: [{ code: '_lastUpdated', descending: false }],
+    filters: [{ code: '_lastUpdated', operator: Operator.LESS_THAN, value: endTimestamp }],
+  };
+  if (cursor) {
+    searchRequest.cursor = cursor;
+  }
+  if (searchFilter?.filters) {
+    searchRequest.filters?.push(...searchFilter.filters);
+  }
+
+  return searchRequest;
+}
+
+/**
+ * Format the current job result status for inclusion in the AsyncJob resource.
+ * @param results - The current results from the job
+ * @returns The formatted output parameters
+ */
+function formatResults(results: ReindexJobData['results']): Parameters {
+  return {
+    resourceType: 'Parameters',
+    parameter: Object.keys(results).map((resourceType) => formatReindexResult(results[resourceType], resourceType)),
+  };
+}
+
+function formatReindexResult(result: ReindexResult, resourceType: string): ParametersParameter {
+  if ('err' in result && result.err) {
+    // Resource types that encountered an error report the error,
+    // and a timestamp to allow restarting from previous checkpoint
+    const parts: ParametersParameter[] = [
+      { name: 'resourceType', valueCode: resourceType },
+      { name: 'error', valueString: normalizeErrorString(result.err) },
+    ];
+    if (result.nextTimestamp) {
+      parts.push({ name: 'nextTimestamp', valueDateTime: result.nextTimestamp });
+    }
+    return {
+      name: 'result',
+      part: parts,
+    };
+  } else if ('cursor' in result) {
+    // In-progress resource types log the next timestamp, which could be used to restart the job
+    return {
+      name: 'result',
+      part: [
+        { name: 'resourceType', valueCode: resourceType },
+        { name: 'nextTimestamp', valueDateTime: result.nextTimestamp },
+      ],
+    };
+  } else {
+    // Completed resource types report the number of indexed resources and wall time for the reindex job(s)
+    return {
+      name: 'result',
+      part: [
+        { name: 'resourceType', valueCode: resourceType },
+        { name: 'count', valueInteger: result.count },
+        { name: 'elapsedTime', valueQuantity: { value: result.duration, code: 'ms' } },
+      ],
+    };
+  }
+}
+
+/**
+ * Returns the reindex queue instance.
+ * This is used by the unit tests.
+ * @returns The reindex queue (if available).
+ */
+export function getReindexQueue(): Queue<ReindexJobData> | undefined {
+  return queue;
+}
+
+async function addReindexJobData(job: ReindexJobData): Promise<Job<ReindexJobData>> {
+  if (!queue) {
+    throw new Error('Job queue not available');
+  }
+  return queue.add(jobName, job);
+}
+
+export async function addReindexJob(
+  resourceTypes: ResourceType[],
+  job: AsyncJob,
+  searchFilter?: SearchRequest
+): Promise<Job<ReindexJobData>> {
+  const { requestId, traceId } = getRequestContext();
+  const endTimestamp = new Date(Date.now() + 1000 * 60 * 5).toISOString(); // Five minutes in the future
+
+  return addReindexJobData({
+    resourceTypes,
+    endTimestamp,
+    asyncJob: job,
+    startTime: Date.now(),
+    searchFilter,
+    results: Object.create(null),
+    requestId,
+    traceId,
+  });
 }

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -5,7 +5,7 @@ import { MedplumServerConfig } from '../config';
 import { getLogger, getRequestContext, tryRunInRequestContext } from '../context';
 import { getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
-import { LongTermJob } from './longterm-job';
+import { LongJob } from './long-job';
 
 /*
  * The reindex worker updates resource rows in the database,
@@ -82,7 +82,7 @@ export async function closeReindexWorker(): Promise<void> {
   }
 }
 
-export class ReindexJob extends LongTermJob<ReindexResult, ReindexJobData> {
+export class ReindexJob extends LongJob<ReindexResult, ReindexJobData> {
   async process(job: Job<ReindexJobData>): Promise<ReindexResult> {
     const result = await processPage(job);
 


### PR DESCRIPTION
Refactors the Reindex job into an instance of an abstract class encapsulating the re-entrant job pattern for long-running background processes, and adds checks to abort the reindex if the associated `AsyncJob` resource has been updated to `cancelled` status:
- Once at the beginning of every iteration of the job
- Updates to the `AsyncJob` resource are now done conditionally to ensure the update is applied to the latest version; if the status was updated to `cancelled` mid-execution it will be caught at this point before an update would clobber the `cancelled` status