### PR TITLE
Fixes #6232 - filter export by care date

### DIFF
--- a/packages/server/src/fhir/operations/patienteverything.ts
+++ b/packages/server/src/fhir/operations/patienteverything.ts
@@ -23,6 +23,7 @@ import { getAuthenticatedContext } from '../../context';
 import { getPatientCompartments } from '../patient';
 import { Repository } from '../repo';
 import { getOperationDefinition } from './definitions';
+import { filterByCareDate } from './utils/caredate';
 import { parseInputParameters } from './utils/parameters';
 
 const operation = getOperationDefinition('Patient', 'everything');
@@ -88,14 +89,6 @@ export async function getPatientEverything(
     },
   ];
 
-  if (params?.start) {
-    filters.push({ code: '_lastUpdated', operator: Operator.GREATER_THAN_OR_EQUALS, value: params.start });
-  }
-
-  if (params?.end) {
-    filters.push({ code: '_lastUpdated', operator: Operator.LESS_THAN_OR_EQUALS, value: params.end });
-  }
-
   if (params?._since) {
     filters.push({ code: '_lastUpdated', operator: Operator.GREATER_THAN_OR_EQUALS, value: params._since });
   }
@@ -108,6 +101,9 @@ export async function getPatientEverything(
     count: params?._count ?? defaultMaxResults,
     offset: params?._offset,
   });
+
+  // Filter by requested date range
+  filterByCareDate(bundle, params?.start, params?.end);
 
   // Recursively resolve references
   await addResolvedReferences(repo, bundle.entry);

--- a/packages/server/src/fhir/operations/utils/caredate.test.ts
+++ b/packages/server/src/fhir/operations/utils/caredate.test.ts
@@ -1,0 +1,102 @@
+import { deepClone, WithId } from '@medplum/core';
+import { Bundle, CodeableConcept, Device, Patient, Reference, Resource } from '@medplum/fhirtypes';
+import { filterByCareDate } from './caredate';
+
+describe('Care Date Utils', () => {
+  test('filterByCareDate', () => {
+    const date = '2015-06-22';
+    const dateTime = '2015-06-22T12:00:00Z';
+    const code: CodeableConcept = { text: 'Test' };
+    const device: Reference<Device> = { reference: 'Device/123' };
+    const patient: Reference<Patient> = { reference: 'Patient/123' };
+    const subject = patient;
+    const status = 'completed';
+    const intent = 'order';
+
+    const resources: Resource[] = [
+      { resourceType: 'AllergyIntolerance', patient, recordedDate: dateTime },
+      { resourceType: 'CarePlan', subject, status, intent, created: dateTime },
+      { resourceType: 'ClinicalImpression', status, subject, date: dateTime },
+      { resourceType: 'Condition', subject, onsetDateTime: dateTime },
+      { resourceType: 'DeviceUseStatement', status, subject, device, recordedOn: dateTime },
+      { resourceType: 'DiagnosticReport', status: 'final', code, issued: dateTime },
+      { resourceType: 'Encounter', class: code, status: 'finished', period: { start: dateTime } },
+      { resourceType: 'Goal', lifecycleStatus: 'completed', description: code, subject, startDate: date },
+      { resourceType: 'Immunization', status, vaccineCode: code, patient, occurrenceDateTime: dateTime },
+      { resourceType: 'MedicationRequest', status, intent, subject, authoredOn: dateTime },
+      { resourceType: 'Observation', status: 'final', code, issued: dateTime },
+      { resourceType: 'Procedure', status, subject, performedDateTime: dateTime },
+      { resourceType: 'ServiceRequest', status, intent, subject, occurrenceDateTime: dateTime },
+    ];
+
+    const bundle = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: resources.map((r) => ({ resource: { id: '123', ...r } })),
+    } satisfies Bundle<WithId<Resource>>;
+
+    const bundle1 = deepClone(bundle);
+    filterByCareDate(bundle1, '2010-01-01', '2015-06-22');
+    expect(bundle1.entry).toHaveLength(0);
+
+    const bundle2 = deepClone(bundle);
+    filterByCareDate(bundle2, '2015-06-21', '2015-06-23');
+    expect(bundle2.entry).toHaveLength(resources.length);
+
+    const bundle3 = deepClone(bundle);
+    filterByCareDate(bundle3, '2015-06-23', '2025-03-25');
+    expect(bundle3.entry).toHaveLength(0);
+
+    const bundle4 = deepClone(bundle);
+    filterByCareDate(bundle4, undefined, undefined);
+    expect(bundle4.entry).toHaveLength(resources.length);
+  });
+
+  test('empty bundle', () => {
+    const bundle: Bundle<WithId<Resource>> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+    };
+    filterByCareDate(bundle, '2010-01-01', '2015-06-22');
+    expect(bundle.entry).toBeUndefined();
+  });
+
+  test('missing date', () => {
+    const bundle: Bundle<WithId<Resource>> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [{ resource: { resourceType: 'AllergyIntolerance', id: '123', patient: { reference: 'Patient/123' } } }],
+    };
+    filterByCareDate(bundle, '2010-01-01', '2015-06-22');
+    expect(bundle.entry).toHaveLength(1);
+  });
+
+  test('malformed date', () => {
+    const bundle: Bundle<WithId<Resource>> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [
+        {
+          resource: {
+            resourceType: 'AllergyIntolerance',
+            id: '123',
+            patient: { reference: 'Patient/123' },
+            recordedDate: '!',
+          },
+        },
+      ],
+    };
+    filterByCareDate(bundle, '2010-01-01', '2015-06-22');
+    expect(bundle.entry).toHaveLength(1);
+  });
+
+  test('missing expression', () => {
+    const bundle: Bundle<WithId<Resource>> = {
+      resourceType: 'Bundle',
+      type: 'searchset',
+      entry: [{ resource: { resourceType: 'Patient', id: '123' } }],
+    };
+    filterByCareDate(bundle, '2010-01-01', '2015-06-22');
+    expect(bundle.entry).toHaveLength(1);
+  });
+});

--- a/packages/server/src/fhir/operations/utils/caredate.test.ts
+++ b/packages/server/src/fhir/operations/utils/caredate.test.ts
@@ -17,7 +17,7 @@ describe('Care Date Utils', () => {
       { resourceType: 'AllergyIntolerance', patient, recordedDate: dateTime },
       { resourceType: 'CarePlan', subject, status, intent, created: dateTime },
       { resourceType: 'ClinicalImpression', status, subject, date: dateTime },
-      { resourceType: 'Condition', subject, onsetDateTime: dateTime },
+      { resourceType: 'Condition', subject, recordedDate: dateTime },
       { resourceType: 'DeviceUseStatement', status, subject, device, recordedOn: dateTime },
       { resourceType: 'DiagnosticReport', status: 'final', code, issued: dateTime },
       { resourceType: 'Encounter', class: code, status: 'finished', period: { start: dateTime } },

--- a/packages/server/src/fhir/operations/utils/caredate.test.ts
+++ b/packages/server/src/fhir/operations/utils/caredate.test.ts
@@ -36,15 +36,15 @@ describe('Care Date Utils', () => {
     } satisfies Bundle<WithId<Resource>>;
 
     const bundle1 = deepClone(bundle);
-    filterByCareDate(bundle1, '2010-01-01', '2015-06-22');
+    filterByCareDate(bundle1, '2010-01-01T00:00:00Z', '2015-06-22T00:00:00Z');
     expect(bundle1.entry).toHaveLength(0);
 
     const bundle2 = deepClone(bundle);
-    filterByCareDate(bundle2, '2015-06-21', '2015-06-23');
+    filterByCareDate(bundle2, '2015-06-22T00:00:00Z', '2015-06-22T23:59:59Z');
     expect(bundle2.entry).toHaveLength(resources.length);
 
     const bundle3 = deepClone(bundle);
-    filterByCareDate(bundle3, '2015-06-23', '2025-03-25');
+    filterByCareDate(bundle3, '2015-06-22T23:59:59Z', '2025-03-25T23:59:59Z');
     expect(bundle3.entry).toHaveLength(0);
 
     const bundle4 = deepClone(bundle);

--- a/packages/server/src/fhir/operations/utils/caredate.ts
+++ b/packages/server/src/fhir/operations/utils/caredate.ts
@@ -8,7 +8,7 @@ const careDateExpressions: Record<string, string> = {
   AllergyIntolerance: 'recordedDate',
   CarePlan: 'created',
   ClinicalImpression: 'date',
-  Condition: 'onsetDateTime',
+  Condition: 'recordedDate',
   DeviceUseStatement: 'recordedOn',
   DiagnosticReport: 'issued',
   Encounter: 'period.start',

--- a/packages/server/src/fhir/operations/utils/caredate.ts
+++ b/packages/server/src/fhir/operations/utils/caredate.ts
@@ -1,0 +1,80 @@
+import { evalFhirPathTyped, toTypedValue, WithId } from '@medplum/core';
+import { Bundle, Resource } from '@medplum/fhirtypes';
+
+/**
+ * Care date expressions for each resource type.
+ */
+const careDateExpressions: Record<string, string> = {
+  AllergyIntolerance: 'recordedDate',
+  CarePlan: 'created',
+  ClinicalImpression: 'date',
+  Condition: 'onsetDateTime',
+  DeviceUseStatement: 'recordedOn',
+  DiagnosticReport: 'issued',
+  Encounter: 'period.start',
+  Goal: 'startDate',
+  Immunization: 'occurrenceDateTime',
+  MedicationRequest: 'authoredOn',
+  Observation: 'issued',
+  Procedure: 'performedDateTime',
+  ServiceRequest: 'occurrenceDateTime',
+};
+
+/**
+ * Filters the bundle by care date.
+ *
+ * @param bundle - The bundle to filter.
+ * @param start - The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no start date is provided, all records prior to the end date are in scope.
+ * @param end - The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no end date is provided, all records subsequent to the start date are in scope.
+ */
+export function filterByCareDate(
+  bundle: Bundle<WithId<Resource>>,
+  start: string | undefined,
+  end: string | undefined
+): void {
+  if (!bundle.entry || (!start && !end)) {
+    return;
+  }
+
+  const isoStart = normalizeDateTime(start);
+  const isoEnd = normalizeDateTime(end);
+
+  bundle.entry = bundle.entry.filter((entry) => {
+    const resource = entry.resource as WithId<Resource>;
+    const isoDate = getCareDate(resource);
+    if (!isoDate) {
+      return true;
+    }
+
+    return (!isoStart || isoDate >= isoStart) && (!isoEnd || isoDate < isoEnd);
+  });
+}
+
+/**
+ * Returns the care date for the given resource.
+ * @param resource - The resource to get the care date for.
+ * @returns The care date if available.
+ */
+export function getCareDate(resource: WithId<Resource>): string | undefined {
+  const expr = careDateExpressions[resource.resourceType];
+  if (!expr) {
+    return undefined;
+  }
+  return normalizeDateTime(evalFhirPathTyped(expr, [toTypedValue(resource)])?.[0]?.value);
+}
+
+/**
+ * Normalizes a date time string to an ISO string.
+ * @param input - The input string.
+ * @returns - The normalized date time string or undefined.
+ */
+function normalizeDateTime(input: string | undefined): string | undefined {
+  if (!input) {
+    return undefined;
+  }
+  try {
+    return new Date(input).toISOString();
+  } catch (_err) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Implements start/end date "care date" filtering.

Note that "care date" is different than "last updated", and unfortunately does not have a concrete definition.

Due to various implementation details, this is done in-memory after the database request.

* C-CDA Export is based on Patient `$summary`
* Patient `$summary` is based on Patient `$everything`
* Patient `$everything` uses multi-type search via `_types` to support consistent pagination
* Using `_types` means you can only use search parameters that are common across all of the resource types
* Of course, not all resources support this, so that leaves this kinda stuck

In the future, we could consider adding custom search parameters to fill in the gaps here.  Most of them have a `date` param, so it would probably be straightforward to fill in `date` params for the remainder.