### PR TITLE
fix(ci): replace env vars w/ placeholders in ci deploy

### DIFF
--- a/scripts/build-docker-app.sh
+++ b/scripts/build-docker-app.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+if [[ -z "${GITHUB_SHA}" ]]; then
+  echo "GITHUB_SHA is missing"
+  exit 1
+fi
+
+# Only build app if APP_DOCKERHUB_REPOSITORY was passed
+if [[ -z "${APP_DOCKERHUB_REPOSITORY}" ]]; then
+  echo "APP_DOCKERHUB_REPOSITORY env var not configured. Skipping..."
+  # Don't fail if no APP_DOCKER_REPOSITORY present
+  exit 0
+fi
+
+# Fail on error
+set -e
+
+# Echo commands
+set -x
+
+# Build app tarball
+# The -C flag rewrites the base path from packages/app/dist/ to ./
+tar \
+  --no-xattrs \
+  -czf ./packages/app/medplum-app.tar.gz \
+  -C packages/app/dist .
+
+# Supply chain attestations
+# See: https://docs.docker.com/scout/policy/#supply-chain-attestations
+ATTESTATIONS="--provenance=true --sbom=true"
+
+# Target platforms
+PLATFORMS="--platform linux/amd64,linux/arm64"
+
+# If this is a release, get version information
+# Release is specified with a "--release" argument
+IS_RELEASE=false
+for arg in "$@"; do
+  if [[ "$arg" == "--release" ]]; then
+    IS_RELEASE=true
+    FULL_VERSION=$(node -p "require('./package.json').version")
+    MAJOR_DOT_MINOR=$(node -p "require('./package.json').version.split('.').slice(0, 2).join('.')")
+    break
+  fi
+done
+
+# This is so we can build the staging server Dockerfile without having to build app
+# Build and push app Docker images
+APP_TAGS="--tag $APP_DOCKERHUB_REPOSITORY:latest --tag $APP_DOCKERHUB_REPOSITORY:$GITHUB_SHA"
+if [[ "$IS_RELEASE" == "true" ]]; then
+  APP_TAGS="$APP_TAGS --tag $APP_DOCKERHUB_REPOSITORY:$FULL_VERSION --tag $APP_DOCKERHUB_REPOSITORY:$MAJOR_DOT_MINOR"
+fi
+docker buildx build $ATTESTATIONS $PLATFORMS $APP_TAGS --push .

--- a/scripts/cicd-deploy.sh
+++ b/scripts/cicd-deploy.sh
@@ -125,7 +125,18 @@ curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHO
 
 if [[ "$DEPLOY_APP" = true ]]; then
   echo "Deploy app"
-  npm run build -- --force --filter=@medplum/app
+  # We create a subshell for the build since we need to set the env vars to our placeholders for the Docker build
+  # We will replace the placeholders later with our actual env vars in deploy-app.sh
+  (
+    export BASE_URL="__MEDPLUM_BASE_URL__"
+    export CLIENT_ID="__MEDPLUM_CLIENT_ID__"
+    export REGISTER_ENABLED="__MEDPLUM_REGISTER_ENABLED__"
+    export AWS_TEXTRACT_ENABLED="__MEDPLUM_AWS_TEXTRACT_ENABLED__"
+    export GOOGLE_CLIENT_ID="__GOOGLE_CLIENT_ID__"
+    export RECAPTCHA_SITE_KEY="__RECAPTCHA_SITE_KEY__"
+    npm run build -- --force --filter=@medplum/app
+  )
+  source ./scripts/build-docker-app.sh
   source ./scripts/deploy-app.sh
 fi
 
@@ -138,6 +149,6 @@ fi
 if [[ "$DEPLOY_SERVER" = true ]]; then
   echo "Deploy server"
   npm run build -- --force --filter=@medplum/server
-  source ./scripts/build-docker.sh
+  source ./scripts/build-docker-server.sh
   source ./scripts/deploy-server.sh
 fi


### PR DESCRIPTION
This fixes a problem where the Docker image `medplum/medplum-app` would be built without 
1. Running `npm run build --filter=@medplum/app`
OR
2. The incorrect replacement env vars were used since the placeholder env vars are only passed during `cicd-deploy.sh` via the `Publish` workflow and not the `Deploy` workflow.

The solution:
1. Splits Docker builds for `medplum/medplum-server` and `medplum/medplum-app` and only builds app when `BUILD_APP` is true and likewise with server
2. Makes it so that app is always built with placeholders in a subshell and then the real env vars replace the placeholders in `deploy-app.sh`.