### PR TITLE
fix(agent): upgrade is no-op when already on target version

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -59,6 +59,7 @@ export interface AgentReloadConfigResponse extends BaseAgentMessage {
 export interface AgentUpgradeRequest extends BaseAgentRequestMessage {
   type: 'agent:upgrade:request';
   version?: string;
+  force?: boolean;
 }
 
 export interface AgentUpgradeResponse extends BaseAgentMessage {

--- a/packages/server/src/fhir/operations/agentupgrade.test.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.test.ts
@@ -201,7 +201,7 @@ describe('Agent/$upgrade', () => {
         {
           severity: 'error',
           code: 'invalid',
-          details: { text: "'timeout' must be an integer representing a duration in milliseconds, if defined" },
+          details: { text: `Invalid value 'INVALID' provided for integer parameter` },
         },
       ]),
     });

--- a/packages/server/src/fhir/operations/agentupgrade.test.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.test.ts
@@ -300,4 +300,45 @@ describe('Agent/$upgrade', () => {
       handle.cleanup();
     }
   });
+
+  test('Agent force upgrade', async () => {
+    // Multi agent example
+    const handlePromises = [] as Promise<MockAgentResponseHandle>[];
+    for (let i = 0; i < agents.length; i++) {
+      handlePromises[i] = mockAgentResponse<AgentUpgradeRequest, AgentUpgradeResponse | AgentError>(
+        agents[i],
+        accessToken,
+        'agent:upgrade:request',
+        { type: 'agent:upgrade:response', statusCode: 200 }
+      );
+    }
+    const handles = await Promise.all(handlePromises);
+
+    let res = await request(app)
+      .get('/fhir/R4/Agent/$upgrade')
+      .query({ force: true })
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(res.status).toBe(200);
+    const bundle = res.body as Bundle<Parameters>;
+
+    for (const agent of agents) {
+      expectBundleToContainOutcome(bundle, agent, allOk);
+    }
+
+    // Agent by ID
+    res = await request(app)
+      .get(`/fhir/R4/Agent/${agents[0].id}/$upgrade`)
+      .query({ force: true })
+      .set('Authorization', 'Bearer ' + accessToken);
+
+    expect(res.status).toBe(200);
+
+    const outcome = res.body as OperationOutcome;
+    expect(outcome).toMatchObject(allOk);
+
+    for (const handle of handles) {
+      handle.cleanup();
+    }
+  });
 });

--- a/packages/server/src/fhir/operations/agentupgrade.test.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.test.ts
@@ -201,7 +201,7 @@ describe('Agent/$upgrade', () => {
         {
           severity: 'error',
           code: 'invalid',
-          details: { text: `Invalid value 'INVALID' provided for integer parameter` },
+          details: { text: `Invalid value 'INVALID' provided for integer parameter 'timeout'` },
         },
       ]),
     });

--- a/packages/server/src/fhir/operations/agentupgrade.ts
+++ b/packages/server/src/fhir/operations/agentupgrade.ts
@@ -1,14 +1,8 @@
-import {
-  AgentUpgradeResponse,
-  OperationOutcomeError,
-  WithId,
-  badRequest,
-  serverError,
-  singularize,
-} from '@medplum/core';
+import { AgentUpgradeResponse, OperationOutcomeError, WithId, badRequest, serverError } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Agent, OperationDefinition } from '@medplum/fhirtypes';
 import { handleBulkAgentOperation, publishAgentRequest } from './utils/agentutils';
+import { parseInputParameters } from './utils/parameters';
 
 const DEFAULT_UPGRADE_TIMEOUT = 45000;
 const MAX_UPGRADE_TIMEOUT = 56000;
@@ -27,6 +21,7 @@ export const operation: OperationDefinition = {
   parameter: [
     { use: 'in', name: 'version', type: 'string', min: 0, max: '1' },
     { use: 'in', name: 'timeout', type: 'integer', min: 0, max: '1' },
+    { use: 'in', name: 'force', type: 'boolean', min: 0, max: '1' },
     { use: 'out', name: 'return', type: 'Bundle', min: 1, max: '1' },
   ],
 };
@@ -42,27 +37,17 @@ export const operation: OperationDefinition = {
  * @returns The FHIR response.
  */
 export async function agentUpgradeHandler(req: FhirRequest): Promise<FhirResponse> {
-  const { version, timeout: _timeout, ...rest } = req.query;
+  const { version: _version, timeout: _timeout, force: _force, ...rest } = req.query;
+  const params = parseInputParameters<AgentUpgradeOptions>(operation, req);
   req.query = rest;
 
-  let timeout: number | undefined;
-  if (_timeout) {
-    timeout = Number.parseInt(singularize(_timeout) as string, 10);
-    if (Number.isNaN(timeout)) {
-      throw new OperationOutcomeError(
-        badRequest("'timeout' must be an integer representing a duration in milliseconds, if defined")
-      );
-    }
-  }
-
-  return handleBulkAgentOperation(req, async (agent) =>
-    upgradeAgent(agent, { version: singularize(version), timeout })
-  );
+  return handleBulkAgentOperation(req, async (agent) => upgradeAgent(agent, params));
 }
 
 export type AgentUpgradeOptions = {
   version?: string;
   timeout?: number;
+  force?: boolean;
 };
 
 async function upgradeAgent(agent: WithId<Agent>, options?: AgentUpgradeOptions): Promise<FhirResponse> {
@@ -74,7 +59,11 @@ async function upgradeAgent(agent: WithId<Agent>, options?: AgentUpgradeOptions)
   // Send agent message
   const [outcome, result] = await publishAgentRequest<AgentUpgradeResponse>(
     agent,
-    { type: 'agent:upgrade:request', ...(options?.version ? { version: options.version } : undefined) },
+    {
+      type: 'agent:upgrade:request',
+      ...(options?.version ? { version: options.version } : undefined),
+      ...(options?.force ? { force: true } : undefined),
+    },
     { waitForResponse: true, timeout }
   );
 

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -259,9 +259,9 @@ describe('Operation Input Parameters parsing', () => {
       'requiredIn=true&complexIn={"reference":"Patient/foo"}',
       'Complex parameter complexIn (Reference) cannot be passed via query string',
     ],
-    ['requiredIn=false&numeric=wrong', `Invalid value 'wrong' provided for integer parameter`],
-    ['requiredIn=false&fractional=wrong', `Invalid value 'wrong' provided for decimal parameter`],
-    ['requiredIn=1', `Invalid value '1' provided for boolean parameter`],
+    ['requiredIn=false&numeric=wrong', `Invalid value 'wrong' provided for integer parameter 'numeric'`],
+    ['requiredIn=false&fractional=wrong', `Invalid value 'wrong' provided for decimal parameter 'fractional'`],
+    ['requiredIn=1', `Invalid value '1' provided for boolean parameter 'requiredIn'`],
   ])('Throws on invalid query string parameters: %s', (query, errorMsg) => {
     const req: Request = { method: 'GET', query: parse(query) } as unknown as Request;
     expect(() => parseInputParameters(opDef, req)).toThrow(new Error(errorMsg));

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -124,7 +124,9 @@ function parseStringifiedParameter(
       return value;
   }
 
-  throw new OperationOutcomeError(badRequest(`Invalid value '${value}' provided for ${param.type} parameter`));
+  throw new OperationOutcomeError(
+    badRequest(`Invalid value '${value}' provided for ${param.type} parameter '${param.name}'`)
+  );
 }
 
 function validateInputParam(param: OperationDefinitionParameter, value: unknown): unknown {


### PR DESCRIPTION
Fixes #6356 

Adds a force parameter to the `$upgrade` operation as well in case you do need to force an upgrade to the official version with the specified semver, even if the current agent version has the same semver.