### PR TITLE
Update sync patients from Photon bot

### DIFF
--- a/examples/medplum-photon-integration/src/pages/HomePage.tsx
+++ b/examples/medplum-photon-integration/src/pages/HomePage.tsx
@@ -46,8 +46,6 @@ export function HomePage(): JSX.Element {
         title: 'Success',
         message: 'Patients synced',
       });
-      close();
-      window.location.reload();
     } catch (err) {
       notifications.show({
         color: 'red',


### PR DESCRIPTION
The bot to sync patients from Photon was not handling cases where a user had an external ID in Photon that was not their medplum ID. This updates the bot to handle this case.