### PR TITLE
$set-accounts not propogating correctly

### DIFF
--- a/packages/server/src/fhir/operations/patientsetaccounts.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.ts
@@ -86,7 +86,7 @@ export async function patientSetAccountsHandler(req: FhirRequest): Promise<FhirR
     if (entry.search?.mode === 'match') {
       const resource = entry.resource;
       if (resource && resource.resourceType !== 'Patient') {
-        delete resource.meta
+        delete resource.meta;
 
         await ctx.repo.updateResource(resource);
         count++;

--- a/packages/server/src/fhir/operations/patientsetaccounts.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.ts
@@ -86,8 +86,7 @@ export async function patientSetAccountsHandler(req: FhirRequest): Promise<FhirR
     if (entry.search?.mode === 'match') {
       const resource = entry.resource;
       if (resource && resource.resourceType !== 'Patient') {
-        delete resource.meta?.accounts;
-        delete resource.meta?.account;
+        delete resource.meta
 
         await ctx.repo.updateResource(resource);
         count++;


### PR DESCRIPTION
After [this change](https://github.com/medplum/medplum/pull/6149) was made, $set-accounts operation now needs to delete all of _meta_ in order for the _meta.accounts_ to be refreshed from any potential changes made to the Patient.