### PR TITLE
Add super admin endpoint to check for invalid indexes

### DIFF
--- a/packages/app/src/admin/SuperAdminPage.test.tsx
+++ b/packages/app/src/admin/SuperAdminPage.test.tsx
@@ -4,6 +4,7 @@ import { allOk } from '@medplum/core';
 import { Parameters } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
+import { getDefaultNormalizer } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { AppRoutes } from '../AppRoutes';
 import { act, fireEvent, render, screen } from '../test-utils/render';
@@ -134,6 +135,31 @@ describe('SuperAdminPage', () => {
     });
 
     expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  test('Invalid indexes', async () => {
+    setup();
+
+    const expectString = 'Some__column_idx:\n  [is_valid: false]';
+    medplum.router.add('POST', '$db-invalid-indexes', async () => {
+      return [
+        allOk,
+        {
+          resourceType: 'Parameters',
+          parameter: [{ name: 'invalidIndex', valueString: expectString }],
+        },
+      ];
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Get Database Invalid Indexes' }));
+    });
+
+    expect(
+      await screen.findByText(expectString, {
+        normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+      })
+    ).toBeInTheDocument();
   });
 
   test('Database Stats', async () => {

--- a/packages/app/src/admin/SuperAdminPage.tsx
+++ b/packages/app/src/admin/SuperAdminPage.tsx
@@ -99,6 +99,24 @@ export function SuperAdminPage(): JSX.Element {
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
   }
 
+  function getDatabaseInvalidIndexes(): void {
+    medplum
+      .post('fhir/R4/$db-invalid-indexes')
+      .then((params: Parameters) => {
+        setModalTitle('Database Invalid Indexes');
+        setModalContent(
+          <pre>
+            {params.parameter
+              ?.filter((p) => p.name === 'invalidIndex')
+              .map((p) => p.valueString)
+              .join('\n')}
+          </pre>
+        );
+        open();
+      })
+      .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
+  }
+
   function getSchemaDiff(): void {
     medplum
       .post('fhir/R4/$db-schema-diff')
@@ -221,6 +239,14 @@ export function SuperAdminPage(): JSX.Element {
             <TextInput id="tableNames" name="tableNames" placeholder="Observation,Observation_History" />
           </FormSection>
           <Button type="submit">Get Database Stats</Button>
+        </Stack>
+      </Form>
+      <Divider my="lg" />
+      <Title order={2}>Database Invalid Indexes</Title>
+      <p>Query invalid indexes from the database.</p>
+      <Form onSubmit={getDatabaseInvalidIndexes}>
+        <Stack>
+          <Button type="submit">Get Database Invalid Indexes</Button>
         </Stack>
       </Form>
       <Divider my="lg" />

--- a/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
@@ -1,0 +1,53 @@
+import { Parameters } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { initTestAuth } from '../../test.setup';
+import { getDatabasePool, DatabaseMode } from '../../database';
+
+describe('$db-schema-diff', () => {
+  const app = express();
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  afterEach(async () => {
+    const client = getDatabasePool(DatabaseMode.WRITER);
+    await client.query(
+      `UPDATE pg_index SET indislive = true 
+      FROM pg_class WHERE pg_class.oid = pg_index.indexrelid 
+      AND pg_class.relname = $1`,
+      ['CarePlan_replaces_idx']
+    );
+  });
+
+  test('Success', async () => {
+    const client = getDatabasePool(DatabaseMode.WRITER);
+    await client.query(
+      `UPDATE pg_index SET indislive = false 
+      FROM pg_class WHERE pg_class.oid = pg_index.indexrelid 
+      AND pg_class.relname = $1`,
+      ['CarePlan_replaces_idx']
+    );
+
+    const accessToken = await initTestAuth({ project: { superAdmin: true } });
+
+    const res = await request(app)
+      .post('/fhir/R4/$db-invalid-indexes')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({});
+    expect(res.status).toBe(200);
+    const params = res.body as Parameters;
+    const invalidIndex = params.parameter?.filter((p) => p.name === 'invalidIndex');
+    expect(invalidIndex).toBeDefined();
+    expect(invalidIndex?.length).toBe(1);
+    expect(invalidIndex?.[0].valueString).toContain('CarePlan_replaces_idx');
+  });
+});

--- a/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
@@ -6,7 +6,7 @@ import { loadTestConfig } from '../../config/loader';
 import { initTestAuth } from '../../test.setup';
 import { getDatabasePool, DatabaseMode } from '../../database';
 
-describe('$db-schema-diff', () => {
+describe('$db-invalid-indexes', () => {
   const app = express();
 
   beforeAll(async () => {
@@ -20,12 +20,7 @@ describe('$db-schema-diff', () => {
 
   afterEach(async () => {
     const client = getDatabasePool(DatabaseMode.WRITER);
-    await client.query(
-      `UPDATE pg_index SET indislive = true 
-      FROM pg_class WHERE pg_class.oid = pg_index.indexrelid 
-      AND pg_class.relname = $1`,
-      ['CarePlan_replaces_idx']
-    );
+    await client.query(`REINDEX INDEX CONCURRENTLY "CarePlan_replaces_idx"`);
   });
 
   test('Success', async () => {

--- a/packages/server/src/fhir/operations/dbinvalidindexes.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.ts
@@ -1,0 +1,126 @@
+import { allOk } from '@medplum/core';
+import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import { OperationDefinition } from '@medplum/fhirtypes';
+import { requireSuperAdmin } from '../../admin/super';
+import { DatabaseMode, getDatabasePool } from '../../database';
+import { buildOutputParameters } from './utils/parameters';
+
+const operation: OperationDefinition = {
+  resourceType: 'OperationDefinition',
+  name: 'db-invalid-indexes',
+  status: 'active',
+  kind: 'operation',
+  code: 'db-invalid-indexes',
+  experimental: true,
+  system: true,
+  type: false,
+  instance: false,
+  parameter: [
+    {
+      use: 'out',
+      name: 'invalidIndex',
+      type: 'string',
+      min: 0,
+      max: '*',
+    },
+  ],
+};
+
+export async function dbInvalidIndexesHandler(_req: FhirRequest): Promise<FhirResponse> {
+  requireSuperAdmin();
+
+  const sql = `SELECT
+    n.nspname AS schema_name,
+    c.relname AS table_name,
+    i.indexrelid::regclass AS index_name,
+    i.indisvalid AS is_valid,
+    i.indisready AS is_ready,
+    i.indislive AS is_live,
+    pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
+    pg_size_pretty(pg_relation_size(i.indrelid)) AS table_size,
+    am.amname AS index_type,
+    i.indisprimary AS is_primary,
+    i.indisunique AS is_unique,
+    array_to_string(i.indkey, ' ') AS column_positions,
+    pg_get_indexdef(i.indexrelid) AS index_definition,
+    s.idx_scan AS index_scans,
+    s.idx_tup_read AS tuples_read,
+    s.idx_tup_fetch AS tuples_fetched,
+    age(c2.relfrozenxid) AS index_age,
+    c2.reltuples::bigint AS estimated_rows,
+    CASE 
+        WHEN i.indisvalid AND i.indisready AND i.indislive THEN 'Healthy'
+        WHEN NOT i.indisvalid AND i.indisready AND i.indislive THEN 'Invalid but maintained'
+        WHEN NOT i.indisready THEN 'Building/Not ready'
+        WHEN NOT i.indislive THEN 'Not maintained'
+        ELSE 'Unknown state'
+    END AS index_status
+FROM
+    pg_index i
+JOIN
+    pg_class c ON i.indrelid = c.oid
+JOIN
+    pg_class c2 ON i.indexrelid = c2.oid
+JOIN
+    pg_namespace n ON c.relnamespace = n.oid
+JOIN
+    pg_am am ON c2.relam = am.oid
+LEFT JOIN
+    pg_stat_all_indexes s ON s.indexrelid = i.indexrelid
+WHERE
+    (NOT i.indisvalid OR NOT i.indisready OR NOT i.indislive)
+ORDER BY
+    n.nspname, c.relname, i.indexrelid::regclass`;
+
+  const client = getDatabasePool(DatabaseMode.WRITER);
+  const results = await client.query<{
+    schema_name: string;
+    table_name: string;
+    index_name: string;
+    is_valid: boolean;
+    is_ready: boolean;
+    is_live: boolean;
+    index_size: string;
+    table_size: string;
+    index_type: string;
+    is_primary: boolean;
+    is_unique: boolean;
+    column_positions: string;
+    index_definition: string;
+    index_scans: number;
+    tuples_read: number;
+    tuples_fetched: number;
+    index_age: string;
+    estimated_rows: number;
+    index_status: string;
+  }>(sql);
+
+  const output: string[] = [];
+  for (const row of results.rows) {
+    output.push(
+      [
+        `${row.index_name}:`,
+        `  [schema: ${row.schema_name}]`,
+        `  [table: ${row.table_name}]`,
+        `  [index_status: ${row.index_status}]`,
+        `  [is_valid: ${row.is_valid}]`,
+        `  [is_ready: ${row.is_ready}]`,
+        `  [is_live: ${row.is_live}]`,
+        `  [index_size: ${row.index_size}]`,
+        `  [table_size: ${row.table_size}]`,
+        `  [index_type: ${row.index_type}]`,
+        `  [is_primary: ${row.is_primary}]`,
+        `  [is_unique: ${row.is_unique}]`,
+        `  [column_positions: ${row.column_positions}]`,
+        `  [index_definition: ${row.index_definition}]`,
+        `  [index_scans: ${row.index_scans}]`,
+        `  [tuples_read: ${row.tuples_read}]`,
+        `  [tuples_fetched: ${row.tuples_fetched}]`,
+        `  [index_age: ${row.index_age}]`,
+        `  [estimated_rows: ${row.estimated_rows}]`,
+      ].join('\n')
+    );
+  }
+
+  return [allOk, buildOutputParameters(operation, { invalidIndex: output })];
+}

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -24,6 +24,7 @@ import { codeSystemLookupHandler } from './operations/codesystemlookup';
 import { codeSystemValidateCodeHandler } from './operations/codesystemvalidatecode';
 import { conceptMapTranslateHandler } from './operations/conceptmaptranslate';
 import { csvHandler } from './operations/csv';
+import { dbInvalidIndexesHandler } from './operations/dbinvalidindexes';
 import { dbSchemaDiffHandler } from './operations/dbschemadiff';
 import { dbStatsHandler } from './operations/dbstats';
 import { deployHandler } from './operations/deploy';
@@ -314,6 +315,7 @@ function initInternalFhirRouter(): FhirRouter {
   // Super admin operations
   router.add('POST', '/$db-stats', dbStatsHandler);
   router.add('POST', '/$db-schema-diff', dbSchemaDiffHandler);
+  router.add('POST', '/$db-invalid-indexes', dbInvalidIndexesHandler);
 
   router.addEventListener('warn', (e: any) => {
     const ctx = getAuthenticatedContext();


### PR DESCRIPTION
Invalid indexes can occur when a `CREATE INDEX CONCURRENTLY...` is interrupted among other reasons.

Fixes #6358

Sample output:

```
"CarePlan_replaces_idx":
  [schema: public]
  [table: CarePlan]
  [index_status: Not maintained]
  [is_valid: true]
  [is_ready: true]
  [is_live: false]
  [index_size: 16 kB]
  [table_size: 0 bytes]
  [index_type: gin]
  [is_primary: false]
  [is_unique: false]
  [column_positions: 21]
  [index_definition: CREATE INDEX "CarePlan_replaces_idx" ON public."CarePlan" USING gin (replaces)]
  [index_scans: 0]
  [tuples_read: 0]
  [tuples_fetched: 0]
  [index_age: 2147483647]
  [estimated_rows: 0]
```