### PR TITLE
Updating Password Reset Example Bot docs

### DIFF
--- a/packages/docs/docs/api/fhir/medplum/passwordchangerequest.mdx
+++ b/packages/docs/docs/api/fhir/medplum/passwordchangerequest.mdx
@@ -11,7 +11,7 @@ import { ResourcePropertiesTable, SearchParamsTable } from '@site/src/components
 
 # PasswordChangeRequest
 
-@deprecated Password change request for the 'forgot password' flow. Use UserSecurityCheck instead.
+@deprecated Password change request for the 'forgot password' flow. Use UserSecurityRequest instead.
 
 <Tabs queryString="section">
   <TabItem value="schema" label="Schema" default>

--- a/packages/examples/src/auth/custom-emails.ts
+++ b/packages/examples/src/auth/custom-emails.ts
@@ -36,7 +36,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<UserSecuri
   // Learn more: https://nodemailer.com/extras/mailcomposer/
 
   if (pcr.type === 'invite') {
-    // This PasswordChangeRequest was created as part of a new user invite flow.
+    // This UserSecurityRequest was created as part of a new user invite flow.
     // Send a Welcome email to the user.
     await medplum.sendEmail({
       to: email,

--- a/packages/examples/src/auth/custom-emails.ts
+++ b/packages/examples/src/auth/custom-emails.ts
@@ -55,7 +55,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<UserSecuri
     });
   } else {
     // This UserSecurityRequest was created as part of a password reset flow.
-    // Send a Password Reset email to the user. 
+    // Send a Password Reset email to the user.
     await medplum.sendEmail({
       to: email,
       subject: 'Example Health Password Reset',

--- a/packages/examples/src/auth/custom-emails.ts
+++ b/packages/examples/src/auth/custom-emails.ts
@@ -1,15 +1,15 @@
 // start-block customEmails
 import { BotEvent, getDisplayString, getReferenceString, MedplumClient, ProfileResource } from '@medplum/core';
-import { PasswordChangeRequest, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import { UserSecurityRequest, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
 
-export async function handler(medplum: MedplumClient, event: BotEvent<PasswordChangeRequest>): Promise<any> {
-  // This Bot executes on every new PasswordChangeRequest resource.
-  // PasswordChangeRequest resources are created when a new user registers or is invited to a project.
-  // PasswordChangeRequest resources are only available to project administrators.
+export async function handler(medplum: MedplumClient, event: BotEvent<UserSecurityRequest>): Promise<any> {
+  // This Bot executes on every new UserSecurityRequest resource.
+  // UserSecurityRequest resources are created when a new user registers or is invited to a project.
+  // UserSecurityRequest resources are only available to project administrators.
   // Therefore, this Bot must be configured as a project admin.
   const pcr = event.input;
 
-  // Get the user from the PasswordChangeRequest.
+  // Get the user from the UserSecurityRequest.
   const user = await medplum.readReference(pcr.user as Reference<User>);
 
   // Get the project membership for the user.
@@ -54,8 +54,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent<PasswordCh
       ].join('\n'),
     });
   } else {
-    // This PasswordChangeRequest was created as part of a password reset flow.
-    // Send a Password Reset email to the user.
+    // This UserSecurityRequest was created as part of a password reset flow.
+    // Send a Password Reset email to the user. 
     await medplum.sendEmail({
       to: email,
       subject: 'Example Health Password Reset',


### PR DESCRIPTION
- It was previously confusing for customers to use the deprecated PasswordChangeRequest
- The recommendation is now to use UserSecurityRequest
