### PR TITLE
[wip] feat: Extended Patient Everything Operation

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -174,7 +174,7 @@ function topologicalSortWithCycles(graph: AdjacencyList): { sorted: string[]; cy
   return { sorted, cycles };
 }
 
-function findReferences(resource: any, callback: (reference: string) => void): void {
+export function findReferences(resource: any, callback: (reference: string) => void): void {
   for (const key in resource) {
     if (resource[key] && typeof resource[key] === 'object') {
       const value = resource[key];


### PR DESCRIPTION
## Why

This just a sketch, and a very inefficient one at that. I'm primarily looking for feedback on: (1) why does this at all?, and (2) how should this work?

**A real implementation will involve efficiently creating searches and with some depth limitation.** There are also likely other helper functions that can be re-used.

1. Why do this at all?

The [Patient $everything spec narrative ](https://build.fhir.org/patient-operation-everything.html) contains this partly ambigious SHOULD:

> The intended use for this operation is to provide a patient with access to their entire record (e.g. "Blue Button"), or for provider or other user to perform a bulk data download. The server SHOULD return at least all resources that it has that are in the patient compartment for the identified patient(s), **_and any resource referenced from those_**, including binaries and attachments.

One of the challenges with using the current implementation is that resources like Practitioners are very commonly referenced in the Bundle, but require additional reference resolutions. 

Changing the Patient $everything operation to include all referenced resources (or some subset) even if they are not patient compartmentalized would make this operation behave similar to the Bulk Export, but at a Patient level instead of Project one.

 2. How should this work?

* Should we return all possibly referenced resources or allow list a "reasonable" list?
* Should this be enabled for all requests to this operation, should it be an input parameter, should it be server config?
  * Firely uses server configuration to enable this: https://docs.fire.ly/projects/Firely-Server/en/latest/features_and_tools/custom_operations/patienteverything.html
  * SmileCDR has it implicitly enabled by default (see Resource list): https://smilecdr.com/docs/fhir_repository/reading_data.html#everything-operation
  * Google FHIR has it explicitly enabled: https://cloud.google.com/healthcare-api/docs/reference/rest/v1/projects.locations.datasets.fhirStores.fhir/Patient-everything

## What
I implemented a very basic (slow) recursive example of how this could work - but the implementation is just a sketch. 