### PR TITLE
Consistent meta.account behavior with on-behalf-of

### DIFF
--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -24,7 +24,7 @@ export type PopulatedAccessPolicy = AccessPolicy & { resource: AccessPolicyResou
  * @returns A repository configured for the login details.
  */
 export async function getRepoForLogin(authState: AuthState, extendedMode?: boolean): Promise<Repository> {
-  const { project, login, membership } = authState;
+  const { project, login, membership, onBehalfOfMembership } = authState;
   const accessPolicy = await getAccessPolicyForLogin(authState);
 
   let allowedProjects: string[] | undefined;
@@ -43,7 +43,7 @@ export async function getRepoForLogin(authState: AuthState, extendedMode?: boole
     author: membership.profile as Reference,
     remoteAddress: login.remoteAddress,
     superAdmin: project.superAdmin,
-    projectAdmin: membership.admin,
+    projectAdmin: onBehalfOfMembership ? onBehalfOfMembership.admin : membership.admin,
     accessPolicy,
     strictMode: project.strictMode,
     extendedMode,


### PR DESCRIPTION
The Medplum `meta.account` property has some special behaviors when calling as a project admin.  Notably, passing in empty `meta` can clear out the account.  That behavior should not apply when using `on-behalf-of`.

Before:  Passing in empty `meta` would try to clear the `meta.account`, and violate the access policy, and result in 403 Forbidden.

After:  Passing in empty `meta` is ignored, therefore preserving `meta.account`, and therefore satisfying the access policy.