### PR TITLE
Allergies passing C-CDA R2.1 Validator for USCDI v3

### DIFF
--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -700,6 +700,9 @@ class CcdaToFhirConverter {
     if (effectiveTime?.['@_value']) {
       return mapCcdaToFhirDateTime(effectiveTime['@_value']);
     }
+    if (effectiveTime?.low?.['@_value']) {
+      return mapCcdaToFhirDateTime(effectiveTime.low['@_value']);
+    }
     return undefined;
   }
 
@@ -1296,7 +1299,6 @@ class CcdaToFhirConverter {
       status: PROCEDURE_STATUS_MAPPER.mapCcdaToFhirWithDefault(procedure.statusCode?.['@_code'], 'completed'),
       code: this.mapCode(procedure.code),
       subject: createReference(this.patient as Patient),
-      performedDateTime: this.mapEffectiveTimeToDateTime(procedure.effectiveTime?.[0]),
       performedPeriod: this.mapEffectiveTimeToPeriod(procedure.effectiveTime?.[0]),
       bodySite: procedure.targetSiteCode ? [this.mapCode(procedure.targetSiteCode) as CodeableConcept] : undefined,
       extension: this.mapTextReference(procedure.text),

--- a/packages/ccda/src/datetime.ts
+++ b/packages/ccda/src/datetime.ts
@@ -71,6 +71,9 @@ export function mapCcdaToFhirDateTime(dateTime: string | undefined): string | un
 
   if (dateTime.length > 14) {
     tz = dateTime.substring(14);
+    if (tz === '+0000') {
+      tz = 'Z';
+    }
   }
 
   return `${year}-${month}-${day}T${hour}:${minute}:${second}${tz}`;

--- a/packages/ccda/src/fhir-to-ccda.ts
+++ b/packages/ccda/src/fhir-to-ccda.ts
@@ -700,10 +700,6 @@ class FhirToCcdaConverter {
       return undefined;
     }
 
-    if (!time) {
-      throw new Error('Author requires time');
-    }
-
     const practitioner = this.findResourceByReference(author);
     if (practitioner?.resourceType !== 'Practitioner') {
       return undefined;

--- a/packages/ccda/src/fhir-to-ccda.ts
+++ b/packages/ccda/src/fhir-to-ccda.ts
@@ -67,6 +67,7 @@ import {
 } from './oids';
 import {
   ADDRESS_USE_MAPPER,
+  ALLERGY_CATEGORY_MAPPER,
   ALLERGY_SEVERITY_MAPPER,
   ALLERGY_STATUS_MAPPER,
   CCDA_NARRATIVE_REFERENCE_URL,
@@ -308,7 +309,6 @@ class FhirToCcdaConverter {
       return undefined;
     }
     return {
-      '@_xsi:type': 'CE',
       '@_code': GENDER_MAPPER.mapFhirToCcda(gender),
       '@_displayName': gender ? capitalize(gender) : 'Unknown',
       '@_codeSystem': OID_ADMINISTRATIVE_GENDER_CODE_SYSTEM,
@@ -534,7 +534,7 @@ class FhirToCcdaConverter {
               'active'
             ),
           },
-          effectiveTime: this.mapEffectiveTime(allergy.recordedDate, undefined),
+          effectiveTime: this.mapEffectivePeriod(allergy.recordedDate, undefined),
           author: this.mapAuthor(allergy.recorder, allergy.recordedDate),
           text: this.createTextFromExtensions(allergy.extension),
           entryRelationship: [
@@ -562,7 +562,11 @@ class FhirToCcdaConverter {
                     '@_code': 'completed',
                   },
                   author: this.mapAuthor(allergy.asserter, allergy.recordedDate),
-                  effectiveTime: this.mapEffectiveDate(allergy.onsetDateTime, undefined),
+                  effectiveTime: this.mapEffectivePeriod(
+                    allergy.onsetPeriod?.start ?? allergy.onsetDateTime,
+                    allergy.onsetPeriod?.end,
+                    true
+                  ),
                   value: this.mapAllergyCategory(allergy.category),
                   text: this.createTextFromExtensions(allergy.extension),
                   participant: [
@@ -574,9 +578,11 @@ class FhirToCcdaConverter {
                           '@_classCode': 'MMAT',
                           code: {
                             ...mapCodeableConceptToCcdaCode(allergy.code),
-                            originalText: {
-                              reference: this.getNarrativeReference(allergy.code?.extension),
-                            },
+                            originalText: allergy.code?.extension
+                              ? {
+                                  reference: this.getNarrativeReference(allergy.code?.extension),
+                                }
+                              : undefined,
                           },
                         },
                       },
@@ -671,21 +677,16 @@ class FhirToCcdaConverter {
    * @returns The C-CDA allergy category.
    */
   private mapAllergyCategory(category: AllergyIntolerance['category']): CcdaValue | undefined {
-    if (!category) {
+    if (!category || category.length === 0) {
       return undefined;
     }
 
-    if (category.length === 1 && category[0] === 'food') {
-      return {
-        '@_xsi:type': 'CD',
-        '@_code': '414285001',
-        '@_displayName': 'Allergy to food (finding)',
-        '@_codeSystem': OID_SNOMED_CT_CODE_SYSTEM,
-        '@_codeSystemName': 'SNOMED CT',
-      };
+    const code = ALLERGY_CATEGORY_MAPPER.mapFhirToCcdaCode(category[0]);
+    if (!code) {
+      return undefined;
     }
 
-    return undefined;
+    return { '@_xsi:type': 'CD', ...code };
   }
 
   /**
@@ -697,6 +698,10 @@ class FhirToCcdaConverter {
   private mapAuthor(author: Reference | undefined, time?: string): CcdaAuthor[] | undefined {
     if (!author) {
       return undefined;
+    }
+
+    if (!time) {
+      throw new Error('Author requires time');
     }
 
     const practitioner = this.findResourceByReference(author);
@@ -1434,7 +1439,6 @@ class FhirToCcdaConverter {
     if (period) {
       return [
         {
-          '@_xsi:type': 'IVL_TS',
           low: { '@_value': mapFhirToCcdaDateTime(period.start) },
           high: { '@_value': mapFhirToCcdaDateTime(period.end) },
         },
@@ -1443,7 +1447,6 @@ class FhirToCcdaConverter {
     if (dateTime) {
       return [
         {
-          '@_xsi:type': 'TS',
           '@_value': mapFhirToCcdaDateTime(dateTime),
         },
       ];
@@ -1455,7 +1458,6 @@ class FhirToCcdaConverter {
     if (period) {
       return [
         {
-          '@_xsi:type': 'IVL_TS',
           low: period.start ? { '@_value': mapFhirToCcdaDate(period.start) } : undefined,
           high: period.end ? { '@_value': mapFhirToCcdaDate(period.end) } : undefined,
         },
@@ -1464,12 +1466,37 @@ class FhirToCcdaConverter {
     if (dateTime) {
       return [
         {
-          '@_xsi:type': 'TS',
           '@_value': mapFhirToCcdaDate(dateTime),
         },
       ];
     }
     return undefined;
+  }
+
+  private mapEffectivePeriod(
+    start: string | undefined,
+    end: string | undefined,
+    useNullFlavor = false
+  ): CcdaEffectiveTime[] | undefined {
+    if (!start && !end) {
+      return undefined;
+    }
+
+    const result: CcdaEffectiveTime = {};
+
+    if (start) {
+      result['low'] = { '@_value': mapFhirToCcdaDateTime(start) };
+    } else if (useNullFlavor) {
+      result['low'] = { '@_nullFlavor': 'NI' };
+    }
+
+    if (end) {
+      result['high'] = { '@_value': mapFhirToCcdaDateTime(end) };
+    } else if (useNullFlavor) {
+      result['high'] = { '@_nullFlavor': 'NI' };
+    }
+
+    return [result];
   }
 
   private createEncounterEntry(encounter: Encounter): CcdaEntry {

--- a/packages/ccda/src/g9.test.ts
+++ b/packages/ccda/src/g9.test.ts
@@ -51,7 +51,7 @@ describe('170.315(g)(9)', () => {
       expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[0]?.['@_use']).toEqual('L');
       expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[0]?.given?.[0]).toEqual('Sarah');
       expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[0]?.family).toEqual('Johnson');
-      expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[1]?.['@_use']).toEqual('M');
+      expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[1]?.['@_use']).toEqual('L');
       expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[1]?.given?.[0]).toEqual('Sarah');
       expect(output.recordTarget?.[0]?.patientRole?.patient?.name?.[1]?.family).toEqual('Smith');
     });
@@ -267,7 +267,7 @@ describe('170.315(g)(9)', () => {
 
       // Check act timing (when recorded)
       expect(
-        output.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0]?.effectiveTime?.[0]?.[
+        output.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0]?.effectiveTime?.[0]?.low?.[
           '@_value'
         ]
       ).toEqual('20240101');
@@ -275,7 +275,7 @@ describe('170.315(g)(9)', () => {
       // Check observation timing (when started)
       expect(
         output.component?.structuredBody?.component?.[0]?.section?.[0]?.entry?.[0]?.act?.[0]?.entryRelationship?.[0]
-          ?.observation?.[0]?.effectiveTime?.[0]?.['@_value']
+          ?.observation?.[0]?.effectiveTime?.[0]?.low?.['@_value']
       ).toEqual('20231225');
 
       // Check status

--- a/packages/ccda/src/roundtrip.test.ts
+++ b/packages/ccda/src/roundtrip.test.ts
@@ -44,7 +44,7 @@ describe('convertCcdaToFhir', () => {
     }
 
     const expected = JSON.parse(readFileSync(join(testDataFolder, `${name}.json`), 'utf8'));
-    expect(bundle).toMatchObject(expected);
+    expect(bundle).toEqual(expected);
   });
 });
 
@@ -53,7 +53,7 @@ describe('convertFhirToCcda', () => {
     const bundle = JSON.parse(readFileSync(join(testDataFolder, `${name}.json`), 'utf8')) as Bundle;
     const result = normalizeCcda(convertFhirToCcda(bundle));
     const expected = convertXmlToCcda(readFileSync(join(testDataFolder, `${name}.xml`), 'utf8'));
-    expect(result).toMatchObject(expected);
+    expect(result).toEqual(expected);
   });
 });
 

--- a/packages/ccda/src/systems.test.ts
+++ b/packages/ccda/src/systems.test.ts
@@ -1,7 +1,9 @@
+import { SNOMED } from '@medplum/core';
+import { OID_SNOMED_CT_CODE_SYSTEM } from './oids';
 import { EnumMapper } from './systems';
 
 describe('EnumMapper', () => {
-  const mapper = new EnumMapper<string, string>('systemName', 'ccdaSystemOid', 'fhirSystemUrl', [
+  const mapper = new EnumMapper<string, string>('SNOMED CT', OID_SNOMED_CT_CODE_SYSTEM, SNOMED, [
     { ccdaValue: 'c0', fhirValue: 'f0', displayName: 'd0' },
     { ccdaValue: 'c1', fhirValue: 'f1', displayName: 'd1' },
     { ccdaValue: 'c2', fhirValue: 'f2', displayName: 'd2' },
@@ -31,7 +33,7 @@ describe('EnumMapper', () => {
   test('mapCcdaToFhirCodeableConcept', () => {
     const r1 = mapper.mapCcdaToFhirCodeableConcept('c0');
     expect(r1?.coding?.[0]?.code).toBe('f0');
-    expect(r1?.coding?.[0]?.system).toBe('fhirSystemUrl');
+    expect(r1?.coding?.[0]?.system).toBe(SNOMED);
     expect(r1?.text).toBe('d0');
 
     const r2 = mapper.mapCcdaToFhirCodeableConcept('c3');
@@ -47,8 +49,8 @@ describe('EnumMapper', () => {
   test('mapFhirToCcdaCode', () => {
     const r1 = mapper.mapFhirToCcdaCode('f0');
     expect(r1?.['@_code']).toBe('c0');
-    expect(r1?.['@_codeSystem']).toBe('ccdaSystemOid');
-    expect(r1?.['@_codeSystemName']).toBe('systemName');
+    expect(r1?.['@_codeSystem']).toBe(OID_SNOMED_CT_CODE_SYSTEM);
+    expect(r1?.['@_codeSystemName']).toBe('SNOMED CT');
     expect(r1?.['@_displayName']).toBe('d0');
 
     const r2 = mapper.mapFhirToCcdaCode('c3');

--- a/packages/ccda/src/systems.ts
+++ b/packages/ccda/src/systems.ts
@@ -104,6 +104,10 @@ export class EnumMapper<TFhirValue extends string, TCcdaValue extends string> {
     return this.fhirToCcdaMap[fhir];
   }
 
+  getEntryByCcda(ccda: TCcdaValue): EnumEntry<TFhirValue, TCcdaValue> | undefined {
+    return this.ccdaToFhirMap[ccda];
+  }
+
   mapCcdaToFhir(ccda: TCcdaValue): TFhirValue | undefined {
     return this.ccdaToFhirMap[ccda]?.fhirValue;
   }
@@ -152,7 +156,7 @@ export class EnumMapper<TFhirValue extends string, TCcdaValue extends string> {
       '@_code': entry.ccdaValue,
       '@_displayName': entry.displayName,
       '@_codeSystem': this.ccdaSystemOid,
-      '@_codeSystemName': this.systemName,
+      '@_codeSystemName': SYSTEM_MAPPER.getEntryByCcda(this.ccdaSystemOid)?.displayName,
     };
   }
 }
@@ -286,6 +290,11 @@ export const SYSTEM_MAPPER = new EnumMapper<string, string>('System', '', '', [
     displayName: 'National Drug File Reference Terminology (NDF-RT)',
   },
   { ccdaValue: OID_CVX_CODE_SYSTEM, fhirValue: CVX_URL, displayName: 'CVX' },
+  {
+    ccdaValue: OID_CONFIDENTIALITY_VALUE_SET,
+    fhirValue: 'Confidentiality',
+    displayName: 'Confidentiality',
+  },
 
   // Alternate FHIR System:
   {
@@ -376,14 +385,18 @@ export const CONFIDENTIALITY_MAPPER = new EnumMapper(
   ]
 );
 
+// FHIR Name Use: https://hl7.org/fhir/R4/valueset-name-use.html
+// CDA Entity Name Use: https://hl7.org/cda/stds/core/2.0.0-sd/ValueSet-CDAEntityNameUse.html
+// CDA does not have any representation of "old" or "maiden" names
+// Instead, it should use "L" for legal with a "validTime" element to indicate the time range of the name
 export const HUMAN_NAME_USE_MAPPER = new EnumMapper('HumanNameUse', '', NAME_USE_VALUE_SET, [
   { ccdaValue: 'C', fhirValue: 'usual', displayName: 'Common/Called by' },
   { ccdaValue: 'L', fhirValue: 'official', displayName: 'Legal' },
   { ccdaValue: 'TEMP', fhirValue: 'temp', displayName: 'Temporary' },
-  { ccdaValue: 'N', fhirValue: 'nickname', displayName: 'Nickname' },
+  { ccdaValue: 'P', fhirValue: 'nickname', displayName: 'Nickname' },
   { ccdaValue: 'ANON', fhirValue: 'anonymous', displayName: 'Anonymous' },
-  { ccdaValue: 'M', fhirValue: 'maiden', displayName: 'Maiden' },
-  { ccdaValue: 'M', fhirValue: 'old', displayName: 'Old' },
+  { ccdaValue: 'L', fhirValue: 'maiden', displayName: 'Maiden' },
+  { ccdaValue: 'L', fhirValue: 'old', displayName: 'Old' },
 ]);
 
 export const GENDER_MAPPER = new EnumMapper('Gender', '', ADMINISTRATIVE_GENDER_VALUE_SET, [
@@ -415,6 +428,26 @@ export const ALLERGY_STATUS_MAPPER = new EnumMapper<string, string>(
     { ccdaValue: 'refuted', fhirValue: 'refuted', displayName: 'Refuted' },
     { ccdaValue: 'entered-in-error', fhirValue: 'entered-in-error', displayName: 'Entered in Error' },
     { ccdaValue: 'unknown', fhirValue: 'unknown', displayName: 'Unknown' },
+  ]
+);
+
+export const ALLERGY_CATEGORY_MAPPER = new EnumMapper<string, string>(
+  'AllergyCategory',
+  OID_SNOMED_CT_CODE_SYSTEM,
+  ALLERGY_CLINICAL_CODE_SYSTEM,
+  [
+    { ccdaValue: '414285001', fhirValue: 'food', displayName: 'Allergy to food (finding)' },
+    {
+      ccdaValue: '419511003',
+      fhirValue: 'medication',
+      displayName: 'Propensity to adverse reactions to drug (finding)',
+    },
+    { ccdaValue: '426232007', fhirValue: 'environment', displayName: 'Environmental allergy (finding)' },
+    {
+      ccdaValue: '418038007',
+      fhirValue: 'biologic',
+      displayName: 'Propensity to adverse reactions to substance (finding)',
+    },
   ]
 );
 

--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -56,7 +56,7 @@ export interface CcdaTelecom {
 }
 
 export interface CcdaName {
-  '@_use'?: 'ANON' | 'C' | 'L' | 'M' | 'N' | 'TEMP';
+  '@_use'?: 'ANON' | 'C' | 'L' | 'P' | 'TEMP';
   family?: string;
   given?: string[];
   suffix?: string[];

--- a/packages/ccda/testdata/AllergyToEgg.json
+++ b/packages/ccda/testdata/AllergyToEgg.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -63,7 +64,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -81,7 +84,9 @@
         "name": [
           {
             "family": "Seven",
-            "given": ["Henry"]
+            "given": [
+              "Henry"
+            ]
           }
         ],
         "telecom": [
@@ -117,7 +122,9 @@
         "name": [
           {
             "family": "Seven",
-            "given": ["Henry"]
+            "given": [
+              "Henry"
+            ]
           }
         ],
         "telecom": [
@@ -161,7 +168,9 @@
           ]
         },
         "type": "allergy",
-        "category": ["food"],
+        "category": [
+          "food"
+        ],
         "patient": {
           "reference": "Patient/d7830f15-e2c8-4cee-aa2d-a24b36080d53",
           "display": "Katherine Madison"

--- a/packages/ccda/testdata/AllergyToEgg.xml
+++ b/packages/ccda/testdata/AllergyToEgg.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />
@@ -72,7 +73,9 @@
                             <statusCode code="active" />
                             <!-- This is the time stamp for when the allergy was first documented as
                             a concern-->
-                            <effectiveTime xsi:type="TS" value="20140104123506-0500" />
+                            <effectiveTime>
+                                <low value="20140104123506-0500"/>
+                            </effectiveTime>
                             <author>
                                 <templateId root="2.16.840.1.113883.10.20.22.4.119" />
                                 <time value="20140104123506-0500" />
@@ -108,7 +111,10 @@
                                     allergy. -->
                                     <!-- Just the year is shown since a specific month and date was
                                     not reported -->
-                                    <effectiveTime xsi:type="TS" value="19980101" />
+                                    <effectiveTime>
+                                        <low value="19980101000000+0000" />
+                                        <high nullFlavor="NI" />
+                                    </effectiveTime>
                                     <!-- This specifies that the allergy is to a food in contrast to
                                     other allergies (drug) -->
                                     <value xsi:type="CD" code="414285001"
@@ -162,7 +168,7 @@
                                                 <reference value="#allergy5reaction" />
                                             </text>
                                             <statusCode code="completed" />
-                                            <effectiveTime xsi:type="TS" value="19980101" />
+                                            <effectiveTime value="19980101" />
                                             <value xsi:type="CD" code="247472004"
                                                 codeSystem="2.16.840.1.113883.6.96"
                                                 codeSystemName="SNOMED CT" displayName="Wheal" />

--- a/packages/ccda/testdata/EncounterHospitalDischarge.xml
+++ b/packages/ccda/testdata/EncounterHospitalDischarge.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="ce862cfe-6559-411e-92e9-e8d005b1c226" />

--- a/packages/ccda/testdata/HealthConcerns.xml
+++ b/packages/ccda/testdata/HealthConcerns.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="ce862cfe-6559-411e-92e9-e8d005b1c226" />

--- a/packages/ccda/testdata/ImmunizationInfluenza.json
+++ b/packages/ccda/testdata/ImmunizationInfluenza.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -64,7 +65,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -76,12 +79,16 @@
         "name": [
           {
             "family": "Assigned",
-            "given": ["Amanda"]
+            "given": [
+              "Amanda"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["1021 Health Drive"],
+            "line": [
+              "1021 Health Drive"
+            ],
             "city": "Ann Arbor",
             "state": "MI",
             "postalCode": "99099",

--- a/packages/ccda/testdata/ImmunizationInfluenza.xml
+++ b/packages/ccda/testdata/ImmunizationInfluenza.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="ce862cfe-6559-411e-92e9-e8d005b1c226" />

--- a/packages/ccda/testdata/MedicationAtBedtime.json
+++ b/packages/ccda/testdata/MedicationAtBedtime.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -64,7 +65,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -99,7 +102,9 @@
           }
         ],
         "meta": {
-          "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"]
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+          ]
         },
         "status": "active",
         "intent": "order",
@@ -136,16 +141,18 @@
             },
             "timing": {
               "repeat": {
-                "when": ["HS"]
+                "when": [
+                  "HS"
+                ]
               }
             },
             "doseAndRate": [
               {
                 "doseQuantity": {
+                  "system": "http://unitsofmeasure.org",
                   "value": 40,
                   "code": "[IU]",
-                  "unit": "[IU]",
-                  "system": "http://unitsofmeasure.org"
+                  "unit": "[IU]"
                 }
               }
             ]

--- a/packages/ccda/testdata/MedicationAtBedtime.xml
+++ b/packages/ccda/testdata/MedicationAtBedtime.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
     <patientRole>
       <id root="5adfedd2-3aaf-4a4f-aa35-5f6600b60c99" />
@@ -79,7 +80,7 @@
               <statusCode code="active" />
               <!-- This first effectiveTime shows that medication was added on January 9, 2009 (not
               known to have stopped)-->
-              <effectiveTime xsi:type="IVL_TS">
+              <effectiveTime>
                 <low value="20090109" />
               </effectiveTime>
               <!-- The second effectiveTime specifies dose frequency, which can be either a period
@@ -100,7 +101,7 @@
               UCUM. [IU] is international units -->
               <!-- Note that this basal insulin is not administered on a sliding scale and a
               specific dose is administered-->
-              <doseQuantity value="40" unit="[IU]" />
+              <doseQuantity xsi:type="PQ" value="40" unit="[IU]" />
               <consumable typeCode="CSM">
                 <manufacturedProduct classCode="MANU">
                   <!-- ** Medication information ** -->

--- a/packages/ccda/testdata/MinimalPassingValidator.json
+++ b/packages/ccda/testdata/MinimalPassingValidator.json
@@ -192,7 +192,10 @@
         "name": [
           {
             "family": "Newman",
-            "given": ["Alice", "Jones"]
+            "given": [
+              "Alice",
+              "Jones"
+            ]
           }
         ],
         "gender": "female",
@@ -239,14 +242,20 @@
         ],
         "name": [
           {
-            "prefix": ["Dr"],
+            "prefix": [
+              "Dr"
+            ],
             "family": "Davis",
-            "given": ["Albert"]
+            "given": [
+              "Albert"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["2472 Rocky Place"],
+            "line": [
+              "2472 Rocky Place"
+            ],
             "city": "Beaverton",
             "state": "CO",
             "postalCode": "97006",
@@ -274,7 +283,9 @@
         "name": "Neighborhood Physicians Practice",
         "address": [
           {
-            "line": ["2472 Rocky place"],
+            "line": [
+              "2472 Rocky place"
+            ],
             "city": "Beaverton",
             "state": "OR",
             "postalCode": "97006",

--- a/packages/ccda/testdata/MinimalPassingValidator.xml
+++ b/packages/ccda/testdata/MinimalPassingValidator.xml
@@ -12,7 +12,7 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Alicia Newman Summary Record</title>
-    <effectiveTime xsi:type="TS" value="20150622120000-0500" />
+    <effectiveTime value="20150622120000-0500" />
     <confidentialityCode code="N" displayName="normal" codeSystem="2.16.840.1.113883.5.25"
         codeSystemName="Confidentiality" />
     <languageCode code="en-US" />
@@ -28,7 +28,7 @@
                     <given>Alice</given>
                     <given>Jones</given>
                 </name>
-                <administrativeGenderCode xsi:type="CE" code="F" displayName="Female"
+                <administrativeGenderCode code="F" displayName="Female"
                     codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" />
                 <birthTime value="19700501" />
                 <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
@@ -80,7 +80,7 @@
     </custodian>
     <documentationOf>
         <serviceEvent classCode="PCPR">
-            <effectiveTime xsi:type="IVL_TS">
+            <effectiveTime>
                 <low value="20130720" />
                 <high value="20130815" />
             </effectiveTime>

--- a/packages/ccda/testdata/Patient.json
+++ b/packages/ccda/testdata/Patient.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -40,18 +41,26 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine", "Jones"]
+            "given": [
+              "Katherine",
+              "Jones"
+            ]
           },
           {
             "family": "Madison",
-            "given": ["Kathy", "Jones"]
+            "given": [
+              "Kathy",
+              "Jones"
+            ]
           }
         ],
         "gender": "female",
         "birthDate": "1970-06-01",
         "address": [
           {
-            "line": ["1001 Amber Dr"],
+            "line": [
+              "1001 Amber Dr"
+            ],
             "city": "Beaverton",
             "state": "OR",
             "postalCode": "97006",

--- a/packages/ccda/testdata/Patient.xml
+++ b/packages/ccda/testdata/Patient.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
     <patientRole>
       <id root="0fedb502-9a38-4990-8bab-24debe2d332b" />

--- a/packages/ccda/testdata/PlanOfTreatmentCarePlan.json
+++ b/packages/ccda/testdata/PlanOfTreatmentCarePlan.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -64,7 +65,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }

--- a/packages/ccda/testdata/PlanOfTreatmentCarePlan.xml
+++ b/packages/ccda/testdata/PlanOfTreatmentCarePlan.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="ce862cfe-6559-411e-92e9-e8d005b1c226" />

--- a/packages/ccda/testdata/PlanOfTreatmentCarePlanGoals.json
+++ b/packages/ccda/testdata/PlanOfTreatmentCarePlanGoals.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -67,7 +68,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }

--- a/packages/ccda/testdata/PlanOfTreatmentCarePlanGoals.xml
+++ b/packages/ccda/testdata/PlanOfTreatmentCarePlanGoals.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="ce862cfe-6559-411e-92e9-e8d005b1c226" />

--- a/packages/ccda/testdata/ProblemPneumonia.json
+++ b/packages/ccda/testdata/ProblemPneumonia.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -65,7 +66,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -83,13 +86,19 @@
         "name": [
           {
             "family": "Sixer",
-            "given": ["Heartly"],
-            "suffix": ["MD"]
+            "given": [
+              "Heartly"
+            ],
+            "suffix": [
+              "MD"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["6666 StreetName St."],
+            "line": [
+              "6666 StreetName St."
+            ],
             "city": "Silver Spring",
             "state": "MD",
             "postalCode": "20901",
@@ -129,13 +138,19 @@
         "name": [
           {
             "family": "Sixer",
-            "given": ["Heartly"],
-            "suffix": ["MD"]
+            "given": [
+              "Heartly"
+            ],
+            "suffix": [
+              "MD"
+            ]
           }
         ],
         "address": [
           {
-            "line": ["6666 StreetName St."],
+            "line": [
+              "6666 StreetName St."
+            ],
             "city": "Silver Spring",
             "state": "MD",
             "postalCode": "20901",
@@ -173,7 +188,9 @@
           }
         ],
         "meta": {
-          "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"]
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ]
         },
         "clinicalStatus": {
           "coding": [

--- a/packages/ccda/testdata/ProblemPneumonia.xml
+++ b/packages/ccda/testdata/ProblemPneumonia.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="ce862cfe-6559-411e-92e9-e8d005b1c226" />
@@ -70,7 +71,7 @@
                             <statusCode code="active" />
                             <!-- This equates to the time the concern was authored in the
                             patient's chart. This may frequently be an EHR timestamp-->
-                            <effectiveTime xsi:type="TS" value="20140302124536-0500" />
+                            <effectiveTime value="20140302124536-0500" />
                             <entryRelationship typeCode="SUBJ">
                                 <observation classCode="OBS" moodCode="EVN">
                                     <templateId root="2.16.840.1.113883.10.20.22.4.4" />

--- a/packages/ccda/testdata/ProcedureSectionActEntry.json
+++ b/packages/ccda/testdata/ProcedureSectionActEntry.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -65,7 +66,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }

--- a/packages/ccda/testdata/ProcedureSectionActEntry.xml
+++ b/packages/ccda/testdata/ProcedureSectionActEntry.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />
@@ -71,7 +72,7 @@
                                 <reference value="#Procedure3" />
                             </text>
                             <statusCode code="completed" />
-                            <effectiveTime xsi:type="TS" value="20140329104513-0500" />
+                            <effectiveTime value="20140329104513-0500" />
                         </act>
                     </entry>
                 </section>

--- a/packages/ccda/testdata/ProcedureSectionObservationEntry.json
+++ b/packages/ccda/testdata/ProcedureSectionObservationEntry.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "978a95c6-248e-49d1-b5dd-7c13282bd938",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -65,7 +66,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -83,7 +86,8 @@
                 "code": "exam",
                 "display": "Procedure Activity Observation"
               }
-            ]
+            ],
+            "text": "Procedure Activity Observation"
           },
           {
             "coding": [

--- a/packages/ccda/testdata/ProcedureSectionObservationEntry.xml
+++ b/packages/ccda/testdata/ProcedureSectionObservationEntry.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />

--- a/packages/ccda/testdata/ProcedureSectionProcedureEntry.generated.xml
+++ b/packages/ccda/testdata/ProcedureSectionProcedureEntry.generated.xml
@@ -10,7 +10,8 @@
   <id root="3db70aff-83f5-4caf-91dc-d23fcc5e03bb"/>
   <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
   <title>Medical Summary</title>
-  <effectiveTime xsi:type="TS" value="20250101000000-0500"/>
+  <effectiveTime value="20250101000000-0500"/>
+  <languageCode code="en-US" />
   <recordTarget>
     <patientRole>
       <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53"/>

--- a/packages/ccda/testdata/ProcedureSectionProcedureEntry.json
+++ b/packages/ccda/testdata/ProcedureSectionProcedureEntry.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -65,7 +66,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }

--- a/packages/ccda/testdata/ProcedureSectionProcedureEntry.xml
+++ b/packages/ccda/testdata/ProcedureSectionProcedureEntry.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />
@@ -73,7 +74,7 @@
                             <statusCode code="completed" />
                             <!-- Effective times can be either a value or interval. For procedures
                             with start and stop times, an interval would be more appropriate -->
-                            <effectiveTime xsi:type="IVL_TS">
+                            <effectiveTime>
                                 <low value="20140203092205-0700" />
                                 <high value="20140203111514-0700" />
                             </effectiveTime>

--- a/packages/ccda/testdata/SmokingStatus.json
+++ b/packages/ccda/testdata/SmokingStatus.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -69,7 +70,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -87,7 +90,9 @@
         "name": [
           {
             "family": "Seven",
-            "given": ["Henry"]
+            "given": [
+              "Henry"
+            ]
           }
         ],
         "telecom": [
@@ -123,7 +128,9 @@
         "name": [
           {
             "family": "Seven",
-            "given": ["Henry"]
+            "given": [
+              "Henry"
+            ]
           }
         ],
         "telecom": [
@@ -165,7 +172,8 @@
                 "code": "social-history",
                 "display": "Smoking Status"
               }
-            ]
+            ],
+            "text": "Smoking Status"
           },
           {
             "coding": [
@@ -237,7 +245,8 @@
                 "code": "social-history",
                 "display": "Tobacco Use"
               }
-            ]
+            ],
+            "text": "Tobacco Use"
           },
           {
             "coding": [

--- a/packages/ccda/testdata/SmokingStatus.xml
+++ b/packages/ccda/testdata/SmokingStatus.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />

--- a/packages/ccda/testdata/VitalSignsGrowthCharts.json
+++ b/packages/ccda/testdata/VitalSignsGrowthCharts.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -69,7 +70,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -93,7 +96,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -171,7 +175,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -249,7 +254,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -327,7 +333,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -405,7 +412,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -483,7 +491,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Organizer"
               }
-            ]
+            ],
+            "text": "Vital Signs Organizer"
           },
           {
             "coding": [
@@ -549,7 +558,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Organizer"
               }
-            ]
+            ],
+            "text": "Vital Signs Organizer"
           },
           {
             "coding": [

--- a/packages/ccda/testdata/VitalSignsGrowthCharts.xml
+++ b/packages/ccda/testdata/VitalSignsGrowthCharts.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />

--- a/packages/ccda/testdata/VitalSignsMetricUnits.json
+++ b/packages/ccda/testdata/VitalSignsMetricUnits.json
@@ -6,6 +6,7 @@
       "resource": {
         "resourceType": "Composition",
         "id": "3db70aff-83f5-4caf-91dc-d23fcc5e03bb",
+        "language": "en-US",
         "status": "final",
         "type": {
           "coding": [
@@ -65,7 +66,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -83,7 +86,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -145,7 +149,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -207,7 +212,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -269,7 +275,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -331,7 +338,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -393,7 +401,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -455,7 +464,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -517,7 +527,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -579,7 +590,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Observation"
               }
-            ]
+            ],
+            "text": "Vital Signs Observation"
           },
           {
             "coding": [
@@ -641,7 +653,8 @@
                 "code": "vital-signs",
                 "display": "Vital Signs Organizer"
               }
-            ]
+            ],
+            "text": "Vital Signs Organizer"
           },
           {
             "coding": [

--- a/packages/ccda/testdata/VitalSignsMetricUnits.xml
+++ b/packages/ccda/testdata/VitalSignsMetricUnits.xml
@@ -15,7 +15,8 @@
     <code code="34133-9" displayName="Summarization of Episode Note"
         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
     <title>Medical Summary</title>
-    <effectiveTime xsi:type="TS" value="20250101000000-0500" />
+    <effectiveTime value="20250101000000-0500" />
+    <languageCode code="en-US" />
     <recordTarget>
         <patientRole>
             <id root="d7830f15-e2c8-4cee-aa2d-a24b36080d53" />

--- a/packages/server/src/fhir/operations/ccdaexport.test.ts
+++ b/packages/server/src/fhir/operations/ccdaexport.test.ts
@@ -70,6 +70,7 @@ describe('C-CDA Export', () => {
         code: { coding: [{ system: LOINC, code: '12345-6' }] },
         subject: createReference(patient),
         performer: [createReference(practitioner), createReference(organization)],
+        effectiveDateTime: new Date().toISOString(),
       } satisfies Observation);
     expect(res2.status).toBe(201);
     const observation = res2.body as Observation;
@@ -87,6 +88,7 @@ describe('C-CDA Export', () => {
         asserter: createReference(patient),
         subject: createReference(patient),
         recorder: createReference(practitioner),
+        recordedDate: new Date().toISOString(),
       } satisfies Condition);
     expect(res3.status).toBe(201);
     const condition = res3.body as Condition;


### PR DESCRIPTION
This includes all of the fixes to `@medplum/ccda` for the [C-CDA R2.1 Validator for USCDI v3](https://ett.healthit.gov/ett/#/validators/ccdauscidv3#ccdaValdReport) to pass the following sections of Alice Newman:

1. USCDI Data Class/Element: Patient Demographics
2. Relevant Information regarding the Visit
3. USCDI Data Class/Element: Allergies and Intolerances

Most of the actual changes are quite tedious and annoying:
* Mapping human name "use" codes
* Mapping various codes such as the allergy category
* Dealing with required element ordering
* Dealing with all of the nuances of "xsi:type" attributes
* Dealing with all of the nuances of `<effectiveTime>`
   * When is it a date vs dateTime vs period?
   * When are `<low>` and `<high>` optional vs required?

References:

* [Alice Newman test data](https://drive.google.com/file/d/1YZ8w0n7dO3yrSTmSsPneMPXDg9ri78n8/view?usp=drive_link) - original guide from Cures Update Test Data for 170.315 (g)(9)
* [Medplum Alice Newman guide](https://docs.google.com/document/d/10ZUP2eUjSovdgdkfDh0EpdFcBUlyNbkRWabfH1zc6z8/edit?usp=sharing) - these are the steps and FHIR resources necessary to pass these steps