### PR TITLE
Use I/O-optimized storage for RDS with SSD available

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -17,7 +17,7 @@ import {
   aws_wafv2 as wafv2,
 } from 'aws-cdk-lib';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
-import { ClusterInstance, ParameterGroup } from 'aws-cdk-lib/aws-rds';
+import { ClusterInstance, DBClusterStorageType, ParameterGroup } from 'aws-cdk-lib/aws-rds';
 import { Construct } from 'constructs';
 import { buildWafConfig } from './waf';
 
@@ -188,6 +188,11 @@ export class BackEnd extends Construct {
         credentials,
         defaultDatabaseName: 'medplum',
         storageEncrypted: true,
+        // Instances with attached NVMe SSD (db.*d* instance classes) should utilize I/O optimized storage
+        // to unlock additional performance improvements (e.g. tiered caching between memory and SSD)
+        storageType: writerInstanceType.match(/^db\.\w+d\w*\./i)
+          ? DBClusterStorageType.AURORA_IOPT1
+          : DBClusterStorageType.AURORA,
         vpc: this.vpc,
         vpcSubnets: {
           subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -190,7 +190,7 @@ export class BackEnd extends Construct {
         storageEncrypted: true,
         // Instances with attached NVMe SSD (db.*d* instance classes) should utilize I/O optimized storage
         // to unlock additional performance improvements (e.g. tiered caching between memory and SSD)
-        storageType: writerInstanceType?.match(/^db\.\w+d\w*\./i)
+        storageType: writerInstanceType?.match(/^\w+d\w*\./i)
           ? DBClusterStorageType.AURORA_IOPT1
           : DBClusterStorageType.AURORA,
         vpc: this.vpc,

--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -190,7 +190,7 @@ export class BackEnd extends Construct {
         storageEncrypted: true,
         // Instances with attached NVMe SSD (db.*d* instance classes) should utilize I/O optimized storage
         // to unlock additional performance improvements (e.g. tiered caching between memory and SSD)
-        storageType: writerInstanceType.match(/^db\.\w+d\w*\./i)
+        storageType: writerInstanceType?.match(/^db\.\w+d\w*\./i)
           ? DBClusterStorageType.AURORA_IOPT1
           : DBClusterStorageType.AURORA,
         vpc: this.vpc,


### PR DESCRIPTION
AWS RDS Aurora allows using database instance types [with attached NVMe SSD](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.DBInstanceClass.Types.html#Concepts.DBInstanceClass.Types.optimized-reads) storage.  By default, these instances will use the SSD only for temporary storage while executing a query plan (e.g. for sorting or merging data).  However, with [I/O-optimized storage](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.StorageReliability.html#aurora-storage-type) enabled, it will also use the SSD as a tiered cache; that should [further reduce latency](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.optimized.reads.html) at a slightly higher overall cost.  When opting into the more expensive SSD-backed instances, it makes sense to ensure they provide the maximum performance relative to price