### PR TITLE
fix(fhircast): make websockets work after endpoint changes

### DIFF
--- a/packages/server/src/fhircast/routes.test.ts
+++ b/packages/server/src/fhircast/routes.test.ts
@@ -326,8 +326,10 @@ describe('FHIRCast routes', () => {
       expect(subRes.status).toBe(202);
       expect(subRes.body['hub.channel.endpoint']).toBeDefined();
 
+      const pathname = new URL(subRes.body['hub.channel.endpoint']).pathname;
+
       await request(server)
-        .ws('/ws/fhircast/topic')
+        .ws(pathname)
         .expectJson((obj) => {
           // Connection verification message
           expect(obj['hub.topic']).toBe('topic');

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -17,7 +17,19 @@ export async function handleFhircastConnection(socket: ws.WebSocket, request: In
 
   const projectAndTopic = await getRedis().get(endpointTopicKey);
   if (!projectAndTopic) {
-    throw new Error('No topic associated with this endpoint');
+    globalLogger.error(`[FHIRcast]: No topic associated with the endpoint '${topicEndpoint}'`);
+    // Close the socket since this endpoint is not valid
+    socket.send(
+      JSON.stringify({
+        'hub.mode': 'denied',
+        'hub.topic': '',
+        'hub.events': '',
+        'hub.reason': 'invalid endpoint',
+      }),
+      { binary: false }
+    );
+    socket.close();
+    return;
   }
 
   // Create a redis client for this connection.


### PR DESCRIPTION
This fixes an error where endpoints were not properly associated with topics on the WebSocket side.

This was accomplished by doing a reverse lookup in Redis for `endpoint` -> `"${project}:${topic}"` so that when a client connects to the endpoint returned from a FHIRcast subscription request, that the server can find which project and topic this endpoint is actually associated with.

This PR also fixes the tests to make sure that the endpoint associated with a topic is actually used in the tests.