### PR TITLE
Text overflows in ResourceDiffTable

### DIFF
--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.module.css
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.module.css
@@ -10,6 +10,10 @@
   & td {
     padding: var(--mantine-spacing-sm) var(--mantine-spacing-sm);
     vertical-align: top;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    white-space: normal; 
+    min-width: 100px; 
   }
 }
 


### PR DESCRIPTION
Example A:
<img src="https://github.com/user-attachments/assets/961dee94-f57b-4722-8790-7241c7ed6fe5" width=500 />

Example B:
<img src="https://github.com/user-attachments/assets/03e73ab6-68dc-4021-9c65-694894a39d49" width=500 />
