### PR TITLE
Add guard to canonical chained search types

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -4636,6 +4636,17 @@ describe('FHIR Search', () => {
           expect(result.entry?.find((e) => e.resource?.valueQuantity?.value === 85)).toBeDefined();
         }));
     });
+
+    test('Invalid canonical chained search link', async () =>
+      withTestContext(async () => {
+        await expect(
+          repo.search(parseSearchRequest('EvidenceVariable?derived-from:ResearchStudy.status=active'))
+        ).rejects.toThrow('ResearchStudy cannot be chained via canonical reference (EvidenceVariable:derived-from)');
+
+        await expect(
+          repo.search(parseSearchRequest('ResearchStudy?_has:EvidenceVariable:derived-from:_id=foo'))
+        ).rejects.toThrow('ResearchStudy cannot be chained via canonical reference (EvidenceVariable:derived-from)');
+      }));
   });
 
   describe('systemRepo', () => {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -1549,12 +1549,23 @@ function linkLiteralReference(selectQuery: SelectQuery, lookupTable: string, lin
 }
 
 function getCanonicalJoinCondition(currentTable: string, link: ChainedSearchLink, nextTable: string): Expression {
-  const eq = link.implementation.array ? 'IN_SUBQUERY' : '=';
+  let sourceTable: string, targetTable: string;
   if (link.direction === Direction.FORWARD) {
-    return new Condition(new Column(nextTable, 'url'), eq, new Column(currentTable, link.implementation.columnName));
+    sourceTable = currentTable;
+    targetTable = nextTable;
   } else {
-    return new Condition(new Column(currentTable, 'url'), eq, new Column(nextTable, link.implementation.columnName));
+    sourceTable = nextTable;
+    targetTable = currentTable;
   }
+
+  if (!getSearchParameter(targetTable, 'url')) {
+    throw new OperationOutcomeError(
+      badRequest(`${targetTable} cannot be chained via canonical reference (${sourceTable}:${link.code})`)
+    );
+  }
+
+  const eq = link.implementation.array ? 'IN_SUBQUERY' : '=';
+  return new Condition(new Column(targetTable, 'url'), eq, new Column(sourceTable, link.implementation.columnName));
 }
 
 function nextChainedTable(link: ChainedSearchLink): string {


### PR DESCRIPTION
The `RelatedArtifact` data type contains an element with type `canonical(Any)`, which is referenced in some search parameters (e.g. `EvidenceVariable:derived-from`).  This can cause issues with chained search, since the canonical reference expects the target type to have `url` search parameter, which many resource types do not have.  Adding an explicit guard will make this more obvious to end users