### PR TITLE
fix(oauth): failed `onBehalfOf` results in 403

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2328,7 +2328,7 @@ describe('Client', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    test.each([400, 401, 404])('%d status code is not retried', async (statusCode) => {
+    test.each([400, 401, 403, 404])('%d status code is not retried', async (statusCode) => {
       const fetch = mockFetch(statusCode, (): OperationOutcome => {
         switch (statusCode) {
           case 400:

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -2335,6 +2335,8 @@ describe('Client', () => {
             return badRequest('The request is not good');
           case 401:
             return unauthorized;
+          case 403:
+            return forbidden;
           case 404:
             return notFound;
           default:
@@ -2350,6 +2352,11 @@ describe('Client', () => {
         case 401:
           await expect(client.get(client.fhirUrl('Patient', '123'))).rejects.toThrow(
             new OperationOutcomeError(unauthorized)
+          );
+          break;
+        case 403:
+          await expect(client.get(client.fhirUrl('Patient', '123'))).rejects.toThrow(
+            new OperationOutcomeError(forbidden)
           );
           break;
         case 404:

--- a/packages/server/src/fhir/onbehalfof.test.ts
+++ b/packages/server/src/fhir/onbehalfof.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, getReferenceString, unauthorized } from '@medplum/core';
+import { ContentType, forbidden, getReferenceString } from '@medplum/core';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -246,7 +246,7 @@ describe('On Behalf Of', () => {
       expect(res6.status).toBe(404);
     }));
 
-  test('Unauthorized for non-admin', () =>
+  test('Forbidden for non-admin', () =>
     withTestContext(async () => {
       // Create a project with a non-admin user
       const testAccount1 = await createTestProject({
@@ -267,11 +267,11 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(testAccount2.profile))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(401);
-      expect(res1.body).toMatchObject(unauthorized);
+      expect(res1.status).toBe(403);
+      expect(res1.body).toMatchObject(forbidden);
     }));
 
-  test('Unauthorized for cross project', () =>
+  test('Forbidden for cross project', () =>
     withTestContext(async () => {
       const adminAccount1 = await createTestProject({
         withClient: true,
@@ -297,7 +297,7 @@ describe('On Behalf Of', () => {
         .set('X-Medplum-On-Behalf-Of', getReferenceString(adminAccount2.client))
         .set('Content-Type', ContentType.FHIR_JSON)
         .send({ resourceType: 'Patient' });
-      expect(res1.status).toBe(401);
-      expect(res1.body).toMatchObject(unauthorized);
+      expect(res1.status).toBe(403);
+      expect(res1.body).toMatchObject(forbidden);
     }));
 });

--- a/packages/server/src/oauth/utils.ts
+++ b/packages/server/src/oauth/utils.ts
@@ -3,6 +3,7 @@ import {
   ContentType,
   createReference,
   Filter,
+  forbidden,
   getDateProperty,
   getReferenceString,
   isString,
@@ -12,7 +13,6 @@ import {
   ProfileResource,
   resolveId,
   tooManyRequests,
-  unauthorized,
   WithId,
 } from '@medplum/core';
 import {
@@ -36,6 +36,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { authenticator } from 'otplib';
 import { getAccessPolicyForLogin, getRepoForLogin } from '../fhir/accesspolicy';
 import { getSystemRepo } from '../fhir/repo';
+import { parseSmartScopes, SmartScope } from '../fhir/smart';
 import { getLogger } from '../logger';
 import {
   AuditEventOutcome,
@@ -53,7 +54,6 @@ import {
   verifyJwt,
 } from './keys';
 import { AuthState } from './middleware';
-import { parseSmartScopes, SmartScope } from '../fhir/smart';
 
 export type CodeChallengeMethod = 'plain' | 'S256';
 
@@ -943,7 +943,7 @@ async function tryAddOnBehalfOf(req: IncomingMessage | undefined, authState: Aut
   }
 
   if (!authState.membership.admin) {
-    throw new OperationOutcomeError(unauthorized);
+    throw new OperationOutcomeError(forbidden);
   }
 
   let onBehalfOfMembership: WithId<ProjectMembership> | undefined = undefined;
@@ -961,7 +961,7 @@ async function tryAddOnBehalfOf(req: IncomingMessage | undefined, authState: Aut
       ],
     });
     if (!onBehalfOfMembership) {
-      throw new OperationOutcomeError(unauthorized);
+      throw new OperationOutcomeError(forbidden);
     }
   }
 


### PR DESCRIPTION
Invalid `onBehalfOf` for a given user should return 403 instead of 401