### PR TITLE
Implement SMART launch operation endpoint

### DIFF
--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -5,6 +5,7 @@ const OK_ID = 'ok';
 const CREATED_ID = 'created';
 const GONE_ID = 'gone';
 const NOT_MODIFIED_ID = 'not-modified';
+const FOUND_ID = 'found';
 const NOT_FOUND_ID = 'not-found';
 const CONFLICT_ID = 'conflict';
 const UNAUTHORIZED_ID = 'unauthorized';
@@ -280,6 +281,23 @@ export function serverTimeout(msg?: string): OperationOutcome {
   };
 }
 
+export function redirect(url: string): OperationOutcome {
+  return {
+    resourceType: 'OperationOutcome',
+    id: FOUND_ID,
+    issue: [
+      {
+        severity: 'information',
+        code: 'informational',
+        details: {
+          coding: [{ system: 'urn:ietf:rfc:3986', code: url }],
+          text: 'Redirect to ' + url,
+        },
+      },
+    ],
+  };
+}
+
 export function isOperationOutcome(value: unknown): value is OperationOutcome {
   return typeof value === 'object' && value !== null && (value as any).resourceType === 'OperationOutcome';
 }
@@ -296,6 +314,10 @@ export function isCreated(outcome: OperationOutcome): boolean {
 
 export function isAccepted(outcome: OperationOutcome): boolean {
   return outcome.id === ACCEPTED_ID;
+}
+
+export function isRedirect(outcome: OperationOutcome): boolean {
+  return outcome.id === FOUND_ID;
 }
 
 export function isNotFound(outcome: OperationOutcome): boolean {
@@ -322,6 +344,8 @@ export function getStatus(outcome: OperationOutcome): number {
       return 201;
     case ACCEPTED_ID:
       return 202;
+    case FOUND_ID:
+      return 302;
     case NOT_MODIFIED_ID:
       return 304;
     case UNAUTHORIZED_ID:

--- a/packages/server/src/fhir/operations/launch.test.ts
+++ b/packages/server/src/fhir/operations/launch.test.ts
@@ -1,0 +1,116 @@
+import express from 'express';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config';
+import { withTestContext, createTestProject } from '../../test.setup';
+import { ClientApplication, Encounter, Patient, SmartAppLaunch } from '@medplum/fhirtypes';
+import request from 'supertest';
+import { Repository } from '../repo';
+import { createReference } from '@medplum/core';
+
+const app = express();
+
+describe('ClientApplication/:id/$launch', () => {
+  let accessToken: string;
+  let client: ClientApplication;
+  let repo: Repository;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await withTestContext(() => initApp(app, config));
+
+    ({ client, accessToken, repo } = await createTestProject({
+      withClient: true,
+      withAccessToken: true,
+      withRepo: true,
+    }));
+  });
+
+  beforeEach(async () => {
+    expect(accessToken).toBeDefined();
+    expect(client.id).toBeDefined();
+    expect(repo).toBeInstanceOf(Repository);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Requires ID', async () => {
+    const res = await request(app)
+      .get('/fhir/R4/ClientApplication/$launch')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res.status).toBe(404);
+  });
+
+  test('Requires launchUri to be configured', async () => {
+    const res = await request(app)
+      .get(`/fhir/R4/ClientApplication/${client.id}/$launch`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res.status).toBe(400);
+  });
+
+  test('Redirects to launchUri', async () => {
+    // Update ClientApplication with launchUri
+    const launchUri = 'https://example.com/smart-launch';
+    client = await repo.updateResource({ ...client, launchUri });
+
+    const res = await request(app)
+      .get(`/fhir/R4/ClientApplication/${client.id}/$launch`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send();
+    expect(res.status).toBe(302);
+    expect(res.headers['location'].startsWith(launchUri + '?')).toBe(true);
+
+    const uri = new URL(res.headers['location']);
+    const launchId = uri.searchParams.get('launch');
+
+    // Ensure resource exists
+    const launch = await repo.readResource<SmartAppLaunch>('SmartAppLaunch', launchId as string);
+    expect(launch.id).toEqual(launchId);
+  });
+
+  test('Preserves launch parameter', async () => {
+    // Update ClientApplication with launchUri
+    const launchUri = 'https://example.com/smart-launch';
+    client = await repo.updateResource({ ...client, launchUri });
+
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+
+    const res = await request(app)
+      .get(`/fhir/R4/ClientApplication/${client.id}/$launch`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .query({ patient: patient.id })
+      .send();
+    expect(res.status).toBe(302);
+    expect(res.headers['location'].startsWith(launchUri + '?')).toBe(true);
+
+    const uri = new URL(res.headers['location']);
+    const launchId = uri.searchParams.get('launch');
+
+    // Ensure resource contains launch context
+    const launch = await repo.readResource<SmartAppLaunch>('SmartAppLaunch', launchId as string);
+    expect(launch.patient).toStrictEqual(createReference(patient));
+  });
+
+  test('Requires single launch parameter', async () => {
+    // Update ClientApplication with launchUri
+    const launchUri = 'https://example.com/smart-launch';
+    client = await repo.updateResource({ ...client, launchUri });
+
+    const patient = await repo.createResource<Patient>({ resourceType: 'Patient' });
+    const encounter = await repo.createResource<Encounter>({
+      resourceType: 'Encounter',
+      status: 'unknown',
+      class: { display: 'Appointment' },
+    });
+
+    const res = await request(app)
+      .get(`/fhir/R4/ClientApplication/${client.id}/$launch`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .query({ patient: patient.id, encounter: encounter.id })
+      .send();
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/fhir/operations/launch.ts
+++ b/packages/server/src/fhir/operations/launch.ts
@@ -1,0 +1,58 @@
+import { badRequest, redirect } from '@medplum/core';
+import { ClientApplication, OperationDefinition, SmartAppLaunch } from '@medplum/fhirtypes';
+import { getSystemRepo } from '../repo';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import { getConfig } from '../../config';
+import { parseInputParameters } from './utils/parameters';
+import { getAuthenticatedContext } from '../../context';
+
+const operation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  name: 'clientapplication-launch',
+  status: 'active',
+  kind: 'operation',
+  code: 'launch',
+  experimental: true,
+  resource: ['ClientApplication'],
+  system: false,
+  type: false,
+  instance: true,
+  parameter: [
+    { use: 'in', name: 'patient', type: 'uuid', min: 0, max: '1' },
+    { use: 'in', name: 'encounter', type: 'uuid', min: 0, max: '1' },
+  ],
+};
+
+type LaunchOperationParameters = {
+  patient?: string;
+  encounter?: string;
+};
+
+export async function appLaunchHandler(req: FhirRequest): Promise<FhirResponse> {
+  if (!req.params.id) {
+    return [badRequest('ClientApplication to launch must be specified')];
+  }
+
+  const params = parseInputParameters<LaunchOperationParameters>(operation, req);
+
+  const clientApp = await getSystemRepo().readResource<ClientApplication>('ClientApplication', req.params.id);
+
+  if (!clientApp.launchUri) {
+    return [badRequest('ClientApplication not configured for launch')];
+  }
+  if (params.patient && params.encounter) {
+    return [badRequest('Only one launch context can be specified')];
+  }
+
+  const launch = await getAuthenticatedContext().repo.createResource<SmartAppLaunch>({
+    resourceType: 'SmartAppLaunch',
+    patient: params.patient ? { reference: `Patient/${params.patient}` } : undefined,
+    encounter: params.encounter ? { reference: `Encounter/${params.encounter}` } : undefined,
+  });
+
+  const url = new URL(clientApp.launchUri);
+  url.searchParams.set('iss', getConfig().baseUrl + 'fhir/R4/');
+  url.searchParams.set('launch', launch.id as string);
+
+  return [redirect(url.toString())];
+}

--- a/packages/server/src/fhir/outcomes.ts
+++ b/packages/server/src/fhir/outcomes.ts
@@ -1,4 +1,4 @@
-import { ContentType, getStatus, isAccepted } from '@medplum/core';
+import { ContentType, getStatus, isAccepted, isRedirect } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Response } from 'express';
 import { Result, ValidationError } from 'express-validator';
@@ -37,6 +37,12 @@ function getValidationErrorExpression(error: ValidationError): string[] | undefi
 export function sendOutcome(res: Response, outcome: OperationOutcome): Response {
   if (isAccepted(outcome) && outcome.issue?.[0].diagnostics) {
     res.set('Content-Location', outcome.issue[0].diagnostics);
+  }
+  if (isRedirect(outcome)) {
+    const uri = outcome.issue[0].details?.coding?.find((c) => c.system === 'urn:ietf:rfc:3986')?.code;
+    if (uri) {
+      res.set('Location', uri);
+    }
   }
   return res
     .status(getStatus(outcome))

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -44,6 +44,7 @@ import { sendOutcome } from './outcomes';
 import { ResendSubscriptionsOptions } from './repo';
 import { sendFhirResponse } from './response';
 import { smartConfigurationHandler, smartStylingHandler } from './smart';
+import { appLaunchHandler } from './operations/launch';
 
 export const fhirRouter = Router();
 
@@ -257,6 +258,9 @@ function initInternalFhirRouter(): FhirRouter {
 
   // StructureDefinition $expand-profile operation
   router.add('POST', '/StructureDefinition/$expand-profile', structureDefinitionExpandProfileHandler);
+
+  // ClientApplication $launch
+  router.add('GET', '/ClientApplication/:id/$launch', appLaunchHandler);
 
   // AWS operations
   router.add('POST', '/:resourceType/:id/$aws-textract', awsTextractHandler);


### PR DESCRIPTION
Adding a bespoke `ClientApplication/:id/$launch` operation endpoint to handle redirecting to the `launchUri`, plus additional logic for validation and creating the `SmartAppLaunch` resource.  This largely replaces the client-side logic in [the `SmartAppLaunchLink` component](https://github.com/medplum/medplum/blob/89791c928fcded92050af7b1f9ab0a37398a301d/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.tsx) and enables simply making a client-side GET request to the operation endpoint from the user's browser and letting the server handle the rest