### PR TITLE
Fix excluded dep upgrades: rimraf, supertest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         node-version: [20, 22]
     env:
-      NODE_OPTIONS: --max-old-space-size=8192
+      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
       NODE_VERSION: ${{ matrix.node-version }}
       SECRETS_TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
@@ -159,7 +159,7 @@ jobs:
         pg-version: [14, 16]
         redis-version: [6, 7]
     env:
-      NODE_OPTIONS: --max-old-space-size=8192
+      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
       NODE_VERSION: ${{ matrix.node-version }}
       PG_VERSION: ${{ matrix.pg-version }}
       REDIS_VERSION: ${{ matrix.redis-version }}
@@ -254,7 +254,7 @@ jobs:
         pg-version: [14, 16]
         redis-version: [6, 7]
     env:
-      NODE_OPTIONS: --max-old-space-size=8192
+      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
       NODE_VERSION: ${{ matrix.node-version }}
       PG_VERSION: ${{ matrix.pg-version }}
       REDIS_VERSION: ${{ matrix.redis-version }}
@@ -378,7 +378,7 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      NODE_OPTIONS: --max-old-space-size=8192
+      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
       NODE_VERSION: 20
       SECRETS_TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 

--- a/examples/medplum-chart-demo/package.json
+++ b/examples/medplum-chart-demo/package.json
@@ -48,6 +48,7 @@
     "react-chartjs-2": "5.3.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
+    "rimraf": "6.0.1",
     "ts-node": "10.9.2",
     "typescript": "5.7.3",
     "vite": "6.2.0",

--- a/examples/medplum-client-external-idp-demo/package.json
+++ b/examples/medplum-client-external-idp-demo/package.json
@@ -34,7 +34,6 @@
     "react-chartjs-2": "5.3.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
-    "rimraf": "5.0.10",
     "typescript": "5.7.3",
     "vite": "6.2.0"
   }

--- a/examples/medplum-demo-bots/package.json
+++ b/examples/medplum-demo-bots/package.json
@@ -46,7 +46,7 @@
     "form-data": "4.0.2",
     "node-fetch": "2.7.0",
     "pdfmake": "0.2.18",
-    "rimraf": "5.0.10",
+    "rimraf": "6.0.1",
     "ssh2-sftp-client": "11.0.0",
     "stripe": "17.7.0",
     "typescript": "5.7.3",

--- a/examples/medplum-eligibility-demo/package.json
+++ b/examples/medplum-eligibility-demo/package.json
@@ -43,6 +43,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
+    "rimraf": "6.0.1",
     "typescript": "5.7.3",
     "vite": "6.2.0"
   }

--- a/examples/medplum-fsh-profiles/package.json
+++ b/examples/medplum-fsh-profiles/package.json
@@ -10,6 +10,7 @@
     "build:profiles": "sushi build src/profiles -o dist -s"
   },
   "devDependencies": {
-    "fsh-sushi": "^3.14.0"
+    "fsh-sushi": "3.14.0",
+    "rimraf": "6.0.1"
   }
 }

--- a/examples/medplum-patient-intake-demo/package.json
+++ b/examples/medplum-patient-intake-demo/package.json
@@ -48,6 +48,7 @@
     "react-chartjs-2": "5.3.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
+    "rimraf": "6.0.1",
     "ts-node": "10.9.2",
     "typescript": "5.7.3",
     "vite": "6.2.0",

--- a/examples/medplum-photon-integration/package.json
+++ b/examples/medplum-photon-integration/package.json
@@ -44,6 +44,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
+    "rimraf": "6.0.1",
     "typescript": "5.7.3",
     "vite": "6.2.0",
     "vitest": "3.0.7"

--- a/examples/medplum-scheduling-demo/package.json
+++ b/examples/medplum-scheduling-demo/package.json
@@ -48,6 +48,7 @@
     "react": "18.2.0",
     "react-chartjs-2": "5.3.0",
     "react-dom": "18.2.0",
+    "rimraf": "6.0.1",
     "ts-node": "10.9.2",
     "vitest": "3.0.7",
     "dayjs": "1.11.13",

--- a/examples/medplum-smart-on-fhir-demo/package.json
+++ b/examples/medplum-smart-on-fhir-demo/package.json
@@ -45,7 +45,7 @@
     "react-chartjs-2": "5.3.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
-    "rimraf": "5.0.10",
+    "rimraf": "6.0.1",
     "typescript": "5.7.3",
     "vite": "6.2.0",
     "vitest": "3.0.7"

--- a/examples/medplum-task-demo/package.json
+++ b/examples/medplum-task-demo/package.json
@@ -45,7 +45,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
-    "rimraf": "5.0.10",
+    "rimraf": "6.0.1",
     "ts-node": "10.9.2",
     "typescript": "5.7.3",
     "vite": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "npm-check-updates": "17.1.15",
         "nyc": "17.1.0",
         "prettier": "3.5.3",
-        "rimraf": "5.0.10",
+        "rimraf": "6.0.1",
         "sort-package-json": "2.15.1",
         "source-map-explorer": "2.5.3",
         "ts-node": "10.9.2",
@@ -111,6 +111,7 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
+        "rimraf": "6.0.1",
         "ts-node": "10.9.2",
         "typescript": "5.7.3",
         "vite": "6.2.0",
@@ -164,7 +165,6 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
-        "rimraf": "5.0.10",
         "typescript": "5.7.3",
         "vite": "6.2.0"
       }
@@ -190,7 +190,7 @@
         "form-data": "4.0.2",
         "node-fetch": "2.7.0",
         "pdfmake": "0.2.18",
-        "rimraf": "5.0.10",
+        "rimraf": "6.0.1",
         "ssh2-sftp-client": "11.0.0",
         "stripe": "17.7.0",
         "typescript": "5.7.3",
@@ -238,6 +238,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
+        "rimraf": "6.0.1",
         "typescript": "5.7.3",
         "vite": "6.2.0"
       }
@@ -268,7 +269,8 @@
     "examples/medplum-fsh-profiles": {
       "version": "4.0.2",
       "devDependencies": {
-        "fsh-sushi": "^3.14.0"
+        "fsh-sushi": "3.14.0",
+        "rimraf": "6.0.1"
       }
     },
     "examples/medplum-health-gorilla-demo": {
@@ -422,6 +424,7 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
+        "rimraf": "6.0.1",
         "ts-node": "10.9.2",
         "typescript": "5.7.3",
         "vite": "6.2.0",
@@ -451,6 +454,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
+        "rimraf": "6.0.1",
         "typescript": "5.7.3",
         "vite": "6.2.0",
         "vitest": "3.0.7"
@@ -531,6 +535,7 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
+        "rimraf": "6.0.1",
         "ts-node": "10.9.2",
         "typescript": "5.7.3",
         "vite": "6.2.0",
@@ -561,7 +566,7 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
-        "rimraf": "5.0.10",
+        "rimraf": "6.0.1",
         "typescript": "5.7.3",
         "vite": "6.2.0",
         "vitest": "3.0.7"
@@ -589,7 +594,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
-        "rimraf": "5.0.10",
+        "rimraf": "6.0.1",
         "ts-node": "10.9.2",
         "typescript": "5.7.3",
         "vite": "6.2.0",
@@ -646,9 +651,9 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.1.tgz",
-      "integrity": "sha512-F2i3xdycesw78QCOBHmpTn7eaD2iNXGwB2gkfwxcOfBbeauYpr8RBSyJOkDrFtKtVRMclg8Sg3n1ip0ACyUuag==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.2.tgz",
+      "integrity": "sha512-N2NGsU5FLBhT8NZ+3l2YrzZSHITjNXNuDhC4iDiikv0IujaJ0Xc6xIxQZ/Ek3Cb+rgPjnLHYyJm11tInuJn+cw==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -18912,9 +18917,9 @@
       "license": "ISC"
     },
     "node_modules/@urql/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-yC3sw8yqjbX45GbXxfiBY8GLYCiyW/hLBbQF9l3TJrv4ro00Y0ChkKaD9I2KntRxAVm9IYBqh0awX8fwWAe/Yw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.1.1.tgz",
+      "integrity": "sha512-aGh024z5v2oINGD/In6rAtVKTm4VmQ2TxKQBAtk2ZSME5dunZFcjltw4p5ENQg+5CBhZ3FHMzl0Oa+rwqiWqlg==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
@@ -18922,12 +18927,12 @@
       }
     },
     "node_modules/@urql/exchange-retry": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.0.tgz",
-      "integrity": "sha512-FLt+d81gP4oiHah4hWFDApimc+/xABWMU1AMYsZ1PVB0L0YPtrMCjbOp9WMM7hBzy4gbTDrG24sio0dCfSh/HQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.1.tgz",
+      "integrity": "sha512-EEmtFu8JTuwsInqMakhLq+U3qN8ZMd5V3pX44q0EqD2imqTDsa8ikZqJ1schVrN8HljOdN+C08cwZ1/r5uIgLw==",
       "license": "MIT",
       "dependencies": {
-        "@urql/core": "^5.0.0",
+        "@urql/core": "^5.1.1",
         "wonka": "^6.3.2"
       },
       "peerDependencies": {
@@ -39017,6 +39022,21 @@
         "node": ">= 18"
       }
     },
+    "node_modules/minizlib/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -46302,15 +46322,113 @@
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^10.3.7"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -49094,10 +49212,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -49106,14 +49223,13 @@
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "formidable": "^3.5.1",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
+        "qs": "^6.11.0"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superagent/node_modules/mime": {
@@ -49129,19 +49245,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/superstruct": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
@@ -49153,17 +49256,17 @@
       }
     },
     "node_modules/supertest": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "methods": "^1.1.2",
-        "superagent": "^8.1.2"
+        "superagent": "^9.0.1"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superwstest": {
@@ -52747,9 +52850,9 @@
       }
     },
     "node_modules/wonka": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
-      "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
+      "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
       "license": "MIT"
     },
     "node_modules/word-wrap": {
@@ -53492,7 +53595,6 @@
         "jsdom": "26.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "rimraf": "5.0.10",
         "vitest": "3.0.7"
       },
       "engines": {
@@ -53579,7 +53681,6 @@
         "jest-expo": "52.0.5",
         "jest-websocket-mock": "2.5.0",
         "react-native": "0.75.4",
-        "rimraf": "5.0.10",
         "ts-jest": "29.2.6"
       },
       "peerDependencies": {
@@ -53727,7 +53828,6 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
-        "rimraf": "5.0.10",
         "vitest": "3.0.7"
       },
       "engines": {
@@ -53816,7 +53916,6 @@
         "react-dom": "18.2.0",
         "react-router": "7.2.0",
         "rfc6902": "5.1.2",
-        "rimraf": "5.0.10",
         "sinon": "19.0.2",
         "storybook": "8.6.3",
         "storybook-addon-mantine": "4.0.2",
@@ -53872,7 +53971,6 @@
         "jest-websocket-mock": "2.5.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "rimraf": "5.0.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -54039,7 +54137,7 @@
         "mailparser": "3.7.2",
         "openapi3-ts": "4.4.0",
         "set-cookie-parser": "2.7.1",
-        "supertest": "6.3.4",
+        "supertest": "7.0.0",
         "superwstest": "2.0.4",
         "ts-node-dev": "2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "npm-check-updates": "17.1.15",
     "nyc": "17.1.0",
     "prettier": "3.5.3",
-    "rimraf": "5.0.10",
+    "rimraf": "6.0.1",
     "sort-package-json": "2.15.1",
     "source-map-explorer": "2.5.3",
     "ts-node": "10.9.2",

--- a/packages/dosespot-react/package.json
+++ b/packages/dosespot-react/package.json
@@ -72,7 +72,6 @@
     "jsdom": "26.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rimraf": "5.0.10",
     "vitest": "3.0.7"
   },
   "peerDependencies": {

--- a/packages/expo-polyfills/package.json
+++ b/packages/expo-polyfills/package.json
@@ -62,7 +62,6 @@
     "jest-expo": "52.0.5",
     "jest-websocket-mock": "2.5.0",
     "react-native": "0.75.4",
-    "rimraf": "5.0.10",
     "ts-jest": "29.2.6"
   },
   "peerDependencies": {

--- a/packages/health-gorilla-react/package.json
+++ b/packages/health-gorilla-react/package.json
@@ -74,7 +74,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
-    "rimraf": "5.0.10",
     "vitest": "3.0.7"
   },
   "peerDependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -74,7 +74,6 @@
     "jest-websocket-mock": "2.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rimraf": "5.0.10",
     "typescript": "5.7.3"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -103,7 +103,6 @@
     "react-dom": "18.2.0",
     "react-router": "7.2.0",
     "rfc6902": "5.1.2",
-    "rimraf": "5.0.10",
     "sinon": "19.0.2",
     "storybook": "8.6.3",
     "storybook-addon-mantine": "4.0.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -123,7 +123,7 @@
     "mailparser": "3.7.2",
     "openapi3-ts": "4.4.0",
     "set-cookie-parser": "2.7.1",
-    "supertest": "6.3.4",
+    "supertest": "7.0.0",
     "superwstest": "2.0.4",
     "ts-node-dev": "2.0.0"
   },

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -9,7 +9,7 @@ set -e
 set -x
 
 # Set node options
-export NODE_OPTIONS='--max-old-space-size=8192'
+export NODE_OPTIONS='--max-old-space-size=8192 --dns-result-order=ipv4first'
 
 # Diagnostics
 node --version

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,7 @@ set -e
 set -x
 
 # Set node options
-export NODE_OPTIONS='--max-old-space-size=5120'
+export NODE_OPTIONS='--max-old-space-size=8192 --dns-result-order=ipv4first'
 
 # Clear old code coverage data
 rm -rf coverage

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -92,11 +92,8 @@ fi
 # commander - v13 has backwards-incompatible changes which require a decent amount of refactoring to get our current code to work. We are considering migrating off of commander but for now we should just freeze it
 # eslint - version 9+ conflicts with Next.js plugins, holding back until fixed
 # jose - version 6+ requires ESM (depending on the precise NodeJS version), holding back until server supports ESM
-# react-router-dom - version 7+ has breaking changes, will fix separately
 # node-fetch - version 3+ requires ESM, holding back until server supports ESM
-# rimraf - version 6+ requires Node 20+, holding back until Medplum v4
-# supertest - version 7+ incompatible with superwstest, waiting for fix
-MAJOR_EXCLUDE="@types/express @types/node @types/react @types/react-dom commander eslint jose react-router-dom node-fetch rimraf supertest"
+MAJOR_EXCLUDE="@types/express @types/node @types/react @types/react-dom commander eslint jose node-fetch"
 
 if [ "$LAST_STEP" -lt 1 ]; then
     # First, only upgrade patch and minor versions


### PR DESCRIPTION
`rimraf` - we were waiting for Node 20 🎉 

`supertest` - we were waiting for `superwstest` to be fixed, which it looks like it is 🎉 

--------

As an aside, I tried upgrading ESLint to 9.  Unfortunately, that is a much bigger endeavor.  The syntax has changed dramatically.  It would be one thing if we were just updating a local ESLint config within a project.  The fact that we're publishing `@medplum/eslint-config` as a dependency available to others makes this quite a bit more complicated though