### PR TITLE
Remove ARMv7 build

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -38,7 +38,7 @@ tar \
 ATTESTATIONS="--provenance=true --sbom=true"
 
 # Target platforms
-PLATFORMS="--platform linux/amd64,linux/arm64,linux/arm/v7"
+PLATFORMS="--platform linux/amd64,linux/arm64"
 
 # Build tags
 TAGS="--tag $DOCKERHUB_REPOSITORY:latest --tag $DOCKERHUB_REPOSITORY:$GITHUB_SHA"


### PR DESCRIPTION
ARMv7 is a legacy 32-bit architecture, and is unlikely to work properly with Medplum.  Removing it from the build should speed up the build process