### PR TITLE
fix(deps): replace `validator.isUUID` with Medplum's `isUUID`, unpin `validator`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30110,6 +30110,7 @@
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
       "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -30124,6 +30125,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -54761,7 +54763,7 @@
         "rfc6902": "5.1.2",
         "semver": "7.7.1",
         "uuid": "11.1.0",
-        "validator": "13.12.0",
+        "validator": "13.15.0",
         "ws": "8.18.1"
       },
       "devDependencies": {
@@ -54809,6 +54811,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/server/node_modules/validator": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
+      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     }
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -773,7 +773,7 @@ export function deepClone<T>(input: T): T {
  * @returns True if the input string matches the UUID format.
  */
 export function isUUID(input: string): input is string {
-  return !!/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/i.exec(input);
+  return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(input);
 }
 
 /**

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -93,7 +93,7 @@
     "rfc6902": "5.1.2",
     "semver": "7.7.1",
     "uuid": "11.1.0",
-    "validator": "13.12.0",
+    "validator": "13.15.0",
     "ws": "8.18.1"
   },
   "devDependencies": {

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -16,6 +16,7 @@ import {
   getSearchParameter,
   IncludeTarget,
   isResource,
+  isUUID,
   OperationOutcomeError,
   Operator,
   parseFilterParameter,
@@ -42,7 +43,6 @@ import {
   ResourceType,
   SearchParameter,
 } from '@medplum/fhirtypes';
-import validator from 'validator';
 import { getConfig } from '../config/loader';
 import { DatabaseMode } from '../database';
 import { deriveIdentifierSearchParameter } from './lookups/util';
@@ -1173,7 +1173,7 @@ function buildIdSearchFilter(
     if (values[i].includes('/')) {
       values[i] = values[i].split('/').pop() as string;
     }
-    if (!validator.isUUID(values[i])) {
+    if (!isUUID(values[i])) {
       values[i] = '00000000-0000-0000-0000-000000000000';
     }
   }

--- a/packages/server/src/wellknown.test.ts
+++ b/packages/server/src/wellknown.test.ts
@@ -1,6 +1,6 @@
+import { isUUID } from '@medplum/core';
 import express from 'express';
 import request from 'supertest';
-import validator from 'validator';
 import { initApp, shutdownApp } from './app';
 import { loadTestConfig } from './config/loader';
 
@@ -28,7 +28,7 @@ describe('Well Known', () => {
     for (const key of keys) {
       expect(key.kid).toBeDefined();
       expect(key.kid.length).toStrictEqual(36); // kid should be a UUID
-      expect(validator.isUUID(key.kid)).toStrictEqual(true);
+      expect(isUUID(key.kid)).toStrictEqual(true);
       expect(key.alg).toStrictEqual('RS256');
       expect(key.kty).toStrictEqual('RSA');
       expect(key.use).toStrictEqual('sig');

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -78,8 +78,7 @@ echo "Last completed step: $LAST_STEP"
 # @tabler/icons-react - to avoid bad interaction with vite https://github.com/tabler/tabler-icons/issues/1233
 # react-native - 0.76.x is broken with an error caused by flow parser breaking when using `expo-crypto`: `SyntaxError: {..}/react-native/Libraries/vendor/emitter/EventEmitter.js: Unexpected token, expected "]" (39:5)`
 # storybook-addon-mantine - 4.1.0 seems to accidentally backported requirement for React 19 from v5: https://github.com/josiahayres/storybook-addon-mantine/issues/18
-# validator 13.15.0 introduced stricter validation of UUIDs which some of UUIDs don't pass for some reason, likely due to historical differences in UUID generation https://github.com/validatorjs/validator.js/pull/2421
-EXCLUDE="react react-dom @tabler/icons-react react-native storybook-addon-mantine validator"
+EXCLUDE="react react-dom @tabler/icons-react react-native storybook-addon-mantine"
 
 # Append any additional excludes from the command line
 if [ -n "$ADDITIONAL_EXCLUDES" ]; then


### PR DESCRIPTION
Based on #6304, after adding a test to protect against regressions for legacy UUIDs, we can avoid triggering the regression by using Medplum's own `isUUID` util from `@medplum/core` in Medplum server.

I also tweaked the regex of our own utility to match the old behavior of `validator.isUUID` before https://github.com/validatorjs/validator.js/pull/2421, which was a bit more correct (no _ allowed like `\w`)