### PR TITLE
Update README and LaunchPage for EHR launch instructions and navigation fixes

### DIFF
--- a/examples/medplum-smart-on-fhir-demo/README.md
+++ b/examples/medplum-smart-on-fhir-demo/README.md
@@ -73,7 +73,8 @@ To test the EHR launch flow, you'll need to:
 
 1. Register your app in the Medplum App
 2. Configure your EHR launch URL as: `http://localhost:8001/launch`
-3. Launch the app from your EHR system using the SMART on FHIR app launcher
+3. Open up [config.ts](./src/config.ts) and set `MEDPLUM_CLIENT_ID` to the `ClientApplication.id` of the
+4. Launch the app from your EHR system using the SMART on FHIR app launcher
 
 For detailed instructions on setting up SMART on FHIR apps with Medplum, see the [SMART App Launch Guide](https://www.medplum.com/docs/integration/smart-app-launch) in the Medplum documentation. Set the launch URI to `http://localhost:8001/launch` and the redirect URI to `http://localhost:8001/launch`.
 

--- a/examples/medplum-smart-on-fhir-demo/src/pages/LaunchPage.tsx
+++ b/examples/medplum-smart-on-fhir-demo/src/pages/LaunchPage.tsx
@@ -2,7 +2,7 @@ import { Container, Loader, Text } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { useMedplumContext } from '@medplum/react';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { FHIR_SCOPE, MEDPLUM_CLIENT_ID, SMART_HEALTH_IT_CLIENT_ID } from '../config';
 
 interface SmartConfiguration {
@@ -179,7 +179,7 @@ export function LaunchPage(): JSX.Element {
         setupMedplumClient(tokenData, iss, medplumContext);
 
         // Redirect to patient page
-        navigate('/patient');
+        navigate('/patient')?.catch(console.error);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
       }

--- a/examples/medplum-smart-on-fhir-demo/src/pages/LaunchPage.tsx
+++ b/examples/medplum-smart-on-fhir-demo/src/pages/LaunchPage.tsx
@@ -2,7 +2,7 @@ import { Container, Loader, Text } from '@mantine/core';
 import { MedplumClient } from '@medplum/core';
 import { useMedplumContext } from '@medplum/react';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import { FHIR_SCOPE, MEDPLUM_CLIENT_ID, SMART_HEALTH_IT_CLIENT_ID } from '../config';
 
 interface SmartConfiguration {
@@ -76,7 +76,6 @@ async function initiateEhrLaunch(params: URLSearchParams): Promise<never> {
     state,
     aud: iss,
     launch: launch as string,
-    prompt: 'none',
   });
 
   const url = new URL(config.authorization_endpoint);
@@ -180,7 +179,7 @@ export function LaunchPage(): JSX.Element {
         setupMedplumClient(tokenData, iss, medplumContext);
 
         // Redirect to patient page
-        navigate('/patient')?.catch(console.error);
+        navigate('/patient');
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error');
       }

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -130,8 +130,8 @@ export function sendLoginCookie(res: Response, login: Login): void {
     res.cookie(cookieName, login.cookie as string, {
       maxAge: 3600 * 1000,
       sameSite: 'none',
-      // secure: true,
-      // httpOnly: true,
+      secure: true,
+      httpOnly: true,
     });
   }
 }

--- a/packages/server/src/auth/utils.ts
+++ b/packages/server/src/auth/utils.ts
@@ -130,8 +130,8 @@ export function sendLoginCookie(res: Response, login: Login): void {
     res.cookie(cookieName, login.cookie as string, {
       maxAge: 3600 * 1000,
       sameSite: 'none',
-      secure: true,
-      httpOnly: true,
+      // secure: true,
+      // httpOnly: true,
     });
   }
 }


### PR DESCRIPTION
- Revised README.md to clarify configuration steps for EHR launch, including setting the MEDPLUM_CLIENT_ID.
- Updated LaunchPage.tsx to use 'react-router-dom' for navigation and removed unnecessary prompt parameter in the launch initiation. This forces a 2nd login when lauched from the Medplum App, but allows the app to be functional