### PR TITLE
fix: add `storageDomainName` to `content-src` in CDK security headers

### DIFF
--- a/packages/cdk/src/frontend.ts
+++ b/packages/cdk/src/frontend.ts
@@ -72,7 +72,7 @@ export class FrontEnd extends Construct {
               `default-src 'none'`,
               `base-uri 'self'`,
               `child-src 'self'`,
-              `connect-src 'self' ${config.apiDomainName} *.google.com`,
+              `connect-src 'self' ${config.apiDomainName} ${config.storageDomainName} *.google.com`,
               `font-src 'self' fonts.gstatic.com`,
               `form-action 'self' *.gstatic.com *.google.com`,
               `frame-ancestors 'none'`,


### PR DESCRIPTION
Fixes #5729 