### PR TITLE
chore: Fix validation warnings for contained and conditional references

### DIFF
--- a/packages/core/src/typeschema/validation.ts
+++ b/packages/core/src/typeschema/validation.ts
@@ -384,7 +384,16 @@ class ResourceValidator implements CrawlerVisitor {
       return;
     }
 
-    const referenceResourceType = reference.reference.split('/')[0];
+    if (reference.reference.startsWith('#')) {
+      // Silently ignore contained references
+      return;
+    }
+
+    // Pick out the resource type from the reference, either as a conditional reference or a literal reference
+    const referenceResourceType = reference.reference.includes('?')
+      ? reference.reference.split('?')[0]
+      : reference.reference.split('/')[0];
+    
     if (!referenceResourceType) {
       // Silently ignore empty references - that will get picked up by constraint validation
       return;


### PR DESCRIPTION
Fixes #6153

I went with the simplest approach possible, which is at least incrementally better. Additional validation, in particular on contained references makes sense.

Details:
- Skip validation for contained references (starting with #) to prevent false warnings
- Handle conditional references by extracting resource type before ? character
- Add comprehensive tests for contained and conditional reference validation scenarios
