### PR TITLE
feat(server): log more stats per table, allow tables to be specified

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -156,7 +156,7 @@ describe('SuperAdminPage', () => {
     const postSpy = jest.spyOn(medplum, 'post');
 
     await act(async () => {
-      fireEvent.change(screen.getByLabelText('Table Names'), { target: { value: 'Observation' } });
+      fireEvent.change(screen.getByLabelText('Table Names (comma-delimited)'), { target: { value: 'Observation' } });
     });
 
     await act(async () => {

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -62,9 +62,17 @@ export function SuperAdminPage(): JSX.Element {
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
   }
 
-  function getDatabaseStats(): void {
+  function getDatabaseStats(formData: Record<string, string>): void {
     medplum
-      .post('fhir/R4/$db-stats', {})
+      .post(
+        'fhir/R4/$db-stats',
+        formData.tableNames
+          ? {
+              resourceType: 'Parameters',
+              parameter: [{ name: 'tableNames', valueString: formData.tableNames }],
+            }
+          : undefined
+      )
       .then((params: Parameters) => {
         setModalTitle('Database Stats');
         setModalContent(<pre>{params.parameter?.find((p) => p.name === 'tableString')?.valueString}</pre>);
@@ -165,7 +173,12 @@ export function SuperAdminPage(): JSX.Element {
       <Title order={2}>Database Stats</Title>
       <p>Query current table statistics from the database.</p>
       <Form onSubmit={getDatabaseStats}>
-        <Button type="submit">Get Database Stats</Button>
+        <Stack>
+          <FormSection title="Table Names (comma-delimited)" htmlFor="tableNames">
+            <TextInput id="tableNames" name="tableNames" placeholder="Observation,Observation_History" />
+          </FormSection>
+          <Button type="submit">Get Database Stats</Button>
+        </Stack>
       </Form>
       <Modal opened={opened} onClose={close} title={modalTitle} centered>
         {modalContent}

--- a/packages/server/src/fhir/operations/dbstats.test.ts
+++ b/packages/server/src/fhir/operations/dbstats.test.ts
@@ -1,4 +1,5 @@
 import { ContentType } from '@medplum/core';
+import { Parameters } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -25,6 +26,20 @@ describe('$db-stats', () => {
       .set('Authorization', 'Bearer ' + accessToken)
       .set('Content-Type', ContentType.FHIR_JSON)
       .send({});
+    expect(res1.status).toBe(200);
+  });
+
+  test('Success - Specified table names', async () => {
+    const accessToken = await initTestAuth({ project: { superAdmin: true } });
+
+    const res1 = await request(app)
+      .post('/fhir/R4/$db-stats')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'tableNames', valueString: 'Observation,Observation_History' }],
+      } satisfies Parameters);
     expect(res1.status).toBe(200);
   });
 

--- a/packages/server/src/fhir/operations/dbstats.ts
+++ b/packages/server/src/fhir/operations/dbstats.ts
@@ -3,7 +3,7 @@ import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
-import { buildOutputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
   resourceType: 'OperationDefinition',
@@ -15,27 +15,57 @@ const operation: OperationDefinition = {
   system: true,
   type: false,
   instance: false,
-  parameter: [{ use: 'out', name: 'tableString', type: 'string', min: 1, max: '1' }],
+  parameter: [
+    {
+      use: 'in',
+      name: 'tableNames',
+      type: 'string',
+      min: 0,
+      max: '1',
+    },
+    {
+      use: 'out',
+      name: 'tableString',
+      type: 'string',
+      min: 1,
+      max: '1',
+    },
+  ],
 };
 
-export async function dbStatsHandler(_req: FhirRequest): Promise<FhirResponse> {
+export async function dbStatsHandler(req: FhirRequest): Promise<FhirResponse> {
   requireSuperAdmin();
+
+  const params = parseInputParameters<{ tableNames?: string }>(operation, req);
 
   const client = getDatabasePool(DatabaseMode.WRITER);
   const sql = `SELECT * FROM (
     SELECT
       i.relname AS table_name,
-      pg_total_relation_size(relid) AS raw_size,
-      pg_size_pretty(pg_total_relation_size(relid)) AS total_size,
-      pg_size_pretty(pg_relation_size(relid)) AS table_size,
-      pg_size_pretty(pg_indexes_size(relid)) AS all_indexes_size,
+      pg_total_relation_size(i.relid) AS raw_size,
+      pg_size_pretty(pg_total_relation_size(i.relid)) AS total_size,
+      pg_size_pretty(pg_relation_size(i.relid)) AS table_size,
+      pg_size_pretty(pg_indexes_size(i.relid)) AS all_indexes_size,
       reltuples::bigint AS estimated_row_count,
       indexrelname AS index_name,
       pg_size_pretty(pg_relation_size(indexrelid)) AS index_size,
-      idx_scan AS index_scans,
-      idx_tup_read AS index_entries_read,
-      idx_tup_fetch AS index_rows_fetched
-    FROM pg_stat_user_indexes i JOIN pg_class c ON i.relid = c.oid
+      i.idx_scan AS index_scans,
+      i.idx_tup_read AS index_entries_read,
+      i.idx_tup_fetch AS index_rows_fetched,
+      c.reloptions AS table_level_overrides,
+      n_live_tup AS live_tuples,
+      n_dead_tup AS dead_tuples,
+      last_autovacuum,
+      last_autoanalyze
+    FROM pg_stat_user_indexes i JOIN pg_class c ON i.relid = c.oid JOIN pg_stat_user_tables u ON i.relname = u.relname
+    ${
+      params.tableNames
+        ? `WHERE i.relname IN (${params.tableNames
+            .split(',')
+            .map((name) => `'${name.trim()}'`)
+            .join(',')})`
+        : ''
+    }
   ) t
   WHERE raw_size > 0
   ORDER BY raw_size DESC, table_name ASC`;
@@ -49,7 +79,12 @@ export async function dbStatsHandler(_req: FhirRequest): Promise<FhirResponse> {
       output.push(
         `${row.table_name}: ${row.total_size}`,
         `  [table: ${row.table_size} indexes: ${row.all_indexes_size}]`,
-        `  [estimated rows: ${row.estimated_row_count}]`
+        `  [estimated rows: ${row.estimated_row_count}]`,
+        `  [settings overrides: ${row.table_level_overrides}]`,
+        `  [live tuples: ${row.live_tuples}]`,
+        `  [dead tuples: ${row.dead_tuples}]`,
+        `  [last autovacuum: ${new Date(row.last_autovacuum).toISOString()}]`,
+        `  [last autoanalyze: ${new Date(row.last_autoanalyze).toISOString()}]`
       );
       currentTable = row.table_name;
     }


### PR DESCRIPTION
This enables logging stats about the per-table autovacuum settings, as well as number of live and dead tuples in a table, when the last auto-vacuum and auto-analyzes ran, as well as the ability to specify which tables to include in the results.