### PR TITLE
Update rate limit docs to the current settings

### DIFF
--- a/packages/docs/docs/rate-limits/index.md
+++ b/packages/docs/docs/rate-limits/index.md
@@ -11,7 +11,7 @@ send many requests in quick succession may receive HTTP error responses with sta
 
 | Category                      | Free tier                        | Paid tier                         |
 | ----------------------------- | -------------------------------- | --------------------------------- |
-| Auth (`/auth/*`, `/oauth2/*`) | 60 request per IP per minute     | 60 request per IP per minute      |
+| Auth (`/auth/*`, `/oauth2/*`) | 160 requests per IP per minute   | 160 requests per IP per minute    |
 | Others                        | 6,000 requests per IP per minute | 60,000 requests per IP per minute |
 
 All rate limits are calculated per IP address over a one minute window.

--- a/packages/docs/docs/rate-limits/index.md
+++ b/packages/docs/docs/rate-limits/index.md
@@ -12,7 +12,7 @@ send many requests in quick succession may receive HTTP error responses with sta
 | Category                      | Free tier                        | Paid tier                         |
 | ----------------------------- | -------------------------------- | --------------------------------- |
 | Auth (`/auth/*`, `/oauth2/*`) | 160 requests per IP per minute   | 160 requests per IP per minute    |
-| Others                        | 6,000 requests per IP per minute | 60,000 requests per IP per minute |
+| Others (including `/auth/me`) | 6,000 requests per IP per minute | 60,000 requests per IP per minute |
 
 All rate limits are calculated per IP address over a one minute window.
 


### PR DESCRIPTION
The default auth rate limit is 160 requests per minute.  See https://github.com/medplum/medplum/blob/12c9ff9394d97759880fa76b53ea1fff5ea39d41/packages/server/src/ratelimit.ts#L14