### PR TITLE
Ensure Edit tab has rendered

### DIFF
--- a/packages/e2e/smoke/medplum.smoke.test.ts
+++ b/packages/e2e/smoke/medplum.smoke.test.ts
@@ -80,6 +80,7 @@ test.describe('Medplum App Smoke Tests', () => {
 
     // Edit and upload image
     await page.getByRole('tab', { name: 'Edit' }).click();
+    await expect(page.getByText('An identifier for this patient.', { exact: true })).toBeVisible();
     await page
       .getByTestId('upload-file-input')
       .setInputFiles(path.resolve(__dirname, '../content', 'frodo_baggins.png'));


### PR DESCRIPTION
Previously, playwright would ocassionally find the AttachmentButton at the top of the PatientTimeline rather than the one on the Edit tab for the Photo element