### PR TITLE
Added MedplumClient.readPatientSummary

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -1440,6 +1440,17 @@ describe('Client', () => {
     );
   });
 
+  test('Read patient summary', async () => {
+    const fetch = mockFetch(200, {});
+    const client = new MedplumClient({ fetch });
+    const result = await client.readPatientSummary('123');
+    expect(result).toBeDefined();
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.medplum.com/fhir/R4/Patient/123/$summary',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
   test('Create resource', async () => {
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });


### PR DESCRIPTION
Added `readPatientSummary` as a convenience method for calling `Patient/{id}/$summary`

Also updated `readPatientEverything` and `readPatientSummary` to use the same resource caching strategy as `search`, `searchResources`, etc.  The model is, after reading a `Bundle` of live resources, those resources can optionally be added to the internal cache for fast reading.