### PR TITLE
Handle missing migration files

### DIFF
--- a/packages/server/src/migrations/migration-utils.test.ts
+++ b/packages/server/src/migrations/migration-utils.test.ts
@@ -1,0 +1,11 @@
+import { getPostDeployMigration, MigrationDefinitionNotFoundError } from './migration-utils';
+
+describe('getPostDeployMigration', () => {
+  test('definition found', () => {
+    expect(getPostDeployMigration(1)).toBeDefined();
+  });
+
+  test('migration definition not found', () => {
+    expect(() => getPostDeployMigration(9999)).toThrow(MigrationDefinitionNotFoundError);
+  });
+});

--- a/packages/server/src/migrations/migration-utils.ts
+++ b/packages/server/src/migrations/migration-utils.ts
@@ -53,12 +53,19 @@ export function getPreDeployMigration(migrationNumber: number): PreDeployMigrati
   return migration as PreDeployMigration;
 }
 
+export class MigrationDefinitionNotFoundError extends Error {
+  constructor(migrationNumber: number) {
+    super(`Migration definition not found for v${migrationNumber}`);
+  }
+}
+
 export function getPostDeployMigration(migrationNumber: number): PostDeployMigration {
   // Get the post-deploy migration from the post-deploy migrations module
-  const migration = (postDeployMigrations as Record<string, { migration: PostDeployMigration }>)['v' + migrationNumber]
-    .migration;
+  const migration = (postDeployMigrations as Record<string, { migration: PostDeployMigration } | undefined>)[
+    'v' + migrationNumber
+  ]?.migration;
   if (!migration) {
-    throw new Error(`Migration definition not found for v${migrationNumber}`);
+    throw new MigrationDefinitionNotFoundError(migrationNumber);
   }
 
   if (!('type' in migration)) {


### PR DESCRIPTION
As would happen when a new post-deploy migration is first deployed but old workers from the previous deploy are still running and consuming jobs