### PR TITLE
Added tests for google auth and register disabled

### DIFF
--- a/packages/server/src/auth/google.test.ts
+++ b/packages/server/src/auth/google.test.ts
@@ -35,6 +35,10 @@ describe('Google Auth', () => {
     await initApp(app, config);
   });
 
+  beforeEach(() => {
+    getConfig().registerEnabled = undefined;
+  });
+
   afterAll(async () => {
     await shutdownApp();
   });
@@ -107,6 +111,25 @@ describe('Google Auth', () => {
         googleCredential: createCredential('Test', 'Test', email),
       });
     expect(res.status).toBe(400);
+
+    const user = await getUserByEmail(email, undefined);
+    expect(user).toBeUndefined();
+  });
+
+  test('Register disabled', async () => {
+    getConfig().registerEnabled = false;
+    const email = 'new-google-' + randomUUID() + '@example.com';
+    const res = await request(app)
+      .post('/auth/google')
+      .type('json')
+      .send({
+        googleClientId: getConfig().googleClientId,
+        googleCredential: createCredential('Test', 'Test', email),
+        createUser: true,
+        projectId: 'new',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.issue[0].details.text).toBe('Registration is disabled');
 
     const user = await getUserByEmail(email, undefined);
     expect(user).toBeUndefined();

--- a/packages/server/src/auth/google.ts
+++ b/packages/server/src/auth/google.ts
@@ -100,6 +100,11 @@ export async function googleHandler(req: Request, res: Response): Promise<void> 
       sendOutcome(res, badRequest('User not found'));
       return;
     }
+    if (getConfig().registerEnabled === false && (!projectId || projectId === 'new')) {
+      // Explicitly check for "false" because the config value may be undefined
+      sendOutcome(res, badRequest('Registration is disabled'));
+      return;
+    }
     const systemRepo = getSystemRepo();
     await systemRepo.createResource<User>({
       resourceType: 'User',


### PR DESCRIPTION
Updated the Google auth registration control flow to ensure consistent error message with `registerEnabled === false`  across all authentication flows, including third-party authentication providers.

- Standardized the validation of registration permission settings across all authentication pathways
- Improved system-wide enforcement of administrative registration controls
- Added additional test coverage for third-party authentication flows

This change strengthens the security posture of the application by ensuring that administrative registration controls are consistently enforced regardless of the authentication method used. No configuration changes are required.