### PR TITLE
Fix cli dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15017,6 +15017,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
       "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -15028,6 +15029,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -15037,6 +15039,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@slorber/remark-comment": {
@@ -18125,6 +18128,7 @@
       "version": "17.0.4",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
       "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -18134,6 +18138,7 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sockjs": {
@@ -20530,6 +20535,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
       "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/sinon": "^17.0.3",
@@ -25235,6 +25241,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -33427,6 +33434,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jwa": {
@@ -34131,6 +34139,7 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -38106,6 +38115,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
       "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -38119,6 +38129,7 @@
       "version": "13.0.5",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
       "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
@@ -38128,6 +38139,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
       "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -45618,6 +45630,7 @@
       "version": "18.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
       "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
@@ -45636,6 +45649,7 @@
       "version": "11.2.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
       "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -45645,6 +45659,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -51384,7 +51399,6 @@
         "@aws-sdk/types": "3.821.0",
         "@medplum/core": "4.1.10",
         "@medplum/hl7": "4.1.10",
-        "aws-sdk-client-mock": "4.1.0",
         "commander": "12.1.0",
         "dotenv": "16.5.0",
         "fast-glob": "3.3.3",
@@ -51400,7 +51414,8 @@
         "@medplum/fhirtypes": "4.1.10",
         "@medplum/mock": "4.1.10",
         "@types/node-fetch": "2.6.12",
-        "@types/semver": "7.7.0"
+        "@types/semver": "7.7.0",
+        "aws-sdk-client-mock": "4.1.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,6 @@
     "@aws-sdk/types": "3.821.0",
     "@medplum/core": "4.1.10",
     "@medplum/hl7": "4.1.10",
-    "aws-sdk-client-mock": "4.1.0",
     "commander": "12.1.0",
     "dotenv": "16.5.0",
     "fast-glob": "3.3.3",
@@ -81,7 +80,8 @@
     "@medplum/fhirtypes": "4.1.10",
     "@medplum/mock": "4.1.10",
     "@types/node-fetch": "2.6.12",
-    "@types/semver": "7.7.0"
+    "@types/semver": "7.7.0",
+    "aws-sdk-client-mock": "4.1.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
I was excited to test the new `medplum` CLI package:

```
$ npx medplum whoami
Need to install the following packages:
medplum@4.1.10
Ok to proceed? (y)

npm warn deprecated lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
Not logged in
```

Hm, why is `lodash.get` in there?

```
$ npm ls lodash.get
root@4.1.9 C:\Users\Cody\dev\medplum
└─┬ @medplum/cli@4.1.9 -> .\packages\cli
  └─┬ aws-sdk-client-mock@4.1.0
    └─┬ sinon@18.0.1
      └─┬ @sinonjs/samsam@8.0.2
        └── lodash.get@4.4.2
```

Hm, why is it installing `aws-sdk-client-mock`, that should be a dev dependency?

Oh, whoops.