### PR TITLE
QuestionnaireBuilder override item.requiered

### DIFF
--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.test.tsx
@@ -122,6 +122,45 @@ describe('QuestionnaireBuilder', () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
+  test('Handles submit with required items', async () => {
+    const onSubmit = jest.fn();
+
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        item: [
+          {
+            linkId: 'q1',
+            type: QuestionnaireItemType.string,
+            required: true,
+            text: 'q1',
+          },
+          {
+            linkId: 'q2',
+            type: QuestionnaireItemType.integer,
+            required: true,
+            text: 'q1',
+          },
+          {
+            linkId: 'q3',
+            type: QuestionnaireItemType.date,
+            required: true,
+            text: 'q3',
+          },
+        ],
+      },
+      onSubmit,
+    });
+
+    expect(screen.getByText('Save')).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+    });
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
   test('Handles AutoSave', async () => {
     const onSubmit = jest.fn();
 

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -117,6 +117,8 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
   const editing = props.selectedKey === props.item.id;
   const hovering = props.hoverKey === props.item.id;
 
+  console.log(item.item)
+
   const itemRef = useRef<T>();
   itemRef.current = props.item;
 
@@ -221,6 +223,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
               <QuestionnaireFormItem
                 item={item}
                 index={0}
+                isRequired={false}
                 onChange={() => undefined}
                 response={{ linkId: item.linkId }}
               />

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -117,8 +117,6 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
   const editing = props.selectedKey === props.item.id;
   const hovering = props.hoverKey === props.item.id;
 
-  console.log(item.item)
-
   const itemRef = useRef<T>();
   itemRef.current = props.item;
 

--- a/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
+++ b/packages/react/src/QuestionnaireBuilder/QuestionnaireBuilder.tsx
@@ -221,7 +221,7 @@ function ItemBuilder<T extends Questionnaire | QuestionnaireItem>(props: ItemBui
               <QuestionnaireFormItem
                 item={item}
                 index={0}
-                isRequired={false}
+                required={false}
                 onChange={() => undefined}
                 response={{ linkId: item.linkId }}
               />

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -37,7 +37,7 @@ import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
 export interface QuestionnaireFormItemProps {
   readonly item: QuestionnaireItem;
   readonly index: number;
-  readonly isRequired?: boolean;
+  readonly required?: boolean;
   readonly response: QuestionnaireResponseItem;
   readonly onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }
@@ -106,7 +106,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step="any"
           id={name}
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueDecimal: e.currentTarget.valueAsNumber })}
         />
@@ -118,7 +118,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step={1}
           id={name}
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueInteger: e.currentTarget.valueAsNumber })}
         />
@@ -129,7 +129,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="date"
           id={name}
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueDate: e.currentTarget.value })}
         />
@@ -138,7 +138,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <DateTimeInput
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(newValue: string) => onChangeAnswer({ valueDateTime: newValue })}
         />
@@ -149,7 +149,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="time"
           id={name}
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueTime: e.currentTarget.value })}
         />
@@ -160,7 +160,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <TextInput
           id={name}
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value })}
         />
@@ -170,7 +170,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <Textarea
           id={name}
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value })}
         />
@@ -190,7 +190,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <ReferenceInput
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           targetTypes={getQuestionnaireItemReferenceTargetTypes(item)}
           searchCriteria={getQuestionnaireItemReferenceFilter(item, context.subject, context.encounter)}
           defaultValue={defaultValue?.value}
@@ -202,7 +202,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <QuantityInput
           path=""
           name={name}
-          required={props.isRequired ?? item.required}
+          required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue })}
           disableWheel

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -37,6 +37,7 @@ import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
 export interface QuestionnaireFormItemProps {
   readonly item: QuestionnaireItem;
   readonly index: number;
+  readonly isRequired: boolean | undefined;
   readonly response: QuestionnaireResponseItem;
   readonly onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }
@@ -105,7 +106,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step="any"
           id={name}
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueDecimal: e.currentTarget.valueAsNumber })}
         />
@@ -117,7 +118,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           step={1}
           id={name}
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueInteger: e.currentTarget.valueAsNumber })}
         />
@@ -128,7 +129,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="date"
           id={name}
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueDate: e.currentTarget.value })}
         />
@@ -137,7 +138,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <DateTimeInput
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(newValue: string) => onChangeAnswer({ valueDateTime: newValue })}
         />
@@ -148,7 +149,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           type="time"
           id={name}
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueTime: e.currentTarget.value })}
         />
@@ -159,7 +160,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <TextInput
           id={name}
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value })}
         />
@@ -169,7 +170,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <Textarea
           id={name}
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) => onChangeAnswer({ valueString: e.currentTarget.value })}
         />
@@ -189,7 +190,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       return (
         <ReferenceInput
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           targetTypes={getQuestionnaireItemReferenceTargetTypes(item)}
           searchCriteria={getQuestionnaireItemReferenceFilter(item, context.subject, context.encounter)}
           defaultValue={defaultValue?.value}
@@ -201,7 +202,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         <QuantityInput
           path=""
           name={name}
-          required={item.required}
+          required={props.isRequired ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(newValue) => onChangeAnswer({ valueQuantity: newValue })}
           disableWheel

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -37,7 +37,7 @@ import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
 export interface QuestionnaireFormItemProps {
   readonly item: QuestionnaireItem;
   readonly index: number;
-  readonly isRequired: boolean | undefined;
+  readonly isRequired?: boolean;
   readonly response: QuestionnaireResponseItem;
   readonly onChange: (newResponseItem: QuestionnaireResponseItem) => void;
 }


### PR DESCRIPTION
QuestionnaireFormItem is being reused by `QuestionnaireForm` and `QuestionnaireBuilder`. 
This introduced an issue that submitting a `QuestionnaireBuilder` that contains an item where `required: true`, the form won't submit.
Added an override to `QuestionnaireFormItem` so  `QuestionnaireBuilder` can set required to false.
