### PR TITLE
Add a startup probe to our helm chart

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -55,6 +55,12 @@ spec:
             httpGet:
               path: /healthcheck
               port: {{ .Values.service.targetPort | default 8103 }}
+          startupProbe:
+            httpGet:
+              path: /healthcheck
+              port: {{ .Values.service.targetPort | default 8103 }}
+            failureThreshold: 60
+            periodSeconds: 10
           env:
             {{- toYaml .Values.deployment.env | nindent 12 }}
           resources:


### PR DESCRIPTION
Fixes #6707 

## Add startup probe to Helm chart deployment

This PR adds a startup probe configuration to the Kubernetes deployment template to improve application reliability during container initialization.

### Changes
- Added `startupProbe` configuration to `charts/templates/deployment.yaml`
- Probe uses the existing `/healthcheck` endpoint on the configured target port (default 8103)
- Configured with `failureThreshold: 60` and `periodSeconds: 10` for a total startup timeout of 10 minutes

### Why this change?
Startup probes help Kubernetes distinguish between slow-starting containers and failed containers. This prevents premature container restarts during application initialization while still allowing the readiness and liveness probes to function normally once the application is running.

The 10-minute timeout (60 failures × 10 seconds) provides sufficient time for the application to complete its startup process without being terminated by Kubernetes.