### PR TITLE
Minor tweaks to CodeInput

### DIFF
--- a/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
+++ b/packages/react/src/AsyncAutocomplete/AsyncAutocomplete.tsx
@@ -11,9 +11,9 @@ import {
 } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
+import { IconCheck } from '@tabler/icons-react';
 import { KeyboardEvent, ReactNode, SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { killEvent } from '../utils/dom';
-import { IconCheck } from '@tabler/icons-react';
 import { AsyncAutocompleteTestIds } from './AsyncAutocomplete.utils';
 
 export interface AsyncAutocompleteOption<T> extends ComboboxItem {
@@ -231,6 +231,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
       }
       lastValueRef.current = undefined;
       if (val === '$create') {
+        setSearch('');
         addSelected(search);
       } else {
         addSelected(val);
@@ -286,6 +287,9 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
     />
   );
 
+  const createVisible = creatable && search.trim().length > 0;
+  const comboboxVisible = options.length > 0 || createVisible;
+
   return (
     <Combobox store={combobox} onOptionSubmit={handleValueSelect} withinPortal={true} shadow="xl" {...rest}>
       <Combobox.DropdownTarget>
@@ -329,7 +333,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
         </PillsInput>
       </Combobox.DropdownTarget>
 
-      <Combobox.Dropdown hidden={options.length === 0} data-testid={AsyncAutocompleteTestIds.options}>
+      <Combobox.Dropdown hidden={!comboboxVisible} data-testid={AsyncAutocompleteTestIds.options}>
         <Combobox.Options>
           <ScrollAreaAutosize type="scroll" mah={optionsDropdownMaxHeight}>
             {options.map((item) => {
@@ -341,9 +345,7 @@ export function AsyncAutocomplete<T>(props: AsyncAutocompleteProps<T>): JSX.Elem
               );
             })}
 
-            {creatable && search.trim().length > 0 && (
-              <Combobox.Option value="$create">+ Create {search}</Combobox.Option>
-            )}
+            {createVisible && <Combobox.Option value="$create">+ Create {search}</Combobox.Option>}
 
             {!creatable && search.trim().length > 0 && options.length === 0 && <EmptyComponent search={search} />}
           </ScrollAreaAutosize>

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -295,7 +295,14 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
     case PropertyType.code:
       // overwrite getPrimitiveInputProps().error since FormSection already shows errors
       return (
-        <CodeInput {...getPrimitiveInputProps()} error={undefined} onChange={onChange} binding={binding?.valueSet} />
+        <CodeInput
+          {...getPrimitiveInputProps()}
+          error={undefined}
+          onChange={onChange}
+          binding={binding?.valueSet}
+          creatable
+          maxValues={1}
+        />
       );
     case PropertyType.boolean:
       return (

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -56,6 +56,7 @@ const searchParamToOperators: Record<string, Operator[]> = {
     Operator.ENDS_BEFORE,
     Operator.APPROXIMATELY,
   ],
+  uri: [Operator.EQUALS, Operator.NOT, Operator.ABOVE, Operator.BELOW],
 };
 
 const operatorNames: Record<Operator, string> = {


### PR DESCRIPTION
1. Make `<CodeInput>` in `<ResourcePropertyInput>` creatable and default maxValues=1
2. Fixed the missing "+ Create" option when no other options visible
3. Clear the text input after using "+ Create"

Drive by fix:  Fixed the "operator" drop down for "url" search parameters in the SearchFilterEditor.  The react component was missing the entry for "uri" -> operators.