### PR TITLE
Project.systemSetting for toggling token columns usage

### DIFF
--- a/packages/server/src/fhir/search.test.ts
+++ b/packages/server/src/fhir/search.test.ts
@@ -56,7 +56,7 @@ import { MedplumServerConfig } from '../config/types';
 import { DatabaseMode } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { getSystemRepo, Repository } from './repo';
-import { clampEstimateCount } from './search';
+import { clampEstimateCount, readFromTokenColumns } from './search';
 import { SelectQuery } from './sql';
 import { TokenColumnsFeature } from './tokens';
 
@@ -82,12 +82,47 @@ describe.each<'token columns' | 'lookup table'>(['token columns', 'lookup table'
         repo = new Repository({
           strictMode: true,
           projects: [project.id],
+          currentProject: project,
           author: { reference: 'User/' + randomUUID() },
         });
       });
 
       afterAll(async () => {
         await shutdownApp();
+      });
+
+      test('readFromTokenColumns without systemSetting', () => {
+        expect(repo.currentProject()).toBeDefined();
+        expect(repo.currentProject()?.systemSetting).toBeUndefined();
+        if (tokenColumnsOrLookupTable === 'token columns') {
+          expect(readFromTokenColumns(repo)).toBe(true);
+        } else {
+          expect(readFromTokenColumns(repo)).toBe(false);
+        }
+      });
+
+      test('readFromTokenColumns with systemSetting', async () => {
+        const { project: projectWithTrue } = await createTestProject({
+          project: { systemSetting: [{ name: 'searchTokenColumns', valueBoolean: true }] },
+        });
+        const repoWithTrue = new Repository({
+          strictMode: true,
+          projects: [projectWithTrue.id],
+          currentProject: projectWithTrue,
+          author: { reference: 'User/' + randomUUID() },
+        });
+        expect(readFromTokenColumns(repoWithTrue)).toBe(true);
+
+        const { project: projectWithFalse } = await createTestProject({
+          project: { systemSetting: [{ name: 'searchTokenColumns', valueBoolean: false }] },
+        });
+        const repoWithFalse = new Repository({
+          strictMode: true,
+          projects: [projectWithFalse.id],
+          currentProject: projectWithFalse,
+          author: { reference: 'User/' + randomUUID() },
+        });
+        expect(readFromTokenColumns(repoWithFalse)).toBe(false);
       });
 
       test('Search total', async () =>
@@ -4749,6 +4784,14 @@ describe.each<'token columns' | 'lookup table'>(['token columns', 'lookup table'
 
       afterAll(async () => {
         await shutdownApp();
+      });
+
+      test('readFromTokenColumns', () => {
+        if (tokenColumnsOrLookupTable === 'token columns') {
+          expect(readFromTokenColumns(systemRepo)).toBe(true);
+        } else {
+          expect(readFromTokenColumns(systemRepo)).toBe(false);
+        }
       });
 
       test('Filter by _project', () =>


### PR DESCRIPTION
The `searchTokenColumns` `Project.systemSetting` can be used to enable usage of the new token column implementation

Fixes #6351 