### PR TITLE
test(repo): add test for legacy non-conformant UUIDs

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1351,6 +1351,26 @@ describe('FHIR Repo', () => {
       expect((await versionQuery.execute(client))[0].__version).toStrictEqual(Repository.VERSION);
     });
   });
+
+  test('Legacy UUID support -- non-conformant IDs that match UUID form are accepted', () =>
+    withTestContext(async () => {
+      const { repo } = await createTestProject({ withRepo: true });
+      // Random invalid UUID that is invalid based on RFC9562 for the following reasons:
+      // 1. The version field (the first digit in the third group) should be 4 to indicate UUID version 4, but here it's e
+      // 2. The variant field (the first digit in the fourth group) should be 8, 9, a, or b, but here it's c
+      // This is invalid in a similar way to some of the legacy UUIDs imported from other systems which we must continue to support
+      // This test fails using the version of the validator.js isUUID (13.15.0) that caused the regression this PR fixed: https://github.com/medplum/medplum/pull/6289
+      const nonconformantUuid = '03a8d57b-91c2-e45f-c312-a7fe09c2d8e4';
+      const patient = await repo.createResource<Patient>(
+        {
+          id: nonconformantUuid,
+          resourceType: 'Patient',
+          name: [{ given: ['Alice'], family: 'Smith' }],
+        },
+        { assignedId: true }
+      );
+      expect(patient.id).toStrictEqual(nonconformantUuid);
+    }));
 });
 
 function shuffleString(s: string): string {


### PR DESCRIPTION
Fixes #6302 