### PR TITLE
actions(publish-meta): Make sure `Publish` runs first

### DIFF
--- a/.github/workflows/publish-meta.yml
+++ b/.github/workflows/publish-meta.yml
@@ -1,9 +1,12 @@
 name: Publish meta
 
 on:
-  push:
-    tags:
-      - 'v*'
+  # We publish meta on workflow run since the release manifest requires artifacts of agent build steps
+  # to be present in the GitHub release manifest that are built and only present after the Publish step runs
+  workflow_run:
+    workflows: [Publish]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I noticed that on localhost when using latest build that I consistently was getting this message in console at startup:
`Failed to check for newer version: Manifest missing assets list`

I console.log'd the manifest for the latest version that comes from `meta.medplum.com` and this is what it looked like:
<img width="802" alt="Screenshot 2025-01-11 at 11 18 04 AM" src="https://github.com/user-attachments/assets/6c20fae8-7594-4306-90ab-08d7dd82c60b" />

It's missing assets for the latest version, which makes sense since the workflow to publish the metadata was running concurrently with the workflow that actually builds and publishes the agent builds to the release assets.

This PR makes it so the `Publish meta` workflow always runs after the `Publish` workflow is completed.
