### PR TITLE
Use exponential backoff for bot deploy retries

### DIFF
--- a/packages/server/src/cloud/aws/deploy.ts
+++ b/packages/server/src/cloud/aws/deploy.ts
@@ -297,7 +297,8 @@ async function updateLambdaCode(client: LambdaClient, name: string, zipFile: Uin
       const isBusy = err instanceof ResourceConflictException;
       const isLastAttempt = attempt === maxAttempts - 1;
       if (isBusy && !isLastAttempt) {
-        await sleep(1000);
+        // 1 sec, 2 sec, 4 sec, 8 sec
+        await sleep(1000 * 2 ** attempt);
       } else {
         throw err;
       }

--- a/packages/server/src/fhir/operations/deploy.ts
+++ b/packages/server/src/fhir/operations/deploy.ts
@@ -32,7 +32,6 @@ export async function deployHandler(req: FhirRequest): Promise<FhirResponse> {
   }
 
   try {
-    const code = req.body.code as string | undefined;
     let updatedBot: Bot | undefined;
 
     let codeToDeploy = code;


### PR DESCRIPTION
Still occasionally running into these errors:

```
[Error]: The operation cannot be performed at this time. An update is in progress for resource: arn:aws:lambda:us-east-1:647991932601:function:medplum-bot-lambda-...
```

Before, we used constant 1 second retry interval.

After, using exponential backoff of 1 sec, 2 sec, 4 sec, etc.