### PR TITLE
DoseSpot bot sync buttons

### DIFF
--- a/examples/medplum-provider/src/pages/patient/DoseSpotAdvancedOptions.tsx
+++ b/examples/medplum-provider/src/pages/patient/DoseSpotAdvancedOptions.tsx
@@ -1,0 +1,149 @@
+import { Button, Text, Stack, Group, Box, TextInput, Modal } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { normalizeErrorString } from '@medplum/core';
+import { DOSESPOT_PRESCRIPTIONS_SYNC_BOT, DOSESPOT_MEDICATION_HISTORY_BOT, DOSESPOT_PATIENT_SYNC_BOT } from '@medplum/dosespot-react';
+import { useMedplum } from '@medplum/react-hooks';
+import { useCallback, useState } from 'react';
+import { IconSettings } from '@tabler/icons-react';
+
+
+export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): JSX.Element {
+  const medplum = useMedplum();
+  const [prescriptionStartDate, setPrescriptionStartDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [prescriptionEndDate, setPrescriptionEndDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [historyStartDate, setHistoryStartDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [historyEndDate, setHistoryEndDate] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const syncPrescriptions = useCallback(async () => {
+    if (!prescriptionStartDate || !prescriptionEndDate) {
+      showNotification({ color: 'red', title: 'Error', message: 'Please select both start and end dates' });
+      return;
+    }
+
+    try {
+      await medplum.executeBot(DOSESPOT_PRESCRIPTIONS_SYNC_BOT, {
+        patientId,
+        start: prescriptionStartDate,
+        end: prescriptionEndDate,
+      });
+      showNotification({ color: 'green', title: 'Success', message: 'Prescriptions synced successfully' });
+    } catch (err) {
+      showNotification({ color: 'red', title: 'Error', message: normalizeErrorString(err) });
+    }
+  }, [medplum, patientId, prescriptionStartDate, prescriptionEndDate]);
+
+  const syncHistory = useCallback(async () => {
+    try {
+      await medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, { 
+        patientId,
+        start: historyStartDate,
+        end: historyEndDate,
+      });
+      showNotification({ color: 'green', title: 'Success', message: 'History synced successfully' });
+    } catch (err) {
+      showNotification({ color: 'red', title: 'Error', message: normalizeErrorString(err) });
+    }
+  }, [medplum, patientId, historyStartDate, historyEndDate]);
+
+  const syncPatient = useCallback(async () => {
+    try {
+      await medplum.executeBot(DOSESPOT_PATIENT_SYNC_BOT, {
+        patientId
+      });
+      showNotification({ color: 'green', title: 'Success', message: 'Patient sync success' });
+    } catch (err) {
+      showNotification({ color: 'red', title: 'Error', message: normalizeErrorString(err) });
+    }
+  }, [medplum, patientId]);
+
+  return (
+    <>
+      <Group style={{ position: 'absolute', top: 8, right: 8, zIndex: 100 }}>
+        <Button 
+          variant="subtle" 
+          size="sm"
+          onClick={() => setShowAdvanced(true)}
+        >
+          <IconSettings size={16} style={{ marginRight: 8 }} />
+          Advanced Options
+        </Button>
+      </Group>
+
+      <Modal
+        opened={showAdvanced}
+        onClose={() => setShowAdvanced(false)}
+        size="lg"
+        title="Advanced DoseSpot Options"
+        styles={{
+          title: {
+            fontSize: '1.5rem',
+            fontWeight: 600
+          }
+        }}
+      >
+        <Box>
+          <Stack>
+            <Box>
+              <Text mb="sm">Prescriptions Sync</Text>
+              <Text c="dimmed" mb="md">
+                Fetches recently completed and active prescriptions from DoseSpot for the specified date range and patient. This will create or update MedicationRequest resources.
+              </Text>
+              <Group align="flex-end">
+                <TextInput
+                  label="Start Date"
+                  type="date"
+                  value={prescriptionStartDate}
+                  onChange={(e) => setPrescriptionStartDate(e.target.value)}
+                />
+                <TextInput
+                  label="End Date"
+                  type="date"
+                  value={prescriptionEndDate}
+                  onChange={(e) => setPrescriptionEndDate(e.target.value)}
+                />
+                <Button onClick={syncPrescriptions}>
+                  Sync Prescriptions
+                </Button>
+              </Group>
+            </Box>
+
+            <Box mt="md">
+              <Text mb="sm">Medication History Sync</Text>
+              <Text c="dimmed" mb="md">
+                Retrieves medication history from DoseSpot for this patient and adds MedicationRequest resources to Medplum.
+              </Text>
+              <Group align="flex-end">
+                <TextInput
+                  label="Start Date"
+                  type="date"
+                  value={historyStartDate}
+                  onChange={(e) => setHistoryStartDate(e.target.value)}
+                />
+                <TextInput
+                  label="End Date"
+                  type="date"
+                  value={historyEndDate}
+                  onChange={(e) => setHistoryEndDate(e.target.value)}
+                />
+                <Button onClick={syncHistory}>
+                  Sync History
+                </Button>
+              </Group>
+            </Box>
+
+            <Box mt="md">
+              <Text mb="sm">Patient Information Sync</Text>
+              <Text c="dimmed" mb="md">
+                Syncs patient between Medplum and DoseSpot. It creates an identifier for the patient in Medplum to link it to the patient's record in DoseSpot. It also adds MedicationRequest and AllergyIntolerance resources from Medplum to that patient's record in DoseSpot.
+              </Text>
+              <Button onClick={syncPatient}>
+                Sync Patient
+              </Button>
+            </Box>
+          </Stack>
+        </Box>
+      </Modal>
+    </>
+  );
+}

--- a/examples/medplum-provider/src/pages/patient/DoseSpotAdvancedOptions.tsx
+++ b/examples/medplum-provider/src/pages/patient/DoseSpotAdvancedOptions.tsx
@@ -1,11 +1,14 @@
 import { Button, Text, Stack, Group, Box, TextInput, Modal } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
-import { DOSESPOT_PRESCRIPTIONS_SYNC_BOT, DOSESPOT_MEDICATION_HISTORY_BOT, DOSESPOT_PATIENT_SYNC_BOT } from '@medplum/dosespot-react';
+import {
+  DOSESPOT_PRESCRIPTIONS_SYNC_BOT,
+  DOSESPOT_MEDICATION_HISTORY_BOT,
+  DOSESPOT_PATIENT_SYNC_BOT,
+} from '@medplum/dosespot-react';
 import { useMedplum } from '@medplum/react-hooks';
 import { useCallback, useState } from 'react';
 import { IconSettings } from '@tabler/icons-react';
-
 
 export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): JSX.Element {
   const medplum = useMedplum();
@@ -35,7 +38,7 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
 
   const syncHistory = useCallback(async () => {
     try {
-      await medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, { 
+      await medplum.executeBot(DOSESPOT_MEDICATION_HISTORY_BOT, {
         patientId,
         start: historyStartDate,
         end: historyEndDate,
@@ -49,7 +52,7 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
   const syncPatient = useCallback(async () => {
     try {
       await medplum.executeBot(DOSESPOT_PATIENT_SYNC_BOT, {
-        patientId
+        patientId,
       });
       showNotification({ color: 'green', title: 'Success', message: 'Patient sync success' });
     } catch (err) {
@@ -60,11 +63,7 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
   return (
     <>
       <Group style={{ position: 'absolute', top: 8, right: 8, zIndex: 100 }}>
-        <Button 
-          variant="subtle" 
-          size="sm"
-          onClick={() => setShowAdvanced(true)}
-        >
+        <Button variant="subtle" size="sm" onClick={() => setShowAdvanced(true)}>
           <IconSettings size={16} style={{ marginRight: 8 }} />
           Advanced Options
         </Button>
@@ -78,8 +77,8 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
         styles={{
           title: {
             fontSize: '1.5rem',
-            fontWeight: 600
-          }
+            fontWeight: 600,
+          },
         }}
       >
         <Box>
@@ -87,7 +86,8 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
             <Box>
               <Text mb="sm">Prescriptions Sync</Text>
               <Text c="dimmed" mb="md">
-                Fetches recently completed and active prescriptions from DoseSpot for the specified date range and patient. This will create or update MedicationRequest resources.
+                Fetches recently completed and active prescriptions from DoseSpot for the specified date range and
+                patient. This will create or update MedicationRequest resources.
               </Text>
               <Group align="flex-end">
                 <TextInput
@@ -102,16 +102,15 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
                   value={prescriptionEndDate}
                   onChange={(e) => setPrescriptionEndDate(e.target.value)}
                 />
-                <Button onClick={syncPrescriptions}>
-                  Sync Prescriptions
-                </Button>
+                <Button onClick={syncPrescriptions}>Sync Prescriptions</Button>
               </Group>
             </Box>
 
             <Box mt="md">
               <Text mb="sm">Medication History Sync</Text>
               <Text c="dimmed" mb="md">
-                Retrieves medication history from DoseSpot for this patient and adds MedicationRequest resources to Medplum.
+                Retrieves medication history from DoseSpot for this patient and adds MedicationRequest resources to
+                Medplum.
               </Text>
               <Group align="flex-end">
                 <TextInput
@@ -126,20 +125,18 @@ export function DoseSpotAdvancedOptions({ patientId }: { patientId: string }): J
                   value={historyEndDate}
                   onChange={(e) => setHistoryEndDate(e.target.value)}
                 />
-                <Button onClick={syncHistory}>
-                  Sync History
-                </Button>
+                <Button onClick={syncHistory}>Sync History</Button>
               </Group>
             </Box>
 
             <Box mt="md">
               <Text mb="sm">Patient Information Sync</Text>
               <Text c="dimmed" mb="md">
-                Syncs patient between Medplum and DoseSpot. It creates an identifier for the patient in Medplum to link it to the patient's record in DoseSpot. It also adds MedicationRequest and AllergyIntolerance resources from Medplum to that patient's record in DoseSpot.
+                Syncs patient between Medplum and DoseSpot. It creates an identifier for the patient in Medplum to link
+                it to the patient's record in DoseSpot. It also adds MedicationRequest and AllergyIntolerance resources
+                from Medplum to that patient's record in DoseSpot.
               </Text>
-              <Button onClick={syncPatient}>
-                Sync Patient
-              </Button>
+              <Button onClick={syncPatient}>Sync Patient</Button>
             </Box>
           </Stack>
         </Box>

--- a/examples/medplum-provider/src/pages/patient/DoseSpotTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/DoseSpotTab.tsx
@@ -17,8 +17,8 @@ export function DoseSpotTab(): JSX.Element {
   return (
     <Box pos="relative">
       {patientId && <DoseSpotAdvancedOptions patientId={patientId} />}
-      
-      <div >
+
+      <div>
         {iframeUrl && (
           <iframe
             id="dosespot-iframe"

--- a/examples/medplum-provider/src/pages/patient/DoseSpotTab.tsx
+++ b/examples/medplum-provider/src/pages/patient/DoseSpotTab.tsx
@@ -2,6 +2,8 @@ import { showNotification } from '@mantine/notifications';
 import { normalizeErrorString } from '@medplum/core';
 import { useDoseSpotIFrame } from '@medplum/dosespot-react';
 import { useParams } from 'react-router';
+import { Box } from '@mantine/core';
+import { DoseSpotAdvancedOptions } from './DoseSpotAdvancedOptions';
 
 export function DoseSpotTab(): JSX.Element {
   const { patientId } = useParams();
@@ -13,16 +15,20 @@ export function DoseSpotTab(): JSX.Element {
   });
 
   return (
-    <div style={{ width: '100%', height: '100%', minHeight: 'calc(100vh - 200px)' }}>
-      {iframeUrl && (
-        <iframe
-          id="dosespot-iframe"
-          name="dosespot-iframe"
-          frameBorder={0}
-          src={iframeUrl}
-          style={{ width: '100%', height: '100%', minHeight: 'calc(100vh - 200px)', border: 'none' }}
-        ></iframe>
-      )}
-    </div>
+    <Box pos="relative">
+      {patientId && <DoseSpotAdvancedOptions patientId={patientId} />}
+      
+      <div >
+        {iframeUrl && (
+          <iframe
+            id="dosespot-iframe"
+            name="dosespot-iframe"
+            frameBorder={0}
+            src={iframeUrl}
+            style={{ width: '100%', height: '100%', minHeight: 'calc(100vh)', border: 'none' }}
+          ></iframe>
+        )}
+      </div>
+    </Box>
   );
 }

--- a/packages/dosespot-react/src/common.ts
+++ b/packages/dosespot-react/src/common.ts
@@ -8,9 +8,15 @@ export const DOSESPOT_PATIENT_SYNC_BOT: Identifier = { system: MEDPLUM_BOT_SYSTE
 
 export const DOSESPOT_IFRAME_BOT: Identifier = { system: MEDPLUM_BOT_SYSTEM, value: 'dosespot-iframe-bot' };
 
-export const DOSESPOT_MEDICATION_HISTORY_BOT: Identifier = { system: MEDPLUM_BOT_SYSTEM, value: 'dosespot-medication-history-bot' };
+export const DOSESPOT_MEDICATION_HISTORY_BOT: Identifier = {
+  system: MEDPLUM_BOT_SYSTEM,
+  value: 'dosespot-medication-history-bot',
+};
 
-export const DOSESPOT_PRESCRIPTIONS_SYNC_BOT: Identifier = { system: MEDPLUM_BOT_SYSTEM, value: 'dosespot-prescriptions-sync-bot' };
+export const DOSESPOT_PRESCRIPTIONS_SYNC_BOT: Identifier = {
+  system: MEDPLUM_BOT_SYSTEM,
+  value: 'dosespot-prescriptions-sync-bot',
+};
 
 export const DOSESPOT_NOTIFICATION_COUNTS_BOT: Identifier = {
   system: MEDPLUM_BOT_SYSTEM,

--- a/packages/dosespot-react/src/common.ts
+++ b/packages/dosespot-react/src/common.ts
@@ -8,6 +8,10 @@ export const DOSESPOT_PATIENT_SYNC_BOT: Identifier = { system: MEDPLUM_BOT_SYSTE
 
 export const DOSESPOT_IFRAME_BOT: Identifier = { system: MEDPLUM_BOT_SYSTEM, value: 'dosespot-iframe-bot' };
 
+export const DOSESPOT_MEDICATION_HISTORY_BOT: Identifier = { system: MEDPLUM_BOT_SYSTEM, value: 'dosespot-medication-history-bot' };
+
+export const DOSESPOT_PRESCRIPTIONS_SYNC_BOT: Identifier = { system: MEDPLUM_BOT_SYSTEM, value: 'dosespot-prescriptions-sync-bot' };
+
 export const DOSESPOT_NOTIFICATION_COUNTS_BOT: Identifier = {
   system: MEDPLUM_BOT_SYSTEM,
   value: 'dosespot-notification-counts-bot',

--- a/packages/dosespot-react/src/index.ts
+++ b/packages/dosespot-react/src/index.ts
@@ -1,2 +1,3 @@
 export * from './useDoseSpotIFrame';
 export * from './useDoseSpotNotifications';
+export * from './common';


### PR DESCRIPTION
Advanced DoseSpot setting button opens a Modal with descriptions and buttons to trigger each DoseSpot bot.

The purpose of this is to help people understand how the syncing operations work. More specifically, showing which resources will be updated in Medplum to reflect changes made in DoseSpot.


<img width="1435" alt="Screenshot 2025-03-04 at 11 50 06 AM" src="https://github.com/user-attachments/assets/8113d3de-92f8-4df7-b1bb-9bde63c6aeb5" />
<img width="861" alt="Screenshot 2025-03-04 at 11 49 59 AM" src="https://github.com/user-attachments/assets/6fcad361-70d4-4b90-9c11-5cacfa81cd7c" />
