### PR TITLE
Add defaultHeaders optional parameter for MedplumClient Constructor

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -254,6 +254,16 @@ describe('Client', () => {
     expect(client.getAuthorizeUrl()).toBe(authorizeUrl);
   });
 
+  test('getDefaultHeaders', () => {
+    const client = new MedplumClient({ defaultHeaders: { 'X-Test': '123', Cookie: 'abc' } });
+    const headers = client.getDefaultHeaders();
+    expect(headers).toBeDefined();
+    expect(headers['X-Test']).toBe('123');
+    expect(headers.Cookie).toBe('abc');
+    const clientWithoutDefaultHeaders = new MedplumClient();
+    expect(clientWithoutDefaultHeaders.getDefaultHeaders()).toStrictEqual({});
+  });
+
   test('Restore from localStorage', async () => {
     window.localStorage.setItem(
       'activeLogin',

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -981,6 +981,16 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   /**
+   * Returns default headers to include in all requests.
+   * This can be used to set custom headers such as Cookies or Authorization headers.
+   * @category HTTP
+   * @returns Default headers to include in all requests.
+   */
+  getDefaultHeaders(): Record<string, string> {
+    return this.defaultHeaders;
+  }
+
+  /**
    * Clears all auth state including local storage and session storage.
    * @category Authentication
    */


### PR DESCRIPTION
# Add support for default headers in MedplumClient

This PR adds the ability to configure default headers that will be included in all requests made by the MedplumClient. This is particularly useful for scenarios where custom headers need to be consistently included, such as:

- Setting authentication cookies for proxy authentication
- Adding custom tracking or debugging headers
- Including organization-specific identifiers
- Setting client application version headers

## Changes

- Added `defaultHeaders` option to `MedplumClientOptions` as a `Record<string, string>`
- Added private `defaultHeaders` field to `MedplumClient` class
- Added `getDefaultHeaders()` method to access the current default headers
- Modified `addFetchOptionsDefaults` and `createFetchRequest` to include default headers in requests
- Added test coverage for default headers functionality

## Example Usage

```typescript
const client = new MedplumClient({
  baseUrl: 'https://api.example.com',
  defaultHeaders: {
    'Cookie': '_oauth2_proxy=abc123',
    'X-Custom-Header': 'value'
  }
});