### PR TITLE
GCP blob storage support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9601,6 +9601,37 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
+      "integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/secret-manager": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.0.1.tgz",
@@ -9611,6 +9642,250 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.15.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.15.2.tgz",
+      "integrity": "sha512-+2k+mcQBb9zkaXMllf2wwR/rI07guAx+eZLWsGTDihW2lJRGfiqB7xu1r7/s4uvSP/T+nAumvzT5TTscwHKJ9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^4.4.1",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@graphiql/react": {
@@ -20429,6 +20704,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/asap": {
@@ -31362,7 +31646,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.3.tgz",
       "integrity": "sha512-D3AfvN7SjhTgBSA8L1BN4FpPzuEd06uy4lHwSoRWr0lndi9BKaNzPLKGOWZ2ocSGguozr08TTb2jhCLHaemruw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -54524,6 +54807,7 @@
         "@azure/keyvault-secrets": "4.9.0",
         "@azure/storage-blob": "12.27.0",
         "@google-cloud/secret-manager": "6.0.1",
+        "@google-cloud/storage": "7.15.2",
         "@medplum/ccda": "4.0.4",
         "@medplum/core": "4.0.4",
         "@medplum/definitions": "4.0.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "@azure/keyvault-secrets": "4.9.0",
     "@azure/storage-blob": "12.27.0",
     "@google-cloud/secret-manager": "6.0.1",
+    "@google-cloud/storage": "7.15.2",
     "@medplum/ccda": "4.0.4",
     "@medplum/core": "4.0.4",
     "@medplum/definitions": "4.0.4",

--- a/packages/server/src/__mocks__/@google-cloud/storage.ts
+++ b/packages/server/src/__mocks__/@google-cloud/storage.ts
@@ -1,0 +1,15 @@
+import { PassThrough } from 'stream';
+
+export const Storage = jest.fn().mockImplementation(() => ({
+  bucket: jest.fn().mockImplementation(() => ({
+    file: jest.fn().mockImplementation(() => ({
+      createWriteStream: jest.fn().mockReturnValue(new PassThrough()),
+      createReadStream: jest.fn().mockImplementation(() => {
+        const stream = new PassThrough();
+        stream.end('Hello, world!');
+        return stream;
+      }),
+      getSignedUrl: jest.fn().mockResolvedValue(['https://example.com/signed-url']),
+    })),
+  })),
+}));

--- a/packages/server/src/cloud/gcp/storage.test.ts
+++ b/packages/server/src/cloud/gcp/storage.test.ts
@@ -1,0 +1,34 @@
+import { Binary } from '@medplum/fhirtypes';
+import { PassThrough } from 'stream';
+import { GoogleCloudStorage } from './storage';
+
+describe('Integration Tests for GoogleCloudStorage', () => {
+  const testStorageString = 'your-project-id:your-test-bucket';
+  const storage = new GoogleCloudStorage(testStorageString);
+  const testBinary: Binary = {
+    id: 'test123',
+    meta: { versionId: 'v1' },
+    resourceType: 'Binary', // Added resourceType
+    contentType: 'text/plain', // Added contentType
+  };
+
+  test('should write and then read a binary file', async () => {
+    const content = 'Hello, world!';
+    const contentStream = new PassThrough();
+    contentStream.end(content);
+
+    await storage.writeBinary(testBinary, 'test.txt', 'text/plain', contentStream);
+
+    const readStream = await storage.readBinary(testBinary);
+    let data = '';
+    for await (const chunk of readStream) {
+      data += chunk;
+    }
+    expect(data).toEqual(content);
+  });
+
+  test('should generate a valid signed URL', async () => {
+    const url = await storage.getPresignedUrl(testBinary);
+    expect(url).toContain('https://');
+  });
+});

--- a/packages/server/src/cloud/gcp/storage.ts
+++ b/packages/server/src/cloud/gcp/storage.ts
@@ -1,0 +1,52 @@
+import { Storage } from '@google-cloud/storage';
+import { Binary } from '@medplum/fhirtypes';
+import { IncomingMessage } from 'http';
+import { Readable } from 'stream';
+import { BaseBinaryStorage } from '../../storage/base';
+import { BinarySource } from '../../storage/types';
+
+export class GoogleCloudStorage extends BaseBinaryStorage {
+  private readonly storage: Storage;
+  private readonly bucket;
+
+  constructor(bucketName: string) {
+    super();
+    this.storage = new Storage();
+    this.bucket = this.storage.bucket(bucketName);
+  }
+
+  async writeFile(key: string, contentType: string | undefined, stream: BinarySource): Promise<void> {
+    const file = this.bucket.file(key);
+    return new Promise((resolve, reject) => {
+      const writeStream = file.createWriteStream({
+        metadata: { contentType: contentType ?? 'application/octet-stream' },
+        resumable: false,
+      });
+      (stream as IncomingMessage)
+        .pipe(writeStream)
+        .on('finish', () => resolve())
+        .on('error', (err: any) => reject(err));
+    });
+  }
+
+  async readFile(key: string): Promise<Readable> {
+    const file = this.bucket.file(key);
+    return file.createReadStream();
+  }
+
+  async copyFile(sourceKey: string, destinationKey: string): Promise<void> {
+    const sourceFile = this.bucket.file(sourceKey);
+    const destinationFile = this.bucket.file(destinationKey);
+    await sourceFile.copy(destinationFile);
+  }
+
+  async getPresignedUrl(binary: Binary): Promise<string> {
+    const file = this.bucket.file(this.getKey(binary));
+    const options = {
+      action: 'read' as const,
+      expires: Date.now() + 3600 * 1000,
+    };
+    const [url] = await file.getSignedUrl(options);
+    return url;
+  }
+}

--- a/packages/server/src/storage/loader.ts
+++ b/packages/server/src/storage/loader.ts
@@ -1,5 +1,6 @@
 import { S3Storage } from '../cloud/aws/storage';
 import { AzureBlobStorage } from '../cloud/azure/storage';
+import { GoogleCloudStorage } from '../cloud/gcp/storage';
 import { FileSystemStorage } from './filesystem';
 import { BinaryStorage } from './types';
 
@@ -12,6 +13,8 @@ export function initBinaryStorage(type?: string): void {
     binaryStorage = new AzureBlobStorage(type.replace('azure:', ''));
   } else if (type?.startsWith('file:')) {
     binaryStorage = new FileSystemStorage(type.replace('file:', ''));
+  } else if (type?.startsWith('gs:')) {
+    binaryStorage = new GoogleCloudStorage(type.replace('gs:', ''));
   } else {
     binaryStorage = undefined;
   }


### PR DESCRIPTION
Thank you @TheLuisZencore for putting together the initial implementation.

This adds Google Cloud Storage as a binary storage target.

Usage: Set `binaryStorage` to `gs:[bucket name]`