### PR TITLE
Fix app config settings in deb package

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -33,6 +33,12 @@ jobs:
 
       - name: Build
         run: npm run build:fast
+        env:
+          MEDPLUM_BASE_URL: '__MEDPLUM_BASE_URL__'
+          MEDPLUM_CLIENT_ID: '__MEDPLUM_CLIENT_ID__'
+          MEDPLUM_REGISTER_ENABLED: '__MEDPLUM_REGISTER_ENABLED__'
+          GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
+          RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
 
       - name: Build Deb
         shell: bash

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -124,7 +124,11 @@ server {
 
     # Enable sub_filter for JavaScript files
     sub_filter_types application/javascript;  # Enable for JS files
-    sub_filter '__MEDPLUM_BASE_URL__' 'https://api.nginx.medplum.dev';  # Replace with actual URL
+    sub_filter '__MEDPLUM_BASE_URL__' 'https://api.example.com';
+    sub_filter '__MEDPLUM_CLIENT_ID__' '';
+    sub_filter '__GOOGLE_CLIENT_ID__' '';
+    sub_filter '__RECAPTCHA_SITE_KEY__' '';
+    sub_filter '__MEDPLUM_REGISTER_ENABLED__' 'true';
     sub_filter_once off;  # Replace all occurrences, not just the first
 
     # Gzip compression


### PR DESCRIPTION
Quick fix for `app` config settings when deployed via `.deb` and nginx

As part of the installation script (further down in `build-deb.sh`), the string "api.example.com" will be replaced with the input string from the installer:

```bash
if [ -f /etc/nginx/sites-available/medplum-app ]; then
    sed -i "s|api\.example\.com|\$SERVER_HOSTNAME|g" /etc/nginx/sites-available/medplum-app
    sed -i "s|app\.example\.com|\$APP_HOSTNAME|g" /etc/nginx/sites-available/medplum-app
fi
```