### PR TITLE
Fixed APT repository codenames

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -73,7 +73,6 @@ jobs:
           deb-s3 upload \
             --bucket apt.medplum.com \
             --prefix debian \
-            --codename "noble,jammy" \
             --component main \
             --visibility nil \
             --preserve-versions \


### PR DESCRIPTION
Claude led me astray.  The `deb-s3` command does not support comma separated codenames.

Here's how it currently looks in S3:

![image](https://github.com/user-attachments/assets/ae04d2b0-5b74-4a13-8246-5b061ee4de99)

There should be separate folders for each codename.

The 2 options are:
1. Call `deb-s3` multiple times, once per codename (i.e., "noble", "jammy" and more if we want to support Debian)
2. Just use "stable" (the `deb-s3` default), and make that part of the installation instructions

I'm inclined to keep it simple for now.  We can add explicit codenames in the future if we find that we need different .deb files for different targets.