### PR TITLE
Refine subscription cleanup condition

### DIFF
--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -351,11 +351,10 @@ async function getSubscriptions(resource: Resource, project: Project): Promise<S
     const redisOnlySubStrs = await redis.mget(redisOnlySubRefStrs);
     if (project.features?.includes('websocket-subscriptions')) {
       const activeSubStrs = redisOnlySubStrs.filter(Boolean);
-      const hitRate = activeSubStrs.length / redisOnlySubStrs.length;
-      if (hitRate < 0.5 && redisOnlySubRefStrs.length >= 100) {
+      if (redisOnlySubStrs.length - activeSubStrs.length >= 100) {
         getLogger().warn('Excessive subscription cache miss', {
           numKeys: redisOnlySubRefStrs.length,
-          hitRate,
+          hitRate: activeSubStrs.length / redisOnlySubStrs.length,
           projectId,
         });
         const inactiveSubs: string[] = [];

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -351,7 +351,7 @@ async function getSubscriptions(resource: Resource, project: Project): Promise<S
     const redisOnlySubStrs = await redis.mget(redisOnlySubRefStrs);
     if (project.features?.includes('websocket-subscriptions')) {
       const activeSubStrs = redisOnlySubStrs.filter(Boolean);
-      if (redisOnlySubStrs.length - activeSubStrs.length >= 100) {
+      if (redisOnlySubStrs.length - activeSubStrs.length >= 50) {
         getLogger().warn('Excessive subscription cache miss', {
           numKeys: redisOnlySubRefStrs.length,
           hitRate: activeSubStrs.length / redisOnlySubStrs.length,


### PR DESCRIPTION
Simplifying/tightening the cleanup condition to trigger when there are at least 50 dead subscriptions to be cleaned up