### PR TITLE
Prevent writing directly to Meta.compartment

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1155,29 +1155,6 @@ describe('FHIR Repo', () => {
       });
     }));
 
-  test('Allows adding compartments for specific types', async () =>
-    withTestContext(async () => {
-      const { repo, project } = await createTestProject({ withRepo: true });
-      const org = await repo.createResource<Organization>({ resourceType: 'Organization' });
-      const practitioner = await repo.createResource<Practitioner>({ resourceType: 'Practitioner' });
-
-      const orgReference = createReference(org);
-      const practitionerReference = createReference(practitioner);
-      const patient = await repo.createResource<Patient>({
-        resourceType: 'Patient',
-        meta: { compartment: [orgReference, practitionerReference] },
-      });
-      expect(patient.meta?.compartment).toContainEqual(orgReference);
-      expect(patient.meta?.compartment).not.toContainEqual(practitionerReference);
-      expect(patient.meta?.compartment).toContainEqual({ reference: getReferenceString(project) });
-      expect(patient.meta?.compartment).toContainEqual({ reference: getReferenceString(patient) });
-
-      const results = await repo.searchResources(
-        parseSearchRequest('Patient?_compartment=' + getReferenceString(orgReference))
-      );
-      expect(results).toHaveLength(1);
-    }));
-
   test('Prevents setting Project compartments', async () =>
     withTestContext(async () => {
       const { repo, project } = await createTestProject({ withRepo: true });

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -19,7 +19,6 @@ import {
   Login,
   Observation,
   OperationOutcome,
-  Organization,
   Patient,
   Practitioner,
   Project,

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1450,20 +1450,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       }
     }
 
-    // Carry forward anything added to the resource compartments array
-    if (resource.meta?.compartment?.length) {
-      for (const compartment of resource.meta.compartment) {
-        const id = resolveId(compartment);
-        if (
-          id &&
-          validator.isUUID(id) &&
-          (compartment.reference?.startsWith('Organization/') || compartment.reference?.startsWith('Location/'))
-        ) {
-          compartments.add(compartment.reference as string);
-        }
-      }
-    }
-
     const results: Reference[] = [];
     for (const reference of compartments.values()) {
       results.push({ reference });


### PR DESCRIPTION
This functionality was originally [added](#5171), [restricted](#5247), and [supplanted](#5264) late last year.  This edge case is no longer required, and should be removed