### PR TITLE
Handle null bytes in search strings

### DIFF
--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -929,6 +929,10 @@ function buildSearchFilterExpression(
     throw new OperationOutcomeError(badRequest('Search filter value must be a string'));
   }
 
+  if (filter.value.includes('\0')) {
+    throw new OperationOutcomeError(badRequest('Search filter value cannot contain null bytes'));
+  }
+
   if (filter.code.startsWith('_has:') || filter.code.includes('.')) {
     const chain = parseChainedParameter(resourceType, filter);
     return buildChainedSearch(repo, selectQuery, resourceType, chain);


### PR DESCRIPTION
When a user tries to use a null byte in a search string (i.e., `Patient?name=%00`), the server currently returns an error (good), but it's an unhandled 500 error (bad).

This PR properly handles the null byte.