### PR TITLE
Pre-process deb app config settings

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -122,15 +122,6 @@ server {
     root /usr/lib/medplum/packages/app/dist;
     index index.html;
 
-    # Enable sub_filter for JavaScript files
-    sub_filter_types application/javascript;  # Enable for JS files
-    sub_filter '__MEDPLUM_BASE_URL__' 'https://api.example.com';
-    sub_filter '__MEDPLUM_CLIENT_ID__' '';
-    sub_filter '__GOOGLE_CLIENT_ID__' '';
-    sub_filter '__RECAPTCHA_SITE_KEY__' '';
-    sub_filter '__MEDPLUM_REGISTER_ENABLED__' 'true';
-    sub_filter_once off;  # Replace all occurrences, not just the first
-
     # Gzip compression
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
@@ -275,6 +266,16 @@ db_get medplum/db_host
 DB_HOST="\$RET"
 db_get medplum/db_password
 DB_PASSWORD="\$RET"
+
+# Update the app config
+# Recursively apply to all text files in the app dist directory
+find "/usr/lib/medplum/packages/app/dist" -type f -exec sed -i \
+  -e "s|__MEDPLUM_BASE_URL__|https://\${SERVER_HOSTNAME}/|g" \
+  -e "s|__MEDPLUM_CLIENT_ID__|\${MEDPLUM_CLIENT_ID}|g" \
+  -e "s|__GOOGLE_CLIENT_ID__|\${GOOGLE_CLIENT_ID}|g" \
+  -e "s|__RECAPTCHA_SITE_KEY__|\${RECAPTCHA_SITE_KEY}|g" \
+  -e "s|__MEDPLUM_REGISTER_ENABLED__|\${MEDPLUM_REGISTER_ENABLED}|g" \
+  {} \;
 
 # Update the server config
 if [ -f /etc/medplum/medplum.config.json ]; then


### PR DESCRIPTION
Nginx `sub_filter` only supports one search/replace operation per request.  You can't chain them together.

There's an unofficial 3rd party nginx extension that would support it (https://github.com/yaoweibin/ngx_http_substitutions_filter_module) but it has a ton of security implications, so I'm going to punt on that one for now.

Instead, this PR pre-processes the config settings directly into the `.js` files.

Pros: it works, faster, less complicated

Cons: this makes it harder to change config settings later, and will basically require a re-install of `app`.  I think that's ok for now, we still have a lot of details to figure out here.