### PR TITLE
Manually record delete interactions for resource expunge

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1172,6 +1172,11 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       await new DeleteQuery(resourceType + '_History').where('id', 'IN', ids).execute(db);
       await this.postCommit(() => this.deleteCacheEntries(resourceType, ids));
     });
+    incrementCounter(
+      `medplum.fhir.interaction.delete.count`,
+      { attributes: { resourceType, result: 'success' } },
+      ids.length
+    );
   }
 
   /**

--- a/packages/server/src/otel/otel.ts
+++ b/packages/server/src/otel/otel.ts
@@ -41,11 +41,11 @@ export function getCounter(name: string, options?: MetricOptions): Counter {
   return result;
 }
 
-export function incrementCounter(name: string, options?: RecordMetricOptions): boolean {
+export function incrementCounter(name: string, options?: RecordMetricOptions, n = 1): boolean {
   if (!isOtelMetricsEnabled()) {
     return false;
   }
-  getCounter(name, options?.options).add(1, options?.attributes);
+  getCounter(name, options?.options).add(n, options?.attributes);
   return true;
 }
 


### PR DESCRIPTION
Since `$expunge` is used to clean up AuditEvent resources from the database, we don't want to emit an AuditEvent for the deletion.  However, we still want to record the deletion in metrics (i.e. `medplum.fhir.interaction.delete.count`) to more accurately reflect the state of the system