### PR TITLE
Clarify behavior of `maxResourceVersion` of zero

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -333,7 +333,7 @@ interface GetBaseSelectQueryOptions {
   addColumns?: boolean;
   /** Callback invoked for each resource type and  its `SelectQuery` after all filters are applied. */
   resourceTypeQueryCallback?: (resourceType: SearchRequest['resourceType'], builder: SelectQuery) => void;
-  /** The maximum resource version to include in the search. */
+  /** The maximum resource version to include in the search. If zero is specified, only resources with a NULL version are included. */
   maxResourceVersion?: number;
 }
 function getBaseSelectQuery(


### PR DESCRIPTION
No behavioral changes, just making the current behavior explicit by adding a test. Primarily applicable only to data migration `v1` since it pre-dated the `__version` column.