### PR TITLE
Use `projectId` instead of compartments for project filtering

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1301,7 +1301,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    */
   private addProjectFilters(builder: SelectQuery): void {
     if (this.context.projects?.length) {
-      builder.where('compartments', 'ARRAY_CONTAINS_AND_IS_NOT_NULL', this.context.projects, 'UUID[]');
+      builder.where('projectId', 'IN', this.context.projects);
     }
   }
 


### PR DESCRIPTION
First step of normalizing on the projectId column and indexing on it. Since all resource tables already have an index on `projectId`, this should be a safe change.

- [x] Ensure Medplum hosted's DB schema drift isn't missing any important indexes.