### PR TITLE
Expose claim/$export as POST request similar to claim/$submit

### DIFF
--- a/examples/medplum-provider/src/pages/encounter/EncounterChart.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterChart.tsx
@@ -313,8 +313,8 @@ export const EncounterChart = (): JSX.Element => {
         },
       ],
       diagnosis: diagnosisArray,
-    }
-    const response = await medplum.post(medplum.fhirUrl('Claim','$export'), {
+    };
+    const response = await medplum.post(medplum.fhirUrl('Claim', '$export'), {
       resourceType: 'Parameters',
       parameter: [{ name: 'resource', resource: claimToExport }],
     });

--- a/examples/medplum-provider/src/pages/encounter/EncounterChart.tsx
+++ b/examples/medplum-provider/src/pages/encounter/EncounterChart.tsx
@@ -303,7 +303,7 @@ export const EncounterChart = (): JSX.Element => {
     }
 
     const diagnosisArray = createDiagnosisArray(diagnosis);
-    await medplum.updateResource({
+    const claimToExport: Claim = {
       ...claim,
       insurance: [
         {
@@ -313,9 +313,11 @@ export const EncounterChart = (): JSX.Element => {
         },
       ],
       diagnosis: diagnosisArray,
+    }
+    const response = await medplum.post(medplum.fhirUrl('Claim','$export'), {
+      resourceType: 'Parameters',
+      parameter: [{ name: 'resource', resource: claimToExport }],
     });
-
-    const response = await medplum.get(medplum.fhirUrl('Claim', claim.id, '$export'));
 
     if (response.resourceType === 'Media' && response.content?.url) {
       const url = response.content.url;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     "migrate": "ts-node --transpileOnly src/migrations/migrate.ts",
     "circular": "npx madge --circular dist/index.js",
     "start": "node --require ./dist/otel/instrumentation.js dist/index.js",
-    "test": "jest  --verbose",
+    "test": "jest",
     "test:seed": "jest seed.test.ts --testTimeout=400000"
   },
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     "migrate": "ts-node --transpileOnly src/migrations/migrate.ts",
     "circular": "npx madge --circular dist/index.js",
     "start": "node --require ./dist/otel/instrumentation.js dist/index.js",
-    "test": "jest",
+    "test": "jest  --verbose",
     "test:seed": "jest seed.test.ts --testTimeout=400000"
   },
   "dependencies": {

--- a/packages/server/src/fhir/operations/claimexport.test.ts
+++ b/packages/server/src/fhir/operations/claimexport.test.ts
@@ -55,13 +55,26 @@ describe('CMS 1500 PDF Bot', () => {
         ]
       });
 
-    console.log(JSON.stringify(response.body, null, 2));
     expect(response).toBeDefined();
     expect(response.status).toBe(200);
     expect(response.body.resourceType).toBe('Media');
     expect(response.body.content.contentType).toBe('application/pdf');
   });
 
+  test('Bad request - claim not found', async () => {
+    const response = await request(app)
+      .post(`/fhir/R4/Claim/$export`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/fhir+json')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [{ name: 'resource'}],
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.resourceType).toBe('OperationOutcome');
+    expect(response.body.issue[0].severity).toBe('error');
+  });
 });
 
 export const fullAnswer: Bundle = {

--- a/packages/server/src/fhir/operations/claimexport.test.ts
+++ b/packages/server/src/fhir/operations/claimexport.test.ts
@@ -50,9 +50,9 @@ describe('CMS 1500 PDF Bot', () => {
         parameter: [
           {
             name: 'resource',
-            resource: claim
-          }
-        ]
+            resource: claim,
+          },
+        ],
       });
 
     expect(response).toBeDefined();
@@ -68,7 +68,7 @@ describe('CMS 1500 PDF Bot', () => {
       .set('Accept', 'application/fhir+json')
       .send({
         resourceType: 'Parameters',
-        parameter: [{ name: 'resource'}],
+        parameter: [{ name: 'resource' }],
       });
 
     expect(response.status).toBe(400);

--- a/packages/server/src/fhir/operations/claimexport.test.ts
+++ b/packages/server/src/fhir/operations/claimexport.test.ts
@@ -42,37 +42,26 @@ describe('CMS 1500 PDF Bot', () => {
     expect(claim.identifier?.some((id) => id.value === 'example-claim-cms1500')).toBe(true);
 
     const response = await request(app)
-      .get(`/fhir/R4/Claim/${claim.id}/$export`)
+      .post(`/fhir/R4/Claim/$export`)
       .set('Authorization', 'Bearer ' + accessToken)
-      .set('Accept', 'application/fhir+json');
+      .set('Accept', 'application/fhir+json')
+      .send({
+        resourceType: 'Parameters',
+        parameter: [
+          {
+            name: 'resource',
+            resource: claim
+          }
+        ]
+      });
 
+    console.log(JSON.stringify(response.body, null, 2));
     expect(response).toBeDefined();
     expect(response.status).toBe(200);
     expect(response.body.resourceType).toBe('Media');
     expect(response.body.content.contentType).toBe('application/pdf');
   });
 
-  test('Bad request - missing claim ID', async () => {
-    const response = await request(app)
-      .get(`/fhir/R4/Claim/$export`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Accept', 'application/fhir+json');
-
-    expect(response.status).toBe(404);
-    expect(response.body.resourceType).toBe('OperationOutcome');
-    expect(response.body.issue[0].severity).toBe('error');
-  });
-
-  test('Bad request - claim not found', async () => {
-    const response = await request(app)
-      .get(`/fhir/R4/Claim/non-existent-id/$export`)
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Accept', 'application/fhir+json');
-
-    expect(response.status).toBe(400);
-    expect(response.body.resourceType).toBe('OperationOutcome');
-    expect(response.body.issue[0].severity).toBe('error');
-  });
 });
 
 export const fullAnswer: Bundle = {

--- a/packages/server/src/fhir/operations/claimexport.test.ts
+++ b/packages/server/src/fhir/operations/claimexport.test.ts
@@ -8,7 +8,7 @@ import { initTestAuth } from '../../test.setup';
 const app = express();
 let accessToken: string;
 
-describe('CMS 1500 PDF Bot', () => {
+describe('CMS 1500 PDF', () => {
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
@@ -19,7 +19,7 @@ describe('CMS 1500 PDF Bot', () => {
     await shutdownApp();
   });
 
-  test('Fully answered CMS1500 pdf', async () => {
+  test('Post Request - Fully answered CMS1500 pdf', async () => {
     const bundleRes = await request(app)
       .post(`/fhir/R4`)
       .set('Authorization', 'Bearer ' + accessToken)
@@ -59,6 +59,50 @@ describe('CMS 1500 PDF Bot', () => {
     expect(response.status).toBe(200);
     expect(response.body.resourceType).toBe('Media');
     expect(response.body.content.contentType).toBe('application/pdf');
+  });
+
+  test('Get Request - Fully answered CMS1500 pdf', async () => {
+    const bundleRes = await request(app)
+      .post(`/fhir/R4`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', 'application/fhir+json')
+      .send(fullAnswer);
+    expect(bundleRes.status).toBe(200);
+    expect(bundleRes.body.resourceType).toBe('Bundle');
+    expect(bundleRes.body.type).toBe('transaction-response');
+
+    const searchRes = await request(app)
+      .get(`/fhir/R4/Claim?identifier=example-claim-cms1500`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/fhir+json');
+    expect(searchRes.status).toBe(200);
+    expect(searchRes.body.resourceType).toBe('Bundle');
+    expect(searchRes.body.entry.length).toBeGreaterThan(0);
+
+    const claim = searchRes.body.entry[0].resource as Claim;
+    expect(claim.resourceType).toBe('Claim');
+    expect(claim.identifier?.some((id) => id.value === 'example-claim-cms1500')).toBe(true);
+
+    const response = await request(app)
+      .get(`/fhir/R4/Claim/${claim.id}/$export`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/fhir+json');
+
+    expect(response).toBeDefined();
+    expect(response.status).toBe(200);
+    expect(response.body.resourceType).toBe('Media');
+    expect(response.body.content.contentType).toBe('application/pdf');
+  });
+
+  test('Bad request - claim not found', async () => {
+    const response = await request(app)
+      .get(`/fhir/R4/Claim/non-existent-id/$export`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/fhir+json');
+
+    expect(response.status).toBe(400);
+    expect(response.body.resourceType).toBe('OperationOutcome');
+    expect(response.body.issue[0].severity).toBe('error');
   });
 
   test('Bad request - claim not found', async () => {

--- a/packages/server/src/fhir/operations/claimexport.ts
+++ b/packages/server/src/fhir/operations/claimexport.ts
@@ -65,6 +65,11 @@ export async function claimExportHandler(req: FhirRequest): Promise<FhirResponse
   try {
     const params = parseInputParameters<ClaimExportParameters>(operation, req);
     const claim: Claim = params.resource;
+
+    if (!claim) {
+      return [badRequest('The resource must be a Claim')];
+    }
+
     const docDefinition = await getClaimPDFDocDefinition(claim);
     const pdfBuffer = await createPdf(docDefinition);
     const binary = await repo.createResource<Binary>({

--- a/packages/server/src/fhir/operations/claimexport.ts
+++ b/packages/server/src/fhir/operations/claimexport.ts
@@ -27,7 +27,7 @@ export const operation: OperationDefinition = {
     {
       use: 'in',
       name: 'resource',
-      type: "Resource",
+      type: 'Resource',
       min: 1,
       max: '1',
       documentation: 'The claim to export',

--- a/packages/server/src/fhir/operations/claimexport.ts
+++ b/packages/server/src/fhir/operations/claimexport.ts
@@ -100,14 +100,13 @@ async function handleClaimExport(claim: Claim): Promise<FhirResponse> {
 /**
  * Handles HTTP GET requests for the Claim $export operation.
  * 
- * Reads the claim and generates a PDF document based on its contents.
- * Returns a Binary resource containing the PDF document directly.
+ * Fetches the claim from the database and generates a PDF document based on its contents.
  * 
  * Endpoint:
  * [fhir base]/Claim/{id}/$export
  * 
  * @param req - The FHIR request.
- * @returns The FHIR response with a Binary resource containing the PDF.
+ * @returns The FHIR response with a Media resource containing PDF reference.
  */
 export async function claimExportGetHandler(req: FhirRequest): Promise<FhirResponse> {
   const { repo } = getAuthenticatedContext();
@@ -129,13 +128,12 @@ export async function claimExportGetHandler(req: FhirRequest): Promise<FhirRespo
  * Handles HTTP POST requests for the Claim $export operation.
  * 
  * Reads the claim and generates a PDF document based on its contents.
- * Returns a Binary resource containing the PDF document directly.
  * 
  * Endpoint:
  * [fhir base]/Claim/$export
  * 
  * @param req - The FHIR request.
- * @returns The FHIR response with a Binary resource containing the PDF.
+ * @returns The FHIR response with a Media resource containing PDF reference.
  */
 export async function claimExportPostHandler(req: FhirRequest): Promise<FhirResponse> {
   try {

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -37,7 +37,6 @@ describe('FHIR Parameters parsing', () => {
     const result = parseParameters(input);
     expect(result).toMatchObject(input);
   });
-  
 });
 
 const opDef: OperationDefinition = {

--- a/packages/server/src/fhir/operations/utils/parameters.test.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.test.ts
@@ -37,6 +37,7 @@ describe('FHIR Parameters parsing', () => {
     const result = parseParameters(input);
     expect(result).toMatchObject(input);
   });
+  
 });
 
 const opDef: OperationDefinition = {
@@ -55,6 +56,7 @@ const opDef: OperationDefinition = {
     { name: 'fractional', use: 'in', min: 0, max: '1', type: 'decimal' },
     { name: 'multiIn', use: 'in', min: 0, max: '*', type: 'string' },
     { name: 'complexIn', use: 'in', min: 0, max: '*', type: 'Reference' },
+    { name: 'resource', use: 'in', min: 0, max: '1', type: 'Resource' },
     {
       name: 'partsIn',
       use: 'in',
@@ -105,6 +107,20 @@ describe('Operation Input Parameters parsing', () => {
         complexIn: [{ reference: 'Patient/test' }, { reference: 'Patient/example' }],
         multiIn: [],
         singleIn: undefined,
+        partsIn: [],
+      },
+    ],
+    [
+      [
+        { name: 'requiredIn', valueBoolean: true },
+        { name: 'resource', resource: { resourceType: 'Patient', id: 'test-patient', name: [{ family: 'Smith' }] } },
+      ],
+      {
+        requiredIn: true,
+        resource: { resourceType: 'Patient', id: 'test-patient', name: [{ family: 'Smith' }] },
+        singleIn: undefined,
+        multiIn: [],
+        complexIn: [],
         partsIn: [],
       },
     ],

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -165,9 +165,15 @@ function parseParams(
     if (param.part?.length) {
       value = inParams.map((input) => parseParams(param.part as [], input.part ?? []));
     } else {
-      value = inParams?.map((v) => v[('value' + capitalize(param.type ?? 'string')) as keyof ParametersParameter]);
+      value = inParams?.map((v) => {
+        const paramType = param.type ?? 'string';
+        if (paramType === 'Resource') {
+          return v.resource;
+        } else {
+          return v[('value' + capitalize(paramType)) as keyof ParametersParameter];
+        }
+      });
     }
-
     parsed[param.name] = validateInputParam(param, value);
   }
 

--- a/packages/server/src/fhir/operations/utils/parameters.ts
+++ b/packages/server/src/fhir/operations/utils/parameters.ts
@@ -160,6 +160,7 @@ function parseParams(
   for (const param of params) {
     // FHIR spec-compliant case: Parameters resource e.g.
     // { resourceType: 'Parameters', parameter: [{ name: 'message', valueString: 'Hello!' }] }
+    // except for Resource parameters, where the value is a whole resource.
     const inParams = inputParameters.filter((p) => p.name === param.name);
     let value: unknown;
     if (param.part?.length) {

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -19,7 +19,7 @@ import { agentUpgradeHandler } from './operations/agentupgrade';
 import { asyncJobCancelHandler } from './operations/asyncjobcancel';
 import { ccdaExportHandler } from './operations/ccdaexport';
 import { chargeItemDefinitionApplyHandler } from './operations/chargeitemdefinitionapply';
-import { claimExportHandler } from './operations/claimexport';
+import { claimExportGetHandler, claimExportPostHandler } from './operations/claimexport';
 import { codeSystemImportHandler } from './operations/codesystemimport';
 import { codeSystemLookupHandler } from './operations/codesystemlookup';
 import { codeSystemValidateCodeHandler } from './operations/codesystemvalidatecode';
@@ -254,7 +254,8 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('POST', '/Bot/:id/$deploy', deployHandler);
 
   // Claim $export operation
-  router.add('POST', '/Claim/$export', claimExportHandler);
+  router.add('POST', '/Claim/$export', claimExportPostHandler);
+  router.add('GET', '/Claim/:id/$export', claimExportGetHandler);
 
   // Group $export operation
   router.add('GET', '/Group/:id/$export', groupExportHandler);

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -254,7 +254,7 @@ function initInternalFhirRouter(): FhirRouter {
   router.add('POST', '/Bot/:id/$deploy', deployHandler);
 
   // Claim $export operation
-  router.add('GET', '/Claim/:id/$export', claimExportHandler);
+  router.add('POST', '/Claim/$export', claimExportHandler);
 
   // Group $export operation
   router.add('GET', '/Group/:id/$export', groupExportHandler);


### PR DESCRIPTION
Although GET claim/$export is working.
I was checking other operations (docs) and noticed POST claim/$submit has the `claim` in the payload.
Move it to POST claim/$export to make it consistent and updated `parameters.ts` to support `resource`.

<img width="801" alt="Screenshot 2025-04-28 at 4 09 05 PM" src="https://github.com/user-attachments/assets/1f86b938-c6f1-490d-abdd-a1b298cae36e" />
