### PR TITLE
Minor CapabilityStatement updates

### DIFF
--- a/packages/server/src/fhir/metadata.ts
+++ b/packages/server/src/fhir/metadata.ts
@@ -3,6 +3,7 @@ import {
   ContentType,
   getAllDataTypes,
   getSearchParameters,
+  HTTP_TERMINOLOGY_HL7_ORG,
   InternalTypeSchema,
   isResourceType,
   MEDPLUM_VERSION,
@@ -241,7 +242,7 @@ function buildSecurity(config: MedplumServerConfig): CapabilityStatementRestSecu
     service: ['OAuth', 'Basic', 'SMART-on-FHIR'].map((service) => ({
       coding: [
         {
-          system: 'http://terminology.hl7.org/CodeSystem/restful-security-service',
+          system: HTTP_TERMINOLOGY_HL7_ORG + '/CodeSystem/restful-security-service',
           code: service,
         },
       ],

--- a/packages/server/src/fhir/metadata.ts
+++ b/packages/server/src/fhir/metadata.ts
@@ -1,4 +1,12 @@
-import { ContentType, getAllDataTypes, getSearchParameters, InternalTypeSchema, isResourceType } from '@medplum/core';
+import {
+  concatUrls,
+  ContentType,
+  getAllDataTypes,
+  getSearchParameters,
+  InternalTypeSchema,
+  isResourceType,
+  MEDPLUM_VERSION,
+} from '@medplum/core';
 import {
   CapabilityStatement,
   CapabilityStatementRest,
@@ -17,12 +25,11 @@ import { MedplumServerConfig } from '../config/types';
 const baseStmt: CapabilityStatement = {
   resourceType: 'CapabilityStatement',
   id: 'medplum-server',
-  url: 'http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server',
-  version: '0.9.34',
+  version: MEDPLUM_VERSION,
   name: 'MedplumCapabilityStatement',
   title: 'Medplum Capability Statement',
   status: 'active',
-  date: '2022-09-02',
+  date: new Date().toISOString(),
   publisher: 'Medplum',
   contact: [
     {
@@ -183,11 +190,11 @@ export function getCapabilityStatement(): CapabilityStatement {
 
 function buildCapabilityStatement(): CapabilityStatement {
   const name = 'medplum';
-  const version = baseStmt.version;
+  const version = MEDPLUM_VERSION;
   const config = getConfig();
   const baseUrl = config.baseUrl;
-  const fhirBaseUrl = baseUrl + 'fhir/R4/';
-  const metadataUrl = fhirBaseUrl + 'metadata';
+  const fhirBaseUrl = concatUrls(baseUrl, 'fhir/R4/');
+  const metadataUrl = concatUrls(fhirBaseUrl, 'metadata');
 
   return {
     ...baseStmt,
@@ -230,6 +237,15 @@ function buildRest(config: MedplumServerConfig): CapabilityStatementRest[] {
 
 function buildSecurity(config: MedplumServerConfig): CapabilityStatementRestSecurity {
   return {
+    cors: true,
+    service: ['OAuth', 'Basic', 'SMART-on-FHIR'].map((service) => ({
+      coding: [
+        {
+          system: 'http://terminology.hl7.org/CodeSystem/restful-security-service',
+          code: service,
+        },
+      ],
+    })),
     extension: [
       {
         url: 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',


### PR DESCRIPTION
1. Update `date` on every build
   * Definition: "The date (and optionally time) when the capability statement was published. The date must change when the business version changes and it must change if the status code changes. In addition, it should change when the substantive content of the capability statement changes."
2. Use `MEDPLUM_VERSION` for `version`
3. Use `concatUrls()` when dynamically constructing URL values
4. Added `security.cors`
5. Added `security.service`

--------

Side note: There's a big looming feature request here to make the `CapabilityStatement` customizable.

Options:
* **Configuration-Driven Overrides**: Allow customers to provide a concise configuration object with specific toggles (e.g., disable US Core profiles, add custom operations) and simple value overrides (e.g., publisher, contact), which Medplum's existing generation logic then applies.
* **Partial FHIR JSON Overlay**: Enable customers to provide a partial CapabilityStatement JSON object that is deeply merged with Medplum's dynamically generated base, offering granular control while still benefiting from Medplum's automatic feature additions.
* **JSON Patch Operations**: Offer advanced users the ability to supply a list of RFC 6902 JSON Patch operations to precisely modify any part of the dynamically generated CapabilityStatement, providing the highest level of control but with a steeper learning curve.
* **Total override**: Allow customers to just completely specify their own JSON in entirety.