### PR TITLE
fix: update bot layer to Node.js 20.x runtime

### DIFF
--- a/scripts/deploy-bot-layer.sh
+++ b/scripts/deploy-bot-layer.sh
@@ -44,7 +44,7 @@ aws lambda publish-layer-version \
   --layer-name "$BOT_LAYER_NAME" \
   --description "Medplum Bot Layer" \
   --license-info "Apache-2.0" \
-  --compatible-runtimes "nodejs18.x" \
+  --compatible-runtimes "nodejs20.x" \
   --zip-file fileb://medplum-bot-layer.zip
 
 # Pop back to original directory


### PR DESCRIPTION
Update AWS Lambda layer compatible runtime from nodejs18.x to nodejs20.x in the bot layer deployment script. This aligns with current minimum node version in bot-layer/package.json

Fixes #6496 