### PR TITLE
fix(fhircast): make sure only one heartbeat listener for all of FHIRcast

### DIFF
--- a/packages/server/src/fhircast/websocket.test.ts
+++ b/packages/server/src/fhircast/websocket.test.ts
@@ -235,7 +235,7 @@ describe('FHIRcast WebSocket', () => {
                 const endTime = Date.now();
 
                 // setInterval doesn't guarantee a minimum time between executions, so we give a little leniency for the 100ms
-                expect(endTime - startTime).toBeGreaterThanOrEqual(95);
+                expect(endTime - startTime).toBeGreaterThanOrEqual(90);
               })
               // We're just expecting the two calls we already caught in the above exec
               .expectJson((obj) => {

--- a/packages/server/src/fhircast/websocket.test.ts
+++ b/packages/server/src/fhircast/websocket.test.ts
@@ -1,6 +1,7 @@
 import { ContentType, serializeFhircastSubscriptionRequest } from '@medplum/core';
 import express, { Express } from 'express';
 import { randomUUID } from 'node:crypto';
+import { once } from 'node:events';
 import { Server } from 'node:http';
 import request from 'superwstest';
 import { initApp, shutdownApp } from '../app';
@@ -125,7 +126,7 @@ describe('FHIRcast WebSocket', () => {
     beforeAll(async () => {
       app = express();
       config = await loadTestConfig();
-      config.heartbeatMilliseconds = 25;
+      config.heartbeatMilliseconds = 100;
       server = await initApp(app, config);
       accessToken = await initTestAuth({ membership: { admin: true } });
       await new Promise<void>((resolve) => {
@@ -166,16 +167,21 @@ describe('FHIRcast WebSocket', () => {
             expect(obj['hub.topic']).toBe(topic);
           })
           .expectJson((obj) => {
-            // Event message
-            expect(obj.event['hub.topic']).toBe(topic);
-            expect(obj.event['hub.event']).toBe('heartbeat');
+            expect(obj).toMatchObject({
+              id: expect.any(String),
+              timestamp: expect.any(String),
+              event: {
+                context: [{ key: 'period', decimal: '10' }],
+                'hub.event': 'heartbeat',
+              },
+            });
           })
           .sendJson({ ok: true })
           .close()
           .expectClosed();
       }));
 
-    test('Check that timer and promises are cleaned up after no topics active', () =>
+    test('Make sure that we only get one heartbeat per tick for a given topic', () =>
       withTestContext(async () => {
         const topic = randomUUID();
 
@@ -207,6 +213,43 @@ describe('FHIRcast WebSocket', () => {
             // Event message
             expect(obj.event['hub.topic']).toBe(topic);
             expect(obj.event['hub.event']).toBe('heartbeat');
+          })
+          .exec(async () => {
+            // Now open up a second connection in order to test that we don't get duplicate heartbeats with multiple clients
+            await request(server)
+              .ws(pathname)
+              .expectJson((obj) => {
+                // Connection verification message
+                expect(obj['hub.topic']).toBe(topic);
+              })
+              .expectJson((obj) => {
+                // Event message
+                expect(obj.event['hub.topic']).toBe(topic);
+                expect(obj.event['hub.event']).toBe('heartbeat');
+              })
+              .exec(async (ws) => {
+                await once(ws, 'message');
+                // We check that the time between two heartbeats is greater than expected minimum time
+                const startTime = Date.now();
+                await once(ws, 'message');
+                const endTime = Date.now();
+
+                // setInterval doesn't guarantee a minimum time between executions, so we give a little leniency for the 100ms
+                expect(endTime - startTime).toBeGreaterThanOrEqual(95);
+              })
+              // We're just expecting the two calls we already caught in the above exec
+              .expectJson((obj) => {
+                // Event message
+                expect(obj.event['hub.topic']).toBe(topic);
+                expect(obj.event['hub.event']).toBe('heartbeat');
+              })
+              .expectJson((obj) => {
+                // Event message
+                expect(obj.event['hub.topic']).toBe(topic);
+                expect(obj.event['hub.event']).toBe('heartbeat');
+              })
+              .close()
+              .expectClosed();
           })
           .sendJson({ ok: true })
           .close()

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -89,6 +89,7 @@ export async function handleFhircastConnection(socket: ws.WebSocket, request: In
   const topic = projectAndTopic?.split(':')[1] ?? 'invalid topic';
   // Increment ref count for the specified topic
   topicRefCountMap.set(projectAndTopic, (topicRefCountMap.get(projectAndTopic) ?? 0) + 1);
+  websocketMap.set(socket, projectAndTopic);
 
   redisSubscriber.on('message', (_channel: string, message: string) => {
     // Forward the message to the client


### PR DESCRIPTION
This PR fixes a bug I noticed when subscribing to the same topic with multiple subscribers where you would get multiple heartbeats per tick. This was because we were creating one listener per subscriber on connect to the FHIRcast WebSocket endpoint.

This PR aligns our FHIRcast heartbeat implementation with the one we use in FHIR WebSocket subscriptions where there is only one driver of heartbeats for all WebSockets / subscriptions.

I also took the opportunity to add some metrics about FHIRcast WebSocket count and number of active topics for FHIRcast.