### PR TITLE
Move R4 project ID to separate constants file

### DIFF
--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * The hardcoded ID for the base FHIR R4 Project.
+ *
+ * This is a UUIDv5 of the string "R4" in the NAMESPACE_DNS namespace.
+ *
+ *     r4ProjectId = v5('R4', nullUuid)
+ */
+export const r4ProjectId = '161452d9-43b7-5c29-aa7b-c85680fa45c6';

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -68,11 +68,11 @@ import { Operation } from 'rfc6902';
 import { v7 } from 'uuid';
 import validator from 'validator';
 import { getConfig } from '../config';
+import { r4ProjectId } from '../constants';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { getLogger } from '../logger';
 import { incrementCounter, recordHistogramValue } from '../otel/otel';
 import { getRedis } from '../redis';
-import { r4ProjectId } from '../seed';
 import {
   AuditEventOutcome,
   AuditEventSubtype,

--- a/packages/server/src/migrations/schema/v48.ts
+++ b/packages/server/src/migrations/schema/v48.ts
@@ -3,9 +3,9 @@
  * Do not edit manually.
  */
 
-import { PoolClient } from 'pg';
-import { r4ProjectId } from '../../seed';
 import { Project } from '@medplum/fhirtypes';
+import { PoolClient } from 'pg';
+import { r4ProjectId } from '../../constants';
 
 export async function run(client: PoolClient): Promise<void> {
   const r4Project: Project = {

--- a/packages/server/src/seed.ts
+++ b/packages/server/src/seed.ts
@@ -1,18 +1,12 @@
 import { createReference } from '@medplum/core';
 import { Practitioner, Project, ProjectMembership, User } from '@medplum/fhirtypes';
-import { NIL as nullUuid, v5 } from 'uuid';
 import { bcryptHashPassword } from './auth/utils';
+import { r4ProjectId } from './constants';
 import { getSystemRepo, Repository } from './fhir/repo';
 import { globalLogger } from './logger';
 import { rebuildR4SearchParameters } from './seeds/searchparameters';
 import { rebuildR4StructureDefinitions } from './seeds/structuredefinitions';
 import { rebuildR4ValueSets } from './seeds/valuesets';
-
-/**
- * The hardcoded ID for the base FHIR R4 Project.
- * (161452d9-43b7-5c29-aa7b-c85680fa45c6)
- */
-export const r4ProjectId = v5('R4', nullUuid);
 
 export async function seedDatabase(): Promise<void> {
   if (await isSeeded()) {

--- a/packages/server/src/seeds/searchparameters.ts
+++ b/packages/server/src/seeds/searchparameters.ts
@@ -1,9 +1,9 @@
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 import { BundleEntry, SearchParameter } from '@medplum/fhirtypes';
+import { r4ProjectId } from '../constants';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { Repository, getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
-import { r4ProjectId } from '../seed';
 
 /**
  * Creates all SearchParameter resources.

--- a/packages/server/src/seeds/structuredefinitions.ts
+++ b/packages/server/src/seeds/structuredefinitions.ts
@@ -1,9 +1,9 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, Resource, StructureDefinition } from '@medplum/fhirtypes';
+import { r4ProjectId } from '../constants';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { Repository, getSystemRepo } from '../fhir/repo';
 import { globalLogger } from '../logger';
-import { r4ProjectId } from '../seed';
 
 /**
  * Creates all StructureDefinition resources.

--- a/packages/server/src/seeds/valuesets.ts
+++ b/packages/server/src/seeds/valuesets.ts
@@ -1,8 +1,8 @@
 import { Operator } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
 import { Bundle, BundleEntry, CodeSystem, ValueSet } from '@medplum/fhirtypes';
+import { r4ProjectId } from '../constants';
 import { Repository, getSystemRepo } from '../fhir/repo';
-import { r4ProjectId } from '../seed';
 
 /**
  * Imports all built-in ValueSets and CodeSystems into the database.


### PR DESCRIPTION
I was getting a lot of spooky "undefined" errors on imports, which historically has been caused by circular imports.

When running `npm run circular`, the `r4ProjectId` was a big culprit for circular imports.

This PR cuts circular dependencies from 46 to 36.
