### PR TITLE
feat(AsyncJob): add `AsyncJob/$complete` operation

### DIFF
--- a/packages/server/src/fhir/operations/asyncjobcomplete.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcomplete.test.ts
@@ -1,4 +1,4 @@
-import { allOk, badRequest, ContentType, forbidden } from '@medplum/core';
+import { badRequest, ContentType, forbidden } from '@medplum/core';
 import { FhirRequest } from '@medplum/fhir-router';
 import { AsyncJob, OperationOutcome } from '@medplum/fhirtypes';
 import express from 'express';
@@ -49,7 +49,13 @@ describe('AsyncJob/$complete', () => {
       .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res2.status).toStrictEqual(200);
-    expect(res2.body).toMatchObject<OperationOutcome>(allOk);
+    expect(res2.body).toMatchObject<AsyncJob>({
+      id: asyncJob.id,
+      resourceType: 'AsyncJob',
+      status: 'completed',
+      requestTime: asyncJob.requestTime,
+      request: 'random-request',
+    });
 
     const res3 = await request(app)
       .get(`/fhir/R4/AsyncJob/${asyncJob.id as string}`)
@@ -91,7 +97,13 @@ describe('AsyncJob/$complete', () => {
       .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res2.status).toStrictEqual(200);
-    expect(res2.body).toMatchObject<OperationOutcome>(allOk);
+    expect(res2.body).toMatchObject<AsyncJob>({
+      id: asyncJob.id,
+      resourceType: 'AsyncJob',
+      status: 'completed',
+      requestTime: asyncJob.requestTime,
+      request: 'random-request',
+    });
 
     const res3 = await request(app)
       .get(`/fhir/R4/AsyncJob/${asyncJob.id as string}`)
@@ -191,7 +203,13 @@ describe('AsyncJob/$complete', () => {
         .set('Authorization', 'Bearer ' + accessToken)
         .set('X-Medplum', 'extended');
       expect(res2.status).toStrictEqual(200);
-      expect(res2.body).toMatchObject(allOk);
+      expect(res2.body).toMatchObject({
+        id: asyncJob.id,
+        resourceType: 'AsyncJob',
+        status: 'completed',
+        requestTime: asyncJob.requestTime,
+        request: 'random-request',
+      });
 
       const res3 = await request(app)
         .get(`/fhir/R4/AsyncJob/${asyncJob.id}`)

--- a/packages/server/src/fhir/operations/asyncjobcomplete.test.ts
+++ b/packages/server/src/fhir/operations/asyncjobcomplete.test.ts
@@ -1,0 +1,219 @@
+import { allOk, badRequest, ContentType, forbidden } from '@medplum/core';
+import { FhirRequest } from '@medplum/fhir-router';
+import { AsyncJob, OperationOutcome } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import * as databaseModule from '../../database';
+import { initTestAuth, withTestContext } from '../../test.setup';
+import { getSystemRepo } from '../repo';
+import { asyncJobCompleteHandler } from './asyncjobcomplete';
+
+const app = express();
+
+describe('AsyncJob/$complete', () => {
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await withTestContext(() => initApp(app, config));
+  });
+
+  beforeEach(async () => {
+    accessToken = await initTestAuth({ superAdmin: true });
+    expect(accessToken).toBeDefined();
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Runs `completeJob` on a job and marks it as `completed`', async () => {
+    const res = await request(app)
+      .post('/fhir/R4/AsyncJob')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'AsyncJob',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+      } satisfies AsyncJob);
+    expect(res.status).toStrictEqual(201);
+    expect(res.body).toBeDefined();
+
+    const asyncJob = res.body as AsyncJob;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toStrictEqual(200);
+    expect(res2.body).toMatchObject<OperationOutcome>(allOk);
+
+    const res3 = await request(app)
+      .get(`/fhir/R4/AsyncJob/${asyncJob.id as string}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON);
+
+    expect(res3.status).toStrictEqual(200);
+    expect(res3.body).toMatchObject<AsyncJob>({
+      id: asyncJob.id,
+      resourceType: 'AsyncJob',
+      status: 'completed',
+      requestTime: asyncJob.requestTime,
+      request: 'random-request',
+    });
+  });
+
+  test('DatabaseMigration table is updated when a data-migration job is completed', async () => {
+    const markDataMigrateCompleteSpy = jest.spyOn(databaseModule, 'markPendingDataMigrationCompleted');
+
+    const res = await request(app)
+      .post('/fhir/R4/AsyncJob')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'AsyncJob',
+        type: 'data-migration',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+        dataVersion: 1337,
+        minServerVersion: '3.3.0',
+      } satisfies AsyncJob);
+    expect(res.status).toStrictEqual(201);
+    expect(res.body).toBeDefined();
+
+    const asyncJob = res.body as AsyncJob;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toStrictEqual(200);
+    expect(res2.body).toMatchObject<OperationOutcome>(allOk);
+
+    const res3 = await request(app)
+      .get(`/fhir/R4/AsyncJob/${asyncJob.id as string}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON);
+
+    expect(res3.status).toStrictEqual(200);
+    expect(res3.body).toMatchObject<AsyncJob>({
+      id: asyncJob.id,
+      type: 'data-migration',
+      resourceType: 'AsyncJob',
+      status: 'completed',
+      requestTime: asyncJob.requestTime,
+      request: 'random-request',
+    });
+    expect(markDataMigrateCompleteSpy).toHaveBeenCalledWith(res.body);
+  });
+
+  test('Requires super admin access', async () => {
+    const nonAdminToken = await initTestAuth({ superAdmin: false });
+    const res = await request(app)
+      .post('/fhir/R4/AsyncJob')
+      .set('Authorization', 'Bearer ' + nonAdminToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'AsyncJob',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+      } satisfies AsyncJob);
+    expect(res.status).toStrictEqual(201);
+    expect(res.body).toBeDefined();
+
+    const asyncJob = res.body as AsyncJob;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
+      .set('Authorization', 'Bearer ' + nonAdminToken);
+    expect(res2.status).toStrictEqual(403);
+    expect(res2.body).toMatchObject<OperationOutcome>(forbidden);
+  });
+
+  test.each(['completed', 'error'] as const)('Fails if AsyncJob.status is `%s`', async (status) => {
+    const res = await request(app)
+      .post('/fhir/R4/AsyncJob')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'AsyncJob',
+        status,
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+      } satisfies AsyncJob);
+    expect(res.status).toStrictEqual(201);
+    expect(res.body).toBeDefined();
+
+    const asyncJob = res.body as AsyncJob;
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toStrictEqual(400);
+
+    const outcome = res2.body as OperationOutcome;
+    expect(outcome).toMatchObject<OperationOutcome>(
+      badRequest(`AsyncJob cannot be completed if status is not 'accepted', job has status '${status}'`)
+    );
+  });
+
+  test('Fails if not executed on an instance (no ID given)', async () => {
+    const req = {
+      method: 'POST',
+      url: 'AsyncJob/$complete',
+      pathname: '',
+      params: {},
+      query: {},
+      body: '',
+      headers: {},
+    } satisfies FhirRequest;
+    await expect(asyncJobCompleteHandler(req)).rejects.toThrow(
+      new Error('This operation can only be executed on an instance')
+    );
+  });
+
+  test('Completed job does not get added to super admin project', () =>
+    withTestContext(async () => {
+      // We create the resource with system repo so that it is like how system AsyncJobs get created
+      const asyncJob = await getSystemRepo().createResource<AsyncJob>({
+        resourceType: 'AsyncJob',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: 'random-request',
+      });
+
+      const res2 = await request(app)
+        .post(`/fhir/R4/AsyncJob/${asyncJob.id as string}/$complete`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Medplum', 'extended');
+      expect(res2.status).toStrictEqual(200);
+      expect(res2.body).toMatchObject(allOk);
+
+      const res3 = await request(app)
+        .get(`/fhir/R4/AsyncJob/${asyncJob.id}`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('X-Medplum', 'extended');
+
+      expect(res3.status).toStrictEqual(200);
+      expect(res3.body).toStrictEqual({
+        id: asyncJob.id as string,
+        resourceType: 'AsyncJob',
+        requestTime: asyncJob.requestTime,
+        request: 'random-request',
+        status: 'completed',
+        meta: {
+          lastUpdated: expect.any(String),
+          versionId: expect.any(String),
+          author: {
+            reference: 'system',
+          },
+          // We make sure meta does not contain project
+        },
+        transactionTime: expect.any(String),
+      });
+    }));
+});

--- a/packages/server/src/fhir/operations/asyncjobcomplete.ts
+++ b/packages/server/src/fhir/operations/asyncjobcomplete.ts
@@ -1,0 +1,44 @@
+import { allOk, assert, badRequest } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import { AsyncJob, OperationDefinition } from '@medplum/fhirtypes';
+import { requireSuperAdmin } from '../../admin/super';
+import { getAuthenticatedContext } from '../../context';
+import { getSystemRepo } from '../repo';
+import { AsyncJobExecutor } from './utils/asyncjobexecutor';
+
+export const operation: OperationDefinition = {
+  id: 'AsyncJob-complete',
+  resourceType: 'OperationDefinition',
+  name: 'asyncjob-complete',
+  status: 'active',
+  kind: 'operation',
+  code: 'complete',
+  experimental: true,
+  resource: ['AsyncJob'],
+  system: false,
+  type: false,
+  instance: true,
+  parameter: [{ use: 'out', name: 'return', type: 'OperationOutcome', min: 1, max: '1' }],
+};
+
+/**
+ * Handles HTTP requests for the AsyncJob $complete operation.
+ * Runs the `AsyncJobExecutor.completeJob` class method on this job and marks the job as completed.
+ *
+ * @param req - A request to complete a particular async job.
+ * @returns A FhirResponse.
+ */
+export async function asyncJobCompleteHandler(req: FhirRequest): Promise<FhirResponse> {
+  assert(req.params.id, 'This operation can only be executed on an instance');
+  requireSuperAdmin();
+
+  const { repo } = getAuthenticatedContext();
+  const job = await repo.readResource<AsyncJob>('AsyncJob', req.params.id);
+  if (job.status !== 'accepted') {
+    return [badRequest(`AsyncJob cannot be completed if status is not 'accepted', job has status '${job.status}'`)];
+  }
+  // We update with system repo so that system is the author
+  const systemRepo = getSystemRepo();
+  await new AsyncJobExecutor(systemRepo, job).completeJob(systemRepo);
+  return [allOk];
+}

--- a/packages/server/src/fhir/operations/asyncjobcomplete.ts
+++ b/packages/server/src/fhir/operations/asyncjobcomplete.ts
@@ -18,7 +18,7 @@ export const operation: OperationDefinition = {
   system: false,
   type: false,
   instance: true,
-  parameter: [{ use: 'out', name: 'return', type: 'OperationOutcome', min: 1, max: '1' }],
+  parameter: [{ use: 'out', name: 'return', type: 'AsyncJob', min: 1, max: '1' }],
 };
 
 /**
@@ -39,6 +39,6 @@ export async function asyncJobCompleteHandler(req: FhirRequest): Promise<FhirRes
   }
   // We update with system repo so that system is the author
   const systemRepo = getSystemRepo();
-  await new AsyncJobExecutor(systemRepo, job).completeJob(systemRepo);
-  return [allOk];
+  const completedJob = (await new AsyncJobExecutor(systemRepo, job).completeJob(systemRepo)) as AsyncJob;
+  return [allOk, completedJob];
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1778,7 +1778,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return resolveId(updated.project);
     }
 
-    if (updated.resourceType === 'User' && this.isSuperAdmin()) {
+    if ((updated.resourceType === 'User' || updated.resourceType === 'AsyncJob') && this.isSuperAdmin()) {
       // Super admins can add, remove, and the project compartment of users.
       return updated?.meta?.project;
     }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2321,7 +2321,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     if (this.transactionDepth === 1) {
       await conn.query('ROLLBACK');
       this.transactionDepth--;
-      console.log('rolled back / releasing');
       this.releaseConnection(error);
     } else {
       await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -17,6 +17,7 @@ import { agentReloadConfigHandler } from './operations/agentreloadconfig';
 import { agentStatusHandler } from './operations/agentstatus';
 import { agentUpgradeHandler } from './operations/agentupgrade';
 import { asyncJobCancelHandler } from './operations/asyncjobcancel';
+import { asyncJobCompleteHandler } from './operations/asyncjobcomplete';
 import { ccdaExportHandler } from './operations/ccdaexport';
 import { codeSystemImportHandler } from './operations/codesystemimport';
 import { codeSystemLookupHandler } from './operations/codesystemlookup';
@@ -230,6 +231,9 @@ function initInternalFhirRouter(): FhirRouter {
 
   // AsyncJob $cancel operation
   router.add('POST', '/AsyncJob/:id/$cancel', asyncJobCancelHandler);
+
+  // AsyncJob $complete operation
+  router.add('POST', '/AsyncJob/:id/$complete', asyncJobCompleteHandler);
 
   // Bot $deploy operation
   router.add('POST', '/Bot/:id/$deploy', deployHandler);


### PR DESCRIPTION
This allows us mainly to complete a `data-migration`-type `AsyncJob` via `AsyncJobExecutor.completeJob`. This triggers the post-complete logic for the `data-migration` job type which updates the `DatabaseMigration` table's `dataVersion` to the `dataVersion` in the `AsyncJob`.

We will be using this specifically to skip a data migration we know we ourselves do not need to apply but most of self-hosted users probably need to or should apply.

Depends on #6010 
