### PR TITLE
Writing resources resilient to null or undefined array items

### DIFF
--- a/packages/server/src/fhir/lookups/address.test.ts
+++ b/packages/server/src/fhir/lookups/address.test.ts
@@ -235,9 +235,9 @@ describe('Address Lookup Table', () => {
       id: '1',
       address: undefined,
     };
-    let result: any[] = [];
-    table.extractValues(result, r1);
-    expect(result).toStrictEqual([]);
+    const result1: any[] = [];
+    table.extractValues(result1, r1);
+    expect(result1).toStrictEqual([]);
 
     const r2: WithId<Patient> = {
       resourceType: 'Patient',
@@ -260,9 +260,9 @@ describe('Address Lookup Table', () => {
       ] as unknown as Address[],
     };
 
-    result = [];
-    table.extractValues(result, r2);
-    expect(result).toStrictEqual([
+    const result2: any[] = [];
+    table.extractValues(result2, r2);
+    expect(result2).toStrictEqual([
       {
         resourceId: '2',
         address: 'Line 1, City 1, State 1, Postal 1',
@@ -289,6 +289,47 @@ describe('Address Lookup Table', () => {
         resourceId: '2',
         state: undefined,
         use: 'home',
+      },
+    ]);
+
+    const r3: WithId<InsurancePlan> = {
+      resourceType: 'InsurancePlan',
+      id: '3',
+      contact: [
+        {
+          address: {
+            use: 'work',
+            line: ['Line 1'],
+            city: 'City 1',
+            country: 'Country 1',
+            postalCode: 'Postal 1',
+            state: 'State 1',
+          },
+        },
+        {
+          address: {
+            use: 'work',
+            line: ['Line 1'],
+            city: 'City 1',
+            country: 'Country 1',
+            postalCode: 'Postal 1',
+            state: 'State 1',
+          },
+        },
+      ],
+    };
+
+    const result3: any[] = [];
+    table.extractValues(result3, r3);
+    expect(result3).toStrictEqual([
+      {
+        resourceId: '3',
+        address: 'Line 1, City 1, State 1, Postal 1',
+        city: 'City 1',
+        country: 'Country 1',
+        postalCode: 'Postal 1',
+        state: 'State 1',
+        use: 'work',
       },
     ]);
   });

--- a/packages/server/src/fhir/lookups/address.ts
+++ b/packages/server/src/fhir/lookups/address.ts
@@ -158,21 +158,28 @@ export class AddressTable extends LookupTable {
       return undefined;
     }
 
+    let addresses: (Address | undefined | null)[] | undefined;
+
     switch (resource.resourceType) {
       case 'Patient':
       case 'Person':
       case 'Practitioner':
       case 'RelatedPerson':
       case 'Organization':
-        return resource.address?.filter((address) => !!address);
+        addresses = resource.address;
+        break;
       case 'InsurancePlan':
-        return resource.contact?.map((contact) => contact.address).filter((address) => !!address);
+        addresses = resource.contact?.map((contact) => contact.address);
+        break;
       case 'Location':
-        return resource.address ? [resource.address] : undefined;
+        addresses = resource.address ? [resource.address] : undefined;
+        break;
       default:
         resource.resourceType satisfies never;
         return undefined;
     }
+
+    return addresses?.filter((a) => !!a);
   }
 
   /**

--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -282,7 +282,7 @@ describe('HumanName Lookup Table', () => {
       {
         resourceId: '2',
         name: 'Family',
-        given: '',
+        given: undefined,
         family: 'Family',
       },
     ]);

--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -1,5 +1,5 @@
-import { Operator } from '@medplum/core';
-import { Patient } from '@medplum/fhirtypes';
+import { Operator, WithId } from '@medplum/core';
+import { HumanName, Patient } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
@@ -257,5 +257,34 @@ describe('HumanName Lookup Table', () => {
     await table.purgeValuesBefore(db, 'AuditEvent', '2024-01-01T00:00:00Z');
 
     expect(db.query).not.toHaveBeenCalled();
+  });
+
+  test('extractValues defensive against nullish values', () => {
+    const table = new HumanNameTable();
+    const r1: WithId<Patient> = {
+      resourceType: 'Patient',
+      id: '1',
+      name: undefined,
+    };
+    let result: any[] = [];
+    table.extractValues(result, r1);
+    expect(result).toStrictEqual([]);
+
+    const r2: WithId<Patient> = {
+      resourceType: 'Patient',
+      id: '2',
+      name: [{}, null, undefined, { family: 'Family' }, { family: 'Family' }] as unknown as HumanName[],
+    };
+
+    result = [];
+    table.extractValues(result, r2);
+    expect(result).toStrictEqual([
+      {
+        resourceId: '2',
+        name: 'Family',
+        given: '',
+        family: 'Family',
+      },
+    ]);
   });
 });

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -73,7 +73,7 @@ export class HumanNameTable extends LookupTable {
       return;
     }
 
-    const names = (resource as HumanNameResource).name;
+    const names: (HumanName | undefined | null)[] | undefined = (resource as HumanNameResource).name;
     if (!Array.isArray(names)) {
       return;
     }

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -19,9 +19,9 @@ type HumanNameResourceType = (typeof resourceTypes)[number];
 type HumanNameResource = Patient | Person | Practitioner | RelatedPerson;
 
 interface HumanNameTableRow extends LookupTableRow {
-  name: string;
-  given: string;
-  family: string;
+  name: string | undefined;
+  given: string | undefined;
+  family: string | undefined;
 }
 
 /**
@@ -78,12 +78,24 @@ export class HumanNameTable extends LookupTable {
       return;
     }
     for (const name of names) {
-      result.push({
+      if (!name) {
+        continue;
+      }
+
+      const extracted = {
         resourceId: resource.id,
-        name: getNameString(name),
-        given: formatGivenName(name),
-        family: formatFamilyName(name),
-      });
+        // logical OR coalesce to ensure that empty strings are inserted as NULL
+        name: getNameString(name) || undefined,
+        given: formatGivenName(name) || undefined,
+        family: formatFamilyName(name) || undefined,
+      };
+
+      if (
+        (extracted.name || extracted.given || extracted.family) &&
+        !result.some((n) => n.name === extracted.name && n.given === extracted.given && n.family === extracted.family)
+      ) {
+        result.push(extracted);
+      }
     }
   }
 

--- a/packages/server/src/fhir/tokens.ts
+++ b/packages/server/src/fhir/tokens.ts
@@ -193,12 +193,9 @@ function buildCodingToken(result: Token[], context: TokensContext, coding: Codin
  * @param contactPoint - The ContactPoint object to be indexed.
  */
 function buildContactPointToken(result: Token[], context: TokensContext, contactPoint: ContactPoint | undefined): void {
-  buildSimpleToken(
-    result,
-    context,
-    contactPoint?.system,
-    contactPoint?.value ? contactPoint.value.toLocaleLowerCase() : contactPoint?.value
-  );
+  if (contactPoint) {
+    buildSimpleToken(result, context, contactPoint.system, contactPoint.value?.toLocaleLowerCase());
+  }
 }
 
 /**


### PR DESCRIPTION
To avoid errors like:

```
TypeError: Cannot read properties of null (reading 'city')
    at AddressTable.extractValues (/usr/src/medplum/packages/server/dist/fhir/lookups/address.js:63:31)
    at AddressTable.batchIndexResources (/usr/src/medplum/packages/server/dist/fhir/lookups/lookuptable.js:50:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async AddressTable.batchIndexResources (/usr/src/medplum/packages/server/dist/fhir/lookups/address.js:75:9)
    at async Repository.batchWriteLookupTables (/usr/src/medplum/packages/server/dist/fhir/repo.js:1379:13)
    at async Repository.reindexResources (/usr/src/medplum/packages/server/dist/fhir/repo.js:705:9)
    at async /usr/src/medplum/packages/server/dist/workers/reindex.js:161:21
    at async Repository.withTransaction (/usr/src/medplum/packages/server/dist/fhir/repo.js:1857:32)
    at async ReindexJob.processIteration (/usr/src/medplum/packages/server/dist/workers/reindex.js:157:13)
    at async ReindexJob.execute (/usr/src/medplum/packages/server/dist/workers/reindex.js:120:28)
```

Fixes #6394 