### PR TITLE
fix(docker/app): prefix conditional default assignment with `:`

### DIFF
--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -1,5 +1,8 @@
 FROM nginxinc/nginx-unprivileged:alpine
 
+# Start off as user root so we have permissions to run APK and chown
+USER root
+
 # Copy nginx configuration
 COPY <<EOF /etc/nginx/conf.d/default.conf
 server {
@@ -24,8 +27,6 @@ server {
 }
 EOF
 
-USER root
-
 # Copy and extract the app tarball
 ADD ./medplum-app.tar.gz /usr/share/nginx/html
 
@@ -39,7 +40,7 @@ RUN chown -R 101:101 /usr/share/nginx/html && \
 
 EXPOSE 3000
 
-# Switch back to the 101 UID
+# Switch back to the 101 UID (non-root user)
 USER 101
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/packages/app/docker-entrypoint.sh
+++ b/packages/app/docker-entrypoint.sh
@@ -4,12 +4,12 @@
 set -e
 
 # Defaults taken from .env.defaults in Medplum monorepo packages/app
-${MEDPLUM_BASE_URL:="http://localhost:8103/"}
-${MEDPLUM_CLIENT_ID:=""}
-${GOOGLE_CLIENT_ID:=""}
-${RECAPTCHA_SITE_KEY:="6LfHdsYdAAAAAC0uLnnRrDrhcXnziiUwKd8VtLNq"}
-${MEDPLUM_REGISTER_ENABLED:="true"}
-${MEDPLUM_AWS_TEXTRACT_ENABLED:="true"}
+: ${MEDPLUM_BASE_URL:="http://localhost:8103/"}
+: ${MEDPLUM_CLIENT_ID:=""}
+: ${GOOGLE_CLIENT_ID:=""}
+: ${RECAPTCHA_SITE_KEY:="6LfHdsYdAAAAAC0uLnnRrDrhcXnziiUwKd8VtLNq"}
+: ${MEDPLUM_REGISTER_ENABLED:="true"}
+: ${MEDPLUM_AWS_TEXTRACT_ENABLED:="true"}
 
 # Find all JS files in the assets directory
 # Update the app config


### PR DESCRIPTION
This fixes `docker-entrypoint.sh`, previously we erroneously thought it was working due to using an older version of the built app Dockerfile