### PR TITLE
Export multiple resource types from app search page

### DIFF
--- a/packages/app/src/HomePage.utils.ts
+++ b/packages/app/src/HomePage.utils.ts
@@ -121,10 +121,9 @@ export function saveLastSearch(search: SearchRequest): void {
 
 export async function getTransactionBundle(search: SearchRequest, medplum: MedplumClient): Promise<Bundle> {
   const transactionBundleSearch: SearchRequest = {
-    resourceType: search.resourceType,
+    ...search,
     count: 1000,
     offset: 0,
-    filters: search.filters,
   };
   const transactionBundleSearchValues = addSearchValues(transactionBundleSearch, medplum.getUserConfiguration());
   const bundle = await medplum.search(

--- a/packages/core/src/bundle.test.ts
+++ b/packages/core/src/bundle.test.ts
@@ -219,6 +219,34 @@ describe('Bundle tests', () => {
       });
     });
 
+    test('Remove empty resource.meta', () => {
+      const patient: Patient = {
+        resourceType: 'Patient',
+        meta: {
+          project: '11111111-2222-3333-4444-555555555555',
+        },
+        active: true,
+      };
+
+      const inputBundle: Bundle = {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [
+          {
+            fullUrl: 'https://example.com/Patient/00000000-0000-0000-0000-000000000000',
+            resource: patient,
+          },
+        ],
+      };
+
+      const result = convertToTransactionBundle(inputBundle);
+
+      // meta.project will be removed
+      // so meta will be empty
+      // and therefore should be removed
+      expect(result?.entry?.[0]?.resource?.meta).toBeUndefined();
+    });
+
     test('Preserve resource.meta', () => {
       const patient: Patient = {
         resourceType: 'Patient',

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -17,14 +17,21 @@ export function convertToTransactionBundle(bundle: Bundle): Bundle {
   const idToUuid: Record<string, string> = {};
   bundle = deepClone(bundle);
   for (const entry of bundle.entry || []) {
-    if (entry.resource?.meta !== undefined) {
-      delete entry.resource.meta.author;
-      delete entry.resource.meta.compartment;
-      delete entry.resource.meta.lastUpdated;
-      delete entry.resource.meta.project;
-      delete entry.resource.meta.versionId;
+    const resource = entry.resource;
+    if (!resource) {
+      continue;
     }
-    const id = entry.resource?.id;
+    if (resource.meta !== undefined) {
+      delete resource.meta.author;
+      delete resource.meta.compartment;
+      delete resource.meta.lastUpdated;
+      delete resource.meta.project;
+      delete resource.meta.versionId;
+      if (Object.keys(resource.meta).length === 0) {
+        delete resource.meta;
+      }
+    }
+    const id = resource?.id;
     if (id) {
       idToUuid[id] = generateId();
 
@@ -37,9 +44,9 @@ export function convertToTransactionBundle(bundle: Bundle): Bundle {
     {
       resourceType: 'Bundle',
       type: 'transaction',
-      entry: input?.map((entry: any) => ({
+      entry: input?.map((entry: BundleEntry) => ({
         fullUrl: entry.fullUrl,
-        request: { method: 'POST', url: entry.resource.resourceType },
+        request: { method: 'POST', url: entry.resource?.resourceType },
         resource: entry.resource,
       })),
     },

--- a/packages/core/src/search/search.test.ts
+++ b/packages/core/src/search/search.test.ts
@@ -384,6 +384,12 @@ describe('Search Utils', () => {
     ).toStrictEqual('?code:not=x');
   });
 
+  test('Format types', () => {
+    expect(formatSearchQuery({ resourceType: 'Patient', types: ['Patient', 'Practitioner', 'Organization'] })).toEqual(
+      '?_type=Patient,Practitioner,Organization'
+    );
+  });
+
   const maritalStatus = 'http://terminology.hl7.org/CodeSystem/v3-MaritalStatus';
   test('Format _include', () => {
     expect(

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -500,6 +500,10 @@ export function formatSearchQuery(definition: SearchRequest): string {
     params.push('_total=' + definition.total);
   }
 
+  if (definition.types && definition.types.length > 0) {
+    params.push('_type=' + definition.types.join(','));
+  }
+
   if (definition.include) {
     definition.include.forEach((target) => params.push(formatIncludeTarget('_include', target)));
   }

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -350,7 +350,7 @@ function getBaseSelectQuery(
     }
     builder = new SelectQuery('combined', new Union(...queries));
     if (opts?.addColumns ?? true) {
-      builder.column('id').column('content');
+      builder.column('id').column('lastUpdated').column('content');
     }
   } else {
     builder = getBaseSelectQueryForResourceType(repo, searchRequest.resourceType, searchRequest, opts);
@@ -368,7 +368,10 @@ function getBaseSelectQueryForResourceType(
   const addColumns = opts?.addColumns !== false;
   const idColumn = new Column(resourceType, 'id');
   if (addColumns) {
-    builder.column(idColumn).column(new Column(resourceType, 'content'));
+    builder
+      .column(idColumn)
+      .column(new Column(resourceType, 'lastUpdated'))
+      .column(new Column(resourceType, 'content'));
   }
   if (opts?.maxResourceVersion !== undefined) {
     const col = new Column(resourceType, '__version');
@@ -792,7 +795,7 @@ async function getAccurateCount(repo: Repository, searchRequest: SearchRequest):
   if (builder.joins.length > 0) {
     builder.raw(`COUNT (DISTINCT "${searchRequest.resourceType}"."id")::int AS "count"`);
   } else {
-    builder.raw('COUNT("id")::int AS "count"');
+    builder.raw('COUNT(*)::int AS "count"');
   }
 
   const rows = await builder.execute(repo.getDatabaseClient(DatabaseMode.READER));

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -26,7 +26,7 @@ jest.mock('pg', () => {
       if (sql === 'SELECT "version" FROM "DatabaseMigration"') {
         return { rows: [{ version: 1000000 }] };
       }
-      if (sql === 'SELECT "User"."id", "User"."content" FROM "User" WHERE "User"."deleted" = $1 LIMIT 2') {
+      if (sql.startsWith('SELECT "User"."id"')) {
         return { rows: [{ id: '1', content: '{}' }] };
       }
       if (sql === 'SELECT pg_try_advisory_lock($1)') {


### PR DESCRIPTION
I was trying to export multiple resource types from the `app` home page using the `_types` param, and found a bunch of little blockers.

1. The "Export as Transaction Bundle" feature dropped a bunch of search request properties, including `_types`
2. Using `formatSearchRequest()` dropped the `_types` param
3. Using `_lastUpdated` (which is valid) resulted in an error because the `lastUpdated` column was not in the `UNION` query
4. Using `_total` (which is valid) resulted in an error because we referenced the `id` column which was not in the `UNION` query

Other drive by fixes:

* Delete `meta` when empty
* Include nested `cause` error when re-throwing database errors for better stack traces

After that, you can export multiple types.  For example:

http://localhost:3000/Patient?_count=1000&_type=Patient,Practitioner,Organization,PractitionerRole,Device,Location,DeviceUseStatement,Condition,ServiceRequest,Observation,DiagnosticReport,Immunization,AllergyIntolerance,Procedure,ClinicalImpression,MedicationRequest,CarePlan,Goal

This is nice, because it gives us a single transaction `Bundle`.

For context, I was trying to build a `Bundle` for the 3 ONC test patients.  At first I was using `Patient/$everything`, but then you have multiple copies of the same `Organization`, `Practitioner`, `Location`, etc.

Using `Project/$export` could have been valid, but that produces a NDJSON file, which is more annoying to work with.