### PR TITLE
Let `/admin/super/vacuum` run `ANALYZE` queries

### DIFF
--- a/packages/cli/src/rest.test.ts
+++ b/packages/cli/src/rest.test.ts
@@ -120,6 +120,25 @@ describe('CLI rest', () => {
     expect(console.log).toHaveBeenCalledWith(expect.stringMatching('Patient'));
   });
 
+  test('Post command with --prefer-async', async () => {
+    const postSpy = jest.spyOn(medplum, 'post');
+
+    await main(['node', 'index.js', 'post', 'Patient', '{ "resourceType": "Patient" }']);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    const headers1 = postSpy.mock.calls[0][3]?.headers as Record<string, string> | undefined;
+    expect(headers1).toBeDefined();
+    expect(headers1?.Prefer).toBe(undefined);
+    postSpy.mockClear();
+
+    await main(['node', 'index.js', 'post', '--prefer-async', 'Patient', '{ "resourceType": "Patient" }']);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    const headers2 = postSpy.mock.calls[0][3]?.headers as Record<string, string> | undefined;
+    expect(headers2).toBeDefined();
+    expect(headers2?.Prefer).toBe('respond-async');
+
+    postSpy.mockRestore();
+  });
+
   test('Basic Auth profile request', async () => {
     const profileName = 'testProfile';
     const obj = {

--- a/packages/cli/src/rest.ts
+++ b/packages/cli/src/rest.ts
@@ -32,11 +32,15 @@ patch.arguments('<url> <body>').action(async (url, body, options) => {
   prettyPrint(await medplum.patch(cleanUrl(medplum, url), parseBody(body)));
 });
 
-post.arguments('<url> <body>').action(async (url, body, options) => {
-  const medplum = await createMedplumClient(options);
+post
+  .arguments('<url> <body>')
+  .option('--prefer-async', 'Sets the Prefer header to "respond-async"')
+  .action(async (url, body, options) => {
+    const medplum = await createMedplumClient(options);
 
-  prettyPrint(await medplum.post(cleanUrl(medplum, url), parseBody(body)));
-});
+    const headers = options.preferAsync ? { Prefer: 'respond-async' } : undefined;
+    prettyPrint(await medplum.post(cleanUrl(medplum, url), parseBody(body), undefined, { headers }));
+  });
 
 put.arguments('<url> <body>').action(async (url, body, options) => {
   const medplum = await createMedplumClient(options);

--- a/packages/server/src/admin/super.test.ts
+++ b/packages/server/src/admin/super.test.ts
@@ -740,12 +740,17 @@ describe('Super Admin routes', () => {
 
       expect(res1.status).toStrictEqual(202);
       expect(res1.headers['content-location']).toBeDefined();
-      await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken);
+      const asyncJob = await waitForAsyncJob(res1.headers['content-location'], app, adminAccessToken);
+
+      const expectedQuery = 'VACUUM;';
+
+      expect(asyncJob.output?.parameter?.find((p) => p.name === 'query')?.valueString).toBe(expectedQuery);
 
       expect(infoSpy).toHaveBeenCalledWith('[Super Admin]: Vacuum completed', {
         durationMs: expect.any(Number),
+        vacuum: true,
         analyze: undefined,
-        query: 'VACUUM;',
+        query: expectedQuery,
         tableNames: undefined,
       });
       infoSpy.mockRestore();
@@ -783,6 +788,7 @@ describe('Super Admin routes', () => {
 
       expect(infoSpy).toHaveBeenCalledWith('[Super Admin]: Vacuum completed', {
         durationMs: expect.any(Number),
+        vacuum: true,
         analyze: undefined,
         query: 'VACUUM "Observation", "Observation_History";',
         tableNames: ['Observation', 'Observation_History'],
@@ -806,6 +812,7 @@ describe('Super Admin routes', () => {
 
       expect(infoSpy).toHaveBeenCalledWith('[Super Admin]: Vacuum completed', {
         durationMs: expect.any(Number),
+        vacuum: true,
         analyze: true,
         query: 'VACUUM ANALYZE "Observation", "Observation_History";',
         tableNames: ['Observation', 'Observation_History'],
@@ -829,6 +836,7 @@ describe('Super Admin routes', () => {
 
       expect(infoSpy).toHaveBeenCalledWith('[Super Admin]: Vacuum completed', {
         durationMs: expect.any(Number),
+        vacuum: false,
         analyze: true,
         query: 'ANALYZE "Observation", "Observation_History";',
         tableNames: ['Observation', 'Observation_History'],

--- a/packages/server/src/admin/super.ts
+++ b/packages/server/src/admin/super.ts
@@ -397,7 +397,9 @@ superAdminRouter.post(
       return;
     }
 
-    let action = (req.body.vacuum ?? true) ? 'VACUUM' : '';
+    const vacuum = req.body.vacuum ?? true;
+
+    let action = vacuum ? 'VACUUM' : '';
     action += req.body.analyze ? ' ANALYZE' : '';
     if (!action) {
       throw new OperationOutcomeError(badRequest('At least one of vacuum or analyze must be true'));
@@ -411,13 +413,17 @@ superAdminRouter.post(
       await getSystemRepo().getDatabaseClient(DatabaseMode.WRITER).query(query);
       globalLogger.info('[Super Admin]: Vacuum completed', {
         tableNames: req.body.tableNames,
+        vacuum,
         analyze: req.body.analyze,
         query,
         durationMs: Date.now() - startTime,
       });
       return {
         resourceType: 'Parameters',
-        parameter: [{ name: 'outcome', resource: allOk }],
+        parameter: [
+          { name: 'outcome', resource: allOk },
+          { name: 'query', valueString: query },
+        ],
       };
     });
   })

--- a/packages/server/src/fhir/operations/dbstats.ts
+++ b/packages/server/src/fhir/operations/dbstats.ts
@@ -60,6 +60,8 @@ export async function dbStatsHandler(req: FhirRequest): Promise<FhirResponse> {
       n_dead_tup AS dead_tuples,
       last_autovacuum,
       last_autoanalyze,
+      last_analyze,
+      last_vacuum,
       indisvalid
     FROM
       pg_stat_user_indexes i
@@ -79,20 +81,22 @@ export async function dbStatsHandler(req: FhirRequest): Promise<FhirResponse> {
     if (row.table_name !== currentTable) {
       output.push(
         `${row.table_name}: ${row.total_size}`,
-        `  [table: ${row.table_size} indexes: ${row.all_indexes_size}]`,
-        `  [estimated rows: ${row.estimated_row_count}]`,
-        `  [settings overrides: ${row.table_level_overrides}]`,
-        `  [live tuples: ${row.live_tuples}]`,
-        `  [dead tuples: ${row.dead_tuples}]`,
-        `  [last autovacuum: ${new Date(row.last_autovacuum).toISOString()}]`,
-        `  [last autoanalyze: ${new Date(row.last_autoanalyze).toISOString()}]`
+        `  [table_size: ${row.table_size} indexes_size: ${row.all_indexes_size}]`,
+        `  [estimated_row_count: ${row.estimated_row_count}]`,
+        `  [table_level_overrides: ${row.table_level_overrides}]`,
+        `  [live_tuples: ${row.live_tuples}]`,
+        `  [dead_tuples: ${row.dead_tuples}]`,
+        `  [last_autovacuum: ${new Date(row.last_autovacuum).toISOString()}]`,
+        `  [last_autoanalyze: ${new Date(row.last_autoanalyze).toISOString()}]`,
+        `  [last_analyze: ${new Date(row.last_analyze).toISOString()}]`,
+        `  [last_vacuum: ${new Date(row.last_vacuum).toISOString()}]`
       );
       currentTable = row.table_name;
     }
     output.push(
       `    ${row.index_name}: ${row.index_size}`,
       row.indisvalid
-        ? `      [scans: ${row.index_scans} entries read: ${row.index_entries_read} rows fetched: ${row.index_rows_fetched}]`
+        ? `      [scans: ${row.index_scans} entries_read: ${row.index_entries_read} rows_fetched: ${row.index_rows_fetched}]`
         : `      [!INVALID!]`
     );
   }


### PR DESCRIPTION
Rounding out the functionality of the endpoint to allow running only `ANALYZE` in addition to `VACUUM` and `VACUUM ANALYZE`.

Added the `--prefer-async` flag to faciliate using the vacuum endpoint via the Medplum CLI.