### PR TITLE
test(fhircast): fix flaky timing check

### DIFF
--- a/packages/server/src/fhircast/websocket.test.ts
+++ b/packages/server/src/fhircast/websocket.test.ts
@@ -895,7 +895,7 @@ describe('FHIRcast WebSocket', () => {
                 const endTime = Date.now();
 
                 // setInterval doesn't guarantee a minimum time between executions, so we give a little leniency for the 100ms
-                expect(endTime - startTime).toBeGreaterThanOrEqual(90);
+                expect(endTime - startTime).toBeGreaterThanOrEqual(80);
               })
               // We're just expecting the two calls we already caught in the above exec
               .expectJson((obj) => {


### PR DESCRIPTION
Fixes flaky test by allowing for more wiggle room in early execution of callback in setTimeout. See:
https://github.com/medplum/medplum/actions/runs/15833501634/job/44631749339?pr=6845