### PR TITLE
Added isError util for cross-realm check

### DIFF
--- a/packages/core/src/outcomes.test.ts
+++ b/packages/core/src/outcomes.test.ts
@@ -11,6 +11,7 @@ import {
   gone,
   isAccepted,
   isCreated,
+  isError,
   isGone,
   isNotFound,
   isOk,
@@ -122,6 +123,15 @@ describe('Outcomes', () => {
     expect(normalizeErrorString({ resourceType: 'OperationOutcome' })).toBe('Unknown error');
     expect(normalizeErrorString({ foo: 'bar' })).toBe('{"foo":"bar"}');
     expect(normalizeErrorString({ code: 'ERR_INVALID_ARG_TYPE' })).toBe('ERR_INVALID_ARG_TYPE');
+  });
+
+  test('isError', () => {
+    expect(isError(undefined)).toBe(false);
+    expect(isError(null)).toBe(false);
+    expect(isError('foo')).toBe(false);
+    expect(isError({ resourceType: 'Patient' })).toBe(false);
+    expect(isError(new Error('foo'))).toBe(true);
+    expect(isError(new DOMException('foo'))).toBe(true);
   });
 
   test('isOperationOutcome', () => {

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -1,5 +1,6 @@
 import { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { Constraint } from './typeschema/types';
+import { isError } from './utils';
 
 const OK_ID = 'ok';
 const CREATED_ID = 'created';
@@ -419,7 +420,7 @@ export function normalizeErrorString(error: unknown): string {
   if (typeof error === 'string') {
     return error;
   }
-  if (error instanceof Error) {
+  if (isError(error)) {
     return error.message;
   }
   if (isOperationOutcome(error)) {

--- a/packages/core/src/outcomes.ts
+++ b/packages/core/src/outcomes.ts
@@ -1,6 +1,5 @@
 import { OperationOutcome, OperationOutcomeIssue } from '@medplum/fhirtypes';
 import { Constraint } from './typeschema/types';
-import { isError } from './utils';
 
 const OK_ID = 'ok';
 const CREATED_ID = 'created';
@@ -298,6 +297,33 @@ export function redirect(url: URL): OperationOutcome {
       },
     ],
   };
+}
+
+/**
+ * Returns true if the input is an Error object.
+ * This should be replaced with `Error.isError` when it is more widely supported.
+ * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError
+ * @param value - The candidate value.
+ * @returns True if the input is an Error object.
+ */
+export function isError(value: unknown): value is Error {
+  // Quick type check
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  // Fast path for same-realm errors using instanceof
+  if (value instanceof Error) {
+    return true;
+  }
+
+  // Handle DOMException case
+  if (typeof DOMException !== 'undefined' && value instanceof DOMException) {
+    return true;
+  }
+
+  // Cross-realm check using toString (most reliable method)
+  return Object.prototype.toString.call(value) === '[object Error]';
 }
 
 export function isOperationOutcome(value: unknown): value is OperationOutcome {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -786,33 +786,6 @@ export function isObject(obj: unknown): obj is Record<string, unknown> {
 }
 
 /**
- * Returns true if the input is an Error object.
- * This should be replaced with `Error.isError` when it is more widely supported.
- * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError
- * @param value - The candidate value.
- * @returns True if the input is an Error object.
- */
-export function isError(value: unknown): value is Error {
-  // Quick type check
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  // Fast path for same-realm errors using instanceof
-  if (value instanceof Error) {
-    return true;
-  }
-
-  // Handle DOMException case
-  if (typeof DOMException !== 'undefined' && value instanceof DOMException) {
-    return true;
-  }
-
-  // Cross-realm check using toString (most reliable method)
-  return Object.prototype.toString.call(value) === '[object Error]';
-}
-
-/**
  * Returns true if the input array is an array of strings.
  * @param arr - Input array.
  * @returns True if the input array is an array of strings.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -786,6 +786,33 @@ export function isObject(obj: unknown): obj is Record<string, unknown> {
 }
 
 /**
+ * Returns true if the input is an Error object.
+ * This should be replaced with `Error.isError` when it is more widely supported.
+ * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError
+ * @param value - The candidate value.
+ * @returns True if the input is an Error object.
+ */
+export function isError(value: unknown): value is Error {
+  // Quick type check
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  // Fast path for same-realm errors using instanceof
+  if (value instanceof Error) {
+    return true;
+  }
+
+  // Handle DOMException case
+  if (typeof DOMException !== 'undefined' && value instanceof DOMException) {
+    return true;
+  }
+
+  // Cross-realm check using toString (most reliable method)
+  return Object.prototype.toString.call(value) === '[object Error]';
+}
+
+/**
  * Returns true if the input array is an array of strings.
  * @param arr - Input array.
  * @returns True if the input array is an array of strings.

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -270,7 +270,9 @@ describe('Email', () => {
           },
         ],
       })
-    ).rejects.toThrow('Invalid email options: ERR_INVALID_ARG_TYPE');
+    ).rejects.toThrow(
+      'Invalid email options: The "chunk" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object'
+    );
 
     expect(mockSESv2Client.send.callCount).toBe(0);
     expect(mockSESv2Client).toHaveReceivedCommandTimes(SendEmailCommand, 0);


### PR DESCRIPTION
Extracted from: https://github.com/medplum/medplum/pull/6648

Before:  When an `Error` is thrown from inside a VMContext bot, that `Error` instance is from a different Node.js "realm", which means it would fail the `error instanceof Error` check, and then we would not get the proper error message.

After:  Added a new `isError()` utility which handles this.

Note: There is a spec for a proper `Error.isErrror()` utility, but it is not available until Node.js 24.  We should use that when it is reliably available.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError