### PR TITLE
Align meta.medplum.com JSON with github releases api

### DIFF
--- a/.github/workflows/publish-meta.yml
+++ b/.github/workflows/publish-meta.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download releases and create versions.json
         run: |
           # Download releases data
-          curl -s https://api.github.com/repos/medplum/medplum/releases > releases.json
+          curl -s "https://api.github.com/repos/medplum/medplum/releases?per_page=100" > releases.json
 
           # Process JSON with jq to create the desired structure
           # including assets array with specified properties
@@ -42,10 +42,38 @@ jobs:
                 ]
               }
             ]
-          }' releases.json > versions.json
+          }' releases.json > all.json
+
+          # Create latest release file
+          jq '.[0] | {
+            tag_name,
+            version: (.tag_name | ltrimstr("v")),
+            published_at,
+            assets: [
+              .assets[] | {
+                name,
+                browser_download_url
+              }
+            ]
+          }' releases.json > latest.json
+
+          # Extract version tag for versioned filename
+          VERSION_TAG=$(jq -r '.[0].tag_name' releases.json)
+          echo "VERSION_TAG=${VERSION_TAG}" >> $GITHUB_ENV
 
       - name: Upload to S3
         run: |
-          aws s3 cp versions.json s3://meta.medplum.com/versions.json \
+          # Upload all versions JSON
+          aws s3 cp all.json s3://meta.medplum.com/releases/all.json \
+            --content-type "application/json" \
+            --cache-control "no-cache"
+
+          # Upload latest.json
+          aws s3 cp latest.json s3://meta.medplum.com/releases/latest.json \
+            --content-type "application/json" \
+            --cache-control "no-cache"
+
+          # Upload versioned copy
+          aws s3 cp latest.json "s3://meta.medplum.com/releases/${VERSION_TAG}.json" \
             --content-type "application/json" \
             --cache-control "no-cache"


### PR DESCRIPTION
This should make it easier to migrate our existing "version check" code to the new https://meta.medplum.com endpoints.