### PR TITLE
fix(build-deb): add fhirtypes to list of packages

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -42,7 +42,7 @@ rm -rf "$TMP_DIR"
 rm -rf "$SERVICE_NAME-$VERSION.deb"
 
 # Copy package files
-PACKAGES=("app" "ccda" "core" "definitions" "fhir-router" "react" "react-hooks" "server")
+PACKAGES=("app" "ccda" "core" "definitions" "fhirtypes" "fhir-router" "react" "react-hooks" "server")
 for package in ${PACKAGES[@]}; do
   echo "Copy $package"
   mkdir -p "$LIB_DIR/packages/$package"


### PR DESCRIPTION
<img width="720" alt="Screenshot 2025-04-29 at 3 20 42 PM" src="https://github.com/user-attachments/assets/4afea460-ab22-49b5-a6ca-56f235c371b2" />

`Build deb` failed again on v4.1.2, this time due to `fhirtypes` missing it seems