### PR TITLE
fix(ci): fix linux agent publish; no git hash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -321,12 +321,12 @@ jobs:
               repo: context.repo.repo,
               release_id: release.data.id,
               name: "medplum-agent-" + packageJson.version + "-linux-${{ matrix.arch.suffix }}",
-              data: await fs.readFileSync(`packages/agent/medplum-agent-${packageJson.version}-${process.env.MEDPLUM_GIT_SHORTHASH}-linux`)
+              data: await fs.readFileSync(`packages/agent/medplum-agent-${packageJson.version}-linux`)
             });
             await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
               name: "medplum-agent-" + packageJson.version + "-linux-${{ matrix.arch.suffix }}.sha256",
-              data: await fs.readFileSync(`packages/agent/medplum-agent-${packageJson.version}-${process.env.MEDPLUM_GIT_SHORTHASH}-linux.sha256`)
+              data: await fs.readFileSync(`packages/agent/medplum-agent-${packageJson.version}-linux.sha256`)
             });


### PR DESCRIPTION
v4.2.3 Windows agent succeeded finally:
<img width="1318" alt="Screenshot 2025-06-27 at 10 34 17 PM" src="https://github.com/user-attachments/assets/f7d3f2c3-a12f-464d-8106-aebe031ee611" /> 

but Linux agent failed...

<img width="1318" alt="Screenshot 2025-06-27 at 10 34 05 PM" src="https://github.com/user-attachments/assets/873d8d12-9658-4b04-842c-3f556d1266b9" />

There is no git hash in the Linux file name:
<img width="1318" alt="Screenshot 2025-06-27 at 10 31 29 PM" src="https://github.com/user-attachments/assets/bdda9894-409f-4276-a638-788e810ce40d" />

