### PR TITLE
Gracefully handle invalide client redirect URI in authorize

### DIFF
--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -59,7 +59,18 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
     return false;
   }
 
-  if (client.redirectUri !== params.redirect_uri) {
+  const redirectUri = client.redirectUri;
+  if (!redirectUri) {
+    res.status(400).send('Client has no redirect URI');
+    return false;
+  }
+
+  if (!URL.canParse(redirectUri)) {
+    res.status(400).send('Invalid redirect URI');
+    return false;
+  }
+
+  if (redirectUri !== params.redirect_uri) {
     res.status(400).send('Incorrect redirect_uri');
     return false;
   }
@@ -70,25 +81,25 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
   // If these are invalid, redirect back to the redirect URI.
   const scope = params.scope as string | undefined;
   if (!scope) {
-    sendErrorRedirect(res, client.redirectUri as string, 'invalid_request', state);
+    sendErrorRedirect(res, redirectUri, 'invalid_request', state);
     return false;
   }
 
   const responseType = params.response_type;
   if (responseType !== 'code') {
-    sendErrorRedirect(res, client.redirectUri as string, 'unsupported_response_type', state);
+    sendErrorRedirect(res, redirectUri, 'unsupported_response_type', state);
     return false;
   }
 
   const requestObject = params.request as string | undefined;
   if (requestObject) {
-    sendErrorRedirect(res, client.redirectUri as string, 'request_not_supported', state);
+    sendErrorRedirect(res, redirectUri, 'request_not_supported', state);
     return false;
   }
 
   const aud = params.aud as string | undefined;
   if (!isValidAudience(aud)) {
-    sendErrorRedirect(res, client.redirectUri as string, 'invalid_request', state);
+    sendErrorRedirect(res, redirectUri, 'invalid_request', state);
     return false;
   }
 
@@ -96,7 +107,7 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
   if (codeChallenge) {
     const codeChallengeMethod = params.code_challenge_method;
     if (!codeChallengeMethod) {
-      sendErrorRedirect(res, client.redirectUri as string, 'invalid_request', state);
+      sendErrorRedirect(res, redirectUri, 'invalid_request', state);
       return false;
     }
   }
@@ -105,7 +116,7 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
 
   const prompt = params.prompt as string | undefined;
   if (prompt === 'none' && !existingLogin) {
-    sendErrorRedirect(res, client.redirectUri as string, 'login_required', state);
+    sendErrorRedirect(res, redirectUri, 'login_required', state);
     return false;
   }
 


### PR DESCRIPTION
Using the `/oauth2/authorize` endpoint with a `ClientApplication` with an invalid `redirectUri` was causing HTTP 500 errors. 

This fixes that, and returns HTTP 400 with a better error message.

![image](https://github.com/user-attachments/assets/2de53019-5d2c-4ac6-9281-160259dd6780)
