### PR TITLE
fix(client): only look for namespace string for CDA content type

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2187,7 +2187,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       // Both of the above strings are required to be within a valid C-CDA document
       // The root element in a CDA document should be a "ClinicalDocument"
       // "urn:hl7-org:v3" is a required namespace to be referenced by all valid C-CDA documents as well
-      if (fileStr.includes('<ClinicalDocument') && fileStr.includes('xmlns="urn:hl7-org:v3"')) {
+      if (fileStr.includes('<ClinicalDocument') && fileStr.includes('urn:hl7-org:v3')) {
         createBinaryOptions = { ...createBinaryOptions, contentType: ContentType.CDA_XML };
       }
     }


### PR DESCRIPTION
Previously our C-CDA detection mechanism depended on an exact match occurring in the file `xmlns="urn:hl7-org:v3"`, but this did not take into account that you can use single-quotes in XML. Just looking for the namespace string itself solves this.