### PR TITLE
ActivityDefinition extension to  ServiceRequest resource.

### DIFF
--- a/packages/server/src/fhir/operations/plandefinitionapply.ts
+++ b/packages/server/src/fhir/operations/plandefinitionapply.ts
@@ -150,6 +150,7 @@ async function createActivityDefinitionTask(
         requester: requester as ServiceRequest['requester'],
         encounter: encounter,
         code: activityDefinition.code,
+        extension: activityDefinition.extension,
       });
 
       return createTask(repo, requester, subject, action, encounter, [


### PR DESCRIPTION
ActivityDefinition to pass extension to ServiceRequest. 
Which will be used in ChargeItem to search for ChargeItemDefinition.
<img width="764" alt="Screenshot 2025-04-02 at 2 36 32 PM" src="https://github.com/user-attachments/assets/c32f83f1-ace9-4388-8f74-c8cfc557cdfa" />
