### PR TITLE
feat(super): add `setdataversion` superadmin route

### DIFF
--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -680,9 +680,9 @@ describe('Super Admin routes', () => {
         expect(res1.body).toMatchObject(allOk);
 
         // Check that data version actually gets set
-        const results = await outOfBandPool.query<{ dataVersion: number }>(
-          'SELECT "dataVersion" FROM "DatabaseMigration";'
-        );
+        const results = await database
+          .getDatabasePool(database.DatabaseMode.WRITER)
+          .query<{ dataVersion: number }>('SELECT "dataVersion" FROM "DatabaseMigration";');
         expect(results.rows[0].dataVersion).toEqual(1337);
       });
 

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -3,10 +3,12 @@ import { AsyncJob, Bot, Login, Practitioner, Project, ProjectMembership, User } 
 import { Job, Queue } from 'bullmq';
 import express from 'express';
 import { randomUUID } from 'node:crypto';
+import { Pool, PoolConfig } from 'pg';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
+import { MedplumServerConfig } from '../config/types';
 import { AuthenticatedRequestContext } from '../context';
 import * as database from '../database';
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
@@ -622,6 +624,77 @@ describe('Super Admin routes', () => {
         expect(res1.status).toStrictEqual(200);
         expect(res1.headers['content-location']).not.toBeDefined();
         expect(res1.body).toMatchObject(allOk);
+      });
+    });
+
+    describe('Set data version', () => {
+      let noMigrationsConfig: MedplumServerConfig;
+      let poolConfig: PoolConfig;
+      let outOfBandPool: Pool;
+      let originalDataVersion: number;
+
+      beforeAll(async () => {
+        console.log = jest.fn();
+
+        noMigrationsConfig = await loadTestConfig();
+
+        poolConfig = {
+          host: noMigrationsConfig.database.host,
+          port: noMigrationsConfig.database.port,
+          database: noMigrationsConfig.database.dbname,
+          user: noMigrationsConfig.database.username,
+          password: noMigrationsConfig.database.password,
+          application_name: 'medplum-server',
+          ssl: noMigrationsConfig.database.ssl,
+          max: noMigrationsConfig.database.maxConnections ?? 100,
+        };
+
+        outOfBandPool = new Pool(poolConfig);
+        const results = await outOfBandPool.query<{ dataVersion: number }>(
+          'SELECT "dataVersion" FROM "DatabaseMigration";'
+        );
+        // We store the original version before our edits for this test suite
+        originalDataVersion = results.rows[0].dataVersion ?? -1;
+      });
+
+      beforeEach(async () => {
+        jest.restoreAllMocks();
+        // We set the dataVersion to 1 so that we can trigger the 'v1' migration to be pending after schema migrations run
+        await outOfBandPool.query('UPDATE "DatabaseMigration" SET "dataVersion" = 0;');
+      });
+
+      afterAll(async () => {
+        // We unset our version changes
+        await outOfBandPool.query('UPDATE "DatabaseMigration" SET "dataVersion"=$1;', [originalDataVersion]);
+        await outOfBandPool.end();
+      });
+
+      test('Set data version -- Valid dataVersion', async () => {
+        const res1 = await request(app)
+          .post('/admin/super/setdataversion')
+          .set('Authorization', 'Bearer ' + adminAccessToken)
+          .type('json')
+          .send({ dataVersion: 1337 });
+
+        expect(res1.status).toStrictEqual(200);
+        expect(res1.body).toMatchObject(allOk);
+
+        // Check that data version actually gets set
+        const results = await outOfBandPool.query<{ dataVersion: number }>(
+          'SELECT "dataVersion" FROM "DatabaseMigration";'
+        );
+        expect(results.rows[0].dataVersion).toEqual(1337);
+      });
+
+      test.each([undefined, '3.3.0'])('Set data version -- invalid dataVersion - %s', async (dataVersion) => {
+        const res1 = await request(app)
+          .post('/admin/super/setdataversion')
+          .set('Authorization', 'Bearer ' + adminAccessToken)
+          .type('json')
+          .send({ dataVersion });
+
+        expect(res1.status).toStrictEqual(400);
+        expect(res1.body).toMatchObject(badRequest('dataVersion must be an integer'));
       });
     });
   });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2321,7 +2321,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     if (this.transactionDepth === 1) {
       await conn.query('ROLLBACK');
       this.transactionDepth--;
-      console.log('rolled back / releasing');
       this.releaseConnection(error);
     } else {
       await conn.query('ROLLBACK TO SAVEPOINT sp' + this.transactionDepth);


### PR DESCRIPTION
This route will allow us to set the data version of the database without having to run a migration we know we don't need to run.