### PR TITLE
Add `setDefaultResultOrder('ipv4first')` in test setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         node-version: [20, 22]
     env:
-      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
+      NODE_OPTIONS: --max-old-space-size=8192
       NODE_VERSION: ${{ matrix.node-version }}
       SECRETS_TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
@@ -159,7 +159,7 @@ jobs:
         pg-version: [14, 16]
         redis-version: [6, 7]
     env:
-      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
+      NODE_OPTIONS: --max-old-space-size=8192
       NODE_VERSION: ${{ matrix.node-version }}
       PG_VERSION: ${{ matrix.pg-version }}
       REDIS_VERSION: ${{ matrix.redis-version }}
@@ -254,7 +254,7 @@ jobs:
         pg-version: [14, 16]
         redis-version: [6, 7]
     env:
-      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
+      NODE_OPTIONS: --max-old-space-size=8192
       NODE_VERSION: ${{ matrix.node-version }}
       PG_VERSION: ${{ matrix.pg-version }}
       REDIS_VERSION: ${{ matrix.redis-version }}
@@ -378,7 +378,7 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      NODE_OPTIONS: --max-old-space-size=8192 --dns-result-order=ipv4first
+      NODE_OPTIONS: --max-old-space-size=8192
       NODE_VERSION: 20
       SECRETS_TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -11,6 +11,7 @@ import {
   Resource,
 } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
+import { setDefaultResultOrder } from 'dns';
 import { Express } from 'express';
 import internal from 'stream';
 import request from 'supertest';
@@ -20,6 +21,9 @@ import { Repository, RepositoryContext, getSystemRepo } from './fhir/repo';
 import { generateAccessToken } from './oauth/keys';
 import { tryLogin } from './oauth/utils';
 import { requestContextStore } from './request-context-store';
+
+// supertest v7 can cause websocket tests to hang without this
+setDefaultResultOrder('ipv4first');
 
 export interface TestProjectOptions {
   project?: Partial<Project>;

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -9,7 +9,7 @@ set -e
 set -x
 
 # Set node options
-export NODE_OPTIONS='--max-old-space-size=8192 --dns-result-order=ipv4first'
+export NODE_OPTIONS='--max-old-space-size=8192'
 
 # Diagnostics
 node --version

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,7 @@ set -e
 set -x
 
 # Set node options
-export NODE_OPTIONS='--max-old-space-size=8192 --dns-result-order=ipv4first'
+export NODE_OPTIONS='--max-old-space-size=8192'
 
 # Clear old code coverage data
 rm -rf coverage


### PR DESCRIPTION
After https://github.com/medplum/medplum/pull/6105, websocket tests in `packages/server` were hanging for me locally (MacOS Sequoia) unless I also add `--dns-result-order=ipv4first` to `NODE_OPTIONS`. Trying this as an alternative.