### PR TITLE
auth/setpassword and auth/resetpassword documentation

### DIFF
--- a/packages/docs/docs/api/auth/_category_.json
+++ b/packages/docs/docs/api/auth/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Auth",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "slug": "/api/auth",
+    "title": "Auth",
+    "description": "Auth Endpoints",
+    "keywords": ["auth", "password", "authentication"]
+  }
+}

--- a/packages/docs/docs/api/auth/resetpassword.md
+++ b/packages/docs/docs/api/auth/resetpassword.md
@@ -1,0 +1,52 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Reset Password Endpoint
+
+## POST `/auth/resetpassword`
+
+Initiates a password reset for a user. If successful, sends a password reset email to the user (unless `sendEmail` is set to false which is recommended for custom reset password flows). Then, the redirectUri in the email sent to the user will bring the user to a page that calls the [/auth/setpassword](/docs/api/auth/setpassword) endpoint after the user enters their new password.
+
+Check out [custom emails](/docs/auth/custom-emails) for directions to create a custom reset password flow.
+
+:::info
+To see an example, check out the the code for the Medplum app's reset password page in [`ResetPasswordPage.tsx`](https://github.com/medplum/medplum/blob/main/packages/app/src/ResetPasswordPage.tsx).
+:::
+
+:::warning
+Please note that you may need to specify _projectId_ if your User is project scoped and _recaptchaSiteKey_ and _recaptchaToken_ if you are using your own recaptcha keys.
+:::
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| email | string | Yes | User's email address (3-72 characters) |
+| projectId | string | No | Project ID for project-scoped users. See [project scoped users](/docs/auth/user-management-guide#project-scoped-users) Omit for system-level users |
+| sendEmail | boolean | No | Whether to send Medplum labeled reset email (defaults to true) |
+| redirectUri | string | No | URI to redirect after password reset |
+| recaptchaSiteKey | string | No | reCAPTCHA site key for verification |
+| recaptchaToken | string | No | reCAPTCHA token for verification |
+
+### Response
+
+Returns a 200 OK response regardless of whether a user was found.
+
+### Example
+
+```typescript
+await medplum.post('auth/resetpassword', {
+  email: 'user@example.com',
+  projectId: 'project-123',
+  sendEmail: true,
+  redirectUri: 'https://app.example.com/reset',
+  recaptchaSiteKey: '6LeIxAcTAAAAAJ55555555555555555555555555555555',
+  recaptchaToken: 'recaptcha-token'
+});
+```
+
+### Notes
+
+- When resetting password for project-scoped users, `projectId` must be provided
+- Omit `projectId` when resetting password for system-level users
+- If you are building a custom reset password email, set sendEmail to false

--- a/packages/docs/docs/api/auth/setpassword.md
+++ b/packages/docs/docs/api/auth/setpassword.md
@@ -1,0 +1,36 @@
+# Set Password Endpoint
+
+## POST `/auth/setpassword`
+
+:::note
+To see an example of the Medplum app's set password page, check out the code in [`SetPasswordPage.tsx`](https://github.com/medplum/medplum/blob/main/packages/app/src/SetPasswordPage.tsx). Notice that the page 
+:::
+
+Sets a new password for a user using a security request token. This endpoint is used to complete both password reset and user invitation flows. After redirect from the reset password or invite email, this endpoint can be called with the following parameters:
+
+### Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| id | string | Yes | The UserSecurityRequest ID received from the reset password email |
+| secret | string | Yes | The security token received from the reset password email |
+| password | string | Yes | The new password (must be at least 8 characters) |
+
+### Response
+
+- Returns `200 OK` if the password was successfully set
+- Returns `400 Bad Request` if:
+  - The security request has already been used
+  - The secret is incorrect
+  - The password is found in breach database
+  - The password is less than 8 characters
+
+### Example
+
+```typescript
+await medplum.post('auth/setpassword', {
+  id: 'security-request-id',
+  secret: 'security-token',
+  password: 'new-password'
+});
+```

--- a/packages/docs/docs/api/oauth/_category_.json
+++ b/packages/docs/docs/api/oauth/_category_.json
@@ -1,10 +1,10 @@
 {
-  "label": "OAuth",
+  "label": "OAuth2",
   "position": 3,
   "link": {
     "type": "generated-index",
     "slug": "/api/oauth",
-    "title": "OAuth",
+    "title": "OAuth2",
     "description": "OAuth2 Authentication",
     "keywords": ["OAuth2", "security", "authentication"]
   }

--- a/packages/docs/docs/auth/custom-emails.mdx
+++ b/packages/docs/docs/auth/custom-emails.mdx
@@ -57,7 +57,7 @@ Key functions of the page:
 
 - Initialize reCAPTCHA
 - Prompts the user for `email`
-- Sends the `email`, `projectId`, and `recaptchaToken` to the `/auth/resetpassword` API endpoint
+- Sends the `email`, `projectId`, and `recaptchaToken` to the [/auth/resetpassword](/docs/api/auth/resetpassword) API endpoint
 
 See the [`ResetPasswordPage.tsx`](https://github.com/medplum/medplum/blob/main/packages/app/src/ResetPasswordPage.tsx) for a full example.
 
@@ -70,7 +70,7 @@ Key functions of the page:
 - Receives `id` and `secret` from URL parameters
 - Prompts the user for `password` and `confirmPassword`
 - Verifies that `password` and `confirmPassword` match
-- Sends the `id`, `secret`, and `password` to the `/auth/setpassword` API endpoint
+- Sends the `id`, `secret`, and `password` to the [/auth/setpassword](/docs/api/auth/setpassword) API endpoint
 
 ## Password Change Request Bot
 


### PR DESCRIPTION
- Adding a new section to docs reference section called _Auth_ with /auth/... endpoints
- I also changed the name of the _oauth_ section to _oauth2_, just to make distinction clear. Note: I did not change anything about the urls to those docs to avoid breaking any links.