### PR TITLE
Adding findResourceInBundle to the official SDK

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -29,6 +29,7 @@ import {
   findObservationReferenceRange,
   findResourceByCode,
   findResourceById,
+  findResourceByLogicalId,
   flatMapFilter,
   getAllQuestionnaireAnswers,
   getCodeBySystem,
@@ -1292,14 +1293,57 @@ describe('Core Utils', () => {
       ],
     };
     test('Should find an Patient by ID', () => {
-      const expectedResult = bundle.entry?.[2].resource;
-      const result = findResourceById(bundle, 'Patient', '2');
+      const expectedResult = bundle.entry?.[1].resource;
+      const result = findResourceById(bundle, 'Patient/1');
       expect(result).toStrictEqual(expectedResult);
     });
     test('Result is undefined for not finding any matching ID', () => {
-      const resultNoIdMatch = findResourceById(bundle, 'Patient', '3');
-      const resultTypeMismatch = findResourceById(bundle, 'Practitioner', '2');
-      const resultNoTypeMatch = findResourceById(bundle, 'Observation', '1');
+      const resultNoIdMatch = findResourceById(bundle, 'Patient/11');
+      const resultTypeMismatch = findResourceById(bundle, 'Practitioner/2');
+      const resultNoTypeMatch = findResourceById(bundle, 'Observation/1');
+      expect(resultNoIdMatch).toStrictEqual(undefined);
+      expect(resultTypeMismatch).toStrictEqual(undefined);
+      expect(resultNoTypeMatch).toStrictEqual(undefined);
+    });
+  });
+
+  describe('findResourceByLogicalId', () => {
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Practitioner',
+            id: '1',
+            identifier: [{ system: 'http://example.com', value: '123' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '1',
+            identifier: [{ system: 'http://example.com', value: '456' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '2',
+            identifier: [{ system: 'http://example.com', value: '789' }],
+          },
+        },
+      ],
+    };
+    test('Should find an Patient by ID', () => {
+      const expectedResult = bundle.entry?.[2].resource;
+      const result = findResourceByLogicalId(bundle, 'Patient', '2');
+      expect(result).toStrictEqual(expectedResult);
+    });
+    test('Result is undefined for not finding any matching ID', () => {
+      const resultNoIdMatch = findResourceByLogicalId(bundle, 'Patient', '3');
+      const resultTypeMismatch = findResourceByLogicalId(bundle, 'Practitioner', '2');
+      const resultNoTypeMatch = findResourceByLogicalId(bundle, 'Observation', '1');
       expect(resultNoIdMatch).toStrictEqual(undefined);
       expect(resultTypeMismatch).toStrictEqual(undefined);
       expect(resultNoTypeMatch).toStrictEqual(undefined);

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -28,8 +28,7 @@ import {
   findObservationInterval,
   findObservationReferenceRange,
   findResourceByCode,
-  findResourceById,
-  findResourceByLogicalId,
+  findResourceInBundle,
   flatMapFilter,
   getAllQuestionnaireAnswers,
   getCodeBySystem,
@@ -1264,50 +1263,7 @@ describe('Core Utils', () => {
     expect(result).toStrictEqual(observations[0]);
   });
 
-  describe('findResourceById', () => {
-    const bundle: Bundle = {
-      resourceType: 'Bundle',
-      type: 'searchset',
-      entry: [
-        {
-          resource: {
-            resourceType: 'Practitioner',
-            id: '1',
-            identifier: [{ system: 'http://example.com', value: '123' }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Patient',
-            id: '1',
-            identifier: [{ system: 'http://example.com', value: '456' }],
-          },
-        },
-        {
-          resource: {
-            resourceType: 'Patient',
-            id: '2',
-            identifier: [{ system: 'http://example.com', value: '789' }],
-          },
-        },
-      ],
-    };
-    test('Should find an Patient by ID', () => {
-      const expectedResult = bundle.entry?.[1].resource;
-      const result = findResourceById(bundle, 'Patient/1');
-      expect(result).toStrictEqual(expectedResult);
-    });
-    test('Result is undefined for not finding any matching ID', () => {
-      const resultNoIdMatch = findResourceById(bundle, 'Patient/11');
-      const resultTypeMismatch = findResourceById(bundle, 'Practitioner/2');
-      const resultNoTypeMatch = findResourceById(bundle, 'Observation/1');
-      expect(resultNoIdMatch).toStrictEqual(undefined);
-      expect(resultTypeMismatch).toStrictEqual(undefined);
-      expect(resultNoTypeMatch).toStrictEqual(undefined);
-    });
-  });
-
-  describe('findResourceByLogicalId', () => {
+  describe('findResourceInBundle', () => {
     const bundle: Bundle = {
       resourceType: 'Bundle',
       type: 'searchset',
@@ -1337,13 +1293,13 @@ describe('Core Utils', () => {
     };
     test('Should find an Patient by ID', () => {
       const expectedResult = bundle.entry?.[2].resource;
-      const result = findResourceByLogicalId(bundle, 'Patient', '2');
+      const result = findResourceInBundle(bundle, 'Patient', '2');
       expect(result).toStrictEqual(expectedResult);
     });
     test('Result is undefined for not finding any matching ID', () => {
-      const resultNoIdMatch = findResourceByLogicalId(bundle, 'Patient', '3');
-      const resultTypeMismatch = findResourceByLogicalId(bundle, 'Practitioner', '2');
-      const resultNoTypeMatch = findResourceByLogicalId(bundle, 'Observation', '1');
+      const resultNoIdMatch = findResourceInBundle(bundle, 'Patient', '3');
+      const resultTypeMismatch = findResourceInBundle(bundle, 'Practitioner', '2');
+      const resultNoTypeMatch = findResourceInBundle(bundle, 'Observation', '1');
       expect(resultNoIdMatch).toStrictEqual(undefined);
       expect(resultTypeMismatch).toStrictEqual(undefined);
       expect(resultNoTypeMatch).toStrictEqual(undefined);

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -28,6 +28,7 @@ import {
   findObservationInterval,
   findObservationReferenceRange,
   findResourceByCode,
+  findResourceById,
   flatMapFilter,
   getAllQuestionnaireAnswers,
   getCodeBySystem,
@@ -1260,6 +1261,49 @@ describe('Core Utils', () => {
 
     const result = findResourceByCode(observations, codeToFindAsString, system);
     expect(result).toStrictEqual(observations[0]);
+  });
+
+  describe('findResourceById', () => {
+    const bundle: Bundle = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [
+        {
+          resource: {
+            resourceType: 'Practitioner',
+            id: '1',
+            identifier: [{ system: 'http://example.com', value: '123' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '1',
+            identifier: [{ system: 'http://example.com', value: '456' }],
+          },
+        },
+        {
+          resource: {
+            resourceType: 'Patient',
+            id: '2',
+            identifier: [{ system: 'http://example.com', value: '789' }],
+          },
+        },
+      ],
+    };
+    test('Should find an Patient by ID', () => {
+      const expectedResult = bundle.entry?.[2].resource;
+      const result = findResourceById(bundle, 'Patient', '2');
+      expect(result).toStrictEqual(expectedResult);
+    });
+    test('Result is undefined for not finding any matching ID', () => {
+      const resultNoIdMatch = findResourceById(bundle, 'Patient', '3');
+      const resultTypeMismatch = findResourceById(bundle, 'Practitioner', '2');
+      const resultNoTypeMatch = findResourceById(bundle, 'Observation', '1');
+      expect(resultNoIdMatch).toStrictEqual(undefined);
+      expect(resultTypeMismatch).toStrictEqual(undefined);
+      expect(resultNoTypeMatch).toStrictEqual(undefined);
+    });
   });
 
   test('splitN', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1019,6 +1019,25 @@ export function findResourceByCode(
   );
 }
 
+/**
+ * Tries to find the first resource in the bundle that matches a given resource type and logical ID.
+ * 
+ * The logical ID is unique wihin the space of all resources of the same type.
+ * @param resourceBundle - The bundle of resources.
+ * @param resourceType - String of the resource type.
+ * @param id - The logical ID of the resource to search for.
+ * @returns The first resource in the input array that matches the specified type and ID, or undefined if no such resource is found.
+ */
+export function findResourceById<T extends Resource = Resource>(
+  resourceBundle: Bundle<T>,
+  resourceType: T['resourceType'],
+  id: string
+): T | undefined {
+  return resourceBundle.entry?.find(
+    ({ resource }) => resource?.resourceType === resourceType && resource?.id === id
+  )?.resource as T | undefined;
+}
+
 export function arrayify<T>(value: T | T[] | undefined): T[] | undefined {
   if (value === undefined) {
     return undefined;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1024,11 +1024,28 @@ export function findResourceByCode(
  * 
  * The logical ID is unique wihin the space of all resources of the same type.
  * @param resourceBundle - The bundle of resources.
+ * @param resourceKey - String of the resource's type and logical ID delimited by a forward slash. E.g. "Patient/123".
+ * @returns The first resource in the input array that matches the key, or undefined if no such resource is found.
+ */
+export function findResourceById<T extends Resource = Resource>(
+  resourceBundle: Bundle<T>,
+  resourceKey: `${T['resourceType']}/${string}`
+): T | undefined {
+  return resourceBundle.entry?.find(
+    ({ resource }) => `${resource?.resourceType}/${resource?.id}` === resourceKey
+  )?.resource as T | undefined;
+}
+
+/**
+ * Tries to find the first resource in the bundle that matches a given resource type and logical ID.
+ * 
+ * The logical ID is unique wihin the space of all resources of the same type.
+ * @param resourceBundle - The bundle of resources.
  * @param resourceType - String of the resource type.
  * @param id - The logical ID of the resource to search for.
  * @returns The first resource in the input array that matches the specified type and ID, or undefined if no such resource is found.
  */
-export function findResourceById<T extends Resource = Resource>(
+export function findResourceByLogicalId<T extends Resource = Resource>(
   resourceBundle: Bundle<T>,
   resourceType: T['resourceType'],
   id: string

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1021,7 +1021,7 @@ export function findResourceByCode(
 
 /**
  * Tries to find the first resource in the bundle that matches a given resource type and logical ID.
- * 
+ *
  * The logical ID is unique wihin the space of all resources of the same type.
  * @param resourceBundle - The bundle of resources.
  * @param resourceKey - String of the resource's type and logical ID delimited by a forward slash. E.g. "Patient/123".
@@ -1031,14 +1031,13 @@ export function findResourceById<T extends Resource = Resource>(
   resourceBundle: Bundle<T>,
   resourceKey: `${T['resourceType']}/${string}`
 ): T | undefined {
-  return resourceBundle.entry?.find(
-    ({ resource }) => `${resource?.resourceType}/${resource?.id}` === resourceKey
-  )?.resource as T | undefined;
+  return resourceBundle.entry?.find(({ resource }) => `${resource?.resourceType}/${resource?.id}` === resourceKey)
+    ?.resource as T | undefined;
 }
 
 /**
  * Tries to find the first resource in the bundle that matches a given resource type and logical ID.
- * 
+ *
  * The logical ID is unique wihin the space of all resources of the same type.
  * @param resourceBundle - The bundle of resources.
  * @param resourceType - String of the resource type.
@@ -1050,9 +1049,8 @@ export function findResourceByLogicalId<T extends Resource = Resource>(
   resourceType: T['resourceType'],
   id: string
 ): T | undefined {
-  return resourceBundle.entry?.find(
-    ({ resource }) => resource?.resourceType === resourceType && resource?.id === id
-  )?.resource as T | undefined;
+  return resourceBundle.entry?.find(({ resource }) => resource?.resourceType === resourceType && resource?.id === id)
+    ?.resource as T | undefined;
 }
 
 export function arrayify<T>(value: T | T[] | undefined): T[] | undefined {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -6,6 +6,7 @@ import {
   Device,
   Extension,
   ExtensionValue,
+  ExtractResource,
   Identifier,
   ObservationDefinition,
   ObservationDefinitionQualifiedInterval,
@@ -18,6 +19,7 @@ import {
   Reference,
   RelatedPerson,
   Resource,
+  ResourceType,
 } from '@medplum/fhirtypes';
 import { getTypedPropertyValue } from './fhirpath/utils';
 import { formatCodeableConcept, formatHumanName } from './format';
@@ -1024,33 +1026,17 @@ export function findResourceByCode(
  *
  * The logical ID is unique wihin the space of all resources of the same type.
  * @param resourceBundle - The bundle of resources.
- * @param resourceKey - String of the resource's type and logical ID delimited by a forward slash. E.g. "Patient/123".
- * @returns The first resource in the input array that matches the key, or undefined if no such resource is found.
- */
-export function findResourceById<T extends Resource = Resource>(
-  resourceBundle: Bundle<T>,
-  resourceKey: `${T['resourceType']}/${string}`
-): T | undefined {
-  return resourceBundle.entry?.find(({ resource }) => `${resource?.resourceType}/${resource?.id}` === resourceKey)
-    ?.resource as T | undefined;
-}
-
-/**
- * Tries to find the first resource in the bundle that matches a given resource type and logical ID.
- *
- * The logical ID is unique wihin the space of all resources of the same type.
- * @param resourceBundle - The bundle of resources.
  * @param resourceType - String of the resource type.
  * @param id - The logical ID of the resource to search for.
  * @returns The first resource in the input array that matches the specified type and ID, or undefined if no such resource is found.
  */
-export function findResourceByLogicalId<T extends Resource = Resource>(
-  resourceBundle: Bundle<T>,
-  resourceType: T['resourceType'],
+export function findResourceInBundle<K extends ResourceType>(
+  bundle: Bundle,
+  resourceType: K,
   id: string
-): T | undefined {
-  return resourceBundle.entry?.find(({ resource }) => resource?.resourceType === resourceType && resource?.id === id)
-    ?.resource as T | undefined;
+): ExtractResource<K> | undefined {
+  return bundle.entry?.find(({ resource }) => resource?.resourceType === resourceType && resource?.id === id)
+    ?.resource as ExtractResource<K> | undefined;
 }
 
 export function arrayify<T>(value: T | T[] | undefined): T[] | undefined {


### PR DESCRIPTION
Fixes #4397 

Looking for an initial review.

The initial request was for a string such as "Patient/123" where the resourceType and id delimited by a forward slash is used as input. I wasn't able to find any FHIR resource documentation stating that this is a conventional input, whereas the [location URL](https://build.fhir.org/resource.html) is stated to be used to identify a unique resource.

I've added a second method that takes two arguments: resourceType and id (representing the Logical ID). I'm also suggesting that requesting a location URL as an argument could be possible here too.