### PR TITLE
feat(bot): add `fast-xml-parser` to bot layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53205,6 +53205,7 @@
       "dependencies": {
         "@medplum/core": "3.2.27",
         "@medplum/definitions": "3.2.27",
+        "fast-xml-parser": "4.5.1",
         "form-data": "4.0.1",
         "jose": "5.9.6",
         "node-fetch": "2.7.0",
@@ -53225,6 +53226,28 @@
         "pdfmake": "^0.2.7",
         "ssh2": "^1.11.0",
         "ssh2-sftp-client": "^9.0.4"
+      }
+    },
+    "packages/bot-layer/node_modules/fast-xml-parser": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "packages/cdk": {

--- a/packages/bot-layer/package.json
+++ b/packages/bot-layer/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@medplum/core": "3.2.27",
     "@medplum/definitions": "3.2.27",
+    "fast-xml-parser": "4.5.1",
     "form-data": "4.0.1",
     "jose": "5.9.6",
     "node-fetch": "2.7.0",


### PR DESCRIPTION
This is to enable parsing C-CDA documents and other XML files from within a Bot.

`fast-xml-parser` is already present in the monorepo, has only 1 small dependency, and overall adds just ~292kB to the bot dependency layer.

<img width="709" alt="Screenshot 2025-01-24 at 12 43 29 PM" src="https://github.com/user-attachments/assets/074195ac-48d4-4464-826f-839bf53a7ffa" />

<img width="709" alt="Screenshot 2025-01-24 at 12 42 05 PM" src="https://github.com/user-attachments/assets/48702d4a-ec17-48de-95f4-53ff8a228390" />

<img width="667" alt="Screenshot 2025-01-24 at 12 41 53 PM" src="https://github.com/user-attachments/assets/a343d932-e4bc-4b13-af06-9a6f6b80d715" />


