### PR TITLE
Multiple small fixes to search filter dialogs

### DIFF
--- a/packages/react/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/react/src/DateTimeInput/DateTimeInput.tsx
@@ -1,9 +1,9 @@
 import { TextInput } from '@mantine/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { ChangeEvent } from 'react';
+import { PrimitiveTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { getErrorsForInput } from '../utils/outcomes';
 import { convertIsoToLocal, convertLocalToIso } from './DateTimeInput.utils';
-import { PrimitiveTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface DateTimeInputProps extends PrimitiveTypeInputProps {
   readonly label?: string;
@@ -34,6 +34,7 @@ export function DateTimeInput(props: DateTimeInputProps): JSX.Element {
       required={props.required}
       disabled={props.disabled}
       type={getInputType()}
+      step={1}
       defaultValue={convertIsoToLocal(props.defaultValue)}
       autoFocus={props.autoFocus}
       error={getErrorsForInput(props.outcome, props.name)}

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -100,6 +100,7 @@ interface SearchControlState {
   readonly exportDialogVisible: boolean;
   readonly filterDialogFilter?: Filter;
   readonly filterDialogSearchParam?: SearchParameter;
+  readonly dialogOpenTime?: number;
 }
 
 /**
@@ -289,7 +290,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               variant={buttonVariant}
               color={buttonColor}
               leftSection={<IconColumns size={iconSize} />}
-              onClick={() => setState({ ...stateRef.current, fieldEditorVisible: true })}
+              onClick={() => setState({ ...stateRef.current, fieldEditorVisible: true, dialogOpenTime: Date.now() })}
             >
               Fields
             </Button>
@@ -298,7 +299,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
               variant={buttonVariant}
               color={buttonColor}
               leftSection={<IconFilter size={iconSize} />}
-              onClick={() => setState({ ...stateRef.current, filterEditorVisible: true })}
+              onClick={() => setState({ ...stateRef.current, filterEditorVisible: true, dialogOpenTime: Date.now() })}
             >
               Filters
             </Button>
@@ -320,7 +321,9 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
                 color={buttonColor}
                 leftSection={<IconTableExport size={iconSize} />}
                 onClick={
-                  props.onExport ? props.onExport : () => setState({ ...stateRef.current, exportDialogVisible: true })
+                  props.onExport
+                    ? props.onExport
+                    : () => setState({ ...stateRef.current, exportDialogVisible: true, dialogOpenTime: Date.now() })
                 }
               >
                 Export...
@@ -401,6 +404,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
                         filterDialogVisible: true,
                         filterDialogSearchParam: searchParam,
                         filterDialogFilter: filter,
+                        dialogOpenTime: Date.now(),
                       });
                     }}
                     onChange={(result) => {
@@ -488,6 +492,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         </Center>
       )}
       <SearchFieldEditor
+        key={`search-field-editor-${state.dialogOpenTime}`}
         search={memoizedSearch}
         visible={stateRef.current.fieldEditorVisible}
         onOk={(result) => {
@@ -505,6 +510,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         }}
       />
       <SearchFilterEditor
+        key={`search-filter-editor-${state.dialogOpenTime}`}
         search={memoizedSearch}
         visible={stateRef.current.filterEditorVisible}
         onOk={(result) => {
@@ -522,6 +528,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         }}
       />
       <SearchExportDialog
+        key={`search-export-dialog-${state.dialogOpenTime}`}
         visible={stateRef.current.exportDialogVisible}
         exportCsv={props.onExportCsv}
         exportTransactionBundle={props.onExportTransactionBundle}
@@ -533,7 +540,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
         }}
       />
       <SearchFilterValueDialog
-        key={state.filterDialogSearchParam?.code}
+        key={`search-filter-dialog-${state.dialogOpenTime}`}
         visible={stateRef.current.filterDialogVisible}
         title={state.filterDialogSearchParam?.code ? buildFieldNameString(state.filterDialogSearchParam.code) : ''}
         resourceType={resourceType}

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -9,10 +9,10 @@ import {
   SearchRequest,
 } from '@medplum/core';
 import { Resource, SearchParameter } from '@medplum/fhirtypes';
+import { MedplumLink } from '../MedplumLink/MedplumLink';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 import { SearchControlField } from './SearchControlField';
-import { MedplumLink } from '../MedplumLink/MedplumLink';
 
 const searchParamToOperators: Record<string, Operator[]> = {
   string: [Operator.EQUALS, Operator.NOT, Operator.CONTAINS, Operator.EXACT],
@@ -244,6 +244,18 @@ function addDayFilter(definition: SearchRequest, field: string, delta: number): 
   endTime.setTime(endTime.getTime() - 1);
 
   return addDateFilterBetween(definition, field, startTime, endTime);
+}
+
+/**
+ * Adds a filter that constrains the specified field to "next 24 hours".
+ * @param definition - The original search request.
+ * @param field - The field key name.
+ * @returns The updated search request.
+ */
+export function addNext24HoursFilter(definition: SearchRequest, field: string): SearchRequest {
+  const now = new Date();
+  const endTime = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  return addDateFilterBetween(definition, field, now, endTime);
 }
 
 /**

--- a/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
+++ b/packages/react/src/SearchFieldEditor/SearchFieldEditor.tsx
@@ -43,10 +43,6 @@ export function SearchFieldEditor(props: SearchFieldEditorProps): JSX.Element | 
     });
   }, [props.visible, props.search.resourceType]);
 
-  if (!props.visible) {
-    return null;
-  }
-
   function handleChange(newFields: string[]): void {
     setState({ search: { ...state.search, fields: newFields } });
   }

--- a/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
+++ b/packages/react/src/SearchFilterEditor/SearchFilterEditor.tsx
@@ -37,10 +37,6 @@ export function SearchFilterEditor(props: SearchFilterEditorProps): JSX.Element 
     setSearch(addFilter(searchRef.current, filter.code, filter.operator, filter.value));
   }
 
-  if (!props.visible) {
-    return null;
-  }
-
   const resourceType = props.search.resourceType;
   const searchParams = getSearchParameters(resourceType) ?? {};
   const filters = search.filters || [];
@@ -149,6 +145,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       <td>
         {operators && (
           <NativeSelect
+            key={`${props.id}-filter-value-${props.value.code}`}
             data-testid={`${props.id}-filter-operation`}
             defaultValue={value.operator}
             onChange={(e) => setFilterOperator(e.currentTarget.value as Operator)}
@@ -159,6 +156,7 @@ function FilterRowInput(props: FilterRowInputProps): JSX.Element {
       <td>
         {searchParam && value.operator && (
           <SearchFilterValueInput
+            key={`${props.id}-filter-value-${props.value.code}-${props.value.operator}`}
             name={`${props.id}-filter-value`}
             resourceType={props.resourceType}
             searchParam={searchParam}

--- a/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
+++ b/packages/react/src/SearchFilterValueDialog/SearchFilterValueDialog.tsx
@@ -19,7 +19,7 @@ export interface SearchFilterValueDialogProps {
 export function SearchFilterValueDialog(props: SearchFilterValueDialogProps): JSX.Element | null {
   const [value, setValue] = useState<string>(props.defaultValue ?? '');
 
-  if (!props.visible || !props.searchParam || !props.filter) {
+  if (!props.searchParam || !props.filter) {
     return null;
   }
 

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.test.tsx
@@ -118,38 +118,44 @@ describe('SearchPopupMenu', () => {
     }
   });
 
-  test.each(['Tomorrow', 'Today', 'Yesterday', 'Next Month', 'This Month', 'Last Month', 'Year to date'])(
-    '%s shortcut',
-    async (option) => {
-      let currSearch: SearchRequest = {
-        resourceType: 'Patient',
-      };
+  test.each([
+    'Tomorrow',
+    'Today',
+    'Yesterday',
+    'Next 24 Hours',
+    'Next Month',
+    'This Month',
+    'Last Month',
+    'Year to date',
+  ])('%s shortcut', async (option) => {
+    let currSearch: SearchRequest = {
+      resourceType: 'Patient',
+    };
 
-      await setup({
-        search: currSearch,
-        searchParams: [globalSchema.types['Patient'].searchParams?.['birthdate'] as SearchParameter],
-        onChange: (e) => (currSearch = e),
-      });
+    await setup({
+      search: currSearch,
+      searchParams: [globalSchema.types['Patient'].searchParams?.['birthdate'] as SearchParameter],
+      onChange: (e) => (currSearch = e),
+    });
 
-      const optionButton = await screen.findByText(option);
-      await act(async () => {
-        fireEvent.click(optionButton);
-      });
+    const optionButton = await screen.findByText(option);
+    await act(async () => {
+      fireEvent.click(optionButton);
+    });
 
-      expect(currSearch.filters).toBeDefined();
-      expect(currSearch.filters?.length).toEqual(2);
-      expect(currSearch.filters).toMatchObject([
-        {
-          code: 'birthdate',
-          operator: Operator.GREATER_THAN_OR_EQUALS,
-        },
-        {
-          code: 'birthdate',
-          operator: Operator.LESS_THAN_OR_EQUALS,
-        },
-      ]);
-    }
-  );
+    expect(currSearch.filters).toBeDefined();
+    expect(currSearch.filters?.length).toEqual(2);
+    expect(currSearch.filters).toMatchObject([
+      {
+        code: 'birthdate',
+        operator: Operator.GREATER_THAN_OR_EQUALS,
+      },
+      {
+        code: 'birthdate',
+        operator: Operator.LESS_THAN_OR_EQUALS,
+      },
+    ]);
+  });
 
   test('Date missing', async () => {
     let currSearch: SearchRequest = {

--- a/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
+++ b/packages/react/src/SearchPopupMenu/SearchPopupMenu.tsx
@@ -20,6 +20,7 @@ import {
 import {
   addLastMonthFilter,
   addMissingFilter,
+  addNext24HoursFilter,
   addNextMonthFilter,
   addThisMonthFilter,
   addTodayFilter,
@@ -169,6 +170,12 @@ function DateFilterSubMenu(props: SearchPopupSubMenuProps): JSX.Element {
         onClick={() => props.onChange(addYesterdayFilter(props.search, code))}
       >
         Yesterday
+      </Menu.Item>
+      <Menu.Item
+        leftSection={<IconCalendar size={14} />}
+        onClick={() => props.onChange(addNext24HoursFilter(props.search, code))}
+      >
+        Next 24 Hours
       </Menu.Item>
       <Menu.Divider />
       <Menu.Item


### PR DESCRIPTION
1. Fixed missing seconds bug in `<DateTimeInput>`
   * Needed to add the `step={1}` prop, the default is `step={60}`
2. Fixed missing `<Modal>` transitions
   * Cannot return `null` when `visible===false`, otherwise component is not rendered
   * Instead let the built-in visibility logic handle it
3. Fixed search dialogs not resetting on "Cancel"
   * Use a `dialogOpenTime` number so that each "open" action resets the dialogs
4. Added "Next 24 Hours" shortcut to datetime popup menu
   * Per customer request