### PR TITLE
Gracefully handle external auth provider missing email

### DIFF
--- a/packages/server/src/auth/external.ts
+++ b/packages/server/src/auth/external.ts
@@ -66,9 +66,17 @@ export const externalCallbackHandler = async (req: Request, res: Response): Prom
   let email: string | undefined = undefined;
   let externalId: string | undefined = undefined;
   if (idp.useSubject) {
-    externalId = userInfo.sub as string;
+    externalId = userInfo.sub as string | undefined;
+    if (!externalId) {
+      sendOutcome(res, badRequest('External token does not contain subject'));
+      return;
+    }
   } else {
-    email = (userInfo.email as string).toLowerCase();
+    email = (userInfo.email as string | undefined)?.toLowerCase();
+    if (!email) {
+      sendOutcome(res, badRequest('External token does not contain email address'));
+      return;
+    }
   }
 
   if (body.domain && !email?.endsWith('@' + body.domain)) {


### PR DESCRIPTION
Setup:
* Using a `ClientApplication` with external auth
* Token URL is valid and returns valid JWTs
* JWT is missing email address though, so cannot authenticate

Before, the server would return HTTP 500 due to calling `toLowerCase()` on undefined email address.

After, adding more explicit error messages for both missing "email" and missing "sub".

![image](https://github.com/user-attachments/assets/8c2fe266-c982-4de0-af4e-930d0612eb39)
