### PR TITLE
Fixes #5257 - Update README & Public Docs to be consistent for Bots

### DIFF
--- a/examples/medplum-demo-bots/README.md
+++ b/examples/medplum-demo-bots/README.md
@@ -52,7 +52,7 @@ npm t
 Deploy one bot:
 
 ```bash
-npx medplum deploy-bot sample-account-setup
+npx medplum bot deploy sample-account-setup
 ```
 
 You will see the following in your command prompt if all goes well:

--- a/examples/medplum-demo-bots/README.md
+++ b/examples/medplum-demo-bots/README.md
@@ -25,6 +25,8 @@ To set up your bot deployment you will need to do the following:
 - Create a .env file locally by copying `.env.example` and putting the `ClientId` and `ClientSecret` from the `ClientApplication` into the file.
 - (Optional) Create an [AccessPolicy](<(https://app.medplum.com/AccessPolicy)>) on Medplum that can only read/write Bots and add it to the Bot in the [admin panel](https://app.medplum.com/admin/project).
 
+Medplum bots can also be created, edited, and deployed entirely from the medplum app. See [creating a bot](https://www.medplum.com/docs/bots/bot-basics#creating-a-bot)
+
 ## Installation
 
 To run and deploy your Bot do the following steps:

--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -127,7 +127,7 @@ Because these properties may be undefined, we make heavy use of the Javascript [
 
 ## Deploying a Bot
 
-Clicking "Save" in the **Editor** tab persists your Bot code to the Medplum database, but _doesn't_ deploy your to run in production.
+Clicking "Save" in the **Editor** tab persists your Bot code to the Medplum database, but _doesn't_ deploy it to run in production.
 To deploy your bot, click the "Deploy" button.
 
 ![Deploy Button](/img/app/bots/deploy_button.png)
@@ -137,6 +137,42 @@ This works well for initial prototyping, but as you get closer to a production i
 **Medplum Bots** are run as [AWS Lambdas](https://aws.amazon.com/lambda/) and in heavily sandboxed environments.
 You can apply an [AccessPolicy](/docs/access/access-policies) to the Bot if you want to further reduce the data it can read and write.
 
+### Creating and Deploying Bot from your IDE instead of Editor tab
+
+Alternatively, you can also write the code for a Bot and deploy from within your IDE.
+
+- [Create a Bot](https://app.medplum.com/admin/project) on Medplum and note its `id`. (All Bots in your account can be found [here](https://app.medplum.com/Bot))
+- Create a new typescript file (e.g. `my-bot.ts`) and copy the contents of `examples/hello-patient.ts` into your new file.
+- With the `id` of the Bot `id` in hand, add a section to `medplum.config.json` like so
+
+```json
+{
+  "name": "sample-account-setup",
+  "id": "aa3a0383-a97b-4172-b65d-430f6241646f",
+  "source": "src/examples/sample-account-setup.ts",
+  "dist": "dist/sample-account-setup.js"
+}
+```
+
+- [Create a ClientApplication](https://app.medplum.com/ClientApplication/new) on Medplum. (All ClientApplications in your account can be found [here](https://app.medplum.com/ClientApplication))
+- Create a .env file locally by copying `.env.example` and putting the `ClientId` and `ClientSecret` from the `ClientApplication` into the file.
+- (Optional) Create an [AccessPolicy](<(https://app.medplum.com/AccessPolicy)>) on Medplum that can only read/write Bots and add it to the Bot in the [admin panel](https://app.medplum.com/admin/project).
+
+
+Deploy your bot:
+
+```bash
+npx medplum deploy-bot sample-account-setup
+```
+
+You will see the following in your command prompt if all goes well:
+
+```bash
+Update bot code.....
+Success! New bot version: 7fcbc375-4192-471c-b874-b3f0d4676226
+Deploying bot...
+Deploy result: All OK
+```
 ## Executing a Bot
 
 Once your bot has been [saved](#editing-a-bot) and [deployed](#deploying-a-bot), it is time to execute the bot.

--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -154,25 +154,8 @@ Alternatively, you can also write the code for a Bot and deploy from within your
 }
 ```
 
-- [Create a ClientApplication](https://app.medplum.com/ClientApplication/new) on Medplum. (All ClientApplications in your account can be found [here](https://app.medplum.com/ClientApplication))
-- Create a .env file locally by copying `.env.example` and putting the `ClientId` and `ClientSecret` from the `ClientApplication` into the file.
-- (Optional) Create an [AccessPolicy](https://app.medplum.com/AccessPolicy) on Medplum that can only read/write Bots and add it to the Bot in the [admin panel](https://app.medplum.com/admin/project).
+Then, you can [deploy your bot from command line](/docs/bots/bots-in-production#deploying-your-bot)
 
-
-Deploy your bot:
-
-```bash
-npx medplum deploy-bot sample-account-setup
-```
-
-You will see the following in your command prompt if all goes well:
-
-```bash
-Update bot code.....
-Success! New bot version: 7fcbc375-4192-471c-b874-b3f0d4676226
-Deploying bot...
-Deploy result: All OK
-```
 ## Executing a Bot
 
 Once your bot has been [saved](#editing-a-bot) and [deployed](#deploying-a-bot), it is time to execute the bot.

--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -156,7 +156,7 @@ Alternatively, you can also write the code for a Bot and deploy from within your
 
 - [Create a ClientApplication](https://app.medplum.com/ClientApplication/new) on Medplum. (All ClientApplications in your account can be found [here](https://app.medplum.com/ClientApplication))
 - Create a .env file locally by copying `.env.example` and putting the `ClientId` and `ClientSecret` from the `ClientApplication` into the file.
-- (Optional) Create an [AccessPolicy](<(https://app.medplum.com/AccessPolicy)>) on Medplum that can only read/write Bots and add it to the Bot in the [admin panel](https://app.medplum.com/admin/project).
+- (Optional) Create an [AccessPolicy](https://app.medplum.com/AccessPolicy) on Medplum that can only read/write Bots and add it to the Bot in the [admin panel](https://app.medplum.com/admin/project).
 
 
 Deploy your bot:

--- a/packages/docs/docs/bots/bot-basics.md
+++ b/packages/docs/docs/bots/bot-basics.md
@@ -148,7 +148,7 @@ Alternatively, you can also write the code for a Bot and deploy from within your
 ```json
 {
   "name": "sample-account-setup",
-  "id": "aa3a0383-a97b-4172-b65d-430f6241646f",
+  "id": "<BOT_ID>",
   "source": "src/examples/sample-account-setup.ts",
   "dist": "dist/sample-account-setup.js"
 }


### PR DESCRIPTION
The medplum-demo-bots README and external public docs had some inconsistencies with respect to creation and deployment of bots:

- On the medplum-demo-bots README, I added link to public docs explaining how to build and deploy bots from medplum app
- On public facing docs (bot-basics.md), I added a new section "Creating and Deploying Bot from your IDE instead of Editor tab" that documents the alternative CLI-based approach referenced in medplum-demo-bots README