### PR TITLE
Stop writing to `Binary` search parameter columns

### DIFF
--- a/packages/core/src/datasampler.ts
+++ b/packages/core/src/datasampler.ts
@@ -29,6 +29,15 @@ export function summarizeObservations(
   return sampler.summarize(summaryCode, summarizeFn);
 }
 
+export interface DataSampleOptions {
+  /** Code for the data points. */
+  code?: CodeableConcept;
+  /** Unit for the data points. */
+  unit?: QuantityUnit;
+  /** Sampling information for high-frequency Observations. */
+  sampling?: Omit<SampledData, 'data'>;
+}
+
 export class DataSampler {
   private code?: CodeableConcept;
   private unit?: QuantityUnit;
@@ -37,11 +46,8 @@ export class DataSampler {
 
   /**
    * @param opts - Optional parameters.
-   * @param opts.code - Code for data points.
-   * @param opts.unit - Unit for data points.
-   * @param opts.sampling - Sampling information for high-frequency Observations.
    */
-  constructor(opts?: { code?: CodeableConcept; unit?: QuantityUnit; sampling?: SamplingInfo }) {
+  constructor(opts?: DataSampleOptions) {
     this.dataPoints = [];
     this.code = opts?.code;
     this.unit = opts?.unit;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -170,7 +170,8 @@ function getOrInitTypeSchema(resourceType: string): TypeInfo {
     globalSchema.types[resourceType] = typeSchema;
   }
 
-  if (!typeSchema.searchParams) {
+  // Binary has no search parameters; not even those inherited from Resource
+  if (!typeSchema.searchParams && resourceType !== 'Binary') {
     typeSchema.searchParams = {
       _id: {
         base: [resourceType],

--- a/packages/server/src/fhir/lookups/util.ts
+++ b/packages/server/src/fhir/lookups/util.ts
@@ -24,14 +24,11 @@ export function deriveIdentifierSearchParameter(inputParam: SearchParameter): Se
   } as SearchParameter;
 }
 
-function getDerivedSearchParameters(resourceType: string): SearchParameter[] {
+function getDerivedSearchParameters(searchParams: SearchParameter[]): SearchParameter[] {
   const result: SearchParameter[] = [];
-  const searchParameters = getSearchParameters(resourceType);
-  if (searchParameters) {
-    for (const searchParameter of Object.values(searchParameters)) {
-      if (searchParameter.type === 'reference') {
-        result.push(deriveIdentifierSearchParameter(searchParameter));
-      }
+  for (const searchParameter of searchParams) {
+    if (searchParameter.type === 'reference') {
+      result.push(deriveIdentifierSearchParameter(searchParameter));
     }
   }
   return result;
@@ -44,6 +41,6 @@ function getDerivedSearchParameters(resourceType: string): SearchParameter[] {
  */
 export function getStandardAndDerivedSearchParameters(resourceType: string): SearchParameter[] {
   const standardParams = Object.values(getSearchParameters(resourceType) ?? {});
-  const derivedParams = getDerivedSearchParameters(resourceType);
+  const derivedParams = getDerivedSearchParameters(standardParams);
   return [...standardParams, ...derivedParams];
 }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -1436,7 +1436,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
   private buildResourceRow(resource: Resource): Record<string, any> {
     const resourceType = resource.resourceType;
     const meta = resource.meta as Meta;
-    const compartments = meta.compartment?.map((ref) => resolveId(ref));
     const content = stringify(resource);
 
     const row: Record<string, any> = {
@@ -1444,7 +1443,6 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       lastUpdated: meta.lastUpdated,
       deleted: false,
       projectId: meta.project,
-      compartments,
       content,
       __version: Repository.VERSION,
     };
@@ -1463,6 +1461,14 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         }
       );
     }
+
+    // compartments is a non-null column on all resource types since it used to be required for access control,
+    // it is in the process of being removed from the Binary resource type, so make sure it meets the NOT NULL
+    // constraint
+    if (resourceType === 'Binary') {
+      row.compartments = [];
+    }
+
     return row;
   }
 
@@ -1572,10 +1578,14 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     if (
       searchParam.code === '_id' ||
       searchParam.code === '_lastUpdated' ||
-      searchParam.code === '_compartment' ||
       searchParam.code === '_compartment:identifier' ||
       searchParam.type === 'composite'
     ) {
+      return;
+    }
+
+    if (searchParam.code === '_compartment') {
+      columns['compartments'] = resource.meta?.compartment?.map((ref) => resolveId(ref)) ?? [];
       return;
     }
 


### PR DESCRIPTION
Even though Medplum does not allow search on `Binary`, the default set of search parameters inherited from `Resource` were being populated when writing to the database.

This is step one: stop writing to the search parameter columns for `Binary`.
Step two (removing the columns from the `Binary` table) needs to wait for a minor version bump.