### PR TITLE
Added C-CDA narratives and display text

### DIFF
--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -25,6 +25,7 @@ import {
   deepClone,
   deepEquals,
   deepIncludes,
+  escapeHtml,
   findObservationInterval,
   findObservationReferenceRange,
   findObservationReferenceRanges,
@@ -1612,4 +1613,18 @@ describe('singularize', () => {
     expect(singularize([false])).toStrictEqual(false);
     expect(singularize([])).toBeUndefined();
   });
+});
+
+describe('escapeHtml', () => {
+  test('Escapes &', () => expect(escapeHtml('&')).toStrictEqual('&amp;'));
+  test('Escapes <', () => expect(escapeHtml('<')).toStrictEqual('&lt;'));
+  test('Escapes >', () => expect(escapeHtml('>')).toStrictEqual('&gt;'));
+  test('Escapes "', () => expect(escapeHtml('"')).toStrictEqual('&quot;'));
+  test('Escapes “', () => expect(escapeHtml('“')).toStrictEqual('&ldquo;'));
+  test('Escapes ”', () => expect(escapeHtml('”')).toStrictEqual('&rdquo;'));
+  test('Escapes ‘', () => expect(escapeHtml('‘')).toStrictEqual('&lsquo;'));
+  test('Escapes ’', () => expect(escapeHtml('’')).toStrictEqual('&rsquo;'));
+  test('Escapes …', () => expect(escapeHtml('…')).toStrictEqual('&hellip;'));
+
+  test('Escapes tag', () => expect(escapeHtml('<foo>')).toStrictEqual('&lt;foo&gt;'));
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1404,3 +1404,21 @@ export function flatMapFilter<T, U>(arr: T[] | undefined, fn: (value: T, idx: nu
   }
   return result;
 }
+
+/**
+ * Returns the escaped HTML string of the input string.
+ * @param unsafe - The unsafe HTML string to escape.
+ * @returns The escaped HTML string.
+ */
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/“/g, '&ldquo;')
+    .replace(/”/g, '&rdquo;')
+    .replace(/‘/g, '&lsquo;')
+    .replace(/’/g, '&rsquo;')
+    .replace(/…/g, '&hellip;');
+}

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -1,6 +1,7 @@
 import {
   buildTypeName,
   capitalize,
+  escapeHtml,
   FileBuilder,
   getAllDataTypes,
   indexStructureDefinitionBundle,
@@ -369,19 +370,6 @@ function getTypeScriptTypeForProperty(
     return baseType + '[]';
   }
   return baseType;
-}
-
-function escapeHtml(unsafe: string): string {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/“/g, '&ldquo;')
-    .replace(/”/g, '&rdquo;')
-    .replace(/‘/g, '&lsquo;')
-    .replace(/’/g, '&rsquo;')
-    .replace(/…/g, '&hellip;');
 }
 
 if (process.argv[1].endsWith('index.ts')) {

--- a/packages/server/src/fhir/operations/patientsummary.test.ts
+++ b/packages/server/src/fhir/operations/patientsummary.test.ts
@@ -128,8 +128,8 @@ describe('Patient Summary Operation', () => {
     expect(result.entry?.[1]?.resource?.resourceType).toBe('Patient');
 
     const composition = result.entry?.[0]?.resource as WithId<Composition>;
-    expectSectionToContain(composition, LOINC_VITAL_SIGNS_SECTION, getReferenceString(observation));
-    expectSectionToContain(composition, LOINC_PROBLEMS_SECTION, getReferenceString(condition));
+    expectSectionToContain(composition, LOINC_VITAL_SIGNS_SECTION, 'Result', getReferenceString(observation));
+    expectSectionToContain(composition, LOINC_PROBLEMS_SECTION, 'Problem', getReferenceString(condition));
   });
 
   describe('PatientSummaryBuilder', () => {
@@ -182,15 +182,15 @@ describe('Patient Summary Operation', () => {
       expect(result.entry?.[1]?.resource?.resourceType).toBe('Patient');
 
       const composition = result.entry?.[0]?.resource as WithId<Composition>;
-      expectSectionToContain(composition, LOINC_ALLERGIES_SECTION, 'AllergyIntolerance/allergy1');
-      expectSectionToContain(composition, LOINC_PROBLEMS_SECTION, 'Condition/condition1');
-      expectSectionToContain(composition, LOINC_DEVICES_SECTION, 'DeviceUseStatement/device1');
-      expectSectionToContain(composition, LOINC_RESULTS_SECTION, 'DiagnosticReport/report1');
-      expectSectionToContain(composition, LOINC_PLAN_OF_TREATMENT_SECTION, 'Goal/goal1');
-      expectSectionToContain(composition, LOINC_IMMUNIZATIONS_SECTION, 'Immunization/imm1');
-      expectSectionToContain(composition, LOINC_MEDICATIONS_SECTION, 'MedicationRequest/med1');
-      expectSectionToContain(composition, LOINC_PROCEDURES_SECTION, 'Procedure/proc1');
-      expectSectionToContain(composition, LOINC_PLAN_OF_TREATMENT_SECTION, 'ServiceRequest/sr1');
+      expectSectionToContain(composition, LOINC_ALLERGIES_SECTION, 'Substance', 'AllergyIntolerance/allergy1');
+      expectSectionToContain(composition, LOINC_PROBLEMS_SECTION, 'Problem', 'Condition/condition1');
+      expectSectionToContain(composition, LOINC_DEVICES_SECTION, 'Device', 'DeviceUseStatement/device1');
+      expectSectionToContain(composition, LOINC_RESULTS_SECTION, 'Result', 'DiagnosticReport/report1');
+      expectSectionToContain(composition, LOINC_PLAN_OF_TREATMENT_SECTION, 'Planned', 'Goal/goal1');
+      expectSectionToContain(composition, LOINC_IMMUNIZATIONS_SECTION, 'Vaccine', 'Immunization/imm1');
+      expectSectionToContain(composition, LOINC_MEDICATIONS_SECTION, 'Medication', 'MedicationRequest/med1');
+      expectSectionToContain(composition, LOINC_PROCEDURES_SECTION, 'Procedure', 'Procedure/proc1');
+      expectSectionToContain(composition, LOINC_PLAN_OF_TREATMENT_SECTION, 'Planned', 'ServiceRequest/sr1');
     });
 
     test('Observations', () => {
@@ -227,7 +227,7 @@ describe('Patient Summary Operation', () => {
       const composition = result.entry?.[0]?.resource as WithId<Composition>;
 
       for (let i = 0; i < categories.length; i++) {
-        expectSectionToContain(composition, categories[i][1], `Observation/obs${i}`);
+        expectSectionToContain(composition, categories[i][1], 'Result', `Observation/obs${i}`);
       }
     });
 
@@ -359,10 +359,14 @@ describe('Patient Summary Operation', () => {
   });
 });
 
-function expectSectionToContain(composition: Composition, code: string, reference: string): void {
+function expectSectionToContain(composition: Composition, code: string, narrative: string, reference: string): void {
   const section = composition.section?.find((s) => s.code?.coding?.[0]?.code === code);
   if (!section) {
     throw new Error(`Section not found: ${code}`);
+  }
+
+  if (!section.text?.div?.includes(narrative)) {
+    throw new Error(`Narrative not found in section ${code}: ${narrative} (${section.text?.div})`);
   }
 
   const entry = section?.entry?.find((e) => e.reference === reference);

--- a/packages/server/src/fhir/operations/patientsummary.test.ts
+++ b/packages/server/src/fhir/operations/patientsummary.test.ts
@@ -173,7 +173,6 @@ describe('Patient Summary Operation', () => {
         { resourceType: 'MedicationRequest', id: 'med1', subject: patientRef, status: 'active', intent: 'plan' },
         { resourceType: 'Procedure', id: 'proc1', subject: patientRef, status: 'completed' },
         { resourceType: 'ServiceRequest', id: 'sr1', subject: patientRef, status: 'active', intent: 'plan' },
-        { resourceType: 'Task', id: 'task1', for: patientRef, status: 'completed', intent: 'order' },
       ];
 
       const builder = new PatientSummaryBuilder(author, patient, everything);
@@ -192,7 +191,6 @@ describe('Patient Summary Operation', () => {
       expectSectionToContain(composition, LOINC_MEDICATIONS_SECTION, 'MedicationRequest/med1');
       expectSectionToContain(composition, LOINC_PROCEDURES_SECTION, 'Procedure/proc1');
       expectSectionToContain(composition, LOINC_PLAN_OF_TREATMENT_SECTION, 'ServiceRequest/sr1');
-      expectSectionToContain(composition, LOINC_PROCEDURES_SECTION, 'Task/task1');
     });
 
     test('Observations', () => {
@@ -205,10 +203,6 @@ describe('Patient Summary Operation', () => {
         ['vital-signs', LOINC_VITAL_SIGNS_SECTION],
         ['imaging', LOINC_RESULTS_SECTION],
         ['laboratory', LOINC_RESULTS_SECTION],
-        ['procedure', LOINC_PROCEDURES_SECTION],
-        ['survey', LOINC_PLAN_OF_TREATMENT_SECTION],
-        ['exam', LOINC_PROCEDURES_SECTION],
-        ['therapy', LOINC_MEDICATIONS_SECTION],
         ['activity', LOINC_RESULTS_SECTION],
       ];
 

--- a/packages/server/src/fhir/operations/patientsummary.ts
+++ b/packages/server/src/fhir/operations/patientsummary.ts
@@ -1,6 +1,10 @@
 import {
   allOk,
   createReference,
+  escapeHtml,
+  formatCodeableConcept,
+  formatDate,
+  formatObservationValue,
   generateId,
   HTTP_TERMINOLOGY_HL7_ORG,
   LOINC,
@@ -10,18 +14,28 @@ import {
 } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import {
+  AllergyIntolerance,
   Bundle,
+  CarePlan,
+  ClinicalImpression,
   Composition,
   CompositionEvent,
   CompositionSection,
+  Condition,
+  DeviceUseStatement,
+  DiagnosticReport,
+  Goal,
+  Immunization,
+  MedicationRequest,
   Observation,
   OperationDefinition,
   OperationDefinitionParameter,
   Patient,
+  Procedure,
   Reference,
   Resource,
   ResourceType,
-  Task,
+  ServiceRequest,
 } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { getLogger } from '../../logger';
@@ -148,17 +162,17 @@ export class PatientSummaryBuilder {
   private readonly author: ProfileResource;
   private readonly patient: Patient;
   private readonly everything: WithId<Resource>[];
-  private readonly allergies: Resource[] = [];
-  private readonly medications: Resource[] = [];
-  private readonly problemList: Resource[] = [];
-  private readonly results: Resource[] = [];
-  private readonly socialHistory: Resource[] = [];
-  private readonly vitalSigns: Resource[] = [];
-  private readonly procedures: Resource[] = [];
-  private readonly assessments: Resource[] = [];
-  private readonly planOfTreatment: Resource[] = [];
-  private readonly immunizations: Resource[] = [];
-  private readonly devices: Resource[] = [];
+  private readonly allergies: AllergyIntolerance[] = [];
+  private readonly medications: MedicationRequest[] = [];
+  private readonly problemList: Condition[] = [];
+  private readonly results: (DiagnosticReport | Observation)[] = [];
+  private readonly socialHistory: Observation[] = [];
+  private readonly vitalSigns: Observation[] = [];
+  private readonly procedures: Procedure[] = [];
+  private readonly assessments: ClinicalImpression[] = [];
+  private readonly planOfTreatment: (CarePlan | Goal | ServiceRequest)[] = [];
+  private readonly immunizations: Immunization[] = [];
+  private readonly devices: DeviceUseStatement[] = [];
   private readonly nestedIds = new Set<string>();
 
   constructor(author: ProfileResource, patient: Patient, everything: WithId<Resource>[]) {
@@ -267,9 +281,6 @@ export class PatientSummaryBuilder {
       case 'Observation':
         this.chooseSectionForObservation(resource);
         break;
-      case 'Task':
-        this.chooseSectionForTask(resource);
-        break;
 
       default:
         getLogger().debug('Unsupported resource type in Patient Summary', { resourceType: resource.resourceType });
@@ -287,38 +298,9 @@ export class PatientSummaryBuilder {
       case 'vital-signs':
         this.vitalSigns.push(obs);
         break;
-      case 'imaging':
-        this.results.push(obs);
-        break;
-      case 'laboratory':
-        this.results.push(obs);
-        break;
-      case 'procedure':
-        this.procedures.push(obs);
-        break;
-      case 'survey':
-        this.planOfTreatment.push(obs);
-        break;
-      case 'exam':
-        this.procedures.push(obs);
-        break;
-      case 'therapy':
-        this.medications.push(obs);
-        break;
-      case 'activity':
-        this.results.push(obs);
-        break;
       default:
         this.results.push(obs);
         break;
-    }
-  }
-
-  private chooseSectionForTask(task: Task): void {
-    if (task.status === 'completed') {
-      this.procedures.push(task);
-    } else {
-      this.planOfTreatment.push(task);
     }
   }
 
@@ -342,17 +324,17 @@ export class PatientSummaryBuilder {
       custodian: this.patient.managingOrganization,
       event: this.buildEvent(),
       section: [
-        createSection(LOINC_ALLERGIES_SECTION, 'Allergies', this.allergies),
-        createSection(LOINC_IMMUNIZATIONS_SECTION, 'Immunizations', this.immunizations),
-        createSection(LOINC_MEDICATIONS_SECTION, 'Medications', this.medications),
-        createSection(LOINC_PROBLEMS_SECTION, 'Problem List', this.problemList),
-        createSection(LOINC_RESULTS_SECTION, 'Results', this.results),
-        createSection(LOINC_SOCIAL_HISTORY_SECTION, 'Social History', this.socialHistory),
-        createSection(LOINC_VITAL_SIGNS_SECTION, 'Vital Signs', this.vitalSigns),
-        createSection(LOINC_PROCEDURES_SECTION, 'Procedures', this.procedures),
-        createSection(LOINC_DEVICES_SECTION, 'Devices', this.devices),
-        createSection(LOINC_ASSESSMENTS_SECTION, 'Assessments', this.assessments),
-        createSection(LOINC_PLAN_OF_TREATMENT_SECTION, 'Plan of Treatment', this.planOfTreatment),
+        this.createAllergiesSection(),
+        this.createImmunizationsSection(),
+        this.createMedicationsSection(),
+        this.createProblemListSection(),
+        this.createResultsSection(),
+        this.createSocialHistorySection(),
+        this.createVitalSignsSection(),
+        this.createProceduresSection(),
+        this.createDevicesSection(),
+        this.createAssessmentsSection(),
+        this.createPlanOfTreatmentSection(),
       ],
     };
     return composition;
@@ -387,6 +369,214 @@ export class PatientSummaryBuilder {
     ];
   }
 
+  private createAllergiesSection(): CompositionSection {
+    return createSection(
+      LOINC_ALLERGIES_SECTION,
+      'Allergies',
+      createTable(
+        ['Substance', 'Reaction', 'Severity', 'Status'],
+        this.allergies.map((a) => [
+          formatCodeableConcept(a.code),
+          formatCodeableConcept(a.reaction?.[0]?.manifestation?.[0]),
+          a.reaction?.[0]?.severity,
+          formatCodeableConcept(a.clinicalStatus),
+        ])
+      ),
+      this.allergies
+    );
+  }
+
+  private createImmunizationsSection(): CompositionSection {
+    return createSection(
+      LOINC_IMMUNIZATIONS_SECTION,
+      'Immunizations',
+      createTable(
+        ['Vaccine', 'Date', 'Status'],
+        this.immunizations.map((i) => [
+          formatCodeableConcept(i.vaccineCode),
+          formatDate(i.occurrenceDateTime),
+          i.status,
+        ])
+      ),
+      this.immunizations
+    );
+  }
+
+  private createMedicationsSection(): CompositionSection {
+    return createSection(
+      LOINC_MEDICATIONS_SECTION,
+      'Medications',
+      createTable(
+        ['Medication', 'Directions', 'Start Date', 'End Date'],
+        this.medications.map((m) => [
+          formatCodeableConcept(m.medicationCodeableConcept),
+          m.dosageInstruction?.[0]?.text,
+          formatDate(m.dispenseRequest?.validityPeriod?.start),
+          formatDate(m.dispenseRequest?.validityPeriod?.end),
+        ])
+      ),
+      this.medications
+    );
+  }
+
+  private createProblemListSection(): CompositionSection {
+    return createSection(
+      LOINC_PROBLEMS_SECTION,
+      'Problem List',
+      createTable(
+        ['Problem', 'Start Date', 'Status'],
+        this.problemList.map((p) => [
+          formatCodeableConcept(p.code),
+          formatDate(p.onsetDateTime),
+          formatCodeableConcept(p.clinicalStatus),
+        ])
+      ),
+      this.problemList
+    );
+  }
+
+  private createResultsSection(): CompositionSection {
+    return createSection(LOINC_RESULTS_SECTION, 'Results', this.buildResultTable(this.results), this.results);
+  }
+
+  private createSocialHistorySection(): CompositionSection {
+    return createSection(
+      LOINC_SOCIAL_HISTORY_SECTION,
+      'Social History',
+      this.buildResultTable(this.socialHistory),
+      this.socialHistory
+    );
+  }
+
+  private createVitalSignsSection(): CompositionSection {
+    return createSection(
+      LOINC_VITAL_SIGNS_SECTION,
+      'Vital Signs',
+      this.buildResultTable(this.vitalSigns),
+      this.vitalSigns
+    );
+  }
+
+  private createProceduresSection(): CompositionSection {
+    return createSection(
+      LOINC_PROCEDURES_SECTION,
+      'Procedures',
+      createTable(
+        ['Procedure', 'Date', 'Target Site', 'Status'],
+        this.procedures.map((p) => [
+          formatCodeableConcept(p.code),
+          formatDate(p.performedDateTime),
+          formatCodeableConcept(p.bodySite?.[0]),
+          p.status,
+        ])
+      ),
+      this.procedures
+    );
+  }
+
+  private createDevicesSection(): CompositionSection {
+    return createSection(
+      LOINC_DEVICES_SECTION,
+      'Devices',
+      createTable(
+        ['Device', 'Status'],
+        this.devices.map((dus) => {
+          const device = this.getByReference(dus.device);
+          return [formatCodeableConcept(device?.type), dus.status];
+        })
+      ),
+      this.devices
+    );
+  }
+
+  private createAssessmentsSection(): CompositionSection {
+    return createSection(
+      LOINC_ASSESSMENTS_SECTION,
+      'Assessments',
+      createTable(
+        ['Summary', 'Date'],
+        this.assessments.map((a) => [a.summary, formatDate(a.date)])
+      ),
+      this.assessments
+    );
+  }
+
+  private createPlanOfTreatmentSection(): CompositionSection {
+    return createSection(
+      LOINC_PLAN_OF_TREATMENT_SECTION,
+      'Plan of Treatment',
+      this.buildPlanTable(this.planOfTreatment),
+      this.planOfTreatment
+    );
+  }
+
+  private buildResultTable(resources: (DiagnosticReport | Observation)[]): string {
+    const rows: (string | undefined)[][] = [];
+    for (const r of resources) {
+      this.buildResultRows(rows, r);
+    }
+    return createTable(['Name', 'Result', 'Date'], rows);
+  }
+
+  private buildResultRows(rows: (string | undefined)[][], resource: DiagnosticReport | Observation): void {
+    if (resource.resourceType === 'DiagnosticReport') {
+      rows.push([formatCodeableConcept(resource.code), undefined, formatDate(resource.effectiveDateTime)]);
+      if (resource.result) {
+        for (const result of resource.result) {
+          const r = this.getByReference(result);
+          if (r && r.resourceType === 'Observation') {
+            this.buildResultRows(rows, r);
+          }
+        }
+      }
+    }
+
+    if (resource.resourceType === 'Observation') {
+      rows.push([
+        formatCodeableConcept(resource.code),
+        formatObservationValue(resource),
+        formatDate(resource.effectiveDateTime),
+      ]);
+
+      if (resource.hasMember) {
+        for (const member of resource.hasMember) {
+          const m = this.getByReference(member);
+          if (m && m.resourceType === 'Observation') {
+            this.buildResultRows(rows, m);
+          }
+        }
+      }
+    }
+  }
+
+  private buildPlanTable(resources: (CarePlan | Goal | ServiceRequest)[]): string {
+    const rows: (string | undefined)[][] = [];
+    for (const r of resources) {
+      this.buildPlanRows(rows, r);
+    }
+    return createTable(['Planned Care', 'Start Date'], rows);
+  }
+
+  private buildPlanRows(rows: (string | undefined)[][], resource: CarePlan | Goal | ServiceRequest): void {
+    if (resource.resourceType === 'CarePlan') {
+      rows.push([formatCodeableConcept(resource.category?.[0]), formatDate(resource.period?.start)]);
+      if (resource.activity) {
+        for (const activity of resource.activity) {
+          const a = this.getByReference(activity.reference);
+          if (a && a.resourceType === 'ServiceRequest') {
+            rows.push([formatCodeableConcept(a.code), formatDate(a.authoredOn)]);
+          }
+        }
+      }
+    }
+    if (resource.resourceType === 'Goal') {
+      rows.push([formatCodeableConcept(resource.description), formatDate(resource.target?.[0]?.dueDate)]);
+    }
+    if (resource.resourceType === 'ServiceRequest') {
+      rows.push([formatCodeableConcept(resource.code), formatDate(resource.authoredOn)]);
+    }
+  }
+
   private buildBundle(composition: Composition): Bundle {
     const allResources = [composition, this.patient, this.author, ...this.everything];
 
@@ -402,13 +592,43 @@ export class PatientSummaryBuilder {
 
     return bundle;
   }
+
+  private getByReference<T extends Resource>(ref: Reference<T> | undefined): T | undefined {
+    if (!ref?.reference) {
+      return undefined;
+    }
+    return this.everything.find((r) => r.id === resolveId(ref)) as T;
+  }
 }
 
-function createSection(code: string, title: string, entry: Resource[]): CompositionSection {
+function createTable(headings: string[], body: (string | undefined)[][]): string {
+  const html = ['<table><thead><tr>'];
+  for (const h of headings) {
+    html.push('<td>');
+    html.push(escapeHtml(h));
+    html.push('</td>');
+  }
+  html.push('</tr></thead><tbody>');
+  for (const row of body) {
+    html.push('<tr>');
+    for (const cell of row) {
+      html.push('<td>');
+      if (cell) {
+        html.push(escapeHtml(cell));
+      }
+      html.push('</td>');
+    }
+    html.push('</tr>');
+  }
+  html.push('</tbody></table>');
+  return html.join('');
+}
+
+function createSection(code: string, title: string, html: string, entry: Resource[]): CompositionSection {
   return {
     title,
     code: { coding: [{ system: LOINC, code }] },
-    text: { status: 'generated', div: `<div xmlns="http://www.w3.org/1999/xhtml">${title}</div>` },
+    text: { status: 'generated', div: `<div xmlns="http://www.w3.org/1999/xhtml">${html}</div>` },
     entry: entry.map(createReference),
   };
 }


### PR DESCRIPTION
This PR enhances our C-CDA and International Patient Summary (IPS) exports by implementing narrative text sections that were previously minimal or blank. While our prior focus was on structured data export, this update addresses the critical need for human-readable narrative content that C-CDA and IPS viewers heavily rely on.

Key changes:
- Added HTML tables in each section's narrative block based on ONC consultant samples
- Implemented consistent formatting across all narrative sections
- Ensured narrative content properly reflects the structured data being exported
- Maintained parallel development across both C-CDA and IPS features due to their significant overlap

These improvements significantly enhance document readability in clinical viewers while maintaining compliance with the expected format. The narrative content follows validated patterns from our ONC consultant samples, giving us confidence that the implementation meets industry requirements.

For example: https://www.ccdaviewer.com/viewer/

![image](https://github.com/user-attachments/assets/759a6054-5c09-4b51-8171-ef085bc8611c)
