### PR TITLE
Fixes #6261 - allow React 19 as peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29912,6 +29912,7 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -29926,6 +29927,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -54068,7 +54070,7 @@
         "@medplum/core": "4.0.4",
         "@medplum/fhirtypes": "4.0.4",
         "@medplum/react-hooks": "4.0.4",
-        "react": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "packages/e2e": {
@@ -54302,7 +54304,7 @@
         "@medplum/fhirtypes": "4.0.4",
         "@medplum/health-gorilla-core": "4.0.4",
         "@medplum/react": "4.0.4",
-        "react": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "packages/hl7": {
@@ -54395,8 +54397,8 @@
         "@mantine/notifications": "^7.0.0",
         "@medplum/core": "4.0.4",
         "@medplum/react-hooks": "4.0.4",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "rfc6902": "^5.0.1"
       },
       "peerDependenciesMeta": {
@@ -54442,8 +54444,7 @@
       },
       "peerDependencies": {
         "@medplum/core": "4.0.4",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
     "packages/react/node_modules/@sinonjs/fake-timers": {

--- a/packages/dosespot-react/package.json
+++ b/packages/dosespot-react/package.json
@@ -78,7 +78,7 @@
     "@medplum/core": "4.0.4",
     "@medplum/fhirtypes": "4.0.4",
     "@medplum/react-hooks": "4.0.4",
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/health-gorilla-react/package.json
+++ b/packages/health-gorilla-react/package.json
@@ -81,7 +81,7 @@
     "@medplum/fhirtypes": "4.0.4",
     "@medplum/health-gorilla-core": "4.0.4",
     "@medplum/react": "4.0.4",
-    "react": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -78,8 +78,7 @@
   },
   "peerDependencies": {
     "@medplum/core": "4.0.4",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -115,8 +115,8 @@
     "@mantine/notifications": "^7.0.0",
     "@medplum/core": "4.0.4",
     "@medplum/react-hooks": "4.0.4",
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0",
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0",
     "rfc6902": "^5.0.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Some notes for potential discussion:
* We still had React 17 as a valid peer dep version.  I don't know if that's correct or not.  I'm leaving it alone for now.
* `@medplum/react-hooks` declared `react-dom` as a peerDep, which I think is wrong because it's a pure hooks lib, so I removed it.

For reference

`@mantine/hooks` uses:

```json
      "peerDependencies": {
        "react": "^18.x || ^19.x"
      }
```

`@mantine/core` uses:

```json
      "peerDependencies": {
        "react": "^18.x || ^19.x",
        "react-dom": "^18.x || ^19.x"
      }
```
