### PR TITLE
Fixes #5590 - cleanup default URLs in server config

### DIFF
--- a/packages/server/medplum.config.json
+++ b/packages/server/medplum.config.json
@@ -1,12 +1,6 @@
 {
   "port": 8103,
   "baseUrl": "http://localhost:8103/",
-  "issuer": "http://localhost:8103/",
-  "audience": "http://localhost:8103/",
-  "jwksUrl": "http://localhost:8103/.well-known/jwks.json",
-  "authorizeUrl": "http://localhost:8103/oauth2/authorize",
-  "tokenUrl": "http://localhost:8103/oauth2/token",
-  "userInfoUrl": "http://localhost:8103/oauth2/userinfo",
   "appBaseUrl": "http://localhost:3000/",
   "binaryStorage": "file:./binary/",
   "storageBaseUrl": "http://localhost:8103/storage/",

--- a/packages/server/src/cloud/aws/signer.ts
+++ b/packages/server/src/cloud/aws/signer.ts
@@ -1,4 +1,5 @@
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
+import { concatUrls } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { getConfig } from '../../config';
 
@@ -13,7 +14,7 @@ import { getConfig } from '../../config';
 export function getPresignedUrl(binary: Binary): string {
   const config = getConfig();
   const storageBaseUrl = config.storageBaseUrl;
-  const unsignedUrl = `${storageBaseUrl}${binary.id}/${binary.meta?.versionId}`;
+  const unsignedUrl = concatUrls(storageBaseUrl, `${binary.id}/${binary.meta?.versionId}`);
   const dateLessThan = new Date();
   dateLessThan.setHours(dateLessThan.getHours() + 1);
   return getSignedUrl({

--- a/packages/server/src/cloud/aws/storage.ts
+++ b/packages/server/src/cloud/aws/storage.ts
@@ -1,6 +1,7 @@
 import { CopyObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/cloudfront-signer';
 import { Upload } from '@aws-sdk/lib-storage';
+import { concatUrls } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { Readable } from 'stream';
 import { getConfig } from '../../config';
@@ -115,7 +116,7 @@ export class S3Storage implements BinaryStorage {
   getPresignedUrl(binary: Binary): string {
     const config = getConfig();
     const storageBaseUrl = config.storageBaseUrl;
-    const unsignedUrl = `${storageBaseUrl}${binary.id}/${binary.meta?.versionId}`;
+    const unsignedUrl = concatUrls(storageBaseUrl, `${binary.id}/${binary.meta?.versionId}`);
     const dateLessThan = new Date();
     dateLessThan.setHours(dateLessThan.getHours() + 1);
     return getSignedUrl({

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,4 +1,4 @@
-import { splitN } from '@medplum/core';
+import { concatUrls, splitN } from '@medplum/core';
 import { KeepJobs } from 'bullmq';
 import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
@@ -274,11 +274,11 @@ async function loadFileConfig(path: string): Promise<MedplumServerConfig> {
 function addDefaults(config: MedplumServerConfig): MedplumServerConfig {
   config.port = config.port || 8103;
   config.issuer = config.issuer || config.baseUrl;
-  config.jwksUrl = config.jwksUrl || config.baseUrl + '/.well-known/jwks.json';
-  config.authorizeUrl = config.authorizeUrl || config.baseUrl + '/oauth2/authorize';
-  config.tokenUrl = config.tokenUrl || config.baseUrl + '/oauth2/token';
-  config.userInfoUrl = config.userInfoUrl || config.baseUrl + '/oauth2/userinfo';
-  config.storageBaseUrl = config.storageBaseUrl || config.baseUrl + '/storage';
+  config.jwksUrl = config.jwksUrl || concatUrls(config.baseUrl, '/.well-known/jwks.json');
+  config.authorizeUrl = config.authorizeUrl || concatUrls(config.baseUrl, '/oauth2/authorize');
+  config.tokenUrl = config.tokenUrl || concatUrls(config.baseUrl, '/oauth2/token');
+  config.userInfoUrl = config.userInfoUrl || concatUrls(config.baseUrl, '/oauth2/userinfo');
+  config.storageBaseUrl = config.storageBaseUrl || concatUrls(config.baseUrl, '/storage');
   config.maxJsonSize = config.maxJsonSize || '1mb';
   config.maxBatchSize = config.maxBatchSize || '50mb';
   config.awsRegion = config.awsRegion || DEFAULT_AWS_REGION;

--- a/packages/server/src/fhir/rewrite.test.ts
+++ b/packages/server/src/fhir/rewrite.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, createReference, deepClone, getReferenceString } from '@medplum/core';
+import { ContentType, concatUrls, createReference, deepClone, getReferenceString } from '@medplum/core';
 import { Binary, Bundle, Media, Patient, Practitioner } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { URL } from 'url';
@@ -202,7 +202,7 @@ describe('URL rewrite', () => {
       photo: [
         {
           contentType: 'image/jpeg',
-          url: `${config.storageBaseUrl}${binary.id}`,
+          url: concatUrls(config.storageBaseUrl, binary.id as string),
         },
       ],
     };

--- a/packages/server/src/fhir/storage.ts
+++ b/packages/server/src/fhir/storage.ts
@@ -1,3 +1,4 @@
+import { concatUrls } from '@medplum/core';
 import { Binary } from '@medplum/fhirtypes';
 import { createSign } from 'crypto';
 import { copyFileSync, createReadStream, createWriteStream, existsSync, mkdirSync } from 'fs';
@@ -129,7 +130,7 @@ class FileSystemStorage implements BinaryStorage {
   getPresignedUrl(binary: Binary): string {
     const config = getConfig();
     const storageBaseUrl = config.storageBaseUrl;
-    const result = new URL(`${storageBaseUrl}${binary.id}/${binary.meta?.versionId}`);
+    const result = new URL(concatUrls(storageBaseUrl, `${binary.id}/${binary.meta?.versionId}`));
 
     const dateLessThan = new Date();
     dateLessThan.setHours(dateLessThan.getHours() + 1);

--- a/packages/server/src/util/auditevent.test.ts
+++ b/packages/server/src/util/auditevent.test.ts
@@ -7,8 +7,7 @@ import {
 import { AuditEvent } from '@medplum/fhirtypes';
 import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
-import fs from 'fs';
-import { loadConfig } from '../config';
+import { loadTestConfig } from '../config';
 import { waitFor } from '../test.setup';
 import { logAuditEvent } from './auditevent';
 
@@ -34,9 +33,8 @@ describe('AuditEvent utils', () => {
     console.info = jest.fn();
     console.log = jest.fn();
 
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ logAuditEvents: false }));
-
-    await loadConfig('file:test.json');
+    const config = await loadTestConfig();
+    config.logAuditEvents = false;
 
     logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);
 
@@ -47,8 +45,8 @@ describe('AuditEvent utils', () => {
   test('AuditEvent to console.log', async () => {
     console.log = jest.fn();
 
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify({ logAuditEvents: true }));
-    await loadConfig('file:test.json');
+    const config = await loadTestConfig();
+    config.logAuditEvents = true;
 
     // Log an AuditEvent
     logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);
@@ -61,16 +59,10 @@ describe('AuditEvent utils', () => {
     console.info = jest.fn();
     console.log = jest.fn();
 
-    // Mock readFileSync for custom config file
-    jest.spyOn(fs, 'readFileSync').mockReturnValue(
-      JSON.stringify({
-        logAuditEvents: true,
-        auditEventLogGroup: 'test-log-group',
-        auditEventLogStream: 'test-log-stream',
-      })
-    );
-
-    await loadConfig('file:test.json');
+    const config = await loadTestConfig();
+    config.logAuditEvents = true;
+    config.auditEventLogGroup = 'test-log-group';
+    config.auditEventLogStream = 'test-log-stream';
 
     // Log an AuditEvent
     logAuditEvent({ resourceType: 'AuditEvent' } as AuditEvent);


### PR DESCRIPTION
While looking into #5590 I noticed a bunch of places where we were doing naive URL concatenation, which is known to be a source of bugs.  Trying to use the `concatUrls()` util more consistently.