### PR TITLE
Ensure index name uniqueness

### DIFF
--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -811,7 +811,6 @@ function buildCodingPropertyTable(result: SchemaDefinition): void {
       { name: 'target', type: 'BIGINT' },
       { name: 'value', type: 'TEXT' },
     ],
-    compositePrimaryKey: ['target', 'property', 'coding'],
     indexes: [
       { columns: ['coding', 'property', 'target', 'value'], indexType: 'btree', unique: true },
       { columns: ['target', 'property', 'coding'], indexType: 'btree', unique: false, where: 'target IS NOT NULL' },


### PR DESCRIPTION
Previously, if index names were computed to be the same, it could lead to strange behavior when attempting to reconcile schema drift. e.g. If two indexes were assigned the name "HumanName_family_idx" as was previously was happening, since we include `IF NOT EXISTS` in our `CREATE INDEX ...` queries, the create index query would be a noop since one of the two indexes already exists.