### PR TITLE
Fixes #5663 - add inner types to base-schema.json

### DIFF
--- a/packages/core/src/base-schema.json
+++ b/packages/core/src/base-schema.json
@@ -673,6 +673,136 @@
       }
     }
   },
+  "DataRequirementCodeFilter": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "path": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "searchParam": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "valueSet": {
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": ["http://hl7.org/fhir/StructureDefinition/ValueSet"]
+          }
+        ]
+      },
+      "code": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Coding"
+          }
+        ]
+      }
+    }
+  },
+  "DataRequirementDateFilter": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "path": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "searchParam": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "value[x]": {
+        "type": [
+          {
+            "code": "dateTime"
+          },
+          {
+            "code": "Period"
+          },
+          {
+            "code": "Duration"
+          }
+        ]
+      }
+    }
+  },
+  "DataRequirementSort": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "path": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "direction": {
+        "min": 1,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      }
+    }
+  },
   "Distance": {
     "elements": {
       "id": {
@@ -844,6 +974,57 @@
       },
       "maxDosePerLifetime": {
         "type": [
+          {
+            "code": "Quantity",
+            "profile": ["http://hl7.org/fhir/StructureDefinition/SimpleQuantity"]
+          }
+        ]
+      }
+    }
+  },
+  "DosageDoseAndRate": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "type": {
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ]
+      },
+      "dose[x]": {
+        "type": [
+          {
+            "code": "Range"
+          },
+          {
+            "code": "Quantity",
+            "profile": ["http://hl7.org/fhir/StructureDefinition/SimpleQuantity"]
+          }
+        ]
+      },
+      "rate[x]": {
+        "type": [
+          {
+            "code": "Ratio"
+          },
+          {
+            "code": "Range"
+          },
           {
             "code": "Quantity",
             "profile": ["http://hl7.org/fhir/StructureDefinition/SimpleQuantity"]
@@ -1664,6 +1845,544 @@
         "type": [
           {
             "code": "ElementDefinitionMapping"
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionSlicingDiscriminator": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "type": {
+        "min": 1,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "path": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionSlicing": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "discriminator": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "ElementDefinitionSlicingDiscriminator"
+          }
+        ]
+      },
+      "description": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "ordered": {
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      "rules": {
+        "min": 1,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionBase": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "path": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "min": {
+        "min": 1,
+        "type": [
+          {
+            "code": "unsignedInt"
+          }
+        ]
+      },
+      "max": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionType": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "code": {
+        "min": 1,
+        "type": [
+          {
+            "code": "uri"
+          }
+        ]
+      },
+      "profile": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/StructureDefinition",
+              "http://hl7.org/fhir/StructureDefinition/ImplementationGuide"
+            ]
+          }
+        ]
+      },
+      "targetProfile": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/StructureDefinition",
+              "http://hl7.org/fhir/StructureDefinition/ImplementationGuide"
+            ]
+          }
+        ]
+      },
+      "aggregation": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "versioning": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionExample": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "label": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "value[x]": {
+        "min": 1,
+        "type": [
+          {
+            "code": "base64Binary"
+          },
+          {
+            "code": "boolean"
+          },
+          {
+            "code": "canonical"
+          },
+          {
+            "code": "code"
+          },
+          {
+            "code": "date"
+          },
+          {
+            "code": "dateTime"
+          },
+          {
+            "code": "decimal"
+          },
+          {
+            "code": "id"
+          },
+          {
+            "code": "instant"
+          },
+          {
+            "code": "integer"
+          },
+          {
+            "code": "markdown"
+          },
+          {
+            "code": "oid"
+          },
+          {
+            "code": "positiveInt"
+          },
+          {
+            "code": "string"
+          },
+          {
+            "code": "time"
+          },
+          {
+            "code": "unsignedInt"
+          },
+          {
+            "code": "uri"
+          },
+          {
+            "code": "url"
+          },
+          {
+            "code": "uuid"
+          },
+          {
+            "code": "Address"
+          },
+          {
+            "code": "Age"
+          },
+          {
+            "code": "Annotation"
+          },
+          {
+            "code": "Attachment"
+          },
+          {
+            "code": "CodeableConcept"
+          },
+          {
+            "code": "Coding"
+          },
+          {
+            "code": "ContactPoint"
+          },
+          {
+            "code": "Count"
+          },
+          {
+            "code": "Distance"
+          },
+          {
+            "code": "Duration"
+          },
+          {
+            "code": "HumanName"
+          },
+          {
+            "code": "Identifier"
+          },
+          {
+            "code": "Money"
+          },
+          {
+            "code": "Period"
+          },
+          {
+            "code": "Quantity"
+          },
+          {
+            "code": "Range"
+          },
+          {
+            "code": "Ratio"
+          },
+          {
+            "code": "Reference"
+          },
+          {
+            "code": "SampledData"
+          },
+          {
+            "code": "Signature"
+          },
+          {
+            "code": "Timing"
+          },
+          {
+            "code": "ContactDetail"
+          },
+          {
+            "code": "Contributor"
+          },
+          {
+            "code": "DataRequirement"
+          },
+          {
+            "code": "Expression"
+          },
+          {
+            "code": "ParameterDefinition"
+          },
+          {
+            "code": "RelatedArtifact"
+          },
+          {
+            "code": "TriggerDefinition"
+          },
+          {
+            "code": "UsageContext"
+          },
+          {
+            "code": "Dosage"
+          },
+          {
+            "code": "Meta"
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionConstraint": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "key": {
+        "min": 1,
+        "type": [
+          {
+            "code": "id"
+          }
+        ]
+      },
+      "requirements": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "severity": {
+        "min": 1,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "human": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "expression": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "xpath": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "source": {
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": ["http://hl7.org/fhir/StructureDefinition/StructureDefinition"]
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionBinding": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "strength": {
+        "min": 1,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "description": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "valueSet": {
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": ["http://hl7.org/fhir/StructureDefinition/ValueSet"]
+          }
+        ]
+      }
+    }
+  },
+  "ElementDefinitionMapping": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "identity": {
+        "min": 1,
+        "type": [
+          {
+            "code": "id"
+          }
+        ]
+      },
+      "language": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "map": {
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "comment": {
+        "type": [
+          {
+            "code": "string"
           }
         ]
       }
@@ -3067,6 +3786,39 @@
       }
     }
   },
+  "SubstanceAmountReferenceRange": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "lowLimit": {
+        "type": [
+          {
+            "code": "Quantity"
+          }
+        ]
+      },
+      "highLimit": {
+        "type": [
+          {
+            "code": "Quantity"
+          }
+        ]
+      }
+    }
+  },
   "Timing": {
     "elements": {
       "id": {
@@ -3111,6 +3863,139 @@
         "type": [
           {
             "code": "CodeableConcept"
+          }
+        ]
+      }
+    }
+  },
+  "TimingRepeat": {
+    "elements": {
+      "id": {
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      "extension": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "Extension"
+          }
+        ]
+      },
+      "bounds[x]": {
+        "type": [
+          {
+            "code": "Duration"
+          },
+          {
+            "code": "Range"
+          },
+          {
+            "code": "Period"
+          }
+        ]
+      },
+      "count": {
+        "type": [
+          {
+            "code": "positiveInt"
+          }
+        ]
+      },
+      "countMax": {
+        "type": [
+          {
+            "code": "positiveInt"
+          }
+        ]
+      },
+      "duration": {
+        "type": [
+          {
+            "code": "decimal"
+          }
+        ]
+      },
+      "durationMax": {
+        "type": [
+          {
+            "code": "decimal"
+          }
+        ]
+      },
+      "durationUnit": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "frequency": {
+        "type": [
+          {
+            "code": "positiveInt"
+          }
+        ]
+      },
+      "frequencyMax": {
+        "type": [
+          {
+            "code": "positiveInt"
+          }
+        ]
+      },
+      "period": {
+        "type": [
+          {
+            "code": "decimal"
+          }
+        ]
+      },
+      "periodMax": {
+        "type": [
+          {
+            "code": "decimal"
+          }
+        ]
+      },
+      "periodUnit": {
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "dayOfWeek": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "timeOfDay": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "time"
+          }
+        ]
+      },
+      "when": {
+        "max": 9007199254740991,
+        "type": [
+          {
+            "code": "code"
+          }
+        ]
+      },
+      "offset": {
+        "type": [
+          {
+            "code": "unsignedInt"
           }
         ]
       }

--- a/packages/generator/src/baseschema.ts
+++ b/packages/generator/src/baseschema.ts
@@ -21,11 +21,7 @@ export function main(): void {
 
   // For each type schema, only keep "display" and "properties"
   for (const [typeName, typeSchema] of Object.entries(allTypes).filter(([name, schema]) => isBaseType(name, schema))) {
-    const output = { elements: Object.create(null) };
-    for (const [propertyName, propertySchema] of Object.entries(typeSchema.elements)) {
-      output.elements[propertyName] = compressElement(propertySchema);
-    }
-    outputTypes[typeName] = output;
+    addOutputType(outputTypes, typeName, typeSchema);
   }
 
   writeFileSync(
@@ -41,4 +37,18 @@ if (require.main === module) {
 
 function isBaseType(name: string, schema: InternalTypeSchema): boolean {
   return !isLowerCase(name.charAt(0)) && schema.kind !== 'resource' && schema.kind !== 'logical' && !schema.parentType;
+}
+
+function addOutputType(outputTypes: BaseSchema, typeName: string, typeSchema: InternalTypeSchema): void {
+  const output = { elements: Object.create(null) };
+  for (const [propertyName, propertySchema] of Object.entries(typeSchema.elements)) {
+    output.elements[propertyName] = compressElement(propertySchema);
+  }
+  outputTypes[typeName] = output;
+
+  if (typeSchema.innerTypes) {
+    for (const innerType of typeSchema.innerTypes) {
+      addOutputType(outputTypes, innerType.name, innerType);
+    }
+  }
 }


### PR DESCRIPTION
`base-schema.json` is autogenerated by `baseschema.ts`

```bash
# Before
$ ls -la base-schema.json
-rw-r--r-- 1 cody cody 58873 Dec 12 10:13 base-schema.json

# After
$ ls -la base-schema.json
-rw-r--r-- 1 cody cody 74267 Dec 12 10:13 base-schema.json
```

16kb bigger.  Probably ~2-4kb bigger after gzip.