### PR TITLE
Provider - use threads/topics to fetch messages

### DIFF
--- a/examples/medplum-provider/src/components/messages/ChatList.tsx
+++ b/examples/medplum-provider/src/components/messages/ChatList.tsx
@@ -15,17 +15,18 @@ interface ChatListProps {
 export const ChatList = (props: ChatListProps): JSX.Element => {
   const { communications, selectedCommunication, onClick } = props;
   const medplum = useMedplum();
-  const [lastCommunications, setLastCommunications] = useState<{ id: string, communication: Communication }[] | undefined>(undefined);
+  const [lastCommunications, setLastCommunications] = useState<
+    { id: string; communication: Communication }[] | undefined
+  >(undefined);
 
   useEffect(() => {
-
     const fetchLastCommunications = async (): Promise<void> => {
       const communicationReferences = communications.map((communication) => createReference(communication));
       const allCommunications = await medplum.graphql(`
         query {
           CommunicationList(
             _sort: "-sent"
-            _filter: "part-of eq ${communicationReferences.map(ref => getReferenceString(ref)).join(' or part-of eq ')}"
+            _filter: "part-of eq ${communicationReferences.map((ref) => getReferenceString(ref)).join(' or part-of eq ')}"
           ) {
             id
             partOf {
@@ -41,24 +42,22 @@ export const ChatList = (props: ChatListProps): JSX.Element => {
       const lastCommunications = allCommunications.data.CommunicationList.map((communication: Communication) => {
         return {
           id: communication.partOf?.[0]?.reference?.split('/')[1],
-          communication: communication
+          communication: communication,
         };
       });
 
       setLastCommunications(lastCommunications);
-    }
+    };
 
     fetchLastCommunications().catch((error) => {
       showErrorNotification(error);
     });
-
   }, [communications, medplum]);
-
 
   return (
     <Stack gap={0} p="xs">
       {communications.map((communication: Communication) => {
-        const lastCommunication = lastCommunications?.find(lc => lc.id === communication.id)?.communication;
+        const lastCommunication = lastCommunications?.find((lc) => lc.id === communication.id)?.communication;
         if (!lastCommunication) {
           return null;
         }

--- a/examples/medplum-provider/src/components/messages/ChatList.tsx
+++ b/examples/medplum-provider/src/components/messages/ChatList.tsx
@@ -5,18 +5,18 @@ import { ChatListItem } from './ChatListItem';
 
 interface ChatListProps {
   communications: Communication[];
-  selectedPatient: Reference<Patient>;
-  onClick: (patient: Reference<Patient>) => void;
+  selectedCommunication: Communication | undefined;
+  onClick: (communication: Communication) => void;
 }
 
 export const ChatList = (props: ChatListProps): JSX.Element => {
-  const { communications, selectedPatient, onClick } = props;
+  const { communications, selectedCommunication, onClick } = props;
 
   return (
     <Stack gap={0} p="xs">
       {communications.map((communication: Communication) => {
         const patient = communication.subject as Reference<Patient>;
-        const _isSelected = selectedPatient.reference === patient.reference;
+        const _isSelected = selectedCommunication?.id === communication.id;
         return (
           <ChatListItem
             key={communication.id}
@@ -24,7 +24,7 @@ export const ChatList = (props: ChatListProps): JSX.Element => {
             communication={communication}
             isSelected={_isSelected}
             onClick={() => {
-              onClick(patient);
+              onClick(communication);
             }}
           />
         );

--- a/examples/medplum-provider/src/components/messages/ChatList.tsx
+++ b/examples/medplum-provider/src/components/messages/ChatList.tsx
@@ -1,7 +1,10 @@
 import { Stack } from '@mantine/core';
-import { Communication, Patient, Reference } from '@medplum/fhirtypes';
-import { JSX } from 'react';
+import { Communication } from '@medplum/fhirtypes';
+import { JSX, useEffect, useState } from 'react';
 import { ChatListItem } from './ChatListItem';
+import { createReference, getReferenceString } from '@medplum/core';
+import { useMedplum } from '@medplum/react';
+import { showErrorNotification } from '../../utils/notifications';
 
 interface ChatListProps {
   communications: Communication[];
@@ -11,17 +14,60 @@ interface ChatListProps {
 
 export const ChatList = (props: ChatListProps): JSX.Element => {
   const { communications, selectedCommunication, onClick } = props;
+  const medplum = useMedplum();
+  const [lastCommunications, setLastCommunications] = useState<{ id: string, communication: Communication }[] | undefined>(undefined);
+
+  useEffect(() => {
+
+    const fetchLastCommunications = async (): Promise<void> => {
+      const communicationReferences = communications.map((communication) => createReference(communication));
+      const allCommunications = await medplum.graphql(`
+        query {
+          CommunicationList(
+            _sort: "-sent"
+            _filter: "part-of eq ${communicationReferences.map(ref => getReferenceString(ref)).join(' or part-of eq ')}"
+          ) {
+            id
+            partOf {
+              reference
+            }
+            payload {
+              contentString
+            }
+            status
+          }
+        }
+      `);
+      const lastCommunications = allCommunications.data.CommunicationList.map((communication: Communication) => {
+        return {
+          id: communication.partOf?.[0]?.reference?.split('/')[1],
+          communication: communication
+        };
+      });
+
+      setLastCommunications(lastCommunications);
+    }
+
+    fetchLastCommunications().catch((error) => {
+      showErrorNotification(error);
+    });
+
+  }, [communications, medplum]);
+
 
   return (
     <Stack gap={0} p="xs">
       {communications.map((communication: Communication) => {
-        const patient = communication.subject as Reference<Patient>;
+        const lastCommunication = lastCommunications?.find(lc => lc.id === communication.id)?.communication;
+        if (!lastCommunication) {
+          return null;
+        }
         const _isSelected = selectedCommunication?.id === communication.id;
         return (
           <ChatListItem
             key={communication.id}
-            patient={patient}
-            communication={communication}
+            topic={communication}
+            lastCommunication={lastCommunication}
             isSelected={_isSelected}
             onClick={() => {
               onClick(communication);

--- a/examples/medplum-provider/src/components/messages/ChatListItem.tsx
+++ b/examples/medplum-provider/src/components/messages/ChatListItem.tsx
@@ -7,23 +7,23 @@ import classes from './ChatListItem.module.css';
 import cx from 'clsx';
 
 interface ChatListItemProps {
-  communication: Communication;
-  patient: Reference<Patient>;
+  topic: Communication;
+  lastCommunication: Communication | undefined;
   isSelected: boolean;
   onClick: () => void;
 }
 
 export const ChatListItem = (props: ChatListItemProps): JSX.Element => {
-  const { communication, patient, isSelected, onClick } = props;
-  const patientResource = useResource(patient);
+  const { topic, lastCommunication, isSelected, onClick } = props;
+  const patientResource = useResource(topic.subject as Reference<Patient>);
   const patientName = formatHumanName(patientResource?.name?.[0] as HumanName);
-  const lastMsg = communication.payload?.[0]?.contentString || 'No preview';
+  const lastMsg = lastCommunication?.payload?.[0]?.contentString || 'No preview';
   const content = lastMsg.length > 100 ? lastMsg.slice(0, 100) + '...' : lastMsg;
 
   return (
     <Group
       p="xs"
-      key={patient.reference}
+      key={topic.id}
       align="center"
       wrap="nowrap"
       className={cx(classes.contentContainer, {
@@ -31,7 +31,7 @@ export const ChatListItem = (props: ChatListItemProps): JSX.Element => {
       })}
       onClick={onClick}
     >
-      <ResourceAvatar value={{ reference: patient.reference }} radius="xl" size={36} />
+      <ResourceAvatar value={topic.subject as Reference<Patient>} radius="xl" size={36} />
       <Stack gap={0}>
         <Text size="sm" fw={700} truncate="end">
           {patientName}
@@ -40,7 +40,7 @@ export const ChatListItem = (props: ChatListItemProps): JSX.Element => {
           {content}
         </Text>
         <Text size="xs" c="gray.6" style={{ marginTop: 2 }}>
-          {formatDateTime(communication.sent)}
+          {lastCommunication ? formatDateTime(lastCommunication.sent) : ''}
         </Text>
       </Stack>
     </Group>

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -1,10 +1,9 @@
 import { ScrollArea, Text, Loader, Grid, Flex, Paper, Group } from '@mantine/core';
 import { Communication, Patient, Reference } from '@medplum/fhirtypes';
-import { useMedplum, BaseChat, PatientSummary, useMedplumProfile } from '@medplum/react';
-import { JSX, useEffect, useState, useMemo, useCallback } from 'react';
-import { createReference, getReferenceString } from '@medplum/core';
+import { useMedplum, PatientSummary, ThreadChat } from '@medplum/react';
+import { JSX, useEffect, useState } from 'react';
+import { getReferenceString } from '@medplum/core';
 import { ChatList } from '../../components/messages/ChatList';
-import { showNotification } from '@mantine/notifications';
 import { showErrorNotification } from '../../utils/notifications';
 
 /**
@@ -14,70 +13,26 @@ import { showErrorNotification } from '../../utils/notifications';
 export function MessagesPage(): JSX.Element {
   const medplum = useMedplum();
   const [loading, setLoading] = useState(false);
-  const [selectedPatient, setSelectedPatient] = useState<Reference<Patient> | undefined>(undefined);
-  const [inProgressCommunications, setInProgressCommunications] = useState<Communication[]>([]);
+  const [selectedThread, setSelectedThread] = useState<Communication | undefined>(undefined);
   const [threadMessages, setThreadMessages] = useState<Communication[]>([]);
-  const profile = useMedplumProfile();
-  const profileRef = useMemo(() => (profile ? createReference(profile) : undefined), [profile]);
 
   useEffect(() => {
     async function fetchAllCommunications(): Promise<void> {
-      if (selectedPatient) {
+      if (selectedThread) {
         return;
       }
-
       const searchParams = new URLSearchParams();
       searchParams.append('_sort', '-sent');
-      searchParams.append('received:missing', 'true');
+      searchParams.append('part-of:missing', 'true');
       const searchResult = await medplum.searchResources('Communication', searchParams, { cache: 'no-cache' });
+      setThreadMessages(searchResult);
 
-      const threads: Communication[] = [];
-      const threadMap: Set<string> = new Set<string>();
-      searchResult.forEach((c) => {
-        if (c.subject?.reference && !threadMap.has(c.subject.reference)) {
-          threadMap.add(c.subject.reference);
-          threads.push(c);
-        }
-      });
-
-      setInProgressCommunications(threads);
-
-      if (threads.length > 0) {
-        setSelectedPatient(threads[0].subject as Reference<Patient>);
+      if (searchResult.length > 0) {
+        setSelectedThread(searchResult[0]);
       }
     }
-    fetchAllCommunications().catch(() => setLoading(false));
-  }, [medplum, selectedPatient]);
-
-  const sendMessage = useCallback(
-    (message: string) => {
-      if (!selectedPatient) {
-        showNotification({
-          title: 'No patient selected',
-          message: 'Please select a patient to send a message',
-          color: 'red',
-        });
-        return;
-      }
-
-      if (!profileRef) {
-        return;
-      }
-
-      medplum
-        .createResource<Communication>({
-          resourceType: 'Communication',
-          status: 'in-progress',
-          sender: profileRef,
-          subject: selectedPatient,
-          recipient: [selectedPatient],
-          sent: new Date().toISOString(),
-          payload: [{ contentString: message }],
-        })
-        .catch(showErrorNotification);
-    },
-    [medplum, selectedPatient, profileRef]
-  );
+    fetchAllCommunications().catch(showErrorNotification);
+  }, [medplum, selectedThread]);
 
   return (
     <Grid style={{ display: 'flex', height: 'calc(100vh - 60px)' }}>
@@ -95,13 +50,12 @@ export function MessagesPage(): JSX.Element {
                 <Loader />
               </Flex>
             ) : (
-              selectedPatient && (
+              threadMessages.length > 0 && (
                 <ChatList
-                  communications={inProgressCommunications}
-                  selectedPatient={selectedPatient}
-                  onClick={(patient) => {
-                    setThreadMessages([]);
-                    setSelectedPatient(patient);
+                  communications={threadMessages}
+                  selectedCommunication={selectedThread}
+                  onClick={(thread) => {
+                    setSelectedThread(thread);
                   }}
                 />
               )
@@ -112,27 +66,16 @@ export function MessagesPage(): JSX.Element {
 
       {/* Main chat area */}
       <Grid.Col span={6} h="100%">
-        {selectedPatient ? (
-          <BaseChat
-            key={`${getReferenceString(selectedPatient)}`}
-            title={'Messages'}
-            communications={threadMessages}
-            setCommunications={setThreadMessages}
-            query={`subject=${getReferenceString(selectedPatient)}`}
-            sendMessage={sendMessage}
-          />
-        ) : (
-          <div style={{ background: 'white', height: '100%' }}>
-            <Text>Select a patient to start a conversation</Text>
-          </div>
+        {selectedThread && (
+          <ThreadChat key={`${getReferenceString(selectedThread)}`} title={'Messages'} thread={selectedThread} />
         )}
       </Grid.Col>
 
       {/* Right sidebar - Patient summary */}
       <Grid.Col span={3} h="100%">
-        {selectedPatient && (
-          <ScrollArea h="100%" scrollbarSize={10} type="hover" scrollHideDelay={250}>
-            <PatientSummary key={selectedPatient.id} patient={selectedPatient} />
+        {selectedThread && (
+          <ScrollArea p={0} h="100%" scrollbarSize={10} type="hover" scrollHideDelay={250}>
+            <PatientSummary key={selectedThread.id} patient={selectedThread.subject as Reference<Patient>} />
           </ScrollArea>
         )}
       </Grid.Col>

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea, Text, Loader, Grid, Flex, Paper, Group } from '@mantine/core';
+import { ScrollArea, Text, Loader, Grid, Paper, Group } from '@mantine/core';
 import { Communication, Patient, Reference } from '@medplum/fhirtypes';
 import { useMedplum, PatientSummary, ThreadChat } from '@medplum/react';
 import { JSX, useEffect, useState } from 'react';
@@ -31,7 +31,10 @@ export function MessagesPage(): JSX.Element {
         setSelectedThread(searchResult[0]);
       }
     }
-    fetchAllCommunications().catch(showErrorNotification);
+    setLoading(true);
+    fetchAllCommunications().catch(showErrorNotification).finally(() => {
+      setLoading(false);
+    });
   }, [medplum, selectedThread]);
 
   return (
@@ -46,9 +49,9 @@ export function MessagesPage(): JSX.Element {
               </Text>
             </Group>
             {loading ? (
-              <Flex h="100%" align="center" justify="center">
+              <Group h="100%" align="center" justify="center">
                 <Loader />
-              </Flex>
+              </Group>
             ) : (
               threadMessages.length > 0 && (
                 <ChatList

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -32,9 +32,11 @@ export function MessagesPage(): JSX.Element {
       }
     }
     setLoading(true);
-    fetchAllCommunications().catch(showErrorNotification).finally(() => {
-      setLoading(false);
-    });
+    fetchAllCommunications()
+      .catch(showErrorNotification)
+      .finally(() => {
+        setLoading(false);
+      });
   }, [medplum, selectedThread]);
 
   return (


### PR DESCRIPTION
- Fetch messages that do not have a part-of. To be treated as topic or root message.
- Fetch last messages of each 'topic'.
- Display only topics that have messages.

<img width="1381" alt="Screenshot 2025-06-26 at 5 48 14 PM" src="https://github.com/user-attachments/assets/4937dd96-0ed9-440c-964b-e7fb16a400cb" />

