### PR TITLE
ci(upgrade): add additional excludes to upgrade script and action

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -2,6 +2,11 @@ name: Upgrade dependencies
 
 on:
   workflow_dispatch:
+    inputs:
+      excludes:
+        description: 'Additional packages to exclude from upgrades (space separated)'
+        required: false
+        type: string
   schedule:
     # Every Monday at 9:00 AM UTC
     # Every Monday at 1:00 AM PST (2:00 AM PDT)
@@ -25,6 +30,13 @@ jobs:
           git config --global user.email "${{ secrets.MEDPLUM_BOT_EMAIL }}"
           git config --global user.name "${{ secrets.MEDPLUM_BOT_NAME }}"
       - name: Upgrade dependencies
-        run: ./scripts/upgrade.sh
+        run: |
+          if [ -n "${{ inputs.excludes }}" ]; then
+            echo "Running upgrade with excludes: ${{ inputs.excludes }}"
+            ./scripts/upgrade.sh --exclude="${{ inputs.excludes }}"
+          else
+            echo "Running upgrade with default excludes"
+            ./scripts/upgrade.sh
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.MEDPLUM_BOT_GITHUB_ACCESS_TOKEN }}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -18,7 +18,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Error: Unknown argument '$1'"
-            echo "Usage: $0 [--exclude="package1 package2 package3"]"
+            echo "Usage: $0 [--exclude=\"package1 package2 package3\"]"
             exit 1
             ;;
     esac

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -6,6 +6,24 @@ set -e
 # Echo commands
 set -x
 
+# Initialize additional exclusions variable
+ADDITIONAL_EXCLUDES=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --exclude=*)
+            ADDITIONAL_EXCLUDES="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'"
+            echo "Usage: $0 [--exclude="package1 package2 package3"]"
+            exit 1
+            ;;
+    esac
+done
+
 # Use the Github gh tool to make sure the user is logged in
 gh auth status
 
@@ -61,6 +79,12 @@ echo "Last completed step: $LAST_STEP"
 # react-native - 0.76.x is broken with an error caused by flow parser breaking when using `expo-crypto`: `SyntaxError: {..}/react-native/Libraries/vendor/emitter/EventEmitter.js: Unexpected token, expected "]" (39:5)`
 # storybook-addon-mantine - 4.1.0 seems to accidentally backported requirement for React 19 from v5: https://github.com/josiahayres/storybook-addon-mantine/issues/18
 EXCLUDE="react react-dom @tabler/icons-react react-native storybook-addon-mantine"
+
+# Append any additional excludes from the command line
+if [ -n "$ADDITIONAL_EXCLUDES" ]; then
+    echo "Adding additional excludes: $ADDITIONAL_EXCLUDES"
+    EXCLUDE="$EXCLUDE $ADDITIONAL_EXCLUDES"
+fi
 
 # @types/express - version 5+ incompatible with express 4, waiting for express 5 upgrade
 # @types/node - We specifically don't want to increment major version for Node types since we need to make sure we satisfy backwards compat with the minimum version of Node that we support


### PR DESCRIPTION
This allows us to one-off exclude packages from upgrades in the case we know that a package temporarily can't be upgraded, without having to attempt to upgrade and then surgically revert the upgrade, or temporarily hard code the exclude into the script.