### PR TITLE
Fix SMTP Configuration via ENV vars

### DIFF
--- a/packages/server/src/config/loader.test.ts
+++ b/packages/server/src/config/loader.test.ts
@@ -23,6 +23,8 @@ describe('Config', () => {
     process.env.MEDPLUM_DATABASE_PORT = '5432';
     process.env.MEDPLUM_REDIS_TLS = '{}';
     process.env.MEDPLUM_DATABASE_SSL = '{"require":true}';
+    process.env.MEDPLUM_SMTP_HOST = 'smtp.example.com';
+
     const config = await loadConfig('env');
     expect(config).toBeDefined();
     expect(config.baseUrl).toStrictEqual('http://localhost:3000');
@@ -30,6 +32,7 @@ describe('Config', () => {
     expect(config.database.port).toStrictEqual(5432);
     expect(config.redis.tls).toStrictEqual({});
     expect(config.database.ssl).toStrictEqual({ require: true });
+    expect(config.smtp?.host).toStrictEqual('smtp.example.com');
     expect(getConfig()).toBe(config);
   });
 });

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -110,6 +110,9 @@ function loadEnvConfig(): MedplumServerConfig {
     } else if (key.startsWith('REDIS_')) {
       key = key.substring('REDIS_'.length);
       currConfig = config.redis = config.redis ?? {};
+    } else if (key.startsWith('SMTP_')) {
+      key = key.substring('SMTP_'.length);
+      currConfig = config.smtp = config.smtp ?? {};
     }
 
     // Convert key from CAPITAL_CASE to camelCase


### PR DESCRIPTION
Currently, if you are using ENV vars to configure the medplum server, you are unable to properly setup `SMTP` as it is required to be an object but the ENV loader does not permit that. This PR fixes this issue by mimicking how `env.database` and `env.redis` are configured. 

With this fix, you can use 

- `MEDPLUM_SMTP_HOST=`
- `MEDPLUM_SMTP_PORT=`
- `MEDPLUM_SMTP_PASSWORD=`
- `MEDPLUM_SMTP_USERNAME=`

to configure the smtp settings via ENV vars