### PR TITLE
Fixes #6686 - tell password managers to ignore Register link

### DIFF
--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -2,7 +2,7 @@ import { Title } from '@mantine/core';
 import { Logo, SignInForm, useMedplumProfile } from '@medplum/react';
 import { JSX, useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
-import { getConfig } from './config';
+import { getConfig, isRegisterEnabled } from './config';
 
 export function SignInPage(): JSX.Element {
   const profile = useMedplumProfile();
@@ -27,13 +27,7 @@ export function SignInPage(): JSX.Element {
     <SignInForm
       onSuccess={() => navigateToNext()}
       onForgotPassword={() => navigate('/resetpassword')?.catch(console.error)}
-      // onRegister={isRegisterEnabled() ? () => navigate('/register')?.catch(console.error) : undefined}
-      onRegister={
-        ((e: React.MouseEvent<HTMLAnchorElement>) => {
-          console.log('Register mouse event', e);
-          navigate('/register')?.catch(console.error);
-        }) as () => void
-      }
+      onRegister={isRegisterEnabled() ? () => navigate('/register')?.catch(console.error) : undefined}
       googleClientId={config.googleClientId}
       login={searchParams.get('login') || undefined}
       projectId={searchParams.get('project') || undefined}

--- a/packages/app/src/SignInPage.tsx
+++ b/packages/app/src/SignInPage.tsx
@@ -2,7 +2,7 @@ import { Title } from '@mantine/core';
 import { Logo, SignInForm, useMedplumProfile } from '@medplum/react';
 import { JSX, useCallback, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
-import { getConfig, isRegisterEnabled } from './config';
+import { getConfig } from './config';
 
 export function SignInPage(): JSX.Element {
   const profile = useMedplumProfile();
@@ -27,7 +27,13 @@ export function SignInPage(): JSX.Element {
     <SignInForm
       onSuccess={() => navigateToNext()}
       onForgotPassword={() => navigate('/resetpassword')?.catch(console.error)}
-      onRegister={isRegisterEnabled() ? () => navigate('/register')?.catch(console.error) : undefined}
+      // onRegister={isRegisterEnabled() ? () => navigate('/register')?.catch(console.error) : undefined}
+      onRegister={
+        ((e: React.MouseEvent<HTMLAnchorElement>) => {
+          console.log('Register mouse event', e);
+          navigate('/register')?.catch(console.error);
+        }) as () => void
+      }
       googleClientId={config.googleClientId}
       login={searchParams.get('login') || undefined}
       projectId={searchParams.get('project') || undefined}

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -122,7 +122,15 @@ export function EmailForm(props: EmailFormProps): JSX.Element {
       <Group justify="space-between" mt="xl" gap={0} wrap="nowrap">
         <div>
           {onRegister && (
-            <Anchor component="button" type="button" color="dimmed" onClick={onRegister} size="xs">
+            <Anchor
+              component="button"
+              type="button"
+              c="dimmed"
+              onClick={onRegister}
+              size="xs"
+              data-no-autofill="true"
+              data-form-type="navigation"
+            >
               Register
             </Anchor>
           )}

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -128,6 +128,8 @@ export function EmailForm(props: EmailFormProps): JSX.Element {
               c="dimmed"
               onClick={onRegister}
               size="xs"
+              data-dashlane-ignore="true"
+              data-lp-ignore="true"
               data-no-autofill="true"
               data-form-type="navigation"
             >


### PR DESCRIPTION
Fixes #6686 

Tested on https://app.staging.medplum.dev/signin

Originally started down the path of using `MouseEvent` / `isTrusted`, but that breaks the ability to use Jest for unit tests and Playwright for e2e tests.

Then switched to using magic `data-` attributes, which feels gross, but appears to be the least gross option.