### PR TITLE
Use meta.medplum.com for version checks

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -598,7 +598,7 @@ export class App {
     let child: ChildProcess;
 
     // If there is an explicit version, check if it's valid
-    if (message.version && !(await checkIfValidMedplumVersion(message.version))) {
+    if (message.version && !(await checkIfValidMedplumVersion('agent-upgrader', message.version))) {
       const versionTag = message.version ? `v${message.version}` : 'latest';
       const errMsg = `Error during upgrading to version '${versionTag}'. '${message.version}' is not a valid version`;
       this.log.error(errMsg);
@@ -653,7 +653,7 @@ export class App {
       this.log.info('Successfully stopped agent network services');
 
       // Write a manifest file
-      const targetVersion = message.version ?? (await fetchLatestVersionString());
+      const targetVersion = message.version ?? (await fetchLatestVersionString('agent-upgrader'));
 
       this.log.info('Writing upgrade manifest...', { previousVersion: MEDPLUM_VERSION, targetVersion });
       writeFileSync(

--- a/packages/agent/src/upgrader-utils.test.ts
+++ b/packages/agent/src/upgrader-utils.test.ts
@@ -1,4 +1,4 @@
-import { GITHUB_RELEASES_URL, ReleaseManifest, clearReleaseCache } from '@medplum/core';
+import { MEDPLUM_RELEASES_URL, ReleaseManifest, clearReleaseCache } from '@medplum/core';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import { resolve } from 'node:path';
@@ -153,7 +153,7 @@ describe.each(VALID_PLATFORMS_LIST)('Upgrader Utils -- Valid Platforms -- %s', (
       );
 
       await downloadRelease('3.1.6', resolve(__dirname, 'tmp', 'test-release-binary'));
-      expect(fetchSpy).toHaveBeenNthCalledWith(1, `${GITHUB_RELEASES_URL}/tags/v3.1.6`);
+      expect(fetchSpy).toHaveBeenNthCalledWith(1, `${MEDPLUM_RELEASES_URL}/v3.1.6.json`);
       expect(fetchSpy).toHaveBeenLastCalledWith(`https://example.com/${_platform}`);
       expect(readFileSync(resolve(__dirname, 'tmp', 'test-release-binary'), { encoding: 'utf-8' })).toStrictEqual(
         'Hello, Medplum!'

--- a/packages/agent/src/upgrader-utils.test.ts
+++ b/packages/agent/src/upgrader-utils.test.ts
@@ -153,7 +153,7 @@ describe.each(VALID_PLATFORMS_LIST)('Upgrader Utils -- Valid Platforms -- %s', (
       );
 
       await downloadRelease('3.1.6', resolve(__dirname, 'tmp', 'test-release-binary'));
-      expect(fetchSpy).toHaveBeenNthCalledWith(1, `${MEDPLUM_RELEASES_URL}/v3.1.6.json`);
+      expect(fetchSpy).toHaveBeenNthCalledWith(1, expect.stringContaining(`${MEDPLUM_RELEASES_URL}/v3.1.6.json`));
       expect(fetchSpy).toHaveBeenLastCalledWith(`https://example.com/${_platform}`);
       expect(readFileSync(resolve(__dirname, 'tmp', 'test-release-binary'), { encoding: 'utf-8' })).toStrictEqual(
         'Hello, Medplum!'

--- a/packages/agent/src/upgrader-utils.ts
+++ b/packages/agent/src/upgrader-utils.ts
@@ -13,7 +13,7 @@ export const UPGRADER_LOG_PATH = resolve(
 export const RELEASES_PATH = resolve(__dirname);
 
 export async function downloadRelease(version: string, path: string): Promise<void> {
-  const release = await fetchVersionManifest(version);
+  const release = await fetchVersionManifest('agent-upgrader', version);
 
   // Get download url
   const downloadUrl = parseDownloadUrl(release, platform());

--- a/packages/agent/src/upgrader.ts
+++ b/packages/agent/src/upgrader.ts
@@ -34,7 +34,7 @@ export async function upgraderMain(argv: string[]): Promise<void> {
   if (argv[3] && !isValidMedplumSemver(argv[3])) {
     throw new Error('Invalid version specified');
   }
-  const version = argv[3] ?? (await fetchLatestVersionString());
+  const version = argv[3] ?? (await fetchLatestVersionString('agent-upgrader'));
   const binPath = getReleaseBinPath(version);
 
   // If release in not locally downloaded, download it first

--- a/packages/app/src/resource/ToolsPage.test.tsx
+++ b/packages/app/src/resource/ToolsPage.test.tsx
@@ -2,7 +2,7 @@ import { MantineProvider } from '@mantine/core';
 import { Notifications, cleanNotifications } from '@mantine/notifications';
 import {
   ContentType,
-  GITHUB_RELEASES_URL,
+  MEDPLUM_RELEASES_URL,
   MEDPLUM_VERSION,
   allOk,
   clearReleaseCache,
@@ -266,7 +266,7 @@ describe('ToolsPage', () => {
   test('Upgrade -- Success', async () => {
     clearReleaseCache();
     globalThis.fetch = mockFetch(200, (url) => {
-      if (url.startsWith(`${GITHUB_RELEASES_URL}/latest`)) {
+      if (url.startsWith(`${MEDPLUM_RELEASES_URL}/latest`)) {
         return {
           tag_name: 'v3.2.14',
           assets: [
@@ -349,7 +349,7 @@ describe('ToolsPage', () => {
   test('Upgrade -- Already up-to-date', async () => {
     clearReleaseCache();
     globalThis.fetch = mockFetch(200, (url) => {
-      if (url.startsWith(`${GITHUB_RELEASES_URL}/latest`)) {
+      if (url.startsWith(`${MEDPLUM_RELEASES_URL}/latest`)) {
         return {
           tag_name: 'v3.2.14',
           assets: [
@@ -428,7 +428,7 @@ describe('ToolsPage', () => {
   test('Upgrade -- Unable to get version', async () => {
     clearReleaseCache();
     globalThis.fetch = mockFetch(200, (url) => {
-      if (url.startsWith(`${GITHUB_RELEASES_URL}/latest`)) {
+      if (url.startsWith(`${MEDPLUM_RELEASES_URL}/latest`)) {
         return {
           tag_name: 'v3.2.14',
           assets: [
@@ -505,7 +505,7 @@ describe('ToolsPage', () => {
   test('Upgrade -- Error', async () => {
     clearReleaseCache();
     globalThis.fetch = mockFetch(200, (url) => {
-      if (url.startsWith(`${GITHUB_RELEASES_URL}/latest`)) {
+      if (url.startsWith(`${MEDPLUM_RELEASES_URL}/latest`)) {
         return {
           tag_name: 'v3.2.14',
           assets: [

--- a/packages/app/src/resource/ToolsPage.tsx
+++ b/packages/app/src/resource/ToolsPage.tsx
@@ -25,7 +25,7 @@ function UpgradeConfirmContent(props: UpgradeConfirmContentProps): JSX.Element {
   useEffect(() => {
     if (opened) {
       if (!latestVersionString) {
-        fetchLatestVersionString().then(setLatestVersionString).catch(console.error);
+        fetchLatestVersionString('app-tools-page').then(setLatestVersionString).catch(console.error);
       }
       handleStatus();
     }

--- a/packages/core/src/version-utils.test.ts
+++ b/packages/core/src/version-utils.test.ts
@@ -140,7 +140,7 @@ describe('fetchVersionManifest', () => {
     );
     await expect(fetchVersionManifest('test')).resolves.toMatchObject<ReleaseManifest>(manifest);
     // Should be called with latest
-    expect(fetchSpy).toHaveBeenLastCalledWith(`${MEDPLUM_RELEASES_URL}/latest.json`);
+    expect(fetchSpy).toHaveBeenLastCalledWith(expect.stringContaining(`${MEDPLUM_RELEASES_URL}/latest.json`));
     // Call again to make sure we don't refetch
     fetchSpy.mockClear();
     await expect(fetchVersionManifest('test')).resolves.toMatchObject<ReleaseManifest>(manifest);
@@ -169,8 +169,8 @@ describe('fetchVersionManifest', () => {
       }) as unknown as typeof globalThis.fetch
     );
     await expect(fetchVersionManifest('test', '3.1.6')).resolves.toMatchObject<ReleaseManifest>(manifest);
-    // Should be called with latest
-    expect(fetchSpy).toHaveBeenLastCalledWith(`${MEDPLUM_RELEASES_URL}/v3.1.6.json`);
+    // Should be called with version
+    expect(fetchSpy).toHaveBeenLastCalledWith(expect.stringContaining(`${MEDPLUM_RELEASES_URL}/v3.1.6.json`));
     // Call again to make sure we don't refetch
     fetchSpy.mockClear();
     await expect(fetchVersionManifest('test', '3.1.6')).resolves.toMatchObject<ReleaseManifest>(manifest);
@@ -277,6 +277,7 @@ describe('warnIfNewerVersionAvailable', () => {
 
     console.warn = jest.fn();
     await warnIfNewerVersionAvailable('test', { foo: 'bar' });
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining(`${MEDPLUM_RELEASES_URL}/latest.json`));
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('A new version (v100.0.0) of Medplum is available.')
     );

--- a/packages/core/src/version-utils.test.ts
+++ b/packages/core/src/version-utils.test.ts
@@ -4,8 +4,8 @@ import {
   clearReleaseCache,
   fetchLatestVersionString,
   fetchVersionManifest,
-  GITHUB_RELEASES_URL,
   isValidMedplumSemver,
+  MEDPLUM_RELEASES_URL,
   ReleaseManifest,
 } from './version-utils';
 
@@ -66,7 +66,7 @@ describe('checkIfValidMedplumVersion', () => {
   });
 
   test('Invalid version format', async () => {
-    await expect(checkIfValidMedplumVersion('3.1.6-alpha')).resolves.toStrictEqual(false);
+    await expect(checkIfValidMedplumVersion('test', '3.1.6-alpha')).resolves.toStrictEqual(false);
   });
 
   test('Version not found', async () => {
@@ -81,7 +81,7 @@ describe('checkIfValidMedplumVersion', () => {
       }) as unknown as typeof globalThis.fetch
     );
 
-    await expect(checkIfValidMedplumVersion('3.1.8')).resolves.toStrictEqual(false);
+    await expect(checkIfValidMedplumVersion('test', '3.1.8')).resolves.toStrictEqual(false);
     fetchSpy.mockRestore();
   });
 
@@ -96,7 +96,7 @@ describe('checkIfValidMedplumVersion', () => {
         });
       }) as unknown as typeof globalThis.fetch
     );
-    await expect(checkIfValidMedplumVersion('3.1.8')).resolves.toStrictEqual(false);
+    await expect(checkIfValidMedplumVersion('test', '3.1.8')).resolves.toStrictEqual(false);
     fetchSpy.mockRestore();
   });
 
@@ -106,7 +106,7 @@ describe('checkIfValidMedplumVersion', () => {
         return Promise.reject(new Error('Network error'));
       })
     );
-    await expect(checkIfValidMedplumVersion('3.1.8')).resolves.toStrictEqual(false);
+    await expect(checkIfValidMedplumVersion('test', '3.1.8')).resolves.toStrictEqual(false);
     fetchSpy.mockRestore();
   });
 });
@@ -136,12 +136,12 @@ describe('fetchVersionManifest', () => {
         });
       }) as unknown as typeof globalThis.fetch
     );
-    await expect(fetchVersionManifest()).resolves.toMatchObject<ReleaseManifest>(manifest);
+    await expect(fetchVersionManifest('test')).resolves.toMatchObject<ReleaseManifest>(manifest);
     // Should be called with latest
-    expect(fetchSpy).toHaveBeenLastCalledWith(`${GITHUB_RELEASES_URL}/latest`);
+    expect(fetchSpy).toHaveBeenLastCalledWith(`${MEDPLUM_RELEASES_URL}/latest.json`);
     // Call again to make sure we don't refetch
     fetchSpy.mockClear();
-    await expect(fetchVersionManifest()).resolves.toMatchObject<ReleaseManifest>(manifest);
+    await expect(fetchVersionManifest('test')).resolves.toMatchObject<ReleaseManifest>(manifest);
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
@@ -166,12 +166,12 @@ describe('fetchVersionManifest', () => {
         });
       }) as unknown as typeof globalThis.fetch
     );
-    await expect(fetchVersionManifest('3.1.6')).resolves.toMatchObject<ReleaseManifest>(manifest);
+    await expect(fetchVersionManifest('test', '3.1.6')).resolves.toMatchObject<ReleaseManifest>(manifest);
     // Should be called with latest
-    expect(fetchSpy).toHaveBeenLastCalledWith(`${GITHUB_RELEASES_URL}/tags/v3.1.6`);
+    expect(fetchSpy).toHaveBeenLastCalledWith(`${MEDPLUM_RELEASES_URL}/v3.1.6.json`);
     // Call again to make sure we don't refetch
     fetchSpy.mockClear();
-    await expect(fetchVersionManifest('3.1.6')).resolves.toMatchObject<ReleaseManifest>(manifest);
+    await expect(fetchVersionManifest('test', '3.1.6')).resolves.toMatchObject<ReleaseManifest>(manifest);
     expect(fetchSpy).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
@@ -182,7 +182,7 @@ describe('fetchVersionManifest', () => {
         return Promise.reject(new Error('Network request failed'));
       })
     );
-    await expect(fetchVersionManifest('3.1.6')).rejects.toThrow('Network request failed');
+    await expect(fetchVersionManifest('test', '3.1.6')).rejects.toThrow('Network request failed');
     fetchSpy.mockRestore();
   });
 
@@ -197,7 +197,7 @@ describe('fetchVersionManifest', () => {
         });
       }) as unknown as typeof globalThis.fetch
     );
-    await expect(fetchVersionManifest('3.1.6')).rejects.toThrow(
+    await expect(fetchVersionManifest('test', '3.1.6')).rejects.toThrow(
       "Received status code 404 while fetching manifest for version '3.1.6'. Message: Not Found"
     );
     fetchSpy.mockRestore();
@@ -229,7 +229,7 @@ describe('fetchLatestVersionString', () => {
         });
       }) as unknown as typeof globalThis.fetch
     );
-    await expect(fetchLatestVersionString()).resolves.toStrictEqual('3.1.6');
+    await expect(fetchLatestVersionString('test')).resolves.toStrictEqual('3.1.6');
     fetchSpy.mockRestore();
   });
 
@@ -253,7 +253,7 @@ describe('fetchLatestVersionString', () => {
         });
       }) as unknown as typeof globalThis.fetch
     );
-    await expect(fetchLatestVersionString()).rejects.toThrow(
+    await expect(fetchLatestVersionString('test')).rejects.toThrow(
       "Invalid release name found. Release tag 'canary' did not start with 'v'"
     );
     fetchSpy.mockRestore();

--- a/packages/core/src/version-utils.ts
+++ b/packages/core/src/version-utils.ts
@@ -52,7 +52,7 @@ export async function fetchVersionManifest(
   let manifest = releaseManifests.get(version ?? 'latest');
   if (!manifest) {
     const versionTag = version ? `v${version}` : 'latest';
-    const url = new URL(`${versionTag}.json`, MEDPLUM_RELEASES_URL);
+    const url = new URL(`${MEDPLUM_RELEASES_URL}/${versionTag}.json`);
     url.searchParams.set('a', appName);
     url.searchParams.set('c', MEDPLUM_VERSION);
     if (params) {
@@ -60,7 +60,7 @@ export async function fetchVersionManifest(
         url.searchParams.set(key, value);
       }
     }
-    const res = await fetch(`${MEDPLUM_RELEASES_URL}/${versionTag}.json`);
+    const res = await fetch(url.toString());
     if (res.status !== 200) {
       let message: string | undefined;
       try {

--- a/packages/core/src/version-utils.ts
+++ b/packages/core/src/version-utils.ts
@@ -1,6 +1,7 @@
+import { MEDPLUM_VERSION } from './client';
 import { normalizeErrorString } from './outcomes';
 
-export const GITHUB_RELEASES_URL = 'https://api.github.com/repos/medplum/medplum/releases';
+export const MEDPLUM_RELEASES_URL = 'https://meta.medplum.com/releases';
 
 export type ReleaseManifest = { tag_name: string; assets: { name: string; browser_download_url: string }[] };
 
@@ -37,14 +38,29 @@ export function assertReleaseManifest(candidate: unknown): asserts candidate is 
 }
 
 /**
+ * Fetches the manifest for a given Medplum release version.
+ * @param appName - The name of the app to fetch the manifest for.
  * @param version - The version to fetch. If no `version` is provided, defaults to the `latest` version.
+ * @param params - An optional list of key-value pairs to be appended to the URL query string.
  * @returns - The manifest for the specified or latest version.
  */
-export async function fetchVersionManifest(version?: string): Promise<ReleaseManifest> {
+export async function fetchVersionManifest(
+  appName: string,
+  version?: string,
+  params?: [string, string][]
+): Promise<ReleaseManifest> {
   let manifest = releaseManifests.get(version ?? 'latest');
   if (!manifest) {
-    const versionTag = version ? `tags/v${version}` : 'latest';
-    const res = await fetch(`${GITHUB_RELEASES_URL}/${versionTag}`);
+    const versionTag = version ? `v${version}` : 'latest';
+    const url = new URL(`${versionTag}.json`, MEDPLUM_RELEASES_URL);
+    url.searchParams.set('a', appName);
+    url.searchParams.set('c', MEDPLUM_VERSION);
+    if (params) {
+      for (const [key, value] of params) {
+        url.searchParams.set(key, value);
+      }
+    }
+    const res = await fetch(`${MEDPLUM_RELEASES_URL}/${versionTag}.json`);
     if (res.status !== 200) {
       let message: string | undefined;
       try {
@@ -79,15 +95,16 @@ export function isValidMedplumSemver(version: string): boolean {
 
 /**
  * Tests that a given version string is a valid existing Medplum release version.
+ * @param appName - The name of the app to check the version for.
  * @param version - A version to be checked against the existing Medplum repo releases.
  * @returns `true` if `version` is a valid semver version that corresponds to an existing release, otherwise `false`.
  */
-export async function checkIfValidMedplumVersion(version: string): Promise<boolean> {
+export async function checkIfValidMedplumVersion(appName: string, version: string): Promise<boolean> {
   if (!isValidMedplumSemver(version)) {
     return false;
   }
   try {
-    await fetchVersionManifest(version);
+    await fetchVersionManifest(appName, version);
   } catch (_err) {
     return false;
   }
@@ -95,10 +112,12 @@ export async function checkIfValidMedplumVersion(version: string): Promise<boole
 }
 
 /**
+ * Fetches the latest Medplum release version string.
+ * @param appName - The name of the app to fetch the latest version for.
  * @returns A version string corresponding to the latest Medplum release version.
  */
-export async function fetchLatestVersionString(): Promise<string> {
-  const latest = await fetchVersionManifest();
+export async function fetchLatestVersionString(appName: string): Promise<string> {
+  const latest = await fetchVersionManifest(appName);
   if (!latest.tag_name.startsWith('v')) {
     throw new Error(`Invalid release name found. Release tag '${latest.tag_name}' did not start with 'v'`);
   }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -143,7 +143,9 @@ function errorHandler(err: any, req: Request, res: Response, next: NextFunction)
 }
 
 export async function initApp(app: Express, config: MedplumServerConfig): Promise<http.Server> {
-  await warnIfNewerVersionAvailable('server', { base: config.baseUrl });
+  if (process.env.NODE_ENV !== 'test') {
+    await warnIfNewerVersionAvailable('server', { base: config.baseUrl });
+  }
 
   await initAppServices(config);
   server = http.createServer(app);


### PR DESCRIPTION
Before: We used `api.github.com` to check for latest versions, and download URLs

After:  We use `meta.medplum.com` for the same API calls