### PR TITLE
Fixes #6913 - More security controls on public webhook bots

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -60543,6 +60543,10 @@
           "description": "Optional flag to indicate that the bot should be run as the user.",
           "$ref": "#/definitions/boolean"
         },
+        "publicWebhook": {
+          "description": "Optional flag to indicate that the bot can be used as an unauthenticated public webhook. Note that this is a security risk and should only be used for public bots that do not require authentication.",
+          "$ref": "#/definitions/boolean"
+        },
         "auditEventTrigger": {
           "description": "Criteria for creating an AuditEvent as a result of the bot invocation. Possible values are \u0027always\u0027, \u0027never\u0027, \u0027on-error\u0027, or \u0027on-output\u0027. Default value is \u0027always\u0027.",
           "enum": ["always", "never", "on-error", "on-output"]

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -2082,6 +2082,21 @@
             }
           },
           {
+            "id" : "Bot.publicWebhook",
+            "path" : "Bot.publicWebhook",
+            "definition" : "Optional flag to indicate that the bot can be used as an unauthenticated public webhook. Note that this is a security risk and should only be used for public bots that do not require authentication.",
+            "min" : 0,
+            "max" : "1",
+            "type" : [{
+              "code" : "boolean"
+            }],
+            "base" : {
+              "path" : "Bot.publicWebhook",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
             "id" : "Bot.auditEventTrigger",
             "path" : "Bot.auditEventTrigger",
             "definition" : "Criteria for creating an AuditEvent as a result of the bot invocation. Possible values are 'always', 'never', 'on-error', or 'on-output'. Default value is 'always'.",

--- a/packages/docs/static/data/medplumDefinitions/bot.json
+++ b/packages/docs/static/data/medplumDefinitions/bot.json
@@ -327,6 +327,22 @@
       "inherited": false
     },
     {
+      "name": "publicWebhook",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "boolean"
+        }
+      ],
+      "path": "Bot.publicWebhook",
+      "min": 0,
+      "max": "1",
+      "short": "",
+      "definition": "Optional flag to indicate that the bot can be used as an unauthenticated public webhook. Note that this is a security risk and should only be used for public bots that do not require authentication.",
+      "comment": "",
+      "inherited": false
+    },
+    {
       "name": "auditEventTrigger",
       "depth": 1,
       "types": [

--- a/packages/fhirtypes/dist/Bot.d.ts
+++ b/packages/fhirtypes/dist/Bot.d.ts
@@ -152,6 +152,14 @@ export interface Bot {
   runAsUser?: boolean;
 
   /**
+   * Optional flag to indicate that the bot can be used as an
+   * unauthenticated public webhook. Note that this is a security risk and
+   * should only be used for public bots that do not require
+   * authentication.
+   */
+  publicWebhook?: boolean;
+
+  /**
    * Criteria for creating an AuditEvent as a result of the bot invocation.
    * Possible values are 'always', 'never', 'on-error', or 'on-output'.
    * Default value is 'always'.

--- a/packages/mock/src/mocks/structuredefinitions.json
+++ b/packages/mock/src/mocks/structuredefinitions.json
@@ -12594,6 +12594,17 @@
           ]
         },
         {
+          "id": "Bot.publicWebhook",
+          "path": "Bot.publicWebhook",
+          "min": 0,
+          "max": "1",
+          "type": [
+            {
+              "code": "boolean"
+            }
+          ]
+        },
+        {
           "id": "Bot.auditEventTrigger",
           "path": "Bot.auditEventTrigger",
           "min": 0,

--- a/packages/server/src/webhook/routes.test.ts
+++ b/packages/server/src/webhook/routes.test.ts
@@ -1,5 +1,5 @@
-import { allOk, ContentType, WithId } from '@medplum/core';
-import { Bot, ProjectMembership } from '@medplum/fhirtypes';
+import { allOk, ContentType, createReference, WithId } from '@medplum/core';
+import { AccessPolicy, Bot, Project, ProjectMembership } from '@medplum/fhirtypes';
 import { randomUUID } from 'crypto';
 import express from 'express';
 import request from 'supertest';
@@ -27,6 +27,8 @@ exports.handler = async function (medplum, event) {
 
 describe('Anonymous webhooks', () => {
   let app: express.Express;
+  let project: WithId<Project>;
+  let accessPolicy: WithId<AccessPolicy>;
   let adminMembership: WithId<ProjectMembership>;
   let accessToken: string;
   let bot: WithId<Bot>;
@@ -44,7 +46,12 @@ describe('Anonymous webhooks', () => {
       withAccessToken: true,
       withClient: true,
       membership: { admin: true },
+      accessPolicy: {
+        resource: [{ resourceType: '*' }],
+      },
     });
+    project = testSetup.project;
+    accessPolicy = testSetup.accessPolicy;
     adminMembership = testSetup.membership;
     accessToken = testSetup.accessToken;
 
@@ -56,6 +63,7 @@ describe('Anonymous webhooks', () => {
       .send({
         name: 'Alice personal bot',
         description: 'Alice bot description',
+        accessPolicy: createReference(testSetup.accessPolicy),
       });
     expect(res1.status).toBe(201);
     expect(res1.body.resourceType).toBe('Bot');
@@ -81,7 +89,7 @@ describe('Anonymous webhooks', () => {
     expect(res3.body.entry.length).toBe(1);
     botMembership = res3.body.entry[0].resource as WithId<ProjectMembership>;
 
-    //Create a bot that returns a binary response with specified content type
+    // Create a bot that returns a binary response with specified content type
     const res4 = await request(app)
       .post('/admin/projects/' + testSetup.project.id + '/bot')
       .set('Authorization', 'Bearer ' + accessToken)
@@ -89,6 +97,7 @@ describe('Anonymous webhooks', () => {
       .send({
         name: 'Binary response bot',
         description: 'Binary response bot description',
+        accessPolicy: createReference(testSetup.accessPolicy),
       });
     expect(res4.status).toBe(201);
     expect(res4.body.resourceType).toBe('Bot');
@@ -113,6 +122,34 @@ describe('Anonymous webhooks', () => {
     expect(res6.body.entry).toBeDefined();
     expect(res6.body.entry.length).toBe(1);
     binaryResponseBotMembership = res6.body.entry[0].resource as WithId<ProjectMembership>;
+
+    // Update the bot to opt-in to public webhook access
+    const res7 = await request(app)
+      .patch(`/fhir/R4/Bot/${bot.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON_PATCH)
+      .send([
+        {
+          op: 'add',
+          path: '/publicWebhook',
+          value: true,
+        },
+      ]);
+    expect(res7.status).toBe(200);
+
+    // Do the same for the binary response bot
+    const res8 = await request(app)
+      .patch(`/fhir/R4/Bot/${binaryResponseBot.id}`)
+      .set('Content-Type', ContentType.FHIR_JSON)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send([
+        {
+          op: 'add',
+          path: '/publicWebhook',
+          value: true,
+        },
+      ]);
+    expect(res8.status).toBe(200);
   });
 
   afterAll(async () => {
@@ -124,7 +161,7 @@ describe('Anonymous webhooks', () => {
       .post(`/webhook/${botMembership.id}`)
       .set('Content-Type', ContentType.TEXT)
       .send('input');
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(403);
     expect(res.text).toStrictEqual('Missing required signature header');
   });
 
@@ -143,7 +180,7 @@ describe('Anonymous webhooks', () => {
       .set('Content-Type', ContentType.TEXT)
       .set('x-signature', 'signature')
       .send('input');
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(403);
     expect(res.text).toStrictEqual('ProjectMembership must be for a Bot resource');
   });
 
@@ -186,5 +223,85 @@ describe('Anonymous webhooks', () => {
     expect(res.status).toBe(200);
     expect(res.header['content-type']).toContain('text/xml');
     expect(res.text.trim()).toBe('<Response><Say>Hello, world!</Say></Response>');
+  });
+
+  test('Bot without publicWebhook flag', async () => {
+    const res1 = await request(app)
+      .post('/admin/projects/' + project.id + '/bot')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .type('json')
+      .send({
+        name: 'Alice personal bot',
+        description: 'Alice bot description',
+        accessPolicy: createReference(accessPolicy),
+      });
+    expect(res1.status).toBe(201);
+    expect(res1.body.resourceType).toBe('Bot');
+    expect(res1.body.id).toBeDefined();
+
+    const botWithoutPublicWebhook = res1.body as WithId<Bot>;
+
+    const res2 = await request(app)
+      .get(`/fhir/R4/ProjectMembership?profile=Bot/${botWithoutPublicWebhook.id}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toBe(200);
+    expect(res2.body.entry).toBeDefined();
+    expect(res2.body.entry.length).toBe(1);
+
+    const projectMembership = res2.body.entry[0].resource as WithId<ProjectMembership>;
+
+    const res3 = await request(app)
+      .post(`/webhook/${projectMembership.id}`)
+      .set('Content-Type', ContentType.TEXT)
+      .set('x-signature', 'signature')
+      .send('input');
+    expect(res3.status).toBe(403);
+    expect(res3.text).toStrictEqual('Bot is not configured for public webhook access');
+  });
+
+  test('Bot without access policy', async () => {
+    const res1 = await request(app)
+      .post('/admin/projects/' + project.id + '/bot')
+      .set('Authorization', 'Bearer ' + accessToken)
+      .type('json')
+      .send({
+        name: 'Alice personal bot',
+        description: 'Alice bot description',
+      });
+    expect(res1.status).toBe(201);
+    expect(res1.body.resourceType).toBe('Bot');
+    expect(res1.body.id).toBeDefined();
+
+    const botWithoutPublicWebhook = res1.body as WithId<Bot>;
+
+    const res2 = await request(app)
+      .get(`/fhir/R4/ProjectMembership?profile=Bot/${botWithoutPublicWebhook.id}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res2.status).toBe(200);
+    expect(res2.body.entry).toBeDefined();
+    expect(res2.body.entry.length).toBe(1);
+
+    const projectMembership = res2.body.entry[0].resource as WithId<ProjectMembership>;
+
+    const res3 = await request(app)
+      .patch(`/fhir/R4/Bot/${botWithoutPublicWebhook.id}`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .set('Content-Type', ContentType.JSON_PATCH)
+      .send([
+        {
+          op: 'add',
+          path: '/publicWebhook',
+          value: true,
+        },
+      ]);
+    expect(res3.status).toBe(200);
+
+    const res4 = await request(app)
+      .post(`/webhook/${projectMembership.id}`)
+      .set('Content-Type', ContentType.TEXT)
+      .set('x-signature', 'signature')
+      .send('input');
+    expect(res4.status).toBe(403);
+    expect(res4.text).toStrictEqual('ProjectMembership must have an Access Policy');
   });
 });

--- a/packages/server/src/webhook/routes.ts
+++ b/packages/server/src/webhook/routes.ts
@@ -35,7 +35,7 @@ export const webhookHandler = asyncWrap(async (req: Request, res: Response) => {
   // At least one of the allowed signature headers must be present
   const hasSignatureHeader = SIGNATURE_HEADERS.some((header) => req.header(header));
   if (!hasSignatureHeader) {
-    res.status(400).send('Missing required signature header');
+    res.status(403).send('Missing required signature header');
     return;
   }
 
@@ -45,11 +45,24 @@ export const webhookHandler = asyncWrap(async (req: Request, res: Response) => {
 
   // The ProjectMembership must be for a Bot resource
   if (!runAs.profile.reference?.startsWith('Bot/')) {
-    res.status(400).send('ProjectMembership must be for a Bot resource');
+    res.status(403).send('ProjectMembership must be for a Bot resource');
+    return;
+  }
+
+  // The ProjectMembership must have an Access Policy
+  if (!runAs.access && !runAs.accessPolicy) {
+    res.status(403).send('ProjectMembership must have an Access Policy');
     return;
   }
 
   const bot = await systemRepo.readReference<Bot>(runAs.profile as Reference<Bot>);
+
+  // The Bot must have a publicWebhook flag set to true
+  if (!bot.publicWebhook) {
+    res.status(403).send('Bot is not configured for public webhook access');
+    return;
+  }
+
   const headers = req.headers as Record<string, string>;
 
   // Execute the bot


### PR DESCRIPTION
2 changes to the public webhook flow:
1. Now requires that bots set `Bot.publicWebhook` to `true`
2. Now requires that the bot's `ProjectMembership` has an `AccessPolicy` (via either `ProjectMembership.access` or `ProjectMembership.accessPolicy`)

Fixes https://github.com/medplum/medplum/issues/6913