### PR TITLE
Display OAuth2 scope consent screen on subsequent authorizations

### DIFF
--- a/packages/app/src/OAuthPage.tsx
+++ b/packages/app/src/OAuthPage.tsx
@@ -15,6 +15,7 @@ export function OAuthPage(): JSX.Element | null {
   const [clientInfo, setClientInfo] = useState<ClientApplicationSignInForm>();
   const [loading, setLoading] = useState(true);
   const clientId = params.get('client_id');
+  const login = params.get('login');
 
   useEffect(() => {
     if (!clientId || clientId === 'medplum-cli') {
@@ -69,6 +70,7 @@ export function OAuthPage(): JSX.Element | null {
       codeChallenge={params.get('code_challenge') || undefined}
       codeChallengeMethod={(params.get('code_challenge_method') as CodeChallengeMethod) || undefined}
       chooseScopes={scope !== 'openid'}
+      login={login || undefined}
     >
       {!loading && (
         <>

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -339,7 +339,7 @@ protectedRoutes.use(
 
     const request: FhirRequest = {
       method: req.method as HttpMethod,
-      url: req.originalUrl.replace('/fhir/R4', ''),
+      url: stripPrefix(req.originalUrl, '/fhir/R4'),
       pathname: '',
       params: req.params,
       query: Object.create(null), // Defer query param parsing to router for consistency
@@ -367,3 +367,7 @@ protectedRoutes.use(
     await sendFhirResponse(req, res, result[0], result[1], result[2]);
   })
 );
+
+function stripPrefix(str: string, prefix: string): string {
+  return str.substring(str.indexOf(prefix) + prefix.length);
+}

--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -293,6 +293,54 @@ describe('OAuth Authorize', () => {
     expect(location.searchParams.get('error')).toBeNull();
   });
 
+  test('Show scope screen on subsequent authorize', async () => {
+    const res1 = await request(app).post('/auth/login').type('json').send({
+      clientId: client.id,
+      email,
+      password,
+      scope: 'openid',
+      codeChallenge: 'xyz',
+      codeChallengeMethod: 'plain',
+    });
+    expect(res1.status).toBe(200);
+    expect(res1.body.code).toBeDefined();
+    expect(res1.headers['set-cookie']).toBeDefined();
+
+    const res2 = await request(app).post('/oauth2/token').type('form').send({
+      grant_type: 'authorization_code',
+      code: res1.body.code,
+      code_verifier: 'xyz',
+    });
+    expect(res2.status).toBe(200);
+    expect(res2.body.id_token).toBeDefined();
+
+    const cookies = setCookieParser.parse(res1.headers['set-cookie']);
+    expect(cookies.length).toBe(1);
+
+    const cookie = cookies[0];
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: client.id as string,
+      redirect_uri: client.redirectUri as string,
+      scope: 'openid user/Patient.rs',
+      code_challenge: 'xyz',
+      code_challenge_method: 'plain',
+    });
+
+    const res3 = await request(app)
+      .get('/oauth2/authorize?' + params.toString())
+      .set('Cookie', cookie.name + '=' + cookie.value);
+    expect(res3.status).toBe(302);
+    expect(res3.headers.location).toBeDefined();
+
+    const location = new URL(res3.headers.location);
+    expect(location.pathname).toBe('/oauth');
+    expect(location.searchParams.get('login')).not.toBeNull();
+    expect(location.searchParams.get('scope')).toContain('user/Patient.rs');
+    expect(location.searchParams.get('error')).toBeNull();
+  });
+
   test('Revoked cookie', async () => {
     const res1 = await request(app).post('/auth/login').type('json').send({
       clientId: client.id,

--- a/packages/server/src/oauth/authorize.test.ts
+++ b/packages/server/src/oauth/authorize.test.ts
@@ -392,7 +392,7 @@ describe('OAuth Authorize', () => {
     const launch = await systemRepo.createResource<SmartAppLaunch>({ resourceType: 'SmartAppLaunch' });
 
     const res3 = await request(app)
-      .get(`/oauth2/authorize?launch=${launch.id}&${params.toString()}`)
+      .get(`/oauth2/authorize?launch=${launch.id}&${params.toString()}&prompt=none`)
       .set('Cookie', cookie.name + '=' + cookie.value);
     expect(res3.status).toBe(302);
     expect(res3.headers.location).toBeDefined();
@@ -438,6 +438,7 @@ describe('OAuth Authorize', () => {
       code_challenge: 'xyz',
       code_challenge_method: 'plain',
       id_token_hint: res2.body.id_token,
+      prompt: 'none',
     });
     const res3 = await request(app).get('/oauth2/authorize?' + params2.toString());
     expect(res3.status).toBe(302);

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -131,7 +131,9 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
     } else {
       // Redirect to scope selection page to allow consent to updated scopes
       params.login = updatedLogin.id;
-      params.scope = updatedLogin.scope;
+      if (!params.scope) {
+        params.scope = updatedLogin.scope;
+      }
       sendSuccessRedirect(req, res, params);
     }
     return false;

--- a/packages/server/src/oauth/authorize.ts
+++ b/packages/server/src/oauth/authorize.ts
@@ -122,10 +122,18 @@ async function validateAuthorizeRequest(req: Request, res: Response, params: Rec
       granted: false,
     });
 
-    const redirectUrl = new URL(params.redirect_uri as string);
-    redirectUrl.searchParams.append('code', updatedLogin.code as string);
-    redirectUrl.searchParams.append('state', state);
-    res.redirect(redirectUrl.toString());
+    if (prompt === 'none') {
+      // Redirect straight to application without allowing scope changes
+      const redirectUrl = new URL(params.redirect_uri as string);
+      redirectUrl.searchParams.append('code', updatedLogin.code as string);
+      redirectUrl.searchParams.append('state', state);
+      res.redirect(redirectUrl.toString());
+    } else {
+      // Redirect to scope selection page to allow consent to updated scopes
+      params.login = updatedLogin.id;
+      params.scope = updatedLogin.scope;
+      sendSuccessRedirect(req, res, params);
+    }
     return false;
   }
 


### PR DESCRIPTION
After authorizing a SMART app launch, if the app tries to re-authorize the user (e.g. to update the scopes requested) the server would redirect straight back to the application without giving the user another chance to consent to scopes.  This ensures that when `prompt=none` is not set, the user will have the opportunity to change the granted scopes on subsequent re-authorization