### PR TITLE
feat(server): add super admin table settings route

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -1,5 +1,6 @@
-import { createReference, getReferenceString } from '@medplum/core';
+import { allOk, badRequest, createReference, getReferenceString } from '@medplum/core';
 import { Login, Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
+import { Job } from 'bullmq';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -8,13 +9,13 @@ import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config';
 import { AuthenticatedRequestContext, requestContextStore } from '../context';
 import { getSystemRepo } from '../fhir/repo';
+import { globalLogger } from '../logger';
 import { generateAccessToken } from '../oauth/keys';
 import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../test.setup';
-import { ReindexJob, ReindexJobData, getReindexQueue } from '../workers/reindex';
-import { Job } from 'bullmq';
+import { getReindexQueue, ReindexJob, ReindexJobData } from '../workers/reindex';
 
 jest.mock('../seeds/valuesets');
 jest.mock('../seeds/structuredefinitions');
@@ -538,5 +539,185 @@ describe('Super Admin routes', () => {
     expect(res1.status).toStrictEqual(202);
     expect(res1.headers['content-location']).toBeDefined();
     await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken);
+  });
+
+  describe('Table settings', () => {
+    test('Set table auto-vacuum settings -- Happy path', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ tableName: 'Observation', settings: { autovacuum_analyze_scale_factor: 0.005 } });
+
+      expect(res1.status).toStrictEqual(200);
+      expect(res1.body).toMatchObject(allOk);
+
+      expect(infoSpy).toHaveBeenCalledWith('[Super Admin]: Table settings updated', {
+        durationMs: expect.any(Number),
+        query: 'ALTER TABLE "Observation" SET (autovacuum_analyze_scale_factor = 0.005);',
+        settings: { autovacuum_analyze_scale_factor: 0.005 },
+        tableName: 'Observation',
+      });
+
+      infoSpy.mockRestore();
+    });
+
+    test('No table name', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ settings: { autovacuum_analyze_scale_factor: 0.005 } });
+
+      expect(res1.status).toStrictEqual(400);
+      expect(res1.body).toMatchObject(badRequest('Table name must be a string'));
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+    });
+
+    test('No settings', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ tableName: 'Observation' });
+
+      expect(res1.status).toStrictEqual(400);
+      expect(res1.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [
+          {
+            code: 'invalid',
+            details: {
+              text: 'Settings must be object mapping valid table settings to desired values',
+            },
+            expression: ['settings'],
+            severity: 'error',
+          },
+          {
+            code: 'invalid',
+            details: {
+              text: 'Cannot convert undefined or null to object',
+            },
+            expression: ['settings'],
+            severity: 'error',
+          },
+        ],
+      });
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+    });
+
+    test('Invalid setting', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ tableName: 'Observation', settings: { autovacuum_analyze_scale: 0.005 } });
+
+      expect(res1.status).toStrictEqual(400);
+      expect(res1.body).toMatchObject({
+        resourceType: 'OperationOutcome',
+        issue: [
+          {
+            code: 'invalid',
+            details: {
+              text: 'autovacuum_analyze_scale is not a valid table setting',
+            },
+            expression: ['settings'],
+            severity: 'error',
+          },
+        ],
+      });
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+    });
+
+    test('Settings with int values reject floats', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ tableName: 'Observation', settings: { autovacuum_analyze_threshold: 0.005 } });
+
+      expect(res1.status).toStrictEqual(400);
+      expect(res1.body).toMatchObject(badRequest('settings.autovacuum_analyze_threshold must be an integer value'));
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+    });
+
+    test('Settings with float values reject non-numeric values', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ tableName: 'Observation', settings: { autovacuum_analyze_scale_factor: 'testing' } });
+
+      expect(res1.status).toStrictEqual(400);
+      expect(res1.body).toMatchObject(badRequest('settings.autovacuum_analyze_scale_factor must be a float value'));
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+    });
+
+    test('Multiple settings', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({
+          tableName: 'Observation',
+          settings: { autovacuum_analyze_scale_factor: 0.005, autovacuum_vacuum_scale_factor: 0.01 },
+        });
+
+      expect(res1.status).toStrictEqual(200);
+      expect(res1.body).toMatchObject(allOk);
+
+      expect(infoSpy).toHaveBeenCalledWith('[Super Admin]: Table settings updated', {
+        durationMs: expect.any(Number),
+        query:
+          'ALTER TABLE "Observation" SET (autovacuum_analyze_scale_factor = 0.005, autovacuum_vacuum_scale_factor = 0.01);',
+        settings: { autovacuum_analyze_scale_factor: 0.005, autovacuum_vacuum_scale_factor: 0.01 },
+        tableName: 'Observation',
+      });
+      infoSpy.mockRestore();
+    });
+
+    test('Multiple settings w/ invalid settings', async () => {
+      const infoSpy = jest.spyOn(globalLogger, 'info');
+
+      const res1 = await request(app)
+        .post('/admin/super/tablesettings')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({
+          tableName: 'Observation',
+          settings: { autovacuum_analyze_scale_factor: 0.005, autovacuum_vacuum_scale: 0.01 },
+        });
+
+      expect(res1.status).toStrictEqual(400);
+      expect(res1.body).toMatchObject(badRequest('autovacuum_vacuum_scale is not a valid table setting'));
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      infoSpy.mockRestore();
+    });
   });
 });

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -39,6 +39,10 @@ export const OVERRIDABLE_TABLE_SETTINGS = {
   autovacuum_vacuum_cost_delay: 'float',
 } as const satisfies Record<string, 'float' | 'int'>;
 
+export function isValidTableName(tableName: string): boolean {
+  return /^(\w_?)+$/.test(tableName);
+}
+
 export const superAdminRouter = Router();
 superAdminRouter.use(authenticateRequest);
 
@@ -239,7 +243,11 @@ superAdminRouter.post(
 superAdminRouter.post(
   '/tablesettings',
   [
-    body('tableName').isString().withMessage('Table name must be a string'),
+    body('tableName')
+      .isString()
+      .withMessage('Table name must be a string')
+      .custom(isValidTableName)
+      .withMessage('Table name must be a snake_cased_string'),
     body('settings')
       .isObject()
       .withMessage('Settings must be object mapping valid table settings to desired values')
@@ -301,7 +309,12 @@ superAdminRouter.post(
   '/vacuum',
   [
     body('tableNames').isArray().withMessage('Table names must be an array of strings').optional(),
-    body('tableNames.*').isString().withMessage('Table name(s) must be a string').optional(),
+    body('tableNames.*')
+      .isString()
+      .withMessage('Table name(s) must be a string')
+      .custom(isValidTableName)
+      .withMessage('Table name(s) must be a snake_cased_string')
+      .optional(),
     body('analyze').isBoolean().optional().default(false),
     checkExact(),
   ],

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -40,7 +40,7 @@ export const OVERRIDABLE_TABLE_SETTINGS = {
 } as const satisfies Record<string, 'float' | 'int'>;
 
 export function isValidTableName(tableName: string): boolean {
-  return /^(\w_?)+$/.test(tableName);
+  return /^[\w_]+$/.test(tableName);
 }
 
 export const superAdminRouter = Router();


### PR DESCRIPTION
Adds both a `/admin/super/tablesettings` route for settings auto-vacuum settings (and maybe other settings later), as well as a `/admin/super/vacuum` for triggering a manual vacuum and optionally an analyze as well.

## TODO:
- [x] Log both for settings parameters and running vacuum
- [x] Write tests