### PR TITLE
ci(actions): move deprecated sonar action to `sonarqube-scan-action`

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -38,7 +38,7 @@ jobs:
       - name: 'Unzip code coverage'
         run: unzip medplum-code-coverage.zip -d coverage
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<img width="1334" alt="Screenshot 2025-02-28 at 11 19 07 AM" src="https://github.com/user-attachments/assets/c92a91b2-eedf-42d1-b63e-f0703c1db1d0" />

Old Sonar action is deprecated, moving to the new action to avoid any interruptions