### PR TITLE
Cache parsed FHIRPath expressions for resource validation

### DIFF
--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -29,6 +29,7 @@ import {
 import { parseDateString } from './date';
 import { tokenize } from './tokenize';
 import { toTypedValue } from './utils';
+import { LRUCache } from '../cache';
 
 /**
  * Operator precedence
@@ -255,14 +256,19 @@ export function evalFhirPath(expression: string, input: unknown): unknown[] {
  * @param expression - The FHIRPath expression to parse.
  * @param input - The resource or object to evaluate the expression against.
  * @param variables - A map of variables for eval input.
+ * @param cache - Cache for parsed ASTs.
  * @returns The result of the FHIRPath expression against the resource or object.
  */
 export function evalFhirPathTyped(
   expression: string,
   input: TypedValue[],
-  variables: Record<string, TypedValue> = {}
+  variables: Record<string, TypedValue> = {},
+  cache: LRUCache<FhirPathAtom> | undefined = undefined
 ): TypedValue[] {
-  const ast = parseFhirPath(expression);
+  const ast = cache?.get(expression) ?? parseFhirPath(expression);
+  if (cache) {
+    cache.set(expression, ast);
+  }
   return ast.eval({ variables }, input).map((v) => ({
     type: v.type,
     value: v.value?.valueOf(),


### PR DESCRIPTION
Parsing FHIRPath expressions from a string into an executable AST is computationally expensive and performs many memory allocations: caching the result should significantly improve efficiency and performance