### PR TITLE
docs(server): add instructions about how to run tests to `README.md`

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -35,6 +35,20 @@ GRANT ALL PRIVILEGES ON DATABASE medplum_test TO medplum;
 npm run dev
 ```
 
+## Running tests
+
+To run the tests, first you need to seed your test database with the required foundational resources, such as `StructureDefinition`s, `ValueSet`s, `SearchParameter`s, and the default admin account resources. To do this run the command:
+
+```bash
+npm run test:seed
+```
+
+After waiting for the seed test to complete, you can then run the rest of the server tests by running:
+
+```bash
+npm run test
+```
+
 ## Production build
 
 ```

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -37,7 +37,7 @@ npm run dev
 
 ## Running tests
 
-To run the tests, first you need to seed your test database with the required foundational resources, such as `StructureDefinition`s, `ValueSet`s, `SearchParameter`s, and the default admin account resources. To do this run the command:
+Before running tests for the first time on a clean database, you first need to seed your test database with the required foundational resources, such as `StructureDefinition`s, `ValueSet`s, `SearchParameter`s, and the default admin account resources. To do this run the command:
 
 ```bash
 npm run test:seed


### PR DESCRIPTION
Realized it's not clear that you need to run `test:seed` before running tests on the server. This PR just adds some instructions about how to run tests to the README.