### PR TITLE
Disable test that writes actual pdf

### DIFF
--- a/examples/medplum-demo-bots/src/billing-bots/cms-1500-pdf.test.ts
+++ b/examples/medplum-demo-bots/src/billing-bots/cms-1500-pdf.test.ts
@@ -22,7 +22,7 @@ describe('CMS 1500 PDF Bot', async () => {
     medplum = new MockClient();
   });
 
-  test('Actual PDF', async () => {
+  test.skip('Actual PDF', async () => {
     await medplum.executeBatch(fullAnswer);
 
     const claim = (await medplum.searchOne('Claim', {


### PR DESCRIPTION
This test is useful for debugging, but it shouldn't be enabled by default, because it will create a bunch of PDF's on people's harddrives.