### PR TITLE
Add support for ES256 jwk signing keys

### DIFF
--- a/packages/definitions/dist/fhir/r4/fhir.schema.json
+++ b/packages/definitions/dist/fhir/r4/fhir.schema.json
@@ -60440,10 +60440,22 @@
         "qi": {
           "description": "The first CRT coefficient.",
           "$ref": "#/definitions/string"
+        },
+        "x": {
+          "description": "The x coordinate of the elliptic curve point (base64url encoded).",
+          "$ref": "#/definitions/string"
+        },
+        "y": {
+          "description": "The y coordinate of the elliptic curve point (base64url encoded).",
+          "$ref": "#/definitions/string"
+        },
+        "crv": {
+          "description": "The cryptographic curve identifier (e.g., \u0027P-256\u0027, \u0027P-384\u0027, \u0027P-521\u0027).",
+          "$ref": "#/definitions/string"
         }
       },
       "additionalProperties": false,
-      "required": ["resourceType"]
+      "required": ["resourceType", "alg", "kty"]
     },
     "Bot": {
       "description": "Bot account for automated actions.",

--- a/packages/definitions/dist/fhir/r4/profiles-medplum.json
+++ b/packages/definitions/dist/fhir/r4/profiles-medplum.json
@@ -3337,7 +3337,7 @@
             "id": "JsonWebKey.alg",
             "path": "JsonWebKey.alg",
             "definition": "The specific cryptographic algorithm used with the key.",
-            "min": 0,
+            "min": 1,
             "max": "1",
             "type": [
               {
@@ -3346,7 +3346,7 @@
             ],
             "base": {
               "path": "JsonWebKey.alg",
-              "min": 0,
+              "min": 1,
               "max": "1"
             }
           },
@@ -3354,7 +3354,7 @@
             "id": "JsonWebKey.kty",
             "path": "JsonWebKey.kty",
             "definition": "The family of cryptographic algorithms used with the key.",
-            "min": 0,
+            "min": 1,
             "max": "1",
             "type": [
               {
@@ -3363,7 +3363,7 @@
             ],
             "base": {
               "path": "JsonWebKey.kty",
-              "min": 0,
+              "min": 1,
               "max": "1"
             }
           },
@@ -3584,6 +3584,57 @@
             ],
             "base": {
               "path" : "JsonWebKey.qi",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id": "JsonWebKey.x",
+            "path": "JsonWebKey.x",
+            "definition": "The x coordinate of the elliptic curve point (base64url encoded).",
+            "min": 0,
+            "max": "1",
+            "type": [
+              {
+                "code": "string"
+              }
+            ],
+            "base": {
+              "path" : "JsonWebKey.x",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id": "JsonWebKey.y",
+            "path": "JsonWebKey.y",
+            "definition": "The y coordinate of the elliptic curve point (base64url encoded).",
+            "min": 0,
+            "max": "1",
+            "type": [
+              {
+                "code": "string"
+              }
+            ],
+            "base": {
+              "path" : "JsonWebKey.y",
+              "min" : 0,
+              "max" : "1"
+            }
+          },
+          {
+            "id": "JsonWebKey.crv",
+            "path": "JsonWebKey.crv",
+            "definition": "The cryptographic curve identifier (e.g., 'P-256', 'P-384', 'P-521').",
+            "min": 0,
+            "max": "1",
+            "type": [
+              {
+                "code": "string"
+              }
+            ],
+            "base": {
+              "path" : "JsonWebKey.crv",
               "min" : 0,
               "max" : "1"
             }

--- a/packages/docs/static/data/medplumDefinitions/jsonwebkey.json
+++ b/packages/docs/static/data/medplumDefinitions/jsonwebkey.json
@@ -184,7 +184,7 @@
         }
       ],
       "path": "JsonWebKey.alg",
-      "min": 0,
+      "min": 1,
       "max": "1",
       "short": "",
       "definition": "The specific cryptographic algorithm used with the key.",
@@ -200,7 +200,7 @@
         }
       ],
       "path": "JsonWebKey.kty",
-      "min": 0,
+      "min": 1,
       "max": "1",
       "short": "",
       "definition": "The family of cryptographic algorithms used with the key.",
@@ -412,6 +412,54 @@
       "max": "1",
       "short": "",
       "definition": "The first CRT coefficient.",
+      "comment": "",
+      "inherited": false
+    },
+    {
+      "name": "x",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "string"
+        }
+      ],
+      "path": "JsonWebKey.x",
+      "min": 0,
+      "max": "1",
+      "short": "",
+      "definition": "The x coordinate of the elliptic curve point (base64url encoded).",
+      "comment": "",
+      "inherited": false
+    },
+    {
+      "name": "y",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "string"
+        }
+      ],
+      "path": "JsonWebKey.y",
+      "min": 0,
+      "max": "1",
+      "short": "",
+      "definition": "The y coordinate of the elliptic curve point (base64url encoded).",
+      "comment": "",
+      "inherited": false
+    },
+    {
+      "name": "crv",
+      "depth": 1,
+      "types": [
+        {
+          "datatype": "string"
+        }
+      ],
+      "path": "JsonWebKey.crv",
+      "min": 0,
+      "max": "1",
+      "short": "",
+      "definition": "The cryptographic curve identifier (e.g., 'P-256', 'P-384', 'P-521').",
       "comment": "",
       "inherited": false
     }

--- a/packages/fhirtypes/dist/JsonWebKey.d.ts
+++ b/packages/fhirtypes/dist/JsonWebKey.d.ts
@@ -98,12 +98,12 @@ export interface JsonWebKey {
   /**
    * The specific cryptographic algorithm used with the key.
    */
-  alg?: string;
+  alg: string;
 
   /**
    * The family of cryptographic algorithms used with the key.
    */
-  kty?: string;
+  kty: string;
 
   /**
    * How the key was meant to be used; sig represents the signature.
@@ -171,4 +171,19 @@ export interface JsonWebKey {
    * The first CRT coefficient.
    */
   qi?: string;
+
+  /**
+   * The x coordinate of the elliptic curve point (base64url encoded).
+   */
+  x?: string;
+
+  /**
+   * The y coordinate of the elliptic curve point (base64url encoded).
+   */
+  y?: string;
+
+  /**
+   * The cryptographic curve identifier (e.g., 'P-256', 'P-384', 'P-521').
+   */
+  crv?: string;
 }

--- a/packages/server/src/oauth/keys.test.ts
+++ b/packages/server/src/oauth/keys.test.ts
@@ -82,7 +82,7 @@ describe('Keys', () => {
 
     // Construct a broken JWT with empty "kid"
     const accessToken = await new SignJWT({})
-      .setProtectedHeader({ alg: 'RS256', kid: '', typ: 'JWT' })
+      .setProtectedHeader({ alg: 'ES256', kid: '', typ: 'JWT' })
       .setIssuedAt()
       .setIssuer(config.issuer)
       .setAudience('my-audience')

--- a/packages/server/src/oauth/keys.ts
+++ b/packages/server/src/oauth/keys.ts
@@ -68,30 +68,43 @@ export interface MedplumRefreshTokenClaims extends MedplumBaseClaims {
   refresh_secret: string;
 }
 
-/**
- * Signing algorithm.
+/*
+ * Signing algorithms.
  *
+ * For the first 4 years of this project, we only supported RS256:
  * RS256 (RSA Signature with SHA-256): An asymmetric algorithm, which means that there are two keys:
  * one public key and one private key that must be kept secret. The server has the private key used to
  * generate the signature, and the consumer of the JWT retrieves a public key from the metadata
  * endpoints provided by the server and uses it to validate the JWT signature.
  *
- * This is the algorithm used by AWS Cognito and Auth0.
+ * Due to customer requests for FAPI 2 compliance, we are now expanding to support ES256:
+ * ES256 (ECDSA using P-256 and SHA-256): An asymmetric algorithm using elliptic curve cryptography.
+ * Like RS256, it uses a public/private key pair, but offers better performance characteristics,
+ * smaller key sizes, and faster signature generation while providing equivalent security to 2048-bit RSA.
+ *
+ * To support existing customers and deployments, we will continue to support existing keys using RS256.
+ * All new keys will use ES256 by default.
+ *
+ * Note: AWS Cognito uses RS256. Auth0 supports RS256, HS256, and PS256 options.
  */
-const ALG = 'RS256';
+
+const ALG_ES256 = 'ES256';
+const ALG_RS256 = 'RS256';
+const PREFERRED_ALG = ALG_ES256;
+const LEGACY_DEFAULT_ALG = ALG_RS256;
 const DEFAULT_ACCESS_LIFETIME = '1h';
 const DEFAULT_REFRESH_LIFETIME = '2w';
 
 let issuer: string | undefined;
 const publicKeys: Record<string, KeyLike> = {};
 const jwks: { keys: JWK[] } = { keys: [] };
+let jsonWebKey: JsonWebKey | undefined;
 let signingKey: KeyLike | undefined;
-let signingKeyId: string | undefined;
 
 export async function initKeys(config: MedplumServerConfig): Promise<void> {
   issuer = undefined;
+  jsonWebKey = undefined;
   signingKey = undefined;
-  signingKeyId = undefined;
   jwks.keys = [];
 
   if (!config) {
@@ -118,11 +131,12 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
     // Generate a key pair
     // https://github.com/panva/jose/blob/HEAD/docs/functions/util_generate_key_pair.generatekeypair.md
     globalLogger.info('No keys found.  Creating new key...');
-    const keyResult = await generateKeyPair(ALG);
+    const keyResult = await generateKeyPair(PREFERRED_ALG);
     const jwk = await exportJWK(keyResult.privateKey);
     const createResult = await systemRepo.createResource<JsonWebKey>({
       resourceType: 'JsonWebKey',
       active: true,
+      alg: PREFERRED_ALG,
       ...jwk,
     } as JsonWebKey);
     jsonWebKeys = [createResult];
@@ -130,14 +144,22 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
 
   // Convert our JsonWebKey array to JWKS
   for (const jwk of jsonWebKeys) {
+    jwk.alg ??= LEGACY_DEFAULT_ALG;
+
     const publicKey: JWK = {
       kid: jwk.id,
-      alg: ALG,
-      kty: 'RSA',
+      alg: jwk.alg,
+      kty: jwk.kty,
       use: 'sig',
-      e: jwk.e,
-      n: jwk.n,
     };
+    if (jwk.alg === ALG_ES256) {
+      publicKey.x = jwk.x;
+      publicKey.y = jwk.y;
+      publicKey.crv = jwk.crv as string;
+    } else {
+      publicKey.e = jwk.e;
+      publicKey.n = jwk.n;
+    }
 
     // Add to the JWKS (JSON Web Key Set)
     // This will be publicly available at /.well-known/jwks.json
@@ -148,10 +170,9 @@ export async function initKeys(config: MedplumServerConfig): Promise<void> {
   }
 
   // Use the first key as the signing key
-  signingKeyId = jsonWebKeys[0].id;
+  jsonWebKey = jsonWebKeys[0];
   signingKey = (await importJWK({
-    ...(jsonWebKeys[0] as JWK),
-    alg: ALG,
+    ...(jsonWebKey as JWK),
     use: 'sig',
   })) as KeyLike;
 }
@@ -226,7 +247,7 @@ export function generateRefreshToken(claims: MedplumRefreshTokenClaims, lifetime
  * @returns Promise to generate and sign the JWT.
  */
 async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
-  if (!signingKey || !issuer) {
+  if (!jsonWebKey || !signingKey || !issuer) {
     throw new Error('Signing key not initialized');
   }
 
@@ -236,7 +257,11 @@ async function generateJwt(exp: string, claims: JWTPayload): Promise<string> {
   }
 
   return new SignJWT(claims)
-    .setProtectedHeader({ alg: ALG, kid: signingKeyId, typ: 'JWT' })
+    .setProtectedHeader({
+      alg: jsonWebKey.alg ?? LEGACY_DEFAULT_ALG,
+      kid: jsonWebKey.id,
+      typ: 'JWT',
+    })
     .setIssuedAt()
     .setIssuer(issuer)
     .setAudience(claims.client_id as string)
@@ -256,7 +281,7 @@ export async function verifyJwt(token: string): Promise<{ payload: JWTPayload; p
 
   const verifyOptions: JWTVerifyOptions = {
     issuer,
-    algorithms: [ALG],
+    algorithms: [ALG_ES256, ALG_RS256],
   };
 
   return jwtVerify(token, getKeyForHeader, verifyOptions);

--- a/packages/server/src/wellknown.test.ts
+++ b/packages/server/src/wellknown.test.ts
@@ -29,21 +29,34 @@ describe('Well Known', () => {
       expect(key.kid).toBeDefined();
       expect(key.kid.length).toStrictEqual(36); // kid should be a UUID
       expect(isUUID(key.kid)).toStrictEqual(true);
-      expect(key.alg).toStrictEqual('RS256');
-      expect(key.kty).toStrictEqual('RSA');
+      expect(key.alg).toMatch(/^(RS256|ES256)$/);
+      expect(key.kty).toMatch(/^(RSA|EC)$/);
       expect(key.use).toStrictEqual('sig');
 
-      // Make sure public key properties are there
-      expect(key.e).toBeDefined();
-      expect(key.n).toBeDefined();
+      if (key.kty === 'EC') {
+        // Make sure public key properties are there
+        expect(key.x).toBeDefined();
+        expect(key.y).toBeDefined();
+        expect(key.crv).toBeDefined();
 
-      // Make sure private key properties are *NOT* there
-      expect(key.d).toBeUndefined();
-      expect(key.p).toBeUndefined();
-      expect(key.q).toBeUndefined();
-      expect(key.dp).toBeUndefined();
-      expect(key.dq).toBeUndefined();
-      expect(key.qi).toBeUndefined();
+        // Make sure private key properties are *NOT* there
+        expect(key.d).toBeUndefined();
+        expect(key.x5c).toBeUndefined();
+        expect(key.x5t).toBeUndefined();
+        expect(key.x5t256).toBeUndefined();
+      } else if (key.kty === 'RSA') {
+        // Make sure public key properties are there
+        expect(key.e).toBeDefined();
+        expect(key.n).toBeDefined();
+
+        // Make sure private key properties are *NOT* there
+        expect(key.d).toBeUndefined();
+        expect(key.p).toBeUndefined();
+        expect(key.q).toBeUndefined();
+        expect(key.dp).toBeUndefined();
+        expect(key.dq).toBeUndefined();
+        expect(key.qi).toBeUndefined();
+      }
     }
   });
 


### PR DESCRIPTION
See: https://github.com/medplum/medplum/discussions/6489

## Overview
This PR adds support for ES256 (ECDSA using P-256 and SHA-256) signing algorithm to our JWT implementation in response to customer requests for FAPI 2 compliance.

## Background
Until now, we only supported RS256 (RSA Signature with SHA-256). While this has served us well, a customer has requested FAPI 2 compliance, which requires either ES256 or PS256 algorithms.

After investigation, our team chose ES256 for the following reasons:
- **Performance Efficiency**: Better performance characteristics for high-volume authentication systems
- **Space Efficiency**: Smaller key sizes and signature lengths reduce bandwidth and storage requirements
- **Security**: Equivalent security to 2048-bit RSA keys with substantially smaller key sizes
- **Industry Direction**: Industry trend toward elliptic curve cryptography for efficiency advantages
- **FAPI 2 Compliance**: Satisfies requirements for our certification goals

## Changes Made
- Added support for EC (Elliptic Curve) keys in our JWK data structure
- Added new string properties for EC keys: `x`, `y`, `crv`
- Updated code comments to reflect the expanded algorithm support
- Implemented ES256 signing and verification logic
- All new keys will default to ES256

## Backwards Compatibility
- Existing RS256 keys will continue to be supported indefinitely
- No breaking changes for existing customers or deployments
- Migration to ES256 is opt-in for existing implementations
