### PR TITLE
ci(agent): add `linux-arm64` as a build target

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -124,7 +124,7 @@ jobs:
           name: medplum-agent-installer-${{ env.MEDPLUM_VERSION }}-windows
           path: packages/agent/medplum-agent-installer-*
 
-  build_agent_linux:
+  build_agent_linux-x64:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -178,15 +178,82 @@ jobs:
         run: |
           set -e
 
-          mkdir medplum-agent-$MEDPLUM_VERSION-linux
+          mkdir medplum-agent-$MEDPLUM_VERSION-linux-x64
 
-          cp packages/agent/medplum-agent-$MEDPLUM_VERSION-linux ./medplum-agent-$MEDPLUM_VERSION-linux
-          cp packages/agent/medplum-agent-$MEDPLUM_VERSION-linux.sha256 ./medplum-agent-$MEDPLUM_VERSION-linux
+          cp packages/agent/medplum-agent-$MEDPLUM_VERSION-linux ./medplum-agent-$MEDPLUM_VERSION-linux-x64/medplum-agent-$MEDPLUM_VERSION-linux-x64
+          cp packages/agent/medplum-agent-$MEDPLUM_VERSION-linux.sha256 ./medplum-agent-$MEDPLUM_VERSION-linux-x64/medplum-agent-$MEDPLUM_VERSION-linux-x64.sha256
 
-          tar -czvf ./medplum-agent-$MEDPLUM_VERSION-linux.tar.gz ./medplum-agent-$MEDPLUM_VERSION-linux
+          tar -czvf ./medplum-agent-$MEDPLUM_VERSION-linux-x64.tar.gz ./medplum-agent-$MEDPLUM_VERSION-linux-x64
 
       - name: Upload agent installer
         uses: actions/upload-artifact@v4
         with:
-          name: medplum-agent-${{ env.MEDPLUM_VERSION }}-linux
-          path: medplum-agent-${{ env.MEDPLUM_VERSION }}-linux.tar.gz
+          name: medplum-agent-${{ env.MEDPLUM_VERSION }}-linux-x64
+          path: medplum-agent-${{ env.MEDPLUM_VERSION }}-linux-x64.tar.gz
+
+  build_agent_linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    env:
+      NODE_VERSION: '20'
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_CACHE: 'remote:rw'
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-agent-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-agent-${{ env.cache-name }}-
+            ${{ runner.os }}-build-agent
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci --maxsockets 1
+
+      - name: Build
+        run: npm run build -- --filter=@medplum/agent
+
+      - name: Build Agent
+        shell: bash
+        run: ./scripts/build-agent-installer-linux.sh
+
+      - name: Set Medplum version
+        shell: bash
+        run: |
+          set -e
+          echo "MEDPLUM_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+      - name: Make tarball
+        shell: bash
+        run: |
+          set -e
+
+          mkdir medplum-agent-$MEDPLUM_VERSION-linux-arm64
+
+          cp packages/agent/medplum-agent-$MEDPLUM_VERSION-linux ./medplum-agent-$MEDPLUM_VERSION-linux-arm64/medplum-agent-$MEDPLUM_VERSION-linux-arm64
+          cp packages/agent/medplum-agent-$MEDPLUM_VERSION-linux.sha256 ./medplum-agent-$MEDPLUM_VERSION-linux-arm64/medplum-agent-$MEDPLUM_VERSION-linux-arm64.sha256
+
+          tar -czvf ./medplum-agent-$MEDPLUM_VERSION-linux-arm64.tar.gz ./medplum-agent-$MEDPLUM_VERSION-linux-arm64
+
+      - name: Upload agent installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: medplum-agent-${{ env.MEDPLUM_VERSION }}-linux-arm64
+          path: medplum-agent-${{ env.MEDPLUM_VERSION }}-linux-arm64.tar.gz


### PR DESCRIPTION
Raspberry Pis run ARM64 processors, we should support Linux/ARM64 architecture as a build target for the agent