### PR TITLE
Adjust serverVersion

### DIFF
--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -57,9 +57,9 @@
     "serverVersion": "4.3.0"
   },
   "v16": {
-    "serverVersion": "4.3.3"
+    "serverVersion": "4.3.2"
   },
   "v17": {
-    "serverVersion": "4.3.3"
+    "serverVersion": "4.3.2"
   }
 }


### PR DESCRIPTION
To avoid this migration from spinning with: `Post-deploy migration v17 delayed since the server cluster is not compatible`