### PR TITLE
 Add Web API Globals to VM Context Sandbox

### DIFF
--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -386,12 +386,15 @@ async function runInVmContext(request: BotExecutionContext): Promise<BotExecutio
   const botConsole = new MockConsole();
 
   const sandbox = {
+    console: botConsole,
+    fetch,
     require,
     ContentType,
     Hl7Message,
     MedplumClient,
-    fetch,
-    console: botConsole,
+    TextEncoder,
+    URL,
+    URLSearchParams,
     event: {
       bot: createReference(bot),
       baseUrl: config.vmContextBaseUrl ?? config.baseUrl,


### PR DESCRIPTION
# Add Web API Globals to VM Context Sandbox

## Description
Add several essential Web API globals (`TextEncoder`, `URL`, `URLSearchParams`) to the default sandbox available to VM context bots. While many built-in JavaScript classes like `Set` and `Map` are automatically available in the VM context, certain Web APIs need to be explicitly added to the sandbox.

## Changes
- Added `TextEncoder` for text encoding operations
- Added `URL` for URL parsing and manipulation
- Added `URLSearchParams` for working with URL query parameters

## Testing
- [x] Verified that bot scripts can use all three Web APIs without reference errors
- [x] Confirmed existing bot functionality is unchanged

## Related
- Implements similar pattern to other globals in VM context sandbox: [execute.ts#L388-L405](https://github.com/medplum/medplum/blob/main/packages/server/src/fhir/operations/execute.ts#L388-L405)
