### PR TITLE
fix(docs): fix reference to `UserSecurityRequest`

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -60082,7 +60082,7 @@
       "required": ["resourceType", "user", "authMethod", "authTime"]
     },
     "PasswordChangeRequest": {
-      "description": "@deprecated Password change request for the \u0027forgot password\u0027 flow. Use UserSecurityCheck instead.",
+      "description": "@deprecated Password change request for the \u0027forgot password\u0027 flow. Use UserSecurityRequest instead.",
       "properties": {
         "resourceType": {
           "description": "This is a PasswordChangeRequest resource",

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -2639,7 +2639,7 @@
       "abstract" : false,
       "type" : "PasswordChangeRequest",
       "baseDefinition" : "http://hl7.org/fhir/StructureDefinition/DomainResource",
-      "description" : "@deprecated Password change request for the 'forgot password' flow. Use UserSecurityCheck instead.",
+      "description" : "@deprecated Password change request for the 'forgot password' flow. Use UserSecurityRequest instead.",
       "snapshot" : {
         "element" : [
           {

--- a/packages/docs/docs/api/fhir/medplum/passwordchangerequest.mdx
+++ b/packages/docs/docs/api/fhir/medplum/passwordchangerequest.mdx
@@ -11,7 +11,7 @@ import { ResourcePropertiesTable, SearchParamsTable } from '@site/src/components
 
 # PasswordChangeRequest
 
-@deprecated Password change request for the 'forgot password' flow. Use UserSecurityRequest instead.
+@deprecated Password change request for the 'forgot password' flow. Use <Link to="/docs/api/fhir/medplum/usersecurityrequest">UserSecurityRequest</Link> instead.
 
 <Tabs queryString="section">
   <TabItem value="schema" label="Schema" default>

--- a/packages/docs/static/data/medplumDefinitions/passwordchangerequest.json
+++ b/packages/docs/static/data/medplumDefinitions/passwordchangerequest.json
@@ -1,7 +1,7 @@
 {
   "name": "PasswordChangeRequest",
   "location": "medplum",
-  "description": "@deprecated Password change request for the 'forgot password' flow. Use UserSecurityCheck instead.",
+  "description": "@deprecated Password change request for the 'forgot password' flow. Use UserSecurityRequest instead.",
   "properties": [
     {
       "name": "PasswordChangeRequest",

--- a/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
+++ b/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
@@ -12,7 +12,7 @@ import { User } from './User';
 
 /**
  * @deprecated Password change request for the 'forgot password' flow.
- * Use UserSecurityCheck instead.
+ * Use UserSecurityRequest instead.
  */
 export interface PasswordChangeRequest {
 


### PR DESCRIPTION
Thanks @finnbergquist for finding the typo, fixed the typo at its source so that all the other places are also updated.

Had to use an older version of the generator because of the generator now adding extra parens as described in #6314