### PR TITLE
dev(prettier): add `organize-imports` plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "npm-check-updates": "17.1.18",
         "nyc": "17.1.0",
         "prettier": "3.5.3",
+        "prettier-plugin-organize-imports": "4.1.0",
         "rimraf": "6.0.1",
         "sort-package-json": "3.0.0",
         "source-map-explorer": "2.5.3",
@@ -43300,6 +43301,23 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
+      "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
   "prettier": {
     "printWidth": 120,
     "singleQuote": true,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "plugins": [
+      "prettier-plugin-organize-imports"
+    ]
   },
   "eslintConfig": {
     "parserOptions": {
@@ -51,6 +54,7 @@
     "npm-check-updates": "17.1.18",
     "nyc": "17.1.0",
     "prettier": "3.5.3",
+    "prettier-plugin-organize-imports": "4.1.0",
     "rimraf": "6.0.1",
     "sort-package-json": "3.0.0",
     "source-map-explorer": "2.5.3",

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -3,7 +3,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router';
 import { App } from './App';
-import { act, userEvent, UserEvent, render, screen } from './test-utils/render';
+import { act, render, screen, userEvent, UserEvent } from './test-utils/render';
 
 const navigateMock = jest.fn();
 

--- a/packages/app/src/CreateResourcePage.test.tsx
+++ b/packages/app/src/CreateResourcePage.test.tsx
@@ -2,7 +2,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router';
 import { AppRoutes } from './AppRoutes';
-import { act, userEvent, UserEvent, render, screen, fireEvent } from './test-utils/render';
+import { act, fireEvent, render, screen, userEvent, UserEvent } from './test-utils/render';
 
 const medplum = new MockClient();
 

--- a/packages/app/src/MfaPage.test.tsx
+++ b/packages/app/src/MfaPage.test.tsx
@@ -4,7 +4,7 @@ import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router';
 import { AppRoutes } from './AppRoutes';
-import { act, userEvent, UserEvent, render, screen } from './test-utils/render';
+import { act, render, screen, userEvent, UserEvent } from './test-utils/render';
 
 const medplum = new MockClient();
 

--- a/packages/app/src/OAuthPage.test.tsx
+++ b/packages/app/src/OAuthPage.test.tsx
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import { MemoryRouter } from 'react-router';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';
-import { act, userEvent, UserEvent, render, screen, waitFor } from './test-utils/render';
+import { act, render, screen, userEvent, UserEvent, waitFor } from './test-utils/render';
 
 const medplum = new MockClient();
 

--- a/packages/app/src/OAuthPage.tsx
+++ b/packages/app/src/OAuthPage.tsx
@@ -1,11 +1,11 @@
 import { Title } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
 import { CodeChallengeMethod, normalizeErrorString } from '@medplum/core';
+import { ClientApplicationSignInForm } from '@medplum/fhirtypes';
 import { Logo, SignInForm, useMedplum } from '@medplum/react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { getConfig } from './config';
-import { useEffect, useState } from 'react';
-import { showNotification } from '@mantine/notifications';
-import { ClientApplicationSignInForm } from '@medplum/fhirtypes';
 
 export function OAuthPage(): JSX.Element | null {
   const navigate = useNavigate();

--- a/packages/app/src/RegisterPage.test.tsx
+++ b/packages/app/src/RegisterPage.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from 'react-router';
 import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';
 import { getConfig } from './config';
-import { act, userEvent, UserEvent, render, screen } from './test-utils/render';
+import { act, render, screen, userEvent, UserEvent } from './test-utils/render';
 
 async function setup(medplum: MedplumClient): Promise<UserEvent> {
   const user = userEvent.setup();

--- a/packages/app/src/ResetPasswordPage.test.tsx
+++ b/packages/app/src/ResetPasswordPage.test.tsx
@@ -3,7 +3,7 @@ import { MedplumProvider } from '@medplum/react';
 import { MemoryRouter } from 'react-router';
 import { ResetPasswordPage } from './ResetPasswordPage';
 import { getConfig } from './config';
-import { userEvent, UserEvent, render, screen } from './test-utils/render';
+import { render, screen, userEvent, UserEvent } from './test-utils/render';
 
 const medplum = new MockClient();
 

--- a/packages/app/src/SmartSearchPage.tsx
+++ b/packages/app/src/SmartSearchPage.tsx
@@ -1,4 +1,4 @@
-import { MemoizedFhirPathTable, FhirPathTableField } from '@medplum/react';
+import { FhirPathTableField, MemoizedFhirPathTable } from '@medplum/react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 

--- a/packages/app/src/lab/AssaysPage.test.tsx
+++ b/packages/app/src/lab/AssaysPage.test.tsx
@@ -1,8 +1,8 @@
 import { ObservationDefinition } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
-import { act, render, screen } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, render, screen } from '../test-utils/render';
 import { AssaysPage } from './AssaysPage';
 
 const medplum = new MockClient();

--- a/packages/app/src/resource/DetailsPage.tsx
+++ b/packages/app/src/resource/DetailsPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Combobox, Group, Stack, useCombobox, Text, UnstyledButton, Code } from '@mantine/core';
+import { Box, Code, Combobox, Group, Stack, Text, UnstyledButton, useCombobox } from '@mantine/core';
 import { isPopulated } from '@medplum/core';
 import { ResourceType } from '@medplum/fhirtypes';
 import { Document, ResourceTable, useResource } from '@medplum/react';

--- a/packages/app/src/resource/JsonCreatePage.tsx
+++ b/packages/app/src/resource/JsonCreatePage.tsx
@@ -1,5 +1,5 @@
-import { stringify } from '@medplum/core';
 import { Button, Group, JsonInput } from '@mantine/core';
+import { stringify } from '@medplum/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
 import { Document, Form, OperationOutcomeAlert } from '@medplum/react';
 import { useCallback, useState } from 'react';

--- a/packages/app/src/resource/ReportPage.tsx
+++ b/packages/app/src/resource/ReportPage.tsx
@@ -1,5 +1,5 @@
 import { DiagnosticReport, MeasureReport, ResourceType } from '@medplum/fhirtypes';
-import { DiagnosticReportDisplay, Document, useResource, MeasureReportDisplay } from '@medplum/react';
+import { DiagnosticReportDisplay, Document, MeasureReportDisplay, useResource } from '@medplum/react';
 import { useParams } from 'react-router';
 
 export function ReportPage(): JSX.Element | null {

--- a/packages/app/src/test-utils/render.tsx
+++ b/packages/app/src/test-utils/render.tsx
@@ -11,7 +11,7 @@ import { ReactNode } from 'react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { AppRoutes } from '../AppRoutes';
 
-export { RenderResult, act, fireEvent, screen, userEvent, UserEvent, waitFor };
+export { act, fireEvent, RenderResult, screen, userEvent, UserEvent, waitFor };
 
 const theme = {};
 

--- a/packages/cdk/src/index.test.ts
+++ b/packages/cdk/src/index.test.ts
@@ -1,9 +1,9 @@
+import { MedplumSourceInfraConfig } from '@medplum/core';
+import { App } from 'aws-cdk-lib';
 import { unlinkSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
-import { main, MedplumStack } from './index';
-import { App } from 'aws-cdk-lib';
 import { normalizeInfraConfig } from './config';
-import { MedplumSourceInfraConfig } from '@medplum/core';
+import { main, MedplumStack } from './index';
 
 function writeConfig(filename: string, config: any): string {
   const resolvedPath = resolve(filename);

--- a/packages/core/src/elements-context.test.ts
+++ b/packages/core/src/elements-context.test.ts
@@ -1,15 +1,15 @@
-import { ExtendedInternalSchemaElement, buildElementsContext } from './elements-context';
+import { readJson } from '@medplum/definitions';
+import { AccessPolicy, Bundle, Patient, StructureDefinition } from '@medplum/fhirtypes';
+import { AccessPolicyInteraction, satisfiedAccessPolicy } from './access';
 import { HTTP_HL7_ORG } from './constants';
-import { isPopulated } from './utils';
+import { ExtendedInternalSchemaElement, buildElementsContext } from './elements-context';
 import {
   InternalTypeSchema,
   getDataType,
   indexStructureDefinitionBundle,
   parseStructureDefinition,
 } from './typeschema/types';
-import { AccessPolicy, Bundle, Patient, StructureDefinition } from '@medplum/fhirtypes';
-import { readJson } from '@medplum/definitions';
-import { AccessPolicyInteraction, satisfiedAccessPolicy } from './access';
+import { isPopulated } from './utils';
 
 describe('buildElementsContext', () => {
   const DEFAULT_EXTENDED_PROPS = { readonly: false, hidden: false };

--- a/packages/core/src/fhirmapper/transform.types.test.ts
+++ b/packages/core/src/fhirmapper/transform.types.test.ts
@@ -1,10 +1,10 @@
 import { readJson } from '@medplum/definitions';
 import { Bundle } from '@medplum/fhirtypes';
 import { toTypedValue } from '../fhirpath/utils';
+import { TypedValue } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
 import { parseMappingLanguage } from './parse';
 import { structureMapTransform } from './transform';
-import { TypedValue } from '../types';
 
 describe('FHIR Mapper transform - dependent', () => {
   beforeAll(() => {

--- a/packages/core/src/fhirpath/parse.ts
+++ b/packages/core/src/fhirpath/parse.ts
@@ -1,4 +1,5 @@
 import { Quantity } from '@medplum/fhirtypes';
+import { LRUCache } from '../cache';
 import { Atom, InfixParselet, Parser, ParserBuilder, PrefixParselet } from '../fhirlexer/parse';
 import { PropertyType, TypedValue } from '../types';
 import {
@@ -29,7 +30,6 @@ import {
 import { parseDateString } from './date';
 import { tokenize } from './tokenize';
 import { toTypedValue } from './utils';
-import { LRUCache } from '../cache';
 
 /**
  * Operator precedence

--- a/packages/core/src/typeschema/crawler.test.ts
+++ b/packages/core/src/typeschema/crawler.test.ts
@@ -1,11 +1,11 @@
 import { readJson } from '@medplum/definitions';
 import { Attachment, Bundle, Coding, Observation, Patient } from '@medplum/fhirtypes';
+import { LOINC } from '../constants';
+import { toTypedValue } from '../fhirpath/utils';
 import { TypedValue } from '../types';
 import { arrayify, sleep } from '../utils';
 import { crawlTypedValue, crawlTypedValueAsync } from './crawler';
 import { indexStructureDefinitionBundle } from './types';
-import { LOINC } from '../constants';
-import { toTypedValue } from '../fhirpath/utils';
 
 describe('ResourceCrawler', () => {
   beforeAll(() => {

--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -1,5 +1,7 @@
 import { OperationOutcomeIssue, Resource, StructureDefinition } from '@medplum/fhirtypes';
+import { LRUCache } from '../cache';
 import { HTTP_HL7_ORG, UCUM } from '../constants';
+import { FhirPathAtom } from '../fhirpath/atoms';
 import { evalFhirPathTyped } from '../fhirpath/parse';
 import { getTypedPropertyValue, toTypedValue } from '../fhirpath/utils';
 import {
@@ -23,8 +25,6 @@ import {
   getDataType,
   parseStructureDefinition,
 } from './types';
-import { LRUCache } from '../cache';
-import { FhirPathAtom } from '../fhirpath/atoms';
 
 /*
  * This file provides schema validation utilities for FHIR JSON objects.

--- a/packages/docs/src/components/MedplumCodeBlock.tsx
+++ b/packages/docs/src/components/MedplumCodeBlock.tsx
@@ -1,5 +1,4 @@
 import CodeBlock, { Props } from '@theme/CodeBlock';
-import * as React from 'react';
 
 const BLOCK_START_PATTERN = /^\s*\/\/\s*start-block\s+([A-Za-z_-]*)/;
 const BLOCK_END_PATTERN = /^\s*\/\/\s*end-block\s+([A-Za-z_-]*)/;

--- a/packages/docs/src/components/ProfileCard.tsx
+++ b/packages/docs/src/components/ProfileCard.tsx
@@ -1,8 +1,8 @@
 import GitHubSvg from './github.svg';
-import LinkedInSvg from './linkedin.svg';
 import LinkSvg from './link.svg';
-import YouTubeSvg from './youtube.svg';
+import LinkedInSvg from './linkedin.svg';
 import styles from './ProfileCard.module.css';
+import YouTubeSvg from './youtube.svg';
 
 export interface ProfileCardProps {
   readonly name: string;

--- a/packages/dosespot-react/src/index.ts
+++ b/packages/dosespot-react/src/index.ts
@@ -1,3 +1,3 @@
+export * from './common';
 export * from './useDoseSpotIFrame';
 export * from './useDoseSpotNotifications';
-export * from './common';

--- a/packages/examples/src/auth/custom-emails.ts
+++ b/packages/examples/src/auth/custom-emails.ts
@@ -1,6 +1,6 @@
 // start-block customEmails
 import { BotEvent, getDisplayString, getReferenceString, MedplumClient, ProfileResource } from '@medplum/core';
-import { UserSecurityRequest, ProjectMembership, Reference, User } from '@medplum/fhirtypes';
+import { ProjectMembership, Reference, User, UserSecurityRequest } from '@medplum/fhirtypes';
 
 export async function handler(medplum: MedplumClient, event: BotEvent<UserSecurityRequest>): Promise<any> {
   // This Bot executes on every new UserSecurityRequest resource.

--- a/packages/examples/src/bots/file-uploads.ts
+++ b/packages/examples/src/bots/file-uploads.ts
@@ -6,8 +6,8 @@ import Client from 'ssh2-sftp-client';
 
 // end-block sftpImport
 // start-block formImports
-import fetch from 'node-fetch';
 import FormData from 'form-data';
+import fetch from 'node-fetch';
 
 // end-block formImports
 

--- a/packages/examples/src/fhir-datastore/binary-data.ts
+++ b/packages/examples/src/fhir-datastore/binary-data.ts
@@ -1,6 +1,6 @@
 // start-block imports
 import { MedplumClient } from '@medplum/core';
-import { Patient, Media } from '@medplum/fhirtypes';
+import { Media, Patient } from '@medplum/fhirtypes';
 // end-block imports
 
 const medplum = new MedplumClient();

--- a/packages/examples/src/migration/convert-to-fhir.ts
+++ b/packages/examples/src/migration/convert-to-fhir.ts
@@ -1,5 +1,5 @@
-import { Condition, Patient } from '@medplum/fhirtypes';
 import { MedplumClient } from '@medplum/core';
+import { Condition, Patient } from '@medplum/fhirtypes';
 const medplum = new MedplumClient();
 
 const patientData: Patient =

--- a/packages/examples/src/tutorials/api-basics/basic-fhir-search.ts
+++ b/packages/examples/src/tutorials/api-basics/basic-fhir-search.ts
@@ -1,6 +1,6 @@
 // start-block core-imports
-import fetch from 'node-fetch';
 import { MedplumClient } from '@medplum/core';
+import fetch from 'node-fetch';
 
 // end-block core-imports
 

--- a/packages/fhir-router/src/index.ts
+++ b/packages/fhir-router/src/index.ts
@@ -1,4 +1,4 @@
+export { BatchEvent, LogEvent } from './batch';
 export * from './fhirrouter';
 export * from './repo';
 export * from './urlrouter';
-export { LogEvent, BatchEvent } from './batch';

--- a/packages/health-gorilla-core/src/aoe.test.ts
+++ b/packages/health-gorilla-core/src/aoe.test.ts
@@ -1,7 +1,7 @@
-import { Bundle, Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
-import { getMissingRequiredQuestionnaireItems, questionnaireItemIterator } from './aoe';
 import { indexStructureDefinitionBundle } from '@medplum/core';
 import { readJson } from '@medplum/definitions';
+import { Bundle, Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
+import { getMissingRequiredQuestionnaireItems, questionnaireItemIterator } from './aoe';
 
 const AoeTestingLinkIds = [
   'date',

--- a/packages/health-gorilla-core/src/lab-order.test.ts
+++ b/packages/health-gorilla-core/src/lab-order.test.ts
@@ -8,6 +8,8 @@ import {
 import { readJson as readDefinitionsJson, SEARCH_PARAMETER_BUNDLE_FILES } from '@medplum/definitions';
 import { Bundle, Organization, Patient, Practitioner, Questionnaire, SearchParameter } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import {
   HEALTH_GORILLA_AUTHORIZED_BY_EXT,
   HEALTH_GORILLA_SYSTEM,
@@ -25,8 +27,6 @@ import {
 } from './lab-order';
 import { expectToBeDefined } from './test-utils';
 import { BillTo, LabOrderTestMetadata, LabOrganization, TestCoding } from './types';
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
 
 interface TestContext {
   medplum: MedplumClient;

--- a/packages/health-gorilla-react/src/test.setup.ts
+++ b/packages/health-gorilla-react/src/test.setup.ts
@@ -1,5 +1,5 @@
-import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
 
 afterEach(() => {
   cleanup();

--- a/packages/health-gorilla-react/src/useHealthGorillaLabOrderContext.ts
+++ b/packages/health-gorilla-react/src/useHealthGorillaLabOrderContext.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
-import { UseHealthGorillaLabOrderReturn } from './useHealthGorillaLabOrder';
 import { HealthGorillaLabOrderContext } from './HealthGorillaLabOrderProvider';
+import { UseHealthGorillaLabOrderReturn } from './useHealthGorillaLabOrder';
 
 export function useHealthGorillaLabOrderContext(): UseHealthGorillaLabOrderReturn {
   const context = useContext(HealthGorillaLabOrderContext);

--- a/packages/mock/src/mocks/alice.ts
+++ b/packages/mock/src/mocks/alice.ts
@@ -1,4 +1,4 @@
-import { lazy, ContentType, createReference, WithId } from '@medplum/core';
+import { ContentType, createReference, lazy, WithId } from '@medplum/core';
 import { Organization, Practitioner, Schedule, Slot } from '@medplum/fhirtypes';
 
 export const TestOrganization: WithId<Organization> = {

--- a/packages/mock/src/mocks/uscore/index.ts
+++ b/packages/mock/src/mocks/uscore/index.ts
@@ -1,7 +1,7 @@
-import { Device, Patient, StructureDefinition } from '@medplum/fhirtypes';
-import StructureDefinitionList from './uscore-v5.0.1-structuredefinitions.json';
 import { HTTP_HL7_ORG, deepClone } from '@medplum/core';
+import { Device, Patient, StructureDefinition } from '@medplum/fhirtypes';
 import { HomerSimpson } from '../simpsons';
+import StructureDefinitionList from './uscore-v5.0.1-structuredefinitions.json';
 
 export const USCoreStructureDefinitionList = StructureDefinitionList as StructureDefinition[];
 

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -1,7 +1,7 @@
-import turbosnap from 'vite-plugin-turbosnap';
 import type { StorybookConfig } from '@storybook/react-vite';
-import { mergeConfig } from 'vite';
 import path from 'path';
+import { mergeConfig } from 'vite';
+import turbosnap from 'vite-plugin-turbosnap';
 
 const config: StorybookConfig = {
   stories: ['../src/stories/Introduction.mdx', '../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],

--- a/packages/react/src/AddressInput/AddressInput.stories.tsx
+++ b/packages/react/src/AddressInput/AddressInput.stories.tsx
@@ -1,9 +1,9 @@
+import { buildElementsContext } from '@medplum/core';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { AddressInput } from './AddressInput';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
-import { buildElementsContext } from '@medplum/core';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { AddressInput } from './AddressInput';
 
 export default {
   title: 'Medplum/AddressInput',

--- a/packages/react/src/AddressInput/AddressInput.test.tsx
+++ b/packages/react/src/AddressInput/AddressInput.test.tsx
@@ -1,7 +1,7 @@
 import { Address } from '@medplum/fhirtypes';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { AddressInput } from './AddressInput';
-import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 const defaultProps: ComplexTypeInputProps<Address> = {
   name: 'a',

--- a/packages/react/src/AddressInput/AddressInput.tsx
+++ b/packages/react/src/AddressInput/AddressInput.tsx
@@ -1,8 +1,8 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Address } from '@medplum/fhirtypes';
 import { useContext, useMemo, useRef, useState } from 'react';
-import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 function getLine(address: Address, index: number): string {
   return address.line && address.line.length > index ? address.line[index] : '';

--- a/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
+++ b/packages/react/src/AttachmentArrayDisplay/AttachmentArrayDisplay.tsx
@@ -1,7 +1,7 @@
+import { InternalSchemaElement, getPathDisplayName, isPopulated } from '@medplum/core';
 import { Attachment } from '@medplum/fhirtypes';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
 import { DescriptionListEntry } from '../DescriptionList/DescriptionList';
-import { InternalSchemaElement, getPathDisplayName, isPopulated } from '@medplum/core';
 
 export interface AttachmentArrayDisplayProps {
   readonly path?: string;

--- a/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
-import { AttachmentInput } from './AttachmentInput';
 import { Document } from '../Document/Document';
+import { AttachmentInput } from './AttachmentInput';
 
 export default {
   title: 'Medplum/AttachmentInput',

--- a/packages/react/src/AttachmentInput/AttachmentInput.tsx
+++ b/packages/react/src/AttachmentInput/AttachmentInput.tsx
@@ -3,8 +3,8 @@ import { Attachment, Reference } from '@medplum/fhirtypes';
 import { MouseEvent, useState } from 'react';
 import { AttachmentButton } from '../AttachmentButton/AttachmentButton';
 import { AttachmentDisplay } from '../AttachmentDisplay/AttachmentDisplay';
-import { killEvent } from '../utils/dom';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { killEvent } from '../utils/dom';
 
 export interface AttachmentInputProps extends ComplexTypeInputProps<Attachment> {
   readonly arrayElement?: boolean;

--- a/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
+++ b/packages/react/src/BackboneElementDisplay/BackboneElementDisplay.tsx
@@ -6,14 +6,14 @@ import {
   tryGetDataType,
   TypedValue,
 } from '@medplum/core';
+import { AccessPolicyResource } from '@medplum/fhirtypes';
+import { useContext, useMemo } from 'react';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 import { DescriptionList, DescriptionListEntry } from '../DescriptionList/DescriptionList';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import { getValueAndType } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
-import { useContext, useMemo } from 'react';
-import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
-import { AccessPolicyResource } from '@medplum/fhirtypes';
 
 const EXTENSION_KEYS = ['extension', 'modifierExtension'];
 const IGNORED_PROPERTIES = DEFAULT_IGNORED_PROPERTIES.filter((prop) => !EXTENSION_KEYS.includes(prop));

--- a/packages/react/src/BookmarkDialog/BookmarkDialog.test.tsx
+++ b/packages/react/src/BookmarkDialog/BookmarkDialog.test.tsx
@@ -1,10 +1,10 @@
 import { showNotification } from '@mantine/notifications';
+import { WithId } from '@medplum/core';
 import { UserConfiguration } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, fireEvent, render, screen } from '../test-utils/render';
 import { BookmarkDialog } from './BookmarkDialog';
-import { WithId } from '@medplum/core';
 
 jest.mock('@mantine/notifications');
 

--- a/packages/react/src/CalendarInput/CalendarInput.stories.tsx
+++ b/packages/react/src/CalendarInput/CalendarInput.stories.tsx
@@ -1,8 +1,8 @@
 import { Slot } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { CalendarInput } from './CalendarInput';
 import { withMockedDate } from '../stories/decorators';
+import { CalendarInput } from './CalendarInput';
 
 export default {
   title: 'Medplum/CalendarInput',

--- a/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
+++ b/packages/react/src/CheckboxFormSection/CheckboxFormSection.tsx
@@ -1,8 +1,8 @@
 import { Group, Input } from '@mantine/core';
 import { ReactNode, useContext } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
-import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
 import classes from '../FormSection/FormSection.module.css';
+import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
 
 export interface CheckboxFormSectionProps {
   readonly htmlFor?: string;

--- a/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.stories.tsx
+++ b/packages/react/src/CodeableConceptDisplay/CodeableConceptDisplay.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
-import { CodeableConceptDisplay } from './CodeableConceptDisplay';
 import { Document } from '../Document/Document';
+import { CodeableConceptDisplay } from './CodeableConceptDisplay';
 
 export default {
   title: 'Medplum/CodeableConceptDisplay',

--- a/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
+++ b/packages/react/src/CodeableConceptInput/CodeableConceptInput.test.tsx
@@ -1,9 +1,9 @@
 import { CodeableConcept } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { AsyncAutocompleteTestIds } from '../AsyncAutocomplete/AsyncAutocomplete.utils';
 import { act, fireEvent, render, screen, within } from '../test-utils/render';
 import { CodeableConceptInput, CodeableConceptInputProps } from './CodeableConceptInput';
-import { AsyncAutocompleteTestIds } from '../AsyncAutocomplete/AsyncAutocomplete.utils';
 
 const medplum = new MockClient();
 const binding = 'https://example.com/test';

--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -1,7 +1,7 @@
-import { Coding, ValueSetExpansionContains, QuestionnaireResponseItem } from '@medplum/fhirtypes';
+import { Coding, QuestionnaireResponseItem, ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { useState } from 'react';
-import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAutocomplete/ValueSetAutocomplete';
 
 export interface CodingInputProps
   extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange' | 'disabled' | 'name'>,

--- a/packages/react/src/ContactDetailInput/ContactDetailInput.stories.tsx
+++ b/packages/react/src/ContactDetailInput/ContactDetailInput.stories.tsx
@@ -1,10 +1,10 @@
+import { buildElementsContext } from '@medplum/core';
 import { ContactDetail } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { ContactDetailInput } from './ContactDetailInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { ContactDetailInput } from './ContactDetailInput';
 
 export default {
   title: 'Medplum/ContactDetailInput',

--- a/packages/react/src/ContactPointInput/ContactPointInput.stories.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.stories.tsx
@@ -1,10 +1,10 @@
+import { buildElementsContext } from '@medplum/core';
 import { ContactPoint } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { ContactPointInput } from './ContactPointInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { ContactPointInput } from './ContactPointInput';
 
 export default {
   title: 'Medplum/ContactPointInput',

--- a/packages/react/src/ContactPointInput/ContactPointInput.tsx
+++ b/packages/react/src/ContactPointInput/ContactPointInput.tsx
@@ -1,8 +1,8 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { ContactPoint } from '@medplum/fhirtypes';
 import { useContext, useMemo, useRef, useState } from 'react';
-import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { getErrorsForInput } from '../utils/outcomes';
 
 export type ContactPointInputProps = ComplexTypeInputProps<ContactPoint> & {

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.stories.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.stories.tsx
@@ -1,11 +1,11 @@
 import { DiagnosticReport } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
-import { useEffect, useState, useContext } from 'react';
-import { Document } from '../Document/Document';
-import { DefaultResourceTimeline } from './DefaultResourceTimeline';
 import { Meta } from '@storybook/react';
+import { useContext, useEffect, useState } from 'react';
+import { Document } from '../Document/Document';
 import { withMockedDate } from '../stories/decorators';
 import { MockDateContext } from '../stories/MockDateWrapper.utils';
+import { DefaultResourceTimeline } from './DefaultResourceTimeline';
 
 export default {
   title: 'Medplum/DefaultResourceTimeline',

--- a/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
+++ b/packages/react/src/DefaultResourceTimeline/DefaultResourceTimeline.test.tsx
@@ -2,8 +2,8 @@ import { createReference } from '@medplum/core';
 import { DiagnosticReport, Patient } from '@medplum/fhirtypes';
 import { ExampleSubscription, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen, waitFor } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, render, screen, waitFor } from '../test-utils/render';
 import { DefaultResourceTimeline, DefaultResourceTimelineProps } from './DefaultResourceTimeline';
 
 const medplum = new MockClient();

--- a/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
+++ b/packages/react/src/DiagnosticReportDisplay/DiagnosticReportDisplay.test.tsx
@@ -2,7 +2,6 @@ import { createReference } from '@medplum/core';
 import { DiagnosticReport, Observation } from '@medplum/fhirtypes';
 import { HomerDiagnosticReport, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
 import {
   HealthGorillaDiagnosticReport,
@@ -12,6 +11,7 @@ import {
   HealthGorillaObservationGroup2,
 } from '../stories/healthgorilla';
 import { CreatinineObservation, ExampleReport } from '../stories/referenceLab';
+import { act, render, screen } from '../test-utils/render';
 import { DiagnosticReportDisplay, DiagnosticReportDisplayProps } from './DiagnosticReportDisplay';
 
 const syntheaReport: DiagnosticReport = {

--- a/packages/react/src/ElementsInput/ElementsInput.test.tsx
+++ b/packages/react/src/ElementsInput/ElementsInput.test.tsx
@@ -1,7 +1,7 @@
-import { ElementsInput } from './ElementsInput';
-import { render, screen } from '../test-utils/render';
-import { ElementsContext } from './ElementsInput.utils';
 import { ElementsContextType } from '@medplum/core';
+import { render, screen } from '../test-utils/render';
+import { ElementsInput } from './ElementsInput';
+import { ElementsContext } from './ElementsInput.utils';
 
 const elementsContext: ElementsContextType = {
   debugMode: false,

--- a/packages/react/src/ElementsInput/ElementsInput.tsx
+++ b/packages/react/src/ElementsInput/ElementsInput.tsx
@@ -6,8 +6,8 @@ import { FormSection } from '../FormSection/FormSection';
 import { setPropertyValue } from '../ResourceForm/ResourceForm.utils';
 import { getValueAndTypeFromElement } from '../ResourcePropertyDisplay/ResourcePropertyDisplay.utils';
 import { ResourcePropertyInput } from '../ResourcePropertyInput/ResourcePropertyInput';
-import { EXTENSION_KEYS, ElementsContext, getElementsToRender } from './ElementsInput.utils';
 import { BaseInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { EXTENSION_KEYS, ElementsContext, getElementsToRender } from './ElementsInput.utils';
 
 export interface ElementsInputProps extends BaseInputProps {
   readonly type: string;

--- a/packages/react/src/ElementsInput/ElementsInput.utils.ts
+++ b/packages/react/src/ElementsInput/ElementsInput.utils.ts
@@ -1,4 +1,4 @@
-import { ExtendedInternalSchemaElement, ElementsContextType, isPopulated } from '@medplum/core';
+import { ElementsContextType, ExtendedInternalSchemaElement, isPopulated } from '@medplum/core';
 import { createContext } from 'react';
 import { DEFAULT_IGNORED_NON_NESTED_PROPERTIES, DEFAULT_IGNORED_PROPERTIES } from '../constants';
 

--- a/packages/react/src/EncounterTimeline/EncounterTimeline.test.tsx
+++ b/packages/react/src/EncounterTimeline/EncounterTimeline.test.tsx
@@ -1,8 +1,8 @@
 import { createReference } from '@medplum/core';
 import { HomerEncounter, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { EncounterTimeline, EncounterTimelineProps } from './EncounterTimeline';
 
 const medplum = new MockClient();

--- a/packages/react/src/ExtensionDisplay/ExtensionDisplay.test.tsx
+++ b/packages/react/src/ExtensionDisplay/ExtensionDisplay.test.tsx
@@ -1,10 +1,10 @@
 import { HTTP_HL7_ORG, loadDataType, tryGetProfile } from '@medplum/core';
-import { act, render, screen } from '../test-utils/render';
-import { ExtensionDisplay, ExtensionDisplayProps } from './ExtensionDisplay';
-import { MockClient } from '@medplum/mock';
-import { MedplumProvider } from '@medplum/react-hooks';
 import { readJson } from '@medplum/definitions';
 import { StructureDefinition } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { MedplumProvider } from '@medplum/react-hooks';
+import { act, render, screen } from '../test-utils/render';
+import { ExtensionDisplay, ExtensionDisplayProps } from './ExtensionDisplay';
 
 const medplum = new MockClient();
 

--- a/packages/react/src/ExtensionInput/ExtensionInput.test.tsx
+++ b/packages/react/src/ExtensionInput/ExtensionInput.test.tsx
@@ -1,8 +1,8 @@
 import { Identifier } from '@medplum/fhirtypes';
-import { act, fireEvent, render, screen } from '../test-utils/render';
-import { ExtensionInput, ExtensionInputProps } from './ExtensionInput';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { act, fireEvent, render, screen } from '../test-utils/render';
+import { ExtensionInput, ExtensionInputProps } from './ExtensionInput';
 
 const medplum = new MockClient();
 

--- a/packages/react/src/FormSection/FormSection.tsx
+++ b/packages/react/src/FormSection/FormSection.tsx
@@ -1,10 +1,10 @@
-import cx from 'clsx';
 import { Input } from '@mantine/core';
 import { OperationOutcome } from '@medplum/fhirtypes';
+import cx from 'clsx';
 import { ReactNode, useContext } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
-import { getErrorsForInput } from '../utils/outcomes';
 import { READ_ONLY_TOOLTIP_TEXT, maybeWrapWithTooltip } from '../utils/maybeWrapWithTooltip';
+import { getErrorsForInput } from '../utils/outcomes';
 import classes from './FormSection.module.css';
 
 export interface FormSectionProps {

--- a/packages/react/src/HumanNameInput/HumanNameInput.stories.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.stories.tsx
@@ -1,10 +1,10 @@
+import { buildElementsContext } from '@medplum/core';
 import { HumanName } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { HumanNameInput } from './HumanNameInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { HumanNameInput } from './HumanNameInput';
 
 export default {
   title: 'Medplum/HumanNameInput',

--- a/packages/react/src/HumanNameInput/HumanNameInput.tsx
+++ b/packages/react/src/HumanNameInput/HumanNameInput.tsx
@@ -1,9 +1,9 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { HumanName } from '@medplum/fhirtypes';
 import { useContext, useMemo, useState } from 'react';
-import { getErrorsForInput } from '../utils/outcomes';
-import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { getErrorsForInput } from '../utils/outcomes';
 
 export type HumanNameInputProps = ComplexTypeInputProps<HumanName>;
 

--- a/packages/react/src/IdentifierInput/IdentifierInput.stories.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.stories.tsx
@@ -1,10 +1,10 @@
+import { buildElementsContext } from '@medplum/core';
 import { Identifier } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { IdentifierInput } from './IdentifierInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { IdentifierInput } from './IdentifierInput';
 
 export default {
   title: 'Medplum/IdentifierInput',

--- a/packages/react/src/IdentifierInput/IdentifierInput.tsx
+++ b/packages/react/src/IdentifierInput/IdentifierInput.tsx
@@ -1,9 +1,9 @@
 import { Group, TextInput } from '@mantine/core';
 import { Identifier } from '@medplum/fhirtypes';
 import { useContext, useMemo, useState } from 'react';
-import { getErrorsForInput } from '../utils/outcomes';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
+import { getErrorsForInput } from '../utils/outcomes';
 
 export type IdentifierInputProps = ComplexTypeInputProps<Identifier>;
 

--- a/packages/react/src/MoneyInput/MoneyInput.stories.tsx
+++ b/packages/react/src/MoneyInput/MoneyInput.stories.tsx
@@ -1,9 +1,9 @@
+import { buildElementsContext } from '@medplum/core';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { MoneyInput } from './MoneyInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { MoneyInput } from './MoneyInput';
 
 export default {
   title: 'Medplum/MoneyInput',

--- a/packages/react/src/NoteDisplay/NoteDisplay.test.tsx
+++ b/packages/react/src/NoteDisplay/NoteDisplay.test.tsx
@@ -1,7 +1,7 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, render, screen } from '../test-utils/render';
 import { NoteDisplay, NoteDisplayProps } from './NoteDisplay';
 
 const medplum = new MockClient();

--- a/packages/react/src/PatientTimeline/PatientTimeline.test.tsx
+++ b/packages/react/src/PatientTimeline/PatientTimeline.test.tsx
@@ -1,8 +1,8 @@
 import { createReference } from '@medplum/core';
 import { HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { PatientTimeline, PatientTimelineProps } from './PatientTimeline';
 
 const medplum = new MockClient();

--- a/packages/react/src/PeriodInput/PeriodInput.stories.tsx
+++ b/packages/react/src/PeriodInput/PeriodInput.stories.tsx
@@ -1,9 +1,9 @@
+import { buildElementsContext } from '@medplum/core';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { PeriodInput } from './PeriodInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { PeriodInput } from './PeriodInput';
 
 export default {
   title: 'Medplum/PeriodInput',

--- a/packages/react/src/QuantityInput/QuantityInput.stories.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.stories.tsx
@@ -1,9 +1,9 @@
+import { buildElementsContext } from '@medplum/core';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { QuantityInput } from './QuantityInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { QuantityInput } from './QuantityInput';
 
 export default {
   title: 'Medplum/QuantityInput',

--- a/packages/react/src/QuantityInput/QuantityInput.tsx
+++ b/packages/react/src/QuantityInput/QuantityInput.tsx
@@ -1,8 +1,8 @@
 import { Group, NativeSelect, TextInput } from '@mantine/core';
 import { Quantity } from '@medplum/fhirtypes';
 import { useContext, useMemo, useState, WheelEvent } from 'react';
-import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface QuantityInputProps extends ComplexTypeInputProps<Quantity> {
   readonly autoFocus?: boolean;

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -1,7 +1,7 @@
+import { QuestionnaireResponse } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
 import { QuestionnaireForm } from './QuestionnaireForm';
-import { QuestionnaireResponse } from '@medplum/fhirtypes';
 
 export default {
   title: 'Medplum/QuestionnaireForm',

--- a/packages/react/src/RangeInput/RangeInput.stories.tsx
+++ b/packages/react/src/RangeInput/RangeInput.stories.tsx
@@ -1,10 +1,10 @@
+import { buildElementsContext } from '@medplum/core';
 import { Range } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { RangeInput } from './RangeInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { RangeInput } from './RangeInput';
 
 export default {
   title: 'Medplum/RangeInput',

--- a/packages/react/src/RangeInput/RangeInput.tsx
+++ b/packages/react/src/RangeInput/RangeInput.tsx
@@ -1,8 +1,8 @@
 import { Group } from '@mantine/core';
 import { Range } from '@medplum/fhirtypes';
 import { useContext, useMemo, useState } from 'react';
-import { QuantityInput } from '../QuantityInput/QuantityInput';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { QuantityInput } from '../QuantityInput/QuantityInput';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface RangeInputProps extends ComplexTypeInputProps<Range> {}

--- a/packages/react/src/RatioInput/RatioInput.stories.tsx
+++ b/packages/react/src/RatioInput/RatioInput.stories.tsx
@@ -1,10 +1,10 @@
+import { buildElementsContext } from '@medplum/core';
 import { Ratio } from '@medplum/fhirtypes';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { RatioInput } from './RatioInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { RatioInput } from './RatioInput';
 
 export default {
   title: 'Medplum/RatioInput',

--- a/packages/react/src/RatioInput/RatioInput.tsx
+++ b/packages/react/src/RatioInput/RatioInput.tsx
@@ -1,8 +1,8 @@
 import { Group } from '@mantine/core';
 import { Ratio } from '@medplum/fhirtypes';
 import { useContext, useMemo, useState } from 'react';
-import { QuantityInput } from '../QuantityInput/QuantityInput';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { QuantityInput } from '../QuantityInput/QuantityInput';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface RatioInputProps extends ComplexTypeInputProps<Ratio> {}

--- a/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.stories.tsx
+++ b/packages/react/src/RequestGroupDisplay/RequestGroupDisplay.stories.tsx
@@ -12,8 +12,8 @@ import {
   Covid19RequestGroup,
   Covid19ReviewLabsTask,
 } from '../stories/covid19';
-import { RequestGroupDisplay } from './RequestGroupDisplay';
 import { withMockedDate } from '../stories/decorators';
+import { RequestGroupDisplay } from './RequestGroupDisplay';
 
 export default {
   title: 'Medplum/RequestGroupDisplay',

--- a/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
+++ b/packages/react/src/ResourceArrayDisplay/ResourceArrayDisplay.tsx
@@ -1,11 +1,11 @@
 import { InternalSchemaElement, SliceDefinitionWithTypes, getPathDisplayName, isPopulated } from '@medplum/core';
-import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
-import { useState, useContext, useEffect, useMemo } from 'react';
-import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
-import { prepareSlices, assignValuesIntoSlices } from '../ResourceArrayInput/ResourceArrayInput.utils';
 import { useMedplum } from '@medplum/react-hooks';
-import { SliceDisplay } from '../SliceDisplay/SliceDisplay';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { DescriptionListEntry } from '../DescriptionList/DescriptionList';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
+import { assignValuesIntoSlices, prepareSlices } from '../ResourceArrayInput/ResourceArrayInput.utils';
+import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
+import { SliceDisplay } from '../SliceDisplay/SliceDisplay';
 
 export interface ResourceArrayDisplayProps {
   /** The path identifies the element and is expressed as a "."-separated list of ancestor elements, beginning with the name of the resource or extension. */

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.test.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.test.tsx
@@ -1,8 +1,8 @@
 import { InternalSchemaElement } from '@medplum/core';
-import { act, fireEvent, render, screen, within } from '../test-utils/render';
-import { ResourceArrayInput, ResourceArrayInputProps } from './ResourceArrayInput';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { act, fireEvent, render, screen, within } from '../test-utils/render';
+import { ResourceArrayInput, ResourceArrayInputProps } from './ResourceArrayInput';
 
 const medplum = new MockClient();
 

--- a/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
+++ b/packages/react/src/ResourceArrayInput/ResourceArrayInput.tsx
@@ -4,13 +4,13 @@ import { useMedplum } from '@medplum/react-hooks';
 import { MouseEvent, useContext, useEffect, useState } from 'react';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { ResourcePropertyInput } from '../ResourcePropertyInput/ResourcePropertyInput';
+import { BaseInputProps, getValuePath } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 import { SliceInput } from '../SliceInput/SliceInput';
 import { ArrayAddButton } from '../buttons/ArrayAddButton';
 import { ArrayRemoveButton } from '../buttons/ArrayRemoveButton';
 import { killEvent } from '../utils/dom';
 import classes from './ResourceArrayInput.module.css';
 import { assignValuesIntoSlices, prepareSlices } from './ResourceArrayInput.utils';
-import { BaseInputProps, getValuePath } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
 
 export interface ResourceArrayInputProps extends BaseInputProps {
   readonly property: ExtendedInternalSchemaElement;

--- a/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.test.tsx
@@ -1,7 +1,7 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, render, screen } from '../test-utils/render';
 import { ResourceBlame, ResourceBlameProps } from './ResourceBlame';
 import { getTimeString } from './ResourceBlame.utils';
 

--- a/packages/react/src/ResourceDiffRow/ResourceDiffRow.tsx
+++ b/packages/react/src/ResourceDiffRow/ResourceDiffRow.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
-import { Table, Button } from '@mantine/core';
-import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
+import { Button, Table } from '@mantine/core';
 import { InternalSchemaElement, TypedValue } from '@medplum/core';
+import { useState } from 'react';
+import { ResourcePropertyDisplay } from '../ResourcePropertyDisplay/ResourcePropertyDisplay';
 import classes from './ResourceDiffRow.module.css';
 
 export interface ResourceDiffRowProps {

--- a/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
+++ b/packages/react/src/ResourceHistoryTable/ResourceHistoryTable.test.tsx
@@ -1,7 +1,7 @@
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
-import { act, render, screen } from '../test-utils/render';
 import { MemoryRouter } from 'react-router';
+import { act, render, screen } from '../test-utils/render';
 import { ResourceHistoryTable, ResourceHistoryTableProps } from './ResourceHistoryTable';
 
 const medplum = new MockClient();

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -7,6 +7,7 @@ import {
   formatTiming,
   isEmpty,
 } from '@medplum/core';
+import { ElementDefinitionType } from '@medplum/fhirtypes';
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import { AddressDisplay } from '../AddressDisplay/AddressDisplay';
 import { AttachmentArrayDisplay } from '../AttachmentArrayDisplay/AttachmentArrayDisplay';
@@ -16,6 +17,7 @@ import { CodeableConceptDisplay } from '../CodeableConceptDisplay/CodeableConcep
 import { CodingDisplay } from '../CodingDisplay/CodingDisplay';
 import { ContactDetailDisplay } from '../ContactDetailDisplay/ContactDetailDisplay';
 import { ContactPointDisplay } from '../ContactPointDisplay/ContactPointDisplay';
+import { ExtensionDisplay } from '../ExtensionDisplay/ExtensionDisplay';
 import { HumanNameDisplay } from '../HumanNameDisplay/HumanNameDisplay';
 import { IdentifierDisplay } from '../IdentifierDisplay/IdentifierDisplay';
 import { MoneyDisplay } from '../MoneyDisplay/MoneyDisplay';
@@ -24,8 +26,6 @@ import { RangeDisplay } from '../RangeDisplay/RangeDisplay';
 import { RatioDisplay } from '../RatioDisplay/RatioDisplay';
 import { ReferenceDisplay } from '../ReferenceDisplay/ReferenceDisplay';
 import { ResourceArrayDisplay } from '../ResourceArrayDisplay/ResourceArrayDisplay';
-import { ExtensionDisplay } from '../ExtensionDisplay/ExtensionDisplay';
-import { ElementDefinitionType } from '@medplum/fhirtypes';
 
 export interface ResourcePropertyDisplayProps {
   readonly property?: InternalSchemaElement;

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.stories.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.stories.tsx
@@ -1,10 +1,10 @@
 import { InternalSchemaElement, PropertyType } from '@medplum/core';
+import { Extension } from '@medplum/fhirtypes';
 import { HomerSimpson } from '@medplum/mock';
 import { Meta } from '@storybook/react';
+import { useCallback } from 'react';
 import { Document } from '../Document/Document';
 import { ResourcePropertyInput } from './ResourcePropertyInput';
-import { Extension } from '@medplum/fhirtypes';
-import { useCallback } from 'react';
 
 export default {
   title: 'Medplum/ResourcePropertyInput',

--- a/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.test.tsx
@@ -1,9 +1,9 @@
 import { createReference, MedplumClient, ProfileResource } from '@medplum/core';
 import { Attachment, Bundle, Encounter, Resource, ResourceType } from '@medplum/fhirtypes';
 import { HomerEncounter, MockClient } from '@medplum/mock';
-import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
-import { MemoryRouter } from 'react-router';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { MemoryRouter } from 'react-router';
+import { act, fireEvent, render, screen, waitFor } from '../test-utils/render';
 import { ResourceTimeline, ResourceTimelineProps } from './ResourceTimeline';
 
 const medplum = new MockClient();

--- a/packages/react/src/SliceDisplay/SliceDisplay.tsx
+++ b/packages/react/src/SliceDisplay/SliceDisplay.tsx
@@ -1,7 +1,7 @@
 import {
-  SliceDefinitionWithTypes,
-  InternalSchemaElement,
   ElementsContextType,
+  InternalSchemaElement,
+  SliceDefinitionWithTypes,
   buildElementsContext,
   isPopulated,
 } from '@medplum/core';

--- a/packages/react/src/SliceInput/SliceInput.tsx
+++ b/packages/react/src/SliceInput/SliceInput.tsx
@@ -1,7 +1,7 @@
 import { Group, Stack, Text } from '@mantine/core';
 import {
-  ExtendedInternalSchemaElement,
   ElementsContextType,
+  ExtendedInternalSchemaElement,
   SliceDefinitionWithTypes,
   buildElementsContext,
   getPropertyDisplayName,

--- a/packages/react/src/TimingInput/TimingInput.stories.tsx
+++ b/packages/react/src/TimingInput/TimingInput.stories.tsx
@@ -1,9 +1,9 @@
+import { buildElementsContext } from '@medplum/core';
 import { Meta } from '@storybook/react';
 import { Document } from '../Document/Document';
-import { TimingInput } from './TimingInput';
-import { buildElementsContext } from '@medplum/core';
 import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { maybeWrapWithContext } from '../utils/maybeWrapWithContext';
+import { TimingInput } from './TimingInput';
 
 export default {
   title: 'Medplum/TimingInput',

--- a/packages/react/src/TimingInput/TimingInput.tsx
+++ b/packages/react/src/TimingInput/TimingInput.tsx
@@ -3,9 +3,9 @@ import { formatTiming } from '@medplum/core';
 import { Timing, TimingRepeat } from '@medplum/fhirtypes';
 import { useContext, useMemo, useRef, useState } from 'react';
 import { DateTimeInput } from '../DateTimeInput/DateTimeInput';
+import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 import { FormSection } from '../FormSection/FormSection';
 import { ComplexTypeInputProps } from '../ResourcePropertyInput/ResourcePropertyInput.utils';
-import { ElementsContext } from '../ElementsInput/ElementsInput.utils';
 
 const daysOfWeek = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
 

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.test.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.test.tsx
@@ -1,9 +1,9 @@
+import { ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
+import { AsyncAutocompleteTestIds } from '../AsyncAutocomplete/AsyncAutocomplete.utils';
 import { act, fireEvent, render, screen, within } from '../test-utils/render';
 import { ValueSetAutocomplete } from '../ValueSetAutocomplete/ValueSetAutocomplete';
-import { ValueSetExpansionContains } from '@medplum/fhirtypes';
-import { AsyncAutocompleteTestIds } from '../AsyncAutocomplete/AsyncAutocomplete.utils';
 
 describe('AsyncAutocomplete', () => {
   beforeEach(() => {

--- a/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
+++ b/packages/react/src/ValueSetAutocomplete/ValueSetAutocomplete.tsx
@@ -2,13 +2,13 @@ import { Group, Text } from '@mantine/core';
 import { ValueSetExpandParams } from '@medplum/core';
 import { ValueSetExpansionContains } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
+import { IconCheck } from '@tabler/icons-react';
 import { forwardRef, useCallback } from 'react';
 import {
   AsyncAutocomplete,
   AsyncAutocompleteOption,
   AsyncAutocompleteProps,
 } from '../AsyncAutocomplete/AsyncAutocomplete';
-import { IconCheck } from '@tabler/icons-react';
 
 export interface ValueSetAutocompleteProps
   extends Omit<AsyncAutocompleteProps<ValueSetExpansionContains>, 'loadOptions' | 'toKey' | 'toOption'> {

--- a/packages/react/src/auth/SignInForm.stories.tsx
+++ b/packages/react/src/auth/SignInForm.stories.tsx
@@ -1,7 +1,7 @@
 import { Title } from '@mantine/core';
 import { Meta } from '@storybook/react';
-import { SignInForm } from './SignInForm';
 import { Logo } from '../Logo/Logo';
+import { SignInForm } from './SignInForm';
 
 export default {
   title: 'Medplum/Auth/SignInForm',

--- a/packages/react/src/stories/MockDateWrapper.tsx
+++ b/packages/react/src/stories/MockDateWrapper.tsx
@@ -1,5 +1,5 @@
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import sinon from 'sinon';
-import { ReactNode, useEffect, useMemo, useState, useRef } from 'react';
 import { MockDateContext, createGlobalTimer } from './MockDateWrapper.utils';
 
 export function MockDateWrapper({ children }: { children: ReactNode }): JSX.Element | null {

--- a/packages/react/src/utils/outcomes.test.ts
+++ b/packages/react/src/utils/outcomes.test.ts
@@ -1,6 +1,6 @@
 import { allOk, badRequest, gone } from '@medplum/core';
-import { getErrorsForInput, getIssuesForExpression } from './outcomes';
 import { OperationOutcome } from '@medplum/fhirtypes';
+import { getErrorsForInput, getIssuesForExpression } from './outcomes';
 
 const MISSING_PROP = 'Missing required property';
 function missingProp(expression: string): OperationOutcome {

--- a/packages/server/src/admin/invite.test.ts
+++ b/packages/server/src/admin/invite.test.ts
@@ -13,9 +13,9 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
-import { addTestUser, initTestAuth, setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
-import { SelectQuery } from '../fhir/sql';
 import { DatabaseMode, getDatabasePool } from '../database';
+import { SelectQuery } from '../fhir/sql';
+import { addTestUser, initTestAuth, setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
 
 jest.mock('hibp');
 jest.mock('node-fetch');

--- a/packages/server/src/auth/clientinfo.test.ts
+++ b/packages/server/src/auth/clientinfo.test.ts
@@ -1,9 +1,9 @@
-import express from 'express';
 import { ClientApplication } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { createTestClient } from '../test.setup';
-import request from 'supertest';
 
 const app = express();
 let client: ClientApplication;

--- a/packages/server/src/auth/me.ts
+++ b/packages/server/src/auth/me.ts
@@ -1,11 +1,11 @@
 import { getReferenceString, Operator, ProfileResource, WithId } from '@medplum/core';
 import { Login, Project, ProjectMembership, Reference, User, UserConfiguration } from '@medplum/fhirtypes';
+import Bowser from 'bowser';
 import { Request, Response } from 'express';
 import { getAuthenticatedContext } from '../context';
 import { getAccessPolicyForLogin } from '../fhir/accesspolicy';
 import { getSystemRepo, Repository } from '../fhir/repo';
 import { rewriteAttachments, RewriteMode } from '../fhir/rewrite';
-import Bowser from 'bowser';
 
 interface UserSession {
   id: string;

--- a/packages/server/src/auth/register.test.ts
+++ b/packages/server/src/auth/register.test.ts
@@ -2,8 +2,8 @@ import { randomUUID } from 'crypto';
 import express from 'express';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
-import { registerNew } from './register';
 import { withTestContext } from '../test.setup';
+import { registerNew } from './register';
 
 const app = express();
 

--- a/packages/server/src/auth/routes.ts
+++ b/packages/server/src/auth/routes.ts
@@ -4,6 +4,7 @@ import { Router } from 'express';
 import { asyncWrap } from '../async';
 import { authenticateRequest } from '../oauth/middleware';
 import { changePasswordHandler, changePasswordValidator } from './changepassword';
+import { clientInfoHandler } from './clientinfo';
 import { exchangeHandler, exchangeValidator } from './exchange';
 import { externalCallbackHandler } from './external';
 import { googleHandler, googleValidator } from './google';
@@ -22,7 +23,6 @@ import { setPasswordHandler, setPasswordValidator } from './setpassword';
 import { statusHandler, statusValidator } from './status';
 import { validateRecaptcha } from './utils';
 import { verifyEmailHandler, verifyEmailValidator } from './verifyemail';
-import { clientInfoHandler } from './clientinfo';
 
 export const authRouter = Router();
 authRouter.use('/mfa', mfaRouter);

--- a/packages/server/src/auth/setpassword.test.ts
+++ b/packages/server/src/auth/setpassword.test.ts
@@ -1,5 +1,6 @@
 import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2';
 import { badRequest, createReference } from '@medplum/core';
+import { UserSecurityRequest } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import { pwnedPassword } from 'hibp';
@@ -8,11 +9,10 @@ import fetch from 'node-fetch';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
+import { getSystemRepo } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
 import { setupPwnedPasswordMock, setupRecaptchaMock, withTestContext } from '../test.setup';
 import { registerNew } from './register';
-import { getSystemRepo } from '../fhir/repo';
-import { UserSecurityRequest } from '@medplum/fhirtypes';
 
 jest.mock('@aws-sdk/client-sesv2');
 jest.mock('hibp');

--- a/packages/server/src/auth/verifyemail.test.ts
+++ b/packages/server/src/auth/verifyemail.test.ts
@@ -1,12 +1,12 @@
 import { createReference, resolveId, WithId } from '@medplum/core';
+import { User, UserSecurityRequest } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
-import { addTestUser, createTestProject, withTestContext } from '../test.setup';
-import { Repository, getSystemRepo } from '../fhir/repo';
-import { User, UserSecurityRequest } from '@medplum/fhirtypes';
+import { getSystemRepo, Repository } from '../fhir/repo';
 import { generateSecret } from '../oauth/keys';
+import { addTestUser, createTestProject, withTestContext } from '../test.setup';
 
 const app = express();
 

--- a/packages/server/src/cloud/aws/textract.ts
+++ b/packages/server/src/cloud/aws/textract.ts
@@ -11,8 +11,8 @@ import { Readable } from 'stream';
 import { getConfig } from '../../config/loader';
 import { getAuthenticatedContext } from '../../context';
 import { Repository } from '../../fhir/repo';
-import { getBinaryStorage } from '../../storage/loader';
 import { getLogger } from '../../logger';
+import { getBinaryStorage } from '../../storage/loader';
 import { S3Storage } from './storage';
 
 export async function awsTextractHandler(req: FhirRequest): Promise<FhirResponse> {

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -5,12 +5,12 @@ import { NextFunction, Request, Response } from 'express';
 import { getConfig } from './config/loader';
 import { getRepoForLogin } from './fhir/accesspolicy';
 import { Repository, getSystemRepo } from './fhir/repo';
+import { FhirRateLimiter } from './fhirinteractionlimit';
 import { systemLogger } from './logger';
 import { AuthState, authenticateTokenImpl, isExtendedMode } from './oauth/middleware';
+import { getRedis } from './redis';
 import { IRequestContext, requestContextStore } from './request-context-store';
 import { parseTraceparent } from './traceparent';
-import { getRedis } from './redis';
-import { FhirRateLimiter } from './fhirinteractionlimit';
 
 export class RequestContext implements IRequestContext {
   readonly requestId: string;

--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -14,7 +14,7 @@ import {
   initDatabase,
   releaseAdvisoryLock,
 } from './database';
-import { GetVersionSql, GetDataVersionSql } from './migration-sql';
+import { GetDataVersionSql, GetVersionSql } from './migration-sql';
 
 describe('Database config', () => {
   let poolSpy: jest.SpyInstance<pg.Pool, [config?: pg.PoolConfig | undefined]>;

--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -5,8 +5,8 @@ import { sendEmailViaSes } from '../cloud/aws/email';
 import { getConfig } from '../config/loader';
 import { MedplumSmtpConfig } from '../config/types';
 import { Repository } from '../fhir/repo';
-import { getBinaryStorage } from '../storage/loader';
 import { globalLogger } from '../logger';
+import { getBinaryStorage } from '../storage/loader';
 import { getFromAddress } from './utils';
 
 /**

--- a/packages/server/src/fhir/bulkdata.test.ts
+++ b/packages/server/src/fhir/bulkdata.test.ts
@@ -1,11 +1,11 @@
+import { ContentType } from '@medplum/core';
+import { BulkDataExport } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { createTestProject } from '../test.setup';
-import express from 'express';
 import { Repository } from './repo';
-import { BulkDataExport } from '@medplum/fhirtypes';
-import request from 'supertest';
-import { ContentType } from '@medplum/core';
 
 const app = express();
 let accessToken: string;

--- a/packages/server/src/fhir/bulkdata.ts
+++ b/packages/server/src/fhir/bulkdata.ts
@@ -2,8 +2,8 @@ import { ContentType, flatMapFilter, isNotFound, notFound, OperationOutcomeError
 import { AsyncJob, BulkDataExport } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
-import { rewriteAttachments, RewriteMode } from './rewrite';
 import { getAuthenticatedContext } from '../context';
+import { rewriteAttachments, RewriteMode } from './rewrite';
 
 // Bulk Data API
 // https://hl7.org/fhir/uv/bulkdata/STU2/

--- a/packages/server/src/fhir/lookups/address.test.ts
+++ b/packages/server/src/fhir/lookups/address.test.ts
@@ -1,11 +1,11 @@
 import { Operator, WithId } from '@medplum/core';
-import { InsurancePlan, Patient, Location, ResourceType, Resource, Address } from '@medplum/fhirtypes';
+import { Address, InsurancePlan, Location, Patient, Resource, ResourceType } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
+import { PoolClient } from 'pg';
 import { initAppServices, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { withTestContext } from '../../test.setup';
 import { getSystemRepo } from '../repo';
-import { PoolClient } from 'pg';
 import { AddressTable, AddressTableRow } from './address';
 
 describe('Address Lookup Table', () => {

--- a/packages/server/src/fhir/lookups/humanname.ts
+++ b/packages/server/src/fhir/lookups/humanname.ts
@@ -10,8 +10,8 @@ import {
   SearchParameter,
 } from '@medplum/fhirtypes';
 import { Pool, PoolClient } from 'pg';
+import { Column, DeleteQuery } from '../sql';
 import { LookupTable, LookupTableRow } from './lookuptable';
-import { DeleteQuery, Column } from '../sql';
 
 const resourceTypes = ['Patient', 'Person', 'Practitioner', 'RelatedPerson'] as const;
 const resourceTypeSet = new Set(resourceTypes);

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -7,12 +7,12 @@ import {
   Conjunction,
   DeleteQuery,
   Disjunction,
+  escapeLikeString,
   Expression,
   InsertQuery,
   Negation,
   SelectQuery,
   SqlFunction,
-  escapeLikeString,
 } from '../sql';
 
 const lookupTableBatchSize = 5_000;

--- a/packages/server/src/fhir/lookups/reference.ts
+++ b/packages/server/src/fhir/lookups/reference.ts
@@ -10,8 +10,8 @@ import {
 } from '@medplum/core';
 import { Resource, ResourceType, SearchParameter } from '@medplum/fhirtypes';
 import { Pool, PoolClient } from 'pg';
-import { LookupTable, LookupTableRow } from './lookuptable';
 import { InsertQuery } from '../sql';
+import { LookupTable, LookupTableRow } from './lookuptable';
 
 export interface ReferenceTableRow extends LookupTableRow {
   resourceId: string;

--- a/packages/server/src/fhir/lookups/token.test.ts
+++ b/packages/server/src/fhir/lookups/token.test.ts
@@ -1,7 +1,7 @@
 import { WithId } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
-import { TokenTable, TokenTableRow } from './token';
 import { loadStructureDefinitions } from '../structure';
+import { TokenTable, TokenTableRow } from './token';
 
 describe('Token lookup table', () => {
   beforeAll(() => {

--- a/packages/server/src/fhir/operations/chargeitemdefinitionapply.ts
+++ b/packages/server/src/fhir/operations/chargeitemdefinitionapply.ts
@@ -1,9 +1,9 @@
 import { allOk, evalFhirPathTyped, toJsBoolean, toTypedValue } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import { ChargeItem, ChargeItemDefinition, Money, Reference } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { getOperationDefinition } from './definitions';
 import { parseInputParameters } from './utils/parameters';
-import { ChargeItem, ChargeItemDefinition, Money, Reference } from '@medplum/fhirtypes';
 
 const operation = getOperationDefinition('ChargeItemDefinition', 'apply');
 

--- a/packages/server/src/fhir/operations/claimexport.test.ts
+++ b/packages/server/src/fhir/operations/claimexport.test.ts
@@ -1,9 +1,9 @@
 import { Bundle, Claim } from '@medplum/fhirtypes';
+import express from 'express';
+import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { initTestAuth } from '../../test.setup';
-import express from 'express';
-import request from 'supertest';
 
 const app = express();
 let accessToken: string;

--- a/packages/server/src/fhir/operations/claimexport.ts
+++ b/packages/server/src/fhir/operations/claimexport.ts
@@ -1,11 +1,11 @@
 import { allOk, badRequest, getReferenceString, normalizeErrorString } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { Binary, Claim, Media, OperationDefinition } from '@medplum/fhirtypes';
+import { Readable } from 'stream';
 import { getAuthenticatedContext } from '../../context';
+import { getBinaryStorage } from '../../storage/loader';
 import { createPdf } from '../../util/pdf';
 import { getClaimPDFDocDefinition } from './utils/cms1500pdf';
-import { getBinaryStorage } from '../../storage/loader';
-import { Readable } from 'stream';
 
 /**
  * Operation definition for the Claim $export operation.

--- a/packages/server/src/fhir/operations/codesystemlookup.test.ts
+++ b/packages/server/src/fhir/operations/codesystemlookup.test.ts
@@ -1,11 +1,11 @@
-import { CodeSystem, OperationOutcome, Parameters } from '@medplum/fhirtypes';
-import express from 'express';
-import { loadTestConfig } from '../../config/loader';
-import { initApp, shutdownApp } from '../../app';
-import { initTestAuth } from '../../test.setup';
-import request from 'supertest';
-import { randomUUID } from 'crypto';
 import { ContentType } from '@medplum/core';
+import { CodeSystem, OperationOutcome, Parameters } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { initTestAuth } from '../../test.setup';
 
 const app = express();
 

--- a/packages/server/src/fhir/operations/codesystemvalidatecode.test.ts
+++ b/packages/server/src/fhir/operations/codesystemvalidatecode.test.ts
@@ -1,11 +1,11 @@
-import { CodeSystem, OperationOutcome, Parameters } from '@medplum/fhirtypes';
-import express from 'express';
-import { loadTestConfig } from '../../config/loader';
-import { initApp, shutdownApp } from '../../app';
-import { initTestAuth } from '../../test.setup';
-import request from 'supertest';
-import { randomUUID } from 'crypto';
 import { ContentType } from '@medplum/core';
+import { CodeSystem, OperationOutcome, Parameters } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../../app';
+import { loadTestConfig } from '../../config/loader';
+import { initTestAuth } from '../../test.setup';
 import { validateCodings } from './codesystemvalidatecode';
 
 const app = express();

--- a/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
+++ b/packages/server/src/fhir/operations/dbinvalidindexes.test.ts
@@ -3,8 +3,8 @@ import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
+import { DatabaseMode, getDatabasePool } from '../../database';
 import { initTestAuth } from '../../test.setup';
-import { getDatabasePool, DatabaseMode } from '../../database';
 
 describe('$db-invalid-indexes', () => {
   const app = express();

--- a/packages/server/src/fhir/operations/dbschemadiff.ts
+++ b/packages/server/src/fhir/operations/dbschemadiff.ts
@@ -3,8 +3,8 @@ import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { OperationDefinition } from '@medplum/fhirtypes';
 import { requireSuperAdmin } from '../../admin/super';
 import { DatabaseMode, getDatabasePool } from '../../database';
-import { buildOutputParameters } from './utils/parameters';
 import { buildMigration } from '../../migrations/migrate';
+import { buildOutputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
   resourceType: 'OperationDefinition',

--- a/packages/server/src/fhir/operations/launch.test.ts
+++ b/packages/server/src/fhir/operations/launch.test.ts
@@ -1,11 +1,11 @@
+import { createReference } from '@medplum/core';
+import { ClientApplication, Encounter, Patient, SmartAppLaunch } from '@medplum/fhirtypes';
 import express from 'express';
+import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
-import { withTestContext, createTestProject } from '../../test.setup';
-import { ClientApplication, Encounter, Patient, SmartAppLaunch } from '@medplum/fhirtypes';
-import request from 'supertest';
+import { createTestProject, withTestContext } from '../../test.setup';
 import { Repository } from '../repo';
-import { createReference } from '@medplum/core';
 
 const app = express();
 

--- a/packages/server/src/fhir/operations/launch.ts
+++ b/packages/server/src/fhir/operations/launch.ts
@@ -1,10 +1,10 @@
 import { badRequest, concatUrls, redirect } from '@medplum/core';
-import { ClientApplication, OperationDefinition, SmartAppLaunch } from '@medplum/fhirtypes';
-import { getSystemRepo } from '../repo';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
+import { ClientApplication, OperationDefinition, SmartAppLaunch } from '@medplum/fhirtypes';
 import { getConfig } from '../../config/loader';
-import { parseInputParameters } from './utils/parameters';
 import { getAuthenticatedContext } from '../../context';
+import { getSystemRepo } from '../repo';
+import { parseInputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
   resourceType: 'OperationDefinition',

--- a/packages/server/src/fhir/operations/patientsetaccounts.test.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.test.ts
@@ -1,5 +1,5 @@
 import { createReference } from '@medplum/core';
-import { Bundle, Observation, Organization, Patient, DiagnosticReport } from '@medplum/fhirtypes';
+import { Bundle, DiagnosticReport, Observation, Organization, Patient } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';

--- a/packages/server/src/fhir/operations/patientsetaccounts.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.ts
@@ -1,9 +1,9 @@
 import { allOk, badRequest, forbidden } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
-import { Patient, Reference, OperationDefinition } from '@medplum/fhirtypes';
+import { OperationDefinition, Patient, Reference } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { getPatientEverything } from './patienteverything';
-import { parseInputParameters, buildOutputParameters } from './utils/parameters';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
   resourceType: 'OperationDefinition',

--- a/packages/server/src/fhir/operations/rotatesecret.test.ts
+++ b/packages/server/src/fhir/operations/rotatesecret.test.ts
@@ -1,10 +1,10 @@
+import { ContentType } from '@medplum/core';
+import { ClientApplication, Parameters } from '@medplum/fhirtypes';
 import express from 'express';
+import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
 import { loadTestConfig } from '../../config/loader';
 import { createTestProject } from '../../test.setup';
-import { ContentType } from '@medplum/core';
-import request from 'supertest';
-import { ClientApplication, Parameters } from '@medplum/fhirtypes';
 
 describe('ClientApplication $rotate-secret', () => {
   const app = express();

--- a/packages/server/src/fhir/operations/rotatesecret.ts
+++ b/packages/server/src/fhir/operations/rotatesecret.ts
@@ -1,10 +1,10 @@
+import { allOk, badRequest, forbidden, OperationOutcomeError } from '@medplum/core';
 import { FhirRequest, FhirResponse } from '@medplum/fhir-router';
 import { ClientApplication, OperationDefinition } from '@medplum/fhirtypes';
 import { getAuthenticatedContext } from '../../context';
 import { generateSecret } from '../../oauth/keys';
-import { allOk, badRequest, forbidden, OperationOutcomeError } from '@medplum/core';
-import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 import { getSystemRepo } from '../repo';
+import { buildOutputParameters, parseInputParameters } from './utils/parameters';
 
 const operation: OperationDefinition = {
   resourceType: 'OperationDefinition',

--- a/packages/server/src/fhir/operations/subsumes.test.ts
+++ b/packages/server/src/fhir/operations/subsumes.test.ts
@@ -1,5 +1,5 @@
-import { Bundle, Parameters } from '@medplum/fhirtypes';
 import { ContentType } from '@medplum/core';
+import { Bundle, Parameters } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.ts
@@ -7,9 +7,9 @@ import {
   HTTP_HL7_ORG,
 } from '@medplum/core';
 import { Address, Claim, HumanName, Practitioner, RelatedPerson } from '@medplum/fhirtypes';
+import path from 'path';
 import { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { getAuthenticatedContext } from '../../../context';
-import path from 'path';
 
 const PAGE_WIDTH = 612;
 const PAGE_HEIGHT = 792;

--- a/packages/server/src/fhir/operations/utils/terminology.ts
+++ b/packages/server/src/fhir/operations/utils/terminology.ts
@@ -1,8 +1,8 @@
 import { OperationOutcomeError, Operator, badRequest, createReference, resolveId } from '@medplum/core';
-import { getAuthenticatedContext } from '../../../context';
 import { CodeSystem, CodeSystemProperty, ConceptMap, Reference, ValueSet } from '@medplum/fhirtypes';
-import { SelectQuery, Conjunction, Condition, Column, Union, Operator as SqlOperator, SqlFunction } from '../../sql';
+import { getAuthenticatedContext } from '../../../context';
 import { getSystemRepo } from '../../repo';
+import { Column, Condition, Conjunction, SelectQuery, SqlFunction, Operator as SqlOperator, Union } from '../../sql';
 
 export const parentProperty = 'http://hl7.org/fhir/concept-properties#parent';
 export const childProperty = 'http://hl7.org/fhir/concept-properties#child';

--- a/packages/server/src/fhir/references.test.ts
+++ b/packages/server/src/fhir/references.test.ts
@@ -7,8 +7,8 @@ import { loadTestConfig } from '../config/loader';
 import { AuthState } from '../oauth/middleware';
 import { createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
-import { getSystemRepo } from './repo';
 import { ReferenceTable, ReferenceTableRow } from './lookups/reference';
+import { getSystemRepo } from './repo';
 
 describe('Reference checks', () => {
   beforeAll(async () => {

--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -40,10 +40,10 @@ import { loadTestConfig } from '../config/loader';
 import { DatabaseMode, getDatabasePool } from '../database';
 import { bundleContains, createTestProject, withTestContext } from '../test.setup';
 import { getRepoForLogin } from './accesspolicy';
-import { getSystemRepo, Repository, setTypedPropertyValue } from './repo';
-import { SelectQuery } from './sql';
-import { lookupTables } from './searchparameter';
 import { TokenTable } from './lookups/token';
+import { getSystemRepo, Repository, setTypedPropertyValue } from './repo';
+import { lookupTables } from './searchparameter';
+import { SelectQuery } from './sql';
 
 jest.mock('hibp');
 

--- a/packages/server/src/fhir/routes.test.ts
+++ b/packages/server/src/fhir/routes.test.ts
@@ -6,8 +6,8 @@ import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { registerNew } from '../auth/register';
 import { loadTestConfig } from '../config/loader';
-import { addTestUser, bundleContains, createTestProject, initTestAuth, withTestContext } from '../test.setup';
 import { DatabaseMode, getDatabasePool } from '../database';
+import { addTestUser, bundleContains, createTestProject, initTestAuth, withTestContext } from '../test.setup';
 
 const app = express();
 let accessToken: string;

--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -19,6 +19,7 @@ import { agentUpgradeHandler } from './operations/agentupgrade';
 import { asyncJobCancelHandler } from './operations/asyncjobcancel';
 import { ccdaExportHandler } from './operations/ccdaexport';
 import { chargeItemDefinitionApplyHandler } from './operations/chargeitemdefinitionapply';
+import { claimExportHandler } from './operations/claimexport';
 import { codeSystemImportHandler } from './operations/codesystemimport';
 import { codeSystemLookupHandler } from './operations/codesystemlookup';
 import { codeSystemValidateCodeHandler } from './operations/codesystemvalidatecode';
@@ -51,7 +52,6 @@ import { sendOutcome } from './outcomes';
 import { ResendSubscriptionsOptions } from './repo';
 import { sendFhirResponse } from './response';
 import { smartConfigurationHandler, smartStylingHandler } from './smart';
-import { claimExportHandler } from './operations/claimexport';
 
 export const fhirRouter = Router();
 

--- a/packages/server/src/fhir/smart.test.ts
+++ b/packages/server/src/fhir/smart.test.ts
@@ -1,7 +1,7 @@
 import { AccessPolicy } from '@medplum/fhirtypes';
-import { applySmartScopes, parseSmartScopes } from './smart';
 import { randomUUID } from 'node:crypto';
 import { PopulatedAccessPolicy } from './accesspolicy';
+import { applySmartScopes, parseSmartScopes } from './smart';
 
 describe('SMART on FHIR', () => {
   test('Parse empty', () => {

--- a/packages/server/src/fhir/smart.ts
+++ b/packages/server/src/fhir/smart.ts
@@ -6,8 +6,8 @@
 import { ContentType, deepClone, OAuthGrantType, OAuthTokenAuthMethod, splitN } from '@medplum/core';
 import { AccessPolicy, AccessPolicyResource } from '@medplum/fhirtypes';
 import { Request, Response } from 'express';
-import { getConfig } from '../config/loader';
 import qs from 'node:querystring';
+import { getConfig } from '../config/loader';
 import { PopulatedAccessPolicy } from './accesspolicy';
 
 const smartScopeFormat = /^(patient|user|system)\/(\w+|\*)\.(read|write|c?r?u?d?s?|\*)$/;

--- a/packages/server/src/fhir/transaction.test.ts
+++ b/packages/server/src/fhir/transaction.test.ts
@@ -1,10 +1,10 @@
 import { OperationOutcomeError, Operator, WithId, conflict, notFound, parseSearchRequest, sleep } from '@medplum/core';
 import { Patient } from '@medplum/fhirtypes';
+import { randomUUID } from 'node:crypto';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { createTestProject, withTestContext } from '../test.setup';
 import { Repository, getSystemRepo } from './repo';
-import { randomUUID } from 'node:crypto';
 
 describe('FHIR Repo Transactions', () => {
   let repo: Repository;

--- a/packages/server/src/fhirinteractionlimit.test.ts
+++ b/packages/server/src/fhirinteractionlimit.test.ts
@@ -1,12 +1,12 @@
-import express, { Express } from 'express';
-import { loadTestConfig } from './config/loader';
-import { initApp, shutdownApp } from './app';
-import { getRedis } from './redis';
-import request from 'supertest';
-import { createTestProject } from './test.setup';
-import { MedplumServerConfig } from './config/types';
-import { Bundle } from '@medplum/fhirtypes';
 import { sleep } from '@medplum/core';
+import { Bundle } from '@medplum/fhirtypes';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from './app';
+import { loadTestConfig } from './config/loader';
+import { MedplumServerConfig } from './config/types';
+import { getRedis } from './redis';
+import { createTestProject } from './test.setup';
 
 describe('FHIR Rate Limits', () => {
   let app: Express;

--- a/packages/server/src/migrations/data/types.ts
+++ b/packages/server/src/migrations/data/types.ts
@@ -1,7 +1,7 @@
 import { WithId } from '@medplum/core';
 import { AsyncJob } from '@medplum/fhirtypes';
-import { Repository } from '../../fhir/repo';
 import { Job } from 'bullmq';
+import { Repository } from '../../fhir/repo';
 
 export interface PostDeployJobData {
   readonly type: 'reindex' | 'custom';

--- a/packages/server/src/migrations/data/v1.ts
+++ b/packages/server/src/migrations/data/v1.ts
@@ -1,6 +1,6 @@
 import { getResourceTypes, WithId } from '@medplum/core';
-import { prepareReindexJobData, ReindexJob, ReindexPostDeployMigration } from '../../workers/reindex';
 import { AsyncJob } from '@medplum/fhirtypes';
+import { prepareReindexJobData, ReindexJob, ReindexPostDeployMigration } from '../../workers/reindex';
 
 export const migration: ReindexPostDeployMigration = {
   type: 'reindex',

--- a/packages/server/src/migrations/data/v3.ts
+++ b/packages/server/src/migrations/data/v3.ts
@@ -1,6 +1,6 @@
 import { getResourceTypes, WithId } from '@medplum/core';
-import { prepareReindexJobData, ReindexJob, ReindexPostDeployMigration } from '../../workers/reindex';
 import { AsyncJob } from '@medplum/fhirtypes';
+import { prepareReindexJobData, ReindexJob, ReindexPostDeployMigration } from '../../workers/reindex';
 
 // Repository.VERSION was bumped to 3 for token-column search parameters,
 // so reindex all resources with a lower version.

--- a/packages/server/src/migrations/data/v4.ts
+++ b/packages/server/src/migrations/data/v4.ts
@@ -1,8 +1,8 @@
 import { PoolClient } from 'pg';
-import { CustomMigrationAction, CustomPostDeployMigration } from './types';
-import * as fns from '../migrate-functions';
 import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
 import { withLongRunningDatabaseClient } from '../migration-utils';
+import { CustomMigrationAction, CustomPostDeployMigration } from './types';
 
 export const migration: CustomPostDeployMigration = {
   type: 'custom',

--- a/packages/server/src/migrations/data/v5.ts
+++ b/packages/server/src/migrations/data/v5.ts
@@ -1,8 +1,8 @@
 import { PoolClient } from 'pg';
-import { CustomMigrationAction, CustomPostDeployMigration } from './types';
-import * as fns from '../migrate-functions';
 import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
 import { withLongRunningDatabaseClient } from '../migration-utils';
+import { CustomMigrationAction, CustomPostDeployMigration } from './types';
 
 export const migration: CustomPostDeployMigration = {
   type: 'custom',

--- a/packages/server/src/migrations/data/v6.ts
+++ b/packages/server/src/migrations/data/v6.ts
@@ -1,8 +1,8 @@
 import { PoolClient } from 'pg';
-import { CustomMigrationAction, CustomPostDeployMigration } from './types';
-import * as fns from '../migrate-functions';
 import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
 import { withLongRunningDatabaseClient } from '../migration-utils';
+import { CustomMigrationAction, CustomPostDeployMigration } from './types';
 
 export const migration: CustomPostDeployMigration = {
   type: 'custom',

--- a/packages/server/src/migrations/migrate-functions.test.ts
+++ b/packages/server/src/migrations/migrate-functions.test.ts
@@ -1,8 +1,8 @@
 import { Client, Pool } from 'pg';
-import { idempotentCreateIndex, MigrationAction } from './migrate-functions';
-import { closeDatabase, DatabaseMode, getDatabasePool, initDatabase } from '../database';
-import { MedplumServerConfig } from '../config/types';
 import { loadTestConfig } from '../config/loader';
+import { MedplumServerConfig } from '../config/types';
+import { closeDatabase, DatabaseMode, getDatabasePool, initDatabase } from '../database';
+import { idempotentCreateIndex, MigrationAction } from './migrate-functions';
 
 interface IndexInfo {
   index_name: string;

--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -22,6 +22,7 @@ import {
   TokenColumnSearchParameterImplementation,
 } from '../fhir/searchparameter';
 import { SqlFunctionDefinition, TokenArrayToTextFn } from '../fhir/sql';
+import { isLegacyTokenColumnSearchParameter } from '../fhir/tokens';
 import {
   doubleEscapeSingleQuotes,
   escapeUnicode,
@@ -29,7 +30,6 @@ import {
   quotedColumnName,
   splitIndexColumnNames,
 } from './migrate-utils';
-import { isLegacyTokenColumnSearchParameter } from '../fhir/tokens';
 
 const SCHEMA_DIR = resolve(__dirname, 'schema');
 let DRY_RUN = false;

--- a/packages/server/src/oauth/introspect.test.ts
+++ b/packages/server/src/oauth/introspect.test.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import request from 'supertest';
-import { loadTestConfig } from '../config/loader';
 import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
 
 describe('OAuth2 UserInfo', () => {
   const app = express();

--- a/packages/server/src/oauth/introspect.ts
+++ b/packages/server/src/oauth/introspect.ts
@@ -1,9 +1,9 @@
-import { RequestHandler, Request, Response } from 'express';
-import { asyncWrap } from '../async';
-import { verifyJwt } from './keys';
-import { getSystemRepo } from '../fhir/repo';
 import { Login, SmartAppLaunch } from '@medplum/fhirtypes';
+import { Request, RequestHandler, Response } from 'express';
 import { JWTPayload } from 'jose';
+import { asyncWrap } from '../async';
+import { getSystemRepo } from '../fhir/repo';
+import { verifyJwt } from './keys';
 
 /**
  * Handles the OAuth2 Token Introspection Endpoint

--- a/packages/server/src/oauth/logout.ts
+++ b/packages/server/src/oauth/logout.ts
@@ -1,9 +1,9 @@
 import { allOk, resolveId } from '@medplum/core';
 import { Request, Response } from 'express';
 import { asyncWrap } from '../async';
+import { getAuthenticatedContext } from '../context';
 import { sendOutcome } from '../fhir/outcomes';
 import { revokeLogin } from '../oauth/utils';
-import { getAuthenticatedContext } from '../context';
 
 export const logoutHandler = asyncWrap(async (req: Request, res: Response): Promise<void> => {
   const ctx = getAuthenticatedContext();

--- a/packages/server/src/oauth/routes.ts
+++ b/packages/server/src/oauth/routes.ts
@@ -1,11 +1,11 @@
 import cookieParser from 'cookie-parser';
 import { Router } from 'express';
 import { authorizeGetHandler, authorizePostHandler } from './authorize';
+import { tokenIntrospectHandler } from './introspect';
 import { logoutHandler } from './logout';
 import { authenticateRequest } from './middleware';
 import { tokenHandler } from './token';
 import { userInfoHandler } from './userinfo';
-import { tokenIntrospectHandler } from './introspect';
 
 export const oauthRouter = Router();
 oauthRouter.get('/authorize', cookieParser(), authorizeGetHandler);

--- a/packages/server/src/oauth/userinfo.test.ts
+++ b/packages/server/src/oauth/userinfo.test.ts
@@ -4,8 +4,8 @@ import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
-import { loadTestConfig } from '../config/loader';
 import { registerNew } from '../auth/register';
+import { loadTestConfig } from '../config/loader';
 import { getSystemRepo } from '../fhir/repo';
 
 const app = express();

--- a/packages/server/src/otel/instrumentation.test.ts
+++ b/packages/server/src/otel/instrumentation.test.ts
@@ -1,8 +1,8 @@
-import { NodeSDK } from '@opentelemetry/sdk-node';
 import { Span, SpanStatusCode } from '@opentelemetry/api';
-import { httpResponseHook, initOpenTelemetry, pgResponseHook, shutdownOpenTelemetry } from './instrumentation';
-import { IncomingMessage, ServerResponse } from 'http';
 import { PgResponseHookInformation } from '@opentelemetry/instrumentation-pg';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { IncomingMessage, ServerResponse } from 'http';
+import { httpResponseHook, initOpenTelemetry, pgResponseHook, shutdownOpenTelemetry } from './instrumentation';
 
 describe('Instrumentation', () => {
   const OLD_ENV = process.env;

--- a/packages/server/src/ratelimit.ts
+++ b/packages/server/src/ratelimit.ts
@@ -1,9 +1,9 @@
 import { tooManyRequests } from '@medplum/core';
-import { Request, Response, Handler } from 'express';
+import { Handler, Request, Response } from 'express';
 import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
+import { MedplumServerConfig } from './config/types';
 import { AuthenticatedRequestContext, getRequestContext } from './context';
 import { getRedis } from './redis';
-import { MedplumServerConfig } from './config/types';
 
 // History:
 // Before, the default "auth rate limit" was 600 per 15 minutes, but used "MemoryStore" rather than "RedisStore"

--- a/packages/server/src/util/pdf.test.ts
+++ b/packages/server/src/util/pdf.test.ts
@@ -1,5 +1,5 @@
-import { createPdf } from './pdf';
 import { TDocumentDefinitions } from 'pdfmake/interfaces';
+import { createPdf } from './pdf';
 
 describe('createPdf', () => {
   test('creates a basic PDF with default fonts', async () => {

--- a/packages/server/src/util/pdf.ts
+++ b/packages/server/src/util/pdf.ts
@@ -1,5 +1,5 @@
-import { TDocumentDefinitions, TFontDictionary, CustomTableLayout } from 'pdfmake/interfaces';
 import PdfPrinter from 'pdfmake';
+import { CustomTableLayout, TDocumentDefinitions, TFontDictionary } from 'pdfmake/interfaces';
 
 /**
  * Generates a PDF buffer from a document definition.

--- a/packages/server/src/util/validator.ts
+++ b/packages/server/src/util/validator.ts
@@ -1,6 +1,6 @@
-import { RequestHandler, Request, Response, NextFunction } from 'express';
+import { NextFunction, Request, RequestHandler, Response } from 'express';
 import { ContextRunner, validationResult } from 'express-validator';
-import { sendOutcome, invalidRequest } from '../fhir/outcomes';
+import { invalidRequest, sendOutcome } from '../fhir/outcomes';
 
 export function makeValidationMiddleware(runners: ContextRunner[]): RequestHandler {
   return async function (req: Request, res: Response, next: NextFunction) {

--- a/packages/server/src/workers/download.ts
+++ b/packages/server/src/workers/download.ts
@@ -14,8 +14,8 @@ import { Readable } from 'stream';
 import { getConfig } from '../config/loader';
 import { tryGetRequestContext, tryRunInRequestContext } from '../context';
 import { getSystemRepo } from '../fhir/repo';
-import { getBinaryStorage } from '../storage/loader';
 import { getLogger, globalLogger } from '../logger';
+import { getBinaryStorage } from '../storage/loader';
 import { parseTraceparent } from '../traceparent';
 import { queueRegistry, WorkerInitializer } from './utils';
 

--- a/packages/server/src/workers/index.test.ts
+++ b/packages/server/src/workers/index.test.ts
@@ -1,10 +1,10 @@
 import { closeWorkers, initWorkers } from '.';
 import { loadTestConfig } from '../config/loader';
 import { closeDatabase, initDatabase } from '../database';
-import { initBinaryStorage } from '../storage/loader';
 import { loadStructureDefinitions } from '../fhir/structure';
 import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
+import { initBinaryStorage } from '../storage/loader';
 
 describe('Workers', () => {
   beforeAll(() => {

--- a/packages/server/src/workers/post-deploy-migration.test.ts
+++ b/packages/server/src/workers/post-deploy-migration.test.ts
@@ -1,6 +1,7 @@
 import { getReferenceString } from '@medplum/core';
 import { AsyncJob, Parameters } from '@medplum/fhirtypes';
-import { Job, Queue, DelayedError } from 'bullmq';
+import { DelayedError, Job, Queue } from 'bullmq';
+import { closeWorkers, initWorkers } from '.';
 import { initAppServices, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import { MedplumServerConfig } from '../config/types';
@@ -20,7 +21,6 @@ import {
   prepareCustomMigrationJobData,
   runCustomMigration,
 } from './post-deploy-migration';
-import { closeWorkers, initWorkers } from '.';
 import { queueRegistry } from './utils';
 
 describe('Post-Deploy Migration Worker', () => {

--- a/packages/server/src/workers/utils.test.ts
+++ b/packages/server/src/workers/utils.test.ts
@@ -1,10 +1,10 @@
 import { Subscription } from '@medplum/fhirtypes';
-import { addVerboseQueueLogging, DefaultQueueRegistry, isJobSuccessful } from './utils';
-import { withTestContext } from '../test.setup';
 import { Job, Queue, Worker } from 'bullmq';
 import EventEmitter from 'node:events';
-import { globalLogger } from '../logger';
 import { loadTestConfig } from '../config/loader';
+import { globalLogger } from '../logger';
+import { withTestContext } from '../test.setup';
+import { addVerboseQueueLogging, DefaultQueueRegistry, isJobSuccessful } from './utils';
 
 describe('worker utils', () => {
   beforeAll(async () => {


### PR DESCRIPTION
I tested it out and it seems to be exactly like running `Organize Imports` in VSCode, as advertised

This means autofix.ci should automatically run and organize any imports that are not already organized before committing during CI

EDIT: Looks like autofix already picked up a lot of things that didn't have organize imports run, nice 🥳 