### PR TITLE
Fix C-CDA Validation Errors

### DIFF
--- a/packages/ccda/src/fhir-to-ccda.ts
+++ b/packages/ccda/src/fhir-to-ccda.ts
@@ -834,6 +834,7 @@ class FhirToCcdaConverter {
    * Map the FHIR author to the C-CDA author.
    * @param author - The author to map.
    * @param time - The time to map.
+   * @param custodian - The represented Organization
    * @returns The C-CDA author.
    */
   private mapAuthor(
@@ -1514,7 +1515,7 @@ class FhirToCcdaConverter {
       ];
     }
 
-    if (code == '76689-9') {
+    if (code === '76689-9') {
       // Birth Sex
       return [{ '@_root': OID_BIRTH_SEX }, { '@_root': OID_BIRTH_SEX, '@_extension': '2016-06-01' }];
     }

--- a/packages/ccda/src/fhir-to-ccda.ts
+++ b/packages/ccda/src/fhir-to-ccda.ts
@@ -851,13 +851,7 @@ class FhirToCcdaConverter {
       return undefined;
     }
 
-    let organization = undefined;
-    if (custodian) {
-      organization = this.findResourceByReference(custodian);
-      if (!organization) {
-        return undefined;
-      }
-    }
+    const organization = this.findResourceByReference(custodian);
 
     return [
       {
@@ -875,11 +869,7 @@ class FhirToCcdaConverter {
           assignedPerson: {
             name: this.mapNames(practitioner.name),
           },
-          representedOrganization: organization
-            ? {
-                name: organization.name ? [organization.name] : undefined,
-              }
-            : undefined,
+          representedOrganization: organization?.name ? { name: [organization.name] } : undefined,
         },
       },
     ];

--- a/packages/ccda/src/systems.ts
+++ b/packages/ccda/src/systems.ts
@@ -432,6 +432,7 @@ export const ADDRESS_USE_MAPPER = new EnumMapper('AddressUse', '', ADDRESS_USE_V
 export const TELECOM_USE_MAPPER = new EnumMapper('TelecomUse', '', CONTACT_ENTITY_USE_VALUE_SET, [
   { ccdaValue: 'WP', fhirValue: 'work', displayName: 'Work' },
   { ccdaValue: 'HP', fhirValue: 'home', displayName: 'Home' },
+  { ccdaValue: 'MC', fhirValue: 'mobile', displayName: 'Mobile' },
 ]);
 
 export const ALLERGY_STATUS_MAPPER = new EnumMapper<string, string>(

--- a/packages/ccda/src/types.ts
+++ b/packages/ccda/src/types.ts
@@ -51,7 +51,7 @@ export interface CcdaPatient {
 }
 
 export interface CcdaTelecom {
-  '@_use'?: 'HP' | 'WP';
+  '@_use'?: 'HP' | 'WP' | 'MC';
   '@_value'?: string;
   '@_nullFlavor'?: 'UNK';
 }
@@ -180,6 +180,7 @@ export interface CcdaAssignedAuthor {
   assignedPerson?: CcdaAssignedPerson;
   addr: CcdaAddr[];
   telecom: CcdaTelecom[];
+  representedOrganization?: CcdaRepresentedOrganization;
 }
 
 export interface CcdaAssignedPerson {

--- a/packages/ccda/testdata/MinimalPassingValidator.xml
+++ b/packages/ccda/testdata/MinimalPassingValidator.xml
@@ -59,6 +59,9 @@
                     <given>Albert</given>
                 </name>
             </assignedPerson>
+            <representedOrganization>
+                <name>Neighborhood Physicians Practice</name>
+            </representedOrganization>
         </assignedAuthor>
     </author>
     <custodian>

--- a/packages/server/src/fhir/operations/patientsummary.ts
+++ b/packages/server/src/fhir/operations/patientsummary.ts
@@ -613,6 +613,10 @@ export class PatientSummaryBuilder {
 }
 
 function createTable(headings: string[], body: (string | undefined)[][]): string {
+  if (body.length === 0) {
+    return '';
+  }
+
   const html = ['<table><thead><tr>'];
   for (const h of headings) {
     html.push('<td>');


### PR DESCRIPTION
# PR: Fix C-CDA Validation Errors

This PR addresses several validation errors in our C-CDA document generation and improves representation of authors with their affiliated organizations.

## Changes:

### Enhanced Author Representation
- Added support for representing an author's organization by passing the custodian reference to the `mapAuthor` function
- Modified the `CcdaAssignedAuthor` interface to include an optional `representedOrganization` property
- Updated test XML to include the author's represented organization

### Fixed Telecom Use Mapping
- Added support for 'mobile' telecom use in addition to 'home' and 'work'
- Updated the `TELECOM_USE_MAPPER` to include the 'mobile' mapping (MC)
- Modified the `CcdaTelecom` interface to accept 'MC' as a valid use value

### Added Birth Sex OID Support
- Implemented proper OID mapping for Birth Sex codes (76689-9)
- Added OID_BIRTH_SEX constant and handling in code mapping function

### Other Improvements
- Fixed empty table rendering issue in patient summary
- Improved error handling in the FHIR to C-CDA conversion process
- Added appropriate imports for newly referenced constants

These changes ensure our generated C-CDA documents pass validation checks and better represent the relationship between healthcare providers and their organizations.