### PR TITLE
Truncate string search columns to accommodate index size limits

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -385,7 +385,7 @@ describe('FHIR Repo', () => {
       expect(patient.meta?.lastUpdated).toStrictEqual(lastUpdated);
     }));
 
-  test.only('Create ResearchDefinition with very long description', () =>
+  test('Create ResearchDefinition with very long description', () =>
     withTestContext(async () => {
       const author = 'Practitioner/' + randomUUID();
 

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -24,6 +24,7 @@ import {
   Project,
   ProjectMembership,
   Questionnaire,
+  ResearchDefinition,
   ResourceType,
   ServiceRequest,
   StructureDefinition,
@@ -382,6 +383,27 @@ describe('FHIR Repo', () => {
       });
 
       expect(patient.meta?.lastUpdated).toStrictEqual(lastUpdated);
+    }));
+
+  test.only('Create ResearchDefinition with very long description', () =>
+    withTestContext(async () => {
+      const author = 'Practitioner/' + randomUUID();
+
+      const repo = new Repository({
+        extendedMode: true,
+        author: {
+          reference: author,
+        },
+      });
+
+      await repo.createResource<ResearchDefinition>({
+        resourceType: 'ResearchDefinition',
+        status: 'active',
+        population: { reference: '123' },
+        // 10 * 50_000 = 500,000 which results in:
+        // index row size 5760 exceeds btree version 4 maximum 2704 for index "ResearchDefinition_description_idx"
+        description: '1234567890'.repeat(50000),
+      });
     }));
 
   test('Update resource with lastUpdated', () =>

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -385,7 +385,12 @@ describe('FHIR Repo', () => {
       expect(patient.meta?.lastUpdated).toStrictEqual(lastUpdated);
     }));
 
-  test('Create ResearchDefinition with very long description', () =>
+  const fourByteChars = '𓃒𓃔𓃕𓃖𓃗𓃘𓃙𓃚𓃛𓃜𓃝𓃞𓃟𓃠𓃡𓃢𓃥𓃦𓃧𓃩𓃪𓃭𓃮𓃯𓃰𓃱𓃲𓄁𓅂𓅃𓅠𓅚';
+  test.each([
+    ['2736 chars, 2736 random bytes', randomBytes(2050).toString('base64')],
+    ['6668 chars, 6668 random bytes', randomBytes(5000).toString('base64')],
+    ['6400 chars, 12800 bytes', shuffleString(fourByteChars.repeat(100))],
+  ])('Create ResearchDefinition with long description (%s)', (_testTitle, description) =>
     withTestContext(async () => {
       const author = 'Practitioner/' + randomUUID();
 
@@ -396,16 +401,14 @@ describe('FHIR Repo', () => {
         },
       });
 
-      const description = randomBytes(2050).toString('base64');
-      const textEncoder = new TextEncoder();
-      expect(textEncoder.encode(description).length).toBeGreaterThan(2704);
       await repo.createResource<ResearchDefinition>({
         resourceType: 'ResearchDefinition',
         status: 'active',
         population: { reference: '123' },
         description,
       });
-    }));
+    })
+  );
 
   test('Update resource with lastUpdated', () =>
     withTestContext(async () => {
@@ -1326,3 +1329,15 @@ describe('FHIR Repo', () => {
       await expect(repo.createResource<Patient>(patient)).resolves.toBeDefined();
     }));
 });
+
+function shuffleString(s: string): string {
+  const arr = Array.from(s);
+  const len = arr.length;
+  for (let i = 0; i < len - 1; ++i) {
+    const j = Math.floor(Math.random() * len);
+    const temp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = temp;
+  }
+  return arr.join('');
+}

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -30,7 +30,7 @@ import {
   StructureDefinition,
   User,
 } from '@medplum/fhirtypes';
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { initAppServices, shutdownApp } from '../app';
@@ -396,13 +396,14 @@ describe('FHIR Repo', () => {
         },
       });
 
+      const description = randomBytes(2050).toString('base64');
+      const textEncoder = new TextEncoder();
+      expect(textEncoder.encode(description).length).toBeGreaterThan(2704);
       await repo.createResource<ResearchDefinition>({
         resourceType: 'ResearchDefinition',
         status: 'active',
         population: { reference: '123' },
-        // 10 * 50_000 = 500,000 which results in:
-        // index row size 5760 exceeds btree version 4 maximum 2704 for index "ResearchDefinition_description_idx"
-        description: '1234567890'.repeat(50000),
+        description,
       });
     }));
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2571,14 +2571,20 @@ function patchObject(obj: any, patch: Operation[]): void {
   }
 }
 
+const textEncoder = new TextEncoder();
+
 /**
  * Apply a maximum string length to ensure the value can accommodate the maximum
- * size for a btree index entry: 2704 bytes. Be as conservative as possible to avoid
- * write errors; so limit to 675 characters to accommodate the entire string being
- * random 4-byte UTF-8 characters.
+ * size for a btree index entry: 2704 bytes. If the string is too large,
+ * be as conservative as possible to avoid write errors by truncating to 675 characters
+ * to accommodate the entire string being 4-byte UTF-8 code points.
  * @param value - The column value to truncate.
  * @returns The possibly truncated column value.
  */
 function truncateTextColumn(value: string): string {
-  return value.substring(0, 675);
+  if (textEncoder.encode(value).length <= 2704) {
+    return value;
+  }
+
+  return Array.from(value).slice(0, 675).join('');
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1480,7 +1480,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return undefined;
     }
 
-    // return stringValue;
     return truncateTextColumn(stringValue);
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1462,19 +1462,26 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return this.buildDateTimeColumn(value);
     }
 
-    if (searchParam.type === 'reference') {
-      return this.buildReferenceColumns(value);
-    }
-
-    if (searchParam.type === 'token') {
-      return this.buildTokenColumn(value);
-    }
-
     if (searchParam.type === 'quantity') {
       return this.buildQuantityColumn(value);
     }
 
-    return typeof value === 'string' ? value : stringify(value);
+    // Handle all string values specially to ensure they are truncated to the correct length
+    let stringValue: string | undefined;
+    if (searchParam.type === 'reference') {
+      stringValue = this.buildReferenceColumns(value);
+    } else if (searchParam.type === 'token') {
+      stringValue = this.buildTokenColumn(value);
+    } else {
+      stringValue = typeof value === 'string' ? value : stringify(value);
+    }
+
+    if (!stringValue) {
+      return undefined;
+    }
+
+    // return stringValue;
+    return truncateTextColumn(stringValue);
   }
 
   /**
@@ -2563,4 +2570,16 @@ function patchObject(obj: any, patch: Operation[]): void {
   } catch (err) {
     throw new OperationOutcomeError(normalizeOperationOutcome(err));
   }
+}
+
+/**
+ * Apply a maximum string length to ensure the value can accommodate the maximum
+ * size for a btree index entry: 2704 bytes. Be as conservative as possible to avoid
+ * write errors; so limit to 675 characters to accommodate the entire string being
+ * random 4-byte UTF-8 characters.
+ * @param value - The column value to truncate.
+ * @returns The possibly truncated column value.
+ */
+function truncateTextColumn(value: string): string {
+  return value.substring(0, 675);
 }


### PR DESCRIPTION
This is using the most conservative possible length of 675. If anyone balks at 675 being too low, we could be smarter about the limit and see how many bytes the string is and iteratively shorten it, but I'm hesitant to over-engineer this.