### PR TITLE
Switch to `pg_try_advisory_lock`

### DIFF
--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -1,72 +1,99 @@
-import { deepClone } from '@medplum/core';
+import { deepClone, sleep } from '@medplum/core';
 import { EventEmitter } from 'node:events';
 import { Duplex } from 'node:stream';
 import pg, { Pool, PoolClient, PoolConfig, QueryArrayResult } from 'pg';
 import { Readable, Writable } from 'stream';
-import { MedplumDatabaseConfig, MedplumDatabaseSslConfig, loadConfig } from './config';
-import { closeDatabase, initDatabase } from './database';
-
-jest.mock('pg');
-
-const poolSpy = jest.spyOn(pg, 'Pool').mockImplementation((_config?: PoolConfig) => {
-  class MockPoolClient extends Duplex implements PoolClient {
-    release(): void {}
-    async connect(): Promise<void> {}
-    async query(): Promise<QueryArrayResult<any>> {
-      return {
-        command: '',
-        rowCount: null,
-        oid: -1,
-        fields: [],
-        rows: [],
-      };
-    }
-    copyFrom(_queryText: string): Writable {
-      return new Writable();
-    }
-    copyTo(_queryText: string): Readable {
-      return new Readable();
-    }
-    pauseDrain(): void {}
-    resumeDrain(): void {}
-    escapeIdentifier(_str: string): string {
-      return '';
-    }
-    escapeLiteral(_str: string): string {
-      return '';
-    }
-    getTypeParser(): any {
-      return undefined;
-    }
-    setTypeParser(): void {}
-  }
-
-  class MockPool extends EventEmitter implements Pool {
-    totalCount = -1;
-    idleCount = -1;
-    waitingCount = -1;
-    async connect(): Promise<pg.PoolClient> {
-      return new MockPoolClient();
-    }
-    on(): this {
-      return this;
-    }
-    async end(): Promise<void> {}
-    async query(): Promise<QueryArrayResult<any>> {
-      return {
-        command: '',
-        rowCount: null,
-        oid: -1,
-        fields: [],
-        rows: [],
-      };
-    }
-  }
-
-  return new MockPool();
-});
+import { MedplumDatabaseConfig, MedplumDatabaseSslConfig, loadConfig, loadTestConfig } from './config';
+import {
+  acquireAdvisoryLock,
+  closeDatabase,
+  DatabaseMode,
+  getDatabasePool,
+  initDatabase,
+  releaseAdvisoryLock,
+} from './database';
 
 describe('Database config', () => {
+  let poolSpy: jest.SpyInstance<pg.Pool, [config?: pg.PoolConfig | undefined]>;
+  beforeAll(() => {
+    jest.mock('pg');
+    poolSpy = jest.spyOn(pg, 'Pool').mockImplementation((_config?: PoolConfig) => {
+      class MockPoolClient extends Duplex implements PoolClient {
+        release(): void {}
+        async connect(): Promise<void> {}
+        async query(): Promise<QueryArrayResult<any>> {
+          return {
+            command: '',
+            rowCount: null,
+            oid: -1,
+            fields: [],
+            rows: [],
+          };
+        }
+        copyFrom(_queryText: string): Writable {
+          return new Writable();
+        }
+        copyTo(_queryText: string): Readable {
+          return new Readable();
+        }
+        pauseDrain(): void {}
+        resumeDrain(): void {}
+        escapeIdentifier(_str: string): string {
+          return '';
+        }
+        escapeLiteral(_str: string): string {
+          return '';
+        }
+        getTypeParser(): any {
+          return undefined;
+        }
+        setTypeParser(): void {}
+      }
+
+      class MockPool extends EventEmitter implements Pool {
+        expiredCount: number;
+        ending: boolean;
+        ended: boolean;
+        options: pg.PoolOptions;
+
+        constructor(_config?: PoolConfig) {
+          super();
+          this.expiredCount = 0;
+          this.ending = false;
+          this.ended = false;
+          this.options = {
+            max: -1,
+            maxUses: -1,
+            allowExitOnIdle: false,
+            maxLifetimeSeconds: -1,
+            idleTimeoutMillis: -1,
+          };
+        }
+
+        totalCount = -1;
+        idleCount = -1;
+        waitingCount = -1;
+        async connect(): Promise<pg.PoolClient> {
+          return new MockPoolClient();
+        }
+        on(): this {
+          return this;
+        }
+        async end(): Promise<void> {}
+        async query(): Promise<QueryArrayResult<any>> {
+          return {
+            command: '',
+            rowCount: null,
+            oid: -1,
+            fields: [],
+            rows: [],
+          };
+        }
+      }
+
+      return new MockPool();
+    });
+  });
   beforeEach(() => {
     poolSpy.mockClear();
   });
@@ -127,5 +154,52 @@ describe('Database config', () => {
         ssl: { require: true },
       })
     );
+  });
+});
+
+describe.only('Advisory locks', () => {
+  let clientA: PoolClient;
+  let clientB: PoolClient;
+
+  beforeEach(async () => {
+    const config = await loadTestConfig();
+    await initDatabase(config);
+    const pool = getDatabasePool(DatabaseMode.READER);
+    clientA = await pool.connect();
+    clientB = await pool.connect();
+    await clientA.query(`SET statement_timeout TO 100`);
+    await clientB.query(`SET statement_timeout TO 100`);
+  });
+
+  afterEach(async () => {
+    clientA.release();
+    clientB.release();
+    await closeDatabase();
+  });
+
+  test('Acquire', async () => {
+    const aLock = await acquireAdvisoryLock(clientA, 123, { maxAttempts: 1, retryDelayMs: 10 });
+    const bLock = await acquireAdvisoryLock(clientB, 123, { maxAttempts: 1, retryDelayMs: 10 });
+
+    expect(aLock).toBe(true);
+    expect(bLock).toBe(false);
+  });
+
+  test('Acquire and release', async () => {
+    const aLock = await acquireAdvisoryLock(clientA, 123, { maxAttempts: 1, retryDelayMs: 10 });
+    expect(aLock).toBe(true);
+
+    let bLock: boolean = false;
+    const aPromise = async (): Promise<void> => {
+      await sleep(10);
+      return releaseAdvisoryLock(clientA, 123);
+    };
+    const bPromise = async (): Promise<void> => {
+      bLock = await acquireAdvisoryLock(clientB, 123, { maxAttempts: 2, retryDelayMs: 20 });
+    };
+
+    await Promise.all([aPromise(), bPromise()]);
+
+    expect(bLock).toBe(true);
   });
 });

--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -108,9 +108,9 @@ describe('Database config', () => {
     poolSpy.mockClear();
   });
 
-  // afterEach(async () => {
-  //   await closeDatabase();
-  // });
+  afterEach(async () => {
+    await closeDatabase();
+  });
 
   test('SSL config', async () => {
     const config = await loadConfig('file:test.config.json');

--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -157,7 +157,7 @@ describe('Database config', () => {
   });
 });
 
-describe.only('Advisory locks', () => {
+describe('Advisory locks', () => {
   let clientA: PoolClient;
   let clientB: PoolClient;
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -125,16 +125,14 @@ export async function acquireAdvisoryLock(
   const maxAttempts = options?.maxAttempts ?? 30;
   let attempts = 0;
   while (attempts < maxAttempts) {
+    attempts++;
     const result = await client.query<{ pg_try_advisory_lock: boolean }>('SELECT pg_try_advisory_lock($1)', [lockId]);
     if (result.rows[0].pg_try_advisory_lock) {
       return true;
     }
-    attempts++;
-    if (attempts === maxAttempts) {
-      return false;
+    if (attempts < maxAttempts) {
+      await sleep(retryDelayMs);
     }
-
-    await sleep(retryDelayMs);
   }
 
   return false;

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -103,6 +103,7 @@ async function runMigrations(pool: Pool): Promise<void> {
     await migrate(client);
   } catch (err: any) {
     globalLogger.error('Database schema migration error', err);
+    throw err;
   } finally {
     if (client) {
       if (hasLock) {

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2,6 +2,7 @@ import { Pool, PoolClient } from 'pg';
 import { MedplumDatabaseConfig, MedplumServerConfig } from './config';
 import { globalLogger } from './logger';
 import * as migrations from './migrations/schema';
+import { sleep } from '@medplum/core';
 
 export enum DatabaseMode {
   READER = 'reader',
@@ -91,25 +92,70 @@ export async function closeDatabase(): Promise<void> {
 
 async function runMigrations(pool: Pool): Promise<void> {
   let client: PoolClient | undefined;
+  let hasLock = false;
   try {
     client = await pool.connect();
-    await client.query('SELECT pg_advisory_lock($1)', [locks.migration]);
+    hasLock = await acquireAdvisoryLock(client, locks.migration);
+    if (!hasLock) {
+      throw new Error('Failed to acquire migration lock');
+    }
     await client.query(`SET statement_timeout TO 0`); // Disable timeout for migrations AFTER getting lock
     await migrate(client);
   } catch (err: any) {
     globalLogger.error('Database schema migration error', err);
     if (client) {
-      await client.query('SELECT pg_advisory_unlock($1)', [locks.migration]);
+      if (hasLock) {
+        await releaseAdvisoryLock(client, locks.migration);
+      }
       client.release(err);
       client = undefined;
     }
   } finally {
     if (client) {
-      await client.query('SELECT pg_advisory_unlock($1)', [locks.migration]);
+      if (hasLock) {
+        await releaseAdvisoryLock(client, locks.migration);
+      }
       client.release(true); // Ensure migration connection is torn down and not re-used
       client = undefined;
     }
   }
+}
+
+type AcquireAdvisoryLockOptions = {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+};
+
+export async function acquireAdvisoryLock(
+  client: PoolClient,
+  lockId: number,
+  options?: AcquireAdvisoryLockOptions
+): Promise<boolean> {
+  const retryDelayMs = options?.retryDelayMs ?? 2000;
+  const maxAttempts = options?.maxAttempts ?? 30;
+  let attempts = 0;
+  while (attempts < maxAttempts) {
+    try {
+      const result = await client.query<{ pg_try_advisory_lock: boolean }>('SELECT pg_try_advisory_lock($1)', [lockId]);
+      if (result.rows[0].pg_try_advisory_lock) {
+        return true;
+      }
+    } catch (err) {
+      console.log('acquireAdvisoryLock error', err);
+    }
+    attempts++;
+    if (attempts === maxAttempts) {
+      return false;
+    }
+
+    await sleep(retryDelayMs);
+  }
+
+  return false;
+}
+
+export async function releaseAdvisoryLock(client: PoolClient, lockId: number): Promise<void> {
+  await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
 }
 
 async function migrate(client: PoolClient): Promise<void> {

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -141,7 +141,7 @@ export async function acquireAdvisoryLock(
         return true;
       }
     } catch (err) {
-      console.log('acquireAdvisoryLock error', err);
+      globalLogger.error('acquireAdvisoryLock error', { err });
     }
     attempts++;
     if (attempts === maxAttempts) {

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -29,6 +29,9 @@ jest.mock('pg', () => {
       if (sql === 'SELECT "User"."id", "User"."content" FROM "User" WHERE "User"."deleted" = $1 LIMIT 2') {
         return { rows: [{ id: '1', content: '{}' }] };
       }
+      if (sql === 'SELECT pg_try_advisory_lock($1)') {
+        return { rows: [{ pg_try_advisory_lock: true }] };
+      }
       return { rows: [] };
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,5 +58,8 @@ export async function main(configName: string): Promise<void> {
 }
 
 if (require.main === module) {
-  main(process.argv.length === 3 ? process.argv[2] : 'file:medplum.config.json').catch(console.log);
+  main(process.argv.length === 3 ? process.argv[2] : 'file:medplum.config.json').catch((err) => {
+    console.log(err);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
As [Sourcegraph discovered](https://sourcegraph.com/blog/introducing-migrator-service), using `pg_advisory_lock` to manage running migrations is self-defeating when the migration includes `CREATE INDEX CONCURRENTLY`.