### PR TITLE
fix(fhircast): make sure we don't start heartbeat before server started

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -32,7 +32,6 @@ import { initKeys } from './oauth/keys';
 import { authenticateRequest } from './oauth/middleware';
 import { oauthRouter } from './oauth/routes';
 import { openApiHandler } from './openapi';
-import { cleanupOtelHeartbeat, initOtelHeartbeat } from './otel/otel';
 import { closeRateLimiter, getRateLimiter } from './ratelimit';
 import { closeRedis, initRedis } from './redis';
 import { requestContextStore } from './request-context-store';
@@ -219,12 +218,10 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
     initBinaryStorage(config.binaryStorage);
     initWorkers(config);
     initHeartbeat(config);
-    initOtelHeartbeat();
   });
 }
 
 export async function shutdownApp(): Promise<void> {
-  cleanupOtelHeartbeat();
   cleanupHeartbeat();
   await closeWebSockets();
   if (server) {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -32,6 +32,7 @@ import { initKeys } from './oauth/keys';
 import { authenticateRequest } from './oauth/middleware';
 import { oauthRouter } from './oauth/routes';
 import { openApiHandler } from './openapi';
+import { cleanupOtelHeartbeat, initOtelHeartbeat } from './otel/otel';
 import { closeRateLimiter, getRateLimiter } from './ratelimit';
 import { closeRedis, initRedis } from './redis';
 import { requestContextStore } from './request-context-store';
@@ -218,10 +219,12 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
     initBinaryStorage(config.binaryStorage);
     initWorkers(config);
     initHeartbeat(config);
+    initOtelHeartbeat();
   });
 }
 
 export async function shutdownApp(): Promise<void> {
+  cleanupOtelHeartbeat();
   cleanupHeartbeat();
   await closeWebSockets();
   if (server) {

--- a/packages/server/src/fhircast/websocket.ts
+++ b/packages/server/src/fhircast/websocket.ts
@@ -15,7 +15,7 @@ let heartbeatHandler: (() => void) | undefined;
 const websocketMap = new Map<ws.WebSocket, string>();
 const topicRefCountMap = new Map<string, number>();
 
-function initHeartbeatHandler(): void {
+export function initFhircastHeartbeat(): void {
   if (!heartbeatHandler) {
     heartbeatHandler = (): void => {
       const baseHeartbeatPayload = {
@@ -48,8 +48,12 @@ function initHeartbeatHandler(): void {
   }
 }
 
-// We always init heartbeat handler early so we get our metrics being tracked at server startup
-initHeartbeatHandler();
+export function stopFhircastHeartbeat(): void {
+  if (heartbeatHandler) {
+    heartbeat.removeEventListener('heartbeat', heartbeatHandler);
+    heartbeatHandler = undefined;
+  }
+}
 
 /**
  * Handles a new WebSocket connection to the FHIRCast hub.

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -6,7 +6,7 @@ import ws from 'ws';
 import { handleAgentConnection } from './agent/websockets';
 import { getConfig } from './config';
 import { RequestContext } from './context';
-import { handleFhircastConnection } from './fhircast/websocket';
+import { handleFhircastConnection, initHeartbeatHandler, stopFhircastHeartbeat } from './fhircast/websocket';
 import { globalLogger } from './logger';
 import { getRedis, getRedisSubscriber } from './redis';
 import { requestContextStore } from './request-context-store';
@@ -89,6 +89,8 @@ export function initWebSockets(server: http.Server): void {
       socket.destroy();
     }
   });
+
+  initHeartbeatHandler();
 }
 
 function getWebSocketPath(path: string): string {
@@ -128,6 +130,8 @@ async function handleEchoConnection(socket: ws.WebSocket): Promise<void> {
 }
 
 export async function closeWebSockets(): Promise<void> {
+  stopFhircastHeartbeat();
+
   if (wsServer) {
     wsServer.close();
     wsServer = undefined;

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -6,7 +6,7 @@ import ws from 'ws';
 import { handleAgentConnection } from './agent/websockets';
 import { getConfig } from './config';
 import { RequestContext } from './context';
-import { handleFhircastConnection, initHeartbeatHandler, stopFhircastHeartbeat } from './fhircast/websocket';
+import { handleFhircastConnection, stopFhircastHeartbeat } from './fhircast/websocket';
 import { globalLogger } from './logger';
 import { getRedis, getRedisSubscriber } from './redis';
 import { requestContextStore } from './request-context-store';
@@ -89,8 +89,6 @@ export function initWebSockets(server: http.Server): void {
       socket.destroy();
     }
   });
-
-  initHeartbeatHandler();
 }
 
 function getWebSocketPath(path: string): string {

--- a/packages/server/src/websockets.ts
+++ b/packages/server/src/websockets.ts
@@ -6,7 +6,7 @@ import ws from 'ws';
 import { handleAgentConnection } from './agent/websockets';
 import { getConfig } from './config';
 import { RequestContext } from './context';
-import { handleFhircastConnection, stopFhircastHeartbeat } from './fhircast/websocket';
+import { handleFhircastConnection, initFhircastHeartbeat, stopFhircastHeartbeat } from './fhircast/websocket';
 import { globalLogger } from './logger';
 import { getRedis, getRedisSubscriber } from './redis';
 import { requestContextStore } from './request-context-store';
@@ -89,6 +89,8 @@ export function initWebSockets(server: http.Server): void {
       socket.destroy();
     }
   });
+
+  initFhircastHeartbeat();
 }
 
 function getWebSocketPath(path: string): string {


### PR DESCRIPTION
This came up in a test where I was trying to simulate a heartbeat firing to test a new heartbeat listener, it ended up causing the test to fail due to the FHIRcast listener firing and throwing because of Redis not being initialized yet.