### PR TITLE
Use uuid v7 for resourceIds

### DIFF
--- a/packages/server/src/fhir/operations/projectclone.ts
+++ b/packages/server/src/fhir/operations/projectclone.ts
@@ -1,7 +1,6 @@
 import { created, forbidden, getResourceTypes, isResourceType, Operator } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Binary, Project, Resource, ResourceType } from '@medplum/fhirtypes';
-import { randomUUID } from 'node:crypto';
 import { getAuthenticatedContext } from '../../context';
 import { Repository } from '../repo';
 import { getBinaryStorage } from '../storage';
@@ -65,7 +64,7 @@ class ProjectCloner {
         if (!entry.resource || !this.isAllowedResourceId(entry.resource.id as string)) {
           continue;
         }
-        this.idMap.set(entry.resource.id as string, randomUUID());
+        this.idMap.set(entry.resource.id as string, repo.generateId());
         buildBinaryIds(entry.resource, binaryIds);
         if (entry.resource.resourceType !== 'Project') {
           allResources.push(entry.resource);
@@ -77,7 +76,7 @@ class ProjectCloner {
     if (this.isAllowedResourceType('Binary')) {
       for (const binaryId of binaryIds) {
         const binary = await repo.readResource<Binary>('Binary', binaryId);
-        this.idMap.set(binary.id as string, randomUUID());
+        this.idMap.set(binary.id as string, repo.generateId());
         allResources.push(binary);
       }
     }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -59,7 +59,6 @@ import {
   SearchParameter,
   StructureDefinition,
 } from '@medplum/fhirtypes';
-import { randomUUID } from 'node:crypto';
 import { Readable } from 'node:stream';
 import { Pool, PoolClient } from 'pg';
 import { Operation } from 'rfc6902';
@@ -107,6 +106,7 @@ import {
   periodToRangeString,
 } from './sql';
 import { getBinaryStorage } from './storage';
+import { v7 } from 'uuid';
 
 const transactionAttempts = 2;
 const retryableTransactionErrorCodes = ['40001'];
@@ -273,7 +273,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
   }
 
   generateId(): string {
-    return randomUUID();
+    return v7();
   }
 
   async readResource<T extends Resource>(
@@ -615,7 +615,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
     const resultMeta: Meta = {
       ...updated.meta,
-      versionId: randomUUID(),
+      versionId: this.generateId(),
       lastUpdated: this.getLastUpdated(existing, resource),
       author: this.getAuthor(resource),
       onBehalfOf: this.context.onBehalfOf,
@@ -1023,7 +1023,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         await new InsertQuery(resourceType + '_History', [
           {
             id,
-            versionId: randomUUID(),
+            versionId: this.generateId(),
             lastUpdated,
             content,
           },


### PR DESCRIPTION
We've been discussing this change for quite a while. The benefit being less churn/computation when Postgres is updating the btree indexes covering resource IDs...in other words, faster writes.