### PR TITLE
Add a Redis-based server registry

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -15,7 +15,7 @@ import { getConfig } from './config/loader';
 import { MedplumServerConfig } from './config/types';
 import { attachRequestContext, AuthenticatedRequestContext, closeRequestContext, getRequestContext } from './context';
 import { corsOptions } from './cors';
-import { closeDatabase, initDatabase } from './database';
+import { closeDatabase, initDatabase, maybeAutoRunPendingPostDeployMigration } from './database';
 import { dicomRouter } from './dicom/routes';
 import { emailRouter } from './email/routes';
 import { binaryRouter } from './fhir/binary';
@@ -217,8 +217,8 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
     initWorkers(config);
     initHeartbeat(config);
     initOtelHeartbeat();
-    await initServerRegistryHeartbeatListener();
-    // await maybeAutoRunPendingPostDeployMigration();
+    initServerRegistryHeartbeatListener();
+    await maybeAutoRunPendingPostDeployMigration();
   });
 }
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -15,7 +15,7 @@ import { getConfig } from './config/loader';
 import { MedplumServerConfig } from './config/types';
 import { attachRequestContext, AuthenticatedRequestContext, closeRequestContext, getRequestContext } from './context';
 import { corsOptions } from './cors';
-import { closeDatabase, initDatabase, maybeAutoRunPendingPostDeployMigration } from './database';
+import { closeDatabase, initDatabase } from './database';
 import { dicomRouter } from './dicom/routes';
 import { emailRouter } from './email/routes';
 import { binaryRouter } from './fhir/binary';
@@ -38,6 +38,7 @@ import { closeRedis, initRedis } from './redis';
 import { requestContextStore } from './request-context-store';
 import { scimRouter } from './scim/routes';
 import { seedDatabase } from './seed';
+import { initServerRegistryHeartbeatListener } from './server-registry';
 import { initBinaryStorage } from './storage/loader';
 import { storageRouter } from './storage/routes';
 import { webhookRouter } from './webhook/routes';
@@ -216,7 +217,8 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
     initWorkers(config);
     initHeartbeat(config);
     initOtelHeartbeat();
-    await maybeAutoRunPendingPostDeployMigration();
+    await initServerRegistryHeartbeatListener();
+    // await maybeAutoRunPendingPostDeployMigration();
   });
 }
 

--- a/packages/server/src/server-registry.test.ts
+++ b/packages/server/src/server-registry.test.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from 'crypto';
+import { heartbeat } from './heartbeat';
+import { getRedis } from './redis';
+import * as serverRegistry from './server-registry';
+import {
+  cleanupServerRegistryHeartbeatListener,
+  getClusterStatus,
+  initServerRegistryHeartbeatListener,
+} from './server-registry';
+
+jest.mock('./redis');
+jest.mock('crypto');
+
+const UUID = '00000000-0000-0000-0000-0000deadbeef';
+
+describe('server-registry', () => {
+  const mockRedis = {
+    setex: jest.fn(),
+    keys: jest.fn(),
+    mget: jest.fn(),
+  };
+
+  const now = new Date('2023-01-15T10:00:00Z');
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+
+    (getRedis as jest.Mock).mockReturnValue(mockRedis);
+    (randomUUID as jest.Mock).mockReturnValue(UUID);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  test('setServerRegistryPayload', async () => {
+    await serverRegistry.setServerRegistryPayload({
+      id: 'test-id',
+      firstSeen: '2021-01-01T00:00:00.000Z',
+      lastSeen: '2021-01-01T00:00:00.000Z',
+      version: '1.0.0',
+      fullVersion: '1.0.0-test',
+    });
+
+    expect(mockRedis.setex).toHaveBeenCalledWith(
+      'medplum:server-registry:test-id',
+      60,
+      JSON.stringify({
+        id: 'test-id',
+        firstSeen: '2021-01-01T00:00:00.000Z',
+        lastSeen: '2021-01-01T00:00:00.000Z',
+        version: '1.0.0',
+        fullVersion: '1.0.0-test',
+      })
+    );
+  });
+
+  test('init and cleanup ServerRegistryHeartbeatListener', async () => {
+    const heartbeatAddListenerSpy = jest.spyOn(heartbeat, 'addEventListener');
+    const heartbeatRemoveListenerSpy = jest.spyOn(heartbeat, 'removeEventListener');
+
+    await initServerRegistryHeartbeatListener();
+    expect(heartbeatAddListenerSpy).toHaveBeenCalledWith('heartbeat', expect.any(Function));
+
+    heartbeatAddListenerSpy.mockClear();
+
+    // Idempotent
+    await initServerRegistryHeartbeatListener();
+    expect(heartbeatAddListenerSpy).not.toHaveBeenCalled();
+
+    // Heartbeat listener is called
+    heartbeat.dispatchEvent({ type: 'heartbeat' });
+    expect(mockRedis.setex).toHaveBeenCalledTimes(1);
+
+    // Cleanup heartbeat
+    cleanupServerRegistryHeartbeatListener();
+    expect(heartbeatRemoveListenerSpy).toHaveBeenCalledWith('heartbeat', expect.any(Function));
+
+    heartbeatRemoveListenerSpy.mockClear();
+
+    // Idempotent
+    cleanupServerRegistryHeartbeatListener();
+    expect(heartbeatRemoveListenerSpy).not.toHaveBeenCalled();
+  });
+
+  test('getClusterStatus - heterogeneous', async () => {
+    const server1 = {
+      id: 'server1',
+      firstSeen: new Date(now.getTime() - 20000).toISOString(),
+      lastSeen: new Date(now.getTime() - 10000).toISOString(),
+      version: '1.0.0',
+      fullVersion: '1.0.0-a',
+    };
+    const server2 = {
+      id: 'server2',
+      firstSeen: new Date(now.getTime() - 40000).toISOString(),
+      lastSeen: new Date(now.getTime() - 5000).toISOString(),
+      version: '1.0.0',
+      fullVersion: '1.0.0-a',
+    };
+    const server3 = {
+      id: 'server3',
+      firstSeen: new Date(now.getTime() - 60000).toISOString(),
+      lastSeen: new Date(now.getTime() - 15000).toISOString(),
+      version: '1.1.0',
+      fullVersion: '1.1.0-b',
+    };
+
+    mockRedis.keys.mockResolvedValue([
+      'medplum:server-registry:server1',
+      'medplum:server-registry:server2',
+      'medplum:server-registry:server3',
+    ]);
+    mockRedis.mget.mockResolvedValue([JSON.stringify(server1), JSON.stringify(server2), JSON.stringify(server3)]);
+
+    const status = await getClusterStatus();
+
+    expect(mockRedis.keys).toHaveBeenCalledWith('medplum:server-registry:*');
+    expect(mockRedis.mget).toHaveBeenCalledWith([
+      'medplum:server-registry:server1',
+      'medplum:server-registry:server2',
+      'medplum:server-registry:server3',
+    ]);
+
+    expect(status.totalServers).toBe(3);
+    expect(status.isHomogeneous).toBe(false);
+    expect(status.oldestVersion).toBe('1.0.0-a');
+    expect(status.newestVersion).toBe('1.1.0-b');
+    expect(status.versions).toEqual({
+      '1.0.0-a': 2,
+      '1.1.0-b': 1,
+    });
+    expect(status.servers).toHaveLength(3);
+    // Note: servers are sorted by fullVersion
+    expect(status.servers[0].id).toBe('server1');
+    expect(status.servers[0].firstSeenAgeMs).toBe(20000);
+    expect(status.servers[0].lastSeenAgeMs).toBe(10000);
+    expect(status.servers[1].id).toBe('server2');
+    expect(status.servers[1].firstSeenAgeMs).toBe(40000);
+    expect(status.servers[1].lastSeenAgeMs).toBe(5000);
+    expect(status.servers[2].id).toBe('server3');
+    expect(status.servers[2].firstSeenAgeMs).toBe(60000);
+    expect(status.servers[2].lastSeenAgeMs).toBe(15000);
+  });
+
+  test('getClusterStatus - homogeneous', async () => {
+    const server1 = {
+      id: 'server1',
+      firstSeen: new Date(now.getTime() - 20000).toISOString(),
+      lastSeen: new Date(now.getTime() - 10000).toISOString(),
+      version: '1.0.0',
+      fullVersion: '1.0.0-a',
+    };
+    const server2 = {
+      id: 'server2',
+      firstSeen: new Date(now.getTime() - 40000).toISOString(),
+      lastSeen: new Date(now.getTime() - 5000).toISOString(),
+      version: '1.0.0',
+      fullVersion: '1.0.0-a',
+    };
+
+    mockRedis.keys.mockResolvedValue(['medplum:server-registry:server1', 'medplum:server-registry:server2']);
+    mockRedis.mget.mockResolvedValue([JSON.stringify(server1), JSON.stringify(server2)]);
+
+    const status = await getClusterStatus();
+
+    expect(status.totalServers).toBe(2);
+    expect(status.isHomogeneous).toBe(true);
+    expect(status.oldestVersion).toBe('1.0.0-a');
+    expect(status.newestVersion).toBe('1.0.0-a');
+    expect(status.versions).toEqual({
+      '1.0.0-a': 2,
+    });
+    expect(status.servers).toHaveLength(2);
+    expect(status.servers[0].firstSeenAgeMs).toBe(20000);
+    expect(status.servers[0].lastSeenAgeMs).toBe(10000);
+    expect(status.servers[1].firstSeenAgeMs).toBe(40000);
+    expect(status.servers[1].lastSeenAgeMs).toBe(5000);
+  });
+
+  test('getClusterStatus - empty mget', async () => {
+    mockRedis.keys.mockResolvedValue(['medplum:server-registry:server1']);
+    mockRedis.mget.mockResolvedValue([null]);
+
+    const status = await getClusterStatus();
+    expect(status.totalServers).toBe(0);
+    expect(status.servers).toHaveLength(0);
+    expect(status.isHomogeneous).toBe(false);
+  });
+});

--- a/packages/server/src/server-registry.ts
+++ b/packages/server/src/server-registry.ts
@@ -106,7 +106,7 @@ function getServersByVersion(servers: ServerRegistryInfo[]): Record<string, Serv
 export async function getClusterStatus(): Promise<ClusterStatus> {
   const servers = await getRegisteredServers();
   const versionMap = getServersByVersion(servers);
-  const versions = Object.keys(versionMap).sort();
+  const versions = Object.keys(versionMap).sort((a, b) => a.localeCompare(b));
   const versionCounts = versions.reduce((versionCounts: Record<string, number>, version) => {
     versionCounts[version] = versionMap[version].length;
     return versionCounts;

--- a/packages/server/src/server-registry.ts
+++ b/packages/server/src/server-registry.ts
@@ -1,0 +1,159 @@
+import { MEDPLUM_VERSION, WithId } from '@medplum/core';
+import { AsyncJob } from '@medplum/fhirtypes';
+import { randomUUID } from 'crypto';
+import { getConfig } from './config/loader';
+import { DatabaseMode, getDatabasePool } from './database';
+import { getSystemRepo } from './fhir/repo';
+import { heartbeat } from './heartbeat';
+import { globalLogger } from './logger';
+import { getPendingPostDeployMigration, queuePostDeployMigration } from './migrations/migration-utils';
+import { MigrationVersion } from './migrations/migration-versions';
+import { getRedis } from './redis';
+import { getServerVersion } from './util/version';
+
+const SERVER_REGISTRY_KEY_PREFIX = 'medplum:server-registry';
+const SERVER_REGISTRY_TTL_SECONDS = 60;
+
+type ServerRegistryInfo = {
+  /* Unique identifier for a server instance */
+  id: string;
+  /* Semver version of Medplum the server is running */
+  version: string;
+  /* Full version (semver + build commit hash) of Medplum the server is running */
+  fullVersion: string;
+};
+
+export type ClusterStatus = {
+  timestamp: string;
+  totalServers: number;
+  versions: Record<string, number>;
+  oldestVersion: string | undefined;
+  newestVersion: string | undefined;
+  isHomogeneous: boolean;
+  servers: ServerRegistryInfo[];
+};
+
+export async function getRegisteredServers(): Promise<ServerRegistryInfo[]> {
+  const redis = getRedis();
+  const servers: ServerRegistryInfo[] = [];
+  const keys = await redis.keys(SERVER_REGISTRY_KEY_PREFIX + ':*');
+  const payloads = await redis.mget(keys);
+  for (const payload of payloads) {
+    if (payload) {
+      servers.push(JSON.parse(payload));
+    }
+  }
+  return servers;
+}
+
+function getServersByVersion(servers: ServerRegistryInfo[]): Record<string, ServerRegistryInfo[]> {
+  const versionMap: Record<string, ServerRegistryInfo[]> = {};
+
+  servers.forEach((server) => {
+    if (!versionMap[server.fullVersion]) {
+      versionMap[server.fullVersion] = [];
+    }
+    versionMap[server.fullVersion].push(server);
+  });
+
+  return versionMap;
+}
+
+export async function getClusterStatus(): Promise<ClusterStatus> {
+  const servers = await getRegisteredServers();
+  const versionMap = await getServersByVersion(servers);
+  const versions = Object.keys(versionMap).sort();
+  const versionCounts = versions.reduce((versionCounts: Record<string, number>, version) => {
+    versionCounts[version] = versionMap[version].length;
+    return versionCounts;
+  }, {});
+
+  return {
+    timestamp: new Date().toISOString(),
+    totalServers: servers.length,
+    versions: versionCounts,
+    oldestVersion: versions[0],
+    newestVersion: versions[versions.length - 1],
+    isHomogeneous: versions.length === 1,
+    servers: servers.sort((a, b) => a.fullVersion.localeCompare(b.fullVersion)),
+  };
+}
+
+export async function setServerRegistryPayload(value: ServerRegistryInfo): Promise<void> {
+  const redis = getRedis();
+  await redis.setex(SERVER_REGISTRY_KEY_PREFIX + ':' + value.id, SERVER_REGISTRY_TTL_SECONDS, JSON.stringify(value));
+}
+
+let serverRegistryHeartbeatListener: (() => Promise<void>) | undefined;
+
+let registryPayload: ServerRegistryInfo | undefined;
+
+let shouldCheckForPendingPostDeployMigration = false;
+
+export async function initServerRegistryHeartbeatListener(): Promise<void> {
+  if (serverRegistryHeartbeatListener) {
+    return;
+  }
+
+  const config = getConfig();
+  const isDisabled = config.database.runMigrations === false || config.database.disableRunPostDeployMigrations;
+  shouldCheckForPendingPostDeployMigration = !isDisabled;
+
+  serverRegistryHeartbeatListener = async () => {
+    if (!registryPayload) {
+      registryPayload = {
+        id: randomUUID(),
+        version: getServerVersion(),
+        fullVersion: MEDPLUM_VERSION,
+      };
+    }
+    await setServerRegistryPayload(registryPayload);
+
+    if (shouldCheckForPendingPostDeployMigration) {
+      const result = await maybeRunPendingPostDeployMigration();
+      shouldCheckForPendingPostDeployMigration = Boolean(result);
+    }
+  };
+  heartbeat.addEventListener('heartbeat', serverRegistryHeartbeatListener);
+}
+
+export function cleanupServerRegistryHeartbeatListener(): void {
+  if (serverRegistryHeartbeatListener) {
+    heartbeat.removeEventListener('heartbeat', serverRegistryHeartbeatListener);
+    serverRegistryHeartbeatListener = undefined;
+    registryPayload = undefined;
+  }
+}
+
+/**
+ * @returns The AsyncJob if the post-deploy migration was started, `true` if the cluster is not yet homogeneous, `false` if there are no pending post-deploy migrations
+ */
+async function maybeRunPendingPostDeployMigration(): Promise<WithId<AsyncJob> | boolean> {
+  const pendingPostDeployMigration = await getPendingPostDeployMigration(getDatabasePool(DatabaseMode.WRITER));
+  if (pendingPostDeployMigration === MigrationVersion.UNKNOWN) {
+    //throwing here seems extreme since it stops the server from starting
+    // if this somehow managed to trigger, but arriving here would mean something
+    // is pretty wrong, so throwing is probably the correct behavior?
+    throw new Error('Cannot run post-deploy migrations; next post-deploy migration version is unknown');
+  }
+
+  if (pendingPostDeployMigration === MigrationVersion.NONE) {
+    globalLogger.debug('No pending post-deploy migrations');
+    return false;
+  }
+
+  const clusterStatus = await getClusterStatus();
+  console.log(clusterStatus);
+
+  if (!clusterStatus.isHomogeneous) {
+    globalLogger.info('Not auto-queueing pending post-deploy migration because cluster is not homogeneous', {
+      version: `v${pendingPostDeployMigration}`,
+      clusterStatus,
+    });
+    return true;
+  }
+
+  const systemRepo = getSystemRepo();
+  globalLogger.debug('Auto-queueing pending post-deploy migration', { version: `v${pendingPostDeployMigration}` });
+  return queuePostDeployMigration(systemRepo, pendingPostDeployMigration);
+}

--- a/packages/server/src/server-registry.ts
+++ b/packages/server/src/server-registry.ts
@@ -29,7 +29,7 @@ let serverRegistryHeartbeatListener: (() => Promise<void>) | undefined;
 
 let registryPayload: ServerRegistryInfo | undefined;
 
-export async function initServerRegistryHeartbeatListener(): Promise<void> {
+export function initServerRegistryHeartbeatListener(): void {
   if (serverRegistryHeartbeatListener) {
     return;
   }

--- a/packages/server/src/server-registry.ts
+++ b/packages/server/src/server-registry.ts
@@ -105,6 +105,7 @@ function getServersByVersion(servers: ServerRegistryInfo[]): Record<string, Serv
 
 export async function getClusterStatus(): Promise<ClusterStatus> {
   const servers = await getRegisteredServers();
+  servers.sort((a, b) => a.fullVersion.localeCompare(b.fullVersion));
   const versionMap = getServersByVersion(servers);
   const versions = Object.keys(versionMap).sort((a, b) => a.localeCompare(b));
   const versionCounts = versions.reduce((versionCounts: Record<string, number>, version) => {
@@ -119,6 +120,6 @@ export async function getClusterStatus(): Promise<ClusterStatus> {
     oldestVersion: versions[0],
     newestVersion: versions[versions.length - 1],
     isHomogeneous: versions.length === 1,
-    servers: servers.sort((a, b) => a.fullVersion.localeCompare(b.fullVersion)),
+    servers,
   };
 }


### PR DESCRIPTION
To facilitate destructive migrations, e.g. columns or tables being deleted, by adding a mechanism to ascertain when all server instances of a previous version have stopped after a rolling deploy.

As an example `4.1.10` currently writes to token lookup tables and reads from them (depending on server configuration). In version `4.2.x`, it will not be possible to read from token lookup tables; they have been deprecated. Ideally, a post-deploy migration added in `v4.2.0` would be able to delete the token lookup tables, but for any deployment of Medplum utilizing rolling deploys as is advised, this would lead to errors during the rolling deploy window since the old server instance would still be attempting to write to the tables deleted in the `v4.2.0` post-deploy migration. If server registry information were available, `4.2.0` could delay running the post-deploy migration until it know with certainty that all old server instances had stopped. 

[Demo video](https://www.loom.com/share/1605f26b6f2444f590d7d45393b462e6?sid=dfa8b1f5-0a38-4728-8ebb-7320ec84a3aa) of a prototype of this system in action.

While this isn't being used directly right now, start having the data collected now so that it can be relied on in future minor versions.