### PR TITLE
Fix mocked `dataVersion` tests

### DIFF
--- a/packages/server/src/database.test.ts
+++ b/packages/server/src/database.test.ts
@@ -15,6 +15,10 @@ import {
   releaseAdvisoryLock,
 } from './database';
 import { GetDataVersionSql, GetVersionSql } from './migration-sql';
+import { getLatestPostDeployMigrationVersion } from './migrations/migration-versions';
+
+// This isn't really a mocked value, but it must be named that way to appease jest
+const latestVersion = getLatestPostDeployMigrationVersion();
 
 describe('Database config', () => {
   let poolSpy: jest.SpyInstance<pg.Pool, [config?: pg.PoolConfig | undefined]>;
@@ -44,7 +48,7 @@ describe('Database config', () => {
             result.rows = [{ pg_try_advisory_lock: advisoryLockResponse } as unknown as R];
           }
           if (sql === mockQueries.GetDataVersionSql) {
-            result.rows = [{ dataVersion: 1 } as unknown as R];
+            result.rows = [{ dataVersion: latestVersion } as unknown as R];
           }
 
           return result;

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -2,6 +2,11 @@ import http from 'node:http';
 import { shutdownApp } from './app';
 import { main } from './index';
 import { GetDataVersionSql, GetVersionSql } from './migration-sql';
+import { getLatestPostDeployMigrationVersion } from './migrations/migration-versions';
+
+// This isn't really a mocked value, but it must be named that way to appease jest
+// If we followed the same mocking pattern as `database.test.ts`, this wouldn't be necessary
+const mockLatestVersion = getLatestPostDeployMigrationVersion();
 
 jest.mock('express', () => {
   const original = jest.requireActual('express');
@@ -34,7 +39,7 @@ jest.mock('pg', () => {
         return { rows: [{ version: 1000000 }] };
       }
       if (sql === mockQueries.GetDataVersionSql) {
-        return { rows: [{ dataVersion: 1 }] };
+        return { rows: [{ dataVersion: mockLatestVersion }] };
       }
       if (sql.startsWith('SELECT "User"."id"')) {
         return { rows: [{ id: '1', content: '{}' }] };

--- a/packages/server/test.config.json
+++ b/packages/server/test.config.json
@@ -27,7 +27,7 @@
   "database": {
     "host": "localhost",
     "port": 5432,
-    "dbname": "medplum",
+    "dbname": "medplum_test",
     "username": "medplum",
     "password": "medplum",
     "disableRunPostDeployMigrations": true


### PR DESCRIPTION
The previous hard-coded `1` was a ticking time bomb for the `4.2.0` release. The mocked value wasn't relevant to the tests it was causing to fail: https://github.com/medplum/medplum/actions/runs/15911694790/job/44880758363?pr=6877