### PR TITLE
_filter eq should result in exact matching

### DIFF
--- a/packages/core/src/filter/parse.test.ts
+++ b/packages/core/src/filter/parse.test.ts
@@ -40,7 +40,7 @@ describe('_filter Parameter parser', () => {
 
     const left = connective.left as FhirFilterComparison;
     expect(left.path).toBe('given');
-    expect(left.operator).toBe(Operator.EQUALS);
+    expect(left.operator).toBe(Operator.EXACT);
     expect(left.value).toBe('peter');
 
     const right = connective.right as FhirFilterComparison;
@@ -61,7 +61,7 @@ describe('_filter Parameter parser', () => {
 
     const left = connective.left as FhirFilterComparison;
     expect(left.path).toBe('given');
-    expect(left.operator).toBe(Operator.EQUALS);
+    expect(left.operator).toBe(Operator.EXACT);
     expect(left.value).toBe('peter');
 
     const right = connective.right as FhirFilterComparison;
@@ -102,7 +102,7 @@ describe('_filter Parameter parser', () => {
 
     const first = connective1.left as FhirFilterComparison;
     expect(first.path).toBe('given');
-    expect(first.operator).toBe(Operator.EQUALS);
+    expect(first.operator).toBe(Operator.EXACT);
     expect(first.value).toBe('alice');
 
     const connective2 = connective1.right as FhirFilterConnective;
@@ -112,7 +112,7 @@ describe('_filter Parameter parser', () => {
 
     const second = connective2.left as FhirFilterComparison;
     expect(second.path).toBe('given');
-    expect(second.operator).toBe(Operator.EQUALS);
+    expect(second.operator).toBe(Operator.EXACT);
     expect(second.value).toBe('peter');
 
     const third = connective2.right as FhirFilterComparison;
@@ -143,22 +143,22 @@ describe('_filter Parameter parser', () => {
 
     const first = connective2.left as FhirFilterComparison;
     expect(first.path).toBe('status');
-    expect(first.operator).toBe(Operator.EQUALS);
+    expect(first.operator).toBe(Operator.EXACT);
     expect(first.value).toBe('preliminary');
 
     const second = connective2.right as FhirFilterComparison;
     expect(second.path).toBe('code');
-    expect(second.operator).toBe(Operator.EQUALS);
+    expect(second.operator).toBe(Operator.EXACT);
     expect(second.value).toBe('123');
 
     const third = connective3.left as FhirFilterComparison;
     expect(third.path).toBe('status');
-    expect(third.operator).toBe(Operator.EQUALS);
+    expect(third.operator).toBe(Operator.EXACT);
     expect(third.value).toBe('final');
 
     const fourth = connective3.right as FhirFilterComparison;
     expect(fourth.path).toBe('code');
-    expect(fourth.operator).toBe(Operator.EQUALS);
+    expect(fourth.operator).toBe(Operator.EXACT);
     expect(fourth.value).toBe('456');
   });
 
@@ -186,23 +186,23 @@ describe('_filter Parameter parser', () => {
 
     const first = connective2.left as FhirFilterComparison;
     expect(first.path).toBe('status');
-    expect(first.operator).toBe(Operator.EQUALS);
+    expect(first.operator).toBe(Operator.EXACT);
     expect(first.value).toBe('preliminary');
 
     const second = connective2.right as FhirFilterComparison;
     expect(second.path).toBe('code');
-    expect(second.operator).toBe(Operator.EQUALS);
+    expect(second.operator).toBe(Operator.EXACT);
     expect(second.value).toBe('123');
 
     const negation = connective3.left as FhirFilterNegation;
     const third = negation.child as FhirFilterComparison;
     expect(third.path).toBe('status');
-    expect(third.operator).toBe(Operator.EQUALS);
+    expect(third.operator).toBe(Operator.EXACT);
     expect(third.value).toBe('preliminary');
 
     const fourth = connective3.right as FhirFilterComparison;
     expect(fourth.path).toBe('code');
-    expect(fourth.operator).toBe(Operator.EQUALS);
+    expect(fourth.operator).toBe(Operator.EXACT);
     expect(fourth.value).toBe('456');
   });
 
@@ -213,7 +213,7 @@ describe('_filter Parameter parser', () => {
 
     const comp = result as FhirFilterComparison;
     expect(comp.path).toBe('code');
-    expect(comp.operator).toBe(Operator.EQUALS);
+    expect(comp.operator).toBe(Operator.EXACT);
     expect(comp.value).toBe('http://loinc.org|1234-5');
   });
 

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -11,7 +11,7 @@ import { FhirFilterComparison, FhirFilterConnective, FhirFilterExpression, FhirF
  */
 const operatorMap: Record<string, Operator | undefined> = {
   // eq - an item in the set has an equal value
-  eq: Operator.EQUALS,
+  eq: Operator.EXACT,
   // ne - An item in the set has an unequal value
   ne: Operator.NOT_EQUALS,
   // co - An item in the set contains this value

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3269,6 +3269,51 @@ describe('FHIR Search', () => {
         expect(result.entry).toHaveLength(2);
       }));
 
+    test('_filter eq', () =>
+      withTestContext(async () => {
+        const patient = await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Evelyn'] }],
+          managingOrganization: { reference: 'Organization/' + randomUUID() },
+        });
+
+        const result1 = await repo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'organization',
+              operator: Operator.EQUALS,
+              value: patient.managingOrganization?.reference as string,
+            },
+            {
+              code: '_filter',
+              operator: Operator.EQUALS,
+              value: 'given eq Eve', // eq with a prefix should NOT match
+            },
+          ],
+        });
+
+        expect(result1.entry).toHaveLength(0);
+
+        const result2 = await repo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: 'organization',
+              operator: Operator.EQUALS,
+              value: patient.managingOrganization?.reference as string,
+            },
+            {
+              code: '_filter',
+              operator: Operator.EQUALS,
+              value: 'given eq Evelyn', // eq with exact value should match
+            },
+          ],
+        });
+
+        expect(result2.entry).toHaveLength(1);
+      }));
+
     test('_filter ne', () =>
       withTestContext(async () => {
         const patient = await repo.createResource<Patient>({


### PR DESCRIPTION
Per [the description](https://www.hl7.org/fhir/r4/search_filter.html) for `eq` within a `_filter`search parameter, map to the exact operator.