### PR TITLE
Exclude 'examples' from default 'npm run build'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "examples/*"
   ],
   "scripts": {
-    "build": "turbo run build --filter=!@medplum/docs",
+    "build": "turbo run build --filter=!@medplum/docs --filter=!./examples/*",
     "build:all": "turbo run build",
     "build:docs": "turbo run build --filter=@medplum/docs",
     "build:fast": "turbo run build --filter=@medplum/app --filter=@medplum/server",


### PR DESCRIPTION
Context:
* We use [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces)
* We use [Turborepo](https://turbo.build/)
* In the root `package.json`, we have 3 "build" commands:
   * `npm run build` - the default (see below)
   * `npm run build:all` - builds all packages - used in CI/CD, also useful for testing changes against all packages
   * `npm run build:fast` - builds `app`, `server`, and necessary dependences - useful for getting started fast

Before:
* `npm run build` translated to `turbo run build --filter=!@medplum/docs`
* That builds everything except the `docs` Docusaurus project (which is the slowest)
* It does build all of the `examples` packages

After:
* `npm run build` translates to `turbo run build --filter=!@medplum/docs --filter=!./examples/*`
* That builds everything except `docs` and all `examples` packages

Why?
* By default, people naturally run `npm run build` by default, and this gives a balanced experience
* All "dependencies" (`core`, `react`, etc) will be built, so you can go into any example package and run `npm run dev` and things should work
* But none of the extra work will be done
* In particular, it skips the Next.js examples, which for some reason are slow and have enormous output

On my MacBook Air M2, running `time npm run build -- --force`

|   | Before | After |
| --- | --- | --- |
| Turborepo time | 1 min 50 sec | 45 sec |

