### PR TITLE
Fixes #6520 - MockClient period search

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -9,6 +9,7 @@ import {
   QuestionnaireResponse,
   SearchParameter,
   ServiceRequest,
+  Task,
 } from '@medplum/fhirtypes';
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
@@ -779,6 +780,107 @@ describe('Search matching', () => {
           filters: [{ code: 'birthdate', operator: Operator.LESS_THAN_OR_EQUALS, value: '1990-01-01' }],
         };
         expect(matchesSearchRequest(patient, search)).toBe(true);
+      });
+    });
+  });
+
+  describe('Period', () => {
+    describe('missing', () => {
+      const task: Task = {
+        resourceType: 'Task',
+        status: 'accepted',
+        intent: 'order',
+      };
+
+      test('true', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '2025-05-01' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(false);
+      });
+
+      test('false', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '2025-06-01' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(false);
+      });
+    });
+
+    describe('invalid', () => {
+      const task: Task = {
+        resourceType: 'Task',
+        status: 'accepted',
+        intent: 'order',
+        restriction: { period: { start: '2025-05-15T12:00:00.000Z' } },
+      };
+
+      test('true', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '.' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(false);
+      });
+
+      test('false', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '.' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(false);
+      });
+    });
+
+    describe('start greater than', () => {
+      const task: Task = {
+        resourceType: 'Task',
+        status: 'accepted',
+        intent: 'order',
+        restriction: { period: { start: '2025-05-15T12:00:00.000Z' } },
+      };
+
+      test('true', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '2025-05-01' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(true);
+      });
+
+      test('false', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '2025-06-01' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(false);
+      });
+    });
+
+    describe('end greater than', () => {
+      const task: Task = {
+        resourceType: 'Task',
+        status: 'accepted',
+        intent: 'order',
+        restriction: { period: { end: '2025-05-15T12:00:00.000Z' } },
+      };
+
+      test('true', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '2025-05-01' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(true);
+      });
+
+      test('false', () => {
+        const search: SearchRequest = {
+          resourceType: 'Task',
+          filters: [{ code: 'due-date', operator: Operator.GREATER_THAN, value: '2025-06-01' }],
+        };
+        expect(matchesSearchRequest(task, search)).toBe(false);
       });
     });
   });

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -274,8 +274,8 @@ function buildDateTimeColumn(value: unknown): string | undefined {
     try {
       const date = new Date(value);
       return date.toISOString();
-    } catch (_err) {
-      // Silent ignore
+    } catch (err) {
+      console.debug('Failed to parse date', value, err);
     }
   } else if (isPeriod(value)) {
     // Can be a Period

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -1,6 +1,8 @@
 import { CodeableConcept, Coding, Identifier, Reference, Resource, SearchParameter } from '@medplum/fhirtypes';
 import { evalFhirPath } from '../fhirpath/parse';
+import { isPeriod } from '../fhirpath/utils';
 import { PropertyType, globalSchema } from '../types';
+import { isString } from '../utils';
 import { SearchParameterType, getSearchParameterDetails } from './details';
 import { Filter, Operator, SearchRequest, splitSearchOnComma } from './search';
 
@@ -268,17 +270,14 @@ function matchesDateValue(resourceValue: string | undefined, operator: Operator,
  * @returns The date/time string if parsed; undefined otherwise.
  */
 function buildDateTimeColumn(value: unknown): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  if (typeof value === 'string') {
+  if (isString(value)) {
     try {
       const date = new Date(value);
       return date.toISOString();
     } catch (_err) {
       // Silent ignore
     }
-  } else if (typeof value === 'object') {
+  } else if (isPeriod(value)) {
     // Can be a Period
     if ('start' in value) {
       return buildDateTimeColumn(value.start);


### PR DESCRIPTION
Before: MockClient date/dateTime filters only worked on date/dateTime property values

After: MockClient date/dateTime filters also work on Period values

Implementation notes:
* This is yet another example of drift between Postgres search and Memory search
* We have been talking about the "search IR" framework, which likely would have caught and fixed this bug

Context: https://medplum.slack.com/archives/C06H7LWCA2U/p1746127075556339?thread_ts=1746111315.434809&cid=C06H7LWCA2U