### PR TITLE
Add Coding synonym reference column

### DIFF
--- a/packages/server/src/fhir/operations/utils/terminology.ts
+++ b/packages/server/src/fhir/operations/utils/terminology.ts
@@ -87,7 +87,7 @@ export function selectCoding(systemId: string, ...code: string[]): SelectQuery {
     .column('display')
     .where('system', '=', systemId)
     .where('code', 'IN', code)
-    .where('isSynonym', '=', false);
+    .where('synonymOf', '=', null);
 }
 
 export function addPropertyFilter(

--- a/packages/server/src/migrations/data/v18.ts
+++ b/packages/server/src/migrations/data/v18.ts
@@ -1,0 +1,26 @@
+import { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import { withLongRunningDatabaseClient } from '../migration-utils';
+import { MigrationActionResult } from '../types';
+import { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => {
+    return runCustomMigration(repo, job, jobData, async () => {
+      return withLongRunningDatabaseClient(async (client) => {
+        const results: MigrationActionResult[] = [];
+        await run(client, results);
+        return results;
+      });
+    });
+  },
+};
+
+// prettier-ignore
+async function run(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'Coding_system_code_primary_idx', `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "Coding_system_code_primary_idx" ON "Coding" ("system", "code") INCLUDE ("id") WHERE ("synonymOf" IS NULL)`);
+  await fns.query(client, results, `DROP INDEX CONCURRENTLY IF EXISTS "Coding_system_code_preferred_idx"`);
+}

--- a/packages/server/src/migrations/migrate.ts
+++ b/packages/server/src/migrations/migrate.ts
@@ -790,6 +790,7 @@ function buildCodingTable(result: SchemaDefinition): void {
       { name: 'code', type: 'TEXT', notNull: true },
       { name: 'display', type: 'TEXT' },
       { name: 'isSynonym', type: 'BOOLEAN', notNull: true },
+      { name: 'synonymOf', type: 'BIGINT' },
     ],
     indexes: [
       { columns: ['id'], indexType: 'btree', unique: true },
@@ -799,8 +800,8 @@ function buildCodingTable(result: SchemaDefinition): void {
         indexType: 'btree',
         unique: true,
         include: ['id'],
-        where: `"isSynonym" = false`,
-        indexNameSuffix: 'preferred_idx',
+        where: `"synonymOf" IS NULL`,
+        indexNameSuffix: 'primary_idx',
       },
       { columns: ['system', 'code', 'display'], indexType: 'btree', unique: true },
       { columns: ['system', { expression: 'display gin_trgm_ops', name: 'displayTrgm' }], indexType: 'gin' },

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -99,3 +99,4 @@ export * as v91 from './v91';
 export * as v92 from './v92';
 export * as v93 from './v93';
 export * as v94 from './v94';
+export * as v95 from './v95';

--- a/packages/server/src/migrations/schema/v95.ts
+++ b/packages/server/src/migrations/schema/v95.ts
@@ -1,0 +1,13 @@
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "Coding" ADD COLUMN IF NOT EXISTS "synonymOf" BIGINT`);
+}


### PR DESCRIPTION
In order to correctly expand ValueSets, a reference is needed from the synonyms to the "main" entry for a code in the `Coding` table.  This PR updates the table with the necessary column and indexes