### PR TITLE
Tighter migration filename regex

### DIFF
--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -986,7 +986,7 @@ function buildIndexSql(tableName: string, index: IndexDefinition): string {
 }
 
 function getMigrationFilenames(): string[] {
-  return readdirSync(SCHEMA_DIR).filter((filename) => /v\d+\.ts/.test(filename));
+  return readdirSync(SCHEMA_DIR).filter((filename) => /^v\d+\.ts$/.test(filename));
 }
 
 function getVersionFromFilename(filename: string): number {


### PR DESCRIPTION
So that, e.g. `v89.ts.new` does NOT match