### PR TITLE
Improve cron job change detection

### DIFF
--- a/packages/server/src/workers/cron.test.ts
+++ b/packages/server/src/workers/cron.test.ts
@@ -126,7 +126,7 @@ describe('Cron Worker', () => {
       });
 
       expect(bot).toBeDefined();
-      expect(queue.getRepeatableJobs).toHaveBeenCalled();
+      expect(queue.removeJobScheduler).toHaveBeenCalled();
       expect(queue.add).toHaveBeenCalledTimes(2);
     }));
 
@@ -140,15 +140,9 @@ describe('Cron Worker', () => {
       });
 
       expect(bot).toBeDefined();
-      expect(queue.getRepeatableJobs).toHaveBeenCalled();
+      expect(queue.removeJobScheduler).toHaveBeenCalled();
       expect(queue.add).toHaveBeenCalled();
 
-      queue.getRepeatableJobs.mockImplementation(() => [
-        {
-          key: `CronJobData:${bot.id}:::* * * * *`,
-          id: bot.id,
-        },
-      ]);
       await botRepo.updateResource({
         resourceType: 'Bot',
         id: bot.id,
@@ -160,7 +154,7 @@ describe('Cron Worker', () => {
         },
       });
 
-      expect(queue.removeRepeatableByKey).toHaveBeenCalled();
+      expect(queue.removeJobScheduler).toHaveBeenCalled();
     }));
 
   test('Job should not be in queue if cron is not enabled', () =>

--- a/packages/server/src/workers/cron.test.ts
+++ b/packages/server/src/workers/cron.test.ts
@@ -36,7 +36,7 @@ describe('Cron Worker', () => {
   test('should add a job to the queue when a bot with cronTiming is created', async () => {
     // Add the bot and check that a job was added to the queue.
     const queue = getCronQueue() as any;
-    queue.add.mockClear();
+    queue.upsertJobScheduler.mockClear();
     const bot = await withTestContext(() =>
       botRepo.createResource<Bot>({
         resourceType: 'Bot',
@@ -50,13 +50,13 @@ describe('Cron Worker', () => {
       })
     );
     expect(bot).toBeDefined();
-    expect(queue.add).toHaveBeenCalled();
+    expect(queue.upsertJobScheduler).toHaveBeenCalled();
   });
 
   test('should add a job to the queue when a bot with cronString added', async () => {
     // Add the bot and check that a job was added to the queue.
     const queue = getCronQueue() as any;
-    queue.add.mockClear();
+    queue.upsertJobScheduler.mockClear();
     const bot = await withTestContext(() =>
       botRepo.createResource<Bot>({
         resourceType: 'Bot',
@@ -65,13 +65,13 @@ describe('Cron Worker', () => {
       })
     );
     expect(bot).toBeDefined();
-    expect(queue.add).toHaveBeenCalled();
+    expect(queue.upsertJobScheduler).toHaveBeenCalled();
   });
 
   test('should not add a job to the queue when a bot with cronString', async () => {
     // Add the bot and check that a job was added to the queue.
     const queue = getCronQueue() as any;
-    queue.add.mockClear();
+    queue.upsertJobScheduler.mockClear();
     const bot = await withTestContext(() =>
       botRepo.createResource<Bot>({
         resourceType: 'Bot',
@@ -80,13 +80,13 @@ describe('Cron Worker', () => {
       })
     );
     expect(bot).toBeDefined();
-    expect(queue.add).not.toHaveBeenCalled();
+    expect(queue.upsertJobScheduler).not.toHaveBeenCalled();
   });
 
   test('should not have added a job to the queue due to a cron not created', async () => {
     // Add the bot and check that a job was added to the queue.
     const queue = getCronQueue() as any;
-    queue.add.mockClear();
+    queue.upsertJobScheduler.mockClear();
     const bot = await withTestContext(() =>
       botRepo.createResource<Bot>({
         resourceType: 'Bot',
@@ -95,14 +95,14 @@ describe('Cron Worker', () => {
     );
     // Bot should have still been created
     expect(bot).toBeDefined();
-    expect(queue.add).not.toHaveBeenCalled();
+    expect(queue.upsertJobScheduler).not.toHaveBeenCalled();
   });
 
   test('Update queue after updating bot', () =>
     withTestContext(async () => {
       // Add the bot and check that a job was added to the queue.
       const queue = getCronQueue() as any;
-      queue.add.mockClear();
+      queue.upsertJobScheduler.mockClear();
       const bot = await botRepo.createResource<Bot>({
         resourceType: 'Bot',
         name: 'bot-1',
@@ -126,8 +126,7 @@ describe('Cron Worker', () => {
       });
 
       expect(bot).toBeDefined();
-      expect(queue.removeJobScheduler).toHaveBeenCalled();
-      expect(queue.add).toHaveBeenCalledTimes(2);
+      expect(queue.upsertJobScheduler).toHaveBeenCalledTimes(2);
     }));
 
   test('Find a previous job to remove after updating bot', () =>
@@ -140,8 +139,7 @@ describe('Cron Worker', () => {
       });
 
       expect(bot).toBeDefined();
-      expect(queue.removeJobScheduler).toHaveBeenCalled();
-      expect(queue.add).toHaveBeenCalled();
+      expect(queue.upsertJobScheduler).toHaveBeenCalled();
 
       await botRepo.updateResource({
         resourceType: 'Bot',
@@ -154,14 +152,14 @@ describe('Cron Worker', () => {
         },
       });
 
-      expect(queue.removeJobScheduler).toHaveBeenCalled();
+      expect(queue.upsertJobScheduler).toHaveBeenCalled();
     }));
 
   test('Job should not be in queue if cron is not enabled', () =>
     withTestContext(async () => {
       // Create a simple project with no advanced features enabled
       const queue = getCronQueue() as any;
-      queue.add.mockClear();
+      queue.upsertJobScheduler.mockClear();
 
       // Create one simple project with no advanced features enabled
       const testProject = await systemRepo.createResource<Project>({
@@ -191,13 +189,13 @@ describe('Cron Worker', () => {
         },
       });
       expect(bot).toBeDefined();
-      expect(queue.add).not.toHaveBeenCalled();
+      expect(queue.upsertJobScheduler).not.toHaveBeenCalled();
     }));
 
   test('Bot should execute successfully', () =>
     withTestContext(async () => {
       const queue = getCronQueue() as any;
-      queue.add.mockClear();
+      queue.upsertJobScheduler.mockClear();
 
       const bot = await botRepo.createResource<Bot>({
         resourceType: 'Bot',

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -22,7 +22,6 @@ export interface CronJobData {
 }
 
 const queueName = 'CronQueue';
-const jobName = 'CronJobData';
 
 let queue: Queue<CronJobData> | undefined = undefined;
 let worker: Worker<CronJobData> | undefined = undefined;
@@ -120,26 +119,23 @@ export async function addCronJobs(resource: Resource, previousVersion: Resource 
     return;
   }
 
-  if (previousVersion) {
-    logger.info('Removing cron job for bot', { botId: bot.id });
-    await queue.removeJobScheduler(bot.id as string);
-  }
-
   if (newCronStr) {
-    logger.info('Adding cron job for bot', { botId: bot.id });
-    if (queue) {
-      await queue.add(
-        jobName,
-        {
+    logger.info('Upsert cron job for bot', { botId: bot.id });
+    await queue.upsertJobScheduler(
+      bot.id as string,
+      {
+        pattern: newCronStr,
+      },
+      {
+        data: {
           resourceType: bot.resourceType,
           botId: bot.id as string,
         },
-        {
-          jobId: bot.id,
-          repeat: { pattern: newCronStr },
-        }
-      );
-    }
+      }
+    );
+  } else {
+    logger.info('Removing cron job for bot', { botId: bot.id });
+    await queue.removeJobScheduler(bot.id as string);
   }
 }
 

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -15,15 +15,6 @@ const daysOfWeekConversion = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, s
  * if it has the Cron property, will add it as a repeatable
  * Cron job
  */
-// Repeatable is based on BullMQ docs https://docs.bullmq.io/guide/jobs/repeatable
-interface Repeatable {
-  repeat: {
-    pattern?: string;
-    every?: number;
-    limit?: number;
-  };
-  jobId?: string;
-}
 
 export interface CronJobData {
   readonly resourceType: string;
@@ -93,9 +84,17 @@ export function getCronQueue(): Queue<CronJobData> | undefined {
 }
 
 /**
+ * Updates the Cron job for the given resource.
+ * Only applies changes if the effective cron string has changed.
  * @param resource - The resource that was created or updated.
+ * @param previousVersion - The previous version of the resource, if available.
  */
-export async function addCronJobs(resource: Resource): Promise<void> {
+export async function addCronJobs(resource: Resource, previousVersion: Resource | undefined): Promise<void> {
+  if (!queue) {
+    // The queue is not available
+    return;
+  }
+
   if (resource.resourceType !== 'Bot') {
     // For now we have only the bot to execute on a timed job
     return;
@@ -112,51 +111,52 @@ export async function addCronJobs(resource: Resource): Promise<void> {
     return;
   }
 
-  let cron;
-  // Validate the cron format
-  if (bot.cronTiming) {
-    cron = convertTimingToCron(bot.cronTiming);
-    if (!cron) {
-      logger.debug('cronTiming had the wrong format for a timed cron job');
-      return;
-    }
-  } else if (bot.cronString && isValidCron(bot.cronString)) {
-    cron = bot.cronString;
-  } else if (bot.cronString === '') {
-    await removeBullMQJobByKey(bot.id as string);
-    logger.debug(`no job for bot: ${bot.id}`);
-    return;
-  } else {
-    logger.debug('cronString had the wrong format for a timed cron job');
+  const oldCronStr = getCronStringForBot(previousVersion as Bot);
+  const newCronStr = getCronStringForBot(bot);
+  logger.info('Cron job for bot', { botId: bot.id, oldCronStr, newCronStr });
+
+  if (oldCronStr === newCronStr) {
+    // No change in cron job
     return;
   }
 
-  const cronObject = { repeat: { pattern: cron } };
+  if (previousVersion) {
+    logger.info('Removing cron job for bot', { botId: bot.id });
+    await queue.removeJobScheduler(bot.id as string);
+  }
 
-  // JobId and repeatable instructions
-  const jobOptions = { ...cronObject, jobId: bot.id };
-  await addCronJobData(
-    {
-      resourceType: bot.resourceType,
-      botId: bot.id as string,
-    },
-    jobOptions
-  );
+  if (newCronStr) {
+    logger.info('Adding cron job for bot', { botId: bot.id });
+    if (queue) {
+      await queue.add(
+        jobName,
+        {
+          resourceType: bot.resourceType,
+          botId: bot.id as string,
+        },
+        {
+          jobId: bot.id,
+          repeat: { pattern: newCronStr },
+        }
+      );
+    }
+  }
 }
 
-/**
- * Adds a Cron job to the queue, and removes the previous job for bot
- * if it exists
- * @param job - The Cron job details.
- * @param repeatable - The repeat format that instructs BullMQ when to run the job
- */
-async function addCronJobData(job: CronJobData, repeatable: Repeatable): Promise<void> {
-  // Check if there was a job previously for this bot, if there was, we remove it.
-  await removeBullMQJobByKey(job.botId);
-  // Parameters of queue.add https://api.docs.bullmq.io/classes/Queue.html#add
-  if (queue) {
-    await queue.add(jobName, job, repeatable);
+function getCronStringForBot(bot: Bot | undefined): string | undefined {
+  if (bot?.cronTiming) {
+    const timingStr = convertTimingToCron(bot.cronTiming);
+    if (timingStr) {
+      return timingStr;
+    }
   }
+
+  if (bot?.cronString && isValidCron(bot.cronString)) {
+    return bot.cronString;
+  }
+
+  // Otherwise, this is not a valid cron job
+  return undefined;
 }
 
 /**
@@ -216,11 +216,7 @@ export async function execBot(job: Job<CronJobData>): Promise<void> {
 }
 
 export async function removeBullMQJobByKey(botId: string): Promise<void> {
-  const previousJobs = (await queue?.getRepeatableJobs())?.filter((p) => p.id === botId) ?? [];
-
-  // There likely should not be more than one repeatable job per bot id.
-  for (const p of previousJobs) {
-    await queue?.removeRepeatableByKey(p.key);
-    getLogger().debug(`Found a previous job for bot ${botId}, updating...`);
+  if (queue) {
+    await queue.removeJobScheduler(botId);
   }
 }

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -1,12 +1,12 @@
-import { Resource } from '@medplum/fhirtypes';
 import { BackgroundJobContext } from '@medplum/core';
+import { Resource } from '@medplum/fhirtypes';
 import { MedplumServerConfig } from '../config';
 import { globalLogger } from '../logger';
+import { closeBatchWorker, initBatchWorker } from './batch';
 import { addCronJobs, closeCronWorker, initCronWorker } from './cron';
 import { addDownloadJobs, closeDownloadWorker, initDownloadWorker } from './download';
-import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } from './subscription';
 import { closeReindexWorker, initReindexWorker } from './reindex';
-import { closeBatchWorker, initBatchWorker } from './batch';
+import { addSubscriptionJobs, closeSubscriptionWorker, initSubscriptionWorker } from './subscription';
 
 /**
  * Initializes all background workers.
@@ -46,5 +46,5 @@ export async function addBackgroundJobs(
 ): Promise<void> {
   await addSubscriptionJobs(resource, previousVersion, context);
   await addDownloadJobs(resource);
-  await addCronJobs(resource);
+  await addCronJobs(resource, previousVersion);
 }


### PR DESCRIPTION
Before:

1. We were checking for `cronString === ''`, which will never happen, because that's not valid FHIR
2. We weren't using `previousVersion`, presumably because it had not been introduced yet at this point
3. Bottom line, "disabling" a cron a very confusing experience
4. Also, we were using a bunch of deprecated features

After:

1. Use `previousVersion` for concrete check on whether the cron string changed or not
2. Use the recommended methods from bullmq
3. Should be much more deterministic regarding updating the bullmq job
