### PR TITLE
Improved PatientSummary react component

### DIFF
--- a/examples/medplum-provider/src/pages/patient/PatientPage.tsx
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.tsx
@@ -3,7 +3,7 @@ import { getReferenceString, isOk } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, OperationOutcomeAlert, PatientSummary } from '@medplum/react';
 import { useCallback, useEffect, useState } from 'react';
-import { Outlet, useLocation, useNavigate, Location } from 'react-router-dom';
+import { Location, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { usePatient } from '../../hooks/usePatient';
 import classes from './PatientPage.module.css';
 import {
@@ -85,6 +85,7 @@ export function PatientPage(): JSX.Element {
           patient={patient}
           appointmentsUrl={formatPatientPageTabUrl(patientId, getPatientPageTabOrThrow('appointments'))}
           encountersUrl={formatPatientPageTabUrl(patientId, getPatientPageTabOrThrow('encounter'))}
+          onClickResource={(resource) => navigate(`/Patient/${patientId}/${resource.resourceType}/${resource.id}`)}
         />
       </div>
       <div className={classes.content}>

--- a/packages/react/src/PatientSummary/Allergies.tsx
+++ b/packages/react/src/PatientSummary/Allergies.tsx
@@ -11,6 +11,7 @@ export interface AllergiesProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly allergies: AllergyIntolerance[];
+  readonly onClickResource?: (resource: AllergyIntolerance) => void;
 }
 
 export function Allergies(props: AllergiesProps): JSX.Element {
@@ -58,6 +59,7 @@ export function Allergies(props: AllergiesProps): JSX.Element {
             <ConceptBadge
               key={allergy.id}
               resource={allergy}
+              onClick={props.onClickResource}
               onEdit={(a) => {
                 setEditAllergy(a);
                 open();

--- a/packages/react/src/PatientSummary/ConceptBadge.tsx
+++ b/packages/react/src/PatientSummary/ConceptBadge.tsx
@@ -1,37 +1,45 @@
-import { Badge } from '@mantine/core';
+import { ActionIcon, Badge } from '@mantine/core';
 import { getDisplayString } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
-import { IconEdit } from '@tabler/icons-react';
+import { IconPencil } from '@tabler/icons-react';
 import { ReactNode } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { killEvent } from '../utils/dom';
 
 export interface ConceptBadgeProps<T extends Resource> {
   readonly resource: T;
+  readonly display?: string;
+  readonly onClick?: (resource: T) => void;
   readonly onEdit?: (resource: T) => void;
 }
 
 export function ConceptBadge<T extends Resource = Resource>(props: ConceptBadgeProps<T>): JSX.Element {
-  const { resource, onEdit } = props;
+  const { resource, display, onClick, onEdit } = props;
 
   let rightSection: ReactNode | undefined = undefined;
   if (onEdit) {
     rightSection = (
-      <IconEdit
-        aria-label={`Edit ${getDisplayString(resource)}`}
-        size={12}
-        onClick={(e) => {
-          killEvent(e);
-          onEdit(resource);
-        }}
-      />
+      <ActionIcon variant="subtle" size={12} radius="xl">
+        <IconPencil
+          aria-label={`Edit ${getDisplayString(resource)}`}
+          size={12}
+          onClick={(e) => {
+            killEvent(e);
+            onEdit(resource);
+          }}
+        />
+      </ActionIcon>
     );
   }
 
   return (
-    <MedplumLink key={resource.id} to={resource}>
-      <Badge variant="light" maw="100%" rightSection={rightSection}>
-        {getDisplayString(resource)}
+    <MedplumLink
+      key={resource.id}
+      to={onClick ? undefined : resource}
+      onClick={onClick ? () => onClick(resource) : undefined}
+    >
+      <Badge variant="light" maw="100%" rightSection={rightSection} style={{ cursor: 'pointer' }}>
+        {display ?? getDisplayString(resource)}
       </Badge>
     </MedplumLink>
   );

--- a/packages/react/src/PatientSummary/Medications.tsx
+++ b/packages/react/src/PatientSummary/Medications.tsx
@@ -11,6 +11,7 @@ export interface MedicationsProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly medicationRequests: MedicationRequest[];
+  readonly onClickResource?: (resource: MedicationRequest) => void;
 }
 
 export function Medications(props: MedicationsProps): JSX.Element {
@@ -58,6 +59,7 @@ export function Medications(props: MedicationsProps): JSX.Element {
             <ConceptBadge<MedicationRequest>
               key={request.id}
               resource={request}
+              onClick={props.onClickResource}
               onEdit={(mr) => {
                 setEditMedication(mr);
                 open();

--- a/packages/react/src/PatientSummary/PatientSummary.tsx
+++ b/packages/react/src/PatientSummary/PatientSummary.tsx
@@ -10,10 +10,12 @@ import {
   Observation,
   Patient,
   Reference,
+  Resource,
 } from '@medplum/fhirtypes';
 import { useMedplum, useResource } from '@medplum/react-hooks';
 import { IconGenderFemale, IconGenderMale, IconStethoscope, IconUserSquare } from '@tabler/icons-react';
 import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourceAvatar } from '../ResourceAvatar/ResourceAvatar';
 import { Allergies } from './Allergies';
 import { Medications } from './Medications';
@@ -21,7 +23,6 @@ import { ProblemList } from './ProblemList';
 import { SexualOrientation } from './SexualOrientation';
 import { SmokingStatus } from './SmokingStatus';
 import { Vitals } from './Vitals';
-import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 export interface PatientSummaryProps extends Omit<CardProps, 'children'> {
   readonly patient: Patient | Reference<Patient>;
@@ -30,6 +31,8 @@ export interface PatientSummaryProps extends Omit<CardProps, 'children'> {
   readonly appointmentsUrl?: string | undefined;
   /** The URL that the documented visits (encounters) link should navigate to or `undefined` to not show the link. */
   readonly encountersUrl?: string | undefined;
+  /** Callback when a resource is clicked in the list */
+  readonly onClickResource?: (resource: Resource) => void;
 }
 
 interface PatientMedicalData {
@@ -73,6 +76,7 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
     background,
     appointmentsUrl: propsAppointmentsUrl,
     encountersUrl: propsEncountersUrl,
+    onClickResource,
     ...cardProps
   } = props;
   const patient = useResource(propsPatient);
@@ -186,17 +190,29 @@ export function PatientSummary(props: PatientSummaryProps): JSX.Element | null {
         )}
         {medicalData && (
           <>
-            <Allergies patient={patient} allergies={medicalData.allergies} />
+            <Allergies patient={patient} allergies={medicalData.allergies} onClickResource={onClickResource} />
             <Divider />
-            <ProblemList patient={patient} problems={medicalData.problems} />
+            <ProblemList patient={patient} problems={medicalData.problems} onClickResource={onClickResource} />
             <Divider />
-            <Medications patient={patient} medicationRequests={medicalData.medicationRequests} />
+            <Medications
+              patient={patient}
+              medicationRequests={medicalData.medicationRequests}
+              onClickResource={onClickResource}
+            />
             <Divider />
-            <SexualOrientation patient={patient} sexualOrientation={medicalData.sexualOrientation} />
+            <SexualOrientation
+              patient={patient}
+              sexualOrientation={medicalData.sexualOrientation}
+              onClickResource={onClickResource}
+            />
             <Divider />
-            <SmokingStatus patient={patient} smokingStatus={medicalData.smokingStatus} />
+            <SmokingStatus
+              patient={patient}
+              smokingStatus={medicalData.smokingStatus}
+              onClickResource={onClickResource}
+            />
             <Divider />
-            <Vitals patient={patient} vitals={medicalData.vitals} />
+            <Vitals patient={patient} vitals={medicalData.vitals} onClickResource={onClickResource} />
           </>
         )}
       </Stack>

--- a/packages/react/src/PatientSummary/ProblemList.tsx
+++ b/packages/react/src/PatientSummary/ProblemList.tsx
@@ -11,6 +11,7 @@ export interface ProblemListProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly problems: Condition[];
+  readonly onClickResource?: (resource: Condition) => void;
 }
 
 export function ProblemList(props: ProblemListProps): JSX.Element {
@@ -61,6 +62,7 @@ export function ProblemList(props: ProblemListProps): JSX.Element {
                 <ConceptBadge<Condition>
                   key={problem.id}
                   resource={problem}
+                  onClick={props.onClickResource}
                   onEdit={(c) => {
                     setEditCondition(c);
                     open();

--- a/packages/react/src/PatientSummary/SexualOrientation.tsx
+++ b/packages/react/src/PatientSummary/SexualOrientation.tsx
@@ -1,12 +1,19 @@
-import { Anchor, Badge, Box, Button, Group, Modal, Radio, Stack, Text } from '@mantine/core';
+import { Anchor, Button, Group, Modal, Radio, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { HTTP_HL7_ORG, HTTP_TERMINOLOGY_HL7_ORG, LOINC, SNOMED, createReference } from '@medplum/core';
+import {
+  HTTP_HL7_ORG,
+  HTTP_TERMINOLOGY_HL7_ORG,
+  LOINC,
+  SNOMED,
+  createReference,
+  formatCodeableConcept,
+} from '@medplum/core';
 import { Encounter, Observation, Patient } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { useCallback, useState } from 'react';
-import { CodeableConceptDisplay } from '../CodeableConceptDisplay/CodeableConceptDisplay';
 import { Form } from '../Form/Form';
 import { killEvent } from '../utils/dom';
+import { ConceptBadge } from './ConceptBadge';
 
 const NULLFLAVOR = HTTP_TERMINOLOGY_HL7_ORG + '/CodeSystem/v3-NullFlavor';
 
@@ -35,6 +42,7 @@ export interface SexualOrientationProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly sexualOrientation?: Observation;
+  readonly onClickResource?: (resource: Observation) => void;
 }
 
 export function SexualOrientation(props: SexualOrientationProps): JSX.Element {
@@ -114,11 +122,13 @@ export function SexualOrientation(props: SexualOrientationProps): JSX.Element {
         </Anchor>
       </Group>
       {sexualOrientation?.valueCodeableConcept ? (
-        <Box>
-          <Badge variant="light">
-            <CodeableConceptDisplay value={sexualOrientation.valueCodeableConcept} />
-          </Badge>
-        </Box>
+        <ConceptBadge<Observation>
+          key={sexualOrientation.id}
+          resource={sexualOrientation}
+          display={formatCodeableConcept(sexualOrientation.valueCodeableConcept)}
+          onClick={props.onClickResource}
+          onEdit={() => open()}
+        />
       ) : (
         <Text>(none)</Text>
       )}

--- a/packages/react/src/PatientSummary/SmokingStatus.tsx
+++ b/packages/react/src/PatientSummary/SmokingStatus.tsx
@@ -1,12 +1,12 @@
-import { Anchor, Badge, Box, Button, Group, Modal, Radio, Stack, Text } from '@mantine/core';
+import { Anchor, Button, Group, Modal, Radio, Stack, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { HTTP_HL7_ORG, LOINC, SNOMED, createReference } from '@medplum/core';
+import { HTTP_HL7_ORG, LOINC, SNOMED, createReference, formatCodeableConcept } from '@medplum/core';
 import { Encounter, Observation, Patient } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { useCallback, useState } from 'react';
-import { CodeableConceptDisplay } from '../CodeableConceptDisplay/CodeableConceptDisplay';
 import { Form } from '../Form/Form';
 import { killEvent } from '../utils/dom';
+import { ConceptBadge } from './ConceptBadge';
 
 // Smoking Status widget
 // See: https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-smokingstatus.html
@@ -26,6 +26,7 @@ export interface SmokingStatusProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly smokingStatus?: Observation;
+  readonly onClickResource?: (resource: Observation) => void;
 }
 
 export function SmokingStatus(props: SmokingStatusProps): JSX.Element {
@@ -105,11 +106,13 @@ export function SmokingStatus(props: SmokingStatusProps): JSX.Element {
         </Anchor>
       </Group>
       {smokingStatus?.valueCodeableConcept ? (
-        <Box>
-          <Badge variant="light">
-            <CodeableConceptDisplay value={smokingStatus.valueCodeableConcept} />
-          </Badge>
-        </Box>
+        <ConceptBadge<Observation>
+          key={smokingStatus.id}
+          resource={smokingStatus}
+          display={formatCodeableConcept(smokingStatus.valueCodeableConcept)}
+          onClick={props.onClickResource}
+          onEdit={() => open()}
+        />
       ) : (
         <Text>(none)</Text>
       )}

--- a/packages/react/src/PatientSummary/Vitals.tsx
+++ b/packages/react/src/PatientSummary/Vitals.tsx
@@ -1,81 +1,113 @@
-import { Anchor, Button, Grid, Group, Modal, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { Anchor, Button, Grid, Group, Modal, SimpleGrid, Text, Textarea, TextInput, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import { formatQuantity } from '@medplum/core';
 import { Encounter, Observation, Patient } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { useCallback, useState } from 'react';
 import { Form } from '../Form/Form';
-import { QuantityDisplay } from '../QuantityDisplay/QuantityDisplay';
 import { killEvent } from '../utils/dom';
+import { ConceptBadge } from './ConceptBadge';
 import {
   createCompoundObservation,
   createLoincCode,
   createObservation,
   createQuantity,
-  getCompoundObservationValue,
   getObservationValue,
 } from './Vitals.utils';
 
 interface ObservationMeta {
+  readonly name: string;
+  readonly short: string;
   readonly code: string;
+  readonly component?: string;
   readonly title: string;
   readonly unit: string;
 }
 
-const LOINC_CODES: Record<string, ObservationMeta> = {
-  bloodPressure: {
-    code: '85354-9',
+const BP = '85354-9';
+const SYSTOLIC = '8480-6';
+const DIASTOLIC = '8462-4';
+
+const LOINC_CODES: ObservationMeta[] = [
+  {
+    name: 'systolic',
+    short: 'BP Sys',
+    code: BP,
+    component: SYSTOLIC,
     title: 'Blood Pressure',
     unit: 'mm[Hg]',
   },
-  heartRate: {
+  {
+    name: 'diastolic',
+    short: 'BP Dias',
+    code: BP,
+    component: DIASTOLIC,
+    title: 'Blood Pressure',
+    unit: 'mm[Hg]',
+  },
+  {
+    name: 'heartRate',
+    short: 'HR',
     code: '8867-4',
     title: 'Heart Rate',
     unit: '/min',
   },
-  bodyTemperature: {
+  {
+    name: 'bodyTemperature',
+    short: 'Temp',
     code: '8310-5',
     title: 'Body Temperature',
     unit: 'Cel',
   },
-  respiratoryRate: {
+  {
+    name: 'respiratoryRate',
+    short: 'RR',
     code: '9279-1',
     title: 'Respiratory Rate',
     unit: '/min',
   },
-  height: {
+  {
+    name: 'height',
+    short: 'Ht',
     code: '8302-2',
-    title: 'height',
+    title: 'Height',
     unit: 'cm',
   },
-  weight: {
+  {
+    name: 'weight',
+    short: 'Wt',
     code: '29463-7',
-    title: 'weight',
+    title: 'Weight',
     unit: 'kg',
   },
-  bmi: {
+  {
+    name: 'bmi',
+    short: 'BMI',
     code: '39156-5',
     title: 'BMI',
     unit: 'kg/m2',
   },
-  oxygen: {
+  {
+    name: 'oxygen',
+    short: 'O2',
     code: '2708-6',
     title: 'Oxygen',
     unit: '%',
   },
-  headCircumference: {
+  {
+    name: 'headCircumference',
+    short: 'HC',
     code: '9843-4',
     title: 'Head Circumference',
     unit: 'cm',
   },
-};
-
-const SYSTOLIC = '8480-6';
-const DIASTOLIC = '8462-4';
+];
 
 export interface VitalsProps {
   readonly patient: Patient;
   readonly encounter?: Encounter;
   readonly vitals: Observation[];
+  readonly onClickResource?: (resource: Observation) => void;
 }
 
 export function Vitals(props: VitalsProps): JSX.Element {
@@ -86,32 +118,39 @@ export function Vitals(props: VitalsProps): JSX.Element {
 
   const handleSubmit = useCallback(
     (formData: Record<string, string>) => {
-      const newObservations = Object.entries(LOINC_CODES)
-        .map(([name, meta]) => {
-          if (name === 'bloodPressure') {
-            return createCompoundObservation(patient, encounter, meta.code, meta.title, [
-              {
-                code: createLoincCode(SYSTOLIC, 'Systolic blood pressure'),
-                valueQuantity: createQuantity(parseFloat(formData['systolic']), 'mm[Hg]'),
-              },
-              {
-                code: createLoincCode(DIASTOLIC, 'Diastolic blood pressure'),
-                valueQuantity: createQuantity(parseFloat(formData['diastolic']), 'mm[Hg]'),
-              },
-            ]);
-          }
-          return createObservation(
+      const newObservations = [];
+
+      // Blood pressure is special because it has two components
+      newObservations.push(
+        createCompoundObservation(patient, encounter, BP, 'Blood pressure', [
+          {
+            code: createLoincCode(SYSTOLIC, 'Systolic blood pressure'),
+            valueQuantity: createQuantity(parseFloat(formData['systolic']), 'mm[Hg]'),
+          },
+          {
+            code: createLoincCode(DIASTOLIC, 'Diastolic blood pressure'),
+            valueQuantity: createQuantity(parseFloat(formData['diastolic']), 'mm[Hg]'),
+          },
+        ])
+      );
+
+      for (const meta of LOINC_CODES) {
+        if (meta.component) {
+          continue;
+        }
+        newObservations.push(
+          createObservation(
             patient,
             encounter,
             meta.code,
             meta.title,
-            createQuantity(parseFloat(formData[name]), meta.unit)
-          );
-        })
-        .filter(Boolean) as Observation[];
+            createQuantity(parseFloat(formData[meta.name]), meta.unit)
+          )
+        );
+      }
 
       // Execute all create requests in parallel to take advantage of autobatching
-      Promise.all(newObservations.map((obs) => medplum.createResource<Observation>(obs)))
+      Promise.all(newObservations.filter(Boolean).map((obs) => medplum.createResource<Observation>(obs as Observation)))
         .then((newVitals) => setVitals([...newVitals, ...vitals]))
         .catch(console.error);
 
@@ -137,92 +176,47 @@ export function Vitals(props: VitalsProps): JSX.Element {
         </Anchor>
       </Group>
       <Grid>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          BP Sys
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getCompoundObservationValue(vitals, LOINC_CODES.bloodPressure.code, SYSTOLIC)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          BP Dias
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getCompoundObservationValue(vitals, LOINC_CODES.bloodPressure.code, DIASTOLIC)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          HR
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.heartRate.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          Temp
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.bodyTemperature.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          RR
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.respiratoryRate.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          Height
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.height.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          Weight
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.weight.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          BMI
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.bmi.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          O2
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.oxygen.code)} />
-        </Grid.Col>
-        <Grid.Col span={3} ta="right" c="dimmed">
-          HC
-        </Grid.Col>
-        <Grid.Col span={3}>
-          <QuantityDisplay value={getObservationValue(vitals, LOINC_CODES.headCircumference.code)} />
-        </Grid.Col>
+        {LOINC_CODES.map((meta) => {
+          const obs = vitals.find((o) => o.code?.coding?.[0].code === meta.code);
+          return (
+            <>
+              <Grid.Col span={2} ta="right">
+                <Tooltip label={meta.title}>
+                  <Text c="dimmed" size="xs">
+                    {meta.short}
+                  </Text>
+                </Tooltip>
+              </Grid.Col>
+              <Grid.Col span={4}>
+                <Text size="xs">
+                  {obs && (
+                    <ConceptBadge<Observation>
+                      key={meta.name}
+                      resource={obs}
+                      display={formatQuantity(getObservationValue(obs, meta.component))}
+                      onClick={props.onClickResource}
+                    />
+                  )}
+                </Text>
+              </Grid.Col>
+            </>
+          );
+        })}
       </Grid>
       <Modal opened={opened} onClose={close} title="Add Vitals">
         <Form onSubmit={handleSubmit}>
-          <Stack>
-            <Group grow>
-              <TextInput name="systolic" label="BP Sys" data-autofocus={true} autoFocus />
-              <TextInput name="diastolic" label="BP Dias" />
-            </Group>
-            <Group grow>
-              <TextInput name="heartRate" label="HR" />
-              <TextInput name="bodyTemperature" label="Temp" />
-            </Group>
-            <Group grow>
-              <TextInput name="respiratoryRate" label="RR" />
-              <TextInput name="height" label="height" />
-            </Group>
-            <Group grow>
-              <TextInput name="weight" label="Wt" />
-              <TextInput name="bmi" label="BMI" />
-            </Group>
-            <Group grow>
-              <TextInput name="oxygen" label="O2" />
-              <TextInput name="headCircumference" label="HC" />
-            </Group>
-            <Textarea name="notes" label="Notes" />
-          </Stack>
+          <SimpleGrid cols={2}>
+            {LOINC_CODES.map((meta, index) => (
+              <TextInput
+                name={meta.name}
+                label={meta.short}
+                description={meta.title}
+                data-autofocus={index === 0}
+                autoFocus={index === 0}
+              />
+            ))}
+          </SimpleGrid>
+          <Textarea name="notes" label="Notes" />
           <Group justify="flex-end" gap={4} mt="md">
             <Button type="submit">Save</Button>
           </Group>

--- a/packages/react/src/PatientSummary/Vitals.tsx
+++ b/packages/react/src/PatientSummary/Vitals.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { formatQuantity } from '@medplum/core';
 import { Encounter, Observation, Patient } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { useCallback, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { Form } from '../Form/Form';
 import { killEvent } from '../utils/dom';
 import { ConceptBadge } from './ConceptBadge';
@@ -179,7 +179,7 @@ export function Vitals(props: VitalsProps): JSX.Element {
         {LOINC_CODES.map((meta) => {
           const obs = vitals.find((o) => o.code?.coding?.[0].code === meta.code);
           return (
-            <>
+            <Fragment key={meta.name}>
               <Grid.Col span={2} ta="right">
                 <Tooltip label={meta.title}>
                   <Text c="dimmed" size="xs">
@@ -199,7 +199,7 @@ export function Vitals(props: VitalsProps): JSX.Element {
                   )}
                 </Text>
               </Grid.Col>
-            </>
+            </Fragment>
           );
         })}
       </Grid>
@@ -208,6 +208,7 @@ export function Vitals(props: VitalsProps): JSX.Element {
           <SimpleGrid cols={2}>
             {LOINC_CODES.map((meta, index) => (
               <TextInput
+                key={meta.name}
                 name={meta.name}
                 label={meta.short}
                 description={meta.title}

--- a/packages/react/src/PatientSummary/Vitals.utils.ts
+++ b/packages/react/src/PatientSummary/Vitals.utils.ts
@@ -1,19 +1,17 @@
 import { LOINC, UCUM, createReference } from '@medplum/core';
 import { CodeableConcept, Encounter, Observation, ObservationComponent, Patient, Quantity } from '@medplum/fhirtypes';
 
-export function getObservationValue(observations: Observation[], code: string): Quantity | undefined {
-  const observation = observations.find((o) => o.code?.coding?.[0].code === code);
-  return observation?.valueQuantity;
-}
-
-export function getCompoundObservationValue(
-  observations: Observation[],
-  code: string,
-  innerCode: string
-): Quantity | undefined {
-  const observation = observations.find((o) => o.code?.coding?.[0].code === code);
-  const component = observation?.component?.find((c) => c.code?.coding?.[0].code === innerCode);
-  return component?.valueQuantity;
+/**
+ * Tries to get the observation quantity value.
+ * @param obs - The observation to check.
+ * @param component - Optional sub-component code to check.
+ * @returns The observation quantity value, if available. Otherwise, undefined.
+ */
+export function getObservationValue(obs: Observation, component?: string): Quantity | undefined {
+  if (component) {
+    return obs.component?.find((c) => c.code?.coding?.[0].code === component)?.valueQuantity;
+  }
+  return obs.valueQuantity;
 }
 
 export function createObservation(


### PR DESCRIPTION
Before:
* Clicking on the pills would always go to the root resource URL (i.e., "/Observation/123")
* That would break the user out of the "patient scope", which was a pretty poor UX

After:
* Optional React props so that apps can customize the click behavior
* Updated `medplum-provider` to stay in "patient scope" (i.e., "/Patient/456/Observation/123")
* This makes it really convenient to flip through all of the patient resources

Drive-by fixes:
* Updated the vitals section to also use the pill/badge component, which helps visually differentiate labels vs values
* Cleaned up vitals section - a bunch of text inconsistencies, capitalization mismatches, no help text, etc



https://github.com/user-attachments/assets/12844cb6-695b-46fc-ac3e-f5df17cab946

