### PR TITLE
Add additional token search tests

### DIFF
--- a/packages/server/src/fhir/lookups/token.test.ts
+++ b/packages/server/src/fhir/lookups/token.test.ts
@@ -1,10 +1,10 @@
-import { Operator } from '@medplum/core';
-import { Patient, ServiceRequest, SpecimenDefinition } from '@medplum/fhirtypes';
+import { createReference, Operator } from '@medplum/core';
+import { Bundle, Condition, Patient, ServiceRequest, SpecimenDefinition } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config';
-import { bundleContains, withTestContext } from '../../test.setup';
-import { getSystemRepo } from '../repo';
+import { bundleContains, createTestProject, withTestContext } from '../../test.setup';
+import { getSystemRepo, Repository } from '../repo';
 
 describe('Identifier Lookup Table', () => {
   const systemRepo = getSystemRepo();
@@ -557,4 +557,425 @@ describe('Identifier Lookup Table', () => {
       expect(r4.entry?.length).toStrictEqual(1);
       expect(r4.entry?.[0]?.resource?.id).toStrictEqual(p1.id);
     }));
+
+  describe('Non-strict mode', () => {
+    let nonStrictRepo: Repository;
+    let repo: Repository;
+    let patient: Patient;
+
+    const sys1 = 'http://sys.one';
+    const val1 = 'ABCDEFGHIJ';
+
+    beforeAll(async () => {
+      const { project } = await createTestProject();
+      nonStrictRepo = new Repository({
+        strictMode: false,
+        projects: [project.id as string],
+        author: { reference: 'User/' + randomUUID() },
+      });
+      repo = new Repository({
+        strictMode: true,
+        projects: [project.id as string],
+        author: { reference: 'User/' + randomUUID() },
+      });
+      patient = await nonStrictRepo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
+    });
+
+    test('Handle malformed system', () =>
+      withTestContext(async () => {
+        const subject = createReference(patient);
+        await nonStrictRepo.createResource<Condition>({
+          resourceType: 'Condition',
+          subject,
+          code: {
+            coding: [
+              {
+                system: [sys1] as unknown as string, // Force malformed data
+                code: val1,
+              },
+            ],
+          },
+        });
+
+        const res = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'code',
+              operator: Operator.EQUALS,
+              value: sys1 + '|',
+            },
+          ],
+        });
+        //TODO what is actually the expected behavior here?
+        expect(toSortedIdentifierValues(res)).toStrictEqual([]);
+      }));
+
+    test('Handle malformed value', () =>
+      withTestContext(async () => {
+        const subject = createReference(patient);
+        await nonStrictRepo.createResource<Condition>({
+          resourceType: 'Condition',
+          subject,
+          code: {
+            coding: [
+              {
+                system: 'https://example.com',
+                code: ['test1'] as unknown as string, // Force malformed data
+              },
+            ],
+          },
+        });
+
+        const res = await repo.search<Condition>({
+          resourceType: 'Condition',
+          filters: [
+            {
+              code: 'code',
+              operator: Operator.EQUALS,
+              value: val1,
+            },
+          ],
+        });
+        //TODO what is actually the expected behavior here?
+        expect(toSortedIdentifierValues(res)).toStrictEqual([undefined]);
+      }));
+  });
+
+  describe('Condition.code token queries', () => {
+    let repo: Repository;
+
+    let patient: Patient;
+
+    const conditionNames = [
+      'noCodeNoCat',
+      'noCodeCatOne',
+      'codeOneNoCat',
+      'codeOneCatOne',
+      'codeOneCatTwo',
+      'codeOneWithoutSystemNoCat',
+      'codeTwoWithoutSystemCatTwo',
+    ] as const;
+    type Conditions = (typeof conditionNames)[number];
+    const cond: Record<Conditions, Condition & { id: string }> = {} as Record<Conditions, Condition & { id: string }>;
+
+    const sys1 = 'http://sys.one';
+    const sys2 = 'http://sys.two';
+
+    const val1 = 'ABCDEFGHIJ';
+    const val2 = '0123456789';
+
+    const disp1 = 'The Quick Brown Fox';
+
+    beforeAll(async () => {
+      const { project } = await createTestProject();
+      repo = new Repository({
+        strictMode: true,
+        projects: [project.id as string],
+        author: { reference: 'User/' + randomUUID() },
+      });
+
+      patient = await repo.createResource<Patient>({ resourceType: 'Patient', name: [{ given: ['Henry'] }] });
+      const subject = createReference(patient);
+
+      const partial = cond as Record<string, Condition>;
+      partial.noCodeNoCat = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'noCodeNoCat' }],
+      });
+      partial.noCodeCatOne = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'noCodeCatOne' }],
+        category: [{ coding: [{ system: sys1, code: val1, display: disp1 }] }],
+      });
+      partial.codeOneNoCat = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneNoCat' }],
+        code: { coding: [{ system: sys1, code: val1, display: disp1 }] },
+      });
+      partial.codeOneCatOne = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneCatOne' }],
+        code: { coding: [{ system: sys1, code: val1 }] },
+        category: [{ coding: [{ system: sys1, code: val1 }] }],
+      });
+      partial.codeOneCatTwo = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneCatTwo' }],
+        code: { coding: [{ system: sys1, code: val1 }] },
+        category: [{ coding: [{ system: sys2, code: val2 }] }],
+      });
+      partial.codeOneWithoutSystemNoCat = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeOneWithoutSystemNoCat' }],
+        code: { coding: [{ code: val1 }] },
+      });
+      partial.codeTwoWithoutSystemCatTwo = await repo.createResource<Condition>({
+        resourceType: 'Condition',
+        subject,
+        identifier: [{ value: 'codeTwoWithoutSystemCatTwo' }],
+        code: { coding: [{ code: val2 }] },
+        category: [{ coding: [{ system: sys2, code: val2 }] }],
+      });
+
+      for (const name of conditionNames) {
+        if (!cond[name]?.id) {
+          throw new Error('Condition "' + name + '" not created');
+        }
+        expect(cond[name].identifier?.[0].value).toEqual(name);
+      }
+      expect(Object.keys(cond)).toHaveLength(conditionNames.length);
+    });
+
+    test('Sort by identifier', () =>
+      withTestContext(async () => {
+        const system = randomUUID();
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'None' }],
+          identifier: [{ system }],
+        });
+
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'AAA' }],
+          identifier: [{ system, value: 'AAA' }],
+        });
+
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'ZZZ' }],
+          identifier: [{ system, value: 'ZZZ' }],
+        });
+
+        const ascending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: false }],
+        });
+        expect(ascending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['AAA', 'ZZZ', 'None']);
+
+        const descending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: true }],
+        });
+        expect(descending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['None', 'ZZZ', 'AAA']);
+      }));
+
+    test.failing('FAILING Sort by identifier with multiple values', () =>
+      withTestContext(async () => {
+        const system = randomUUID();
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'First' }],
+          identifier: [
+            { system, value: 'AAA' },
+            { system, value: 'ZZZ' },
+          ],
+        });
+
+        await repo.createResource<Patient>({
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Second' }],
+          identifier: [{ system, value: 'LLL' }],
+        });
+
+        const ascending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: false }],
+        });
+
+        const descending = await repo.search<Patient>({
+          resourceType: 'Patient',
+          filters: [{ code: 'identifier', operator: Operator.EQUALS, value: system + '|' }],
+          sortRules: [{ code: 'identifier', descending: true }],
+        });
+
+        // Counterintuitive results, but yes: the same sort order is expected for both ascending/descending
+        // since ascending should use "AAA" and descending should use "ZZZ"
+        expect(ascending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['First', 'Second']);
+        expect(descending.entry?.map((e) => e.resource?.name?.[0]?.family)).toStrictEqual(['First', 'Second']);
+      })
+    );
+
+    test.each<[string, Conditions[]]>([
+      [sys1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo']],
+      [sys2, []],
+      [val1, []], // incorrectly passing val as a system
+    ])('code by system %s', async (value, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: value + '|',
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(res)).toStrictEqual(expected.toSorted());
+    });
+
+    test.each<[string, Conditions[]]>([
+      [sys1, []], // incorrectly passing sys as a value
+      [val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo', 'codeOneWithoutSystemNoCat']],
+      [val2, ['codeTwoWithoutSystemCatTwo']],
+    ])('code by value %s', async (value, expected) => {
+      const resEquals = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(resEquals)).toStrictEqual(expected.toSorted());
+
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.CONTAINS,
+            value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(resContains)).toStrictEqual(expected.toSorted());
+    });
+
+    test.each<[string, string, Conditions[]]>([
+      [sys1, val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo']],
+      [sys1, val2, []],
+      [sys2, val1, []],
+      [sys2, val2, []],
+    ])('code by system and value %s|%s', async (system, value, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: system + '|' + value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(res)).toStrictEqual(expected.toSorted());
+    });
+
+    test.each<[string, Conditions[]]>([
+      [val1, ['codeOneWithoutSystemNoCat']],
+      [val2, ['codeTwoWithoutSystemCatTwo']],
+    ])('code by missing system and value %s', async (value, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: '|' + value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(res)).toStrictEqual(expected);
+    });
+
+    test.each<[string, string, Conditions[]]>([
+      [val1, val1, ['codeOneCatOne']],
+      [val1, val2, ['codeOneCatTwo']],
+      [val2, val1, []],
+      [sys1 + '|', val2, ['codeOneCatTwo']],
+      ['|' + val1, val1, []],
+      ['|' + val2, sys2 + '|' + val2, ['codeTwoWithoutSystemCatTwo']],
+    ])('code and category by code=%s category=%s', async (codeValue, categoryValue, expected) => {
+      const res = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.EQUALS,
+            value: codeValue,
+          },
+          {
+            code: 'category',
+            operator: Operator.EQUALS,
+            value: categoryValue,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(res)).toStrictEqual(expected);
+    });
+
+    test.each<[string, Conditions[]]>([
+      [val1, ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo', 'codeOneWithoutSystemNoCat']],
+      [val1.slice(0, 3), ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo', 'codeOneWithoutSystemNoCat']],
+    ])('code :contains beginning of value %s', async (value, expected) => {
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.CONTAINS,
+            value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(resContains)?.toSorted()).toStrictEqual(expected.toSorted());
+    });
+
+    //TODO{mattlong} these tests should pass in new token implementation
+    test.failing.each<[string, Conditions[]]>([
+      [val1.slice(1, 3), ['codeOneNoCat', 'codeOneCatOne', 'codeOneCatTwo', 'codeOneWithoutSystemNoCat']],
+      [val2.slice(1, 3), ['codeTwoWithoutSystemCatTwo']],
+    ])('FAILING code :contains middle of value %s', async (value, expected) => {
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.CONTAINS,
+            value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(resContains)).toStrictEqual(expected.toSorted());
+    });
+
+    test.each<[string, Conditions[]]>([
+      [disp1, ['codeOneNoCat']],
+      [disp1.split(' ').slice(0, 2).join(' '), ['codeOneNoCat']],
+      [disp1.split(' ').slice(1, 3).join(' '), ['codeOneNoCat']],
+      [disp1.split(' ').slice(-2).join(' '), ['codeOneNoCat']],
+    ])('code :text %s', async (value, expected) => {
+      const resContains = await repo.search<Condition>({
+        resourceType: 'Condition',
+        filters: [
+          {
+            code: 'code',
+            operator: Operator.TEXT,
+            value,
+          },
+        ],
+      });
+      expect(toSortedIdentifierValues(resContains)).toStrictEqual(expected);
+    });
+  });
 });
+
+function toIdentifierValues(bundle: Bundle<Condition | Patient>): string[] {
+  return bundle.entry?.map((e) => e.resource?.identifier?.[0].value as string) ?? [];
+}
+
+function toSortedIdentifierValues(bundle: Bundle<Condition | Patient>): string[] {
+  return toIdentifierValues(bundle).toSorted();
+}

--- a/packages/server/src/fhir/lookups/token.test.ts
+++ b/packages/server/src/fhir/lookups/token.test.ts
@@ -821,7 +821,7 @@ describe('Identifier Lookup Table', () => {
           },
         ],
       });
-      expect(toSortedIdentifierValues(res)).toStrictEqual(expected.toSorted());
+      expect(toSortedIdentifierValues(res)).toStrictEqual(toSorted(expected));
     });
 
     test.each<[string, Conditions[]]>([
@@ -839,7 +839,7 @@ describe('Identifier Lookup Table', () => {
           },
         ],
       });
-      expect(toSortedIdentifierValues(resEquals)).toStrictEqual(expected.toSorted());
+      expect(toSortedIdentifierValues(resEquals)).toStrictEqual(toSorted(expected));
 
       const resContains = await repo.search<Condition>({
         resourceType: 'Condition',
@@ -851,7 +851,7 @@ describe('Identifier Lookup Table', () => {
           },
         ],
       });
-      expect(toSortedIdentifierValues(resContains)).toStrictEqual(expected.toSorted());
+      expect(toSortedIdentifierValues(resContains)).toStrictEqual(toSorted(expected));
     });
 
     test.each<[string, string, Conditions[]]>([
@@ -870,7 +870,7 @@ describe('Identifier Lookup Table', () => {
           },
         ],
       });
-      expect(toSortedIdentifierValues(res)).toStrictEqual(expected.toSorted());
+      expect(toSortedIdentifierValues(res)).toStrictEqual(toSorted(expected));
     });
 
     test.each<[string, Conditions[]]>([
@@ -930,7 +930,7 @@ describe('Identifier Lookup Table', () => {
           },
         ],
       });
-      expect(toSortedIdentifierValues(resContains)?.toSorted()).toStrictEqual(expected.toSorted());
+      expect(toSortedIdentifierValues(resContains)).toStrictEqual(toSorted(expected));
     });
 
     //TODO{mattlong} these tests should pass in new token implementation
@@ -948,7 +948,7 @@ describe('Identifier Lookup Table', () => {
           },
         ],
       });
-      expect(toSortedIdentifierValues(resContains)).toStrictEqual(expected.toSorted());
+      expect(toSortedIdentifierValues(resContains)).toStrictEqual(toSorted(expected));
     });
 
     test.each<[string, Conditions[]]>([
@@ -977,5 +977,12 @@ function toIdentifierValues(bundle: Bundle<Condition | Patient>): string[] {
 }
 
 function toSortedIdentifierValues(bundle: Bundle<Condition | Patient>): string[] {
-  return toIdentifierValues(bundle).toSorted();
+  return toSorted(toIdentifierValues(bundle));
+}
+
+// Array.prototype.toSorted isn't available in Node 18, so write our own
+function toSorted<T extends string>(array: T[]): T[] {
+  const newArray = Array.from(array);
+  newArray.sort((a, b) => a.localeCompare(b));
+  return newArray;
 }

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -97,6 +97,7 @@ export class TokenTable extends LookupTable {
     const values = tokens.map((token) => ({
       resourceId,
       code: token.code,
+      // logical OR coalesce to ensure that empty strings are inserted as NULL
       system: token.system?.trim?.() || undefined,
       value: token.value?.trim?.() || undefined,
     }));
@@ -515,8 +516,9 @@ function buildWhereCondition(
   const parts = splitN(query, '|', 2);
   // Handle the case where the query value is a system|value pair (e.g. token or identifier search)
   if (parts.length === 2) {
-    const [system, value] = parts;
-    const systemCondition = new Condition(new Column(tableName, 'system'), '=', system || null);
+    const system = parts[0] || null; // Logical OR coalesce to account for system being the empty string, i.e. [parameter]=|[code]
+    const value = parts[1];
+    const systemCondition = new Condition(new Column(tableName, 'system'), '=', system);
     return value
       ? new Conjunction([systemCondition, buildValueCondition(tableName, operator, caseSensitive, value)])
       : systemCondition;

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -97,8 +97,8 @@ export class TokenTable extends LookupTable {
     const values = tokens.map((token) => ({
       resourceId,
       code: token.code,
-      system: token.system?.trim?.(),
-      value: token.value?.trim?.(),
+      system: token.system?.trim?.() || undefined,
+      value: token.value?.trim?.() || undefined,
     }));
 
     await this.insertValuesForResource(client, resourceType, values);

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -97,7 +97,7 @@ export class TokenTable extends LookupTable {
     const values = tokens.map((token) => ({
       resourceId,
       code: token.code,
-      system: token.system?.trim(),
+      system: token.system?.trim?.(),
       value: token.value?.trim?.(),
     }));
 

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -516,7 +516,7 @@ function buildWhereCondition(
   // Handle the case where the query value is a system|value pair (e.g. token or identifier search)
   if (parts.length === 2) {
     const [system, value] = parts;
-    const systemCondition = new Condition(new Column(tableName, 'system'), '=', system);
+    const systemCondition = new Condition(new Column(tableName, 'system'), '=', system || null);
     return value
       ? new Conjunction([systemCondition, buildValueCondition(tableName, operator, caseSensitive, value)])
       : systemCondition;


### PR DESCRIPTION
This also corrects our implementation of search for token of the form `[parameter]=|[code]` by falling back to `NULL` rather than looking for rows in the token table with a system value of the empty string.

From the spec:
> [parameter]=|[code]: the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property