### PR TITLE
Fixed various g9 C-CDA issues

### DIFF
--- a/packages/ccda/src/g9.test.ts
+++ b/packages/ccda/src/g9.test.ts
@@ -100,6 +100,14 @@ describe('170.315(g)(9)', () => {
                   display: 'White',
                 },
               },
+              {
+                url: 'detailed',
+                valueCoding: {
+                  system: RACE_CODE_SYSTEM,
+                  code: '2108-9',
+                  display: 'White European',
+                },
+              },
             ],
           },
           {
@@ -130,6 +138,13 @@ describe('170.315(g)(9)', () => {
       expect(output.recordTarget?.[0]?.patientRole?.patient?.raceCode?.[0]?.['@_codeSystemName']).toEqual(
         'CDC Race and Ethnicity'
       );
+
+      // Test detailed race code
+      const detailed = output.recordTarget?.[0]?.patientRole?.patient?.['sdtc:raceCode']?.[0];
+      expect(detailed?.['@_code']).toEqual('2108-9');
+      expect(detailed?.['@_displayName']).toEqual('White European');
+      expect(detailed?.['@_codeSystem']).toEqual(OID_CDC_RACE_AND_ETHNICITY_CODE_SYSTEM);
+      expect(detailed?.['@_codeSystemName']).toEqual('CDC Race and Ethnicity');
 
       // Test ethnicity code
       expect(output.recordTarget?.[0]?.patientRole?.patient?.ethnicGroupCode?.[0]?.['@_code']).toEqual('2186-5');
@@ -190,9 +205,9 @@ describe('170.315(g)(9)', () => {
       };
       const input = createCompositionBundle(patient);
       const output = convertFhirToCcda(input);
-      expect(output.recordTarget?.[0]?.patientRole?.patient?.languageCommunication?.[0]?.['@_languageCode']).toEqual(
-        'en-US'
-      );
+      expect(
+        output.recordTarget?.[0]?.patientRole?.patient?.languageCommunication?.[0]?.languageCode?.['@_code']
+      ).toEqual('en-US');
     });
 
     // Current Address

--- a/packages/ccda/src/templates.ts
+++ b/packages/ccda/src/templates.ts
@@ -77,6 +77,7 @@ export const CCDA_TEMPLATE_IDS = [
 // Allergies and Intolerances 2.16.840.1.113883.10.20.22.2.6.1 Allergies Section (entries required)
 export const ALLERGIES_SECTION_TEMPLATE_IDS: CcdaTemplateId[] = [
   { '@_root': OID_ALLERGIES_SECTION_ENTRIES_REQUIRED, '@_extension': '2015-08-01' },
+  { '@_root': OID_ALLERGIES_SECTION_ENTRIES_REQUIRED },
 ];
 
 // Medications 2.16.840.1.113883.10.20.22.2.1.1 Medications Section (entries required)
@@ -87,6 +88,7 @@ export const MEDICATIONS_SECTION_TEMPLATE_IDS: CcdaTemplateId[] = [
 // Problems 2.16.840.1.113883.10.20.22.2.5.1 Problem Section (entries required)
 export const PROBLEMS_SECTION_TEMPLATE_IDS: CcdaTemplateId[] = [
   { '@_root': OID_PROBLEMS_SECTION_ENTRIES_REQUIRED, '@_extension': '2015-08-01' },
+  { '@_root': OID_PROBLEMS_SECTION_ENTRIES_REQUIRED },
 ];
 
 // Immunizations 2.16.840.1.113883.10.20.22.2.2.1 Immunizations Section (entries required)

--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -45,6 +45,7 @@ export interface CcdaPatient {
   administrativeGenderCode?: CcdaCode;
   birthTime?: CcdaTimeStamp;
   raceCode?: CcdaCode[];
+  'sdtc:raceCode'?: CcdaCode[];
   ethnicGroupCode?: CcdaCode[];
   languageCommunication?: CcdaLanguageCommunication[];
 }
@@ -349,7 +350,7 @@ export interface CcdaManufacturedLabeledDrug {
 }
 
 export interface CcdaLanguageCommunication {
-  '@_languageCode'?: string;
+  languageCode?: CcdaCode;
 }
 
 export interface CcdaPerformer {

--- a/packages/ccda/src/xml.ts
+++ b/packages/ccda/src/xml.ts
@@ -22,6 +22,7 @@ const ARRAY_PATHS = [
 
   // Patient
   'patient.raceCode',
+  'patient.sdtc:raceCode',
   'patient.ethnicGroupCode',
   'patient.languageCommunication',
 

--- a/packages/ccda/testdata/AllergyToEgg.xml
+++ b/packages/ccda/testdata/AllergyToEgg.xml
@@ -36,6 +36,7 @@
             <component>
                 <section>
                     <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" />
                     <code code="48765-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
                     <title>Allergies, Adverse Reactions and Alerts</title>
                     <text>

--- a/packages/ccda/testdata/MinimalPassingValidator.xml
+++ b/packages/ccda/testdata/MinimalPassingValidator.xml
@@ -91,6 +91,7 @@
             <component>
                 <section nullFlavor="NI">
                     <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" />
                     <code code="48765-2" displayName="Allergies and Adverse Reactions"
                         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
                     <title>Allergies, Adverse Reactions and Alerts</title>
@@ -109,6 +110,7 @@
             <component>
                 <section nullFlavor="NI">
                     <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
                     <code code="11450-4" displayName="Problem List"
                         codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
                     <title>Problem List</title>

--- a/packages/ccda/testdata/ProblemPneumonia.xml
+++ b/packages/ccda/testdata/ProblemPneumonia.xml
@@ -36,6 +36,7 @@
             <component>
                 <section>
                     <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
                     <code code="11450-4" displayName="Problem List" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"></code>
                     <title>Problem List</title>
                     <text>


### PR DESCRIPTION
* Added `<sdtc:race>` element for "detailed" race information
* Fixed `languageCode` which we previous implemented as an attribute, but is supposed to be a child element
* Added missing required `<templateId>` elements without `extension` attributes

2 other fixes in the [Medplum Alice Newman Guide](https://docs.google.com/document/d/10ZUP2eUjSovdgdkfDh0EpdFcBUlyNbkRWabfH1zc6z8/edit?tab=t.0#heading=h.rmqji2otlb0h)
* Added `Patient.communication` for language preferences
* Changed `Observation.valueQuantity.unit` from `{ratio}` to `1` for "Specific gravity of Urine by Test strip"

cc @ianplunkett 