### PR TITLE
Do not automatically apply security label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,15 +24,6 @@ auth:
           - packages/server/src/fhir/accesspolicy.ts
           - packages/core/src/access.ts
 
-security:
-  - changed-files:
-      - any-glob-to-any-file:
-          - packages/server/src/auth/**/*
-          - packages/server/src/oauth/**/*
-          - packages/server/src/scim/**/*
-          - packages/server/src/fhir/accesspolicy.ts
-          - packages/core/src/access.ts
-
 fhir-datastore:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
Removing "security" from the Github "auto labeler" action.

Our new Vanta integration has special treatment for the "security" label (remediation workflows, notifications, etc).  We will now only use the "security" label for issues that are truly "security" incidents.

In our auto labeler configuration, the "security" label was effectively the same as the "auth" label, so we will still essentially get the same automatic behavior.