### PR TITLE
ci(agent): finally fix windows cache path

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -34,12 +34,18 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      # See: https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/examples.md#node---npm
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: pwsh
+        run: echo "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
+
       - name: Cache node modules
         uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
-          path: '%AppData%/npm-cache'
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-agent-${{ env.cache-name }}-

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           cache-name: cache-node-modules
         with:
-          path: '%LocalAppData%/npm-cache'
+          path: '%AppData%/npm-cache'
           key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-agent-${{ env.cache-name }}-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,7 +132,7 @@ jobs:
         env:
           cache-name: cache-node-modules
         with:
-          path: '%LocalAppData%/npm-cache'
+          path: '%AppData%/npm-cache'
           key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-agent-${{ env.cache-name }}-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,12 +127,18 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      # See: https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/examples.md#node---npm
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: pwsh
+        run: echo "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
+
       - name: Cache node modules
         uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
-          path: '%AppData%/npm-cache'
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-agent-${{ env.cache-name }}-


### PR DESCRIPTION
See: https://github.com/cypress-io/github-actions-cache/blob/4fc8abd580f3084f31c4bcddae97fd15aefe8339/examples.md?plain=1#L73C59-L73C78

Not much docs about Windows npm cache on GitHub Actions runners anywhere else

EDIT: After looking on the official `actions/cache` repo, I saw the recommended way is to get the cache directory directly from npm by running `npm config get cache`

https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/examples.md#node---npm