### PR TITLE
Always populate default search parameters

### DIFF
--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -104,7 +104,7 @@ function buildSearchParameterDetails(resourceType: string, searchParam: SearchPa
       builder.array = true;
       builder.propertyTypes.add('code');
     } else {
-      crawlSearchParameterDetails(builder, flattenAtom(expression), resourceType, 1);
+      crawlSearchParameterDetails(builder, atomArray, resourceType, 1);
     }
 
     // To support US Core "us-core-condition-asserted-date" search parameter without

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,11 +7,12 @@ import {
   Resource,
   ResourceType,
   SearchParameter,
+  StructureDefinition,
 } from '@medplum/fhirtypes';
 import { formatHumanName } from './format';
 import { SearchParameterDetails } from './search/details';
 import { InternalSchemaElement, InternalTypeSchema, getAllDataTypes, tryGetDataType } from './typeschema/types';
-import { capitalize, createReference, flatMapFilter } from './utils';
+import { capitalize, createReference } from './utils';
 
 export type TypeName<T> = T extends string
   ? 'string'
@@ -151,12 +152,12 @@ export function indexSearchParameterBundle(bundle: Bundle<SearchParameter>): voi
   }
 }
 
-export function indexDefaultSearchParameters(bundle: Bundle): void {
-  const sds =
-    flatMapFilter(bundle.entry, (e) => (e.resource?.resourceType === 'StructureDefinition' ? e.resource : undefined)) ??
-    [];
-  for (const sd of sds) {
-    getOrInitTypeSchema(sd.type);
+export function indexDefaultSearchParameters(bundle: StructureDefinition[] | Bundle): void {
+  const maybeSDs = Array.isArray(bundle) ? bundle : (bundle.entry?.map((e) => e.resource) ?? []);
+  for (const sd of maybeSDs) {
+    if (sd?.resourceType === 'StructureDefinition' && sd.kind === 'resource') {
+      getOrInitTypeSchema(sd.type);
+    }
   }
 }
 

--- a/packages/core/src/typeschema/types.ts
+++ b/packages/core/src/typeschema/types.ts
@@ -10,7 +10,7 @@ import { DataTypesMap, inflateBaseSchema } from '../base-schema';
 import baseSchema from '../base-schema.json';
 import { getTypedPropertyValue } from '../fhirpath/utils';
 import { OperationOutcomeError, badRequest } from '../outcomes';
-import { TypedValue, getElementDefinitionTypeName, isResourceTypeSchema } from '../types';
+import { TypedValue, getElementDefinitionTypeName, indexDefaultSearchParameters, isResourceTypeSchema } from '../types';
 import { capitalize, getExtension, isEmpty } from '../utils';
 
 /**
@@ -123,7 +123,9 @@ function getDataTypesMap(profileUrl: string): DataTypesMap {
  * @param bundle - Bundle or array of structure definitions to be parsed and indexed
  */
 export function indexStructureDefinitionBundle(bundle: StructureDefinition[] | Bundle): void {
-  const sds = Array.isArray(bundle) ? bundle : (bundle.entry?.map((e) => e.resource as StructureDefinition) ?? []);
+  const maybeSds = Array.isArray(bundle) ? bundle : (bundle.entry?.map((e) => e.resource) ?? []);
+  const sds: StructureDefinition[] = maybeSds.filter((r) => r?.resourceType === 'StructureDefinition');
+  indexDefaultSearchParameters(sds);
   for (const sd of sds) {
     loadDataType(sd);
   }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -21,7 +21,6 @@
     "generate": "npm run valuesets && npm run fhirtypes && npm run jsonschema && npm run baseschema && npm run mockclient && npm run docs",
     "jsonschema": "ts-node src/jsonschema.ts && npx prettier ../definitions/dist/fhir/r4/fhir.schema.json --write",
     "lint": "eslint .",
-    "migrate": "ts-node src/migrate.ts",
     "mockclient": "ts-node src/mockclient.ts && npx prettier ../mock/src/mocks/*.json --write",
     "test": "jest",
     "valuesets": "ts-node src/valuesets.ts"

--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -1,5 +1,6 @@
 import {
   createReference,
+  Filter,
   getReferenceString,
   LOINC,
   normalizeErrorString,
@@ -3128,10 +3129,14 @@ describe('FHIR Search', () => {
         expect(bundleContains(bundle2, task2)).not.toBeTruthy();
       }));
 
-    test('Resource search params', () =>
-      withTestContext(async () => {
-        const patientIdentifier = randomUUID();
-        const patient = await repo.createResource<Patient>({
+    describe('Resource meta search params', () => {
+      let patientIdentifier: string;
+      let patient: Patient;
+      let identifierFilter: Filter;
+
+      beforeAll(async () => {
+        patientIdentifier = randomUUID();
+        patient = await repo.createResource<Patient>({
           resourceType: 'Patient',
           identifier: [{ system: 'http://example.com', value: patientIdentifier }],
           meta: {
@@ -3141,64 +3146,77 @@ describe('FHIR Search', () => {
             tag: [{ system: 'http://hl7.org/fhir/v3/ObservationValue', code: 'SUBSETTED' }],
           },
         });
-        const identifierFilter = {
+        identifierFilter = {
           code: 'identifier',
           operator: Operator.EQUALS,
           value: patientIdentifier,
         };
+      });
 
-        const bundle1 = await repo.search({
-          resourceType: 'Patient',
-          filters: [
-            identifierFilter,
-            {
-              code: '_profile',
-              operator: Operator.EQUALS,
-              value: 'http://example.com/fhir/a-patient-profile',
-            },
-          ],
-        });
-        expect(bundleContains(bundle1, patient)).toBeTruthy();
+      test('Search by identifier', () =>
+        withTestContext(async () => {
+          const bundle1 = await repo.search({
+            resourceType: 'Patient',
+            filters: [
+              identifierFilter,
+              {
+                code: '_profile',
+                operator: Operator.EQUALS,
+                value: 'http://example.com/fhir/a-patient-profile',
+              },
+            ],
+          });
+          expect(bundleContains(bundle1, patient)).toBeTruthy();
+        }));
 
-        const bundle2 = await repo.search({
-          resourceType: 'Patient',
-          filters: [
-            identifierFilter,
-            {
-              code: '_security',
-              operator: Operator.EQUALS,
-              value: 'http://hl7.org/fhir/v3/Confidentiality|N',
-            },
-          ],
-        });
-        expect(bundleContains(bundle2, patient)).toBeTruthy();
+      test('Search by _security', () =>
+        withTestContext(async () => {
+          const bundle2 = await repo.search({
+            resourceType: 'Patient',
+            filters: [
+              identifierFilter,
+              {
+                code: '_security',
+                operator: Operator.EQUALS,
+                value: 'http://hl7.org/fhir/v3/Confidentiality|N',
+              },
+            ],
+          });
+          expect(bundleContains(bundle2, patient)).toBeTruthy();
+        }));
 
-        const bundle3 = await repo.search({
-          resourceType: 'Patient',
-          filters: [
-            identifierFilter,
-            {
-              code: '_source',
-              operator: Operator.EQUALS,
-              value: 'http://example.org',
-            },
-          ],
-        });
-        expect(bundleContains(bundle3, patient)).toBeTruthy();
+      test('Search by _source', () =>
+        withTestContext(async () => {
+          const bundle3 = await repo.search({
+            resourceType: 'Patient',
+            filters: [
+              identifierFilter,
+              {
+                code: '_source',
+                operator: Operator.EQUALS,
+                value: 'http://example.org',
+              },
+            ],
+          });
+          expect(bundleContains(bundle3, patient)).toBeTruthy();
+        }));
 
-        const bundle4 = await repo.search({
-          resourceType: 'Patient',
-          filters: [
-            identifierFilter,
-            {
-              code: '_tag',
-              operator: Operator.EQUALS,
-              value: 'http://hl7.org/fhir/v3/ObservationValue|SUBSETTED',
-            },
-          ],
-        });
-        expect(bundleContains(bundle4, patient)).toBeTruthy();
-      }));
+      test('Search by _tag', () =>
+        withTestContext(async () => {
+          const bundle4 = await repo.search({
+            resourceType: 'Patient',
+            filters: [
+              identifierFilter,
+              {
+                code: '_tag',
+                operator: Operator.EQUALS,
+                value: 'http://hl7.org/fhir/v3/ObservationValue|SUBSETTED',
+              },
+            ],
+          });
+          expect(bundleContains(bundle4, patient)).toBeTruthy();
+        }));
+    });
 
     test('Token :text search', () =>
       withTestContext(async () => {

--- a/packages/server/src/fhir/structure.ts
+++ b/packages/server/src/fhir/structure.ts
@@ -1,8 +1,4 @@
-import {
-  indexSearchParameterBundle,
-  indexStructureDefinitionBundle,
-  indexDefaultSearchParameters,
-} from '@medplum/core';
+import { indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import { Bundle, SearchParameter } from '@medplum/fhirtypes';
 
@@ -11,11 +7,9 @@ let loaded = false;
 export function loadStructureDefinitions(): void {
   if (!loaded) {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
-    const resourcesBundle = readJson('fhir/r4/profiles-resources.json') as Bundle;
-    indexStructureDefinitionBundle(resourcesBundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-medplum.json') as Bundle);
 
-    indexDefaultSearchParameters(resourcesBundle);
     for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
       indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
     }

--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -427,7 +427,7 @@ function buildSearchColumns(tableDefinition: TableDefinition, resourceType: stri
       for (const column of getSearchParameterColumns(impl)) {
         const existing = tableDefinition.columns.find((c) => c.name === column.name);
         if (existing) {
-          if (!deepEquals(existing, column)) {
+          if (!columnDefinitionsEqual(existing, column)) {
             throw new Error(
               `Search Parameter ${searchParam.id ?? searchParam.code} attempting to define the same column on ${tableDefinition.name} with conflicting types: ${existing.type} vs ${column.type}`
             );
@@ -437,7 +437,7 @@ function buildSearchColumns(tableDefinition: TableDefinition, resourceType: stri
         tableDefinition.columns.push(column);
       }
       for (const index of getSearchParameterIndexes(impl)) {
-        const existing = tableDefinition.indexes.find((i) => deepEquals(i, index));
+        const existing = tableDefinition.indexes.find((i) => indexDefinitionsEqual(i, index));
         if (existing) {
           continue;
         }


### PR DESCRIPTION
previously, `indexDefaultSearchParameters` had to be explicitly called for a bundle containing resource StructureDefinitions. Now that happens implicitly in `indexStructureDefinitionBundle`.

Note this is chained off of another open PR, https://github.com/medplum/medplum/pull/5812, so I'll need to merge the other one first.