### PR TITLE
Hotfix upgrade bullmq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21759,33 +21759,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/bullmq": {
-      "version": "5.34.9",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.34.9.tgz",
-      "integrity": "sha512-olCiFMy9o+pUpBcb/RguS5uUwbma+E80cYgDcG5p7ksvWpoyoEmxq5FOUQcobeTQwO7R9PEIvVsel5yewt0mlw==",
-      "license": "MIT",
-      "dependencies": {
-        "cron-parser": "^4.9.0",
-        "ioredis": "^5.4.1",
-        "msgpackr": "^1.11.2",
-        "node-abort-controller": "^3.1.1",
-        "semver": "^7.5.4",
-        "tslib": "^2.0.0",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/bullmq/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -29510,6 +29483,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -29524,6 +29498,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -53905,7 +53880,7 @@
         "bcryptjs": "2.4.3",
         "body-parser": "1.20.3",
         "bowser": "2.11.0",
-        "bullmq": "5.34.9",
+        "bullmq": "5.34.10",
         "bytes": "3.1.2",
         "compression": "1.7.5",
         "cookie-parser": "1.4.7",
@@ -53974,6 +53949,46 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/server/node_modules/bullmq": {
+      "version": "5.34.10",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.34.10.tgz",
+      "integrity": "sha512-ia6EzpQm1ZPq6GUBSLyfvzJrhdBTd1f3Gn2g9pFtLX4hBOob6QHmcmBzGgPlSCyr/i2Qfe4OdjS21bRd02srbw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.9.0",
+        "ioredis": "^5.4.1",
+        "msgpackr": "^1.11.2",
+        "node-abort-controller": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "packages/server/node_modules/bullmq/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "packages/server/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "packages/server/node_modules/uuid": {
       "version": "11.0.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -65,7 +65,7 @@
     "bcryptjs": "2.4.3",
     "body-parser": "1.20.3",
     "bowser": "2.11.0",
-    "bullmq": "5.34.9",
+    "bullmq": "5.34.10",
     "bytes": "3.1.2",
     "compression": "1.7.5",
     "cookie-parser": "1.4.7",


### PR DESCRIPTION
Bullmq had a regression in https://github.com/taskforcesh/bullmq/releases/tag/v5.34.9

Fixed in https://github.com/taskforcesh/bullmq/releases/tag/v5.34.10

Root cause: https://github.com/taskforcesh/bullmq/issues/3009

Net effect: cron jobs stopped working after first execution