### PR TITLE
fix(cli/agent): `agent upgrade` - change flag to `--agentVersion`, add `--force`

### DIFF
--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -23,6 +23,7 @@ export type CallAgentBulkOperationArgs<T extends Record<string, string>, R exten
   operation: string;
   agentIds: string[];
   options: MedplumClientOptions & { criteria: string; output?: 'json' };
+  params?: Record<string, string | boolean | number>;
   parseSuccessfulResponse: (response: AgentBulkOpResponse<R>) => T;
 };
 
@@ -197,8 +198,12 @@ agentUpgradeCommand
     'An optional FHIR search criteria to resolve the agent(s) to upgrade. Mutually exclusive with [agentIds...] arg'
   )
   .option(
-    '--version <version>',
-    'An optional version to upgrade to. Defaults to the latest version if flag not included'
+    '--agentVersion <version>',
+    'An optional agent version to upgrade to. Defaults to the latest version if flag not included'
+  )
+  .option(
+    '--force',
+    'Used to force an upgrade in a scenario where a pending upgrade may have gotten into a bad state. USE AT YOUR OWN RISK!'
   )
   .addOption(
     new Option('--output <format>', 'An optional output format, defaults to table')
@@ -206,15 +211,24 @@ agentUpgradeCommand
       .default('table')
   )
   .action(async (agentIds, options) => {
+    const params: Record<string, string | boolean | number> = {};
+    if (options.agentVersion) {
+      params.version = options.agentVersion;
+    }
+    if (options.force) {
+      params.force = true;
+    }
+
     await callAgentBulkOperation({
       operation: '$upgrade',
       agentIds,
       options,
+      params,
       parseSuccessfulResponse: (response: AgentBulkOpResponse<OperationOutcome>) => {
         return {
           id: response.agent.id,
           name: response.agent.name,
-          version: options.version ?? 'latest',
+          version: options.agentVersion ?? 'latest',
         };
       },
     });
@@ -223,11 +237,20 @@ agentUpgradeCommand
 export async function callAgentBulkOperation<
   T extends Record<string, string>,
   R extends Parameters | OperationOutcome,
->({ operation, agentIds, options, parseSuccessfulResponse }: CallAgentBulkOperationArgs<T, R>): Promise<void> {
+>({
+  operation,
+  agentIds,
+  options,
+  params = {},
+  parseSuccessfulResponse,
+}: CallAgentBulkOperationArgs<T, R>): Promise<void> {
   const normalized = parseEitherIdsOrCriteria(agentIds, options);
   const medplum = await createMedplumClient(options);
   const usedCriteria = normalized.type === 'criteria' ? normalized.criteria : `Agent?_id=${normalized.ids.join(',')}`;
   const searchParams = new URLSearchParams(usedCriteria.split('?')[1]);
+  for (const [paramName, paramVal] of Object.entries(params)) {
+    searchParams.append(paramName, paramVal.toString());
+  }
 
   let result: Bundle<Parameters> | Parameters | OperationOutcome;
   try {

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -203,7 +203,7 @@ agentUpgradeCommand
   )
   .option(
     '--force',
-    'Used to force an upgrade in a scenario where a pending upgrade may have gotten into a bad state. USE AT YOUR OWN RISK!'
+    'Forces an upgrade when a pending upgrade is in an inconsistent state. Use with caution.'
   )
   .addOption(
     new Option('--output <format>', 'An optional output format, defaults to table')

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -201,10 +201,7 @@ agentUpgradeCommand
     '--agentVersion <version>',
     'An optional agent version to upgrade to. Defaults to the latest version if flag not included'
   )
-  .option(
-    '--force',
-    'Forces an upgrade when a pending upgrade is in an inconsistent state. Use with caution.'
-  )
+  .option('--force', 'Forces an upgrade when a pending upgrade is in an inconsistent state. Use with caution.')
   .addOption(
     new Option('--output <format>', 'An optional output format, defaults to table')
       .choices(['table', 'json'])


### PR DESCRIPTION
Fixes #6953 

Also enables using the `force` parameter on the `Agent/$upgrade` operation from the CLI