### PR TITLE
Add jszip to bot-layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29912,6 +29912,7 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -29926,6 +29927,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -53824,6 +53826,7 @@
         "fast-xml-parser": "5.0.9",
         "form-data": "4.0.2",
         "jose": "5.10.0",
+        "jszip": "3.10.1",
         "node-fetch": "2.7.0",
         "pdfmake": "0.2.18",
         "ssh2": "1.16.0",
@@ -53838,7 +53841,10 @@
       "peerDependencies": {
         "@medplum/ccda": "4.0.4",
         "@medplum/core": "4.0.4",
+        "fast-xml-parser": "^5.0.9",
         "form-data": "^4.0.0",
+        "jose": "^5.10.0",
+        "jszip": "^3.10.1",
         "node-fetch": "^2.7.0",
         "pdfmake": "^0.2.7",
         "ssh2": "^1.11.0",

--- a/packages/bot-layer/README.md
+++ b/packages/bot-layer/README.md
@@ -7,7 +7,10 @@ This package defines the packages in the default AWS Lambda Layer.
 Current packages:
 
 - [`@medplum/core`](https://www.npmjs.com/package/@medplum/core)
+- [`fast-xml-parser`](https://www.npmjs.com/package/fast-xml-parser)
 - [`form-data`](https://www.npmjs.com/package/form-data)
+- [`jose`](https://www.npmjs.com/package/jose)
+- [`jszip`](https://www.npmjs.com/package/jszip)
 - [`node-fetch`](https://www.npmjs.com/package/node-fetch)
 - [`pdfmake`](https://www.npmjs.com/package/pdfmake)
 - [`ssh2`](https://www.npmjs.com/package/ssh2)

--- a/packages/bot-layer/package.json
+++ b/packages/bot-layer/package.json
@@ -27,6 +27,7 @@
     "fast-xml-parser": "5.0.9",
     "form-data": "4.0.2",
     "jose": "5.10.0",
+    "jszip": "3.10.1",
     "node-fetch": "2.7.0",
     "pdfmake": "0.2.18",
     "ssh2": "1.16.0",
@@ -38,7 +39,10 @@
   "peerDependencies": {
     "@medplum/ccda": "4.0.4",
     "@medplum/core": "4.0.4",
+    "fast-xml-parser": "^5.0.9",
     "form-data": "^4.0.0",
+    "jose": "^5.10.0",
+    "jszip": "^3.10.1",
     "node-fetch": "^2.7.0",
     "pdfmake": "^0.2.7",
     "ssh2": "^1.11.0",


### PR DESCRIPTION
We recently had the need to work with ZIP files inside bots, which seems like a relatively common thing to do.

We're already using the `jszip` library in `server`, so this isn't a big impact on `node_modules`.

Some drive-by fixes in `bot-layer`'s `peerDependencies` and `README.md`