### PR TITLE
Address vscode vitest extension errors

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -6,8 +6,8 @@ import path from 'path';
 import { defineConfig } from 'vite';
 import packageJson from './package.json' with { type: 'json' };
 
-if (!existsSync('.env')) {
-  copyFileSync('.env.defaults', '.env');
+if (!existsSync(path.join(__dirname, '.env'))) {
+  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
 }
 
 let gitHash;

--- a/packages/graphiql/vite.config.ts
+++ b/packages/graphiql/vite.config.ts
@@ -1,10 +1,11 @@
 /// <reference types="vite/client" />
 import react from '@vitejs/plugin-react';
 import { copyFileSync, existsSync } from 'fs';
+import path from 'path';
 import { defineConfig } from 'vite';
 
-if (!existsSync('.env')) {
-  copyFileSync('.env.defaults', '.env');
+if (!existsSync(path.join(__dirname, '.env'))) {
+  copyFileSync(path.join(__dirname, '.env.defaults'), path.join(__dirname, '.env'));
 }
 
 export default defineConfig({

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,1 @@
-export default ['packages/*', 'examples/*'];
+export default ['packages/*/', 'examples/*/'];


### PR DESCRIPTION
vitest [made a breaking change](https://github.com/vitest-dev/vitest/issues/6553) in how `packages/*` was expanded such that it was attempting to load `packages/README.md` as a config file:

```
error: No loader is configured for ".md" files: packages/README.md
    at failureErrorWithLog (/Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:1476:15)
    at /Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:945:25
    at runOnEndCallbacks (/Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:1316:45)
    at buildResponseToResult (/Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:943:7)
    at /Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:970:16
    at responseCallbacks.<computed> (/Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:622:9)
    at handleIncomingPacket (/Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:677:12)
    at Socket.readFromStdout (/Users/mattlong/repos/medplum/node_modules/esbuild/lib/main.js:600:7)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12)
```