### PR TITLE
Create DFT transfer bot for coverage and claim

### DIFF
--- a/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
@@ -1,7 +1,11 @@
 /**
- * This bot listens for ADT messages and creates a Medplum Patient and Encounter.
- *
- * The bot will return an ACK message to the sender of the ADT message.
+ * This example shows how you might listen for ADT (Admit, Discharge, and Transfer)
+ * messages. ADT messages are commonly used to record patients information and log 
+ * their movement between departments or facilities for the purposes of care coordination.
+ * 
+ * This bot listens for ADT messages and creates a FHIR Patient and Encounter via the PID and PV1 segments.
+ * 
+ * More information about the sections of ADT messages can be found here: https://rhapsody.health/resources/hl7-adt/
  */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';
 import { Encounter, Patient } from '@medplum/fhirtypes';

--- a/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
@@ -1,6 +1,6 @@
 /**
  * This bot listens for ADT messages and creates a Medplum Patient and Encounter.
- * 
+ *
  * The bot will return an ACK message to the sender of the ADT message.
  */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';

--- a/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
@@ -1,3 +1,8 @@
+/**
+ * This bot listens for ADT messages and creates a Medplum Patient and Encounter.
+ * 
+ * The bot will return an ACK message to the sender of the ADT message.
+ */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';
 import { Encounter, Patient } from '@medplum/fhirtypes';
 

--- a/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/adt-transfer-listener/adt-transfer-bot.ts
@@ -1,10 +1,10 @@
 /**
  * This example shows how you might listen for ADT (Admit, Discharge, and Transfer)
- * messages. ADT messages are commonly used to record patients information and log 
+ * messages. ADT messages are commonly used to record patients information and log
  * their movement between departments or facilities for the purposes of care coordination.
- * 
+ *
  * This bot listens for ADT messages and creates a FHIR Patient and Encounter via the PID and PV1 segments.
- * 
+ *
  * More information about the sections of ADT messages can be found here: https://rhapsody.health/resources/hl7-adt/
  */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
@@ -27,8 +27,6 @@ IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
     const contentType = 'x-application/hl7-v2+er7';
     const secrets = {};
     const result = await handler(medplum, { bot, input, contentType, secrets });
-
-    // Verify ACK message
     expect(result.get('MSA')).toBeDefined();
 
     // Verify Patient creation
@@ -64,6 +62,7 @@ IN1|1|BCBS|67890|Blue Cross Blue Shield||||||||||||||||||||||||||||||||XYZ789`);
     const contentType = 'x-application/hl7-v2+er7';
     const secrets = {};
     const result = await handler(medplum, { bot, input, contentType, secrets });
+    expect(result.get('MSA')).toBeDefined();
 
     // Verify Patient creation
     const patient = await medplum.searchOne('Patient', 'identifier=12345');

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
@@ -17,7 +17,8 @@ describe('DFT Message Cursor Tests', async () => {
   test('DFT Message with Insurance Creates Patient, Coverage, and Claim', async () => {
     const medplum = new MockClient();
     const bot: Reference<Bot> = { reference: 'Bot/123' };
-    const input = Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||DFT^P03|MSG00001|P|2.3
+    const input =
+      Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||DFT^P03|MSG00001|P|2.3
 EVN|P03|20240218153044
 PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA
 FT1|1|ABC123|9876|20240218|20240218|CG|150.00|1|Units|||||||||||||99213^Office Visit^CPT
@@ -26,7 +27,7 @@ IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
     const contentType = 'x-application/hl7-v2+er7';
     const secrets = {};
     const result = await handler(medplum, { bot, input, contentType, secrets });
-    
+
     // Verify ACK message
     expect(result.get('MSA')).toBeDefined();
 
@@ -52,7 +53,8 @@ IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
   test('DFT Message with Multiple Procedures Creates Single Claim', async () => {
     const medplum = new MockClient();
     const bot: Reference<Bot> = { reference: 'Bot/123' };
-    const input = Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||DFT^P03|MSG00002|P|2.3
+    const input =
+      Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||DFT^P03|MSG00002|P|2.3
 EVN|P03|20240218153044
 PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA
 FT1|1|ABC123|9876|20240218|20240218|CG|150.00|1|Units|||||||||||||99213^Office Visit^CPT
@@ -78,14 +80,13 @@ IN1|1|BCBS|67890|Blue Cross Blue Shield||||||||||||||||||||||||||||||||XYZ789`);
   test('Non-DFT Message Type Returns Error', async () => {
     const medplum = new MockClient();
     const bot: Reference<Bot> = { reference: 'Bot/123' };
-    const input = Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||ADT^A01|MSG00004|P|2.3
+    const input =
+      Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||ADT^A01|MSG00004|P|2.3
 EVN|A01|20240218153044
 PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA`);
     const contentType = 'x-application/hl7-v2+er7';
     const secrets = {};
-    
-    await expect(handler(medplum, { bot, input, contentType, secrets }))
-      .rejects
-      .toThrow('Not a DFT message');
+
+    await expect(handler(medplum, { bot, input, contentType, secrets })).rejects.toThrow('Not a DFT message');
   });
-}); 
+});

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
@@ -5,7 +5,7 @@ import { expect, test } from 'vitest';
 import { handler } from './dft-transfer-bot';
 import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
 
-describe('DFT Message Cursor Tests', async () => {
+describe('DFT Message Tests', async () => {
   beforeAll(() => {
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
     indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
@@ -57,7 +57,7 @@ IN1|1|MEDICARE|INS123|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
     expect(claim?.diagnosis?.[0].diagnosisCodeableConcept?.coding?.[0].code).toBe('E11.9');
   });
 
-  test('DFT Message with Multiple Procedures Creates Single Claim', async () => {
+  test('DFT Message with Multiple Procedures Creates Single Claim with Multiple Diagnoses', async () => {
     const medplum = new MockClient();
     const bot: Reference<Bot> = { reference: 'Bot/123' };
     const input =

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
@@ -29,8 +29,6 @@ IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
     
     // Verify ACK message
     expect(result.get('MSA')).toBeDefined();
-    expect(result.get('MSA.1')).toBe('AA');
-    expect(result.get('MSA.2')).toBe('MSG00001');
 
     // Verify Patient creation
     const patient = await medplum.searchOne('Patient', 'identifier=12345');
@@ -41,8 +39,8 @@ IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
     // Verify Coverage creation
     const coverage = await medplum.searchOne('Coverage', 'subscriber=Patient/' + patient?.id);
     expect(coverage).toBeDefined();
-    expect(coverage?.subscriberId).toBe('123456789A');
-    expect(coverage?.payor?.[0].display).toBe('MEDICARE');
+    expect(coverage?.subscriberId?.components?.[0][0]).toBe('123456789A');
+    expect(coverage?.payor?.[0].display?.components?.[0][0]).toBe('MEDICARE');
 
     // Verify Claim creation
     const claim = await medplum.searchOne('Claim', 'patient=Patient/' + patient?.id);

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
@@ -1,0 +1,93 @@
+import { Hl7Message, indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { Bot, Bundle, Reference, SearchParameter } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { expect, test } from 'vitest';
+import { handler } from './dft-transfer-bot';
+import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
+
+describe('DFT Message Cursor Tests', async () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+      indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+    }
+  });
+
+  test('DFT Message with Insurance Creates Patient, Coverage, and Claim', async () => {
+    const medplum = new MockClient();
+    const bot: Reference<Bot> = { reference: 'Bot/123' };
+    const input = Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||DFT^P03|MSG00001|P|2.3
+EVN|P03|20240218153044
+PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA
+FT1|1|ABC123|9876|20240218|20240218|CG|150.00|1|Units|||||||||||||99213^Office Visit^CPT
+PR1|1||99213^Office Visit^CPT|20240218|GP
+IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
+    const contentType = 'x-application/hl7-v2+er7';
+    const secrets = {};
+    const result = await handler(medplum, { bot, input, contentType, secrets });
+    
+    // Verify ACK message
+    expect(result.get('MSA')).toBeDefined();
+    expect(result.get('MSA.1')).toBe('AA');
+    expect(result.get('MSA.2')).toBe('MSG00001');
+
+    // Verify Patient creation
+    const patient = await medplum.searchOne('Patient', 'identifier=12345');
+    expect(patient).toBeDefined();
+    expect(patient?.name?.[0].family).toBe('DOE');
+    expect(patient?.name?.[0].given?.[0]).toBe('JOHN');
+
+    // Verify Coverage creation
+    const coverage = await medplum.searchOne('Coverage', 'subscriber=Patient/' + patient?.id);
+    expect(coverage).toBeDefined();
+    expect(coverage?.subscriberId).toBe('123456789A');
+    expect(coverage?.payor?.[0].display).toBe('MEDICARE');
+
+    // Verify Claim creation
+    const claim = await medplum.searchOne('Claim', 'patient=Patient/' + patient?.id);
+    expect(claim).toBeDefined();
+    expect(claim?.insurance?.[0].coverage?.reference).toBe('Coverage/' + coverage?.id);
+    expect(claim?.item?.[0].productOrService.coding?.[0].code).toBe('99213');
+  });
+
+  test('DFT Message with Multiple Procedures Creates Single Claim', async () => {
+    const medplum = new MockClient();
+    const bot: Reference<Bot> = { reference: 'Bot/123' };
+    const input = Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||DFT^P03|MSG00002|P|2.3
+EVN|P03|20240218153044
+PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA
+FT1|1|ABC123|9876|20240218|20240218|CG|150.00|1|Units|||||||||||||99213^Office Visit^CPT
+PR1|1||99213^Office Visit^CPT|20240218|GP
+PR1|2||85025^Blood Test^CPT|20240218|GP
+IN1|1|BCBS|67890|Blue Cross Blue Shield||||||||||||||||||||||||||||||||XYZ789`);
+    const contentType = 'x-application/hl7-v2+er7';
+    const secrets = {};
+    const result = await handler(medplum, { bot, input, contentType, secrets });
+
+    // Verify Patient creation
+    const patient = await medplum.searchOne('Patient', 'identifier=12345');
+    expect(patient).toBeDefined();
+
+    // Verify Claim has multiple procedures
+    const claim = await medplum.searchOne('Claim', 'patient=Patient/' + patient?.id);
+    expect(claim).toBeDefined();
+    expect(claim?.item?.length).toBe(2);
+    expect(claim?.item?.[0].productOrService.coding?.[0].code).toBe('99213');
+    expect(claim?.item?.[1].productOrService.coding?.[0].code).toBe('85025');
+  });
+
+  test('Non-DFT Message Type Returns Error', async () => {
+    const medplum = new MockClient();
+    const bot: Reference<Bot> = { reference: 'Bot/123' };
+    const input = Hl7Message.parse(`MSH|^~\\&|SENDING_APP|SENDING_FAC|REC_APP|REC_FAC|20240218153044||ADT^A01|MSG00004|P|2.3
+EVN|A01|20240218153044
+PID|1||12345^^^MRN^MR||DOE^JOHN^A||19800101|M|||123 MAIN ST^^CITY^ST^12345^USA`);
+    const contentType = 'x-application/hl7-v2+er7';
+    const secrets = {};
+    
+    await expect(handler(medplum, { bot, input, contentType, secrets }))
+      .rejects
+      .toThrow('Not a DFT message');
+  });
+}); 

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.test.ts
@@ -38,8 +38,9 @@ IN1|1|MEDICARE|12345|MEDICARE||||||||||||||||||||||||||||||||123456789A`);
     // Verify Coverage creation
     const coverage = await medplum.searchOne('Coverage', 'subscriber=Patient/' + patient?.id);
     expect(coverage).toBeDefined();
-    expect(coverage?.subscriberId?.components?.[0][0]).toBe('123456789A');
-    expect(coverage?.payor?.[0].display?.components?.[0][0]).toBe('MEDICARE');
+    expect(coverage?.subscriberId).toBe('123456789A');
+    expect(coverage?.payor?.[0].display).toBe('MEDICARE');
+    expect(coverage?.beneficiary?.reference).toBe('Patient/' + patient?.id);
 
     // Verify Claim creation
     const claim = await medplum.searchOne('Claim', 'patient=Patient/' + patient?.id);

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -1,7 +1,7 @@
-/** 
- * This bot listens for DFT messages and finds/creates a Medplum Patient from PID, 
+/**
+ * This bot listens for DFT messages and finds/creates a Medplum Patient from PID,
  * Coverage from IN1, and Claim from PR1.
- * 
+ *
  * The bot will return an ACK message to the sender of the DFT message.
  */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -77,7 +77,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   }
 
   // Get all procedures
-  const procedures = input.getSegments('PR1').map(pr1 => ({
+  const procedures = input.getAllSegments('PR1').map(pr1 => ({
     code: pr1.getField(3)?.getComponent(1) as string,
     display: pr1.getField(3)?.getComponent(2) as string,
   }));

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -216,7 +216,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   }
 
   // Process insurance information if present
-  const insuranceInfo = await handleInsuranceFromIn1(medplum, input.getSegment('IN1'), patient);
+  const insuranceInfo = await handleCoverageFromIn1(medplum, input.getSegment('IN1'), patient);
 
   // Create claim from procedures if present
   await handleClaimFromPr1s(medplum, input.getAllSegments('PR1'), patient, insuranceInfo);

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -151,7 +151,7 @@ export async function handleClaimFromPr1s(
 
   const [coverage] = insuranceInfo;
 
-  return await medplum.createResource<Claim>({
+  const claim = await medplum.createResource<Claim>({
     resourceType: 'Claim',
     status: 'active',
     type: {
@@ -196,6 +196,8 @@ export async function handleClaimFromPr1s(
       },
     })),
   });
+
+  return claim;
 }
 
 export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message>): Promise<Hl7Message> {

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -61,9 +61,9 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   let coverage: Coverage | undefined;
 
   if (in1Segment) {
-    const insurerId = in1Segment.getField(3) as string;
-    const insurerName = in1Segment.getField(4) as string;
-    const subscriberId = in1Segment.getField(36) as string;
+    const insurerId = in1Segment.getField(3)?.getComponent(1) as string;
+    const insurerName = in1Segment.getField(4)?.getComponent(1) as string;
+    const subscriberId = in1Segment.getField(36)?.getComponent(1) as string;
 
     coverage = await medplum.createResource<Coverage>({
       resourceType: 'Coverage',

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -1,3 +1,9 @@
+/** 
+ * This bot listens for DFT messages and finds/creates a Medplum Patient from PID, 
+ * Coverage from IN1, and Claim from PR1.
+ * 
+ * The bot will return an ACK message to the sender of the DFT message.
+ */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';
 import { Claim, Coverage, Patient } from '@medplum/fhirtypes';
 

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -1,11 +1,11 @@
 /**
- * This example shows how you might listen for DFT (Detailed Financial Transaction) HL7 
+ * This example shows how you might listen for DFT (Detailed Financial Transaction) HL7
  * messages. DFT messages are commonly used to transmit services rendered and patient insurance
- * information for the purpose of claim generation. 
- * 
+ * information for the purpose of claim generation.
+ *
  * This bot listens for DFT messages and finds/creates a FHIR Patient from PID, adds
  * a FHIR Coverage attached to that patient from IN1, and a FHIR Claim from PR1.
- * 
+ *
  * More information about the sections of DFT messages can be found here: https://rhapsody.health/resources/hl7-dft-message/
  */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -73,7 +73,7 @@ export async function handlePatientFromPid(
  * @param patient - The patient to link the coverage to
  * @returns The created insurance resources
  */
-export async function handleInsuranceFromIn1(
+export async function handleCoverageFromIn1(
   medplum: MedplumClient,
   in1Segment: Hl7Segment | undefined,
   patient: Patient

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -158,15 +158,15 @@ function extractDiagnosisFromPr1(pr1: Hl7Segment): { code: string; display: stri
   const diagnosisCode = pr1.getField(15)?.getComponent(1) ?? ''; // PR1.15.1 Diagnosis Code
   const diagnosisDesc = pr1.getField(15)?.getComponent(2) ?? ''; // PR1.15.2 Diagnosis Description
   const diagnosisSystem = pr1.getField(15)?.getComponent(3) ?? ''; // PR1.15.3 Diagnosis Coding System
-  
+
   if (!diagnosisCode) {
     return undefined;
   }
-  
+
   return {
     code: diagnosisCode,
     display: diagnosisDesc,
-    system: diagnosisSystem || 'ICD-10',  // Default to ICD-10 if not specified
+    system: diagnosisSystem || 'ICD-10', // Default to ICD-10 if not specified
   };
 }
 

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -16,20 +16,20 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   const systemString = 'MRN';
 
   // Verify message type is DFT
-  const messageType = input.getSegment('MSH')?.getField(9)?.getComponent(1) as string;
+  const messageType = input.getSegment('MSH')?.getField(9)?.getComponent(1) ?? '';
   if (messageType !== 'DFT') {
     throw new Error('Not a DFT message');
   }
 
   // Get patient information
-  const mrnNumber = input.getSegment('PID')?.getField(3)?.getComponent(1) as string;
-  const givenName = input.getSegment('PID')?.getField(5)?.getComponent(2) as string;
-  const familyName = input.getSegment('PID')?.getField(5)?.getComponent(1) as string;
-  const addressLine = input.getSegment('PID')?.getField(11)?.getComponent(1) as string;
-  const city = input.getSegment('PID')?.getField(11)?.getComponent(3) as string;
-  const state = input.getSegment('PID')?.getField(11)?.getComponent(4) as string;
-  const postalCode = input.getSegment('PID')?.getField(11)?.getComponent(5) as string;
-  const country = input.getSegment('PID')?.getField(11)?.getComponent(6) as string;
+  const mrnNumber = input.getSegment('PID')?.getField(3)?.getComponent(1) ?? ''; // PID.3 Patient Identifier List
+  const givenName = input.getSegment('PID')?.getField(5)?.getComponent(2) ?? ''; // PID.5 Patient Name (XPN.2 Given Name)
+  const familyName = input.getSegment('PID')?.getField(5)?.getComponent(1) ?? ''; // PID.5 Patient Name (XPN.1 Family Name)
+  const addressLine = input.getSegment('PID')?.getField(11)?.getComponent(1) ?? ''; // PID.11 Patient Address (XAD.1 Street Address)
+  const city = input.getSegment('PID')?.getField(11)?.getComponent(3) ?? ''; // PID.11 Patient Address (XAD.3 City)
+  const state = input.getSegment('PID')?.getField(11)?.getComponent(4) ?? ''; // PID.11 Patient Address (XAD.4 State or Province)
+  const postalCode = input.getSegment('PID')?.getField(11)?.getComponent(5) ?? ''; // PID.11 Patient Address (XAD.5 Zip or Postal Code)
+  const country = input.getSegment('PID')?.getField(11)?.getComponent(6) ?? ''; // PID.11 Patient Address (XAD.6 Country)
 
   // Find or create patient
   let patient = await medplum.searchOne('Patient', 'identifier=' + mrnNumber);
@@ -65,9 +65,9 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   let coverage: Coverage | undefined;
 
   if (in1Segment) {
-    const insurerId = in1Segment.getField(3)?.getComponent(1) as string;
-    const insurerName = in1Segment.getField(4)?.getComponent(1) as string;
-    const subscriberId = in1Segment.getField(36)?.getComponent(1) as string;
+    const insurerId = in1Segment.getField(3)?.getComponent(1) ?? ''; // IN1.3 Insurance Company ID
+    const insurerName = in1Segment.getField(4)?.getComponent(1) ?? ''; // IN1.4 Insurance Company Name
+    const subscriberId = in1Segment.getField(36)?.getComponent(1) ?? ''; // IN1.36 Policy Number
 
     coverage = await medplum.createResource<Coverage>({
       resourceType: 'Coverage',
@@ -88,8 +88,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
 
   // Get all procedures
   const procedures = input.getAllSegments('PR1').map((pr1) => ({
-    code: pr1.getField(3)?.getComponent(1) as string,
-    display: pr1.getField(3)?.getComponent(2) as string,
+    code: pr1.getField(3)?.getComponent(1) ?? '', // PR1.3.1 Procedure Code
+    display: pr1.getField(3)?.getComponent(2) ?? '', // PR1.3.2 Procedure Description
   }));
 
   if (procedures.length !== 0 && coverage) {

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -1,8 +1,12 @@
 /**
- * This bot listens for DFT messages and finds/creates a Medplum Patient from PID,
- * Coverage from IN1, and Claim from PR1.
- *
- * The bot will return an ACK message to the sender of the DFT message.
+ * This example shows how you might listen for DFT (Detailed Financial Transaction) HL7 
+ * messages. DFT messages are commonly used to transmit services rendered and patient insurance
+ * information for the purpose of claim generation. 
+ * 
+ * This bot listens for DFT messages and finds/creates a FHIR Patient from PID, adds
+ * a FHIR Coverage attached to that patient from IN1, and a FHIR Claim from PR1.
+ * 
+ * More information about the sections of DFT messages can be found here: https://rhapsody.health/resources/hl7-dft-message/
  */
 import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';
 import { Claim, Coverage, Patient } from '@medplum/fhirtypes';

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -53,7 +53,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   // Process insurance information if present
   const in1Segment = input.getSegment('IN1');
   let coverage: Coverage | undefined;
-  
+
   if (in1Segment) {
     const insurerId = in1Segment.getField(3) as string;
     const insurerName = in1Segment.getField(4) as string;
@@ -77,7 +77,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   }
 
   // Get all procedures
-  const procedures = input.getAllSegments('PR1').map(pr1 => ({
+  const procedures = input.getAllSegments('PR1').map((pr1) => ({
     code: pr1.getField(3)?.getComponent(1) as string,
     display: pr1.getField(3)?.getComponent(2) as string,
   }));
@@ -109,7 +109,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
           },
         ],
       },
-      insurance:[
+      insurance: [
         {
           sequence: 1,
           focal: true,
@@ -132,4 +132,4 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
   }
 
   return input.buildAck();
-} 
+}

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -75,18 +75,24 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message
       // Create new organization if it doesn't exist
       insurerOrg = await medplum.createResource({
         resourceType: 'Organization',
-        identifier: [{
-          system: 'http://terminology.hl7.org/CodeSystem/insurance-plan-identifier',
-          value: insurerId
-        }],
+        identifier: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/insurance-plan-identifier',
+            value: insurerId,
+          },
+        ],
         name: insurerName,
-        type: [{
-          coding: [{
-            system: 'http://terminology.hl7.org/CodeSystem/organization-type',
-            code: 'ins',
-            display: 'Insurance Company'
-          }]
-        }]
+        type: [
+          {
+            coding: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/organization-type',
+                code: 'ins',
+                display: 'Insurance Company',
+              },
+            ],
+          },
+        ],
       });
     }
 

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -17,7 +17,10 @@ import { Claim, Coverage, Patient, Organization } from '@medplum/fhirtypes';
  * @param pidSegment - The PID segment from an HL7 message
  * @returns The created or found Patient resource
  */
-export async function handlePatientFromPid(medplum: MedplumClient, pidSegment: Hl7Segment | undefined): Promise<Patient | undefined> {
+export async function handlePatientFromPid(
+  medplum: MedplumClient,
+  pidSegment: Hl7Segment | undefined
+): Promise<Patient | undefined> {
   if (!pidSegment) {
     return undefined;
   }
@@ -89,18 +92,24 @@ export async function handleInsuranceFromIn1(
     // Create new organization if it doesn't exist
     insurerOrg = await medplum.createResource({
       resourceType: 'Organization',
-      identifier: [{
-        system: 'http://terminology.hl7.org/CodeSystem/insurance-plan-identifier',
-        value: insurerId,
-      }],
+      identifier: [
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/insurance-plan-identifier',
+          value: insurerId,
+        },
+      ],
       name: insurerName,
-      type: [{
-        coding: [{
-          system: 'http://terminology.hl7.org/CodeSystem/organization-type',
-          code: 'ins',
-          display: 'Insurance Company',
-        }],
-      }],
+      type: [
+        {
+          coding: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/organization-type',
+              code: 'ins',
+              display: 'Insurance Company',
+            },
+          ],
+        },
+      ],
     });
   }
 
@@ -113,7 +122,7 @@ export async function handleInsuranceFromIn1(
     payor: [createReference(insurerOrg)],
   });
 
-  return [ coverage, insurerOrg ];
+  return [coverage, insurerOrg];
 }
 
 /**

--- a/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
+++ b/examples/medplum-demo-bots/src/dft-transfer-listener/dft-transfer-bot.ts
@@ -1,0 +1,135 @@
+import { BotEvent, createReference, Hl7Message, MedplumClient } from '@medplum/core';
+import { Claim, Coverage, Patient } from '@medplum/fhirtypes';
+
+export async function handler(medplum: MedplumClient, event: BotEvent<Hl7Message>): Promise<Hl7Message> {
+  const input = event.input;
+  const systemString = 'MRN';
+
+  // Verify message type is DFT
+  const messageType = input.getSegment('MSH')?.getField(9)?.getComponent(1) as string;
+  if (messageType !== 'DFT') {
+    throw new Error('Not a DFT message');
+  }
+
+  // Get patient information
+  const mrnNumber = input.getSegment('PID')?.getField(3)?.getComponent(1) as string;
+  const givenName = input.getSegment('PID')?.getField(5)?.getComponent(2) as string;
+  const familyName = input.getSegment('PID')?.getField(5)?.getComponent(1) as string;
+  const addressLine = input.getSegment('PID')?.getField(11)?.getComponent(1) as string;
+  const city = input.getSegment('PID')?.getField(11)?.getComponent(3) as string;
+  const state = input.getSegment('PID')?.getField(11)?.getComponent(4) as string;
+  const postalCode = input.getSegment('PID')?.getField(11)?.getComponent(5) as string;
+  const country = input.getSegment('PID')?.getField(11)?.getComponent(6) as string;
+
+  // Find or create patient
+  let patient = await medplum.searchOne('Patient', 'identifier=' + mrnNumber);
+  if (!patient) {
+    patient = await medplum.createResource<Patient>({
+      resourceType: 'Patient',
+      identifier: [
+        {
+          system: systemString,
+          value: mrnNumber,
+        },
+      ],
+      name: [
+        {
+          given: [givenName],
+          family: familyName,
+        },
+      ],
+      address: [
+        {
+          line: [addressLine],
+          city: city,
+          state: state,
+          postalCode: postalCode,
+          country: country,
+        },
+      ],
+    });
+  }
+
+  // Process insurance information if present
+  const in1Segment = input.getSegment('IN1');
+  let coverage: Coverage | undefined;
+  
+  if (in1Segment) {
+    const insurerId = in1Segment.getField(3) as string;
+    const insurerName = in1Segment.getField(4) as string;
+    const subscriberId = in1Segment.getField(36) as string;
+
+    coverage = await medplum.createResource<Coverage>({
+      resourceType: 'Coverage',
+      status: 'active',
+      subscriber: createReference(patient),
+      subscriberId: subscriberId,
+      beneficiary: createReference(patient),
+      payor: [
+        {
+          display: insurerName,
+          identifier: {
+            value: insurerId,
+          },
+        },
+      ],
+    });
+  }
+
+  // Get all procedures
+  const procedures = input.getSegments('PR1').map(pr1 => ({
+    code: pr1.getField(3)?.getComponent(1) as string,
+    display: pr1.getField(3)?.getComponent(2) as string,
+  }));
+
+  if (procedures.length !== 0 && coverage) {
+    // Create claim
+    await medplum.createResource<Claim>({
+      resourceType: 'Claim',
+      status: 'active',
+      type: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/claim-type',
+            code: 'professional',
+          },
+        ],
+      },
+      use: 'claim',
+      patient: createReference(patient),
+      created: new Date().toISOString(),
+      provider: {
+        display: 'Unknown',
+      },
+      priority: {
+        coding: [
+          {
+            system: 'http://terminology.hl7.org/CodeSystem/processpriority',
+            code: 'normal',
+          },
+        ],
+      },
+      insurance:[
+        {
+          sequence: 1,
+          focal: true,
+          coverage: createReference(coverage),
+        },
+      ],
+      item: procedures.map((proc, index) => ({
+        sequence: index + 1,
+        productOrService: {
+          coding: [
+            {
+              system: 'CPT',
+              code: proc.code,
+              display: proc.display,
+            },
+          ],
+        },
+      })),
+    });
+  }
+
+  return input.buildAck();
+} 


### PR DESCRIPTION
This example shows how you might listen for DFT (Detailed Financial Transaction) HL7 messages. DFT messages are commonly used to transmit services rendered and patient insurance information for the purpose of claim generation.

This bot listens for DFT messages and finds/creates a FHIR Patient from PID, adds a FHIR Coverage attached to that patient from IN1, and a FHIR Claim from PR1.

More information about the sections of DFT messages can be found here: https://rhapsody.health/resources/hl7-dft-message/



<img width="770" alt="Screenshot 2025-02-18 at 2 41 44 PM" src="https://github.com/user-attachments/assets/b5cfa9d3-562f-4969-b004-ec9c137238b5" />
