### PR TITLE
actions(upgrade-deps): make sure pr exists before step 2

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -88,8 +88,9 @@ fi
 
 # Check if there is a PR for this branch already
 # Skip creation if there is, otherwise create the PR for this branch
-PR_VIEW_RESULT=$(gh pr view &>/dev/null)
-if [ "$PR_VIEW_RESULT" -ne 0 ]; then
+gh pr view &>/dev/null || true
+PR_VIEW_EXIT_CODE=$?
+if [ "$PR_VIEW_EXIT_CODE" -ne 0 ]; then
     echo "No existing PR found, creating PR..."
     gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --draft
 else

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -84,10 +84,16 @@ if [ "$LAST_STEP" -lt 1 ]; then
     git add -u .
     git commit -m "Dependency upgrades - step 1"
     git push origin "$BRANCH_NAME"
-    
-    if [ "$LAST_STEP" -eq 0 ]; then
-        gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --draft
-    fi
+fi
+
+# Check if there is a PR for this branch already
+# Skip creation if there is, otherwise create the PR for this branch
+PR_VIEW_RESULT=$(gh pr view &>/dev/null)
+if [ "$PR_VIEW_RESULT" -ne 0 ]; then
+    echo "No existing PR found, creating PR..."
+    gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --draft
+else
+    echo "Existing PR found, skipping create"
 fi
 
 if [ "$LAST_STEP" -lt 2 ]; then

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -86,10 +86,17 @@ if [ "$LAST_STEP" -lt 1 ]; then
     git push origin "$BRANCH_NAME"
 fi
 
+# Temporarily unset -e flag so that script won't exit early on next error
+set +e
+
 # Check if there is a PR for this branch already
 # Skip creation if there is, otherwise create the PR for this branch
-gh pr view &>/dev/null || true
+gh pr view
 PR_VIEW_EXIT_CODE=$?
+
+# Set the -e flag back 
+set -e
+
 if [ "$PR_VIEW_EXIT_CODE" -ne 0 ]; then
     echo "No existing PR found, creating PR..."
     gh pr create --title "Dependency upgrades $DATE" --body "Dependency upgrades" --draft


### PR DESCRIPTION
This PR makes sure the PR exists before step 2, whether this is the first run or if we've already completed step 1 in a previous run.

We had a failure in step 1 where the PR wasn't opened but the branch existed already so we skipped the PR creation in the second run of the workflow and when the workflow got to `gh pr ready` there was no existing PR to ready.

This should prevent that from happening in the future.