### PR TITLE
Assorted fixes to build-deb action

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -4,7 +4,11 @@ concurrency:
   group: ci-build-deb-${{ github.sha }}
   cancel-in-progress: true
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
   build_deb:
@@ -43,18 +47,6 @@ jobs:
       - name: Build Deb
         shell: bash
         run: ./scripts/build-deb.sh
-
-      - name: Upload Deb
-        uses: actions/upload-artifact@v4
-        with:
-          name: medplum_${{ env.MEDPLUM_VERSION }}_all.deb
-          path: medplum_${{ env.MEDPLUM_VERSION }}_all.deb
-
-      - name: Upload Deb SHA256
-        uses: actions/upload-artifact@v4
-        with:
-          name: medplum_${{ env.MEDPLUM_VERSION }}_all.deb.sha256
-          path: medplum_${{ env.MEDPLUM_VERSION }}_all.deb.sha256
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Several minor fixes found while working on https://github.com/medplum/medplum/pull/5682

1. Publish deb on release, not just manual `workflow_dispatch`
2. Removed uploading as artifacts
    * Action was broken because using unset `env.MEDPLUM_VERSION`
    * Already uploading to `apt.medplum.com`, which is better anyway
3. Don't disable the systemd service on upgrade, only on remove
4. Automatically start the service on install and upgrade