### PR TITLE
Client-side filtering in requestSchema to avoid loading  extra SDs

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1820,7 +1820,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
 
         const response = (await this.graphql(query)) as SchemaGraphQLResponse;
 
-        indexStructureDefinitionBundle(response.data.StructureDefinitionList);
+        indexStructureDefinitionBundle(response.data.StructureDefinitionList.filter((sd) => sd.name === resourceType));
 
         for (const searchParameter of response.data.SearchParameterList) {
           indexSearchParameter(searchParameter);


### PR DESCRIPTION
Until the v4 fix of `eq` in `_filter` using exact match lands.

Previously, if a StructureDefinition exists without a snapshot element and has a name that begins with another resourceType, it was unintentially loaded and indexed by `requestSchema`. The indexing throws an error "No snapshot defined for StructureDefinition <name>" that bubbles up leading to unexpected errors, e.g. in @medplum/app.