### PR TITLE
Do not modify resources used by post-commit hook

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -657,8 +657,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       await this.handleBinaryUpdate(existing, result);
       await addBackgroundJobs(result, existing, { interaction: create ? 'create' : 'update' });
     });
-    this.removeHiddenFields(result);
-    return result;
+
+    const output = deepClone(result);
+    return this.removeHiddenFields(output);
   }
 
   /**


### PR DESCRIPTION
In order to prevent issues where an access policy could remove fields that might affect processing of subscriptions or other post-commit background jobs, the fields are instead stripped from a copy of the resource