### PR TITLE
fix(cdk): add `*.medplum.com` to `connect-src`

### DIFF
--- a/packages/cdk/src/frontend.ts
+++ b/packages/cdk/src/frontend.ts
@@ -72,7 +72,7 @@ export class FrontEnd extends Construct {
               `default-src 'none'`,
               `base-uri 'self'`,
               `child-src 'self'`,
-              `connect-src 'self' ${config.apiDomainName} *.google.com`,
+              `connect-src 'self' ${config.apiDomainName} *.medplum.com *.google.com`,
               `font-src 'self' fonts.gstatic.com`,
               `form-action 'self' *.gstatic.com *.google.com`,
               `frame-ancestors 'none'`,


### PR DESCRIPTION
This fixes a CORS issue in appdot when querying `meta.medplum.com` for a list of Medplum versions when appdot is hosted on another domain