### PR TITLE
fix(core/fhircast): fix special casing of `DiagnosticReport-select`

### DIFF
--- a/packages/core/src/fhircast/index.test.ts
+++ b/packages/core/src/fhircast/index.test.ts
@@ -1,4 +1,3 @@
-import { Reference } from '@medplum/fhirtypes';
 import WS from 'jest-websocket-mock';
 import {
   assertContextVersionOptional,
@@ -536,7 +535,11 @@ describe('createFhircastMessagePayload', () => {
       },
       {
         key: 'select',
-        reference: [{ reference: 'Observation/123' }],
+        reference: { reference: 'Observation/123' },
+      },
+      {
+        key: 'select',
+        reference: { reference: 'Observation/456' },
       },
     ]);
 
@@ -548,31 +551,6 @@ describe('createFhircastMessagePayload', () => {
     });
     expect(new Date(messagePayload.timestamp).toISOString()).toStrictEqual(messagePayload.timestamp);
     expect(messagePayload.event.context[0]).toBeDefined();
-  });
-
-  test('Using single reference context for multi-reference context', () => {
-    expect(() =>
-      createFhircastMessagePayload('abc-123', 'DiagnosticReport-select', [
-        {
-          key: 'report',
-          reference: { reference: 'DiagnosticReport/123' },
-        },
-        // @ts-expect-error Should have an array of references at 'references'
-        { key: 'select', reference: { reference: 'Observation/123' } as Reference },
-      ])
-    ).toThrow(OperationOutcomeError);
-  });
-
-  test('Invalid references array context', () => {
-    expect(() =>
-      createFhircastMessagePayload('abc-123', 'DiagnosticReport-select', [
-        {
-          key: 'report',
-          reference: { reference: 'DiagnosticReport/123' },
-        },
-        { key: 'select', reference: [{ resourceType: 'Patient' } as Reference] },
-      ])
-    ).toThrow(OperationOutcomeError);
   });
 
   test('Valid `DiagnosticReport-update` event', () => {


### PR DESCRIPTION
After some findings at the IHE Connectathon that the spec was inconsistent on the handling of the `select` context key in the `DiagnosticReport-select` event, there was a recent update to the FHIRcast spec docs made it clear that the `select` context of the `DiagnosticReport-select` special casing was not intended.

The context should be treated like all the other keys that are allowed multiple values (ie., many keys, each having one reference or resource, rather than one key with an array of references.)

See the updated example:
https://build.fhir.org/ig/HL7/fhircast-docs/3-6-4-DiagnosticReport-select.html#diagnosticreport-select-example
<img width="742" alt="Screenshot 2025-02-24 at 9 56 05 AM" src="https://github.com/user-attachments/assets/14658c03-c6bd-46a9-9fb7-b16bec543f6b" />