### PR TITLE
fix(ci): upgrade `autofix.ci`

### DIFF
--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -23,4 +23,4 @@ jobs:
       - run: npm ci --maxsockets 1
       - run: npm run prettier
 
-      - uses: autofix-ci/action@d3e591514b99d0fca6779455ff8338516663f7cc
+      - uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944


### PR DESCRIPTION
Updates to latest version of `autofix.ci` after noticing our CI was failing when autofix tries to make changes currently

See: https://github.com/medplum/medplum/actions/runs/13273520758