### PR TITLE
Correctly set statement_timeout in ReindexJob

### DIFF
--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -10,6 +10,7 @@ import {
   closeDatabase,
   DatabaseMode,
   getDatabasePool,
+  getDefaultStatementTimeout,
   initDatabase,
   releaseAdvisoryLock,
 } from './database';
@@ -192,6 +193,19 @@ describe('Database config', () => {
     jest.runAllTimersAsync().catch((reason) => console.error('Unexpected error in jest.runAllTimersAsync', reason));
 
     await expect(initDBPromise).rejects.toThrow('Failed to acquire migration lock');
+  });
+
+  test('getDefaultStatementTimeout', async () => {
+    const config = await loadTestConfig();
+    config.database.disableConnectionConfiguration = true;
+    expect(getDefaultStatementTimeout(config.database)).toBe('DEFAULT');
+
+    config.database.disableConnectionConfiguration = false;
+    config.database.queryTimeout = 5000;
+    expect(getDefaultStatementTimeout(config.database)).toBe(5000);
+
+    config.database.queryTimeout = undefined;
+    expect(getDefaultStatementTimeout(config.database)).toBe(60000);
   });
 });
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -92,6 +92,13 @@ async function initPool(config: MedplumDatabaseConfig, proxyEndpoint: string | u
   return pool;
 }
 
+export function getDefaultStatementTimeout(config: MedplumDatabaseConfig): number | 'DEFAULT' {
+  if (config.disableConnectionConfiguration) {
+    return 'DEFAULT';
+  }
+  return config.queryTimeout ?? 60000;
+}
+
 export async function closeDatabase(): Promise<void> {
   if (pool) {
     await pool.end();

--- a/packages/server/src/workers/reindex.ts
+++ b/packages/server/src/workers/reindex.ts
@@ -62,7 +62,7 @@ const defaultProgressLogThreshold = 50_000;
 
 // Version that can be bumped when the worker code changes, typically for bug fixes,
 // to prevent workers running older versions of the reindex worker from processing jobs
-export const REINDEX_WORKER_VERSION = 1;
+export const REINDEX_WORKER_VERSION = 2;
 
 export const initReindexWorker: WorkerInitializer = (config) => {
   const defaultOptions: QueueBaseOptions = {


### PR DESCRIPTION
It is only possible to consistently set a statement_timeout on a `Repository` within a transaction. At some point, we may want to make it possible for a Repository to have a sticky connection outside of transactions, but for now that is not part of its API.