### PR TITLE
Duplicate SMART well-known routes

### DIFF
--- a/packages/server/src/fhir/routes.ts
+++ b/packages/server/src/fhir/routes.ts
@@ -134,6 +134,8 @@ publicRoutes.get('/([$]|%24)versions', (_req: Request, res: Response) => {
 });
 
 // SMART-on-FHIR configuration
+// Medplum hosts the SMART well-known both at the root and at the /fhir/R4 paths.
+// See: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#sample-request
 publicRoutes.get('/.well-known/smart-configuration', smartConfigurationHandler);
 publicRoutes.get('/.well-known/smart-styles.json', smartStylingHandler);
 

--- a/packages/server/src/wellknown.ts
+++ b/packages/server/src/wellknown.ts
@@ -1,6 +1,7 @@
 import { OAuthGrantType, OAuthTokenAuthMethod } from '@medplum/core';
 import { Request, Response, Router } from 'express';
 import { getConfig } from './config/loader';
+import { smartConfigurationHandler, smartStylingHandler } from './fhir/smart';
 import { getJwks } from './oauth/keys';
 
 export const wellKnownRouter = Router();
@@ -52,3 +53,9 @@ function handleOauthProtectedResource(_req: Request, res: Response): void {
 wellKnownRouter.get('/oauth-authorization-server', handleOAuthConfig);
 wellKnownRouter.get('/openid-configuration', handleOAuthConfig);
 wellKnownRouter.get('/oauth-protected-resource', handleOauthProtectedResource);
+
+// SMART-on-FHIR configuration
+// Medplum hosts the SMART well-known both at the root and at the /fhir/R4 paths.
+// See: https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#sample-request
+wellKnownRouter.get('/smart-configuration', smartConfigurationHandler);
+wellKnownRouter.get('/smart-styles.json', smartStylingHandler);


### PR DESCRIPTION
Host SMART configuration at both server root and FHIR root for maximum compatibility. The SMART App Launch spec doesn't explicitly specify which location is canonical, leading to different implementations across vendors:
- Some servers (like Epic) serve it at the OAuth server root (/)
- Others serve it at the FHIR endpoint root (/fhir/R4/)
- Apps may look for it at either location depending on their implementation

By serving identical content at both endpoints, we ensure compatibility with all SMART client implementations while maintaining spec compliance.

See discussion: https://github.com/medplum/medplum/discussions/6647