### PR TITLE
Fix clearing a string value when choice-of-type

### DIFF
--- a/packages/react/src/ResourceForm/ResourceForm.utils.ts
+++ b/packages/react/src/ResourceForm/ResourceForm.utils.ts
@@ -17,7 +17,9 @@ export function setPropertyValue(
       }
     }
   }
-  obj[propName] = value;
+  if (!isEmpty(value)) {
+    obj[propName] = value;
+  }
   return obj;
 }
 


### PR DESCRIPTION
Recently when testing changes to `Bot.cronString`, I noticed that trying to delete the value would fail in the UI, and you had to go to the JSON editor.

It turns out clearning normal string properties works fine, it was only busted on the choice-of-type `[x]` properties.