### PR TITLE
Fixes #5616 - replace add/save buttons on search filter editor

### DIFF
--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
@@ -51,6 +51,10 @@ describe('SearchFilterEditor', () => {
       />
     );
 
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add Filter'));
+    });
+
     const fieldInput = screen.getByTestId('filter-field');
     expect(fieldInput).toBeInTheDocument();
     expect(fieldInput).toHaveValue('');
@@ -71,10 +75,6 @@ describe('SearchFilterEditor', () => {
       fireEvent.change(screen.getByTestId('filter-value'), {
         target: { value: 'Alice' },
       });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Add'));
     });
 
     await act(async () => {
@@ -118,10 +118,6 @@ describe('SearchFilterEditor', () => {
     // Wait for the resource to load
     expect(screen.getByText('Test Organization')).toBeInTheDocument();
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Edit'));
-    });
-
     // Clear the existing value
     const clearButton = screen.getByTitle('Clear all');
     await act(async () => {
@@ -148,10 +144,6 @@ describe('SearchFilterEditor', () => {
     // Press "Enter"
     await act(async () => {
       fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Save'));
     });
 
     // Wait for the resource to load
@@ -192,7 +184,7 @@ describe('SearchFilterEditor', () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Delete'));
+      fireEvent.click(screen.getByLabelText('Delete filter'));
     });
 
     await act(async () => {
@@ -224,15 +216,7 @@ describe('SearchFilterEditor', () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Edit'));
-    });
-
-    await act(async () => {
       fireEvent.change(screen.getByDisplayValue('Alice'), { target: { value: 'Bob' } });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Save'));
     });
 
     await act(async () => {
@@ -241,51 +225,6 @@ describe('SearchFilterEditor', () => {
 
     expect(currSearch.filters?.length).toEqual(1);
     expect(currSearch.filters?.[0]?.value).toEqual('Bob');
-  });
-
-  test('Cancel edit', async () => {
-    let currSearch: SearchRequest = {
-      resourceType: 'Patient',
-      filters: [
-        {
-          code: 'name',
-          operator: Operator.CONTAINS,
-          value: 'Alice',
-        },
-      ],
-    };
-
-    await setup(
-      <SearchFilterEditor
-        search={currSearch}
-        visible={true}
-        onOk={(e) => (currSearch = e)}
-        onCancel={() => console.log('onCancel')}
-      />
-    );
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Edit'));
-    });
-
-    await act(async () => {
-      fireEvent.change(screen.getByDisplayValue('Alice'), { target: { value: 'Bob' } });
-    });
-
-    await act(async () => {
-      // There are 2 cancel buttons
-      // First one for the row
-      // Second one for the dialog overall
-      // Click on the first one
-      fireEvent.click(screen.getAllByText('Cancel')[0]);
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('OK'));
-    });
-
-    expect(currSearch.filters?.length).toEqual(1);
-    expect(currSearch.filters?.[0]?.value).toEqual('Alice');
   });
 
   test('Handle unknown search param type', async () => {
@@ -308,12 +247,6 @@ describe('SearchFilterEditor', () => {
         onCancel={() => console.log('onCancel')}
       />
     );
-
-    expect(screen.getByText('Not A Code')).toBeInTheDocument();
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Edit'));
-    });
 
     expect(screen.queryByDisplayValue('not-a-code')).not.toBeInTheDocument();
   });
@@ -345,10 +278,6 @@ describe('SearchFilterEditor', () => {
       await waitFor(() => screen.queryAllByText('Last Updated').length > 0);
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Edit'));
-    });
-
     const input = screen.getByTestId('filter-value') as HTMLInputElement;
     expect(input.value).toMatch(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
   });
@@ -374,20 +303,10 @@ describe('SearchFilterEditor', () => {
       />
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByText('Edit'));
-    });
-
     const input = screen.getByDisplayValue('5') as HTMLInputElement;
     await act(async () => {
       fireEvent.change(input, { target: { value: '6' } });
     });
-
-    await act(async () => {
-      fireEvent.click(screen.getByText('Save'));
-    });
-
-    expect(await screen.findByText('6')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByText('OK'));

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.test.tsx
@@ -55,24 +55,24 @@ describe('SearchFilterEditor', () => {
       fireEvent.click(screen.getByText('Add Filter'));
     });
 
-    const fieldInput = screen.getByTestId('filter-field');
+    const fieldInput = screen.getByTestId('filter-0-row-filter-field');
     expect(fieldInput).toBeInTheDocument();
     expect(fieldInput).toHaveValue('');
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('filter-field'), {
+      fireEvent.change(screen.getByTestId('filter-0-row-filter-field'), {
         target: { value: 'name' },
       });
     });
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('filter-operation'), {
+      fireEvent.change(screen.getByTestId('filter-0-row-filter-operation'), {
         target: { value: 'contains' },
       });
     });
 
     await act(async () => {
-      fireEvent.change(screen.getByTestId('filter-value'), {
+      fireEvent.change(screen.getByTestId('filter-0-row-filter-value'), {
         target: { value: 'Alice' },
       });
     });
@@ -278,7 +278,7 @@ describe('SearchFilterEditor', () => {
       await waitFor(() => screen.queryAllByText('Last Updated').length > 0);
     });
 
-    const input = screen.getByTestId('filter-value') as HTMLInputElement;
+    const input = screen.getByTestId('filter-0-row-filter-value') as HTMLInputElement;
     expect(input.value).toMatch(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})$/);
   });
 

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -1,7 +1,10 @@
-import { Button, Group, Modal, NativeSelect } from '@mantine/core';
-import { Filter, Operator, SearchRequest, getSearchParameters, stringify } from '@medplum/core';
+import { ActionIcon, Button, Group, Modal, NativeSelect } from '@mantine/core';
+import { Filter, Operator, SearchRequest, deepClone, getSearchParameters } from '@medplum/core';
 import { SearchParameter } from '@medplum/fhirtypes';
+import { IconX } from '@tabler/icons-react';
 import { useEffect, useRef, useState } from 'react';
+import { ArrayAddButton } from '../buttons/ArrayAddButton';
+import { Form } from '../Form/Form';
 import {
   addFilter,
   buildFieldNameString,
@@ -10,7 +13,6 @@ import {
   getSearchOperators,
   setFilters,
 } from '../SearchControl/SearchUtils';
-import { SearchFilterValueDisplay } from '../SearchFilterValueDisplay/SearchFilterValueDisplay';
 import { SearchFilterValueInput } from '../SearchFilterValueInput/SearchFilterValueInput';
 
 export interface SearchFilterEditorProps {
@@ -21,14 +23,13 @@ export interface SearchFilterEditorProps {
 }
 
 export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element | null {
-  const [search, setSearch] = useState<SearchRequest>(JSON.parse(stringify(props.search)) as SearchRequest);
-  const [editingIndex, setEditingIndex] = useState<number>(-1);
+  const [search, setSearch] = useState<SearchRequest>(deepClone(props.search) as SearchRequest);
 
   const searchRef = useRef<SearchRequest>(search);
   searchRef.current = search;
 
   useEffect(() => {
-    setSearch(JSON.parse(stringify(props.search)) as SearchRequest);
+    setSearch(deepClone(props.search) as SearchRequest);
   }, [props.search]);
 
   function onAddFilter(filter: Filter): void {
@@ -51,116 +52,79 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
       opened={props.visible}
       onClose={props.onCancel}
     >
-      <div>
-        <table>
-          <colgroup>
-            <col style={{ width: 200 }} />
-            <col style={{ width: 200 }} />
-            <col style={{ width: 380 }} />
-            <col style={{ width: 120 }} />
-          </colgroup>
-          <thead>
-            <tr>
-              <th>Field</th>
-              <th>Operation</th>
-              <th>Value</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filters.map((filter: Filter, index: number) => {
-              if (index === editingIndex) {
-                return (
-                  <FilterRowInput
-                    key={`filter-${filter.code}-${filter.operator}-${filter.value}-input`}
-                    resourceType={resourceType}
-                    searchParams={searchParams}
-                    defaultValue={filter}
-                    okText="Save"
-                    onOk={(newFilter: Filter) => {
-                      const newFilters = [...filters];
-                      newFilters[index] = newFilter;
-                      setSearch(setFilters(searchRef.current, newFilters));
-                      setEditingIndex(-1);
-                    }}
-                    onCancel={() => setEditingIndex(-1)}
-                  />
-                );
-              } else {
-                return (
-                  <FilterRowDisplay
-                    key={`filter-${filter.code}-${filter.operator}-${filter.value}-display`}
-                    resourceType={resourceType}
-                    filter={filter}
-                    onEdit={() => setEditingIndex(index)}
-                    onDelete={() => setSearch(deleteFilter(searchRef.current, index))}
-                  />
-                );
-              }
-            })}
-            <FilterRowInput resourceType={resourceType} searchParams={searchParams} okText="Add" onOk={onAddFilter} />
-          </tbody>
-        </table>
-      </div>
-      <Group justify="flex-end" mt="xl">
-        <Button onClick={() => props.onOk(searchRef.current)}>OK</Button>
-      </Group>
+      <Form onSubmit={() => props.onOk(searchRef.current)}>
+        <div>
+          <table>
+            <colgroup>
+              <col style={{ width: 200 }} />
+              <col style={{ width: 200 }} />
+              <col style={{ width: 380 }} />
+              <col style={{ width: 40 }} />
+            </colgroup>
+            <thead>
+              <tr>
+                <th>Field</th>
+                <th>Operation</th>
+                <th>Value</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filters.map((filter: Filter, index: number) => (
+                <FilterRowInput
+                  key={`filter-${index}-row`}
+                  resourceType={resourceType}
+                  searchParams={searchParams}
+                  value={filter}
+                  onChange={(newFilter: Filter) => {
+                    const newFilters = [...filters];
+                    newFilters[index] = newFilter;
+                    setSearch(setFilters(searchRef.current, newFilters));
+                  }}
+                  onDelete={() => setSearch(deleteFilter(searchRef.current, index))}
+                />
+              ))}
+            </tbody>
+          </table>
+          <ArrayAddButton propertyDisplayName="Filter" onClick={() => onAddFilter({} as Filter)} />
+        </div>
+        <Group justify="flex-end" mt="xl">
+          <Button onClick={() => props.onOk(searchRef.current)}>OK</Button>
+        </Group>
+      </Form>
     </Modal>
-  );
-}
-
-interface FilterRowDisplayProps {
-  readonly resourceType: string;
-  readonly filter: Filter;
-  readonly onEdit: () => void;
-  readonly onDelete: () => void;
-}
-
-function FilterRowDisplay(props: FilterRowDisplayProps): JSX.Element | null {
-  const { filter } = props;
-  return (
-    <tr>
-      <td>{buildFieldNameString(filter.code)}</td>
-      <td>{getOpString(filter.operator)}</td>
-      <td>
-        <SearchFilterValueDisplay resourceType={props.resourceType} filter={filter} />
-      </td>
-      <td>
-        <Button size="compact-md" variant="outline" onClick={props.onEdit}>
-          Edit
-        </Button>
-        <Button size="compact-md" variant="outline" onClick={props.onDelete}>
-          Delete
-        </Button>
-      </td>
-    </tr>
   );
 }
 
 interface FilterRowInputProps {
   readonly resourceType: string;
   readonly searchParams: Record<string, SearchParameter>;
-  readonly defaultValue?: Filter;
-  readonly okText: string;
-  readonly onOk: (value: Filter) => void;
-  readonly onCancel?: () => void;
+  readonly value: Filter;
+  readonly onChange: (value: Filter) => void;
+  readonly onDelete?: () => void;
 }
 
 function FilterRowInput(props: FilterRowInputProps): JSX.Element {
-  const [value, setValue] = useState<Filter>(props.defaultValue ?? ({} as Filter));
+  const value: Filter = props.value;
   const valueRef = useRef<Filter>(value);
   valueRef.current = value;
 
   function setFilterCode(newCode: string): void {
-    setValue({ ...valueRef.current, code: newCode });
+    valueRef.current.code = newCode;
+    valueRef.current.operator = Operator.EQUALS;
+    valueRef.current.value = '';
+    props.onChange(valueRef.current);
   }
 
   function setFilterOperator(newOperator: Operator): void {
-    setValue({ ...valueRef.current, operator: newOperator });
+    valueRef.current.operator = newOperator;
+    valueRef.current.value = '';
+    props.onChange(valueRef.current);
   }
 
   function setFilterValue(newFilterValue: string): void {
-    setValue({ ...valueRef.current, value: newFilterValue });
+    valueRef.current.value = newFilterValue;
+    props.onChange(valueRef.current);
   }
 
   const searchParam = props.searchParams[value.code];
@@ -171,7 +135,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       <td>
         <NativeSelect
           data-testid="filter-field"
-          defaultValue={valueRef.current.code}
+          defaultValue={props.value.code}
           onChange={(e) => setFilterCode(e.currentTarget.value)}
           data={[
             '',
@@ -200,22 +164,10 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
         )}
       </td>
       <td>
-        {value.code && value.operator && (
-          <Button
-            size="compact-md"
-            variant="outline"
-            onClick={() => {
-              props.onOk(valueRef.current);
-              setValue({} as Filter);
-            }}
-          >
-            {props.okText}
-          </Button>
-        )}
-        {props.onCancel && (
-          <Button size="compact-md" variant="outline" onClick={props.onCancel}>
-            Cancel
-          </Button>
+        {props.onDelete && (
+          <ActionIcon variant="outline" color="red" radius="xl" aria-label="Delete filter" onClick={props.onDelete}>
+            <IconX style={{ width: '70%', height: '70%' }} stroke={1.5} />
+          </ActionIcon>
         )}
       </td>
     </tr>

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -72,6 +72,7 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
             <tbody>
               {filters.map((filter: Filter, index: number) => (
                 <FilterRowInput
+                  id={`filter-${index}-row`}
                   key={`filter-${index}-row`}
                   resourceType={resourceType}
                   searchParams={searchParams}
@@ -89,7 +90,7 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
           <ArrayAddButton propertyDisplayName="Filter" onClick={() => onAddFilter({} as Filter)} />
         </div>
         <Group justify="flex-end" mt="xl">
-          <Button onClick={() => props.onOk(searchRef.current)}>OK</Button>
+          <Button type="submit">OK</Button>
         </Group>
       </Form>
     </Modal>
@@ -97,6 +98,7 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
 }
 
 interface FilterRowInputProps {
+  readonly id: string;
   readonly resourceType: string;
   readonly searchParams: Record<string, SearchParameter>;
   readonly value: Filter;
@@ -134,7 +136,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
     <tr>
       <td>
         <NativeSelect
-          data-testid="filter-field"
+          data-testid={`${props.id}-filter-field`}
           defaultValue={props.value.code}
           onChange={(e) => setFilterCode(e.currentTarget.value)}
           data={[
@@ -146,7 +148,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       <td>
         {operators && (
           <NativeSelect
-            data-testid="filter-operation"
+            data-testid={`${props.id}-filter-operation`}
             defaultValue={value.operator}
             onChange={(e) => setFilterOperator(e.currentTarget.value as Operator)}
             data={['', ...operators.map((op) => ({ value: op, label: getOpString(op) }))]}
@@ -156,6 +158,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       <td>
         {searchParam && value.operator && (
           <SearchFilterValueInput
+            name={`${props.id}-filter-value`}
             resourceType={props.resourceType}
             searchParam={searchParam}
             defaultValue={value.value}

--- a/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
+++ b/packages/react/src/SearchFilterValueInput/SearchFilterValueInput.tsx
@@ -8,6 +8,7 @@ import { ReferenceInput } from '../ReferenceInput/ReferenceInput';
 export interface SearchFilterValueInputProps {
   readonly resourceType: string;
   readonly searchParam: SearchParameter;
+  readonly name?: string;
   readonly defaultValue?: string;
   readonly autoFocus?: boolean;
   readonly onChange: (value: string) => void;
@@ -15,7 +16,7 @@ export interface SearchFilterValueInputProps {
 
 export function SearchFilterValueInput(props: SearchFilterValueInputProps): JSX.Element | null {
   const details = getSearchParameterDetails(props.resourceType, props.searchParam);
-  const name = 'filter-value';
+  const name = props.name ?? 'filter-value';
 
   switch (details.type) {
     case SearchParameterType.REFERENCE:


### PR DESCRIPTION
Before:
* The search filter editor dialog showed an "in progress" filter row
* But that row was only added if the user hit "Add" first
* That led to a common source of customer confusion

![image](https://github.com/user-attachments/assets/2525f8ae-1f55-4c9b-bfb7-2f4b65c8ff7a)


After
* No default "in progress" filter row
* You have to hit "Add Filter" add a new filter
* All rows are in "edit" mode

![image](https://github.com/user-attachments/assets/7dacae4c-d9b2-4b00-ae08-b40446be5c5f)

