### PR TITLE
$apply PlanDefinition for ActivityDefinition ServiceRequest

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     "migrate": "ts-node --transpileOnly src/migrations/migrate.ts",
     "circular": "npx madge --circular dist/index.js",
     "start": "node --require ./dist/otel/instrumentation.js dist/index.js",
-    "test": "jest",
+    "test": "jest --silent=false",
     "test:seed": "jest seed.test.ts --testTimeout=400000"
   },
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     "migrate": "ts-node --transpileOnly src/migrations/migrate.ts",
     "circular": "npx madge --circular dist/index.js",
     "start": "node --require ./dist/otel/instrumentation.js dist/index.js",
-    "test": "jest --silent=false",
+    "test": "jest",
     "test:seed": "jest seed.test.ts --testTimeout=400000"
   },
   "dependencies": {

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -1,5 +1,12 @@
 import { ContentType, createReference, getReferenceString } from '@medplum/core';
-import { Encounter, OperationOutcome, Patient, Questionnaire, RequestGroup, Task } from '@medplum/fhirtypes';
+import {
+  Encounter,
+  OperationOutcome,
+  Patient,
+  Questionnaire,
+  RequestGroup,
+  Task,
+} from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -347,5 +354,116 @@ describe('PlanDefinition apply', () => {
         ],
       });
     expect(res4.status).toBe(200);
+  });
+
+  test('ActivityDefinition ServiceRequest', async () => {
+    const res1 = await request(app)
+      .post(`/fhir/R4/ActivityDefinition`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'ActivityDefinition',
+        status: 'active',
+        kind: 'ServiceRequest',
+        name: 'CompleteBloodCountOrder',
+        title: 'Complete Blood Count Order',
+        description: 'Order for a complete blood count',
+        code: {
+          coding: [
+            {
+              system: 'http://snomed.info/sct',
+              code: '26604007',
+              display: 'Complete blood count',
+            },
+            {
+              system: 'http://www.ama-assn.org/go/cpt',
+              code: '85025',
+              display: 'Complete CBC with automated differential WBC',
+            },
+          ],
+        },
+        intent: 'order',
+        priority: 'routine',
+        participant: [
+          {
+            type: 'practitioner',
+            role: {
+              coding: [
+                {
+                  system: 'http://terminology.hl7.org/CodeSystem/practitioner-role',
+                  code: 'doctor',
+                  display: 'Doctor',
+                },
+              ],
+            },
+          },
+        ],
+      });
+    expect(res1.status).toBe(201);
+    expect(res1.body.resourceType).toBe('ActivityDefinition');
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/PlanDefinition`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'PlanDefinition',
+        title: 'Example Plan Definition',
+        status: 'active',
+        action: [
+          {
+            title: 'Order a CBC',
+            definitionCanonical: getReferenceString(res1.body),
+          },
+        ],
+      });
+
+    expect(res2.status).toBe(201);
+    expect(res2.body.resourceType).toBe('PlanDefinition');
+    expect(res2.body.id).toBeDefined();
+
+    const res3 = await request(app)
+      .post(`/fhir/R4/Patient`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Patient',
+        name: [{ given: ['Workflow'], family: 'Demo' }],
+      });
+    expect(res3.status).toBe(201);
+
+    const res4 = await request(app)
+      .post(`/fhir/R4/PlanDefinition/${res2.body.id}/$apply`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'subject',
+            valueString: getReferenceString(res3.body as Patient),
+          },
+        ],
+      });
+
+    expect(res4.status).toBe(200);
+
+    const res5 = await request(app)
+      .get(`/fhir/R4/RequestGroup/${res4.body.id}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res5.status).toBe(200);
+    expect(res5.body.resourceType).toBe('RequestGroup');
+
+    const res6 = await request(app)
+      .get(`/fhir/R4/${(res5.body as RequestGroup).action?.[0]?.resource?.reference}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res6.status).toBe(200);
+
+    const resultTask = res6.body as Task;
+    const res7 = await request(app)
+      .get(`/fhir/R4/${resultTask.focus?.reference}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res7.status).toBe(200);
+    expect(res7.body.resourceType).toBe('ServiceRequest');
   });
 });

--- a/packages/server/src/fhir/operations/plandefinitionapply.test.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.test.ts
@@ -1,12 +1,5 @@
 import { ContentType, createReference, getReferenceString } from '@medplum/core';
-import {
-  Encounter,
-  OperationOutcome,
-  Patient,
-  Questionnaire,
-  RequestGroup,
-  Task,
-} from '@medplum/fhirtypes';
+import { Encounter, OperationOutcome, Patient, Questionnaire, RequestGroup, Task } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -149,7 +149,7 @@ async function createActivityDefinitionTask(
         subject: subject,
         requester: requester as ServiceRequest['requester'],
         encounter: encounter,
-        code: activityDefinition.code
+        code: activityDefinition.code,
       });
 
       return createTask(repo, requester, subject, action, encounter, [

--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -123,6 +123,15 @@ async function createQuestionnaireTask(
   ]);
 }
 
+/**
+ * Creates a Task and RequestGroup action to request a resource.
+ * @param repo - The repository configured for the current user.
+ * @param requester - The user who requested the plan definition.
+ * @param subject - The subject of the plan definition.
+ * @param action - The PlanDefinition action.
+ * @param encounter - Optional encounter reference.
+ * @returns The RequestGroup action.
+ */
 async function createActivityDefinitionTask(
   repo: Repository,
   requester: Reference<Bot | ClientApplication | ProfileResource>,


### PR DESCRIPTION
handles https://github.com/medplum/medplum/issues/6161
Creates a `ServiceRequest` from a `ActivityDefinition` during /PlanDefinition/[id]/$apply.

Procedure was not handled as ActivityDefinition.kind does not support it.
https://hl7.org/fhir/valueset-request-resource-types.html
