### PR TITLE
ci(agent): fix cache path for windows, add caching on agent publish

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           cache-name: cache-node-modules
         with:
-          path: ~/.npm
+          path: '%LocalAppData%/npm-cache'
           key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-agent-${{ env.cache-name }}-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,6 +127,18 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: '%LocalAppData%/npm-cache'
+          key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-agent-${{ env.cache-name }}-
+            ${{ runner.os }}-build-agent
+            ${{ runner.os }}-
+
       - name: Install dependencies
         run: npm ci --maxsockets 1
 
@@ -238,6 +250,18 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-agent-${{ env.cache-name }}-
+            ${{ runner.os }}-build-agent
+            ${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci --maxsockets 1


### PR DESCRIPTION
Fixes Windows cache location and also adds caching to agent build in the Publish action

Later follow up would be to unify these into one Build agent action that runs after or concurrently with Publish on publishing a new release, see: #6568