### PR TITLE
fix(subscription): rewrite attachments for subscriptions

### DIFF
--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -818,8 +818,8 @@ describe('WebSocket Subscription', () => {
 
 describe('Subscription Heartbeat', () => {
   let app: Express;
-  let config: any;
-  let server: any;
+  let config: MedplumServerConfig;
+  let server: Server;
   let project: WithId<Project>;
   let repo: Repository;
   let accessToken: string;

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -18,17 +18,21 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { MedplumServerConfig } from '../config/types';
 import { Repository } from '../fhir/repo';
+import * as rewriteModule from '../fhir/rewrite';
+import { RewriteMode } from '../fhir/rewrite';
+import { globalLogger } from '../logger';
+import * as keysModule from '../oauth/keys';
 import { getRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 
 jest.mock('hibp');
 
-describe('WebSockets Subscriptions', () => {
-  let app: Express;
+describe('WebSocket Subscription', () => {
   let config: MedplumServerConfig;
   let server: Server;
   let project: Project;
   let repo: Repository;
+  let app: Express;
   let accessToken: string;
   let patientSubscription: WithId<Subscription>;
 
@@ -497,12 +501,325 @@ describe('WebSockets Subscriptions', () => {
           await sleep(0);
         });
     }));
+
+  test('Missing login_id in token', () =>
+    withTestContext(async () => {
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: 'Patient',
+        channel: {
+          type: 'websocket',
+        },
+      });
+      expect(subscription).toBeDefined();
+
+      // Mock verifyJwt to return a payload without login_id
+      const verifyJwtSpy = jest.spyOn(keysModule, 'verifyJwt').mockImplementation(async () => {
+        return {
+          payload: {
+            subscription_id: subscription.id,
+            // login_id is missing intentionally
+          },
+          protectedHeader: {},
+        };
+      });
+
+      await request(server)
+        .ws('/ws/subscriptions-r4')
+        .sendJson({ type: 'bind-with-token', payload: { token: 'fake-token' } })
+        .expectJson({
+          resourceType: 'OperationOutcome',
+          issue: [
+            {
+              severity: 'error',
+              code: 'invalid',
+              details: { text: 'Token claims missing login_id. Make sure you are sending the correct token.' },
+            },
+          ],
+        })
+        .close()
+        .expectClosed()
+        .exec(async () => {
+          // Without this, marking subscription cannot cleanup cannot run before the test scope ends and redis has already closed
+          // Since the websocket close listener executes on the next tick
+          await sleep(0);
+        });
+
+      // Restore original implementation
+      verifyJwtSpy.mockRestore();
+    }));
+
+  test('Token failed to validate', () =>
+    withTestContext(async () => {
+      // Mock verifyJwt to throw an error
+      const verifyJwtSpy = jest.spyOn(keysModule, 'verifyJwt').mockImplementation(async () => {
+        throw new Error('Token validation failed');
+      });
+
+      await request(server)
+        .ws('/ws/subscriptions-r4')
+        .sendJson({ type: 'bind-with-token', payload: { token: 'invalid-token' } })
+        .expectJson({
+          resourceType: 'OperationOutcome',
+          issue: [
+            {
+              severity: 'error',
+              code: 'invalid',
+              details: { text: 'Token failed to validate. Check token expiry.' },
+            },
+          ],
+        })
+        .close()
+        .expectClosed()
+        .exec(async () => {
+          // Without this, marking subscription cannot cleanup cannot run before the test scope ends and redis has already closed
+          // Since the websocket close listener executes on the next tick
+          await sleep(0);
+        });
+
+      // Restore original implementation
+      verifyJwtSpy.mockRestore();
+    }));
+
+  test('Error while rewriting attachments', () =>
+    withTestContext(async () => {
+      // Don't mock rewriteAttachments until after the handshake
+      const originalRewriteAttachments = rewriteModule.rewriteAttachments;
+      let mockRewriteAttachments = false;
+      const rewriteAttachmentsSpy = jest
+        .spyOn(rewriteModule, 'rewriteAttachments')
+        .mockImplementation(async (...args) => {
+          if (mockRewriteAttachments && args[0] === RewriteMode.PRESIGNED_URL) {
+            throw new Error('Error rewriting attachments');
+          }
+          return originalRewriteAttachments(...args);
+        });
+      const globalLoggerErrorSpy = jest.spyOn(globalLogger, 'error');
+
+      const binary = await repo.createResource<Binary>({
+        resourceType: 'Binary',
+        contentType: ContentType.TEXT,
+      });
+
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: `DocumentReference?location=Binary/${binary.id}`,
+        channel: {
+          type: 'websocket',
+        },
+      });
+
+      expect(subscription).toBeDefined();
+      expect(subscription.id).toBeDefined();
+
+      // Call $get-ws-binding-token
+      const res = await request(server)
+        .get(`/fhir/R4/Subscription/${subscription.id}/$get-ws-binding-token`)
+        .set('Authorization', 'Bearer ' + accessToken);
+
+      expect(res.body).toBeDefined();
+      const body = res.body as Parameters;
+      expect(body.resourceType).toStrictEqual('Parameters');
+      expect(body.parameter?.[0]).toBeDefined();
+      expect(body.parameter?.[0]?.name).toStrictEqual('token');
+      expect(body.parameter?.[0]?.valueString).toBeDefined();
+
+      const token = body.parameter?.[0]?.valueString as string;
+
+      expect(res.body).toBeDefined();
+
+      // Connect with WebSocket and bind to subscription
+      await request(server)
+        .ws('/ws/subscriptions-r4')
+        .sendJson({ type: 'bind-with-token', payload: { token } })
+        .expectJson((actual) => {
+          expect(actual).toMatchObject({
+            id: expect.any(String),
+            resourceType: 'Bundle',
+            type: 'history',
+            timestamp: expect.any(String),
+            entry: [
+              {
+                resource: {
+                  resourceType: 'SubscriptionStatus',
+                  type: 'handshake',
+                  subscription: { reference: `Subscription/${subscription.id}` },
+                },
+              },
+            ],
+          });
+        })
+        // Add a new document reference for this project
+        .exec(async () => {
+          mockRewriteAttachments = true;
+
+          const documentRef = await repo.createResource<DocumentReference>({
+            resourceType: 'DocumentReference',
+            status: 'current',
+            content: [
+              {
+                attachment: {
+                  url: `Binary/${binary.id}`,
+                },
+              },
+            ],
+          });
+          expect(documentRef).toBeDefined();
+          let subActive = false;
+          while (!subActive) {
+            await sleep(0);
+            subActive =
+              (
+                await getRedis().smismember(
+                  `medplum:subscriptions:r4:project:${project.id}:active`,
+                  `Subscription/${subscription.id}`
+                )
+              )[0] === 1;
+          }
+          expect(subActive).toStrictEqual(true);
+        })
+        .close()
+        .expectClosed()
+        .exec(async () => {
+          // Without this, marking subscription cannot cleanup cannot run before the test scope ends and redis has already closed
+          // Since the websocket close listener executes on the next tick
+          await sleep(0);
+        });
+
+      expect(globalLoggerErrorSpy).toHaveBeenCalledWith('[WS] Error occurred while rewriting attachments', {
+        err: expect.any(Error),
+      });
+
+      // Restore original implementations
+      rewriteAttachmentsSpy.mockRestore();
+      globalLoggerErrorSpy.mockRestore();
+    }));
+
+  test('Undefined authState returned', () =>
+    withTestContext(async () => {
+      // Import the module to mock
+      const originalGetLoginForAccessToken = jest.requireActual('../oauth/utils').getLoginForAccessToken;
+      let mockGetLoginForAccessToken = false;
+      const getLoginForAccessTokenSpy = jest
+        .spyOn(require('../oauth/utils'), 'getLoginForAccessToken')
+        .mockImplementation(async (...args) => {
+          if (mockGetLoginForAccessToken) {
+            return undefined; // Return undefined auth state
+          }
+          return originalGetLoginForAccessToken(...args);
+        });
+      const globalLoggerInfoSpy = jest.spyOn(globalLogger, 'info');
+
+      const binary = await repo.createResource<Binary>({
+        resourceType: 'Binary',
+        contentType: ContentType.TEXT,
+      });
+
+      const subscription = await repo.createResource<Subscription>({
+        resourceType: 'Subscription',
+        reason: 'test',
+        status: 'active',
+        criteria: `DocumentReference?location=Binary/${binary.id}`,
+        channel: {
+          type: 'websocket',
+        },
+      });
+
+      expect(subscription).toBeDefined();
+      expect(subscription.id).toBeDefined();
+
+      // Call $get-ws-binding-token
+      const res = await request(server)
+        .get(`/fhir/R4/Subscription/${subscription.id}/$get-ws-binding-token`)
+        .set('Authorization', 'Bearer ' + accessToken);
+
+      expect(res.body).toBeDefined();
+      const body = res.body as Parameters;
+      expect(body.resourceType).toStrictEqual('Parameters');
+      expect(body.parameter?.[0]).toBeDefined();
+      expect(body.parameter?.[0]?.name).toStrictEqual('token');
+      expect(body.parameter?.[0]?.valueString).toBeDefined();
+
+      const token = body.parameter?.[0]?.valueString as string;
+
+      expect(res.body).toBeDefined();
+
+      // Connect with WebSocket and bind to subscription
+      await request(server)
+        .ws('/ws/subscriptions-r4')
+        .sendJson({ type: 'bind-with-token', payload: { token } })
+        .expectJson((actual) => {
+          expect(actual).toMatchObject({
+            id: expect.any(String),
+            resourceType: 'Bundle',
+            type: 'history',
+            timestamp: expect.any(String),
+            entry: [
+              {
+                resource: {
+                  resourceType: 'SubscriptionStatus',
+                  type: 'handshake',
+                  subscription: { reference: `Subscription/${subscription.id}` },
+                },
+              },
+            ],
+          });
+        })
+        // Add a new document reference for this project
+        .exec(async () => {
+          mockGetLoginForAccessToken = true;
+
+          const documentRef = await repo.createResource<DocumentReference>({
+            resourceType: 'DocumentReference',
+            status: 'current',
+            content: [
+              {
+                attachment: {
+                  url: `Binary/${binary.id}`,
+                },
+              },
+            ],
+          });
+          expect(documentRef).toBeDefined();
+          let subActive = false;
+          while (!subActive) {
+            await sleep(0);
+            subActive =
+              (
+                await getRedis().smismember(
+                  `medplum:subscriptions:r4:project:${project.id}:active`,
+                  `Subscription/${subscription.id}`
+                )
+              )[0] === 1;
+          }
+          expect(subActive).toStrictEqual(true);
+        })
+        .close()
+        .expectClosed()
+        .exec(async () => {
+          // Without this, marking subscription cannot cleanup cannot run before the test scope ends and redis has already closed
+          // Since the websocket close listener executes on the next tick
+          await sleep(0);
+        });
+
+      expect(globalLoggerInfoSpy).toHaveBeenCalledWith('[WS] Unable to get login for the given access token', {
+        subscriptionId: expect.any(String),
+      });
+
+      // Restore original implementations
+      getLoginForAccessTokenSpy.mockRestore();
+      globalLoggerInfoSpy.mockRestore();
+    }));
 });
 
 describe('Subscription Heartbeat', () => {
   let app: Express;
-  let config: MedplumServerConfig;
-  let server: Server;
+  let config: any;
+  let server: any;
   let project: WithId<Project>;
   let repo: Repository;
   let accessToken: string;

--- a/packages/server/src/subscriptions/websockets.test.ts
+++ b/packages/server/src/subscriptions/websockets.test.ts
@@ -22,6 +22,7 @@ import * as rewriteModule from '../fhir/rewrite';
 import { RewriteMode } from '../fhir/rewrite';
 import { globalLogger } from '../logger';
 import * as keysModule from '../oauth/keys';
+import * as oauthUtilsModule from '../oauth/utils';
 import { getRedis } from '../redis';
 import { createTestProject, withTestContext } from '../test.setup';
 
@@ -702,10 +703,10 @@ describe('WebSocket Subscription', () => {
   test('Undefined authState returned', () =>
     withTestContext(async () => {
       // Import the module to mock
-      const originalGetLoginForAccessToken = jest.requireActual('../oauth/utils').getLoginForAccessToken;
+      const originalGetLoginForAccessToken = oauthUtilsModule.getLoginForAccessToken;
       let mockGetLoginForAccessToken = false;
       const getLoginForAccessTokenSpy = jest
-        .spyOn(require('../oauth/utils'), 'getLoginForAccessToken')
+        .spyOn(oauthUtilsModule, 'getLoginForAccessToken')
         .mockImplementation(async (...args) => {
           if (mockGetLoginForAccessToken) {
             return undefined; // Return undefined auth state

--- a/packages/server/src/subscriptions/websockets.ts
+++ b/packages/server/src/subscriptions/websockets.ts
@@ -5,12 +5,15 @@ import { JWTPayload } from 'jose';
 import crypto from 'node:crypto';
 import os from 'node:os';
 import ws from 'ws';
+import { getRepoForLogin } from '../fhir/accesspolicy';
 import { AdditionalWsBindingClaims } from '../fhir/operations/getwsbindingtoken';
 import { CacheEntry } from '../fhir/repo';
 import { getFullUrl } from '../fhir/response';
+import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
 import { heartbeat } from '../heartbeat';
 import { globalLogger } from '../logger';
-import { verifyJwt } from '../oauth/keys';
+import { MedplumBaseClaims, verifyJwt } from '../oauth/keys';
+import { getLoginForAccessToken } from '../oauth/utils';
 import { setGauge } from '../otel/otel';
 import { getRedis, getRedisSubscriber } from '../redis';
 
@@ -31,17 +34,24 @@ export interface UnbindFromTokenMsg extends BaseSubscriptionClientMsg {
 
 export type SubscriptionClientMsg = BindWithTokenMsg | UnbindFromTokenMsg | { type: 'ping' };
 
+export interface WebSocketSubMetadata {
+  rawToken: string;
+}
+
+export type WebSocketSubToken = JWTPayload & MedplumBaseClaims & AdditionalWsBindingClaims;
+
 const hostname = os.hostname();
 const METRIC_OPTIONS = { attributes: { hostname } };
 
-const wsToSubLookup = new Map<ws.WebSocket, Set<string>>();
+const wsToSubLookup = new Map<ws.WebSocket, Map<string, WebSocketSubMetadata>>();
 const subToWsLookup = new Map<string, Set<ws.WebSocket>>();
+
 let redisSubscriber: Redis | undefined;
 let heartbeatHandler: (() => void) | undefined;
 
 async function setupSubscriptionHandler(): Promise<void> {
   redisSubscriber = getRedisSubscriber();
-  redisSubscriber.on('message', (channel: string, events: string) => {
+  redisSubscriber.on('message', async (channel: string, events: string) => {
     globalLogger.debug('[WS] redis subscription events', { channel, events });
     const subEventArgsArr = JSON.parse(events) as [
       WithId<Resource>,
@@ -51,7 +61,35 @@ async function setupSubscriptionHandler(): Promise<void> {
     for (const [resource, subscriptionId, options] of subEventArgsArr) {
       const bundle = createSubEventNotification(resource, subscriptionId, options);
       for (const socket of subToWsLookup.get(subscriptionId) ?? []) {
-        socket.send(JSON.stringify(bundle), { binary: false });
+        // Get the repo for this socket in the context of the subscription
+        const subMetadataMap = wsToSubLookup.get(socket);
+        if (!subMetadataMap) {
+          // We should really never hit this log, this is a true error
+          globalLogger.error('[WS] Unable to find sub metadata map for WebSocket');
+          continue;
+        }
+        const subMetadata = subMetadataMap.get(subscriptionId);
+        if (!subMetadata) {
+          // We should really never hit this log, this is a true error
+          globalLogger.error('[WS] Unable to find sub metadata entry for WebSocket', { subscriptionId });
+          continue;
+        }
+
+        let rewrittenBundle: Bundle;
+        try {
+          const authState = await getLoginForAccessToken(undefined, subMetadata.rawToken);
+          if (!authState) {
+            globalLogger.info('[WS] Unable to get login for the given access token', { subscriptionId });
+            continue;
+          }
+          const repo = await getRepoForLogin(authState);
+          rewrittenBundle = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, bundle);
+        } catch (err) {
+          globalLogger.error('[WS] Error occured while rewriting attachments', { err });
+          continue;
+        }
+
+        socket.send(JSON.stringify(rewrittenBundle), { binary: false });
       }
     }
   });
@@ -61,8 +99,8 @@ async function setupSubscriptionHandler(): Promise<void> {
 function ensureHeartbeatHandler(): void {
   if (!heartbeatHandler) {
     heartbeatHandler = (): void => {
-      for (const [ws, subscriptionIds] of wsToSubLookup.entries()) {
-        ws.send(JSON.stringify(createSubHeartbeatEvent(subscriptionIds)));
+      for (const [ws, metadata] of wsToSubLookup.entries()) {
+        ws.send(JSON.stringify(createSubHeartbeatEvent(metadata)));
       }
       setGauge('medplum.subscription.websocketCount', wsToSubLookup.size, METRIC_OPTIONS);
       setGauge('medplum.subscription.subscriptionCount', subToWsLookup.size, METRIC_OPTIONS);
@@ -71,19 +109,19 @@ function ensureHeartbeatHandler(): void {
   }
 }
 
-function subscribeWsToSubscription(ws: ws.WebSocket, subscriptionId: string): void {
+function subscribeWsToSubscription(ws: ws.WebSocket, subscriptionId: string, rawToken: string): void {
   let wsSet = subToWsLookup.get(subscriptionId);
-  let subIdSet = wsToSubLookup.get(ws);
+  let subEntryMap = wsToSubLookup.get(ws);
   if (!wsSet) {
     wsSet = new Set();
     subToWsLookup.set(subscriptionId, wsSet);
   }
-  if (!subIdSet) {
-    subIdSet = new Set();
-    wsToSubLookup.set(ws, subIdSet);
+  if (!subEntryMap) {
+    subEntryMap = new Map();
+    wsToSubLookup.set(ws, subEntryMap);
   }
   wsSet.add(ws);
-  subIdSet.add(subscriptionId);
+  subEntryMap.set(subscriptionId, { rawToken });
 }
 
 function unsubscribeWsFromSubscription(ws: ws.WebSocket, subscriptionId: string): void {
@@ -109,12 +147,12 @@ function unsubscribeWsFromSubscription(ws: ws.WebSocket, subscriptionId: string)
 }
 
 function unsubscribeWsFromAllSubscriptions(ws: ws.WebSocket): void {
-  const subscriptionIds = wsToSubLookup.get(ws);
-  if (!subscriptionIds) {
+  const subEntries = wsToSubLookup.get(ws);
+  if (!subEntries) {
     globalLogger.error('[WS] No entry for given WebSocket in subscription lookup');
     return;
   }
-  for (const subscriptionId of subscriptionIds) {
+  for (const subscriptionId of subEntries.keys()) {
     if (!subToWsLookup.has(subscriptionId)) {
       globalLogger.error(`[WS] Subscription binding to subscription ${subscriptionId} for this WebSocket is missing`);
       continue;
@@ -140,61 +178,83 @@ export async function handleR4SubscriptionConnection(socket: ws.WebSocket): Prom
   const redis = getRedis();
   let onDisconnect: (() => Promise<void>) | undefined;
 
-  const onBind = async (tokenPayload: JWTPayload & Partial<AdditionalWsBindingClaims>): Promise<void> => {
-    const subscriptionId = tokenPayload?.subscription_id;
-    if (!subscriptionId) {
+  const verifyWsToken = async (token: string): Promise<WebSocketSubToken | undefined> => {
+    let tokenPayload: JWTPayload;
+    try {
+      const { payload } = await verifyJwt(token);
+      tokenPayload = payload;
+    } catch (err) {
+      globalLogger.warn(`[WS]: Error occurred while verifying client message token: ${normalizeErrorString(err)}`);
+      socket.send(JSON.stringify(badRequest('Token failed to validate. Check token expiry.')));
+      return undefined;
+    }
+
+    if (!tokenPayload?.subscription_id) {
       socket.send(
         JSON.stringify(badRequest('Token claims missing subscription_id. Make sure you are sending the correct token.'))
       );
       socket.terminate();
+      return undefined;
+    }
+    if (!tokenPayload?.login_id) {
+      socket.send(
+        JSON.stringify(badRequest('Token claims missing login_id. Make sure you are sending the correct token.'))
+      );
+      socket.terminate();
+      return undefined;
+    }
+    return tokenPayload as WebSocketSubToken;
+  };
+
+  const onBind = async (rawToken: string): Promise<void> => {
+    const verifiedToken = await verifyWsToken(rawToken);
+    if (!verifiedToken) {
+      // If no token, this was not a valid token, don't bind
       return;
     }
 
     if (!redisSubscriber) {
       await setupSubscriptionHandler();
     }
-    subscribeWsToSubscription(socket, subscriptionId);
+    subscribeWsToSubscription(socket, verifiedToken.subscription_id, rawToken);
     ensureHeartbeatHandler();
     // Send a handshake to notify client that this subscription is active for this connection
-    socket.send(JSON.stringify(createHandshakeBundle(subscriptionId)));
+    socket.send(JSON.stringify(createHandshakeBundle(verifiedToken.subscription_id)));
 
     onDisconnect = async (): Promise<void> => {
-      const subscriptionIds = wsToSubLookup.get(socket);
-      if (!subscriptionIds) {
+      const subEntries = wsToSubLookup.get(socket);
+      if (!subEntries) {
         globalLogger.warn('[WS] No entry for given WebSocket in subscription lookup');
         return;
       }
       unsubscribeWsFromAllSubscriptions(socket);
-      const cacheEntryStr = (await redis.get(`Subscription/${subscriptionId}`)) as string | null;
+      const cacheEntryStr = (await redis.get(`Subscription/${verifiedToken.subscription_id}`)) as string | null;
       if (!cacheEntryStr) {
         globalLogger.warn('[WS] Failed to retrieve subscription cache entry on WebSocket disconnect');
         return;
       }
       const cacheEntry = JSON.parse(cacheEntryStr) as CacheEntry<Subscription>;
-      await markInMemorySubscriptionsInactive(cacheEntry.projectId, subscriptionIds);
+      await markInMemorySubscriptionsInactive(cacheEntry.projectId, new Set(subEntries.keys()));
     };
   };
 
-  const onUnbind = async (tokenPayload: JWTPayload & Partial<AdditionalWsBindingClaims>): Promise<void> => {
-    const subscriptionId = tokenPayload?.subscription_id;
-    if (!subscriptionId) {
-      socket.send(
-        JSON.stringify(badRequest('Token claims missing subscription_id. Make sure you are sending the correct token.'))
-      );
-      socket.terminate();
+  const onUnbind = async (rawToken: string): Promise<void> => {
+    const verifiedToken = await verifyWsToken(rawToken);
+    if (!verifiedToken) {
+      // If no token, this was not a valid token, don't attempt unbind
       return;
     }
 
-    unsubscribeWsFromSubscription(socket, subscriptionId);
-    const cacheEntryStr = (await redis.get(`Subscription/${subscriptionId}`)) as string | null;
+    unsubscribeWsFromSubscription(socket, verifiedToken.subscription_id);
+    const cacheEntryStr = (await redis.get(`Subscription/${verifiedToken.subscription_id}`)) as string | null;
     if (!cacheEntryStr) {
       globalLogger.warn('[WS] Failed to retrieve subscription cache entry when unbinding from token', {
-        subscriptionId,
+        subscriptionId: verifiedToken.subscription_id,
       });
       return;
     }
     const cacheEntry = JSON.parse(cacheEntryStr) as CacheEntry<Subscription>;
-    await markInMemorySubscriptionsInactive(cacheEntry.projectId, new Set([subscriptionId]));
+    await markInMemorySubscriptionsInactive(cacheEntry.projectId, new Set([verifiedToken.subscription_id]));
   };
 
   socket.on('message', async (data: ws.RawData) => {
@@ -210,30 +270,20 @@ export async function handleR4SubscriptionConnection(socket: ws.WebSocket): Prom
         return;
       }
 
-      let tokenPayload: JWTPayload;
-      try {
-        const { payload } = await verifyJwt(token);
-        tokenPayload = payload;
-      } catch (err) {
-        globalLogger.warn(`[WS]: Error occurred while verifying client message token: ${normalizeErrorString(err)}`);
-        socket.send(JSON.stringify(badRequest('Token failed to validate. Check token expiry.')));
-        return;
-      }
-
       // It's actually ok to rebind or unbind to the same token...
       // Since it will essentially tell Redis to subscribe or unsubscribe to these channels
       // Which the current client is already subscribed or unsubscribed from
       switch (msg.type) {
         case 'bind-with-token':
           try {
-            await onBind(tokenPayload);
+            await onBind(token);
           } catch (err: unknown) {
             globalLogger.error(`[WS]: Error while binding with token: ${normalizeErrorString(err)}`);
           }
           break;
         case 'unbind-from-token':
           try {
-            await onUnbind(tokenPayload);
+            await onUnbind(token);
           } catch (err: unknown) {
             globalLogger.error(`[WS]: Error while unbinding from token: ${normalizeErrorString(err)}`);
           }
@@ -252,14 +302,14 @@ export async function handleR4SubscriptionConnection(socket: ws.WebSocket): Prom
 export type SubStatus = 'requested' | 'active' | 'error' | 'off';
 export type SubEventsOptions = { status?: SubStatus; includeResource?: boolean };
 
-export function createSubHeartbeatEvent(subscriptionIds: Set<string>): Bundle {
+export function createSubHeartbeatEvent(subMetadata: Map<string, WebSocketSubMetadata>): Bundle {
   const timestamp = new Date().toISOString();
   return {
     id: crypto.randomUUID(),
     resourceType: 'Bundle',
     type: 'history',
     timestamp,
-    entry: Array.from(subscriptionIds).map((subscriptionId) => ({
+    entry: Array.from(subMetadata.keys()).map((subscriptionId) => ({
       resource: {
         resourceType: 'SubscriptionStatus',
         id: crypto.randomUUID(),

--- a/packages/server/src/subscriptions/websockets.ts
+++ b/packages/server/src/subscriptions/websockets.ts
@@ -85,7 +85,7 @@ async function setupSubscriptionHandler(): Promise<void> {
           const repo = await getRepoForLogin(authState);
           rewrittenBundle = await rewriteAttachments(RewriteMode.PRESIGNED_URL, repo, bundle);
         } catch (err) {
-          globalLogger.error('[WS] Error occured while rewriting attachments', { err });
+          globalLogger.error('[WS] Error occurred while rewriting attachments', { err });
           continue;
         }
 

--- a/packages/server/src/workers/subscription.test.ts
+++ b/packages/server/src/workers/subscription.test.ts
@@ -11,7 +11,9 @@ import {
 import {
   AccessPolicy,
   AuditEvent,
+  Binary,
   Bot,
+  DocumentReference,
   Observation,
   Patient,
   ProjectMembership,
@@ -1899,6 +1901,60 @@ describe('Subscription Worker', () => {
         expect(updatedPatient).toBeDefined();
 
         await assertPromise;
+      }));
+
+    test('WebSocket Subscription -- Attachments are Rewritten', () =>
+      withTestContext(async () => {
+        const { repo: wsSubRepo } = await createTestProject({
+          withClient: true,
+          withRepo: true,
+          project: {
+            name: 'WebSocket Attachments Rewritten Project',
+            features: ['websocket-subscriptions'],
+          },
+        });
+
+        const binary = await wsSubRepo.createResource<Binary>({
+          resourceType: 'Binary',
+          contentType: ContentType.TEXT,
+        });
+
+        const subscription = await wsSubRepo.createResource<Subscription>({
+          resourceType: 'Subscription',
+          reason: 'test',
+          status: 'active',
+          criteria: `DocumentReference?location=Binary/${binary.id}`,
+          channel: {
+            type: 'websocket',
+          },
+        });
+
+        expect(subscription).toBeDefined();
+        expect(subscription.id).toBeDefined();
+
+        const nextArgsPromise = waitForNextSubNotification<DocumentReference>();
+        const documentRef = await wsSubRepo.createResource<DocumentReference>({
+          resourceType: 'DocumentReference',
+          status: 'current',
+          content: [
+            {
+              attachment: {
+                url: `Binary/${binary.id}`,
+              },
+            },
+          ],
+        });
+        expect(documentRef).toBeDefined();
+
+        const notificationArgs = await nextArgsPromise;
+        expect(notificationArgs).toMatchObject<EventNotificationArgs<DocumentReference>>([
+          expect.objectContaining({
+            ...documentRef,
+            content: [{ attachment: { url: expect.stringContaining('?Expires=') } }],
+          }),
+          subscription.id,
+          { includeResource: true },
+        ]);
       }));
   });
 });

--- a/packages/server/src/workers/subscription.ts
+++ b/packages/server/src/workers/subscription.ts
@@ -263,8 +263,6 @@ export async function addSubscriptionJobs(
         continue;
       }
       if (subscription.channel.type === 'websocket') {
-        // We use the resource with rewritten attachments here since we want subscribers to get the resource with the same attachment URLs
-        // They would get if they did a search
         wsEvents.push([resource, subscription.id, { includeResource: true }]);
         continue;
       }


### PR DESCRIPTION
Currently subscriptions send back resources that have not had their attachment URLs rewritten to presigned URLs. This is because we currently only rewrite attachments just before we send back a FHIR response when it comes to your average case. Because we take a different path for subscriptions, we send back the Binary reference version of the attachment URLs. This PR makes it so that we rewrite resource attachment URLs just before sending the subscription notification for both WebSocket subscription and rest hook subscription cases.