### PR TITLE
feat(react,server): add ability to disable MFA

### DIFF
--- a/packages/app/src/MfaPage.test.tsx
+++ b/packages/app/src/MfaPage.test.tsx
@@ -1,3 +1,5 @@
+import { MantineProvider } from '@mantine/core';
+import { notifications, Notifications } from '@mantine/notifications';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -10,15 +12,22 @@ async function setup(): Promise<void> {
   await act(async () => {
     render(
       <MemoryRouter initialEntries={['/mfa']} initialIndex={0}>
-        <MedplumProvider medplum={medplum}>
-          <AppRoutes />
-        </MedplumProvider>
+        <MantineProvider>
+          <MedplumProvider medplum={medplum}>
+            <AppRoutes />
+            <Notifications />
+          </MedplumProvider>
+        </MantineProvider>
       </MemoryRouter>
     );
   });
 }
 
 describe('MfaPage', () => {
+  beforeEach(() => {
+    notifications.clean();
+  });
+
   test('Renders', async () => {
     await setup();
     expect(screen.getByText('Multi Factor Auth Setup')).toBeInTheDocument();
@@ -30,5 +39,89 @@ describe('MfaPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Enroll' }));
     });
     expect(screen.getByText('MFA is enabled')).toBeInTheDocument();
+  });
+
+  test('Disable -- success', async () => {
+    const getSpy = jest.spyOn(medplum, 'get');
+    await setup();
+
+    // Enroll into MFA
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Enroll' }));
+    });
+    expect(screen.getByText('MFA is enabled')).toBeInTheDocument();
+
+    // Clean notifications
+    await act(async () => {
+      notifications.clean();
+    });
+
+    // Open disable MFA modal
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Disable MFA' }));
+    });
+
+    // Wait for MFA code input to appear
+    await expect(screen.findByLabelText(/mfa code*/i)).resolves.toBeInTheDocument();
+
+    // Enter in a token value
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/mfa code*/i), { target: { value: '1234567890' } });
+    });
+
+    // Submit disable request
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit code' }));
+    });
+
+    // Check that the toast confirms that MFA was disabled
+    await expect(screen.findByText('MFA disabled')).resolves.toBeInTheDocument();
+    expect(screen.getByText('Enroll')).toBeInTheDocument();
+    // Make sure that we called status to refresh MFA QR code
+    expect(getSpy).toHaveBeenCalledWith('auth/mfa/status', expect.objectContaining({ cache: 'no-cache' }));
+    getSpy.mockRestore();
+  });
+
+  test('Disable -- failed', async () => {
+    const getSpy = jest.spyOn(medplum, 'get');
+    await setup();
+
+    // Enroll into MFA
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Enroll' }));
+    });
+    expect(screen.getByText('MFA is enabled')).toBeInTheDocument();
+
+    // Clean notifications
+    await act(async () => {
+      notifications.clean();
+    });
+
+    // Open disable MFA modal
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Disable MFA' }));
+    });
+
+    // Wait for MFA code input to appear
+    await expect(screen.findByLabelText(/mfa code*/i)).resolves.toBeInTheDocument();
+
+    // Enter in an INVALID_TOKEN value
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/mfa code*/i), { target: { value: 'INVALID_TOKEN' } });
+    });
+
+    // Reset the mock before submitting code
+    getSpy.mockReset();
+
+    // Attempt to submit code without entering
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Submit code' }));
+    });
+
+    // Make sure invalid token came back
+    await expect(screen.findByText('Invalid token')).resolves.toBeInTheDocument();
+    await expect(screen.findByText('Enroll')).rejects.toThrow();
+    expect(getSpy).not.toHaveBeenCalledWith('auth/mfa/status', expect.objectContaining({ cache: 'no-cache' }));
+    getSpy.mockRestore();
   });
 });

--- a/packages/app/src/MfaPage.tsx
+++ b/packages/app/src/MfaPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Center, Group, Modal, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { isOk, normalizeErrorString, OperationOutcomeError } from '@medplum/core';
+import { normalizeErrorString } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, Form, useMedplum } from '@medplum/react';
 import { IconCircleCheck } from '@tabler/icons-react';
@@ -57,10 +57,8 @@ export function MfaPage(): JSX.Element | null {
         <Modal title="Disable MFA" opened={disabling} onClose={() => setDisabling(false)}>
           <MfaForm
             onSubmit={async (formData) => {
-              const outcome = await disableMfa(formData);
-              if (!isOk(outcome)) {
-                throw new OperationOutcomeError(outcome);
-              }
+              // This will throw if MFA failed to disable
+              await disableMfa(formData);
               setDisabling(false);
               setEnrolled(false);
               showNotification({

--- a/packages/app/src/MfaPage.tsx
+++ b/packages/app/src/MfaPage.tsx
@@ -1,23 +1,31 @@
-import { Button, Center, Group, TextInput, Title } from '@mantine/core';
+import { Button, Center, Group, Modal, TextInput, Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { normalizeErrorString } from '@medplum/core';
+import { isOk, normalizeErrorString, OperationOutcomeError } from '@medplum/core';
+import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, Form, useMedplum } from '@medplum/react';
+import { IconCircleCheck } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
+import { MfaForm, MfaFormFields } from '../../react/src/auth/MfaForm';
 
 export function MfaPage(): JSX.Element | null {
   const medplum = useMedplum();
   const [qrCodeUrl, setQrCodeUrl] = useState<string>();
   const [enrolled, setEnrolled] = useState<boolean | undefined>(undefined);
+  const [disabling, setDisabling] = useState<boolean>(false);
 
-  useEffect(() => {
+  const fetchStatus = useCallback(() => {
     medplum
-      .get('auth/mfa/status')
+      .get('auth/mfa/status', { cache: 'no-cache' })
       .then((response) => {
         setQrCodeUrl(response.enrollQrCode);
         setEnrolled(response.enrolled);
       })
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
   }, [medplum]);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
 
   const enableMfa = useCallback(
     (formData: Record<string, string>) => {
@@ -32,9 +40,12 @@ export function MfaPage(): JSX.Element | null {
     [medplum]
   );
 
-  const disableMfa = useCallback(() => {
-    medplum.post('auth/mfa/disable', {}).catch(console.log);
-  }, [medplum]);
+  const disableMfa = useCallback(
+    async (formData: Record<MfaFormFields, string>): Promise<OperationOutcome> => {
+      return medplum.post('auth/mfa/disable', { token: formData.token });
+    },
+    [medplum]
+  );
 
   if (enrolled === undefined) {
     return null;
@@ -43,9 +54,30 @@ export function MfaPage(): JSX.Element | null {
   if (enrolled) {
     return (
       <Document>
+        <Modal title="Disable MFA" opened={disabling} onClose={() => setDisabling(false)}>
+          <MfaForm
+            onSubmit={async (formData) => {
+              const outcome = await disableMfa(formData);
+              if (!isOk(outcome)) {
+                throw new OperationOutcomeError(outcome);
+              }
+              setDisabling(false);
+              setEnrolled(false);
+              showNotification({
+                id: 'mfa-disabled',
+                color: 'green',
+                title: 'Success',
+                message: 'MFA disabled',
+                icon: <IconCircleCheck />,
+              });
+              // We fetch the status so that the MFA QR code is refreshed
+              fetchStatus();
+            }}
+          />
+        </Modal>
         <Group>
           <Title>MFA is enabled</Title>
-          <Button onClick={disableMfa}>Disable MFA</Button>
+          <Button onClick={() => setDisabling(true)}>Disable MFA</Button>
         </Group>
       </Document>
     );

--- a/packages/mock/src/client.test.ts
+++ b/packages/mock/src/client.test.ts
@@ -10,6 +10,7 @@ import {
   OperationOutcomeError,
   SubscriptionEmitter,
   allOk,
+  badRequest,
   getReferenceString,
   indexSearchParameterBundle,
   indexStructureDefinitionBundle,
@@ -200,6 +201,23 @@ describe('MockClient', () => {
   test('MFA enroll', async () => {
     const client = new MockClient();
     expect(await client.post('auth/mfa/enroll', { token: 'foo' })).toMatchObject(allOk);
+  });
+
+  test('MFA verify', async () => {
+    const client = new MockClient();
+    expect(await client.post('auth/mfa/verify', { token: 'foo' })).toMatchObject({ login: '123', code: 'xyz' });
+  });
+
+  test('MFA disable -- success', async () => {
+    const client = new MockClient();
+    expect(await client.post('auth/mfa/disable', { token: 'foo' })).toMatchObject(allOk);
+  });
+
+  test('MFA disable -- invalid token', async () => {
+    const client = new MockClient();
+    await expect(client.post('auth/mfa/disable', { token: 'INVALID_TOKEN' })).rejects.toThrow(
+      new OperationOutcomeError(badRequest('Invalid token'))
+    );
   });
 
   test('Batch request', async () => {

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -523,6 +523,13 @@ export class MockFetchClient {
       return allOk;
     }
 
+    if (path.startsWith('auth/mfa/verify')) {
+      return {
+        login: '123',
+        code: 'xyz',
+      };
+    }
+
     if (path.startsWith('auth/mfa/disable')) {
       if (options.body && JSON.parse(options.body)?.token !== 'INVALID_TOKEN') {
         return allOk;

--- a/packages/mock/src/client.ts
+++ b/packages/mock/src/client.ts
@@ -523,6 +523,13 @@ export class MockFetchClient {
       return allOk;
     }
 
+    if (path.startsWith('auth/mfa/disable')) {
+      if (options.body && JSON.parse(options.body)?.token !== 'INVALID_TOKEN') {
+        return allOk;
+      }
+      return badRequest('Invalid token');
+    }
+
     return null;
   }
 

--- a/packages/react/src/auth/MfaForm.tsx
+++ b/packages/react/src/auth/MfaForm.tsx
@@ -1,30 +1,23 @@
 import { Alert, Button, Center, Group, Stack, TextInput, Title } from '@mantine/core';
-import { LoginAuthenticationResponse, normalizeErrorString } from '@medplum/core';
-import { useMedplum } from '@medplum/react-hooks';
+import { normalizeErrorString } from '@medplum/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useState } from 'react';
 import { Form } from '../Form/Form';
 import { Logo } from '../Logo/Logo';
 
+export type MfaFormFields = 'token';
+
 export interface MfaFormProps {
-  readonly login: string;
-  readonly handleAuthResponse: (response: LoginAuthenticationResponse) => void;
+  readonly onSubmit: (formData: Record<MfaFormFields, string>) => Promise<void>;
 }
 
 export function MfaForm(props: MfaFormProps): JSX.Element {
-  const medplum = useMedplum();
   const [errorMessage, setErrorMessage] = useState<string>();
   return (
     <Form
-      onSubmit={(formData: Record<string, string>) => {
+      onSubmit={(formData: Record<MfaFormFields, string>) => {
         setErrorMessage(undefined);
-        medplum
-          .post('auth/mfa/verify', {
-            login: props.login,
-            token: formData.token,
-          })
-          .then(props.handleAuthResponse)
-          .catch((err) => setErrorMessage(normalizeErrorString(err)));
+        props.onSubmit(formData).catch((err) => setErrorMessage(normalizeErrorString(err)));
       }}
     >
       <Stack>

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -129,7 +129,17 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
             </AuthenticationForm>
           );
         } else if (mfaRequired) {
-          return <MfaForm login={login} handleAuthResponse={handleAuthResponse} />;
+          return (
+            <MfaForm
+              onSubmit={async (fields) => {
+                const res = await medplum.post('auth/mfa/verify', {
+                  login: login,
+                  token: fields.token,
+                });
+                handleAuthResponse(res);
+              }}
+            />
+          );
         } else if (memberships) {
           return <ChooseProfileForm login={login} memberships={memberships} handleAuthResponse={handleAuthResponse} />;
         } else if (props.projectId === 'new') {

--- a/packages/react/src/auth/SignInForm.tsx
+++ b/packages/react/src/auth/SignInForm.tsx
@@ -136,6 +136,7 @@ export function SignInForm(props: SignInFormProps): JSX.Element {
                   login: login,
                   token: fields.token,
                 });
+                console.log({ res });
                 handleAuthResponse(res);
               }}
             />

--- a/packages/server/src/auth/mfa.test.ts
+++ b/packages/server/src/auth/mfa.test.ts
@@ -1,11 +1,13 @@
+import { allOk, badRequest } from '@medplum/core';
+import { OperationOutcome } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { authenticator } from 'otplib';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config';
-import { registerNew } from './register';
 import { withTestContext } from '../test.setup';
+import { registerNew } from './register';
 
 const app = express();
 
@@ -146,5 +148,112 @@ describe('MFA', () => {
     expect(res13.status).toBe(200);
     expect(res13.body.login).toBeDefined();
     expect(res13.body.code).toBeDefined();
+  });
+
+  test('Disable end-to-end', async () => {
+    const email = `alex${randomUUID()}@example.com`;
+    const password = 'password!@#';
+
+    const { accessToken } = await withTestContext(() =>
+      registerNew({
+        firstName: 'Alexander',
+        lastName: 'The Great',
+        projectName: 'Macedonian Project',
+        email,
+        password,
+        remoteAddress: '5.5.5.5',
+        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/107.0.0.0',
+      })
+    );
+
+    // Call disable while not enrolled yet and before status, should error
+    const res1 = await request(app)
+      .post('/auth/mfa/disable')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({
+        token: '123',
+      });
+    expect(res1.status).toBe(400);
+    expect(res1.body).toMatchObject<OperationOutcome>(badRequest('Secret not found'));
+
+    // Get status; should not be enrolled and should get a secret
+    const res2 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
+    expect(res2.status).toBe(200);
+    expect(res2.body.enrolled).toBe(false);
+    expect(res2.body).toBeDefined();
+    expect(res2.body.enrollUri).toBeDefined();
+
+    // Start new login
+    const res3 = await request(app).post('/auth/login').type('json').send({
+      email,
+      password,
+      scope: 'openid',
+    });
+    expect(res3.status).toBe(200);
+    expect(res3.body.login).toBeDefined();
+
+    // Get MFA status, should be disabled
+    const res4 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
+    expect(res4.status).toBe(200);
+    expect(res4.body).toBeDefined();
+    expect(res4.body.enrolled).toBe(false);
+    expect(res4.body.enrollUri).toBeDefined();
+
+    const secret = new URL(res4.body.enrollUri).searchParams.get('secret') as string;
+
+    // Enroll MFA
+    const res5 = await request(app)
+      .post('/auth/mfa/enroll')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({ token: authenticator.generate(secret) });
+    expect(res5.status).toBe(200);
+
+    // Call disable without token, should fail
+    const res6 = await request(app)
+      .post('/auth/mfa/disable')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json');
+    expect(res6.status).toBe(400);
+    expect(res6.body).toMatchObject<OperationOutcome>(badRequest('Missing token'));
+
+    // Call disable with invalid token, should fail
+    const res7 = await request(app)
+      .post('/auth/mfa/disable')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({ token: 'invalid' });
+    expect(res7.status).toBe(400);
+    expect(res7.body).toMatchObject<OperationOutcome>(badRequest('Invalid token'));
+
+    // Call disable with token, should succeed
+    const res8 = await request(app)
+      .post('/auth/mfa/disable')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({ token: authenticator.generate(secret) });
+    expect(res8.status).toBe(200);
+    expect(res8.body).toMatchObject<OperationOutcome>(allOk);
+
+    // Get status should not be enrolled and should have a new secret
+    const res9 = await request(app).get('/auth/mfa/status').set('Authorization', `Bearer ${accessToken}`);
+    expect(res9.status).toBe(200);
+    expect(res9.body.enrolled).toBe(false);
+    expect(res9.body).toBeDefined();
+    expect(res9.body.enrollUri).not.toBe(res4.body.enrollUri);
+
+    const secret2 = new URL(res9.body.enrollUri).searchParams.get('secret') as string;
+
+    // Call disable while no longer enrolled, should error
+    const res10 = await request(app)
+      .post('/auth/mfa/disable')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .type('json')
+      .send({
+        token: authenticator.generate(secret2),
+      });
+    expect(res10.status).toBe(400);
+    expect(res10.body).toMatchObject<OperationOutcome>(badRequest('User not enrolled in MFA'));
   });
 });


### PR DESCRIPTION
https://github.com/user-attachments/assets/5b25d47e-8f04-45c8-a8dc-dc04abfa2c50

Fixes #5627 

* Adds a `/auth/mfa/disable` endpoint for disabling MFA for the authed user
* Also changes secret on disable of MFA so next enrollment uses a new secret
* Refactors `MfaForm` to take only a `onSubmit` handler so it can be reused for entering MFA before disabling
* Adds tests for all of these things