### PR TITLE
Log requests made on behalf of another user

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1,4 +1,4 @@
-import { badRequest, ContentType } from '@medplum/core';
+import { badRequest, ContentType, getReferenceString } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
 import express, { json } from 'express';
 import request from 'supertest';
@@ -7,7 +7,8 @@ import { getConfig, loadTestConfig } from './config';
 import { DatabaseMode, getDatabasePool } from './database';
 import { globalLogger } from './logger';
 import { getRedis } from './redis';
-import { initTestAuth } from './test.setup';
+import { createTestProject, initTestAuth } from './test.setup';
+import { inviteUser } from './admin/invite';
 
 describe('App', () => {
   test('Get HTTP config', async () => {
@@ -148,6 +149,41 @@ describe('App', () => {
       const logLine = (process.stdout.write as jest.Mock).mock.calls[0][0];
       const logObj = JSON.parse(logLine);
       expect(logObj).toMatchObject({ method: 'POST', path: '/fhir/R4/Patient', status: 201 });
+    });
+
+    test('Authenticated request with On-Behalf-Of', async () => {
+      const { accessToken, project, client } = await createTestProject({
+        withAccessToken: true,
+        withClient: true,
+        membership: { admin: true },
+      });
+
+      const { profile } = await inviteUser({
+        project,
+        resourceType: 'Practitioner',
+        firstName: 'Test',
+        lastName: 'Person',
+      });
+
+      (process.stdout.write as jest.Mock).mockClear();
+
+      const patient: Patient = {
+        resourceType: 'Patient',
+        name: [{ family: 'Simpson', given: ['Lisa'] }],
+      };
+      const res1 = await request(app)
+        .post(`/fhir/R4/Patient`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Medplum-On-Behalf-Of', getReferenceString(profile))
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send(patient);
+      expect(res1.status).toBe(201);
+      expect(res1.body).toMatchObject(patient);
+      expect(process.stdout.write).toHaveBeenCalledTimes(1);
+
+      const logLine = (process.stdout.write as jest.Mock).mock.calls[0][0];
+      const logObj = JSON.parse(logLine);
+      expect(logObj).toMatchObject({ profile: `${getReferenceString(client)} (as ${getReferenceString(profile)})` });
     });
   });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -256,10 +256,11 @@ const loggingMiddleware = (req: Request, res: Response, next: NextFunction): voi
     let userProfile: string | undefined;
     let projectId: string | undefined;
     if (ctx instanceof AuthenticatedRequestContext) {
-      if (ctx.profile.reference === ctx.realProfile.reference) {
+      const underlyingProfile = ctx.authState.membership.profile;
+      if (ctx.profile.reference === underlyingProfile.reference) {
         userProfile = ctx.profile.reference;
       } else {
-        userProfile = `${ctx.realProfile.reference} (as ${ctx.profile.reference})`;
+        userProfile = `${underlyingProfile.reference} (as ${ctx.profile.reference})`;
       }
       projectId = ctx.project.id;
     }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -256,7 +256,11 @@ const loggingMiddleware = (req: Request, res: Response, next: NextFunction): voi
     let userProfile: string | undefined;
     let projectId: string | undefined;
     if (ctx instanceof AuthenticatedRequestContext) {
-      userProfile = ctx.profile.reference;
+      if (ctx.profile.reference === ctx.realProfile.reference) {
+        userProfile = ctx.profile.reference;
+      } else {
+        userProfile = `${ctx.realProfile.reference} (as ${ctx.profile.reference})`;
+      }
       projectId = ctx.project.id;
     }
 

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -63,10 +63,6 @@ export class AuthenticatedRequestContext extends RequestContext {
     return this.membership.profile;
   }
 
-  get realProfile(): Reference<ProfileResource | Bot | ClientApplication> {
-    return this.authState.membership.profile;
-  }
-
   [Symbol.dispose](): void {
     this.repo[Symbol.dispose]();
   }

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -1,5 +1,5 @@
 import { Logger, ProfileResource, isUUID, parseLogLevel } from '@medplum/core';
-import { Extension, Login, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
+import { Bot, ClientApplication, Extension, Login, Project, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { NextFunction, Request, Response } from 'express';
 import { getConfig } from './config';
@@ -59,8 +59,12 @@ export class AuthenticatedRequestContext extends RequestContext {
     return this.authState.login;
   }
 
-  get profile(): Reference<ProfileResource> {
-    return this.membership.profile as Reference<ProfileResource>;
+  get profile(): Reference<ProfileResource | Bot | ClientApplication> {
+    return this.membership.profile;
+  }
+
+  get realProfile(): Reference<ProfileResource | Bot | ClientApplication> {
+    return this.authState.membership.profile;
   }
 
   [Symbol.dispose](): void {

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -1,6 +1,8 @@
 import { allOk, createReference, getReferenceString, ProfileResource } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import {
+  Bot,
+  ClientApplication,
   Encounter,
   Patient,
   PlanDefinition,
@@ -77,7 +79,7 @@ export async function planDefinitionApplyHandler(req: FhirRequest): Promise<Fhir
  */
 async function createAction(
   repo: Repository,
-  requester: Reference<ProfileResource>,
+  requester: Reference<ProfileResource | Bot | ClientApplication>,
   subject: Reference<Patient>,
   action: PlanDefinitionAction,
   encounter?: Reference<Encounter>
@@ -99,7 +101,7 @@ async function createAction(
  */
 async function createQuestionnaireTask(
   repo: Repository,
-  requester: Reference<ProfileResource>,
+  requester: Reference<ProfileResource | Bot | ClientApplication>,
   subject: Reference<Patient>,
   action: PlanDefinitionAction,
   encounter?: Reference<Encounter>
@@ -129,7 +131,7 @@ async function createQuestionnaireTask(
  */
 async function createTask(
   repo: Repository,
-  requester: Reference<ProfileResource>,
+  requester: Reference<ProfileResource | Bot | ClientApplication>,
   subject: Reference<Patient>,
   action: PlanDefinitionAction,
   encounter?: Reference<Encounter>,
@@ -143,7 +145,7 @@ async function createTask(
     intent: 'order',
     status: 'requested',
     authoredOn: new Date().toISOString(),
-    requester,
+    requester: requester as Task['requester'],
     for: subject,
     encounter: encounter,
     owner: subject,

--- a/packages/server/src/oauth/userinfo.test.ts
+++ b/packages/server/src/oauth/userinfo.test.ts
@@ -1,4 +1,4 @@
-import { ContentType } from '@medplum/core';
+import { ContentType, parseJWTPayload } from '@medplum/core';
 import { ContactPoint } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
@@ -18,7 +18,7 @@ describe('OAuth2 UserInfo', () => {
     await shutdownApp();
   });
 
-  test('Get userinfo with profile email', async () => {
+  test('Get userinfo with user email', async () => {
     const res = await request(app).post('/auth/login').type('json').send({
       email: 'admin@example.com',
       password: 'medplum_admin',
@@ -46,6 +46,52 @@ describe('OAuth2 UserInfo', () => {
     expect(res3.body.given_name).toBe('Medplum');
     expect(res3.body.family_name).toBe('Admin');
     expect(res3.body.email).toBe('admin@example.com');
+  });
+
+  test('Get userinfo with profile email', async () => {
+    const res = await request(app).post('/auth/login').type('json').send({
+      email: 'admin@example.com',
+      password: 'medplum_admin',
+      scope: 'openid profile email phone address',
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+    });
+    expect(res.status).toBe(200);
+
+    const res2 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'authorization_code',
+      code: res.body.code,
+      code_verifier: 'xyz',
+    });
+    expect(res2.status).toBe(200);
+    expect(res2.body.access_token).toBeDefined();
+    const accessToken = res2.body.access_token;
+
+    const userId = parseJWTPayload(accessToken).sub;
+
+    // Temporarily clear out `email` field
+    const updateRes = await request(app)
+      .patch(`/fhir/R4/User/${userId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send([{ op: 'remove', path: '/email' }]);
+    expect(updateRes.status).toBe(200);
+
+    const res3 = await request(app)
+      .get(`/oauth2/userinfo`)
+      .set('Authorization', 'Bearer ' + res2.body.access_token);
+    expect(res3.status).toBe(200);
+    expect(res3.body.sub).toBeDefined();
+    expect(res3.body.profile).toBeDefined();
+    expect(res3.body.name).toBe('Medplum Admin');
+    expect(res3.body.given_name).toBe('Medplum');
+    expect(res3.body.family_name).toBe('Admin');
+    expect(res3.body.email).toBe('admin@example.com');
+
+    const replaceRes = await request(app)
+      .patch(`/fhir/R4/User/${userId}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send([{ op: 'add', path: '/email', value: 'admin@example.com' }]);
+    expect(replaceRes.status).toBe(200);
   });
 
   test('Get userinfo with phone', async () => {

--- a/packages/server/src/oauth/userinfo.ts
+++ b/packages/server/src/oauth/userinfo.ts
@@ -7,7 +7,7 @@ import {
   getReferenceString,
   ProfileResource,
 } from '@medplum/core';
-import { Reference, User } from '@medplum/fhirtypes';
+import { Bot, ClientApplication, Reference, User } from '@medplum/fhirtypes';
 import { Request, RequestHandler, Response } from 'express';
 import { asyncWrap } from '../async';
 import { getAuthenticatedContext } from '../context';
@@ -43,17 +43,17 @@ export const userInfoHandler: RequestHandler = asyncWrap(async (_req: Request, r
   res.status(200).json(userInfo);
 });
 
-function buildProfile(userInfo: Record<string, any>, profile: ProfileResource): void {
+function buildProfile(userInfo: Record<string, any>, profile: ProfileResource | Bot | ClientApplication): void {
   userInfo.profile = getReferenceString(profile);
   userInfo.locale = 'en-US';
-  userInfo.birthdate = profile.birthDate;
+  userInfo.birthdate = 'birthDate' in profile ? profile.birthDate : '';
 
   const lastUpdated = getDateProperty(profile.meta?.lastUpdated);
   if (lastUpdated) {
     userInfo.updated_at = lastUpdated.getTime() / 1000;
   }
 
-  const humanName = profile.name?.[0];
+  const humanName = typeof profile.name === 'object' ? profile.name?.[0] : undefined;
   if (humanName) {
     userInfo.name = formatHumanName(humanName);
     userInfo.given_name = formatGivenName(humanName);
@@ -69,12 +69,16 @@ function buildProfile(userInfo: Record<string, any>, profile: ProfileResource): 
   userInfo.nickname = '';
 }
 
-function buildEmail(userInfo: Record<string, any>, profile: ProfileResource, user: User): void {
+function buildEmail(
+  userInfo: Record<string, any>,
+  profile: ProfileResource | Bot | ClientApplication,
+  user: User
+): void {
   if (user.email) {
     userInfo.email = user.email;
     userInfo.email_verified = Boolean(user.emailVerified);
   } else {
-    const contactPoint = profile.telecom?.find((cp) => cp.system === 'email');
+    const contactPoint = 'telecom' in profile ? profile.telecom?.find((cp) => cp.system === 'email') : undefined;
     if (contactPoint) {
       userInfo.email = contactPoint.value;
       userInfo.email_verified = false;
@@ -82,16 +86,16 @@ function buildEmail(userInfo: Record<string, any>, profile: ProfileResource, use
   }
 }
 
-function buildPhone(userInfo: Record<string, any>, profile: ProfileResource): void {
-  const contactPoint = profile.telecom?.find((cp) => cp.system === 'phone');
+function buildPhone(userInfo: Record<string, any>, profile: ProfileResource | Bot | ClientApplication): void {
+  const contactPoint = 'telecom' in profile ? profile.telecom?.find((cp) => cp.system === 'phone') : undefined;
   if (contactPoint) {
     userInfo.phone_number = contactPoint.value;
     userInfo.phone_number_verified = false;
   }
 }
 
-function buildAddress(userInfo: Record<string, any>, profile: ProfileResource): void {
-  const address = profile.address?.[0];
+function buildAddress(userInfo: Record<string, any>, profile: ProfileResource | Bot | ClientApplication): void {
+  const address = 'address' in profile ? profile.address?.[0] : undefined;
   if (address) {
     userInfo.address = {
       formatted: formatAddress(address),


### PR DESCRIPTION
When a request is made with the `X-Medplum-On-Behalf-Of` header, ensure that server logs accurately reflect which actors are involved