### PR TITLE
[CLI] Suppress dotenv tips

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -135,7 +135,7 @@ function writeErrorToStderr(err: unknown, verbose = false): void {
 }
 
 export async function run(): Promise<void> {
-  dotenv.config();
+  dotenv.config({ quiet: true });
   await main(process.argv);
 }
 


### PR DESCRIPTION
Update dotenv configuration in run function to suppress warnings

As of dotenv@17.0.0, the library has started emitting the following "tip" by default: 
`[dotenv@17.0.0] injecting env (13) from .env – 🔐 encrypt with dotenvx: `

This was creating problems for CLI users expecting a pure JSON response