### PR TITLE
Conditionally include WWW-Authenticate header if query param included in request

### DIFF
--- a/packages/server/src/oauth/middleware.ts
+++ b/packages/server/src/oauth/middleware.ts
@@ -4,6 +4,7 @@ import { NextFunction, Request, Response } from 'express';
 import { IncomingMessage } from 'http';
 import { AuthenticatedRequestContext, getRequestContext } from '../context';
 import { getLoginForAccessToken, getLoginForBasicAuth } from './utils';
+import { getConfig } from '../config';
 
 export interface AuthState {
   login: Login;
@@ -15,11 +16,16 @@ export interface AuthState {
   onBehalfOfMembership?: ProjectMembership;
 }
 
+export const PROMPT_BASIC_AUTH_PARAM = '_medplum-prompt-basic-auth';
+
 export function authenticateRequest(req: Request, res: Response, next: NextFunction): void {
   const ctx = getRequestContext();
   if (ctx instanceof AuthenticatedRequestContext) {
     next();
   } else {
+    if (res.req.query[PROMPT_BASIC_AUTH_PARAM]) {
+      res.set('WWW-Authenticate', `Basic realm="${getConfig().baseUrl}"`);
+    }
     next(new OperationOutcomeError(unauthorized));
   }
 }


### PR DESCRIPTION
We've tried [including WWW-Authenticate](https://github.com/medplum/medplum/pull/4167), but doing so unconditionally unfortunately leads to [a very bad experience](https://github.com/medplum/medplum/pull/4200) in browsers, e.g. when using `@medplum/app`, since it causes a basic authentication dialog to be shown to the user.