### PR TITLE
More verbose logging in post-deploy migration jobs

### DIFF
--- a/packages/server/src/__mocks__/bullmq.ts
+++ b/packages/server/src/__mocks__/bullmq.ts
@@ -11,3 +11,4 @@ export class Queue extends bullmq.Queue {
 }
 export const Worker = bullmq.Worker;
 export const DelayedError = bullmq.DelayedError;
+export const Job = bullmq.Job;

--- a/packages/server/src/fhir/tokens.test.ts
+++ b/packages/server/src/fhir/tokens.test.ts
@@ -88,7 +88,7 @@ describe.each<'token columns' | 'lookup table'>(['token columns', 'lookup table'
         expect(badTextResult.entry?.length).toStrictEqual(0);
       }));
 
-    test.only.each(TokenQueryOperators)('%s with empty value does not throw errors', async (operator) => {
+    test.each(TokenQueryOperators)('%s with empty value does not throw errors', async (operator) => {
       const search = systemRepo.search({
         resourceType: 'Patient',
         filters: [

--- a/packages/server/src/migrations/migrate-functions.ts
+++ b/packages/server/src/migrations/migrate-functions.ts
@@ -1,4 +1,5 @@
 import { Pool, PoolClient } from 'pg';
+import { globalLogger } from '../logger';
 
 export type MigrationAction = { name: string; durationMs: number };
 
@@ -51,13 +52,17 @@ export async function idempotentCreateIndex(
 
     const start = Date.now();
     await client.query(`DROP INDEX IF EXISTS ${indexName}`);
-    actions.push({ name: `DROP INDEX IF EXISTS ${indexName}`, durationMs: Date.now() - start });
+    const durationMs = Date.now() - start;
+    globalLogger.info('Dropped invalid index', { indexName, durationMs });
+    actions.push({ name: `DROP INDEX IF EXISTS ${indexName}`, durationMs });
     exists = false;
   }
 
   if (!exists) {
     const start = Date.now();
     await client.query(createIndexSql);
-    actions.push({ name: createIndexSql, durationMs: Date.now() - start });
+    const durationMs = Date.now() - start;
+    globalLogger.info('Created index', { indexName, durationMs });
+    actions.push({ name: createIndexSql, durationMs });
   }
 }

--- a/packages/server/src/workers/reindex.test.ts
+++ b/packages/server/src/workers/reindex.test.ts
@@ -582,7 +582,7 @@ describe('Job cancellation', () => {
       expect(finalJob.output).toBeUndefined();
     }));
 
-  test.only.each(['some-token', undefined])('Job handles queue closing with job.token %s', async (jobToken) =>
+  test.each(['some-token', undefined])('Job handles queue closing with job.token %s', async (jobToken) =>
     withTestContext(async () => {
       const originalJob = await repo.createResource<AsyncJob>({
         resourceType: 'AsyncJob',

--- a/packages/server/src/workers/reindex.test.ts
+++ b/packages/server/src/workers/reindex.test.ts
@@ -9,6 +9,7 @@ import {
   ResourceType,
   User,
 } from '@medplum/fhirtypes';
+import { DelayedError, Job } from 'bullmq';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
@@ -17,6 +18,7 @@ import { getSystemRepo, Repository } from '../fhir/repo';
 import { SelectQuery } from '../fhir/sql';
 import { createTestProject, withTestContext } from '../test.setup';
 import { addReindexJob, getReindexQueue, prepareReindexJobData, ReindexJob, ReindexJobData } from './reindex';
+import { queueRegistry } from './utils';
 
 describe('Reindex Worker', () => {
   let repo: Repository;
@@ -579,6 +581,58 @@ describe('Job cancellation', () => {
       expect(finalJob.status).toStrictEqual('cancelled');
       expect(finalJob.output).toBeUndefined();
     }));
+
+  test.only.each(['some-token', undefined])('Job handles queue closing with job.token %s', async (jobToken) =>
+    withTestContext(async () => {
+      const originalJob = await repo.createResource<AsyncJob>({
+        resourceType: 'AsyncJob',
+        status: 'accepted',
+        requestTime: new Date().toISOString(),
+        request: '/admin/super/reindex',
+      });
+
+      const queueName = 'ReindexQueue';
+      const queue = queueRegistry.get(queueName);
+      if (!queue) {
+        throw new Error('Could not find queue');
+      }
+
+      const isClosingSpy = jest.spyOn(queueRegistry, 'isClosing').mockReturnValue(true);
+      const jobData = prepareReindexJobData(['MedicinalProductContraindication'], originalJob.id);
+      const job = new Job(queue, 'ReindexJob', jobData, { attempts: 55 });
+
+      // job.token generally gets set deep in the internals of bullmq, but we mock the module
+      job.token = jobToken;
+
+      // DelayedError is part of the mocked bullmq module. Something about that causes
+      // the usual `expect(...).rejects.toThrow(...)`; it seems to be becuase DelayedError
+      // is no longer an `Error`. So instead, we manually check that it threw
+      let threw = undefined;
+      let manuallyThrownError = undefined;
+      try {
+        await new ReindexJob().execute(job, jobData);
+        manuallyThrownError = new Error(
+          jobToken ? 'Expected job to throw DelayedError' : 'Expected job to throw Error'
+        );
+        throw manuallyThrownError;
+      } catch (err) {
+        threw = err;
+      }
+      expect(threw).toBeDefined();
+      expect(threw).not.toBe(manuallyThrownError);
+      expect(threw).toBeInstanceOf(jobToken ? DelayedError : Error);
+
+      expect(isClosingSpy).toHaveBeenCalledTimes(1);
+      isClosingSpy.mockRestore();
+
+      if (jobToken) {
+        expect(job.moveToDelayed).toHaveBeenCalledTimes(1);
+        expect(job.moveToDelayed).toHaveBeenCalledWith(expect.any(Number), 'some-token');
+      } else {
+        expect(job.moveToDelayed).not.toHaveBeenCalled();
+      }
+    })
+  );
 
   test('Ensure updates from job do not clobber cancellation status', () =>
     withTestContext(async () => {

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -14,7 +14,7 @@ import { getRequestContext, tryRunInRequestContext } from '../context';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { AsyncJobExecutor } from '../fhir/operations/utils/asyncjobexecutor';
 import { getSystemRepo, Repository } from '../fhir/repo';
-import { getLogger, globalLogger } from '../logger';
+import { globalLogger } from '../logger';
 import { getPostDeployVersion } from '../migration-sql';
 import { PostDeployJobData, PostDeployMigration } from '../migrations/data/types';
 import { MigrationVersion } from '../migrations/migration-versions';
@@ -46,7 +46,7 @@ export interface ReindexJobData extends PostDeployJobData {
 
 export type ReindexResult =
   | { count: number; cursor: string; nextTimestamp: string; err?: Error }
-  | { count: number; duration: number };
+  | { count: number; durationMs: number };
 
 export interface ReindexPostDeployMigration extends PostDeployMigration<ReindexJobData> {
   type: 'reindex';
@@ -101,6 +101,7 @@ export class ReindexJob {
   private readonly systemRepo: Repository;
   private readonly batchSize: number;
   private readonly progressLogThreshold: number;
+  private readonly logger = globalLogger;
 
   constructor(systemRepo?: Repository, batchSize?: number, progressLogThreshold?: number) {
     this.systemRepo = systemRepo ?? getSystemRepo();
@@ -115,7 +116,7 @@ export class ReindexJob {
   private async maybeSkipJob(asyncJob: WithId<AsyncJob>): Promise<boolean> {
     const postDeployVersion = await getPostDeployVersion(getDatabasePool(DatabaseMode.WRITER));
     if (Boolean(asyncJob.dataVersion) && postDeployVersion === MigrationVersion.FIRST_BOOT) {
-      globalLogger.info('Skipping reindex post-deploy migration since server is in firstBoot mode', {
+      this.logger.info('Skipping reindex post-deploy migration since server is in firstBoot mode', {
         asyncJob: getReferenceString(asyncJob),
         version: `v${asyncJob.dataVersion}`,
       });
@@ -126,6 +127,36 @@ export class ReindexJob {
       return true;
     }
     return false;
+  }
+
+  private async checkForQueueClosing(
+    job: Job<ReindexJobData> | undefined,
+    asyncJob: WithId<AsyncJob>,
+    nextJobData: ReindexJobData
+  ): Promise<void> {
+    if (queueRegistry.isClosing(job?.queueName ?? '')) {
+      this.logger.info('Reindex job detected queue is closing', {
+        queueName: job?.queueName,
+        token: job?.token,
+        asyncJob: getReferenceString(asyncJob),
+      });
+      if (job?.token) {
+        this.logger.info('Reindex job delaying self', {
+          queueName: job.queueName,
+          token: job.token,
+          asyncJob: getReferenceString(asyncJob),
+          jobData: JSON.stringify(nextJobData),
+        });
+        await job.updateData(nextJobData);
+        await job.moveToDelayed(Date.now() + 60_000, job.token);
+        this.logger.info('Reindex job delayed', {
+          queueName: job.queueName,
+          token: job.token,
+          asyncJob: getReferenceString(asyncJob),
+        });
+        throw new DelayedError('Reindex job delayed since queue is closing');
+      }
+    }
   }
 
   async execute(
@@ -149,29 +180,7 @@ export class ReindexJob {
 
     let nextJobData: ReindexJobData | undefined = inputJobData;
     while (nextJobData) {
-      if (queueRegistry.isClosing(job?.queueName ?? '')) {
-        getLogger().info('Reindex job detected queue is closing', {
-          queueName: job?.queueName,
-          token: job?.token,
-          asyncJob: getReferenceString(asyncJob),
-        });
-        if (job?.token) {
-          getLogger().info('Reindex job delaying self', {
-            queueName: job.queueName,
-            token: job.token,
-            asyncJob: getReferenceString(asyncJob),
-            jobData: JSON.stringify(nextJobData),
-          });
-          await job.updateData(nextJobData);
-          await job.moveToDelayed(Date.now() + 60_000, job.token);
-          getLogger().info('Reindex job delayed', {
-            queueName: job.queueName,
-            token: job.token,
-            asyncJob: getReferenceString(asyncJob),
-          });
-          throw new DelayedError('Reindex job delayed since queue is closing');
-        }
-      }
+      await this.checkForQueueClosing(job, asyncJob, nextJobData);
       const result = await this.processIteration(this.systemRepo, nextJobData);
       const resourceType = nextJobData.resourceTypes[0];
       nextJobData.results[resourceType] = result;
@@ -234,17 +243,17 @@ export class ReindexJob {
     } else if (resourceTypes.length > 1) {
       // Completed reindex for this resource type
       const elapsedTime = Date.now() - jobData.startTime;
-      getLogger().info('Reindex completed', {
+      this.logger.info('Reindex completed for resourceType', {
         resourceType,
         count: newCount,
-        duration: `${elapsedTime} ms`,
+        durationMs: elapsedTime,
       });
 
-      return { count: newCount, duration: elapsedTime };
+      return { count: newCount, durationMs: elapsedTime };
     } else {
       const elapsedTime = Date.now() - jobData.startTime;
-      getLogger().info('Reindex completed', { resourceType, count, duration: `${elapsedTime} ms` });
-      return { count: newCount, duration: elapsedTime };
+      this.logger.info('Reindex completed', { resourceType, count, durationMs: elapsedTime });
+      return { count: newCount, durationMs: elapsedTime };
     }
   }
 
@@ -262,7 +271,7 @@ export class ReindexJob {
       }
 
       // Log periodic progress updates for the job
-      globalLogger.info('Reindex in progress', {
+      this.logger.info('Reindex in progress', {
         resourceType: jobData.resourceTypes[0],
         cursor: result.cursor,
         currentCount: result.count,
@@ -338,7 +347,7 @@ export class ReindexJob {
 }
 
 function isResultComplete(result: ReindexResult): boolean {
-  return 'duration' in result || 'err' in result;
+  return 'durationMs' in result || 'err' in result;
 }
 
 function isResultInProgress(
@@ -402,7 +411,7 @@ function formatReindexResult(result: ReindexResult, resourceType: string): Param
       part: [
         { name: 'resourceType', valueCode: resourceType },
         { name: 'count', valueInteger: result.count },
-        { name: 'elapsedTime', valueQuantity: { value: result.duration, code: 'ms' } },
+        { name: 'elapsedTime', valueQuantity: { value: result.durationMs, code: 'ms' } },
       ],
     };
   }

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -156,6 +156,10 @@ export class ReindexJob {
         });
         throw new DelayedError('Reindex job delayed since queue is closing');
       }
+
+      // This is one of those "this should never happen" errors. job.token is expected to always be set
+      // given the way we use bullmq.
+      throw new Error('Reindex job detected queue is closing, but job.token not available to delay the job');
     }
   }
 


### PR DESCRIPTION
Most impactful change was normalizing on `globalLogger` (versus `getLogger()`) in `ReindexJob` to get all intended log lines to actually show up. Previously, `getLogger()` had been falling back to `systemLogger` which has its log level set to ERROR, causing the log lines to be missed. The fallback to `systemLogger` was happening since no requestId and traceId are set for jobs created by the `RequestContext.system()` context as will be the case for auto-run post-deploy migrations.