### PR TITLE
Allows Twilio request header in unauthenticated webhooks

### DIFF
--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -241,7 +241,7 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
   return result;
 }
 
-function getResponseBodyFromResult(result: BotExecutionResult): string | { [key: string]: any } | any[] | boolean {
+export function getResponseBodyFromResult(result: BotExecutionResult): string | { [key: string]: any } | any[] | boolean {
   let responseBody = result.returnValue;
   if (responseBody === undefined) {
     // If the bot did not return a value, then return an OperationOutcome
@@ -555,7 +555,7 @@ async function addBotSecrets(
 
 const MIRRORED_CONTENT_TYPES: string[] = [ContentType.TEXT, ContentType.HL7_V2];
 
-function getResponseContentType(req: Request): string {
+export function getResponseContentType(req: Request): string {
   const requestContentType = req.get('Content-Type');
   if (requestContentType && MIRRORED_CONTENT_TYPES.includes(requestContentType)) {
     return requestContentType;

--- a/packages/server/src/fhir/operations/execute.ts
+++ b/packages/server/src/fhir/operations/execute.ts
@@ -241,7 +241,9 @@ export async function executeBot(request: BotExecutionRequest): Promise<BotExecu
   return result;
 }
 
-export function getResponseBodyFromResult(result: BotExecutionResult): string | { [key: string]: any } | any[] | boolean {
+export function getResponseBodyFromResult(
+  result: BotExecutionResult
+): string | { [key: string]: any } | any[] | boolean {
   let responseBody = result.returnValue;
   if (responseBody === undefined) {
     // If the bot did not return a value, then return an OperationOutcome

--- a/packages/server/src/webhook/README.md
+++ b/packages/server/src/webhook/README.md
@@ -23,7 +23,8 @@ For security, all webhook requests must include one of the following signature h
 - `X-Signature` - standard generic signature header
 - `X-HMAC-Signature` - standard HMAC signature header
 - `X-Cal-Signature-256` - Cal.com specific signature header
-- `X-Twilio-Email-Event-Webhook-Signature` - Twilio specific signature header
+- `X-Twilio-Email-Event-Webhook-Signature` - Twilio SendGrid specific signature header
+- `X-Twilio-Signature` - Twilio specific signature header
 
 ### Response
 

--- a/packages/server/src/webhook/routes.test.ts
+++ b/packages/server/src/webhook/routes.test.ts
@@ -118,4 +118,15 @@ describe('Anonymous webhooks', () => {
       .send(allOk);
     expect(res.status).toBe(200);
   });
+
+  test('Response contains a body', async () => {
+    const input = { test: 'response' };
+    const res = await request(app)
+      .post(`/webhook/${botMembership.id}`)
+      .set('Content-Type', ContentType.JSON)
+      .set('x-signature', 'signature')
+      .send(JSON.stringify(input));
+    expect(res.body).toEqual(input);
+    expect(res.header['content-type']).toContain("application/json")
+  });
 });

--- a/packages/server/src/webhook/routes.test.ts
+++ b/packages/server/src/webhook/routes.test.ts
@@ -127,6 +127,6 @@ describe('Anonymous webhooks', () => {
       .set('x-signature', 'signature')
       .send(JSON.stringify(input));
     expect(res.body).toEqual(input);
-    expect(res.header['content-type']).toContain("application/json")
+    expect(res.header['content-type']).toContain('application/json');
   });
 });

--- a/packages/server/src/webhook/routes.ts
+++ b/packages/server/src/webhook/routes.ts
@@ -1,11 +1,10 @@
-import { allOk, badRequest, getStatus, isOperationOutcome, isResource } from '@medplum/core';
+import { allOk, badRequest, getStatus, isOperationOutcome } from '@medplum/core';
 import { Bot, ProjectMembership, Reference } from '@medplum/fhirtypes';
 import { Request, Response, Router } from 'express';
 import { asyncWrap } from '../async';
 import { executeBot, getResponseBodyFromResult, getResponseContentType } from '../fhir/operations/execute';
 import { sendOutcome } from '../fhir/outcomes';
 import { getSystemRepo } from '../fhir/repo';
-import { sendFhirResponse } from '../fhir/response';
 
 /**
  * Allowed signature headers are:
@@ -71,12 +70,6 @@ export const webhookHandler = asyncWrap(async (req: Request, res: Response) => {
   const responseBody = getResponseBodyFromResult(result);
   const outcome = result.success ? allOk : badRequest(result.logResult);
 
-  if (isResource(responseBody, 'Binary')) {
-    await sendFhirResponse(req, res, outcome, responseBody);
-    return;
-  }
-
-  // Send the response
   res.status(getStatus(outcome)).type(getResponseContentType(req)).send(responseBody);
 });
 

--- a/packages/server/src/webhook/routes.ts
+++ b/packages/server/src/webhook/routes.ts
@@ -7,7 +7,6 @@ import { sendOutcome } from '../fhir/outcomes';
 import { getSystemRepo } from '../fhir/repo';
 import { sendFhirResponse } from '../fhir/response';
 
-
 /**
  * Allowed signature headers are:
  *

--- a/packages/server/src/webhook/routes.ts
+++ b/packages/server/src/webhook/routes.ts
@@ -13,14 +13,17 @@ import { getSystemRepo } from '../fhir/repo';
  *      - See: https://consensus.stoplight.io/docs/fax-services/1c4979f1d8ca0-fax-inbound-notification
  *   - `X-Cal-Signature-256` - Cal.com specific signature header
  *      - See: https://cal.com/docs/developing/guides/automation/webhooks
- *   - `X-Twilio-Email-Event-Webhook-Signature` - Twilio specific signature header
+ *   - `X-Twilio-Email-Event-Webhook-Signature` - Twilio SendGrid specific signature header
  *     - See: https://www.twilio.com/docs/sendgrid/for-developers/tracking-events/getting-started-event-webhook-security-features
+ *   - `X-Twilio-Signature` - Twilio specific signature header
+ *     - See: https://www.twilio.com/docs/usage/webhooks/webhooks-security
  */
 const SIGNATURE_HEADERS = [
   'x-signature',
   'x-hmac-signature',
   'x-cal-signature-256',
   'x-twilio-email-event-webhook-signature',
+  'x-twilio-signature',
 ];
 
 /**


### PR DESCRIPTION
Adds the Twilio `X-Twilio-Signature` header to the list of allowed webhook signatures (as documented [here](https://www.twilio.com/docs/usage/webhooks/webhooks-security)). Since we already allowed the Twilio email signature I believe this is a simple and reasonable addition but please LMK if this requires more thought before it's merged, I'll be happy to open a discussion.