### PR TITLE
Include resources with missing values when sorting

### DIFF
--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -241,7 +241,7 @@ describe('HumanName Lookup Table', () => {
       expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
     }));
 
-  test('Sort by name, missing always last', () =>
+  test('Sort by name with some missing', () =>
     withTestContext(async () => {
       const name = randomUUID();
       const identifier = randomUUID();
@@ -279,7 +279,7 @@ describe('HumanName Lookup Table', () => {
       });
 
       expect(descending.entry?.length).toStrictEqual(3);
-      expect(descending.entry?.map((e) => e.resource?.id)).toStrictEqual([p2.id, p1.id, p3.id]);
+      expect(descending.entry?.map((e) => e.resource?.id)).toStrictEqual([p3.id, p2.id, p1.id]);
     }));
 
   test('Purges related resource type', async () => {

--- a/packages/server/src/fhir/lookups/humanname.test.ts
+++ b/packages/server/src/fhir/lookups/humanname.test.ts
@@ -241,6 +241,47 @@ describe('HumanName Lookup Table', () => {
       expect(searchResult.entry?.[0]?.resource?.id).toStrictEqual(patient.id);
     }));
 
+  test('Sort by name, missing always last', () =>
+    withTestContext(async () => {
+      const name = randomUUID();
+      const identifier = randomUUID();
+
+      const p1 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [{ value: identifier }],
+        name: [{ given: ['Alice'], family: name }],
+      });
+
+      const p2 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [{ value: identifier }],
+        name: [{ given: ['Bob'], family: name }],
+      });
+
+      const p3 = await systemRepo.createResource<Patient>({
+        resourceType: 'Patient',
+        identifier: [{ value: identifier }],
+      });
+
+      const ascending = await systemRepo.search({
+        resourceType: 'Patient',
+        sortRules: [{ code: 'name' }],
+        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: identifier }],
+      });
+
+      expect(ascending.entry?.length).toStrictEqual(3);
+      expect(ascending.entry?.map((e) => e.resource?.id)).toStrictEqual([p1.id, p2.id, p3.id]);
+
+      const descending = await systemRepo.search({
+        resourceType: 'Patient',
+        sortRules: [{ code: 'name', descending: true }],
+        filters: [{ code: 'identifier', operator: Operator.EQUALS, value: identifier }],
+      });
+
+      expect(descending.entry?.length).toStrictEqual(3);
+      expect(descending.entry?.map((e) => e.resource?.id)).toStrictEqual([p2.id, p1.id, p3.id]);
+    }));
+
   test('Purges related resource type', async () => {
     const db = { query: jest.fn().mockReturnValue({ rowCount: 0, rows: [] }) } as unknown as PoolClient;
 

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -191,12 +191,12 @@ export abstract class LookupTable {
     const columnName = this.getColumnName(sortRule.code);
     const joinOnExpression = new Condition(new Column(resourceType, 'id'), '=', new Column(joinName, 'resourceId'));
     selectQuery.join(
-      'INNER JOIN',
+      'LEFT JOIN',
       new SelectQuery(lookupTableName).distinctOn('resourceId').column('resourceId').column(columnName),
       joinName,
       joinOnExpression
     );
-    selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending);
+    selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending, 'last');
   }
 
   /**

--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -196,7 +196,7 @@ export abstract class LookupTable {
       joinName,
       joinOnExpression
     );
-    selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending, 'last');
+    selectQuery.orderBy(new Column(joinName, columnName), sortRule.descending);
   }
 
   /**

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -167,7 +167,7 @@ export class TokenTable extends LookupTable {
       joinName,
       joinOnExpression
     );
-    selectQuery.orderBy(new Column(joinName, 'value'), sortRule.descending, 'last');
+    selectQuery.orderBy(new Column(joinName, 'value'), sortRule.descending);
   }
 }
 

--- a/packages/server/src/fhir/lookups/token.ts
+++ b/packages/server/src/fhir/lookups/token.ts
@@ -158,7 +158,7 @@ export class TokenTable extends LookupTable {
     const joinName = selectQuery.getNextJoinAlias();
     const joinOnExpression = new Condition(new Column(resourceType, 'id'), '=', new Column(joinName, 'resourceId'));
     selectQuery.join(
-      'INNER JOIN',
+      'LEFT JOIN',
       new SelectQuery(lookupTableName)
         .distinctOn('resourceId')
         .column('resourceId')
@@ -167,7 +167,7 @@ export class TokenTable extends LookupTable {
       joinName,
       joinOnExpression
     );
-    selectQuery.orderBy(new Column(joinName, 'value'), sortRule.descending);
+    selectQuery.orderBy(new Column(joinName, 'value'), sortRule.descending, 'last');
   }
 }
 

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -408,10 +408,12 @@ export class GroupBy {
 export class OrderBy {
   readonly key: Column | Expression;
   readonly descending?: boolean;
+  readonly nulls?: 'first' | 'last';
 
-  constructor(key: Column | Expression, descending?: boolean) {
+  constructor(key: Column | Expression, descending?: boolean, nulls?: 'first' | 'last') {
     this.key = key;
     this.descending = descending;
+    this.nulls = nulls;
   }
 }
 
@@ -647,13 +649,13 @@ export class SelectQuery extends BaseQuery implements Expression {
     return this;
   }
 
-  orderBy(column: Column | string, descending?: boolean): this {
-    this.orderBys.push(new OrderBy(getColumn(column, this.tableName), descending));
+  orderBy(column: Column | string, descending?: boolean, nulls?: 'first' | 'last'): this {
+    this.orderBys.push(new OrderBy(getColumn(column, this.tableName), descending, nulls));
     return this;
   }
 
-  orderByExpr(expr: Expression, descending?: boolean): this {
-    this.orderBys.push(new OrderBy(expr, descending));
+  orderByExpr(expr: Expression, descending?: boolean, nulls?: 'first' | 'last'): this {
+    this.orderBys.push(new OrderBy(expr, descending, nulls));
     return this;
   }
 
@@ -797,6 +799,9 @@ export class SelectQuery extends BaseQuery implements Expression {
       sql.appendExpression(orderBy.key);
       if (orderBy.descending) {
         sql.append(' DESC');
+      }
+      if (orderBy.nulls) {
+        sql.append(' NULLS ' + orderBy.nulls.toUpperCase());
       }
       first = false;
     }

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -408,12 +408,10 @@ export class GroupBy {
 export class OrderBy {
   readonly key: Column | Expression;
   readonly descending?: boolean;
-  readonly nulls?: 'first' | 'last';
 
-  constructor(key: Column | Expression, descending?: boolean, nulls?: 'first' | 'last') {
+  constructor(key: Column | Expression, descending?: boolean) {
     this.key = key;
     this.descending = descending;
-    this.nulls = nulls;
   }
 }
 
@@ -649,13 +647,13 @@ export class SelectQuery extends BaseQuery implements Expression {
     return this;
   }
 
-  orderBy(column: Column | string, descending?: boolean, nulls?: 'first' | 'last'): this {
-    this.orderBys.push(new OrderBy(getColumn(column, this.tableName), descending, nulls));
+  orderBy(column: Column | string, descending?: boolean): this {
+    this.orderBys.push(new OrderBy(getColumn(column, this.tableName), descending));
     return this;
   }
 
-  orderByExpr(expr: Expression, descending?: boolean, nulls?: 'first' | 'last'): this {
-    this.orderBys.push(new OrderBy(expr, descending, nulls));
+  orderByExpr(expr: Expression, descending?: boolean): this {
+    this.orderBys.push(new OrderBy(expr, descending));
     return this;
   }
 
@@ -799,9 +797,6 @@ export class SelectQuery extends BaseQuery implements Expression {
       sql.appendExpression(orderBy.key);
       if (orderBy.descending) {
         sql.append(' DESC');
-      }
-      if (orderBy.nulls) {
-        sql.append(' NULLS ' + orderBy.nulls.toUpperCase());
       }
       first = false;
     }


### PR DESCRIPTION
Before merging, needs to be perf tested. UPDATE: Performance seemed to be largely unchanged.

[Slack thread](https://medplum.slack.com/archives/C051SKJKZ50/p1749841080728269)

Previous PR that introduced the INNER JOIN: https://github.com/medplum/medplum/pull/3823