### PR TITLE
Report rate limit status from client

### DIFF
--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -3473,6 +3473,31 @@ describe('Client', () => {
     expect(fetchOptions.headers).not.toHaveProperty('x-medplum');
   });
 
+  test('Track rate limit status', async () => {
+    const fetch = jest.fn((_url: string, _options?: any) => {
+      return Promise.resolve(
+        mockFetchResponse(
+          200,
+          { resourceType: 'Patient' },
+          {
+            'content-type': 'application/fhir+json',
+            ratelimit: `"requests",t=59,r=15; "fhirInteractions",r=255,t=59`,
+          }
+        )
+      );
+    });
+
+    const client = new MedplumClient({ fetch });
+    const result = await client.readResource('Patient', '123');
+    expect(result).toBeDefined();
+    expect(client.rateLimitStatus()).toStrictEqual(
+      expect.arrayContaining([
+        { name: 'requests', remainingUnits: 15, secondsUntilReset: 59 },
+        { name: 'fhirInteractions', remainingUnits: 255, secondsUntilReset: 59 },
+      ])
+    );
+  });
+
   test('Call-time auto-batch opt-out', async () => {
     const fetch = mockFetch(200, { resourceType: 'Patient', id: '123' });
     const client = new MedplumClient({ fetch, autoBatchTime: 50 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -846,6 +846,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   private refreshPromise?: Promise<any>;
   private profilePromise?: Promise<any>;
   private sessionDetails?: SessionDetails;
+  private currentRateLimits?: string;
   private basicAuth?: string;
   private initPromise: Promise<void>;
   private initComplete = true;
@@ -3349,9 +3350,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         if (this.options.verbose) {
           this.logResponse(response);
         }
-        // Handle non-500 response and max retries exceeded
-        // We return immediately for non-500 or 500 that has exceeded max retries
+
+        this.setCurrentRateLimit(response);
+
         if (response.status < 500 || attemptNum === maxRetries) {
+          // Handle non-500 response and max retries exceeded
+          // We return immediately for non-500 or 500 that has exceeded max retries
           return response;
         }
       } catch (err) {
@@ -3387,6 +3391,38 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     if (response.headers) {
       response.headers.forEach((value, key) => console.log(`< ${key}: ${value}`));
     }
+  }
+
+  private setCurrentRateLimit(res: Response): void {
+    const rateLimitHeader = res.headers.get('ratelimit');
+    if (rateLimitHeader) {
+      this.currentRateLimits = rateLimitHeader;
+    }
+  }
+
+  rateLimitStatus(): { name: string; remainingUnits: number; secondsUntilReset: number }[] {
+    if (!this.currentRateLimits) {
+      return [];
+    }
+
+    const header = this.currentRateLimits;
+    return header.split(/\s*;\s*/g).map((str) => {
+      const parts = str.split(/\s*,\s*/g);
+      if (parts.length !== 3) {
+        throw new Error('Could not parse RateLimit header: ' + header);
+      }
+
+      const name = parts[0].substring(1, parts[0].length - 1);
+      const remainingPart = parts.find((p) => p.startsWith('r='));
+      const remainingUnits = remainingPart ? parseInt(remainingPart.substring(2), 10) : NaN;
+      const timePart = parts.find((p) => p.startsWith('t='));
+      const secondsUntilReset = timePart ? parseInt(timePart.substring(2), 10) : NaN;
+      if (!name || Number.isNaN(remainingUnits) || Number.isNaN(secondsUntilReset)) {
+        throw new Error('Could not parse RateLimit header: ' + header);
+      }
+
+      return { name, remainingUnits, secondsUntilReset };
+    });
   }
 
   private async pollStatus<T>(statusUrl: string, options: MedplumRequestOptions, state: RequestState): Promise<T> {


### PR DESCRIPTION
Adding a `MedplumClient.rateLimitStatus()` method to report the most recent rate limit information received from the server