### PR TITLE
Merge wildcard AccessPolicy and readonly scopes

### DIFF
--- a/packages/server/src/fhir/smart.test.ts
+++ b/packages/server/src/fhir/smart.test.ts
@@ -131,4 +131,29 @@ describe('SMART on FHIR', () => {
       ],
     });
   });
+
+  test('Intersect with wildcard access policy', () => {
+    const startAccessPolicy: AccessPolicy = {
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: '*',
+        },
+      ],
+    };
+
+    const scope = 'patient/Patient.cruds patient/ServiceRequest.cruds';
+
+    expect(applySmartScopes(startAccessPolicy, scope)).toMatchObject({
+      resourceType: 'AccessPolicy',
+      resource: [
+        {
+          resourceType: 'Patient',
+        },
+        {
+          resourceType: 'ServiceRequest',
+        },
+      ],
+    });
+  });
 });

--- a/packages/server/src/fhir/smart.test.ts
+++ b/packages/server/src/fhir/smart.test.ts
@@ -9,6 +9,9 @@ describe('SMART on FHIR', () => {
     expect(parseSmartScopes('openid')).toStrictEqual([]);
     expect(parseSmartScopes('x/y.z')).toStrictEqual([]);
     expect(parseSmartScopes('patient/Observation.chum')).toStrictEqual([]);
+    expect(parseSmartScopes('patient/Observation.sdurc')).toStrictEqual([]);
+    expect(parseSmartScopes('patient/Observation.c*')).toStrictEqual([]);
+    expect(parseSmartScopes('patient/Observation.*c')).toStrictEqual([]);
   });
 
   test('Parse scopes', () => {

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -154,21 +154,17 @@ function intersectSmartScopes(accessPolicy: AccessPolicy, smartScope: SmartScope
   const result: AccessPolicy & { resource: AccessPolicyResource[] } = { ...accessPolicy, resource: [] };
   for (const policy of accessPolicy.resource) {
     const scope = getScopeForResourceType(smartScope, policy.resourceType);
-    if (!scope) {
-      if (policy.resourceType === '*') {
-        for (const scope of smartScope) {
-          const merged = mergeAccessPolicyWithScope(policy, scope);
-          merged.resourceType = scope.resourceType;
-          result.resource.push(merged);
-        }
+    if (scope) {
+      const merged = mergeAccessPolicyWithScope(policy, scope);
+      result.resource.push(merged);
+    } else if (policy.resourceType === '*') {
+      for (const scope of smartScope) {
+        const merged = mergeAccessPolicyWithScope(policy, scope);
+        merged.resourceType = scope.resourceType;
+        result.resource.push(merged);
       }
-      continue;
     }
-
-    const merged = mergeAccessPolicyWithScope(policy, scope);
-    result.resource.push(merged);
   }
-
   return result;
 }
 

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -110,7 +110,7 @@ export function parseSmartScopes(scope: string | undefined): SmartScope[] {
 
   if (scope) {
     for (const scopeTerm of scope.split(' ')) {
-      const match = /^(patient|user|system)\/(\w+|\*)\.([cruds*]+)$/.exec(scopeTerm);
+      const match = /^(patient|user|system)\/(\w+|\*)\.(\*|c?r?u?d?s?)$/.exec(scopeTerm);
       if (match) {
         result.push({
           permissionType: match[1] as 'patient' | 'user' | 'system',

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -110,12 +110,12 @@ export function parseSmartScopes(scope: string | undefined): SmartScope[] {
 
   if (scope) {
     for (const scopeTerm of scope.split(' ')) {
-      const match = /(patient|user|system)\/(\w+|\*)\.(\w+)/.exec(scopeTerm);
+      const match = /^(patient|user|system)\/(\w+|\*)\.([cruds*]+)$/.exec(scopeTerm);
       if (match) {
         result.push({
           permissionType: match[1] as 'patient' | 'user' | 'system',
           resourceType: match[2],
-          scope: match[3],
+          scope: match[3] === '*' ? 'cruds' : match[3],
         });
       }
     }
@@ -145,45 +145,45 @@ export function applySmartScopes(accessPolicy: AccessPolicy, scope: string | und
 }
 
 function intersectSmartScopes(accessPolicy: AccessPolicy, smartScope: SmartScope[]): AccessPolicy {
-  const result = deepClone(accessPolicy);
-
   // Build list of AccessPolicy entries
-  const accessPolicyEntries = result.resource;
-  if (!accessPolicyEntries) {
+  if (!accessPolicy.resource) {
     // If none specified, generate an AccessPolicy from scratch
     return generateSmartScopesPolicy(smartScope);
   }
 
-  // Sort both by resource type
-  accessPolicyEntries.sort((a, b) => (a.resourceType as string).localeCompare(b.resourceType as string));
-  smartScope.sort((a, b) => a.resourceType.localeCompare(b.resourceType));
-
-  let i = 0; // accessPolicyEntries index
-  let j = 0; // smartScope index
-  while (i < accessPolicyEntries.length && j < smartScope.length) {
-    const accessPolicyResourceType = accessPolicyEntries[i].resourceType as string;
-    const smartScopeResourceType = smartScope[j].resourceType;
-
-    if (accessPolicyResourceType === smartScopeResourceType) {
-      // Merge
-      i++;
-      j++;
-    } else if (accessPolicyResourceType < smartScopeResourceType) {
-      // Remove
-      accessPolicyEntries.splice(i, 1);
-    } else {
-      // Ignore
-      j++;
+  const result: AccessPolicy & { resource: AccessPolicyResource[] } = { ...accessPolicy, resource: [] };
+  for (const policy of accessPolicy.resource) {
+    const scope = getScopeForResourceType(smartScope, policy.resourceType);
+    if (!scope) {
+      if (policy.resourceType === '*') {
+        for (const scope of smartScope) {
+          const merged = mergeAccessPolicyWithScope(policy, scope);
+          merged.resourceType = scope.resourceType;
+          result.resource.push(merged);
+        }
+      }
+      continue;
     }
-  }
 
-  // Ignore SMART scopes that don't match the resource type
-  // Remove AccessPolicy entries that don't match the SMART scope
-  if (i < accessPolicyEntries.length) {
-    accessPolicyEntries.splice(i);
+    const merged = mergeAccessPolicyWithScope(policy, scope);
+    result.resource.push(merged);
   }
 
   return result;
+}
+
+const readOnlyScope = /^[rs]+$/;
+function mergeAccessPolicyWithScope(policy: AccessPolicyResource, scope: SmartScope): AccessPolicyResource {
+  const result = deepClone(policy);
+
+  if (scope.scope.match(readOnlyScope)) {
+    result.readonly = true;
+  }
+  return result;
+}
+
+function getScopeForResourceType(scopes: SmartScope[], resourceType: string): SmartScope | undefined {
+  return scopes.find((s) => s.resourceType === resourceType) ?? scopes.find((s) => s.resourceType === '*');
 }
 
 function generateSmartScopesPolicy(smartScopes: SmartScope[]): AccessPolicy {


### PR DESCRIPTION
Scopes were failing to merge with a wildcard (`*`) `AccessPolicy`, resulting in a fail-closed scenario where the user was granted no access at all.  This fixes the merging behavior for wildcard access policies and scopes, as well as roughly maps read-only scopes into the generated `AccessPolicy`