### PR TITLE
Medications passing C-CDA R2.1 Validator for USCDI v3

### DIFF
--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -231,7 +231,7 @@ export interface CcdaSubstanceAdministration {
   '@_negationInd'?: string;
   templateId: CcdaTemplateId[];
   id?: CcdaId[];
-  text?: CcdaText;
+  text?: string | CcdaText;
   statusCode?: CcdaStatusCode<'active' | 'completed' | 'aborted' | 'cancelled'>;
   effectiveTime?: CcdaEffectiveTime[];
   routeCode?: CcdaCode;
@@ -253,8 +253,8 @@ export type CcdaValue = CcdaCode | CcdaText | CcdaQuantity | CcdaReference;
 
 export interface CcdaPeriod {
   '@_xsi:type'?: 'PIVL_TS';
-  '@_value': string;
-  '@_unit': string;
+  '@_value'?: string;
+  '@_unit'?: 's' | 'min' | 'h' | 'd' | 'wk' | 'mo' | 'a';
 }
 
 export interface CcdaEvent {
@@ -262,7 +262,7 @@ export interface CcdaEvent {
 }
 
 export interface CcdaEffectiveTime {
-  '@_xsi:type'?: 'IVL_TS' | 'TS';
+  '@_xsi:type'?: 'IVL_TS' | 'TS' | 'PIVL_TS';
   '@_institutionSpecified'?: string;
   '@_operator'?: string;
   '@_value'?: string;

--- a/packages/ccda/testdata/MedicationAtBedtime.json
+++ b/packages/ccda/testdata/MedicationAtBedtime.json
@@ -65,9 +65,7 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": [
-              "Katherine"
-            ]
+            "given": ["Katherine"]
           }
         ]
       }
@@ -102,9 +100,7 @@
           }
         ],
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-          ]
+          "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"]
         },
         "extension": [
           {

--- a/packages/ccda/testdata/MedicationAtBedtime.json
+++ b/packages/ccda/testdata/MedicationAtBedtime.json
@@ -65,7 +65,9 @@
           {
             "use": "official",
             "family": "Madison",
-            "given": ["Katherine"]
+            "given": [
+              "Katherine"
+            ]
           }
         ]
       }
@@ -100,8 +102,16 @@
           }
         ],
         "meta": {
-          "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"]
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+          ]
         },
+        "extension": [
+          {
+            "url": "https://medplum.com/fhir/StructureDefinition/ccda-narrative-reference",
+            "valueString": "#Medication_6"
+          }
+        ],
         "status": "active",
         "intent": "order",
         "medicationReference": {
@@ -118,11 +128,10 @@
         },
         "dosageInstruction": [
           {
-            "text": "#Medication_6",
             "extension": [
               {
                 "url": "https://medplum.com/fhir/StructureDefinition/ccda-narrative-reference",
-                "valueString": "#Medication_6"
+                "valueString": "#MedicationSig_6"
               }
             ],
             "route": {
@@ -137,7 +146,8 @@
             },
             "timing": {
               "repeat": {
-                "when": ["HS"]
+                "period": 12,
+                "periodUnit": "h"
               }
             },
             "doseAndRate": [

--- a/packages/ccda/testdata/MedicationAtBedtime.xml
+++ b/packages/ccda/testdata/MedicationAtBedtime.xml
@@ -71,6 +71,7 @@
           <entry>
             <substanceAdministration classCode="SBADM" moodCode="EVN">
               <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.16" />
               <id root="1310a2d3-f888-4722-b4c4-a3c5911ac7f9" />
               <text>
                 <!-- This reference refers to medication information in unstructured portion of
@@ -80,7 +81,7 @@
               <statusCode code="active" />
               <!-- This first effectiveTime shows that medication was added on January 9, 2009 (not
               known to have stopped)-->
-              <effectiveTime>
+              <effectiveTime xsi:type="IVL_TS">
                 <low value="20090109" />
               </effectiveTime>
               <!-- The second effectiveTime specifies dose frequency, which can be either a period
@@ -92,6 +93,12 @@
                 <event code="HS" />
               </effectiveTime>
               -->
+              <effectiveTime
+                  xsi:type = "PIVL_TS"
+                  institutionSpecified = "true"
+                  operator = "A">
+                  <period value = "12" unit = "h"/>
+              </effectiveTime>
               <!-- This route uses the NCI (National Cancer Institute) Thesauraus code system, which
               is constrained to the value set of 2.16.840.1.113883.3.88.12.3221.8.7 (FDA Medication
               Route) -->
@@ -101,11 +108,12 @@
               UCUM. [IU] is international units -->
               <!-- Note that this basal insulin is not administered on a sliding scale and a
               specific dose is administered-->
-              <doseQuantity xsi:type="PQ" value="40" unit="[IU]" />
+              <doseQuantity value="40" unit="[IU]" />
               <consumable typeCode="CSM">
                 <manufacturedProduct classCode="MANU">
                   <!-- ** Medication information ** -->
                   <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.23" />
                   <manufacturedMaterial>
                     <!-- Medications should be specified at a level corresponding to prescription
                     when possible (branded medication below)-->

--- a/packages/ccda/testdata/MinimalPassingValidator.xml
+++ b/packages/ccda/testdata/MinimalPassingValidator.xml
@@ -80,7 +80,7 @@
     </custodian>
     <documentationOf>
         <serviceEvent classCode="PCPR">
-            <effectiveTime>
+            <effectiveTime xsi:type="IVL_TS">
                 <low value="20130720" />
                 <high value="20130815" />
             </effectiveTime>


### PR DESCRIPTION
Adds support for the USCDI Data Class/Element: Medications

![image](https://github.com/user-attachments/assets/453140fc-2179-4cc9-ad78-a3f852104c5a)

Passing the validator:

![image](https://github.com/user-attachments/assets/4f3cb2e8-fbca-4c09-88bd-c9d66007ecbd)

Medplum C-CDA guide updated: https://docs.google.com/document/d/10ZUP2eUjSovdgdkfDh0EpdFcBUlyNbkRWabfH1zc6z8/edit?tab=t.0