### PR TITLE
Conditionally show DoseSpot icon in medplum-provider

### DIFF
--- a/examples/medplum-provider/src/App.tsx
+++ b/examples/medplum-provider/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import { Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { DoseSpotIcon } from './components/DoseSpotIcon';
+import { hasDoseSpotIdentifier } from './components/utils';
 import { HomePage } from './pages/HomePage';
 import { OnboardingPage } from './pages/OnboardingPage';
 import { SearchPage } from './pages/SearchPage';
@@ -46,6 +47,9 @@ export function App(): JSX.Element | null {
   if (medplum.isLoading()) {
     return null;
   }
+
+  const membership = medplum.getProjectMembership();
+  const hasDoseSpot = hasDoseSpotIdentifier(membership);
 
   return (
     <AppShell
@@ -104,7 +108,7 @@ export function App(): JSX.Element | null {
                 )
               }
             />
-            <DoseSpotIcon />
+            {hasDoseSpot && <DoseSpotIcon />}
           </>
         )
       }
@@ -119,7 +123,7 @@ export function App(): JSX.Element | null {
                 <Route path="encounter" element={<EncounterTab />} />
                 <Route path="communication" element={<CommunicationTab />} />
                 <Route path="communication/:id" element={<CommunicationTab />} />
-                <Route path="dosespot" element={<DoseSpotTab />} />
+                {hasDoseSpot && <Route path="dosespot" element={<DoseSpotTab />} />}
                 <Route path="task/:id/*" element={<TaskTab />} />
                 <Route path="timeline" element={<TimelineTab />} />
                 <Route path=":resourceType" element={<PatientSearchPage />} />

--- a/examples/medplum-provider/src/components/utils.ts
+++ b/examples/medplum-provider/src/components/utils.ts
@@ -1,0 +1,15 @@
+import { ProjectMembership } from '@medplum/fhirtypes';
+
+/**
+ * Returns true if the profile has a DoseSpot identifier.
+ *
+ * This is a crude approximation for demonstration purposes.
+ *
+ * In your application, you may want to make this distinction based on user groups, access control lists, etc.
+ *
+ * @param membership - The current user's project membership.
+ * @returns True if the profile has a DoseSpot identifier.
+ */
+export function hasDoseSpotIdentifier(membership: ProjectMembership | undefined): boolean {
+  return !!membership?.identifier?.some((i) => i.system?.includes('dosespot'));
+}


### PR DESCRIPTION
In the first version of the DoseSpot demo in `medplum-provider`, we only showed the icon if the user had a DoseSpot identifier.

Then we made a bunch of changes, refactored the DoseSpot components into hooks in `@medplum/react-hooks`, and moved the identifier from `Practitioner.identifier` to `ProjectMembership.identifier`.  

Along the way, we lost the check to only show the icon if the user had a DoseSpot identifier.

This fixes that, makes the icon and the tab conditional on having an identifier containing "dosespot".
