### PR TITLE
Fixes #5844 - stringify removes nested empty values

### DIFF
--- a/packages/ccda/src/roundtrip.test.ts
+++ b/packages/ccda/src/roundtrip.test.ts
@@ -60,21 +60,7 @@ describe('convertFhirToCcda', () => {
 function normalizeFhir<T extends Resource>(resource: T): T {
   // We need to remove all "empty" elements, such as empty strings and empty objects
   // This is because FHIR is very strict about what is allowed in the JSON
-  // Medplum "stringify" function does this, althought it is not perfect
-  // So, we need to use a hack and iteratively do this until we get no more changes
-  let currResource = resource;
-  let currString = stringify(currResource);
-
-  for (let i = 0; i < 100; i++) {
-    currResource = JSON.parse(stringify(currResource)) as T;
-    const nextString = stringify(currResource);
-    if (nextString === currString) {
-      break;
-    }
-    currString = nextString;
-  }
-
-  return currResource;
+  return JSON.parse(stringify(resource)) as T;
 }
 
 function normalizeCcda(ccda: Ccda): Ccda {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -646,13 +646,20 @@ describe('Core Utils', () => {
     expect(stringify('foo')).toStrictEqual('"foo"');
     expect(stringify({ x: 'y' })).toStrictEqual('{"x":"y"}');
     expect(stringify({ x: 123 })).toStrictEqual('{"x":123}');
-    expect(stringify({ x: undefined })).toStrictEqual('{}');
-    expect(stringify({ x: null })).toStrictEqual('{}');
-    expect(stringify({ x: {} })).toStrictEqual('{}');
+    expect(stringify({ x: undefined })).toStrictEqual('');
+    expect(stringify({ x: null })).toStrictEqual('');
+    expect(stringify({ x: {} })).toStrictEqual('');
     expect(stringify({ x: { y: 'z' } })).toStrictEqual('{"x":{"y":"z"}}');
     expect(stringify({ x: 2 }, true)).toStrictEqual('{\n  "x": 2\n}');
+
+    // Arrays with all empty values can be stripped
     expect(stringify({ resourceType: 'Patient', address: [{ line: [''] }] })).toStrictEqual(
-      '{"resourceType":"Patient","address":[{"line":[""]}]}'
+      '{"resourceType":"Patient"}'
+    );
+
+    // Arrays with some empty values should not be stripped, but empty values should be replaced with "null"
+    expect(stringify({ resourceType: 'Patient', address: [{ line: ['', 'x'] }] })).toStrictEqual(
+      '{"resourceType":"Patient","address":[{"line":[null,"x"]}]}'
     );
   });
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -649,8 +649,16 @@ describe('Core Utils', () => {
     expect(stringify({ x: undefined })).toStrictEqual('');
     expect(stringify({ x: null })).toStrictEqual('');
     expect(stringify({ x: {} })).toStrictEqual('');
+    expect(stringify({ x: [] })).toStrictEqual('');
     expect(stringify({ x: { y: 'z' } })).toStrictEqual('{"x":{"y":"z"}}');
     expect(stringify({ x: 2 }, true)).toStrictEqual('{\n  "x": 2\n}');
+    expect(stringify({ x: [''] })).toStrictEqual('');
+    expect(stringify({ x: ['', ''] })).toStrictEqual('');
+    expect(stringify({ x: ['y', ''] })).toStrictEqual('{"x":["y",null]}');
+    expect(stringify({ x: ['', 'y'] })).toStrictEqual('{"x":[null,"y"]}');
+    expect(stringify({ x: ['y', '', ''] })).toStrictEqual('{"x":["y",null,null]}');
+    expect(stringify({ x: ['', 'y', ''] })).toStrictEqual('{"x":[null,"y",null]}');
+    expect(stringify({ x: ['', '', 'y'] })).toStrictEqual('{"x":[null,null,"y"]}');
 
     // Arrays with all empty values can be stripped
     expect(stringify({ resourceType: 'Patient', address: [{ line: [''] }] })).toStrictEqual(

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -661,6 +661,12 @@ describe('Core Utils', () => {
     expect(stringify({ resourceType: 'Patient', address: [{ line: ['', 'x'] }] })).toStrictEqual(
       '{"resourceType":"Patient","address":[{"line":[null,"x"]}]}'
     );
+
+    // Make sure we preserve "0", even though falsy
+    expect(stringify({ low: 0, high: 100 })).toStrictEqual('{"low":0,"high":100}');
+
+    // Make sure we preserve "false", even though falsy
+    expect(stringify({ low: false, high: true })).toStrictEqual('{"low":false,"high":true}');
   });
 
   test('Deep equals', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -454,37 +454,142 @@ export function getExtension(resource: any, ...urls: string[]): Extension | unde
 }
 
 /**
- * FHIR JSON stringify.
+ * Returns the FHIR JSON string representation of the input value.
+ *
  * Removes properties with empty string values.
  * Removes objects with zero properties.
+ *
+ * Does not modify the input value.
+ * If the input value does not contain any empty properties, then the original value is returned.
+ * Otherwise, a new value is returned with the empty properties removed.
+ *
  * See: https://www.hl7.org/fhir/json.html
+ *
  * @param value - The input value.
  * @param pretty - Optional flag to pretty-print the JSON.
  * @returns The resulting JSON string.
  */
 export function stringify(value: any, pretty?: boolean): string {
-  return JSON.stringify(value, stringifyReplacer, pretty ? 2 : undefined) ?? '';
+  const processedValue = removeEmptyFromUnknown(value);
+  return JSON.stringify(processedValue, null, pretty ? 2 : undefined) ?? '';
 }
 
 /**
- * Evaluates JSON key/value pairs for FHIR JSON stringify.
- * Removes properties with empty string values.
- * Removes objects with zero properties.
- * @param k - Property key.
- * @param v - Property value.
- * @returns The replaced value.
+ * Removes empty properties from an unknown value.
+ *
+ * Does not modify the input value.
+ *
+ * If the input value does not contain any empty properties, then the original value is returned.
+ *
+ * Otherwise, a new value is returned with the empty properties removed.
+ *
+ * @param value - The unknown input value.
+ * @returns The value with empty properties removed.
  */
-function stringifyReplacer(k: string, v: any): any {
-  return !isArrayKey(k) && isEmpty(v) ? undefined : v;
+function removeEmptyFromUnknown(value: unknown): any {
+  if (!value) {
+    // For null, undefined, and empty strings, return undefined
+    return undefined;
+  }
+
+  if (typeof value === 'object') {
+    if (Array.isArray(value)) {
+      return removeEmptyFromArray(value);
+    }
+    return removeEmptyFromObject(value);
+  }
+
+  // Otherwise, return the primitive value
+  return value;
 }
 
 /**
- * Returns true if the key is an array key.
- * @param k - The property key.
- * @returns True if the key is an array key.
+ * Removes empty elements from an array.
+ *
+ * If the input array is empty, then undefined is returned.
+ * Otherwise, a new array is returned with the empty values replaced with null.
+ *
+ * FHIR arrays must maintain the same length, so null is used to replace empty values.
+ *
+ * @param inputArray - The input array value.
+ * @returns The array with empty values removed.
  */
-function isArrayKey(k: string): boolean {
-  return !!/\d+$/.exec(k);
+function removeEmptyFromArray(inputArray: unknown[]): any[] | undefined {
+  const len = inputArray.length;
+  if (len === 0) {
+    return undefined;
+  }
+  let newArray = undefined; // Only create a new array if needed
+  let count = 0;
+  for (let i = 0; i < len; i++) {
+    const inputElement = inputArray[i];
+    const processedElement = removeEmptyFromUnknown(inputElement);
+
+    if (processedElement !== inputElement && !newArray) {
+      newArray = Array.from(inputArray); // Clone only when a change is needed
+    }
+
+    if (processedElement === undefined) {
+      if (newArray) {
+        newArray[i] = null;
+      }
+    } else {
+      if (newArray) {
+        newArray[i] = processedElement; // Propagate changed element
+      }
+      count++;
+    }
+  }
+  if (count === 0) {
+    return undefined;
+  }
+  return newArray ?? inputArray;
+}
+
+/**
+ * Removes empty properties from an object.
+ *
+ * If the input object is empty, then undefined is returned.
+ *
+ * @param inputObject - The input object value.
+ * @returns The object with empty properties removed.
+ */
+function removeEmptyFromObject(inputObject: Record<string, any>): Record<string, any> | undefined {
+  let newObject = undefined;
+  let count = 0;
+
+  // Use 'in' for faster key iteration
+  // Using `Object.keys()` and `Object.entries()` is 2x+ slower
+  // Using `Object.hasOwn` guard is about 50% slower
+  // We can safely skip the hasOwn check, because this value will be passed to JSON.stringify,
+  // which has its own property checking.
+  // eslint-disable-next-line guard-for-in
+  for (const key in inputObject) {
+    const inputValue = inputObject[key];
+    const processedValue = removeEmptyFromUnknown(inputValue);
+
+    // If the processed value is different than the input value, then we need to clone the object
+    if (processedValue !== inputValue && !newObject) {
+      newObject = { ...inputObject }; // Shallow clone only when a change is needed
+    }
+
+    if (processedValue === undefined) {
+      if (newObject) {
+        delete newObject[key];
+      }
+    } else {
+      if (newObject) {
+        newObject[key] = processedValue;
+      }
+      count++;
+    }
+  }
+
+  if (count === 0) {
+    return undefined;
+  }
+
+  return newObject ?? inputObject;
 }
 
 /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -487,7 +487,7 @@ export function stringify(value: any, pretty?: boolean): string {
  * @returns The value with empty properties removed.
  */
 function removeEmptyFromUnknown(value: unknown): any {
-  if (!value) {
+  if (value === undefined || value === null || value === '') {
     // For null, undefined, and empty strings, return undefined
     return undefined;
   }


### PR DESCRIPTION
### Performance results

Methodology:

- 1,000,000 iterations of JSON.stringify on an object with a nested array.
- Run 3 times
- Take the best of 3

| Method                            | Time   | Relative to JSON.stringify | Relative to old stringify |
| --------------------------------- | ------ | -------------------------- | ------------------------- |
| JSON.stringify                    | 275 ms | 1.0x                       | 0.3x                      |
| Old stringify                     | 850 ms | 3.1x                       | 1.0x                      |
| New stringify                     | 597 ms | 2.2x                       | 0.7x                      |
| New stringify with ownKey guard   | 716 ms | 2.6x                       | 0.8x                      |
| New stringify with Object.entries | 910 ms | 3.3x                       | 1.1x                      |
