### PR TITLE
Adding Code System to Eligibility Demo App

### DIFF
--- a/examples/medplum-eligibility-demo/data/core/core-data.json
+++ b/examples/medplum-eligibility-demo/data/core/core-data.json
@@ -841,6 +841,24 @@
           ]
         }
       }
+    },
+    {
+      "request": { "method": "POST", "url": "CodeSystem" },
+      "resource": {
+        "resourceType": "CodeSystem",
+        "url": "https://example.org/x12-service-type-codes",
+        "name": "x12-service-type-codes",
+        "title": "X12 Service Type Codes",
+        "status": "active",
+        "content": "complete",
+        "concept": [
+          {
+            "code": "30",
+            "display": "Plan Coverage and General Benefits",
+            "definition": "Services related to plan coverage and general benefits information"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
In order to select an X-12 service type, there's no code system to populate the drop down in the eligibility demo app.

Added a Code System in the Bundle resource which is added when the user clicks "Upload Core Data". The code system only contains one x12-service-type-code, which is "30"

closes #5892 