### PR TITLE
Azure helm chart

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if (eq .Values.global.cloudProvider "azure") }}
+        azure.workload.identity/use: "true"
+        {{- end }}
     spec:
       {{- with .Values.deployment.imagePullSecrets }}
       imagePullSecrets:
@@ -45,6 +48,9 @@ spec:
             {{- if (eq .Values.global.cloudProvider "gcp") }}
             - "gcp:{{ .Values.global.gcp.projectId }}:{{ .Values.global.gcp.secretId }}"
             {{- end }}
+            {{- if (eq .Values.global.cloudProvider "azure") }}
+            - "azure:{{ .Values.global.azure.keyVaultURL }}:{{ .Values.global.azure.secretName }}"
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort | default 8103 }}
@@ -53,15 +59,15 @@ spec:
             httpGet:
               path: /healthcheck
               port: {{ .Values.service.targetPort | default 8103 }}
+              initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /healthcheck
               port: {{ .Values.service.targetPort | default 8103 }}
+          env:
+            {{- toYaml .Values.deployment.env | nindent 12 }}
           resources:
-            limits:
-              memory: "512Mi"
-            requests:
-              memory: "256Mi"
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -24,3 +24,31 @@ spec:
                 port:
                   number: {{ .Values.service.port | default 80 }}
 {{- end }}
+
+{{- if and (eq .Values.global.cloudProvider "azure") (eq .Values.ingress.deploy true) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "medplum.fullname" . }}
+  namespace: {{ include "medplum.namespace" . }}
+  labels:
+    {{- include "medplum.labels" . | nindent 4 }}
+spec:
+  tls:
+    - hosts:
+      - {{ .Values.ingress.domain }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+  ingressClassName: azure-application-gateway
+  rules:
+  - host: {{ .Values.ingress.domain }}
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: {{ include "medplum.fullname" . }}-service
+            port:
+              number: {{ .Values.service.port | default 80 }}
+
+{{- end }}

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.global.cloudProvider "gcp" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +9,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if eq .Values.global.cloudProvider "gcp" }}
 automountServiceAccountToken: true
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -3,14 +3,20 @@
 # Declare variables to be passed into your templates.
 
 global:
-  cloudProvider: gcp # Supported values: gcp. # roadmap: aws, azure
+  cloudProvider: gcp # Supported values: gcp, azure
+  # GCP required values
   gcp:
     projectId: [MY_PROJECT_ID] # Your Google Cloud Platform project ID
-    secretId: [MY_CONFIG_SECRET_ID] # The secret ID for configuration in Google Cloud Platform
+    secretId: [MY_CONFIG_SECRET_ID] # The configuration secret ID in Google Cloud Platform
+  # Azure required values
+  azure:
+    keyVaultURL: [MY_KEYVAULT_URL] # Your Azure Key Vault URL
+    secretName: [MY_CONFIG_SECRET_NAME] # The configuration secret Name in Azure
  
 serviceAccount: 
   annotations:
     iam.gke.io/gcp-service-account: [MY_GCP_SERVICE_ACCOUNT] # Your Google Cloud Platform service account e.i: medplum-server@[MY_PROJECT_ID].iam.gserviceaccount.com
+    # azure.workload.identity/client-id: "7f644391-4b27-4f76-8427-17bae90d7ee8" # Azure Managed Identity Client ID
 
 namespace: medplum
 
@@ -19,11 +25,21 @@ deployment:
   image:
     repository: medplum/medplum-server
     tag: latest
-
+  env:
+    # - name: SQL_DEBUG
+    #   value: '*'
+  resources:
+    requests:
+      memory: "1Gi"
+    limits:
+      memory: "2Gi"
   autoscaling:
     enabled: true
+
+service: {}
 
 ingress:
   deploy: true
   domain: [MY_DOMAIN] # Your domain name
+  tlsSecretName: [TLS_SECRET_NAME] # Azure only
   


### PR DESCRIPTION
This PR modifies the helm chart to support Azure.

AZURE ONLY: If deploy `ingress=true`, an Application Gateway must already be present in Azure.
`ingressClassName: azure-application-gateway`