### PR TITLE
Remove unnecessary IS NOT NULL

### DIFF
--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -49,16 +49,14 @@ describe('SqlBuilder', () => {
     test('Select where array contains', () => {
       const sql = new SqlBuilder();
       new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', 'x', 'TEXT[]').buildSql(sql);
-      expect(sql.toString()).toBe(
-        'SELECT "MyTable"."id" FROM "MyTable" WHERE ("MyTable"."name" IS NOT NULL AND "MyTable"."name" && ARRAY[$1]::TEXT[])'
-      );
+      expect(sql.toString()).toBe('SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name" && ARRAY[$1]::TEXT[]');
     });
 
     test('Select where array contains array', () => {
       const sql = new SqlBuilder();
       new SelectQuery('MyTable').column('id').where('name', 'ARRAY_CONTAINS', ['x', 'y'], 'TEXT[]').buildSql(sql);
       expect(sql.toString()).toBe(
-        'SELECT "MyTable"."id" FROM "MyTable" WHERE ("MyTable"."name" IS NOT NULL AND "MyTable"."name" && ARRAY[$1,$2]::TEXT[])'
+        'SELECT "MyTable"."id" FROM "MyTable" WHERE "MyTable"."name" && ARRAY[$1,$2]::TEXT[]'
       );
     });
 

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -56,9 +56,6 @@ export const Operator = {
   '>=': simpleBinaryOperator('>='),
   IN: simpleBinaryOperator('IN'),
   ARRAY_CONTAINS: (sql: SqlBuilder, column: Column, parameter: any, paramType?: string) => {
-    sql.append('(');
-    sql.appendColumn(column);
-    sql.append(' IS NOT NULL AND ');
     sql.appendColumn(column);
     sql.append(' && ARRAY[');
     sql.appendParameters(parameter, false);
@@ -66,7 +63,6 @@ export const Operator = {
     if (paramType) {
       sql.append('::' + paramType);
     }
-    sql.append(')');
   },
   TSVECTOR_SIMPLE: (sql: SqlBuilder, column: Column, parameter: any, _paramType?: string) => {
     const query = formatTsquery(parameter);


### PR DESCRIPTION
On its own, it wasn't a big deal, but when it was being negated, it is problematic since a NULL value passes negation when it shouldn't.

In particular, `old_negated` being `true` is problematic.
```
postgres=# SELECT
    (NULL IS NOT NULL AND NULL && ARRAY['1']::text[]) as old_normal,
    NOT(NULL IS NOT NULL AND NULL && ARRAY['1']::text[]) as old_negated,
    (NULL && ARRAY['1']::text[]) as new_normal,
    NOT(NULL && ARRAY['1']::text[]) as new_negated;
 old_normal | old_negated | new_normal | new_negated
------------+-------------+------------+-------------
 f          | t           |            |
```

For non-null values, everything still works as expected:

```
postgres=# SELECT
    ('{1}' IS NOT NULL AND '{1}' && ARRAY['1']::text[]) as old_normal,
    NOT('{1}' IS NOT NULL AND '{1}' && ARRAY['1']::text[]) as old_negated,
    ('{1}' && ARRAY['1']::text[]) as new_normal,
    NOT('{1}' && ARRAY['1']::text[]) as new_negated;
 old_normal | old_negated | new_normal | new_negated
------------+-------------+------------+-------------
 t          | f           | t          | f
```

```
postgres=# SELECT
    ('{2}' IS NOT NULL AND '{2}' && ARRAY['1']::text[]) as old_normal,
    NOT('{2}' IS NOT NULL AND '{2}' && ARRAY['1']::text[]) as old_negated,
    ('{2}' && ARRAY['1']::text[]) as new_normal,
    NOT('{2}' && ARRAY['1']::text[]) as new_negated;
 old_normal | old_negated | new_normal | new_negated
------------+-------------+------------+-------------
 f          | t           | f          | t
```