### PR TITLE
Fixed sonar warnings and styles on batch create page

### DIFF
--- a/packages/app/src/BatchPage.tsx
+++ b/packages/app/src/BatchPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, JsonInput, Tabs, Text, Title, useMantineTheme } from '@mantine/core';
+import { Anchor, Button, Group, JsonInput, Tabs, Text, Title, useMantineTheme } from '@mantine/core';
 import { Dropzone, FileWithPath } from '@mantine/dropzone';
 import { notifications } from '@mantine/notifications';
 import { convertToTransactionBundle, normalizeErrorString } from '@medplum/core';
@@ -114,10 +114,10 @@ export function BatchPage(): JSX.Element {
   return (
     <Document>
       <Title>Batch Create</Title>
-      <p>
-        Use this page to create, read, or update multiple resources. For more details, see&nbsp;
-        <a href="https://www.hl7.org/fhir/http.html#transaction">FHIR Batch and Transaction</a>.
-      </p>
+      <Text>
+        Use this page to create, read, or update multiple resources. For more details, see{' '}
+        <Anchor href="https://www.hl7.org/fhir/http.html#transaction">FHIR Batch and Transaction</Anchor>.
+      </Text>
       {Object.keys(output).length === 0 && (
         <>
           <h3>Input</h3>


### PR DESCRIPTION
Super minor cleanup.

Sonar warning:

![image](https://github.com/user-attachments/assets/7b809f9d-7cc8-4e09-88cc-407714240fea)

Also fixes the non-Mantine link.

Before:
![image](https://github.com/user-attachments/assets/55d088e7-5052-4c8a-ad46-c4471472daf5)


After:
![image](https://github.com/user-attachments/assets/79ef3b83-74c3-4422-98c7-c9e917175585)

