### PR TITLE
Add sw operator to _filter search

### DIFF
--- a/packages/core/src/filter/parse.test.ts
+++ b/packages/core/src/filter/parse.test.ts
@@ -5,7 +5,6 @@ import { FhirFilterComparison, FhirFilterConnective, FhirFilterNegation } from '
 describe('_filter Parameter parser', () => {
   test('Simple comparison', () => {
     const result = parseFilterParameter('name co "pet"');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterComparison);
 
     const comp = result as FhirFilterComparison;
@@ -16,7 +15,6 @@ describe('_filter Parameter parser', () => {
 
   test('Negation', () => {
     const result = parseFilterParameter('not (name co "pet")');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterNegation);
 
     const negation = result as FhirFilterNegation;
@@ -30,7 +28,6 @@ describe('_filter Parameter parser', () => {
 
   test('And connective', () => {
     const result = parseFilterParameter('given eq "peter" and birthdate ge 2014-10-10');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterConnective);
 
     const connective = result as FhirFilterConnective;
@@ -51,7 +48,6 @@ describe('_filter Parameter parser', () => {
 
   test('Or connective', () => {
     const result = parseFilterParameter('given eq "peter" or birthdate ge 2014-10-10');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterConnective);
 
     const connective = result as FhirFilterConnective;
@@ -72,7 +68,6 @@ describe('_filter Parameter parser', () => {
 
   test('Top level parentheses', () => {
     const result = parseFilterParameter('(given ne "alice" and given ne "bob")');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterConnective);
 
     const connective = result as FhirFilterConnective;
@@ -92,7 +87,6 @@ describe('_filter Parameter parser', () => {
 
   test('Nested expressions', () => {
     const result = parseFilterParameter('given eq "alice" or (given eq "peter" and birthdate ge 2014-10-10)');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterConnective);
 
     const connective1 = result as FhirFilterConnective;
@@ -123,7 +117,6 @@ describe('_filter Parameter parser', () => {
 
   test('Nested connectives', () => {
     const result = parseFilterParameter('(status eq preliminary and code eq 123) or (status eq final and code eq 456)');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterConnective);
 
     const connective1 = result as FhirFilterConnective;
@@ -166,7 +159,6 @@ describe('_filter Parameter parser', () => {
     const result = parseFilterParameter(
       '(status eq preliminary and code eq 123) or (not (status eq preliminary) and code eq 456)'
     );
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterConnective);
 
     const connective1 = result as FhirFilterConnective;
@@ -208,7 +200,6 @@ describe('_filter Parameter parser', () => {
 
   test('Observation with system and code', () => {
     const result = parseFilterParameter('code eq http://loinc.org|1234-5');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterComparison);
 
     const comp = result as FhirFilterComparison;
@@ -219,7 +210,6 @@ describe('_filter Parameter parser', () => {
 
   test('Identifier search', () => {
     const result = parseFilterParameter('performer identifier https://example.com/1234');
-    expect(result).toBeDefined();
     expect(result).toBeInstanceOf(FhirFilterComparison);
 
     const comp = result as FhirFilterComparison;
@@ -228,12 +218,20 @@ describe('_filter Parameter parser', () => {
     expect(comp.value).toBe('https://example.com/1234');
   });
 
+  test('Starts with', () => {
+    const result = parseFilterParameter('name sw ali');
+    expect(result).toBeInstanceOf(FhirFilterComparison);
+
+    const comp = result as FhirFilterComparison;
+    expect(comp.operator).toEqual(Operator.STARTS_WITH);
+  });
+
   test('Unsupported search operator', () => {
     try {
-      parseFilterParameter('name sw ali');
+      parseFilterParameter('name ew ali');
       throw new Error('Expected error');
     } catch (err: any) {
-      expect(err.message).toBe('Invalid operator: sw');
+      expect(err.message).toBe('Invalid operator: ew');
     }
   });
 });

--- a/packages/core/src/filter/parse.ts
+++ b/packages/core/src/filter/parse.ts
@@ -17,7 +17,7 @@ const operatorMap: Record<string, Operator | undefined> = {
   // co - An item in the set contains this value
   co: Operator.CONTAINS,
   // sw - An item in the set starts with this value
-  sw: undefined,
+  sw: Operator.STARTS_WITH,
   // ew - An item in the set ends with this value
   ew: undefined,
   // gt / lt / ge / le - A value in the set is (greater than, less than, greater or equal, less or equal) the given value

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -66,6 +66,7 @@ export enum Operator {
 
   // String
   CONTAINS = 'contains',
+  STARTS_WITH = 'sw',
   EXACT = 'exact',
 
   // Token
@@ -124,6 +125,7 @@ const PREFIX_OPERATORS: Record<string, Operator> = {
   sa: Operator.STARTS_AFTER,
   eb: Operator.ENDS_BEFORE,
   ap: Operator.APPROXIMATELY,
+  sw: Operator.STARTS_WITH,
 };
 
 /**

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -68,6 +68,7 @@ const operatorNames: Record<Operator, string> = {
   sa: 'starts after',
   eb: 'ends before',
   ap: 'approximately',
+  sw: 'starts with',
   contains: 'contains',
   exact: 'exact',
   text: 'text',

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -3319,6 +3319,42 @@ describe('FHIR Search', () => {
         expect(result.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
       }));
 
+    test('_filter sw', () =>
+      withTestContext(async () => {
+        const patient = await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Evelyn', 'Dierdre'], family: 'Arachnae' }],
+        });
+
+        // NOTE: This incorrect behavior is currently kept for backwards compatibility,
+        // and should be changed to exact matching in Medplum v4
+        const result = await repo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: '_filter',
+              operator: Operator.EQUALS,
+              value: 'name eq Evel',
+            },
+          ],
+        });
+        expect(result.entry).toHaveLength(1);
+        expect(result.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+
+        const result2 = await repo.search({
+          resourceType: 'Patient',
+          filters: [
+            {
+              code: '_filter',
+              operator: Operator.EQUALS,
+              value: 'name sw Evel',
+            },
+          ],
+        });
+        expect(result2.entry).toHaveLength(1);
+        expect(result2.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
+      }));
+
     test.each([true, false])('_filter with chained search', (ff) =>
       withTestContext(async () => {
         config.chainedSearchWithReferenceTables = ff;

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1108,14 +1108,17 @@ function buildStringSearchFilter(
   return expression;
 }
 
+const prefixMatchOperators = [Operator.EQUALS, Operator.STARTS_WITH];
 function buildStringFilterExpression(column: Column, operator: Operator, values: string[]): Expression {
   const conditions = values.map((v) => {
     if (operator === Operator.EXACT) {
       return new Condition(column, '=', v);
     } else if (operator === Operator.CONTAINS) {
       return new Condition(column, 'LIKE', `%${escapeLikeString(v)}%`);
-    } else {
+    } else if (prefixMatchOperators.includes(operator)) {
       return new Condition(column, 'LIKE', `${escapeLikeString(v)}%`);
+    } else {
+      throw new OperationOutcomeError(badRequest('Unsupported string search operator: ' + operator));
     }
   });
   return new Disjunction(conditions);


### PR DESCRIPTION
Adds support for the `sw` (starts with) operator to the `_filter` search parameter.  This enables a seamless transition from the current prefix-matching behavior of `eq` on `string` parameters to spec-compliant exact matching in Medplum v4