### PR TITLE
Fix ResourceForm clearing values

### DIFF
--- a/packages/react/src/ResourceForm/ResourceForm.utils.ts
+++ b/packages/react/src/ResourceForm/ResourceForm.utils.ts
@@ -17,7 +17,9 @@ export function setPropertyValue(
       }
     }
   }
-  if (!isEmpty(value)) {
+  if (isEmpty(value)) {
+    obj[propName] = undefined;
+  } else {
     obj[propName] = value;
   }
   return obj;


### PR DESCRIPTION
A regression was introduced in https://github.com/medplum/medplum/pull/5849

That change was intended to prevent setting values to empty string or empty array, which is invalid FHIR.

Unfortunately it missed an important step, which is that it still needs to clear the value.

This PR adds that final step.