### PR TITLE
Replace deprecated usage of createAttachment

### DIFF
--- a/packages/app/src/resource/BotEditor.tsx
+++ b/packages/app/src/resource/BotEditor.tsx
@@ -79,7 +79,7 @@ export function BotEditor(): JSX.Element | null {
         const sourceCode = await medplum.createAttachment({
           data: code,
           filename: 'index.ts',
-          contentType: 'text/typescript'
+          contentType: 'text/typescript',
         });
         const executableCode = await medplum.createAttachment({
           data: codeOutput,

--- a/packages/app/src/resource/BotEditor.tsx
+++ b/packages/app/src/resource/BotEditor.tsx
@@ -76,8 +76,16 @@ export function BotEditor(): JSX.Element | null {
       try {
         const code = await getCode();
         const codeOutput = await getCodeOutput();
-        const sourceCode = await medplum.createAttachment(code, 'index.ts', 'text/typescript');
-        const executableCode = await medplum.createAttachment(codeOutput, 'index.js', 'text/typescript');
+        const sourceCode = await medplum.createAttachment({
+          data: code,
+          filename: 'index.ts',
+          contentType: 'text/typescript'
+        });
+        const executableCode = await medplum.createAttachment({
+          data: codeOutput,
+          filename: 'index.js',
+          contentType: 'text/javascript',
+        });
         const operations: PatchOperation[] = [
           {
             op: 'add',

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -55,7 +55,11 @@ export async function saveBot(medplum: MedplumClient, botConfig: MedplumBotConfi
   }
 
   console.log('Saving source code...');
-  const sourceCode = await medplum.createAttachment(code, basename(codePath), getCodeContentType(codePath));
+  const sourceCode = await medplum.createAttachment({
+    data: code,
+    filename: basename(codePath),
+    contentType: getCodeContentType(codePath),
+  });
 
   console.log('Updating bot...');
   const updateResult = await medplum.updateResource({

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -2120,7 +2120,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * Example:
    *
    * ```typescript
-   * const result = await medplum.createAttachment(myFile, 'test.jpg', 'image/jpeg');
+   * const result = await medplum.createAttachment({ data: myFile, filename: 'test.jpg', contentType: 'image/jpeg' });
    * console.log(result);
    * ```
    *

--- a/packages/docs/docs/fhir-datastore/binary-data.mdx
+++ b/packages/docs/docs/fhir-datastore/binary-data.mdx
@@ -77,7 +77,11 @@ Once uploaded, the `Binary` resource can be referenced in various FHIR resources
 **a. Patient Profile Picture - `Patient.photo`:**
 
 ```javascript
-const photo = await medplum.createAttachment(myFile, 'test.jpg', 'image/jpeg');
+const photo = await medplum.createAttachment({
+  data: myFile,
+  filename: 'test.jpg',
+  contentType: 'image/jpeg',
+});
 
 const patient = await medplum.createResource('Patient', {
   resourceType: 'Patient',
@@ -88,7 +92,11 @@ const patient = await medplum.createResource('Patient', {
 **b. Message Attachment - `Communication.payload.contentAttachment`:**
 
 ```javascript
-const document = await medplum.createAttachment(myFile, 'test.pdf', 'application/pdf');
+const document = await medplum.createAttachment({
+  data: myFile,
+  filename: 'test.pdf',
+  contentType: 'application/pdf',
+});
 
 const communication = await medplum.createResource('Communication', {
   resourceType: 'Communication',


### PR DESCRIPTION
Ran across a few instances of `createAttachment` using the deprecated options. I think this cleans it up?