### PR TITLE
Agent: (backwards compat) Handle transmission response from server without callback string

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -212,7 +212,7 @@ export class App {
           case 'transmit':
           case 'agent:transmit:response': {
             if (!command.callback) {
-              throw new Error('Transmit response missing callback');
+              this.log.warn('Transmit response missing callback');
             }
             if (this.config?.status !== 'active') {
               this.sendAgentDisabledError(command);


### PR DESCRIPTION
## Summary
This PR changes the handling of `agent:transmit:response` messages on the Medplum Agent in cases where the message omits a `callback` property. Previously the agent would error without responding to the host device, causing many host devices to hang indefinitely. 

This PR logs this case as a warning, but still responds to the host device. 

## Why
The `callback` property was introduced in version `3.2.5` (#4979 ). However, some users are running the latest version of the agent against older server versions, and we guarantee compatibility with version `3.1.11`. 

## Why this is OK

The callback isn't used for routing **within the agent** - it's used for:

1. **Server-side request-response correlation** via Redis pub/sub
2. **Enabling synchronous-style API operations** like `$push` that wait for responses
3. **Debugging and logging** to track message flows


## Where Callback Correlation Happens

The callback correlation primarily happens **on the server side**, not in the agent:

### 1. Request Initiation (e.g., Agent $push operation)

When someone calls the Agent `$push` operation with `waitForResponse: true`, this triggers the callback mechanism:

[177:180:packages/server/src/fhir/operations/utils/agentutils.ts]
```177:180:packages/server/src/fhir/operations/utils/agentutils.ts
// If a callback doesn't already exist on the message, tie callback to the associated agent and assign a random ID
message.callback = getReferenceString(agent) + '-' + randomUUID();

const redisSubscriber = getRedisSubscriber();
await redisSubscriber.subscribe(message.callback);
```

### 2. Server Creates Callback Subscription

The **server itself** subscribes to the callback channel **before** sending the request to the agent:

[182:193:packages/server/src/fhir/operations/utils/agentutils.ts]
```182:193:packages/server/src/fhir/operations/utils/agentutils.ts
const resultPromise = new Promise<[OperationOutcome, T | AgentError]>((resolve, reject) => {
  redisSubscriber.on('message', (_channel: string, message: string) => {
    const response = JSON.parse(message) as T | AgentError;
    resolve([allOk, response]);
    cleanup();
  });

  // Create a timer for 5 seconds for timeout
  const timer = setTimeout(() => {
    cleanup();
    // eslint-disable-next-line prefer-promise-reject-errors
    reject(new OperationOutcomeError(badRequest('Timeout')) as Error);
  }, options?.timeout ?? 5000);
```

### 3. Agent Processes and Responds

The agent receives the request, processes it, and sends back a response with the same callback ID:

[73:82:packages/server/src/agent/websockets.ts]
```73:82:packages/server/src/agent/websockets.ts
case 'agent:transmit:response':
case 'agent:reloadconfig:response':
case 'agent:upgrade:response':
  if (command.callback) {
    const redis = getRedis();
    await redis.publish(command.callback, JSON.stringify(command));
  }
  break;
```

### 4. Server Receives Response via Redis

The Redis message arrives at the **same server process** that subscribed to the callback channel, which resolves the waiting Promise and returns the response to the original API caller.


## Agent-Side Routing Still Uses Channel + Remote

Looking at the agent code, the correlation within the agent **still uses the old method**:

[502:510:packages/agent/src/app.ts]
```502:510:packages/agent/src/app.ts
private trySendToHl7Connection(): void {
  while (this.hl7Queue.length > 0) {
    const msg = this.hl7Queue.shift();
    if (msg && msg.type === 'agent:transmit:response' && msg.channel) {
      const channel = this.channels.get(msg.channel);
      if (channel) {
        channel.sendToRemote(msg);
      }
    }
  }
}
```

And in the HL7 channel:

[47:52:packages/agent/src/hl7.ts]
```47:52:packages/agent/src/hl7.ts
sendToRemote(msg: AgentTransmitResponse): void {
  const connection = this.connections.get(msg.remote as string);
  if (connection) {
    connection.hl7Connection.send(Hl7Message.parse(msg.body));
  }
}
```