### PR TITLE
feat: Support POST on Bulk Patient Export and Bulk Group Export

### DIFF
--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -233,9 +233,11 @@ function initInternalFhirRouter(): FhirRouter {
 
   // Group $export operation
   router.add('GET', '/Group/:id/$export', groupExportHandler);
+  router.add('POST', '/Group/:id/$export', groupExportHandler);
 
   // Patient $export operation
   router.add('GET', '/Patient/$export', patientExportHandler);
+  router.add('POST', '/Patient/$export', patientExportHandler);
 
   // Measure $evaluate-measure operation
   router.add('POST', '/Measure/:id/$evaluate-measure', evaluateMeasureHandler);


### PR DESCRIPTION
## Why
* The System-level export supports both POST and GET method
* Patient and Group-level export only supports GET
* The IG supports both methods: https://build.fhir.org/ig/HL7/bulk-data/export.html#bulk-data-kick-off-request
* However, the Medplum CLI / @medplum/core only implements the POST operation, so Patient and Group exports in the CLI are currently broken

## What
* Adds POST method routes for the Patient and Group, the handler is the same for all of them