### PR TITLE
enable adding deployment sidecars from helm chart values

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             httpGet:
               path: /healthcheck
               port: {{ .Values.service.targetPort | default 8103 }}
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -63,6 +63,9 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- with .Values.deployment.sidecars }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -11,8 +11,8 @@ global:
     # type: "gcp:projectId:secretId"
     # type: "azure:keyVaultURL:secretName"
     type: "env"  # Default to env
- 
-serviceAccount: 
+
+serviceAccount:
   annotations:
     iam.gke.io/gcp-service-account: [MY_GCP_SERVICE_ACCOUNT] # Your Google Cloud Platform service account e.i: medplum-server@[MY_PROJECT_ID].iam.gserviceaccount.com
     # azure.workload.identity/client-id: "7f644391-4b27-4f76-8427-17bae90d7ee8" # Azure Managed Identity Client ID
@@ -34,6 +34,9 @@ deployment:
       memory: "2Gi"
   autoscaling:
     enabled: true
+  # Structure this deployment.sidecar value as if you were adding the container
+  # to the Deployment's spec.template.spec.containers key.
+  sidecars: []
 
 service: {}
 


### PR DESCRIPTION
We would like to deploy a sidecar, [GCP's SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy), with the medplum deployment. Here's a change to allow adding sidecars to the deployment via the chart's values. 

There should be no differences for users upgrading; a user has to explicitly add a valid container spec to a new value that will be empty by default.

This fixes a small bug as well, the livenessProbe's initialDelaySeconds was indented under httpGet where [k8s doesn't like it](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#probe-v1-core).