### PR TITLE
MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11404,6 +11404,222 @@
         "resolve": "~1.22.2"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.0.tgz",
+      "integrity": "sha512-P5FZsXU0kY881F6Hbk9GhsYx02/KgWK1DYf7/tyE/1lcFKhDYPQR9iYjhQXJn+Sg6hQleMo3DB7h7+p4wgp2Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -27031,6 +27247,27 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/exec-async": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
@@ -27349,6 +27586,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
     "node_modules/express-validator": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
@@ -27513,7 +27765,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -31166,6 +31417,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -39871,6 +40128,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -44528,6 +44794,31 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -49172,7 +49463,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -51061,10 +51351,18 @@
       "version": "3.25.67",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zustand": {
@@ -51893,6 +52191,7 @@
         "@medplum/core": "4.1.10",
         "@medplum/definitions": "4.1.10",
         "@medplum/fhir-router": "4.1.10",
+        "@modelcontextprotocol/sdk": "1.13.0",
         "@opentelemetry/exporter-metrics-otlp-proto": "0.57.2",
         "@opentelemetry/exporter-trace-otlp-proto": "0.57.2",
         "@opentelemetry/instrumentation-dataloader": "0.16.1",
@@ -51936,7 +52235,8 @@
         "semver": "7.7.2",
         "uuid": "11.1.0",
         "validator": "13.15.15",
-        "ws": "8.18.2"
+        "ws": "8.18.2",
+        "zod": "3.25.67"
       },
       "devDependencies": {
         "@jest/test-sequencer": "29.7.0",

--- a/packages/server/medplum.config.json
+++ b/packages/server/medplum.config.json
@@ -21,7 +21,6 @@
   "defaultBotRuntimeVersion": "vmcontext",
   "allowedOrigins": "*",
   "introspectionEnabled": true,
-  "mcpEnabled": true,
   "database": {
     "host": "localhost",
     "port": 5432,

--- a/packages/server/medplum.config.json
+++ b/packages/server/medplum.config.json
@@ -21,6 +21,7 @@
   "defaultBotRuntimeVersion": "vmcontext",
   "allowedOrigins": "*",
   "introspectionEnabled": true,
+  "mcpEnabled": true,
   "database": {
     "host": "localhost",
     "port": 5432,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,6 +47,7 @@
     "@medplum/core": "4.1.10",
     "@medplum/definitions": "4.1.10",
     "@medplum/fhir-router": "4.1.10",
+    "@modelcontextprotocol/sdk": "1.13.0",
     "@opentelemetry/exporter-metrics-otlp-proto": "0.57.2",
     "@opentelemetry/exporter-trace-otlp-proto": "0.57.2",
     "@opentelemetry/instrumentation-dataloader": "0.16.1",
@@ -90,7 +91,8 @@
     "semver": "7.7.2",
     "uuid": "11.1.0",
     "validator": "13.15.15",
-    "ws": "8.18.2"
+    "ws": "8.18.2",
+    "zod": "3.25.67"
   },
   "devDependencies": {
     "@jest/test-sequencer": "29.7.0",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -28,6 +28,7 @@ import { cleanupHeartbeat, initHeartbeat } from './heartbeat';
 import { hl7BodyParser } from './hl7/parser';
 import { keyValueRouter } from './keyvalue/routes';
 import { getLogger, globalLogger } from './logger';
+import { mcpRouter } from './mcp/routes';
 import { initKeys } from './oauth/keys';
 import { authenticateRequest } from './oauth/middleware';
 import { oauthRouter } from './oauth/routes';
@@ -197,6 +198,7 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
   apiRouter.use('/scim/v2/', scimRouter);
   apiRouter.use('/storage/', storageRouter);
   apiRouter.use('/webhook/', webhookRouter);
+  apiRouter.use('/mcp', mcpRouter);
 
   app.use('/api/', apiRouter);
   app.use('/', apiRouter);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -198,7 +198,10 @@ export async function initApp(app: Express, config: MedplumServerConfig): Promis
   apiRouter.use('/scim/v2/', scimRouter);
   apiRouter.use('/storage/', storageRouter);
   apiRouter.use('/webhook/', webhookRouter);
-  apiRouter.use('/mcp', mcpRouter);
+
+  if (config.mcpEnabled) {
+    apiRouter.use('/mcp', mcpRouter);
+  }
 
   app.use('/api/', apiRouter);
   app.use('/', apiRouter);

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -101,6 +101,9 @@ export interface MedplumServerConfig {
   /** Optional list of default OAuth2 clients */
   defaultOAuthClients?: ClientApplication[];
 
+  /** Optional flag to enable the MCP server beta */
+  mcpEnabled?: boolean;
+
   /** @deprecated */
   auditEventLogGroup?: string;
 

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -93,6 +93,7 @@ const booleanKeys = [
   'readonlyDatabase.disableConnectionConfiguration',
   'logRequests',
   'logAuditEvents',
+  'mcpEnabled',
   'registerEnabled',
   'require',
   'rejectUnauthorized',

--- a/packages/server/src/database-migration.test.ts
+++ b/packages/server/src/database-migration.test.ts
@@ -56,7 +56,6 @@ const mockMarkPostDeployMigrationCompleted = jest
   });
 
 jest.mock('./migrations/data/v1', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { prepareCustomMigrationJobData, runCustomMigration } = jest.requireActual('./workers/post-deploy-migration');
   const migration: CustomPostDeployMigration = {
     type: 'custom',

--- a/packages/server/src/mcp/README.md
+++ b/packages/server/src/mcp/README.md
@@ -1,0 +1,25 @@
+# Medplum MCP
+
+What is [Model Context Protocol (MCP)](https://modelcontextprotocol.org/)?
+
+> MCP is an open protocol that standardizes how applications provide context to LLMs. Think of MCP like a USB-C port for AI applications. Just as USB-C provides a standardized way to connect your devices to various peripherals and accessories, MCP provides a standardized way to connect AI models to different data sources and tools.
+
+## Testing with MCP Inspector
+
+Start the inspector:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+### Testing Streamable HTTP
+
+Set "Transport Type" to "Streamable HTTP" (recommended transport).
+
+Set "URL" to the `/mcp` path on your server, e.g. `http://localhost:8103/mcp`.
+
+### Testing SSE
+
+Set "Transport Type" to "SSE" (required by Claude and ChatGPT).
+
+Set "URL" to the `/mcp/sse` path on your server, e.g. `http://localhost:8103/mcp/sse`.

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import request from 'supertest';
+import { initApp, shutdownApp } from '../app';
+import { loadTestConfig } from '../config/loader';
+import { initTestAuth } from '../test.setup';
+
+describe('MCP Routes', () => {
+  const app = express();
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const config = await loadTestConfig();
+    await initApp(app, config);
+    accessToken = await initTestAuth();
+  });
+
+  afterAll(async () => {
+    await shutdownApp();
+  });
+
+  test('Unauthenticated streamable HTTP', async () => {
+    const res = await request(app).get('/mcp/stream');
+    expect(res.status).toBe(401);
+  });
+
+  test('Unauthenticated SSE', async () => {
+    const res = await request(app).get('/mcp/sse');
+    expect(res.status).toBe(401);
+  });
+
+  test('Streamable HTTP session not found', async () => {
+    const res = await request(app)
+      .post('/mcp/stream')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    expect(res.status).toBe(400);
+    expect(res.text).toStrictEqual(
+      '{"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: No valid session ID provided"},"id":null}'
+    );
+  });
+
+  test('Streamable HTTP success', async () => {
+    const res1 = await request(app)
+      .post('/mcp/stream')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: { sampling: {}, roots: { listChanged: true } },
+          clientInfo: { name: 'mcp-inspector', version: '0.14.3' },
+        },
+      });
+    expect(res1.status).toBe(200);
+    expect(res1.text).toContain('event: message');
+    expect(res1.text).toContain('data: {"result":{"protocolVersion":"2025-03-26"');
+
+    const sessionId = res1.headers['mcp-session-id'];
+
+    const res2 = await request(app)
+      .post('/mcp/stream')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', sessionId)
+      .send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    expect(res2.status).toBe(202);
+  });
+});

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -19,6 +19,8 @@ describe('MCP Routes', () => {
 
   beforeAll(async () => {
     const config = await loadTestConfig();
+    config.mcpEnabled = true;
+
     await initApp(app, config);
     accessToken = await initTestAuth();
 

--- a/packages/server/src/mcp/routes.test.ts
+++ b/packages/server/src/mcp/routes.test.ts
@@ -1,4 +1,8 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import express from 'express';
+import { Server } from 'http';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
@@ -7,15 +11,30 @@ import { initTestAuth } from '../test.setup';
 describe('MCP Routes', () => {
   const app = express();
   let accessToken: string;
+  let server: Server;
+  let port: number;
 
   beforeAll(async () => {
     const config = await loadTestConfig();
     await initApp(app, config);
     accessToken = await initTestAuth();
+
+    server = await new Promise<Server>((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Could not determine server address');
+    }
+    port = address.port;
   });
 
   afterAll(async () => {
     await shutdownApp();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
   });
 
   test('Unauthenticated streamable HTTP', async () => {
@@ -40,33 +59,116 @@ describe('MCP Routes', () => {
     );
   });
 
-  test('Streamable HTTP success', async () => {
-    const res1 = await request(app)
-      .post('/mcp/stream')
+  test('SSE POST to non-existent session ID should return 400', async () => {
+    const res = await request(app)
+      .post('/mcp/sse')
+      .query({ sessionId: 'non-existent-session' })
       .set('Authorization', 'Bearer ' + accessToken)
-      .set('Accept', 'application/json, text/event-stream')
-      .send({
-        jsonrpc: '2.0',
-        id: 0,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2025-03-26',
-          capabilities: { sampling: {}, roots: { listChanged: true } },
-          clientInfo: { name: 'mcp-inspector', version: '0.14.3' },
-        },
-      });
-    expect(res1.status).toBe(200);
-    expect(res1.text).toContain('event: message');
-    expect(res1.text).toContain('data: {"result":{"protocolVersion":"2025-03-26"');
-
-    const sessionId = res1.headers['mcp-session-id'];
-
-    const res2 = await request(app)
-      .post('/mcp/stream')
-      .set('Authorization', 'Bearer ' + accessToken)
-      .set('Accept', 'application/json, text/event-stream')
-      .set('mcp-session-id', sessionId)
+      .set('Accept', 'application/json')
       .send({ jsonrpc: '2.0', method: 'notifications/initialized' });
-    expect(res2.status).toBe(202);
+    expect(res.status).toBe(400);
+    expect(res.text).toBe('No transport found for sessionId');
+  });
+
+  test('Use SSEClientTransport', async () => {
+    const sseBaseUrl = `http://localhost:${port}/mcp/sse`;
+    const receivedMessages: any[] = [];
+
+    const transport = new SSEClientTransport(new URL(sseBaseUrl), {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    });
+    transport.onmessage = (msg) => receivedMessages.push(msg);
+
+    const client = new Client({
+      name: 'example-client',
+      version: '1.0.0',
+    });
+
+    await client.connect(transport);
+
+    const tools = await client.listTools();
+    expect(tools).toBeDefined();
+
+    const searchResult = await client.callTool({
+      name: 'search',
+      arguments: {
+        query: 'example',
+      },
+    });
+    expect(searchResult).toBeDefined();
+
+    const fetchResult = await client.callTool({
+      name: 'fetch',
+      arguments: {
+        id: 'example-id',
+      },
+    });
+    expect(fetchResult).toBeDefined();
+
+    const fhirRequestResult = await client.callTool({
+      name: 'fhir-request',
+      arguments: {
+        method: 'GET',
+        path: 'Patient',
+      },
+    });
+    expect(fhirRequestResult).toBeDefined();
+
+    await client.close();
+  });
+
+  test('Use StreamableHTTPClientTransport', async () => {
+    const streamableBaseUrl = `http://localhost:${port}/mcp/stream`;
+    const receivedMessages: any[] = [];
+
+    const transport = new StreamableHTTPClientTransport(new URL(streamableBaseUrl), {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    });
+    transport.onmessage = (msg) => receivedMessages.push(msg);
+
+    const client = new Client({
+      name: 'example-client',
+      version: '1.0.0',
+    });
+
+    await client.connect(transport);
+
+    const tools = await client.listTools();
+    expect(tools).toBeDefined();
+
+    const searchResult = await client.callTool({
+      name: 'search',
+      arguments: {
+        query: 'example',
+      },
+    });
+    expect(searchResult).toBeDefined();
+
+    const fetchResult = await client.callTool({
+      name: 'fetch',
+      arguments: {
+        id: 'example-id',
+      },
+    });
+    expect(fetchResult).toBeDefined();
+
+    const fhirRequestResult = await client.callTool({
+      name: 'fhir-request',
+      arguments: {
+        method: 'GET',
+        path: 'Patient',
+      },
+    });
+    expect(fhirRequestResult).toBeDefined();
+
+    await client.close();
   });
 });

--- a/packages/server/src/mcp/routes.ts
+++ b/packages/server/src/mcp/routes.ts
@@ -18,9 +18,9 @@ mcpRouter.all(
   asyncWrap(async (req: Request, res: Response) => {
     const server = getMcpServer();
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-    res.on('close', () => {
-      transport.close();
-      server.close();
+    res.on('close', async () => {
+      await transport.close();
+      await server.close();
     });
     await server.connect(transport);
     await transport.handleRequest(req, res, req.body);
@@ -52,10 +52,10 @@ mcpRouter.get('/sse', async (req, res) => {
   const server = getMcpServer();
   await server.connect(transport);
 
-  res.on('close', () => {
+  res.on('close', async () => {
     redisSubscriber.disconnect();
-    transport.close();
-    server.close();
+    await transport.close();
+    await server.close();
   });
 });
 

--- a/packages/server/src/mcp/routes.ts
+++ b/packages/server/src/mcp/routes.ts
@@ -1,0 +1,74 @@
+import { getStatus, normalizeErrorString, normalizeOperationOutcome } from '@medplum/core';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { Request, Response, Router } from 'express';
+import { asyncWrap } from '../async';
+import { authenticateRequest } from '../oauth/middleware';
+import { getMcpServer } from './server';
+
+export const mcpRouter = Router().use(authenticateRequest);
+
+// Model Context Protocol (MCP) routes
+// Medplum supports 2 MCP transports:
+// 1. Streamable HTTP - for newer clients that support streaming
+// 2. Server-Sent Events (SSE) - for older clients that do not support streaming
+
+const transports = {
+  streamable: {} as Record<string, StreamableHTTPServerTransport>,
+  sse: {} as Record<string, SSEServerTransport>,
+};
+
+async function handleStreamableHttpRequest(req: Request, res: Response): Promise<void> {
+  try {
+    const server = getMcpServer();
+    const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    res.on('close', async () => {
+      await transport.close();
+      await server.close();
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    if (!res.headersSent) {
+      const outcome = normalizeOperationOutcome(err);
+      res.status(getStatus(outcome)).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: normalizeErrorString(err),
+        },
+        id: null,
+      });
+    }
+  }
+}
+
+mcpRouter.get('/', asyncWrap(handleStreamableHttpRequest));
+mcpRouter.post('/', asyncWrap(handleStreamableHttpRequest));
+mcpRouter.delete('/', asyncWrap(handleStreamableHttpRequest));
+
+// Legacy SSE endpoint for older clients
+mcpRouter.get('/sse', async (req, res) => {
+  const transport = new SSEServerTransport('/mcp/sse', res);
+  transports.sse[transport.sessionId] = transport;
+
+  res.on('close', () => {
+    delete transports.sse[transport.sessionId];
+  });
+
+  const server = getMcpServer();
+  await server.connect(transport);
+});
+
+// Legacy message endpoint for older clients
+mcpRouter.post('/sse', async (req, res) => {
+  const sessionId = req.query.sessionId as string;
+  const transport = transports.sse[sessionId];
+  if (transport) {
+    await transport.handlePostMessage(req, res, req.body);
+  } else {
+    res.status(400).send('No transport found for sessionId');
+  }
+});

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -4,6 +4,7 @@ import fetch from 'node-fetch';
 import { z } from 'zod';
 import { getConfig } from '../config/loader';
 import { getAuthenticatedContext } from '../context';
+import { getLogger } from '../logger';
 
 const server = new McpServer({
   name: 'medplum',
@@ -25,7 +26,7 @@ const dummyDocument = {
 } as const;
 
 server.tool('search', { query: z.string() }, async ({ query }) => {
-  console.log(`Performing search for: "${query}"`);
+  getLogger().debug(`Performing search for: "${query}"`);
   return { content: [dummyDocument] };
 });
 
@@ -35,7 +36,7 @@ server.tool(
     id: z.string().describe('The ID of the resource to fetch, obtained from a search result.'),
   },
   async ({ id }) => {
-    console.log(`Performing fetch for ID: "${id}"`);
+    getLogger().debug(`Performing fetch for ID: "${id}"`);
     return { content: [dummyDocument] };
   }
 );
@@ -64,7 +65,7 @@ server.tool(
       body = JSON.parse(body);
     }
 
-    let response: any;
+    let response: unknown;
     switch (method.toLowerCase()) {
       case 'get':
         response = await proxy.get(fhirUrl);

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -1,0 +1,102 @@
+import { concatUrls, isString, MEDPLUM_VERSION, MedplumClient } from '@medplum/core';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import fetch from 'node-fetch';
+import { z } from 'zod';
+import { getConfig } from '../config/loader';
+import { getAuthenticatedContext } from '../context';
+
+const server = new McpServer({
+  name: 'medplum',
+  version: MEDPLUM_VERSION,
+});
+
+/**
+ * Dummy document used for testing purposes.
+ *
+ * ChatGPT requires two standrad tools: "search" and "fetch".
+ * We implement stub versions of these tools that return a dummy document.
+ * If these tools are not implemented, ChatGPT will not connect to the Medplum server.
+ */
+const dummyDocument = {
+  type: 'text',
+  id: 'dummy-doc',
+  text: 'This is a dummy document used for testing purposes.',
+  uri: 'https://example.com/dummy-doc',
+} as const;
+
+server.tool('search', { query: z.string() }, async ({ query }) => {
+  console.log(`Performing search for: "${query}"`);
+  return { content: [dummyDocument] };
+});
+
+server.tool(
+  'fetch',
+  {
+    id: z.string().describe('The ID of the resource to fetch, obtained from a search result.'),
+  },
+  async ({ id }) => {
+    console.log(`Performing fetch for ID: "${id}"`);
+    return { content: [dummyDocument] };
+  }
+);
+
+// This the main FHIR request tool that allows clients to make FHIR requests to the Medplum server.
+// The current implmentation uses the very suboptimal approach of re-fetching the URL on behalf of the client.
+// Over time, we should definitely replace this with the "FhirRouter" approach, which would stay within the Medplum server and not re-fetch the URL.
+// However, there are a few FHIR endpoints that are not yet available in FhirRouter, so we need to use fetch for now.
+server.tool(
+  'fhir-request',
+  {
+    method: z.string(),
+    path: z.string(),
+    body: z.any(),
+  },
+  async ({ method, path, body }) => {
+    const ctx = getAuthenticatedContext();
+    const baseUrl = getConfig().baseUrl;
+    const baseFhirUrl = concatUrls(baseUrl, 'fhir/R4');
+    const fhirUrl = concatUrls(baseFhirUrl, path);
+    const accessToken = ctx.authState.accessToken;
+    const proxy = new MedplumClient({ baseUrl, accessToken, fetch });
+
+    // MCP allows sending JSON, but some clients (like Claude) send the body as a string
+    if (isString(body)) {
+      body = JSON.parse(body);
+    }
+
+    let response: any;
+    switch (method.toLowerCase()) {
+      case 'get':
+        response = await proxy.get(fhirUrl);
+        break;
+      case 'delete':
+        response = await proxy.delete(fhirUrl, body);
+        break;
+      case 'patch':
+        response = await proxy.patch(fhirUrl, body);
+        break;
+      case 'post':
+        response = await proxy.post(fhirUrl, body);
+        break;
+      case 'put':
+        response = await proxy.put(fhirUrl, body);
+        break;
+      default:
+        throw new Error(`Unsupported method: ${method}`);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(response),
+          uri: fhirUrl,
+        },
+      ],
+    };
+  }
+);
+
+export function getMcpServer(): McpServer {
+  return server;
+}


### PR DESCRIPTION
Adds optional MCP server support.  Must opt-in using `mcpEnabled: true` server config setting.

We expose 3 MCP "tools", 1 real tool and 2 dummy tools:
- Real tool
   - `fhir-request` - Make a Medplum FHIR request
      - `method` - the HTTP method (i.e., `GET`, `POST`, `DELETE`, etc)
      - `path` - the FHIR path (i.e., `/Patient`, `/Patient/123`, `/Patient/123/$everything`, etc)
      - `body` - optional FHIR request body, can be string or JSON
- Dummy tools - these are required by some major LLMs, but are not applicable to Medplum
   - `search` - This is supposed to be for free text search for the purpose of finding related articles
   - `fetch` - This is supposed to be for retrieving articles for citations

This is largely just a thin adapter/wrapper around our existing API.

The one tricky part was implementing the SSE transport, which requires a persistent connection similar to WebSockets.  Technically, the SSE transport is deprecated, but at the time of this writing it is the only transport supported by Claude.

To work around that limitation, we used the Redis pub/sub model, exactly how we handle WebSocket subscriptions and Agent WebSocket connections.

TODO:
- [x] Add optional "default scopes" to `ClientApplication`
- [x] Add tests for `/oauth2/register`
- [x] Add MCP tests
- [x] Figure out how to do SSE with multiple boxes behind load balancer
- [x] Add SSE heartbeat

Proof it works:

![image](https://github.com/user-attachments/assets/5758dbf6-d3f0-468a-a0a9-85950b2e3701)