### PR TITLE
Use Questionniare.url, fallback to Questionnaire reference

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -362,6 +362,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        url: 'https://example.com/Questionnaire/123',
         status: 'active',
         item: [
           {
@@ -445,6 +446,9 @@ describe('QuestionnaireForm', () => {
 
     const response = onSubmit.mock.calls[0][0];
     const answers = getQuestionnaireAnswers(response);
+    expect(response.resourceType).toBe('QuestionnaireResponse');
+    expect(response.status).toBe('completed');
+    expect(response.questionnaire).toBe('https://example.com/Questionnaire/123');
     expect(answers['q1']).toMatchObject({ valueString: 'a1' });
     expect(answers['q2']).toMatchObject({ valueInteger: 2 });
     expect(answers['q3']).toMatchObject({ valueDate: '2023-03-03' });
@@ -457,6 +461,7 @@ describe('QuestionnaireForm', () => {
     await setup({
       questionnaire: {
         resourceType: 'Questionnaire',
+        id: '456',
         status: 'active',
       },
       onSubmit,
@@ -473,6 +478,7 @@ describe('QuestionnaireForm', () => {
     const response = onSubmit.mock.calls[0][0];
     expect(response.resourceType).toBe('QuestionnaireResponse');
     expect(response.status).toBe('completed');
+    expect(response.questionnaire).toBe('Questionnaire/456');
     expect(response.authored).toBeDefined();
     expect(response.source).toBeDefined();
   });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.tsx
@@ -1,5 +1,5 @@
 import { Title } from '@mantine/core';
-import { createReference } from '@medplum/core';
+import { createReference, getReferenceString } from '@medplum/core';
 import {
   Encounter,
   Questionnaire,
@@ -13,9 +13,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Form } from '../Form/Form';
 import {
   buildInitialResponse,
+  evaluateCalculatedExpressionsInQuestionnaire,
   getNumberOfPages,
   isQuestionEnabled,
-  evaluateCalculatedExpressionsInQuestionnaire,
   mergeUpdatedItems,
 } from '../utils/questionnaire';
 import { QuestionnaireFormContext } from './QuestionnaireForm.context';
@@ -81,7 +81,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
 
   const handleSubmit = useCallback(() => {
     const onSubmit = onSubmitRef.current;
-    if (onSubmit && response) {
+    if (onSubmit && questionnaire && response) {
       let source = sourceFromProps;
       if (!source) {
         const profile = medplum.getProfile();
@@ -91,7 +91,7 @@ export function QuestionnaireForm(props: QuestionnaireFormProps): JSX.Element | 
       }
       onSubmit({
         ...response,
-        questionnaire: questionnaire?.url,
+        questionnaire: questionnaire.url ?? getReferenceString(questionnaire),
         subject,
         source,
         authored: new Date().toISOString(),

--- a/packages/react/src/utils/questionnaire.ts
+++ b/packages/react/src/utils/questionnaire.ts
@@ -395,7 +395,7 @@ export function buildInitialResponse(
 ): QuestionnaireResponse {
   const response: QuestionnaireResponse = {
     resourceType: 'QuestionnaireResponse',
-    questionnaire: getReferenceString(questionnaire),
+    questionnaire: questionnaire.url ?? getReferenceString(questionnaire),
     item: buildInitialResponseItems(questionnaire.item, questionnaireResponse?.item),
     status: 'in-progress',
   };


### PR DESCRIPTION
This is the quick surgical fix to support both `Questionnaire.url` and `Questionnaire.id` formats in the QuestionnaireForm builder

The longer version is @ThatOneBro 's PR: https://github.com/medplum/medplum/pull/6062