### PR TITLE
Remove post-filtering of exports for efficiency

### DIFF
--- a/packages/server/src/fhir/operations/export.test.ts
+++ b/packages/server/src/fhir/operations/export.test.ts
@@ -145,7 +145,7 @@ describe('Export', () => {
         },
       });
 
-      const exporter = new BulkExporter(systemRepo, undefined);
+      const exporter = new BulkExporter(systemRepo);
       const exportWriteResourceSpy = jest.spyOn(exporter, 'writeResource');
       await exporter.start('http://example.com');
 

--- a/packages/server/src/fhir/operations/export.ts
+++ b/packages/server/src/fhir/operations/export.ts
@@ -50,10 +50,10 @@ async function startExport(req: FhirRequest, exportType: string): Promise<FhirRe
   const since = singularize(req.query._since);
   const types = singularize(req.query._type)?.split(',');
 
-  const exporter = new BulkExporter(ctx.repo, since);
+  const exporter = new BulkExporter(ctx.repo);
   const bulkDataExport = await exporter.start(concatUrls(baseUrl, 'fhir/R4' + req.pathname));
 
-  exportResources(exporter, ctx.project, types, exportType)
+  exportResources(exporter, ctx.project, types, exportType, since)
     .then(() => ctx.logger.info('Export completed', { exportType, id: ctx.project.id }))
     .catch((err) => ctx.logger.error('Export failure', { exportType, id: ctx.project.id, error: err }));
 
@@ -119,6 +119,7 @@ const unexportedResourceTypes = [
   'ValueSet',
   'BulkDataExport',
   'AsyncJob',
+  'AuditEvent',
 ];
 
 function canBeExported(resourceType: string): boolean {

--- a/packages/server/src/fhir/operations/groupexport.test.ts
+++ b/packages/server/src/fhir/operations/groupexport.test.ts
@@ -318,7 +318,7 @@ describe('Group Export', () => {
   test('groupExportResources without members', async () => {
     const { project } = await createTestProject();
     expect(project).toBeDefined();
-    const exporter = new BulkExporter(systemRepo, undefined);
+    const exporter = new BulkExporter(systemRepo);
     const exportWriteResourceSpy = jest.spyOn(exporter, 'writeResource');
 
     const group: Group = await systemRepo.createResource<Group>({
@@ -327,7 +327,7 @@ describe('Group Export', () => {
       actual: true,
     });
     await exporter.start('http://example.com');
-    await groupExportResources(exporter, project, group, systemRepo);
+    await groupExportResources(systemRepo, exporter, project, group);
     const bulkDataExport = await exporter.close(project);
     expect(bulkDataExport.status).toBe('completed');
     expect(exportWriteResourceSpy).toHaveBeenCalledTimes(0);
@@ -336,7 +336,7 @@ describe('Group Export', () => {
   test('groupExportResources members without reference', async () => {
     const { project } = await createTestProject();
     expect(project).toBeDefined();
-    const exporter = new BulkExporter(systemRepo, undefined);
+    const exporter = new BulkExporter(systemRepo);
 
     const patient: Patient = await systemRepo.createResource<Patient>({
       resourceType: 'Patient',
@@ -354,7 +354,7 @@ describe('Group Export', () => {
       member: [{ entity: { reference: '' } }, { entity: { reference: `Patient/${patient.id}` } }],
     });
     await exporter.start('http://example.com');
-    await groupExportResources(exporter, project, group, systemRepo);
+    await groupExportResources(systemRepo, exporter, project, group);
     const bulkDataExport = await exporter.close(project);
     expect(bulkDataExport.status).toBe('completed');
   });

--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -11,10 +11,11 @@ const operation = getOperationDefinition('Patient', 'everything');
 
 const defaultMaxResults = 1000;
 
-type PatientEverythingParameters = {
+export type PatientEverythingParameters = {
   _since?: string;
   _count?: number;
   _offset?: number;
+  _type?: ResourceType[];
 };
 
 // Patient everything operation.
@@ -54,7 +55,7 @@ export async function getPatientEverything(
   params?: PatientEverythingParameters
 ): Promise<Bundle> {
   const resourceList = getPatientCompartments().resource as CompartmentDefinitionResource[];
-  const types = resourceList.map((r) => r.code as ResourceType).filter((t) => t !== 'Binary');
+  const types = params?._type ?? resourceList.map((r) => r.code as ResourceType).filter((t) => t !== 'Binary');
   types.push('Patient');
   sortStringArray(types);
 

--- a/packages/server/src/fhir/operations/utils/bulkexporter.ts
+++ b/packages/server/src/fhir/operations/utils/bulkexporter.ts
@@ -31,16 +31,12 @@ class BulkFileWriter {
 
 export class BulkExporter {
   readonly repo: Repository;
-  readonly since: string | undefined;
-  readonly types: string[];
   private resource: AsyncJob | undefined;
   readonly writers: Record<string, BulkFileWriter> = {};
   readonly resourceSet = new Set<string>();
 
-  constructor(repo: Repository, since: string | undefined, types: string[] = []) {
+  constructor(repo: Repository) {
     this.repo = repo;
-    this.since = since;
-    this.types = types;
   }
 
   async start(url: string): Promise<AsyncJob> {
@@ -77,15 +73,6 @@ export class BulkExporter {
   }
 
   async writeResource(resource: Resource): Promise<void> {
-    if (this.types.length > 0 && !this.types.includes(resource.resourceType)) {
-      return;
-    }
-    if (resource.resourceType === 'AuditEvent') {
-      return;
-    }
-    if (this.since !== undefined && (resource.meta?.lastUpdated as string) < this.since) {
-      return;
-    }
     const ref = getReferenceString(resource);
     if (!this.resourceSet.has(ref)) {
       const writer = await this.getWriter(resource.resourceType);


### PR DESCRIPTION
The internal `BulkExporter` utility was applying filtering to the results written, which is inefficient: these resources would be loaded from the database only to be thrown away.  This refactor moves three classes of filtering from `BulkExporter` into the upstream export logic, where they can be applied at the time the database is accessed:
- Removing `AuditEvent` resources from Bulk Export results
- General type filtering (i.e. `_type` in `Patient/$everything` and Group Export)
- `_since` parameter in `Patient/$everything` and Group Export

Incidentally, this also adds support for the `_type` parameter to the `Patient/$everything` operation