### PR TITLE
Align crawler function signatures

### DIFF
--- a/packages/core/src/typeschema/crawler.test.ts
+++ b/packages/core/src/typeschema/crawler.test.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@medplum/definitions';
 import { Attachment, Bundle, Coding, Observation, Patient } from '@medplum/fhirtypes';
+import { LOINC } from '../constants';
+import { toTypedValue } from '../fhirpath/utils';
 import { TypedValue } from '../types';
 import { arrayify, sleep } from '../utils';
 import { crawlTypedValue, crawlTypedValueAsync } from './crawler';
 import { indexStructureDefinitionBundle } from './types';
-import { LOINC } from '../constants';
-import { toTypedValue } from '../fhirpath/utils';
 
 describe('ResourceCrawler', () => {
   beforeAll(() => {
@@ -50,13 +50,11 @@ describe('ResourceCrawler', () => {
 
     const attachments: Attachment[] = [];
     crawlTypedValue(toTypedValue(patient), {
-      visitProperty: (_parent, _key, _path, propertyValues) => {
-        for (const propertyValue of propertyValues) {
-          if (propertyValue) {
-            for (const value of arrayify(propertyValue) as TypedValue[]) {
-              if (value.type === 'Attachment') {
-                attachments.push(value.value as Attachment);
-              }
+      visitProperty: (_parent, _key, _path, propertyValue) => {
+        if (propertyValue) {
+          for (const value of arrayify(propertyValue) as TypedValue[]) {
+            if (value.type === 'Attachment') {
+              attachments.push(value.value as Attachment);
             }
           }
         }
@@ -124,13 +122,11 @@ describe('ResourceCrawler', () => {
     crawlTypedValue(
       toTypedValue(obs),
       {
-        visitProperty: (_parent, _key, _path, propertyValues) => {
-          for (const propertyValue of propertyValues) {
-            if (propertyValue) {
-              for (const value of arrayify(propertyValue) as TypedValue[]) {
-                if (value.type === 'Coding') {
-                  resultCodes.push(value.value);
-                }
+        visitProperty: (_parent, _key, _path, propertyValue) => {
+          if (propertyValue) {
+            for (const value of arrayify(propertyValue) as TypedValue[]) {
+              if (value.type === 'Coding') {
+                resultCodes.push(value.value);
               }
             }
           }

--- a/packages/core/src/typeschema/crawler.ts
+++ b/packages/core/src/typeschema/crawler.ts
@@ -13,7 +13,7 @@ export interface CrawlerVisitor {
     parent: TypedValueWithPath,
     key: string,
     path: string,
-    propertyValues: (TypedValueWithPath | TypedValueWithPath[])[],
+    propertyValues: TypedValueWithPath | TypedValueWithPath[],
     schema: InternalTypeSchema
   ) => void;
 }
@@ -116,7 +116,9 @@ class Crawler {
   private crawlProperty(parent: TypedValueWithPath, key: string, schema: InternalTypeSchema, path: string): void {
     const propertyValues = getNestedProperty(parent, key, { withPath: true });
     if (this.visitor.visitProperty) {
-      this.visitor.visitProperty(parent, key, path, propertyValues, schema);
+      for (const value of propertyValues) {
+        this.visitor.visitProperty(parent, key, path, value, schema);
+      }
     }
 
     for (const propertyValue of propertyValues) {

--- a/packages/server/src/fhir/references.ts
+++ b/packages/server/src/fhir/references.ts
@@ -1,5 +1,6 @@
 import {
   badRequest,
+  crawlTypedValue,
   crawlTypedValueAsync,
   createReference,
   createStructureIssue,
@@ -60,10 +61,10 @@ export async function validateResourceReferences<T extends Resource>(repo: Repos
   const references: Record<string, Reference> = Object.create(null);
   const systemReferences: Record<string, Reference> = Object.create(null);
 
-  await crawlTypedValueAsync(
+  crawlTypedValue(
     toTypedValue(resource),
     {
-      async visitPropertyAsync(parent, _key, path, propertyValue, _schema) {
+      async visitProperty(parent, _key, path, propertyValue, _schema) {
         if (!isCheckableReference(propertyValue) || parent.type === PropertyType.Meta) {
           return;
         }

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -240,13 +240,11 @@ export async function execDownloadJob<T extends Resource = Resource>(job: Job<Do
 function getAttachments(resource: Resource): Attachment[] {
   const attachments: Attachment[] = [];
   crawlTypedValue(toTypedValue(resource), {
-    visitProperty: (_parent, _key, _path, propertyValues) => {
-      for (const propertyValue of propertyValues) {
-        if (propertyValue) {
-          for (const value of arrayify(propertyValue) as TypedValue[]) {
-            if (value.type === 'Attachment') {
-              attachments.push(value.value as Attachment);
-            }
+    visitProperty: (_parent, _key, _path, propertyValue) => {
+      if (propertyValue) {
+        for (const value of arrayify(propertyValue) as TypedValue[]) {
+          if (value.type === 'Attachment') {
+            attachments.push(value.value as Attachment);
           }
         }
       }


### PR DESCRIPTION
This is technically a breaking API change, although this is pretty deep in the internals, such that i'm 99% sure this is ok.  Open to feedback if there are any objections.

The key goal here is to align the function signatures of `crawlTypedValue` and `crawlTypedValueAsync`