### PR TITLE
fix(core): allow raw buf and views in arrayBuffer fns

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -315,15 +315,25 @@ describe('Core Utils', () => {
   });
 
   test('Convert ArrayBuffer to hex string', () => {
-    const input = new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    const output = arrayBufferToHex(input);
-    expect(output).toBe('000102030405060708090a');
+    expect(arrayBufferToHex(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toBe('000102030405060708090a');
+    expect(arrayBufferToHex(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).buffer)).toBe('000102030405060708090a');
+    expect(arrayBufferToHex(new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toBe(
+      '000000000100000002000000030000000400000005000000060000000700000008000000090000000a000000'
+    );
+    expect(arrayBufferToHex(new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).buffer)).toBe(
+      '000000000100000002000000030000000400000005000000060000000700000008000000090000000a000000'
+    );
   });
 
   test('Convert ArrayBuffer to base-64 encoded string', () => {
-    const input = new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    const output = arrayBufferToBase64(input);
-    expect(output).toBe('AAECAwQFBgcICQo=');
+    expect(arrayBufferToBase64(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toBe('AAECAwQFBgcICQo=');
+    expect(arrayBufferToBase64(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).buffer)).toBe('AAECAwQFBgcICQo=');
+    expect(arrayBufferToBase64(new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toBe(
+      'AAAAAAEAAAACAAAAAwAAAAQAAAAFAAAABgAAAAcAAAAIAAAACQAAAAoAAAA='
+    );
+    expect(arrayBufferToBase64(new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).buffer)).toBe(
+      'AAAAAAEAAAACAAAAAwAAAAQAAAAFAAAABgAAAAcAAAAIAAAACQAAAAoAAAA='
+    );
   });
 
   test('Get date property', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -726,6 +726,10 @@ for (let n = 0; n < 256; n++) {
  * @returns The resulting hex string.
  */
 export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
+  // We want to allow both views and raw ArrayBuffers, so we conditionally "unwrap" the underlying ArrayBuffer
+  // If `arrayBuffer` was a view
+  // Otherwise, each of the views "elements" (ie. a uint32) will be truncated to a uint8
+  // And you end up with an incorrect shortened result of the same number of bytes as there were elements in the original TypedArray
   const buffer = ArrayBuffer.isView(arrayBuffer) ? arrayBuffer.buffer : arrayBuffer;
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
@@ -741,6 +745,10 @@ export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
  * @returns The base-64 encoded string.
  */
 export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
+  // We want to allow both views and raw ArrayBuffers, so we conditionally "unwrap" the underlying ArrayBuffer
+  // If `arrayBuffer` was a view
+  // Otherwise, each of the views "elements" (ie. a uint32) will be truncated to a uint8
+  // And you end up with an incorrect shortened result of the same number of bytes as there were elements in the original TypedArray
   const buffer = ArrayBuffer.isView(arrayBuffer) ? arrayBuffer.buffer : arrayBuffer;
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -760,7 +760,7 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBufferLike | ArrayBufferVi
  * @returns The raw `ArrayBuffer` without a view.
  */
 export function normalizeArrayBufferView(typedArrayOrBuffer: ArrayBufferLike | ArrayBufferView): ArrayBufferLike {
-  return ArrayBuffer.isView(typedArrayOrBuffer) ? (typedArrayOrBuffer.buffer as ArrayBuffer) : typedArrayOrBuffer;
+  return ArrayBuffer.isView(typedArrayOrBuffer) ? typedArrayOrBuffer.buffer : typedArrayOrBuffer;
 }
 
 export function capitalize(word: string): string {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -726,11 +726,7 @@ for (let n = 0; n < 256; n++) {
  * @returns The resulting hex string.
  */
 export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
-  // We want to allow both views and raw ArrayBuffers, so we conditionally "unwrap" the underlying ArrayBuffer
-  // If `arrayBuffer` was a view
-  // Otherwise, each of the views "elements" (ie. a uint32) will be truncated to a uint8
-  // And you end up with an incorrect shortened result of the same number of bytes as there were elements in the original TypedArray
-  const buffer = ArrayBuffer.isView(arrayBuffer) ? arrayBuffer.buffer : arrayBuffer;
+  const buffer = normalizeArrayBufferView(arrayBuffer);
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
@@ -745,17 +741,26 @@ export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
  * @returns The base-64 encoded string.
  */
 export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
-  // We want to allow both views and raw ArrayBuffers, so we conditionally "unwrap" the underlying ArrayBuffer
-  // If `arrayBuffer` was a view
-  // Otherwise, each of the views "elements" (ie. a uint32) will be truncated to a uint8
-  // And you end up with an incorrect shortened result of the same number of bytes as there were elements in the original TypedArray
-  const buffer = ArrayBuffer.isView(arrayBuffer) ? arrayBuffer.buffer : arrayBuffer;
+  const buffer = normalizeArrayBufferView(arrayBuffer);
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
     result[i] = String.fromCharCode(bytes[i]);
   }
   return window.btoa(result.join(''));
+}
+
+/**
+ * Normalizes an `ArrayBuffer` to a raw `ArrayBuffer` (without a view). If the passed `ArrayBuffer` is a view, it gives the raw `ArrayBuffer`.
+ *
+ * This is useful in cases where you need to operate on the raw bytes of an `ArrayBuffer` where a `TypedArray` (eg. `Uint32Array`) might be passed in.
+ * This ensures that you will always operate on the raw bytes rather than accidentally truncating the input by operating on the elements of the view.
+ *
+ * @param typedArrayOrBuffer - The `ArrayBuffer` (either `TypedArray` or raw `ArrayBuffer`) to normalize to raw `ArrayBuffer`.
+ * @returns The raw `ArrayBuffer` without a view.
+ */
+export function normalizeArrayBufferView(typedArrayOrBuffer: ArrayBuffer): ArrayBuffer {
+  return ArrayBuffer.isView(typedArrayOrBuffer) ? typedArrayOrBuffer.buffer : typedArrayOrBuffer;
 }
 
 export function capitalize(word: string): string {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -725,7 +725,7 @@ for (let n = 0; n < 256; n++) {
  * @param arrayBuffer - The input array buffer.
  * @returns The resulting hex string.
  */
-export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
+export function arrayBufferToHex(arrayBuffer: ArrayBufferLike | ArrayBufferView): string {
   const buffer = normalizeArrayBufferView(arrayBuffer);
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
@@ -740,7 +740,7 @@ export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
  * @param arrayBuffer - The input array buffer.
  * @returns The base-64 encoded string.
  */
-export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
+export function arrayBufferToBase64(arrayBuffer: ArrayBufferLike | ArrayBufferView): string {
   const buffer = normalizeArrayBufferView(arrayBuffer);
   const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
@@ -751,16 +751,16 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
 }
 
 /**
- * Normalizes an `ArrayBuffer` to a raw `ArrayBuffer` (without a view). If the passed `ArrayBuffer` is a view, it gives the raw `ArrayBuffer`.
+ * Normalizes an `ArrayBufferLike` (eg. an `ArrayBuffer`) to a raw `ArrayBufferLike` (without a view). If the passed buffer is a view, it gives the raw `ArrayBufferLike`.
  *
  * This is useful in cases where you need to operate on the raw bytes of an `ArrayBuffer` where a `TypedArray` (eg. `Uint32Array`) might be passed in.
  * This ensures that you will always operate on the raw bytes rather than accidentally truncating the input by operating on the elements of the view.
  *
- * @param typedArrayOrBuffer - The `ArrayBuffer` (either `TypedArray` or raw `ArrayBuffer`) to normalize to raw `ArrayBuffer`.
+ * @param typedArrayOrBuffer - The `ArrayBufferLike` (either `TypedArray` or raw `ArrayBuffer`) to normalize to raw `ArrayBuffer`.
  * @returns The raw `ArrayBuffer` without a view.
  */
-export function normalizeArrayBufferView(typedArrayOrBuffer: ArrayBuffer): ArrayBuffer {
-  return ArrayBuffer.isView(typedArrayOrBuffer) ? typedArrayOrBuffer.buffer : typedArrayOrBuffer;
+export function normalizeArrayBufferView(typedArrayOrBuffer: ArrayBufferLike | ArrayBufferView): ArrayBufferLike {
+  return ArrayBuffer.isView(typedArrayOrBuffer) ? (typedArrayOrBuffer.buffer as ArrayBuffer) : typedArrayOrBuffer;
 }
 
 export function capitalize(word: string): string {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -725,8 +725,9 @@ for (let n = 0; n < 256; n++) {
  * @param arrayBuffer - The input array buffer.
  * @returns The resulting hex string.
  */
-export function arrayBufferToHex(arrayBuffer: ArrayLike<number> | ArrayBuffer): string {
-  const bytes = new Uint8Array(arrayBuffer);
+export function arrayBufferToHex(arrayBuffer: ArrayBuffer): string {
+  const buffer = ArrayBuffer.isView(arrayBuffer) ? arrayBuffer.buffer : arrayBuffer;
+  const bytes = new Uint8Array(buffer);
   const result: string[] = new Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
     result[i] = byteToHex[bytes[i]];
@@ -739,9 +740,10 @@ export function arrayBufferToHex(arrayBuffer: ArrayLike<number> | ArrayBuffer): 
  * @param arrayBuffer - The input array buffer.
  * @returns The base-64 encoded string.
  */
-export function arrayBufferToBase64(arrayBuffer: ArrayLike<number> | ArrayBuffer): string {
-  const bytes = new Uint8Array(arrayBuffer);
-  const result: string[] = [];
+export function arrayBufferToBase64(arrayBuffer: ArrayBuffer): string {
+  const buffer = ArrayBuffer.isView(arrayBuffer) ? arrayBuffer.buffer : arrayBuffer;
+  const bytes = new Uint8Array(buffer);
+  const result: string[] = new Array(bytes.length);
   for (let i = 0; i < bytes.length; i++) {
     result[i] = String.fromCharCode(bytes[i]);
   }


### PR DESCRIPTION
Somehow our tests have been passing for a long time with incorrect assertions.

This is because ArrayBuffer accepts both TypedArray (eg. Uint32Array), ie. views on ArrayBuffer, as well as raw bytes ArrayBuffer.

Suddenly in the last dependency upgrade, the tests actually failed, which is actually correct. The strings we have been producing are actually truncated.