### PR TITLE
QuestionnaireForm: Add Item Format for Multi-select via Checkbox

### DIFF
--- a/packages/react/src/CodingInput/CodingInput.tsx
+++ b/packages/react/src/CodingInput/CodingInput.tsx
@@ -5,36 +5,26 @@ import { ValueSetAutocomplete, ValueSetAutocompleteProps } from '../ValueSetAuto
 
 export interface CodingInputProps
   extends Omit<ValueSetAutocompleteProps, 'defaultValue' | 'onChange' | 'disabled' | 'name'>,
-    Omit<ComplexTypeInputProps<Coding>, 'onChange'> {
+    ComplexTypeInputProps<Coding> {
   readonly response?: QuestionnaireResponseItem;
-  readonly onChange?: (value: Coding[]) => void;
 }
 
 export function CodingInput(props: CodingInputProps): JSX.Element {
   const { defaultValue, onChange, withHelpText, response, ...rest } = props;
-  const [value, setValue] = useState<Coding[] | undefined>(() => {
-    if (response?.answer?.[0]?.valueCoding) {
-      return [response.answer[0].valueCoding];
-    }
-    if (defaultValue) {
-      return [defaultValue];
-    }
-    return undefined;
-  });
+  const [value, setValue] = useState<Coding | undefined>(response?.answer?.[0]?.valueCoding ?? defaultValue);
 
   function handleChange(newValues: ValueSetExpansionContains[]): void {
-    if (newValues && newValues.length > 0) {
-      const concepts = newValues.map((value) => valueSetElementToCoding(value));
-      setValue(concepts);
-      if (onChange) {
-        onChange(concepts);
-      }
+    const newValue = newValues[0];
+    const newConcept = newValue && valueSetElementToCoding(newValue);
+    setValue(newConcept);
+    if (onChange) {
+      onChange(newConcept);
     }
   }
 
   return (
     <ValueSetAutocomplete
-      defaultValue={value?.map(codingToValueSetElement)}
+      defaultValue={value ? codingToValueSetElement(value) : undefined}
       maxValues={1}
       onChange={handleChange}
       withHelpText={withHelpText ?? true}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -1034,7 +1034,28 @@ export const Choices = (): JSX.Element => (
           },
           {
             linkId: 'q4',
-            text: 'Question 4 - Value Set MultiselectDropdown',
+            type: 'choice',
+            text: 'Question 4 - Value Set Checkbox Choice',
+            answerValueSet: 'http://loinc.org/vs/LL4436-3',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'check-box',
+                      display: 'Check box',
+                    },
+                  ],
+                  text: 'Check box',
+                },
+              },
+            ],
+          },
+          {
+            linkId: 'q5',
+            text: 'Question 5 - Value Set Multiselect Dropdown',
             type: 'choice',
             answerValueSet: 'http://loinc.org/vs/LL4436-3',
             extension: [
@@ -1062,27 +1083,6 @@ export const Choices = (): JSX.Element => (
                     },
                   ],
                   text: 'Multi select',
-                },
-              },
-            ],
-          },
-          {
-            linkId: 'q5',
-            type: 'choice',
-            text: 'Question 5 - Value Set Checkbox Choice > 30 items',
-            answerValueSet: 'http://terminology.hl7.org/ValueSet/v3-Ethnicity',
-            extension: [
-              {
-                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-                valueCodeableConcept: {
-                  coding: [
-                    {
-                      system: 'http://hl7.org/fhir/questionnaire-item-control',
-                      code: 'check-box',
-                      display: 'Check box',
-                    },
-                  ],
-                  text: 'Check box',
                 },
               },
             ],

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -985,21 +985,21 @@ export const MultipleChoice = (): JSX.Element => (
                 valueString: 'Yellow',
               },
             ],
-            "extension": [
+            extension: [
               {
-                url: "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
                 valueCodeableConcept: {
                   coding: [
                     {
-                      system: "http://hl7.org/fhir/questionnaire-item-control",
-                      code: "check-box",
-                      display: "Check box",
-                    }
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'check-box',
+                      display: 'Check box',
+                    },
                   ],
-                  text: "Check box",
-                }
-              }
-            ]
+                  text: 'Check box',
+                },
+              },
+            ],
           },
         ],
       }}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -1073,19 +1073,19 @@ export const Choices = (): JSX.Element => (
             answerValueSet: 'http://terminology.hl7.org/ValueSet/v3-Ethnicity',
             extension: [
               {
-                url: "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
                 valueCodeableConcept: {
                   coding: [
                     {
-                      system: "http://hl7.org/fhir/questionnaire-item-control",
-                      code: "check-box",
-                      display: "Check box",
-                    }
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'check-box',
+                      display: 'Check box',
+                    },
                   ],
-                  text: "Check box",
-                }
-              }
-            ]
+                  text: 'Check box',
+                },
+              },
+            ],
           },
         ],
       }}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -87,7 +87,7 @@ export const Groups = (): JSX.Element => (
   </Document>
 );
 
-export const Choices = (): JSX.Element => (
+export const NestedGroups = (): JSX.Element => (
   <Document>
     <QuestionnaireForm
       questionnaire={{
@@ -946,7 +946,7 @@ export const PageAndNonPageSequence = (): JSX.Element => (
   </Document>
 );
 
-export const MultipleChoice = (): JSX.Element => (
+export const Choices = (): JSX.Element => (
   <Document>
     <QuestionnaireForm
       questionnaire={{
@@ -956,7 +956,7 @@ export const MultipleChoice = (): JSX.Element => (
         item: [
           {
             linkId: 'q1',
-            text: 'Question 1',
+            text: 'Question 1 - Default Radio',
             type: 'choice',
             answerOption: [
               {
@@ -972,7 +972,7 @@ export const MultipleChoice = (): JSX.Element => (
           },
           {
             linkId: 'q2',
-            text: 'Question 2',
+            text: 'Question 2 - Checkbox',
             type: 'choice',
             answerOption: [
               {
@@ -1000,6 +1000,92 @@ export const MultipleChoice = (): JSX.Element => (
                 },
               },
             ],
+          },
+          {
+            linkId: 'q3',
+            text: 'Question 3 - Dropdown',
+            type: 'choice',
+            answerOption: [
+              {
+                valueString: 'Red',
+              },
+              {
+                valueString: 'Blue',
+              },
+              {
+                valueString: 'Yellow',
+              },
+            ],
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                  text: 'Drop down',
+                },
+              },
+            ],
+          },
+          {
+            linkId: 'q4',
+            text: 'Question 4 - Value Set MultiselectDropdown',
+            type: 'choice',
+            answerValueSet: 'http://loinc.org/vs/LL4436-3',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                  text: 'Drop down',
+                },
+              },
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'multi-select',
+                      display: 'Multi select',
+                    },
+                  ],
+                  text: 'Multi select',
+                },
+              },
+            ],
+          },
+          {
+            linkId: 'q5',
+            type: 'choice',
+            text: 'Question 5 - Value Set Checkbox Choice > 30 items',
+            answerValueSet: 'http://terminology.hl7.org/ValueSet/v3-Ethnicity',
+            extension: [
+              {
+                url: "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: "http://hl7.org/fhir/questionnaire-item-control",
+                      code: "check-box",
+                      display: "Check box",
+                    }
+                  ],
+                  text: "Check box",
+                }
+              }
+            ]
           },
         ],
       }}
@@ -1609,12 +1695,6 @@ export const KitchenSink = (): JSX.Element => (
             linkId: 'quantity',
             type: 'quantity',
             text: 'Quantity',
-          },
-          {
-            linkId: 'value-set-checkbox-choice',
-            type: 'choice',
-            text: 'Value Set Checkbox Choice',
-            answerValueSet: 'http://terminology.hl7.org/ValueSet/v3-Ethnicity',
           },
         ],
       }}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.stories.tsx
@@ -970,6 +970,37 @@ export const MultipleChoice = (): JSX.Element => (
               },
             ],
           },
+          {
+            linkId: 'q2',
+            text: 'Question 2',
+            type: 'choice',
+            answerOption: [
+              {
+                valueString: 'Red',
+              },
+              {
+                valueString: 'Blue',
+              },
+              {
+                valueString: 'Yellow',
+              },
+            ],
+            "extension": [
+              {
+                url: "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: "http://hl7.org/fhir/questionnaire-item-control",
+                      code: "check-box",
+                      display: "Check box",
+                    }
+                  ],
+                  text: "Check box",
+                }
+              }
+            ]
+          },
         ],
       }}
       onSubmit={(formData: any) => {
@@ -1578,6 +1609,12 @@ export const KitchenSink = (): JSX.Element => (
             linkId: 'quantity',
             type: 'quantity',
             text: 'Quantity',
+          },
+          {
+            linkId: 'value-set-checkbox-choice',
+            type: 'choice',
+            text: 'Value Set Checkbox Choice',
+            answerValueSet: 'http://terminology.hl7.org/ValueSet/v3-Ethnicity',
           },
         ],
       }}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1423,7 +1423,7 @@ describe('QuestionnaireForm', () => {
     expect(checkboxes.length).toBeGreaterThan(0);
 
     // Verify that the cutoff message is shown
-    const cutoffMessage = screen.getByText(/Showing first 30 of \d+ options/);
+    const cutoffMessage = screen.getByText(/Showing first 30 options/);
     expect(cutoffMessage).toBeInTheDocument();
 
     // Click the first checkbox

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1,4 +1,4 @@
-import { getQuestionnaireAnswers } from '@medplum/core';
+import { getQuestionnaireAnswers, getAllQuestionnaireAnswers } from '@medplum/core';
 import { Extension, Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
@@ -1431,16 +1431,29 @@ describe('QuestionnaireForm', () => {
       fireEvent.click(checkboxes[0]);
     });
 
+    // Click the second checkbox
+    await act(async () => {
+      fireEvent.click(checkboxes[1]);
+    });
+
+    // Click the third checkbox
+    await act(async () => {
+      fireEvent.click(checkboxes[2]);
+    });
+
     await act(async () => {
       fireEvent.click(screen.getByText('Submit'));
     });
 
     expect(onSubmit).toHaveBeenCalled();
     const response = onSubmit.mock.calls[0][0];
-    const answer = getQuestionnaireAnswers(response);
+    const answer = getAllQuestionnaireAnswers(response);
     expect(answer['q1']).toBeDefined();
-    expect(answer['q1']).toMatchObject({
+    expect(answer['q1'][0]).toMatchObject({
       valueCoding: { code: 'test-code-0', display: 'Test Display 0', system: 'x' },
+    });
+    expect(answer['q1'][2]).toMatchObject({
+      valueCoding: { code: 'test-code-2', display: 'Test Display 2', system: 'x' },
     });
   });
 
@@ -2588,41 +2601,5 @@ describe('QuestionnaireForm', () => {
     expect(answers['q1']).toMatchObject({ valueDecimal: 100 }); // Original Fahrenheit value
     expect(answers['q2']).toMatchObject({ valueDecimal: 38 }); // Calculated Celsius
     expect(answers['q3']).toMatchObject({ valueDecimal: 311 }); // Calculated Kelvin
-  });
-
-  test('Dropdown with no value set or options', async () => {
-    await setup({
-      questionnaire: {
-        resourceType: 'Questionnaire',
-        status: 'active',
-        id: 'no-options-dropdown',
-        title: 'No Options Dropdown Example',
-        item: [
-          {
-            linkId: 'choices',
-            text: 'Choices',
-            type: 'choice',
-            extension: [
-              {
-                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
-                valueCodeableConcept: {
-                  coding: [
-                    {
-                      system: 'http://hl7.org/fhir/questionnaire-item-control',
-                      code: 'drop-down',
-                      display: 'Drop down',
-                    },
-                  ],
-                  text: 'Drop down',
-                },
-              },
-            ],
-          },
-        ],
-      },
-      onSubmit: jest.fn(),
-    });
-
-    expect(screen.getByPlaceholderText('No Answers Defined')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1636,7 +1636,7 @@ describe('QuestionnaireForm', () => {
 
     // Select all options
     await act(async () => {
-      checkboxes.forEach(checkbox => {
+      checkboxes.forEach((checkbox) => {
         fireEvent.click(checkbox);
       });
     });
@@ -1651,16 +1651,12 @@ describe('QuestionnaireForm', () => {
     const response1 = onSubmit.mock.calls[0][0];
     expect(response1.item[0].answer).toHaveLength(3);
     expect(response1.item[0].answer).toEqual(
-      expect.arrayContaining([
-        { valueString: 'Option 1' },
-        { valueString: 'Option 2' },
-        { valueString: 'Option 3' },
-      ])
+      expect.arrayContaining([{ valueString: 'Option 1' }, { valueString: 'Option 2' }, { valueString: 'Option 3' }])
     );
 
     // Deselect all options
     await act(async () => {
-      checkboxes.forEach(checkbox => {
+      checkboxes.forEach((checkbox) => {
         fireEvent.click(checkbox);
       });
     });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1327,6 +1327,42 @@ describe('QuestionnaireForm', () => {
     });
   });
 
+  test('Dropdown with no value set or options', async () => {
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        id: 'no-options-dropdown',
+        title: 'No Options Dropdown Example',
+        item: [
+          {
+            linkId: 'choices',
+            text: 'Choices',
+            type: 'choice',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                  text: 'Drop down',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      onSubmit: jest.fn(),
+    });
+
+    expect(screen.getByPlaceholderText('No Answers Defined')).toBeInTheDocument();
+  });
+
   test('Value Set Checkbox', async () => {
     const onSubmit = jest.fn();
 
@@ -2372,5 +2408,41 @@ describe('QuestionnaireForm', () => {
     expect(answers['q1']).toMatchObject({ valueDecimal: 100 }); // Original Fahrenheit value
     expect(answers['q2']).toMatchObject({ valueDecimal: 38 }); // Calculated Celsius
     expect(answers['q3']).toMatchObject({ valueDecimal: 311 }); // Calculated Kelvin
+  });
+
+  test('Dropdown with no value set or options', async () => {
+    await setup({
+      questionnaire: {
+        resourceType: 'Questionnaire',
+        status: 'active',
+        id: 'no-options-dropdown',
+        title: 'No Options Dropdown Example',
+        item: [
+          {
+            linkId: 'choices',
+            text: 'Choices',
+            type: 'choice',
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system: 'http://hl7.org/fhir/questionnaire-item-control',
+                      code: 'drop-down',
+                      display: 'Drop down',
+                    },
+                  ],
+                  text: 'Drop down',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      onSubmit: jest.fn(),
+    });
+
+    expect(screen.getByPlaceholderText('No Answers Defined')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1329,7 +1329,7 @@ describe('QuestionnaireForm', () => {
 
   test('Value Set Checkbox', async () => {
     const onSubmit = jest.fn();
-    
+
     // Mock the value set expansion to return more than 30 items
     const mockValueSet = {
       resourceType: 'ValueSet',
@@ -1341,7 +1341,7 @@ describe('QuestionnaireForm', () => {
         })),
       },
     };
-    
+
     // Mock the medplum client's valueSetExpand method
     medplum.valueSetExpand = jest.fn().mockResolvedValue(mockValueSet);
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -1,4 +1,4 @@
-import { getQuestionnaireAnswers, getAllQuestionnaireAnswers } from '@medplum/core';
+import { getAllQuestionnaireAnswers, getQuestionnaireAnswers } from '@medplum/core';
 import { Extension, Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -253,17 +253,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       break;
     case QuestionnaireItemType.choice:
     case QuestionnaireItemType.openChoice:
-      if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) {
-        formComponent = (
-          <QuestionnaireDropdownInput
-            name={name}
-            item={item}
-            initial={initial}
-            response={response}
-            onChangeAnswer={(e) => onChangeAnswer(e)}
-          />
-        );
-      } else if (isCheckboxChoice(item)) {
+      if (isCheckboxChoice(item)) {
         formComponent = (
           <QuestionnaireCheckboxInput
             name={response?.id ?? name}
@@ -271,6 +261,16 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             initial={initial}
             response={response}
             onChangeAnswer={onChangeAnswer}
+          />
+        );
+      } else if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) {
+        formComponent = (
+          <QuestionnaireDropdownInput
+            name={name}
+            item={item}
+            initial={initial}
+            response={response}
+            onChangeAnswer={(e) => onChangeAnswer(e)}
           />
         );
       } else {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -27,10 +27,11 @@ import {
   QuestionnaireItemInitial,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
-  ValueSetExpansionContains,
   ValueSet,
+  ValueSetExpansionContains,
 } from '@medplum/fhirtypes';
-import { ChangeEvent, JSX, useContext, useState, useEffect } from 'react';
+import { useMedplum } from '@medplum/react-hooks';
+import { ChangeEvent, JSX, useContext, useEffect, useState } from 'react';
 import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
 import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
 import { CodingInput } from '../../CodingInput/CodingInput';
@@ -47,7 +48,6 @@ import {
   QuestionnaireItemType,
 } from '../../utils/questionnaire';
 import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
-import { useMedplum } from '@medplum/react-hooks';
 
 export interface QuestionnaireFormItemProps {
   readonly item: QuestionnaireItem;
@@ -387,15 +387,20 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
   }
 }
 
-function getValueSetOptions(valueSetUrl: string | undefined, medplum: ReturnType<typeof useMedplum>): Promise<ValueSetExpansionContains[]> {
+function getValueSetOptions(
+  valueSetUrl: string | undefined,
+  medplum: ReturnType<typeof useMedplum>
+): Promise<ValueSetExpansionContains[]> {
   if (!valueSetUrl) {
     return Promise.resolve([]);
   }
 
-  return medplum.valueSetExpand({
-    url: valueSetUrl,
-    count: 50, // Limit to 50 items for performance
-  }).then((valueSet: ValueSet) => valueSet.expansion?.contains ?? []);
+  return medplum
+    .valueSetExpand({
+      url: valueSetUrl,
+      count: 50, // Limit to 50 items for performance
+    })
+    .then((valueSet: ValueSet) => valueSet.expansion?.contains ?? []);
 }
 
 function getOptionsFromValueSet(valueSetOptions: ValueSetExpansionContains[], name: string): [string, TypedValue][] {
@@ -604,14 +609,16 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
             onChange={(event) => {
               const selected = event.currentTarget.checked;
               if (item.answerValueSet) {
-                const currentCodings = (response.answer?.map(a => a.valueCoding) || []).filter((c): c is Coding => c !== undefined);
+                const currentCodings = (response.answer?.map((a) => a.valueCoding) || []).filter(
+                  (c): c is Coding => c !== undefined
+                );
                 let newCodings: Coding[];
                 if (selected) {
                   newCodings = [...currentCodings, optionValue.value as Coding];
                 } else {
-                  newCodings = currentCodings.filter(c => !deepEquals(c, optionValue.value));
+                  newCodings = currentCodings.filter((c) => !deepEquals(c, optionValue.value));
                 }
-                onChangeAnswer(newCodings.map(coding => ({ valueCoding: coding })));
+                onChangeAnswer(newCodings.map((coding) => ({ valueCoding: coding })));
               } else {
                 const currentValues = currentAnswers || [];
                 let newValues: string[];

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -46,8 +46,8 @@ import {
   getQuestionnaireItemReferenceTargetTypes,
   QuestionnaireItemType,
 } from '../../utils/questionnaire';
-import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
 import { ValueSetAutocomplete } from '../../ValueSetAutocomplete/ValueSetAutocomplete';
+import { QuestionnaireFormContext } from '../QuestionnaireForm.context';
 
 const MAX_DISPLAYED_CHECKBOX_RADIO_OPTIONS = 30;
 
@@ -400,7 +400,7 @@ function getValueSetOptions(
   return medplum
     .valueSetExpand({
       url: valueSetUrl,
-      count: MAX_DISPLAYED_CHECKBOX_RADIO_OPTIONS+1, // Limit to 50 items for performance
+      count: MAX_DISPLAYED_CHECKBOX_RADIO_OPTIONS + 1, // Limit to 50 items for performance
     })
     .then((valueSet: ValueSet) => valueSet.expansion?.contains ?? []);
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -490,35 +490,44 @@ function QuestionnaireRadiobuttonInput(props: QuestionnaireChoiceInputProps): JS
     return <NoAnswerDisplay />;
   }
 
+  const limitedOptions = options.slice(0, 30);
+
   return (
-    <Radio.Group
-      name={name}
-      value={answerLinkId ?? defaultValue}
-      onChange={(newValue) => {
-        const option = options.find((option) => option[0] === newValue);
-        if (option) {
-          const optionValue = option[1];
-          const propertyName = 'value' + capitalize(optionValue.type);
-          onChangeAnswer({ [propertyName]: optionValue.value });
-        }
-      }}
-    >
-      {options.map(([optionName, optionValue]) => (
-        <Radio
-          key={optionName}
-          id={optionName}
-          value={optionName}
-          py={4}
-          label={
-            <ResourcePropertyDisplay
-              property={valueElementDefinition}
-              propertyType={optionValue.type}
-              value={optionValue.value}
-            />
+    <>
+      <Radio.Group
+        name={name}
+        value={answerLinkId ?? defaultValue}
+        onChange={(newValue) => {
+          const option = options.find((option) => option[0] === newValue);
+          if (option) {
+            const optionValue = option[1];
+            const propertyName = 'value' + capitalize(optionValue.type);
+            onChangeAnswer({ [propertyName]: optionValue.value });
           }
-        />
-      ))}
-    </Radio.Group>
+        }}
+      >
+        {limitedOptions.map(([optionName, optionValue]) => (
+          <Radio
+            key={optionName}
+            id={optionName}
+            value={optionName}
+            py={4}
+            label={
+              <ResourcePropertyDisplay
+                property={valueElementDefinition}
+                propertyType={optionValue.type}
+                value={optionValue.value}
+              />
+            }
+          />
+        ))}
+      </Radio.Group>
+      {options.length > 30 && (
+        <Text size="sm" c="dimmed" mt="xs">
+          Showing first 30 of {options.length} options
+        </Text>
+      )}
+    </>
   );
 }
 
@@ -587,9 +596,11 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
     return <NoAnswerDisplay />;
   }
 
+  const limitedOptions = options.slice(0, 30);
+
   return (
     <Group style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
-      {options.map(([optionName, optionValue]) => {
+      {limitedOptions.map(([optionName, optionValue]) => {
         const isChecked = item.answerValueSet
           ? response.answer?.some((answer) => deepEquals(answer.valueCoding, optionValue.value))
           : currentAnswers?.includes(typedValueToString(optionValue));
@@ -634,6 +645,11 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
           />
         );
       })}
+      {options.length > 30 && (
+        <Text size="sm" c="dimmed">
+          Showing first 30 of {options.length} options
+        </Text>
+      )}
     </Group>
   );
 }

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -32,8 +32,8 @@ import {
 } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { ChangeEvent, JSX, useContext, useEffect, useState } from 'react';
-import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
 import { AsyncAutocomplete } from '../../AsyncAutocomplete/AsyncAutocomplete';
+import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
 import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
 import { DateTimeInput } from '../../DateTimeInput/DateTimeInput';
 import { QuantityInput } from '../../QuantityInput/QuantityInput';
@@ -335,11 +335,16 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
             filter: inputValue,
             count: 50,
           });
-          return valueSet.expansion?.contains?.map((item) => ({
-            system: item.system,
-            code: item.code,
-            display: item.display,
-          } as Coding)) ?? [];
+          return (
+            valueSet.expansion?.contains?.map(
+              (item) =>
+                ({
+                  system: item.system,
+                  code: item.code,
+                  display: item.display,
+                }) as Coding
+            ) ?? []
+          );
         }}
         toOption={(coding: Coding) => ({
           value: coding.code as string,

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -263,7 +263,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             item={item}
             initial={initial}
             response={response}
-            onChangeAnswer={onChangeAnswer}
+            onChangeAnswer={(e) => onChangeAnswer(e)}
           />
         );
       } else if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) {
@@ -284,7 +284,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             item={item}
             initial={initial}
             response={response}
-            onChangeAnswer={onChangeAnswer}
+            onChangeAnswer={(e) => onChangeAnswer(e)}
           />
         );
       }
@@ -336,7 +336,11 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
         maxValues={isMultiSelect ? undefined : 1}
         onChange={(values) => {
           if (isMultiSelect) {
-            onChangeAnswer(values.map((coding) => ({ valueCoding: coding })));
+            if (values.length === 0) {
+              onChangeAnswer({});
+            } else {
+              onChangeAnswer(values.map((coding) => ({ valueCoding: coding })));
+            }
           } else {
             onChangeAnswer({ valueCoding: values[0] });
           }
@@ -355,8 +359,12 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
         searchable
         defaultValue={currentAnswer || [typedValueToString(initialValue)]}
         onChange={(selected) => {
-          const values = getNewMultiSelectValues(selected, propertyName, item);
-          onChangeAnswer(values);
+          if (selected.length === 0) {
+            onChangeAnswer({});
+          } else {
+            const values = getNewMultiSelectValues(selected, propertyName, item);
+            onChangeAnswer(values);
+          }
         }}
       />
     );
@@ -571,7 +579,7 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
 
   const limitedOptions = options.slice(0, MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS);
 
-  const handleCheckboxChange = (optionValue: TypedValue, selected: boolean) => {
+  const handleCheckboxChange = (optionValue: TypedValue, selected: boolean): void => {
     if (item.answerValueSet) {
       const currentCodings = selectedValues as Coding[];
       let newCodings: Coding[];
@@ -583,7 +591,11 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
       }
 
       setSelectedValues(newCodings);
-      onChangeAnswer(newCodings.map((coding) => ({ valueCoding: coding })));
+      if (newCodings.length === 0) {
+        onChangeAnswer({});
+      } else {
+        onChangeAnswer(newCodings.map((coding) => ({ valueCoding: coding })));
+      }
     } else {
       const currentValues = selectedValues as string[];
       const optionValueStr = typedValueToString(optionValue);
@@ -596,8 +608,12 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
       }
 
       setSelectedValues(newValues);
-      const values = getNewMultiSelectValues(newValues, 'value' + capitalize(optionValue.type), item);
-      onChangeAnswer(values);
+      if (newValues.length === 0) {
+        onChangeAnswer({});
+      } else {
+        const values = getNewMultiSelectValues(newValues, 'value' + capitalize(optionValue.type), item);
+        onChangeAnswer(values);
+      }
     }
   };
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -401,7 +401,7 @@ function getValueSetOptions(
   return medplum
     .valueSetExpand({
       url: valueSetUrl,
-      count: MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS+1, 
+      count: MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS + 1,
     })
     .then((valueSet: ValueSet) => valueSet.expansion?.contains ?? []);
 }
@@ -485,7 +485,7 @@ function QuestionnaireRadiobuttonInput(props: QuestionnaireChoiceInputProps): JS
         return [optionName, optionValue] as [string, TypedValue];
       })
       .filter((option): option is [string, TypedValue] => option !== null);
-    
+
     options.push(...mappedOptions);
   }
 
@@ -532,7 +532,8 @@ function QuestionnaireRadiobuttonInput(props: QuestionnaireChoiceInputProps): JS
           />
         ))}
       </Radio.Group>
-      {((item.answerValueSet && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS) || (item.answerOption && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_EXPLICITOPTION_OPTIONS)) && (
+      {((item.answerValueSet && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS) ||
+        (item.answerOption && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_EXPLICITOPTION_OPTIONS)) && (
         <Text size="sm" c="dimmed" mt="xs">
           Showing first {MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS} options
         </Text>
@@ -557,10 +558,10 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
       .map((option, i) => {
         const optionName = `${name}-option-${i}`;
         const optionValue = getItemAnswerOptionValue(option);
-        return optionValue?.value ? [optionName, optionValue] as [string, TypedValue] : null;
+        return optionValue?.value ? ([optionName, optionValue] as [string, TypedValue]) : null;
       })
       .filter((option): option is [string, TypedValue] => option !== null);
-    
+
     options.push(...mappedOptions);
   }
 
@@ -621,7 +622,8 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
           />
         );
       })}
-      {((item.answerValueSet && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS) || (item.answerOption && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_EXPLICITOPTION_OPTIONS)) && (
+      {((item.answerValueSet && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS) ||
+        (item.answerOption && options.length > MAX_DISPLAYED_CHECKBOX_RADIO_EXPLICITOPTION_OPTIONS)) && (
         <Text size="sm" c="dimmed">
           Showing first {MAX_DISPLAYED_CHECKBOX_RADIO_VALUE_SET_OPTIONS} options
         </Text>

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -274,7 +274,6 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           <QuestionnaireChoiceSetInput
             name={name}
             item={item}
-            initial={initial}
             response={response}
             onChangeAnswer={(e) => onChangeAnswer(e)}
           />
@@ -390,7 +389,7 @@ function QuestionnaireMultiSelectInput(props: QuestionnaireChoiceInputProps): JS
 }
 
 function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.Element {
-  const { name, item, initial, onChangeAnswer, response } = props;
+  const { name, item, onChangeAnswer, response } = props;
 
   if (!item.answerOption?.length && !item.answerValueSet) {
     return <NoAnswerDisplay />;
@@ -414,7 +413,6 @@ function QuestionnaireChoiceSetInput(props: QuestionnaireChoiceInputProps): JSX.
       <QuestionnaireCheckboxInput
         name={response?.id ?? name}
         item={item}
-        initial={initial}
         response={response}
         onChangeAnswer={onChangeAnswer}
       />
@@ -492,7 +490,7 @@ function QuestionnaireChoiceRadioInput(props: QuestionnaireChoiceInputProps): JS
 }
 
 function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.Element {
-  const { name, item, initial, onChangeAnswer, response } = props;
+  const { name, item, onChangeAnswer, response } = props;
   const valueElementDefinition = getElementDefinition('QuestionnaireItemAnswerOption', 'value[x]');
   const currentAnswers = getCurrentMultiSelectAnswer(response);
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -253,14 +253,14 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
       break;
     case QuestionnaireItemType.choice:
     case QuestionnaireItemType.openChoice:
-      if (isRadiobuttonChoice(item)) {
+      if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) {
         formComponent = (
-          <QuestionnaireRadiobuttonInput
-            name={response?.id ?? name}
+          <QuestionnaireDropdownInput
+            name={name}
             item={item}
             initial={initial}
             response={response}
-            onChangeAnswer={onChangeAnswer}
+            onChangeAnswer={(e) => onChangeAnswer(e)}
           />
         );
       } else if (isCheckboxChoice(item)) {
@@ -275,12 +275,12 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
         );
       } else {
         formComponent = (
-          <QuestionnaireDropdownInput
-            name={name}
+          <QuestionnaireRadiobuttonInput
+            name={response?.id ?? name}
             item={item}
             initial={initial}
             response={response}
-            onChangeAnswer={(e) => onChangeAnswer(e)}
+            onChangeAnswer={onChangeAnswer}
           />
         );
       }
@@ -676,11 +676,11 @@ function getCurrentRadioAnswer(options: [string, TypedValue][], defaultAnswer: T
   return options.find((option) => deepEquals(option[1].value, defaultAnswer?.value))?.[0];
 }
 
-function isMultiSelectChoice(item: QuestionnaireItem): boolean {
+function isDropdownChoice(item: QuestionnaireItem): boolean {
   return !!item.extension?.some(
     (e) =>
-      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
-      e.valueCodeableConcept?.coding?.[0]?.code === 'multi-select'
+      e.url === 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl' &&
+      e.valueCodeableConcept?.coding?.[0]?.code === 'drop-down'
   );
 }
 
@@ -697,6 +697,14 @@ function isRadiobuttonChoice(item: QuestionnaireItem): boolean {
     (e) =>
       e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
       e.valueCodeableConcept?.coding?.[0]?.code === 'radio-button'
+  );
+}
+
+function isMultiSelectChoice(item: QuestionnaireItem): boolean {
+  return !!item.extension?.some(
+    (e) =>
+      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
+      e.valueCodeableConcept?.coding?.[0]?.code === 'multi-select'
   );
 }
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -263,7 +263,8 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             onChangeAnswer={onChangeAnswer}
           />
         );
-      } else if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) { // defaults answervalueset items to dropdown and everything else to radio button
+      } else if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) {
+        // defaults answervalueset items to dropdown and everything else to radio button
         formComponent = (
           <QuestionnaireDropdownInput
             name={name}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -669,36 +669,30 @@ function getCurrentRadioAnswer(options: [string, TypedValue][], defaultAnswer: T
   return options.find((option) => deepEquals(option[1].value, defaultAnswer?.value))?.[0];
 }
 
-function isDropdownChoice(item: QuestionnaireItem): boolean {
-  return !!item.extension?.some(
+type ChoiceType = 'check-box' | 'drop-down' | 'radio-button' | 'multi-select' | undefined;
+
+function getChoiceType(item: QuestionnaireItem): ChoiceType {
+  return item.extension?.find(
     (e) =>
-      e.url === 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl' &&
-      e.valueCodeableConcept?.coding?.[0]?.code === 'drop-down'
-  );
+      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
+      e.valueCodeableConcept?.coding?.[0]?.code
+  )?.valueCodeableConcept?.coding?.[0]?.code as ChoiceType;
+}
+
+function isDropdownChoice(item: QuestionnaireItem): boolean {
+  return getChoiceType(item) === 'drop-down';
 }
 
 function isCheckboxChoice(item: QuestionnaireItem): boolean {
-  return !!item.extension?.some(
-    (e) =>
-      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
-      e.valueCodeableConcept?.coding?.[0]?.code === 'check-box'
-  );
+  return getChoiceType(item) === 'check-box';
 }
 
 function isRadiobuttonChoice(item: QuestionnaireItem): boolean {
-  return !!item.extension?.some(
-    (e) =>
-      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
-      e.valueCodeableConcept?.coding?.[0]?.code === 'radio-button'
-  );
+  return getChoiceType(item) === 'radio-button';
 }
 
 function isMultiSelectChoice(item: QuestionnaireItem): boolean {
-  return !!item.extension?.some(
-    (e) =>
-      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
-      e.valueCodeableConcept?.coding?.[0]?.code === 'multi-select'
-  );
+  return getChoiceType(item) === 'multi-select';
 }
 
 interface FormattedData {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -512,7 +512,7 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
   }
 
   return (
-    <Group>
+    <Group style={{ flexDirection: 'column', alignItems: 'flex-start' }}>
       {options.map(([optionName, optionValue]) => {
         const optionValueStr = typedValueToString(optionValue);
         return (

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -329,6 +329,7 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
     return (
       <AsyncAutocomplete<Coding>
         name={name}
+        placeholder="Select items"
         loadOptions={async (inputValue: string, _signal: AbortSignal) => {
           const valueSet = await medplum.valueSetExpand({
             url: item.answerValueSet as string,

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -30,7 +30,6 @@ import {
 import { ChangeEvent, JSX, useContext } from 'react';
 import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';
 import { CheckboxFormSection } from '../../CheckboxFormSection/CheckboxFormSection';
-import { CodingInput } from '../../CodingInput/CodingInput';
 import { DateTimeInput } from '../../DateTimeInput/DateTimeInput';
 import { QuantityInput } from '../../QuantityInput/QuantityInput';
 import { ReferenceInput } from '../../ReferenceInput/ReferenceInput';
@@ -256,7 +255,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           initial={initial}
           response={response}
           onChangeAnswer={onChangeAnswer}
-        />
+        />;
       } else if (isCheckboxChoice(item)) {
         <QuestionnaireCheckboxInput
           name={response?.id ?? name}
@@ -264,7 +263,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           initial={initial}
           response={response}
           onChangeAnswer={onChangeAnswer}
-        />
+        />;
       } else {
         formComponent = (
           <QuestionnaireDropdownInput
@@ -395,12 +394,12 @@ function QuestionnaireDropdownInput(props: QuestionnaireChoiceInputProps): JSX.E
   if (isMultiSelectChoice(item)) {
     return (
       <QuestionnaireDropdownMultiSelectInput
-            name={name}
-            item={item}
-            initial={initial}
-            response={response}
-            onChangeAnswer={(e) => onChangeAnswer(e)}
-          />
+        name={name}
+        item={item}
+        initial={initial}
+        response={response}
+        onChangeAnswer={(e) => onChangeAnswer(e)}
+      />
     );
   } else {
     return (

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -21,12 +21,12 @@ import {
   typedValueToString,
 } from '@medplum/core';
 import {
+  Coding,
   QuestionnaireItem,
   QuestionnaireItemAnswerOption,
   QuestionnaireItemInitial,
   QuestionnaireResponseItem,
   QuestionnaireResponseItemAnswer,
-  Coding,
 } from '@medplum/fhirtypes';
 import { ChangeEvent, JSX, useContext } from 'react';
 import { AttachmentInput } from '../../AttachmentInput/AttachmentInput';

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -536,12 +536,12 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
   const { name, item, onChangeAnswer, response } = props;
   const valueElementDefinition = getElementDefinition('QuestionnaireItemAnswerOption', 'value[x]');
   const [valueSetOptions, isLoading] = useValueSetOptions(item.answerValueSet);
-  
+
   // Get initial values from response
   const initialSelectedValues = item.answerValueSet
     ? (response.answer?.map((a) => a.valueCoding) || []).filter((c): c is Coding => c !== undefined)
     : getCurrentMultiSelectAnswer(response);
-  
+
   const [selectedValues, setSelectedValues] = useState(initialSelectedValues);
 
   const options: [string, TypedValue][] = [];
@@ -575,26 +575,26 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
     if (item.answerValueSet) {
       const currentCodings = selectedValues as Coding[];
       let newCodings: Coding[];
-      
+
       if (selected) {
         newCodings = [...currentCodings, optionValue.value as Coding];
       } else {
         newCodings = currentCodings.filter((c) => !deepEquals(c, optionValue.value));
       }
-      
+
       setSelectedValues(newCodings);
       onChangeAnswer(newCodings.map((coding) => ({ valueCoding: coding })));
     } else {
       const currentValues = selectedValues as string[];
       const optionValueStr = typedValueToString(optionValue);
       let newValues: string[];
-      
+
       if (selected) {
         newValues = [...currentValues, optionValueStr];
       } else {
         newValues = currentValues.filter((v) => v !== optionValueStr);
       }
-      
+
       setSelectedValues(newValues);
       const values = getNewMultiSelectValues(newValues, 'value' + capitalize(optionValue.type), item);
       onChangeAnswer(values);

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -656,28 +656,28 @@ function getCurrentRadioAnswer(options: [string, TypedValue][], defaultAnswer: T
 
 type ChoiceType = 'check-box' | 'drop-down' | 'radio-button' | 'multi-select' | undefined;
 
-function getChoiceType(item: QuestionnaireItem): ChoiceType {
-  return item.extension?.find(
+function hasChoiceType(item: QuestionnaireItem, type: ChoiceType): boolean {
+  return !!item.extension?.some(
     (e) =>
-      e.url === HTTP_HL7_ORG + '/fhir/StructureDefinition/questionnaire-itemControl' &&
-      e.valueCodeableConcept?.coding?.[0]?.code
-  )?.valueCodeableConcept?.coding?.[0]?.code as ChoiceType;
+      e.url === 'http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl' &&
+      e.valueCodeableConcept?.coding?.[0]?.code === type
+  );
 }
 
 function isDropdownChoice(item: QuestionnaireItem): boolean {
-  return getChoiceType(item) === 'drop-down';
+  return hasChoiceType(item, 'drop-down');
 }
 
 function isCheckboxChoice(item: QuestionnaireItem): boolean {
-  return getChoiceType(item) === 'check-box';
+  return hasChoiceType(item, 'check-box');
 }
 
 function isRadiobuttonChoice(item: QuestionnaireItem): boolean {
-  return getChoiceType(item) === 'radio-button';
+  return hasChoiceType(item, 'radio-button');
 }
 
 function isMultiSelectChoice(item: QuestionnaireItem): boolean {
-  return getChoiceType(item) === 'multi-select';
+  return hasChoiceType(item, 'multi-select');
 }
 
 interface FormattedData {

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -263,7 +263,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
             onChangeAnswer={onChangeAnswer}
           />
         );
-      } else if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) {
+      } else if (isDropdownChoice(item) || (item.answerValueSet && !isRadiobuttonChoice(item))) { // defaults answervalueset items to dropdown and everything else to radio button
         formComponent = (
           <QuestionnaireDropdownInput
             name={name}

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem/QuestionnaireFormItem.tsx
@@ -21,7 +21,7 @@ import {
   typedValueToString,
 } from '@medplum/core';
 import {
-QuestionnaireItem,
+  QuestionnaireItem,
   QuestionnaireItemAnswerOption,
   QuestionnaireItemInitial,
   QuestionnaireResponseItem,
@@ -531,11 +531,11 @@ function QuestionnaireCheckboxInput(props: QuestionnaireChoiceInputProps): JSX.E
               const selected = event.currentTarget.checked;
               const currentValues = currentAnswers || [];
               let newValues: string[];
-              
+
               if (selected) {
                 newValues = [...currentValues, optionValueStr];
               } else {
-                newValues = currentValues.filter(v => v !== optionValueStr);
+                newValues = currentValues.filter((v) => v !== optionValueStr);
               }
 
               const values = getNewMultiSelectValues(newValues, 'value' + capitalize(optionValue.type), item);


### PR DESCRIPTION
Adds functionality to choice questionnaire items: 

- Allows dropdown component to be both multi and single select for both explicit element items and valueset items. 

- Extends radio buttons (single select only) to be rendered for valueset items along with explicit element items. 

- Creates checkboxes (multi select only), that can render both explicit element items and valueset items. 
