### PR TITLE
Removed 'any' from fhir operation param utils

### DIFF
--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -20,6 +20,7 @@ import {
   getPropertyDisplayName,
   isReference,
   isResource,
+  isTypedValue,
   stringifyTypedValue,
 } from './types';
 
@@ -86,6 +87,15 @@ describe('Type Utils', () => {
 
     // shoudl NOT be found
     expect(getElementDefinitionFromElements(elements, 'notreal')).toBeUndefined();
+  });
+
+  test('isTypedValue', () => {
+    expect(isTypedValue(undefined)).toBe(false);
+    expect(isTypedValue(null)).toBe(false);
+    expect(isTypedValue('Patient')).toBe(false);
+    expect(isTypedValue({})).toBe(false);
+    expect(isTypedValue({ type: 'string', value: 'foo' })).toBe(true);
+    expect(isTypedValue({ type: 'string' })).toBe(false);
   });
 
   test('isResource', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -418,6 +418,15 @@ export function getElementDefinitionFromElements(
 }
 
 /**
+ * Returns true if the value is a TypedValue.
+ * @param value - The unknown value to check.
+ * @returns True if the value is a TypedValue.
+ */
+export function isTypedValue(value: unknown): value is TypedValue {
+  return !!(value && typeof value === 'object' && 'type' in value && 'value' in value);
+}
+
+/**
  * Type guard to validate that an object is a FHIR resource
  * @param value - The object to check
  * @param resourceType - Checks that the resource is of the given type

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -5,6 +5,7 @@ import {
   flatMapFilter,
   isEmpty,
   isResource,
+  isTypedValue,
   validateResource,
 } from '@medplum/core';
 import { FhirRequest } from '@medplum/fhir-router';
@@ -36,7 +37,7 @@ export function parseParameters<T>(input: T | Parameters): T {
  */
 export function parseInputParameters<T>(operation: OperationDefinition, req: Request | FhirRequest): T {
   if (!operation.parameter) {
-    return {} as any;
+    return {} as T;
   }
   const inputParameters = operation.parameter.filter((p) => p.use === 'in');
 
@@ -46,21 +47,21 @@ export function parseInputParameters<T>(operation: OperationDefinition, req: Req
 
   if (input.resourceType === 'Parameters') {
     if (!input.parameter) {
-      return {} as any;
+      return {} as T;
     }
     validateResource(input as Parameters);
-    return parseParams(inputParameters, input.parameter) as any;
+    return parseParams(inputParameters, input.parameter) as T;
   } else {
     return Object.fromEntries(
       inputParameters.map((param) => [param.name, validateInputParam(param, input[param.name as string])])
-    ) as any;
+    ) as T;
   }
 }
 
 function parseQueryString(
-  query: Record<string, any> | undefined,
+  query: Record<string, unknown> | undefined,
   inputParams: OperationDefinitionParameter[]
-): Record<string, any> {
+): Record<string, unknown> {
   const parsed = Object.create(null);
   if (!query) {
     return parsed;
@@ -85,7 +86,14 @@ function parseQueryString(
   return parsed;
 }
 
-function parseStringifiedParameter(value: string, param: OperationDefinitionParameter): number | boolean | string {
+function parseStringifiedParameter(
+  value: unknown,
+  param: OperationDefinitionParameter
+): number | boolean | string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
   switch (param.type) {
     case 'integer':
     case 'positiveInt':
@@ -119,7 +127,7 @@ function parseStringifiedParameter(value: string, param: OperationDefinitionPara
   throw new OperationOutcomeError(badRequest(`Invalid value '${value}' provided for ${param.type} parameter`));
 }
 
-function validateInputParam(param: OperationDefinitionParameter, value: any): any {
+function validateInputParam(param: OperationDefinitionParameter, value: unknown): unknown {
   // Check parameter cardinality (min and max)
   const min = param.min ?? 0;
   const max = parseInt(param.max ?? '1', 10);
@@ -145,26 +153,26 @@ function validateInputParam(param: OperationDefinitionParameter, value: any): an
 function parseParams(
   params: OperationDefinitionParameter[],
   inputParameters: ParametersParameter[]
-): Record<string, any> {
-  const parsed: Record<string, any> = Object.create(null);
+): Record<string, unknown> {
+  const parsed: Record<string, unknown> = Object.create(null);
   for (const param of params) {
     // FHIR spec-compliant case: Parameters resource e.g.
     // { resourceType: 'Parameters', parameter: [{ name: 'message', valueString: 'Hello!' }] }
     const inParams = inputParameters.filter((p) => p.name === param.name);
-    let value: any;
+    let value: unknown;
     if (param.part?.length) {
       value = inParams.map((input) => parseParams(param.part as [], input.part ?? []));
     } else {
       value = inParams?.map((v) => v[('value' + capitalize(param.type ?? 'string')) as keyof ParametersParameter]);
     }
 
-    parsed[param.name as string] = validateInputParam(param, value);
+    parsed[param.name] = validateInputParam(param, value);
   }
 
   return parsed;
 }
 
-export function buildOutputParameters(operation: OperationDefinition, output: any): Parameters {
+export function buildOutputParameters(operation: OperationDefinition, output: object | undefined): Parameters {
   const outputParameters = operation.parameter?.filter((p) => p.use === 'out');
   const param1 = outputParameters?.[0];
   if (outputParameters?.length === 1 && param1 && param1.name === 'return') {
@@ -186,7 +194,7 @@ export function buildOutputParameters(operation: OperationDefinition, output: an
   response.parameter = [];
   for (const param of outputParameters) {
     const key = param.name ?? '';
-    const value = output[key];
+    const value = (output as Record<string, unknown> | undefined)?.[key];
     const count = Array.isArray(value) ? value.length : +(value !== undefined);
 
     if (param.min && param.min > 0 && count < param.min) {
@@ -215,12 +223,12 @@ export function buildOutputParameters(operation: OperationDefinition, output: an
   return response;
 }
 
-function makeParameter(param: OperationDefinitionParameter, value: any): ParametersParameter | undefined {
-  if (param.part) {
+function makeParameter(param: OperationDefinitionParameter, value: unknown): ParametersParameter | undefined {
+  if (param.part && value && typeof value === 'object') {
     // Handle nested parameters by flattening dictionary object value
     const parts: ParametersParameter[] = [];
     for (const part of param.part) {
-      const nestedValue = value[part.name ?? ''];
+      const nestedValue = (value as Record<string, unknown>)[part.name ?? ''];
       if (nestedValue !== undefined) {
         const nestedParam = makeParameter(part, nestedValue);
         if (nestedParam) {
@@ -235,7 +243,7 @@ function makeParameter(param: OperationDefinitionParameter, value: any): Paramet
   const type = getParameterType(param);
   if (type?.length === 1) {
     return { name: param.name, ['value' + capitalize(type[0])]: value };
-  } else if (typeof value.type === 'string' && value.value !== undefined && type?.length) {
+  } else if (isTypedValue(value) && value.value !== undefined && type?.length) {
     // Handle TypedValue
     for (const t of type) {
       if (value.type === t) {


### PR DESCRIPTION
I was doing some work inside `parameters.ts` and got a little lost with `any` params, so I tried to tighten it up by changing `any` to `unknown` everywhere.

It turns out that I was on a dead end (I was going to add `Reference` to stringified GET param parsing, but that's not valid).  So this is all unnecessary.

But maybe the cleanup is nice?  

Should not be any changes to functionality.