### PR TITLE
fix(client): don't try to parse when `content-length: 0`

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1116,12 +1116,14 @@ describe('Client', () => {
         switch (type) {
           case 'json': {
             // Simulate parsing non-JSON
+            // This will always throw
             JSON.parse('EMPTY');
             break;
           }
           default:
             return '';
         }
+        throw new Error('UNREACHABLE');
       };
       return Promise.resolve({
         ok: true,


### PR DESCRIPTION
Fixes #5713

Testing this was a little challenging since our test utils for mocking fetch prevent this error from happening by always returning the body, even when the body is not parseable JSON. We should probably polyfill the fetch API in `core`, `react`, and `app` instead of trying to mock them to prevent these kinds of hidden bugs. 

I did verify and attempting to call `.json` on a `Response` when the body is `null` does cause it to throw the described error:
<img width="912" alt="Screenshot 2024-12-24 at 12 20 00 AM" src="https://github.com/user-attachments/assets/f0b48c65-6668-4c77-b357-28b39a9303d6" />