### PR TITLE
Fixes #5678 - aws-textract operation improvements

### DIFF
--- a/examples/medplum-demo-bots/src/textract-bot.test.ts
+++ b/examples/medplum-demo-bots/src/textract-bot.test.ts
@@ -1,0 +1,26 @@
+import { MockClient } from '@medplum/mock';
+import { expect, test } from 'vitest';
+import { handler } from './textract-bot';
+
+test('AWS Textract', async () => {
+  const medplum = new MockClient();
+
+  // Mock the medplum.post method
+  medplum.post = async () => ({
+    JobStatus: 'SUCCEEDED',
+    Blocks: [
+      { BlockType: 'WORD', Text: 'Hello' },
+      { BlockType: 'WORD', Text: 'World' },
+    ],
+  });
+
+  const result = await handler(medplum, {
+    bot: { reference: 'Bot/123' },
+    contentType: 'application/fhir+json',
+    input: { resourceType: 'Media', id: '456' },
+    secrets: {},
+  });
+
+  expect(result).toBeDefined();
+  expect(result).toEqual('Hello\nWorld');
+});

--- a/examples/medplum-demo-bots/src/textract-bot.ts
+++ b/examples/medplum-demo-bots/src/textract-bot.ts
@@ -1,0 +1,28 @@
+import { BotEvent, MedplumClient } from '@medplum/core';
+import { Media } from '@medplum/fhirtypes';
+
+// Some types for the AWS Textract response
+// You can find these types in the AWS Textract documentation
+// https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-textract/Interface/GetDocumentTextDetectionCommandOutput/
+type TextractBlock = { Text?: string };
+type TextractResponse = { Blocks: TextractBlock[] };
+
+export async function handler(medplum: MedplumClient, event: BotEvent<Partial<Media>>): Promise<string> {
+  // This example bot expects a Media input
+  // In your own application, you could grab the Media from a different source
+  const media = event.input;
+
+  // Send the media to AWS Textract via the Medplum `$aws-textract` operation
+  // The operation will return the Textract results
+  // The results will also be available as a FHIR Binary and FHIR Media
+  // You can optionally include `comprehend: true` to send the Textract results to AWS Comprehend
+  const textractResult = (await medplum.post(
+    medplum.fhirUrl('Media', media.id as string, '$aws-textract'),
+    {}
+  )) as TextractResponse;
+
+  // Convert the AWS Textract output to an array of string lines
+  const lines = textractResult.Blocks.map((b) => b.Text).filter(Boolean);
+  console.log(lines);
+  return lines.join('\n');
+}

--- a/packages/app/src/resource/TimelinePage.test.tsx
+++ b/packages/app/src/resource/TimelinePage.test.tsx
@@ -1,6 +1,6 @@
 import { Notifications } from '@mantine/notifications';
 import { createReference, generateId, getReferenceString } from '@medplum/core';
-import { Communication, ProjectMembership } from '@medplum/fhirtypes';
+import { Communication, Media, ProjectMembership } from '@medplum/fhirtypes';
 import { HomerServiceRequest, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router-dom';
@@ -258,6 +258,43 @@ describe('TimelinePage', () => {
     const deleteButton = await screen.findByLabelText('Delete ' + getReferenceString(comment));
     await act(async () => {
       fireEvent.click(deleteButton);
+    });
+  });
+
+  test('Textract document', async () => {
+    const medplum = new MockClient();
+    const filename = 'test.pdf';
+
+    // Create a PDF attachment
+    const media = await medplum.createResource<Media>({
+      resourceType: 'Media',
+      status: 'completed',
+      basedOn: [createReference(HomerServiceRequest)],
+      subject: createReference(HomerSimpson),
+      content: {
+        contentType: 'application/pdf',
+        url: 'Binary/123',
+        title: filename,
+      },
+    });
+
+    await setup(`/${getReferenceString(HomerServiceRequest)}`, medplum);
+
+    // See if the Communication timeline item is loaded
+    expect(await screen.findByText(filename)).toBeInTheDocument();
+
+    // Check for the Actions menu icon
+    expect(screen.getByLabelText('Actions for ' + getReferenceString(media))).toBeInTheDocument();
+
+    // Click on the actions link
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Actions for ' + getReferenceString(media)));
+    });
+
+    // Click on the "AWS Textract" menu item
+    const textractButton = await screen.findByLabelText('AWS Textract ' + getReferenceString(media));
+    await act(async () => {
+      fireEvent.click(textractButton);
     });
   });
 });


### PR DESCRIPTION
Example usage:

```ts
import { BotEvent, MedplumClient } from '@medplum/core';
import { Media } from '@medplum/fhirtypes';

// Some types for the AWS Textract response
// You can find these types in the AWS Textract documentation
// https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-textract/Interface/GetDocumentTextDetectionCommandOutput/
type TextractBlock = { Text?: string };
type TextractResponse = { Blocks: TextractBlock[] };

export async function handler(medplum: MedplumClient, event: BotEvent<Partial<Media>>): Promise<string> {
  // This example bot expects a Media input
  // In your own application, you could grab the Media from a different source
  const media = event.input;

  // Send the media to AWS Textract via the Medplum `$aws-textract` operation
  // The operation will return the Textract results
  // The results will also be available as a FHIR Binary and FHIR Media
  // You can optionally include `comprehend: true` to send the Textract results to AWS Comprehend
  const textractResult = (await medplum.post(
    medplum.fhirUrl('Media', media.id as string, '$aws-textract'),
    {}
  )) as TextractResponse;

  // Convert the AWS Textract output to an array of string lines
  const lines = textractResult.Blocks.map((b) => b.Text).filter(Boolean);
  console.log(lines);
  return lines.join('\n');
}
```