### PR TITLE
Fixing broken routes in example apps from react-router v7 upgrade

### DIFF
--- a/examples/medplum-chart-demo/src/App.tsx
+++ b/examples/medplum-chart-demo/src/App.tsx
@@ -62,13 +62,16 @@ export function App(): JSX.Element | null {
             <Route path="/" element={profile ? <SearchPage /> : <LandingPage />} />
             <Route path="/signin" element={<SignInPage />} />
             <Route path="/Patient/:id">
+              <Route index element={<PatientPage />} />
               <Route path="*" element={<PatientPage />} />
             </Route>
             <Route path="/:resourceType/:id">
+              <Route index element={<ResourcePage />} />
               <Route path="*" element={<ResourcePage />} />
             </Route>
             <Route path="/:resourceType" element={<SearchPage />} />
             <Route path="/Encounter/:id">
+              <Route index element={<EncounterPage />} />
               <Route path="*" element={<EncounterPage />} />
             </Route>
             <Route path="/upload/:dataType" element={<UploadDataPage />} />

--- a/examples/medplum-chat-demo/src/App.tsx
+++ b/examples/medplum-chat-demo/src/App.tsx
@@ -49,7 +49,7 @@ export function App(): JSX.Element | null {
         {
           // A section of the sidebar that links to a page to upload example data for the app
           title: 'Upload Data',
-          links: [{ icon: <IconFileImport />, label: 'Upload Example Data', href: 'upload/example' }],
+          links: [{ icon: <IconFileImport />, label: 'Upload Example Data', href: '/upload/example' }],
         },
       ]}
       // This adds notification icons for unread messages and active tasks for the current user
@@ -67,13 +67,16 @@ export function App(): JSX.Element | null {
           <Route path="/" element={profile ? <SearchPage /> : <LandingPage />} />
           <Route path="/signin" element={<SignInPage />} />
           <Route path="/Communication/:id">
+            <Route index element={<CommunicationPage />} />
             <Route path="*" element={<CommunicationPage />} />
           </Route>
           <Route path="/:resourceType" element={<SearchPage />} />
           <Route path="/:resourceType/:id">
+            <Route index element={<ResourcePage />} />
             <Route path="*" element={<ResourcePage />} />
           </Route>
           <Route path="/Patient/:id">
+            <Route index element={<PatientPage />} />
             <Route path="*" element={<PatientPage />} />
           </Route>
           <Route path="/:resourceType/:id" element={<ResourcePage />} />

--- a/examples/medplum-eligibility-demo/src/App.tsx
+++ b/examples/medplum-eligibility-demo/src/App.tsx
@@ -45,12 +45,15 @@ export function App(): JSX.Element | null {
           <Route path="/:resourceType" element={<SearchPage />} />
           <Route path="/signin" element={<SignInPage />} />
           <Route path="/Coverage/:id">
+            <Route index element={<CoveragePage />} />
             <Route path="*" element={<CoveragePage />} />
           </Route>
           <Route path="/Patient/:id">
+            <Route index element={<PatientPage />} />
             <Route path="*" element={<PatientPage />} />
           </Route>
           <Route path="/:resourceType/:id">
+            <Route index element={<ResourcePage />} />
             <Route path="*" element={<ResourcePage />} />
           </Route>
           <Route path="/:resourceType/:id/_history/:versionId" element={<ResourcePage />} />

--- a/examples/medplum-patient-intake-demo/src/App.tsx
+++ b/examples/medplum-patient-intake-demo/src/App.tsx
@@ -88,11 +88,13 @@ export function App(): JSX.Element | null {
               <Route path="/" element={profile ? <SearchPage /> : <LandingPage />} />
               <Route path="/signin" element={<SignInPage />} />
               <Route path="/Patient/:id">
+                <Route index element={<PatientPage />} />
                 <Route path="*" element={<PatientPage />} />
               </Route>
               <Route path="/Patient/:patientId/intake/:responseId" element={<IntakeResponsePage />} />
               <Route path="/onboarding" element={<IntakeFormPage />} />
               <Route path="/:resourceType/:id">
+                <Route index element={<ResourcePage />} />
                 <Route path="*" element={<ResourcePage />} />
               </Route>
               <Route path="/:resourceType" element={<SearchPage />} />

--- a/examples/medplum-photon-integration/src/App.tsx
+++ b/examples/medplum-photon-integration/src/App.tsx
@@ -49,9 +49,11 @@ export function App(): JSX.Element | null {
               <Route path="/" element={profile ? <HomePage /> : <LandingPage />} />
               <Route path="/signin" element={<SignInPage />} />
               <Route path="/Patient/:id">
+                <Route index element={<PatientPage />} />
                 <Route path="*" element={<PatientPage />} />
               </Route>
               <Route path="/MedicationRequest/:id">
+                <Route index element={<PrescriptionPage />} />
                 <Route path="*" element={<PrescriptionPage />} />
               </Route>
               <Route path="/:resourceType/:id" element={<ResourcePage />} />
@@ -59,6 +61,7 @@ export function App(): JSX.Element | null {
               <Route path="/upload/:dataType" element={<UploadDataPage />} />
               <Route path="/MedicationKnowledge" element={<MedicationsPage />} />
               <Route path="/MedicationKnowledge/:id">
+                <Route index element={<MedicationPage />} />
                 <Route path="*" element={<MedicationPage />} />
               </Route>
             </Routes>

--- a/examples/medplum-scheduling-demo/src/App.tsx
+++ b/examples/medplum-scheduling-demo/src/App.tsx
@@ -107,13 +107,22 @@ export function App(): JSX.Element | null {
                 path="/Patient/:patientId/Schedule/:scheduleId"
                 element={schedule ? <PatientSchedulePage /> : <Loading />}
               />
-              <Route path="/Patient/:id" element={<PatientPage />} />
+              <Route path="/Patient/:id" element={<PatientPage />}>
+                <Route index element={<PatientPage />} />
+                <Route path="*" element={<PatientPage />} />
+              </Route>
               <Route path="/Appointment/upcoming" element={<AppointmentsPage />} />
               <Route path="/Appointment/past" element={<AppointmentsPage />} />
-              <Route path="/Appointment/:id" element={<AppointmentDetailPage />} />
+              <Route path="/Appointment/:id" element={<AppointmentDetailPage />}>
+                <Route index element={<AppointmentDetailPage />} />
+                <Route path="*" element={<AppointmentDetailPage />} />
+              </Route>
               <Route path="/upload/:dataType" element={<UploadDataPage />} />
               <Route path="/:resourceType" element={<SearchPage />} />
-              <Route path="/:resourceType/:id" element={<ResourcePage />} />
+              <Route path="/:resourceType/:id" element={<ResourcePage />}>
+                <Route index element={<ResourcePage />} />
+                <Route path="*" element={<ResourcePage />} />
+              </Route>
             </Routes>
           </Suspense>
         </ErrorBoundary>

--- a/examples/medplum-task-demo/src/App.tsx
+++ b/examples/medplum-task-demo/src/App.tsx
@@ -103,9 +103,11 @@ export function App(): JSX.Element | null {
             <Route path="/signin" element={<SignInPage />} />
             <Route path="/:resourceType" element={<SearchPage />} />
             <Route path="/:resourceType/:id">
+              <Route index element={<ResourcePage />} />
               <Route path="*" element={<ResourcePage />} />
             </Route>
             <Route path="/Task/:id">
+              <Route index element={<TaskPage />} />
               <Route path="*" element={<TaskPage />} />
             </Route>
             <Route path="/Task" element={<SearchPage />} />


### PR DESCRIPTION
### Change required for example apps routing to work with v7 react-router

Everything that follows this pattern
```
<Route path="/:someResource/:id">
  <Route path="*" element={<SomePage />} />
</Route>
```
throws a `/<someResource>/<id> does not have an element or Component in the console and the page never mounts.`
This can be fixed by adding the index route
```
<Route path="/:someResource/:id">
  <Route index element={<TaskTab />} />
  <Route path="*" element={<SomePage />} />
</Route>
```

Reference to discussion about this in react-router/issues [here](https://github.com/remix-run/react-router/issues/12460#issuecomment-2518973962)