### PR TITLE
Fixes #1237 - matchesStringValue match on tokens

### DIFF
--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -1031,6 +1031,12 @@ describe('Search matching', () => {
         expect(matchesStringValue(token, '', false)).toBe(false);
       });
 
+      it('matches exact and substring for object types', () => {
+        expect(matchesStringValue({ foo: 'bar' }, 'foo', false)).toBe(true);
+        expect(matchesStringValue({ foo: 'bar' }, 'bar', false)).toBe(true);
+        expect(matchesStringValue({ foo: 'bar' }, '123', false)).toBe(false);
+      });
+
       describe('asToken = true', () => {
         it('matches exact and substring when found in system portion', () => {
           expect(matchesStringValue(token, 'example', true)).toBe(true);

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@medplum/fhirtypes';
 import { indexSearchParameterBundle } from '../types';
 import { indexStructureDefinitionBundle } from '../typeschema/types';
-import { matchesSearchRequest } from './match';
+import { matchesSearchRequest, matchesStringValue } from './match';
 import { Operator, SearchRequest, parseSearchRequest } from './search';
 
 // Dimensions:
@@ -1007,5 +1007,63 @@ describe('Search matching', () => {
       filters: [{ code: 'organization', operator: Operator.PRESENT, value: 'false' }],
     };
     expect(matchesSearchRequest(resource, search2)).toBe(false);
+  });
+
+  describe('Utils', () => {
+    describe('matchesStringValue', () => {
+      const token = 'http://example.com/mrn|12345';
+      const systemToken = 'http://example.com/mrn|';
+
+      it('matches exact and substring (case-insensitive)', () => {
+        expect(matchesStringValue('Foo Bar', 'bar')).toBe(true);
+        expect(matchesStringValue('FOO', 'foo')).toBe(true);
+        expect(matchesStringValue('foo', 'bar')).toBe(false);
+      });
+
+      it('matches token substring when asToken is false', () => {
+        expect(matchesStringValue(token, 'example', false)).toBe(true);
+        expect(matchesStringValue(token, '1234', false)).toBe(true);
+        expect(matchesStringValue(token, '5678', false)).toBe(false);
+      });
+
+      it('does not match when value is empty', () => {
+        expect(matchesStringValue('foo', '', false)).toBe(false);
+        expect(matchesStringValue(token, '', false)).toBe(false);
+      });
+
+      describe('asToken = true', () => {
+        it('matches exact and substring when found in system portion', () => {
+          expect(matchesStringValue(token, 'example', true)).toBe(true);
+          expect(matchesStringValue(token, 'http://example.com', true)).toBe(true);
+          expect(matchesStringValue(token, 'http://example.com/mrn', true)).toBe(true);
+          expect(matchesStringValue(token, 'mrn', true)).toBe(true);
+        });
+
+        it('matches exact and substring when found in code portion', () => {
+          expect(matchesStringValue(token, '123', true)).toBe(true);
+          expect(matchesStringValue(token, '12345', true)).toBe(true);
+        });
+
+        it('matches when value is found in both system and code', () => {
+          expect(matchesStringValue('http://12345.org|12345', '12345', true)).toBe(true);
+        });
+
+        it('does not match if neither system or code', () => {
+          expect(matchesStringValue(token, 'foo', true)).toBe(false);
+          expect(matchesStringValue(token, '456', true)).toBe(false);
+        });
+
+        it('handles tokens with no code portion', () => {
+          expect(matchesStringValue(systemToken, 'example', true)).toBe(true);
+          expect(matchesStringValue(systemToken, 'http://example.com/mrn', true)).toBe(true);
+          expect(matchesStringValue(systemToken, '1234', true)).toBe(false);
+        });
+
+        it('handles tokens with empty string', () => {
+          expect(matchesStringValue(token, '', true)).toBe(false);
+          expect(matchesStringValue(systemToken, '', true)).toBe(false);
+        });
+      });
+    });
   });
 });

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -133,7 +133,7 @@ function matchesStringFilter(
       } else if (searchParamElementType === PropertyType.CodeableConcept) {
         match = matchesTokenCodeableConceptValue(resourceValue as Coding, filter.operator, filterValue);
       } else {
-        match = matchesStringValue(resourceValue, filter.operator, filterValue, asToken);
+        match = matchesStringValue(resourceValue, filterValue, asToken);
       }
       if (match) {
         return !negated;
@@ -145,27 +145,28 @@ function matchesStringFilter(
   return negated;
 }
 
-function matchesStringValue(
-  resourceValue: unknown,
-  operator: Operator,
-  filterValue: string,
-  asToken?: boolean
-): boolean {
-  if (asToken && filterValue.includes('|')) {
-    const [system, code] = filterValue.split('|');
-    return (
-      matchesStringValue(resourceValue, operator, system, false) &&
-      (!code || matchesStringValue(resourceValue, operator, code, false))
-    );
+export function matchesStringValue(resourceValue: unknown, filterValue: string, asToken?: boolean): boolean {
+  // If the filter value is empty, then it does not match anything
+  if (filterValue === '') {
+    return false;
   }
+
+  if (asToken && typeof resourceValue === 'string' && resourceValue.includes('|')) {
+    const [system, code] = resourceValue.split('|');
+    // Match system or code (if code exists)
+    const systemMatches = matchesStringValue(system, filterValue, false);
+    const codeMatches = code ? matchesStringValue(code, filterValue, false) : false;
+
+    return systemMatches || codeMatches;
+  }
+
   let str = '';
-  if (resourceValue) {
-    if (typeof resourceValue === 'string') {
-      str = resourceValue;
-    } else if (typeof resourceValue === 'object') {
-      str = JSON.stringify(resourceValue);
-    }
+  if (typeof resourceValue === 'string') {
+    str = resourceValue;
+  } else if (typeof resourceValue === 'object') {
+    str = JSON.stringify(resourceValue);
   }
+
   return str.toLowerCase().includes(filterValue.toLowerCase());
 }
 

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -161,10 +161,12 @@ export function matchesStringValue(resourceValue: unknown, filterValue: string, 
   }
 
   let str = '';
-  if (typeof resourceValue === 'string') {
-    str = resourceValue;
-  } else if (typeof resourceValue === 'object') {
-    str = JSON.stringify(resourceValue);
+  if (resourceValue) {
+    if (typeof resourceValue === 'string') {
+      str = resourceValue;
+    } else if (typeof resourceValue === 'object') {
+      str = JSON.stringify(resourceValue);
+    }
   }
 
   return str.toLowerCase().includes(filterValue.toLowerCase());


### PR DESCRIPTION
Fixes #1237 

* Matches on system|code tokens
* Handles empty strings/falsy values
* Removed operator argument from `matchesStringValue` (wasn't used)
* Adds tests for `matchesStringValue`

#### Outstanding questions
* Do we need to trim whitespace for filters?
* Should tokens be exact match for either (otherwise includes should catch it)?