### PR TITLE
Scroll to top of viewport on route change in Medplum web ui

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -4,7 +4,7 @@ import { Space } from '@mantine/core';
 import { MEDPLUM_VERSION } from '@medplum/core';
 import type { UserConfiguration } from '@medplum/fhirtypes';
 import type { NavbarMenu } from '@medplum/react';
-import { AppShell, Loading, Logo, useMedplum } from '@medplum/react';
+import { AppShell, Loading, Logo, ScrollToTop, useMedplum } from '@medplum/react';
 import {
   IconBrandAsana,
   IconBuilding,
@@ -46,6 +46,7 @@ export function App(): JSX.Element {
       menus={userConfigToMenu(config)}
       displayAddBookmark={!!config?.id}
     >
+      <ScrollToTop />
       <Suspense fallback={<Loading />}>
         <AppRoutes />
       </Suspense>

--- a/packages/app/src/test.setup.ts
+++ b/packages/app/src/test.setup.ts
@@ -75,3 +75,4 @@ for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
 }
 
 Object.defineProperty(globalThis.window, 'sessionStorage', { value: new MemoryStorage() });
+Object.defineProperty(globalThis.window, 'scrollTo', { value: () => {} });

--- a/packages/react/src/ScrollToTop/ScrollToTop.test.tsx
+++ b/packages/react/src/ScrollToTop/ScrollToTop.test.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { act, fireEvent, render } from '../test-utils/render';
+import { ScrollToTop } from './ScrollToTop';
+
+describe('ScrollToTop', () => {
+  beforeEach(() => {
+    window.scrollTo = jest.fn();
+  });
+
+  test('scrolls to top on route change', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/initial']}>
+        <Routes>
+          <Route path="*" element={<ScrollToTop />} />
+        </Routes>
+        <Link to="/new-route">Navigate</Link>
+      </MemoryRouter>
+    );
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+
+    // Clear mock calls
+    (window.scrollTo as jest.Mock).mockClear();
+
+    // Simulate navigation
+    await act(() => fireEvent.click(container.querySelector('a') as HTMLAnchorElement));
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/packages/react/src/ScrollToTop/ScrollToTop.tsx
+++ b/packages/react/src/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Component that scrolls the window to the top when the route changes.
+ * This is useful for maintaining a good user experience when navigating between pages.
+ * @returns Empty JSX fragment as this is a utility component with no visual representation
+ */
+export function ScrollToTop(): null {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -100,6 +100,7 @@ export * from './ResourcePropertyInput/ResourcePropertyInput.utils';
 export * from './ResourceTable/ResourceTable';
 export * from './ResourceTimeline/ResourceTimeline';
 export * from './Scheduler/Scheduler';
+export * from './ScrollToTop/ScrollToTop';
 export * from './SearchControl/SearchControl';
 export * from './SearchControl/SearchControlField';
 export * from './SearchControl/SearchUtils';


### PR DESCRIPTION
Running into a bit of pain, I've been spending a lot of time flicking between resources in the web ui to debug various things and finding myself doing a lot of scrolling.

When navigating between a sufficiently long `Patient` (or any other entity) and an entity of the same type, the scroll position is maintained - this PR fixes this behavior. Usually I hit it when searching, but also happens when manually throwing a reference in the url.

Let me know if you'd rather this be a hook.