### PR TITLE
feat(super): add `reloadcron` super admin endpoint

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -195,6 +195,16 @@ describe('SuperAdminPage', () => {
     expect(await screen.findByText(returnValue)).toBeInTheDocument();
   });
 
+  test('Reload cron resources', async () => {
+    setup();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Reload Cron Resources' }));
+    });
+
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
   test('Access denied', async () => {
     jest.spyOn(medplum, 'isSuperAdmin').mockImplementationOnce(() => false);
     setup();

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -41,6 +41,10 @@ export function SuperAdminPage(): JSX.Element {
     startAsyncJob(medplum, 'Reindexing Resources', 'admin/super/reindex', formData);
   }
 
+  function reloadCron(): void {
+    startAsyncJob(medplum, 'Reload Cron Resources', 'admin/super/reloadcron');
+  }
+
   function removeBotIdJobsFromQueue(formData: Record<string, string>): void {
     medplum
       .post('admin/super/removebotidjobsfromqueue', formData)
@@ -89,13 +93,6 @@ export function SuperAdminPage(): JSX.Element {
         setModalContent(<pre>{params.parameter?.find((p) => p.name === 'migrationString')?.valueString}</pre>);
         open();
       })
-      .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
-  }
-
-  function reloadCron(): void {
-    medplum
-      .post('admin/super/reloadcron')
-      .then(() => showNotification({ color: 'green', message: 'Done' }))
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
   }
 

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -92,6 +92,13 @@ export function SuperAdminPage(): JSX.Element {
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
   }
 
+  function reloadCron(): void {
+    medplum
+      .post('admin/super/reloadcron')
+      .then(() => showNotification({ color: 'green', message: 'Done' }))
+      .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
+  }
+
   return (
     <Document width={600}>
       <Title order={1}>Super Admin</Title>
@@ -197,6 +204,14 @@ export function SuperAdminPage(): JSX.Element {
       <Form onSubmit={getSchemaDiff}>
         <Stack>
           <Button type="submit">Get Database Schema Drift</Button>
+        </Stack>
+      </Form>
+      <Divider my="lg" />
+      <Title order={2}>Reload Cron Resources</Title>
+      <p>Obliterates the cron queue and rebuilds all the cron job schedulers for cron resources (eg. cron bots).</p>
+      <Form onSubmit={reloadCron}>
+        <Stack>
+          <Button type="submit">Reload Cron Resources</Button>
         </Stack>
       </Form>
 

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -907,9 +907,12 @@ describe('Super Admin routes', () => {
       const res2 = await request(app)
         .post('/admin/super/reloadcron')
         .set('Authorization', 'Bearer ' + adminAccessToken)
+        .set('Prefer', 'respond-async')
         .type('json');
 
-      expect(res2.status).toStrictEqual(200);
+      expect(res2.status).toStrictEqual(202);
+      expect(res2.headers['content-location']).toBeDefined();
+      await waitForAsyncJob(res2.headers['content-location'], app, adminAccessToken);
 
       expect(obliterateSpy).toHaveBeenCalledWith({ force: true });
       expect(upsertJobSchedulerSpy).toHaveBeenCalledWith(

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -1,8 +1,8 @@
 import { allOk, badRequest, createReference, getReferenceString } from '@medplum/core';
-import { Login, Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
-import { Job } from 'bullmq';
-import { randomUUID } from 'crypto';
+import { Bot, Login, Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
+import { Job, Queue } from 'bullmq';
 import express from 'express';
+import { randomUUID } from 'node:crypto';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
@@ -16,6 +16,7 @@ import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
 import { createTestProject, waitForAsyncJob, withTestContext } from '../test.setup';
+import { CronJobData, getCronQueue } from '../workers/cron';
 import { getReindexQueue, ReindexJob, ReindexJobData } from '../workers/reindex';
 import { isValidTableName } from './super';
 
@@ -881,6 +882,48 @@ describe('Super Admin routes', () => {
       expect(res1.status).toStrictEqual(400);
       expect(res1.headers['content-location']).not.toBeDefined();
       expect(res1.body).toMatchObject(badRequest('Operation requires "Prefer: respond-async"'));
+    });
+  });
+
+  describe('Reload cron', () => {
+    test('Happy path', async () => {
+      const cronQueue = getCronQueue() as Queue<CronJobData>;
+      expect(cronQueue).toBeDefined();
+
+      const res1 = await request(app)
+        .post('/fhir/R4/Bot')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json')
+        .send({ resourceType: 'Bot', cronString: '*/20 * * * *' } satisfies Bot);
+
+      expect(res1.status).toStrictEqual(201);
+      expect(res1.body).toBeDefined();
+
+      const bot = res1.body as Bot & { id: string };
+
+      const obliterateSpy = jest.spyOn(cronQueue, 'obliterate');
+      const upsertJobSchedulerSpy = jest.spyOn(cronQueue, 'upsertJobScheduler');
+
+      const res2 = await request(app)
+        .post('/admin/super/reloadcron')
+        .set('Authorization', 'Bearer ' + adminAccessToken)
+        .type('json');
+
+      expect(res2.status).toStrictEqual(200);
+
+      expect(obliterateSpy).toHaveBeenCalledWith({ force: true });
+      expect(upsertJobSchedulerSpy).toHaveBeenCalledWith(
+        bot.id,
+        {
+          pattern: '*/20 * * * *',
+        },
+        {
+          data: {
+            resourceType: bot.resourceType,
+            botId: bot.id,
+          },
+        }
+      );
     });
   });
 });

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -27,7 +27,7 @@ import { getUserByEmail } from '../oauth/utils';
 import { rebuildR4SearchParameters } from '../seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from '../seeds/structuredefinitions';
 import { rebuildR4ValueSets } from '../seeds/valuesets';
-import { removeBullMQJobByKey } from '../workers/cron';
+import { reloadCronBots, removeBullMQJobByKey } from '../workers/cron';
 import { addReindexJob } from '../workers/reindex';
 
 export const OVERRIDABLE_TABLE_SETTINGS = {
@@ -344,6 +344,22 @@ superAdminRouter.post(
         parameter: [{ name: 'outcome', resource: allOk }],
       };
     });
+  })
+);
+
+// POST to /admin/super/reloadcron
+// to clear out the cron queue and reload all cron strings from cron bots
+superAdminRouter.post(
+  '/reloadcron',
+  asyncWrap(async (_req: Request, res: Response) => {
+    requireSuperAdmin();
+
+    const startTime = Date.now();
+    await reloadCronBots();
+    globalLogger.info('[Super Admin]: Cron bots reloaded', {
+      durationMs: Date.now() - startTime,
+    });
+    sendOutcome(res, allOk);
   })
 );
 

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -351,15 +351,21 @@ superAdminRouter.post(
 // to clear out the cron queue and reload all cron strings from cron bots
 superAdminRouter.post(
   '/reloadcron',
-  asyncWrap(async (_req: Request, res: Response) => {
+  asyncWrap(async (req: Request, res: Response) => {
     requireSuperAdmin();
+    requireAsync(req);
 
-    const startTime = Date.now();
-    await reloadCronBots();
-    globalLogger.info('[Super Admin]: Cron bots reloaded', {
-      durationMs: Date.now() - startTime,
+    await sendAsyncResponse(req, res, async () => {
+      const startTime = Date.now();
+      await reloadCronBots();
+      globalLogger.info('[Super Admin]: Cron bots reloaded', {
+        durationMs: Date.now() - startTime,
+      });
+      return {
+        resourceType: 'Parameters',
+        parameter: [{ name: 'outcome', resource: allOk }],
+      };
     });
-    sendOutcome(res, allOk);
   })
 );
 

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -98,10 +98,8 @@ export async function exportResourceType<T extends Resource>(
     filters: since ? [{ code: '_lastUpdated', operator: Operator.GREATER_THAN_OR_EQUALS, value: since }] : undefined,
     sortRules: [{ code: '_lastUpdated', descending: false }],
   };
-  await repo.processAllResources(searchRequest, async (resources: T[]) => {
-    for (const resource of resources) {
-      await exporter.writeResource(resource);
-    }
+  await repo.processAllResources(searchRequest, async (resource: T) => {
+    await exporter.writeResource(resource);
   });
 }
 

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -3,13 +3,12 @@ import {
   concatUrls,
   getResourceTypes,
   Operator,
-  parseSearchRequest,
   protectedResourceTypes,
   SearchRequest,
   singularize,
 } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import { Bundle, Project, Resource, ResourceType } from '@medplum/fhirtypes';
+import { Project, Resource, ResourceType } from '@medplum/fhirtypes';
 import { getConfig } from '../../config';
 import { getAuthenticatedContext } from '../../context';
 import { getPatientResourceTypes } from '../patient';
@@ -93,30 +92,17 @@ export async function exportResourceType<T extends Resource>(
   since?: string
 ): Promise<void> {
   const repo = exporter.repo;
-  let searchRequest: SearchRequest<T> | undefined = {
+  const searchRequest: SearchRequest<T> | undefined = {
     resourceType,
     count,
     filters: since ? [{ code: '_lastUpdated', operator: Operator.GREATER_THAN_OR_EQUALS, value: since }] : undefined,
     sortRules: [{ code: '_lastUpdated', descending: false }],
   };
-  while (searchRequest) {
-    const bundle: Bundle<T> = await repo.search<T>(searchRequest);
-    if (!bundle.entry || bundle.entry.length === 0) {
-      break;
+  await repo.processAllResources(searchRequest, async (resources: T[]) => {
+    for (const resource of resources) {
+      await exporter.writeResource(resource);
     }
-
-    for (const entry of bundle.entry) {
-      if (entry.resource) {
-        await exporter.writeResource(entry.resource);
-      }
-    }
-
-    const linkNext = bundle.link?.find((b) => b.relation === 'next')?.url;
-    if (!linkNext) {
-      break;
-    }
-    searchRequest = parseSearchRequest<T>(linkNext);
-  }
+  });
 }
 
 function getResourceTypesByExportLevel(exportLevel: string): ResourceType[] {

--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -59,6 +59,10 @@ export class Expunger {
     }
 
     const repo = this.repo;
+    // NOTE(ThatOneBro 23/01/2025): Attempted to convert this to using `repo.processAllResources`,
+    // But it doesn't quite fit the pattern since the "next" links are not usable
+    // As the expunge process is destructive and the "cursor" essentially is always at the beginning of the table
+    // We delete the next N resources over and over and use the "next" link as a signal if there are more resources to delete
     let hasNext = true;
     while (hasNext) {
       const bundle = await repo.search({
@@ -80,9 +84,7 @@ export class Expunger {
           buildBinaryIds(entry.resource, binaryIds);
         }
       }
-
       await repo.expungeResources(resourceType, resourcesToExpunge);
-
       if (binaryIds.size > 0) {
         await repo.expungeResources('Binary', Array.from(binaryIds));
       }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1163,7 +1163,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
   async processAllResources<T extends Resource>(
     initialSearchRequest: SearchRequest<T>,
-    processPage: (resources: T[]) => Promise<void>,
+    process: (resource: T) => Promise<void>,
     options?: ProcessAllResourcesOptions
   ): Promise<void> {
     let searchRequest: SearchRequest<T> | undefined = initialSearchRequest;
@@ -1172,13 +1172,11 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       if (!bundle.entry?.length) {
         break;
       }
-      const resources: T[] = [];
       for (const entry of bundle.entry) {
         if (entry.resource?.id) {
-          resources.push(entry.resource);
+          await process(entry.resource);
         }
       }
-      await processPage(resources);
       const nextLink = bundle.link?.find((b) => b.relation === 'next');
       if (nextLink) {
         searchRequest = parseSearchRequest<T>(nextLink.url);

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -216,3 +216,19 @@ export async function removeBullMQJobByKey(botId: string): Promise<void> {
     await queue.removeJobScheduler(botId);
   }
 }
+
+export async function reloadCronBots(): Promise<void> {
+  if (queue) {
+    // Clears all jobs from the cron queue, including active ones
+    await queue.obliterate({ force: true });
+
+    const allBots = await getSystemRepo().searchResources<Bot>({ resourceType: 'Bot' });
+    for (const bot of allBots) {
+      // If the bot has a cron, then add a scheduler for it
+      if (bot.cronString || bot.cronTiming) {
+        // We pass `undefined` as previous version to make sure that the latest cron string is used
+        await addCronJobs(bot, undefined);
+      }
+    }
+  }
+}

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -225,13 +225,11 @@ export async function reloadCronBots(): Promise<void> {
 
     await getSystemRepo().processAllResources<Bot>(
       { resourceType: 'Bot', count: MAX_BOTS_PER_PAGE },
-      async (bots: Bot[]) => {
-        for (const bot of bots) {
-          // If the bot has a cron, then add a scheduler for it
-          if (bot.cronString || bot.cronTiming) {
-            // We pass `undefined` as previous version to make sure that the latest cron string is used
-            await addCronJobs(bot, undefined);
-          }
+      async (bot: Bot) => {
+        // If the bot has a cron, then add a scheduler for it
+        if (bot.cronString || bot.cronTiming) {
+          // We pass `undefined` as previous version to make sure that the latest cron string is used
+          await addCronJobs(bot, undefined);
         }
       },
       { delayBetweenPagesMs: 1000 }

--- a/packages/server/src/workers/cron.ts
+++ b/packages/server/src/workers/cron.ts
@@ -222,13 +222,14 @@ export async function reloadCronBots(): Promise<void> {
     // Clears all jobs from the cron queue, including active ones
     await queue.obliterate({ force: true });
 
-    const allBots = await getSystemRepo().searchResources<Bot>({ resourceType: 'Bot' });
-    for (const bot of allBots) {
-      // If the bot has a cron, then add a scheduler for it
-      if (bot.cronString || bot.cronTiming) {
-        // We pass `undefined` as previous version to make sure that the latest cron string is used
-        await addCronJobs(bot, undefined);
+    await getSystemRepo().processAllResources<Bot>({ resourceType: 'Bot' }, async (bots: Bot[]) => {
+      for (const bot of bots) {
+        // If the bot has a cron, then add a scheduler for it
+        if (bot.cronString || bot.cronTiming) {
+          // We pass `undefined` as previous version to make sure that the latest cron string is used
+          await addCronJobs(bot, undefined);
+        }
       }
-    }
+    });
   }
 }


### PR DESCRIPTION
Serves two purposes:
1. Clears out potentially orphaned jobs in the `cron` queue
2. Makes sure cron queue job schedulers are synced with the current cron strings of all `Bot` resources

Tested locally:
<img width="912" alt="Screenshot 2025-01-21 at 9 43 20 AM" src="https://github.com/user-attachments/assets/001441ef-af1d-47aa-8905-44231a392134" />

