### PR TITLE
Use @link in client docs

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -119,7 +119,7 @@ export interface MedplumClientOptions {
   /**
    * Base server URL.
    *
-   * Default value is https://api.medplum.com/
+   * Default value is `https://api.medplum.com/`
    *
    * Use this to point to a custom Medplum deployment.
    */
@@ -128,7 +128,7 @@ export interface MedplumClientOptions {
   /**
    * OAuth2 authorize URL.
    *
-   * Default value is baseUrl + "/oauth2/authorize".
+   * Default value is `baseUrl + "/oauth2/authorize"`.
    *
    * Can be specified as absolute URL or relative to baseUrl.
    *
@@ -139,7 +139,7 @@ export interface MedplumClientOptions {
   /**
    * FHIR URL path.
    *
-   * Default value is "fhir/R4/".
+   * Default value is `fhir/R4/`.
    *
    * Can be specified as absolute URL or relative to baseUrl.
    *
@@ -150,7 +150,7 @@ export interface MedplumClientOptions {
   /**
    * OAuth2 token URL.
    *
-   * Default value is baseUrl + "/oauth2/token".
+   * Default value is `baseUrl + "/oauth2/token"`.
    *
    * Can be specified as absolute URL or relative to baseUrl.
    *
@@ -161,7 +161,7 @@ export interface MedplumClientOptions {
   /**
    * OAuth2 logout URL.
    *
-   * Default value is baseUrl + "/oauth2/logout".
+   * Default value is `baseUrl + "/oauth2/logout"`.
    *
    * Can be specified as absolute URL or relative to baseUrl.
    *
@@ -211,7 +211,7 @@ export interface MedplumClientOptions {
   /**
    * Number of resources to store in the cache.
    *
-   * Default value is 1000.
+   * Default value is `1000`.
    *
    * Consider using this for performance of displaying Patient or Practitioner resources.
    */
@@ -220,13 +220,13 @@ export interface MedplumClientOptions {
   /**
    * The length of time in milliseconds to cache resources.
    *
-   * Default value is 60000 (60 seconds).
+   * Default value is `60000` (60 seconds).
    *
    * Cache time of zero disables all caching.
    *
    * For any individual request, the cache behavior can be overridden by setting the cache property on request options.
    *
-   * See: https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
+   * See: {@link https://developer.mozilla.org/en-US/docs/Web/API/Request/cache}
    */
   cacheTime?: number;
 
@@ -235,7 +235,7 @@ export interface MedplumClientOptions {
    *
    * Auto batching attempts to group multiple requests together into a single batch request.
    *
-   * Default value is 0, which disables auto batching.
+   * Default value is `0`, which disables auto batching.
    */
   autoBatchTime?: number;
 
@@ -244,14 +244,14 @@ export interface MedplumClientOptions {
    *
    * This is the amount of time before the access token expires that the client will attempt to refresh the token.
    *
-   * Default value is 300000 (5 minutes).
+   * Default value is `300000` (5 minutes).
    */
   refreshGracePeriod?: number;
 
   /**
    * Fetch implementation.
    *
-   * Default is window.fetch (if available).
+   * Default is `window.fetch` (if available).
    *
    * For Node.js applications, consider the 'node-fetch' package.
    */
@@ -260,7 +260,7 @@ export interface MedplumClientOptions {
   /**
    * Storage implementation.
    *
-   * Default is window.localStorage (if available), this is the common implementation for use in the browser, or an in-memory storage implementation.  If using Medplum on a server it may be useful to provide a custom storage implementation, for example using redis, a database or a file based storage.  Medplum CLI is an an example of `FileSystemStorage`, for reference.
+   * Default is `window.localStorage` (if available), this is the common implementation for use in the browser, or an in-memory storage implementation.  If using Medplum on a server it may be useful to provide a custom storage implementation, for example using redis, a database or a file based storage.  Medplum CLI is an an example of `FileSystemStorage`, for reference.
    */
   storage?: IClientStorage;
 
@@ -595,7 +595,7 @@ export interface CreateDocumentReferenceOptions extends CreateBinaryOptions {
  */
 export interface CreatePdfOptions extends Omit<CreateBinaryOptions, 'data' | 'contentType'> {
   /**
-   * The PDF document definition. See https://pdfmake.github.io/docs/0.1/document-definition-object/
+   * The PDF document definition. See {@link https://pdfmake.github.io/docs/0.1/document-definition-object/}
    */
   readonly docDefinition: TDocumentDefinitions;
 
@@ -693,9 +693,9 @@ interface RequestState {
 
 /**
  * OAuth 2.0 Grant Type Identifiers
- * Standard identifiers: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-07#name-grant-types
- * JWT bearer extension: https://datatracker.ietf.org/doc/html/rfc7523
- * Token exchange extension: https://datatracker.ietf.org/doc/html/rfc8693
+ * Standard identifiers: {@link https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-07#name-grant-types}
+ * JWT bearer extension: {@link https://datatracker.ietf.org/doc/html/rfc7523}
+ * Token exchange extension: {@link https://datatracker.ietf.org/doc/html/rfc8693}
  */
 export const OAuthGrantType = {
   ClientCredentials: 'client_credentials',
@@ -708,7 +708,7 @@ export type OAuthGrantType = (typeof OAuthGrantType)[keyof typeof OAuthGrantType
 
 /**
  * OAuth 2.0 Token Type Identifiers
- * See: https://datatracker.ietf.org/doc/html/rfc8693#name-token-type-identifiers
+ * See {@link https://datatracker.ietf.org/doc/html/rfc8693#name-token-type-identifiers | RFC 8693 Section 3.1} for full details.
  */
 export const OAuthTokenType = {
   /** Indicates that the token is an OAuth 2.0 access token issued by the given authorization server. */
@@ -739,7 +739,7 @@ export type OAuthTokenAuthMethod = (typeof OAuthTokenAuthMethod)[keyof typeof OA
 
 /**
  * OAuth 2.0 Client Authentication Methods
- * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
+ * See {@link https://datatracker.ietf.org/doc/html/rfc7523#section-2.2 | RFC 7523 Section 2.2} for full details.
  */
 export const OAuthClientAssertionType = {
   /** Using JWTs for Client Authentication */
@@ -757,7 +757,7 @@ interface SessionDetails {
 
 /**
  * ValueSet $expand operation parameters.
- * See: https://hl7.org/fhir/r4/valueset-operation-expand.html
+ * See {@link https://hl7.org/fhir/r4/valueset-operation-expand.html | FHIR ValueSet $expand Operation Parameters} for full details.
  */
 export interface ValueSetExpandParams {
   url?: string;
@@ -798,7 +798,7 @@ export type MedplumClientEventMap = {
  *   6. Searching
  *   7. Making GraphQL queries
  *
- * The client can also be used to integrate with other FHIR servers. For an example, see the Epic Connection Demo Bot [here](https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/epic).
+ * The client can also be used to integrate with other FHIR servers. For an example, see the {@link https://github.com/medplum/medplum/tree/main/examples/medplum-demo-bots/src/epic | Epic Connection Demo Bot}.
  *
  * @example
  * Here is a quick example of how to use the client:
@@ -1313,7 +1313,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   /**
    * Tries to sign in with Google authentication.
    * The response parameter is the result of a Google authentication.
-   * See: https://developers.google.com/identity/gsi/web/guides/handle-credential-responses-js-functions
+   * See {@link https://developers.google.com/identity/gsi/web/guides/handle-credential-responses-js-functions | Google Sign-In Credential Response} for full details.
    * @category Authentication
    * @param loginRequest - Login request including Google credential response.
    * @param options - Optional fetch options.
@@ -1542,7 +1542,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * const patients = medplum.search('Patient', '_summary=count');
    * ```
    *
-   * See FHIR search for full details: https://www.hl7.org/fhir/search.html
+   * See {@link https://www.hl7.org/fhir/search.html | FHIR search} for full details.
    * @category Search
    * @param resourceType - The FHIR resource type.
    * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1580,7 +1580,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    *
    * The return value is the resource, if available; otherwise, undefined.
    *
-   * See FHIR search for full details: https://www.hl7.org/fhir/search.html
+   * See {@link https://www.hl7.org/fhir/search.html | FHIR search} for full details.
    * @category Search
    * @param resourceType - The FHIR resource type.
    * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1622,7 +1622,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    *
    * The return value is an array of resources.
    *
-   * See FHIR search for full details: https://www.hl7.org/fhir/search.html
+   * See {@link https://www.hl7.org/fhir/search.html | FHIR search} for full details.
    * @category Search
    * @param resourceType - The FHIR resource type.
    * @param query - Optional FHIR search query or structured query object. Can be any valid input to the URLSearchParams() constructor.
@@ -1647,11 +1647,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
 
   /**
    * Creates an
-   * [async generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator)
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator | async generator}
    * over a series of FHIR search requests for paginated search results. Each iteration of the generator yields
    * the array of resources on each page. Searches using _offset based pagination are limited to 10,000 records.
    * For larger result sets, _cursor based pagination should be used instead.
-   * See: https://www.medplum.com/docs/search/paginated-search#cursor-based-pagination
+   *
+   * See {@link https://www.medplum.com/docs/search/paginated-search#cursor-based-pagination | the docs} for more information.
    *
    * @example
    *
@@ -1942,7 +1943,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(history);
    * ```
    *
-   * See the FHIR "history" operation for full details: https://www.hl7.org/fhir/http.html#history
+   * See the {@link https://www.hl7.org/fhir/http.html#history | FHIR "history" operation} for full details.
    * @category Read
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
@@ -1968,7 +1969,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(version);
    * ```
    *
-   * See the FHIR "vread" operation for full details: https://www.hl7.org/fhir/http.html#vread
+   * See the {@link https://www.hl7.org/fhir/http.html#vread | FHIR "vread" operation} for full details.
    * @category Read
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
@@ -1996,7 +1997,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(bundle);
    * ```
    *
-   * See the FHIR "patient-everything" operation for full details: https://hl7.org/fhir/operation-patient-everything.html
+   * See the {@link https://hl7.org/fhir/operation-patient-everything.html | FHIR "patient-everything" operation} for full details.
    * @category Read
    * @param id - The Patient Id
    * @param options - Optional fetch options.
@@ -2017,9 +2018,9 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(bundle);
    * ```
    *
-   * See International Patient Summary Implementation Guide: https://build.fhir.org/ig/HL7/fhir-ips/index.html
+   * See the {@link https://build.fhir.org/ig/HL7/fhir-ips/index.html | International Patient Summary Implementation Guide} for full details.
    *
-   * See Patient summary operation: https://build.fhir.org/ig/HL7/fhir-ips/OperationDefinition-summary.html
+   * See the {@link https://build.fhir.org/ig/HL7/fhir-ips/OperationDefinition-summary.html | Patient summary operation} for full details.
    *
    * @param id - The Patient ID.
    * @param options - Optional fetch options.
@@ -2048,7 +2049,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(result.id);
    * ```
    *
-   * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
+   * See the {@link https://www.hl7.org/fhir/http.html#create | FHIR "create" operation} for full details.
    * @category Create
    * @param resource - The FHIR resource to create.
    * @param options - Optional fetch options.
@@ -2096,7 +2097,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    *
    * The query parameter only contains the search parameters (what would be in the URL following the "?").
    *
-   * See the FHIR "conditional create" operation for full details: https://www.hl7.org/fhir/http.html#ccreate
+   * See the {@link https://www.hl7.org/fhir/http.html#create | FHIR "conditional create" operation} for full details.
    * @category Create
    * @param resource - The FHIR resource to create.
    * @param query - The search query for an equivalent resource (should not include resource type or "?").
@@ -2173,7 +2174,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(result);
    * ```
    *
-   * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
+   * See the {@link https://www.hl7.org/fhir/http.html#create | FHIR "create" operation} for full details.
    * @category Create
    * @param createBinaryOptions -The binary options. See `CreateBinaryOptions` for full details.
    * @param requestOptions - Optional fetch options. **NOTE:** only `options.signal` is respected when `onProgress` is also provided.
@@ -2267,7 +2268,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(result.id);
    * ```
    *
-   * See the FHIR "create" operation for full details: https://www.hl7.org/fhir/http.html#create
+   * See the {@link https://www.hl7.org/fhir/http.html#create | FHIR "create" operation} for full details.
    *
    * @category Create
    * @param createBinaryOptions -The binary options. See `CreateBinaryOptions` for full details.
@@ -2403,7 +2404,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(result.id);
    * ```
    *
-   * See the pdfmake document definition for full details: https://pdfmake.github.io/docs/0.1/document-definition-object/
+   * See the {@link https://pdfmake.github.io/docs/0.1/document-definition-object/ | pdfmake document definition} for full details.
    * @category Media
    * @param createPdfOptions - The PDF creation options. See `CreatePdfOptions` for full details.
    * @param requestOptions - Optional fetch options.
@@ -2508,7 +2509,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(result.meta.versionId);
    * ```
    *
-   * See the FHIR "update" operation for full details: https://www.hl7.org/fhir/http.html#update
+   * See the {@link https://www.hl7.org/fhir/http.html#update | FHIR "update" operation} for full details.
    * @category Write
    * @param resource - The FHIR resource to update.
    * @param options - Optional fetch options.
@@ -2548,9 +2549,9 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * console.log(result.meta.versionId);
    * ```
    *
-   * See the FHIR "update" operation for full details: https://www.hl7.org/fhir/http.html#patch
+   * See the {@link https://www.hl7.org/fhir/http.html#patch | FHIR "update" operation} for full details.
    *
-   * See the JSONPatch specification for full details: https://tools.ietf.org/html/rfc6902
+   * See the {@link https://tools.ietf.org/html/rfc6902 | JSONPatch specification} for full details.
    * @category Write
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
@@ -2581,7 +2582,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * await medplum.deleteResource('Patient', '123');
    * ```
    *
-   * See the FHIR "delete" operation for full details: https://www.hl7.org/fhir/http.html#delete
+   * See the {@link https://www.hl7.org/fhir/http.html#delete | FHIR "delete" operation} for full details.
    * @category Delete
    * @param resourceType - The FHIR resource type.
    * @param id - The resource ID.
@@ -2607,7 +2608,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * });
    * ```
    *
-   * See the FHIR "$validate" operation for full details: https://www.hl7.org/fhir/resource-operation-validate.html
+   * See the {@link https://www.hl7.org/fhir/resource-operation-validate.html | FHIR "$validate" operation} for full details.
    * @param resource - The FHIR resource.
    * @param options - Optional fetch options.
    * @returns The validate operation outcome.
@@ -2685,7 +2686,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * });
    * ```
    *
-   * See The FHIR "batch/transaction" section for full details: https://hl7.org/fhir/http.html#transaction
+   * See the {@link https://hl7.org/fhir/http.html#transaction | FHIR "batch/transaction" section} for full details.
    * @category Batch
    * @param bundle - The FHIR batch/transaction bundle.
    * @param options - Optional fetch options.
@@ -2729,7 +2730,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * });
    * ```
    *
-   * See options here: https://nodemailer.com/extras/mailcomposer/
+   * See the {@link https://nodemailer.com/extras/mailcomposer/ | nodemailer MailComposer options} for full details.
    * @category Media
    * @param email - The MailComposer options.
    * @param options - Optional fetch options.
@@ -2778,9 +2779,9 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * );
    * ```
    *
-   * See the GraphQL documentation for more details: https://graphql.org/learn/
+   * See the {@link https://graphql.org/learn/ | GraphQL documentation} for more details.
    *
-   * See the FHIR GraphQL documentation for FHIR specific details: https://www.hl7.org/fhir/graphql.html
+   * See the {@link https://www.hl7.org/fhir/graphql.html | FHIR GraphQL documentation} for FHIR specific details.
    * @category Read
    * @param query - The GraphQL query.
    * @param operationName - Optional GraphQL operation name.
@@ -3178,12 +3179,12 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   /**
-   * Performs Bulk Data Export operation request flow. See The FHIR "Bulk Data Export" for full details: https://build.fhir.org/ig/HL7/bulk-data/export.html#bulk-data-export
+   * Performs Bulk Data Export operation request flow. See the {@link https://build.fhir.org/ig/HL7/bulk-data/export.html#bulk-data-export | FHIR "Bulk Data Export"} for full details.
    * @param exportLevel - Optional export level. Defaults to system level export. 'Group/:id' - Group of Patients, 'Patient' - All Patients.
    * @param resourceTypes - A string of comma-delimited FHIR resource types.
    * @param since - Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).
    * @param options - Optional fetch options.
-   * @returns Bulk Data Response containing links to Bulk Data files. See "Response - Complete Status" for full details: https://build.fhir.org/ig/HL7/bulk-data/export.html#response---complete-status
+   * @returns Bulk Data Response containing links to Bulk Data files. See the {@link https://build.fhir.org/ig/HL7/bulk-data/export.html#response---complete-status | "Response - Complete Status"} for full details.
    */
   async bulkExport(
     //eslint-disable-next-line default-param-last
@@ -3207,7 +3208,9 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
 
   /**
    * Starts an async request following the FHIR "Asynchronous Request Pattern".
-   * See: https://hl7.org/fhir/r4/async.html
+   *
+   * See the {@link https://hl7.org/fhir/r4/async.html | FHIR "Asynchronous Request Pattern"} for full details.
+   *
    * @param url - The URL to request.
    * @param options - Optional fetch options.
    * @returns The response body.
@@ -3815,7 +3818,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * await medplum.searchResources('Patient')
    * ```
    *
-   * See: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+   * See {@link https://datatracker.ietf.org/doc/html/rfc6749#section-4.4 | RFC 6749 Section 4.4} for full details.
    *
    * @category Authentication
    * @param clientId - The client ID.
@@ -3843,7 +3846,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * await medplum.searchResources('Patient')
    * ```
    *
-   * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.1
+   * See {@link https://datatracker.ietf.org/doc/html/rfc7523#section-2.1 | RFC 7523 Section 2.1} for full details.
    *
    * @category Authentication
    * @param clientId - The client ID.
@@ -3865,7 +3868,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   /**
    * Starts a new OAuth2 JWT assertion flow.
    *
-   * See: https://datatracker.ietf.org/doc/html/rfc7523#section-2.2
+   * See {@link https://datatracker.ietf.org/doc/html/rfc7523#section-2.2 | RFC 7523 Section 2.2} for full details.
    *
    * @category Authentication
    * @param jwt - The JWT assertion.
@@ -4052,7 +4055,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
 
   /**
    * Makes a POST request to the tokens endpoint.
-   * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
+   * See {@link https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint | OpenID Connect Core 1.0 TokenEndpoint} for full details.
    * @param params - Token parameters.
    * @returns The user profile resource.
    */
@@ -4103,7 +4106,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   /**
    * Verifies the tokens received from the auth server.
    * Validates the JWT against the JWKS.
-   * See: https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
+   * See {@link https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint | OpenID Connect Core 1.0 TokenEndpoint} for full details.
    * @param tokens - The token response.
    * @returns Promise to complete.
    */


### PR DESCRIPTION
First pass at fixing malformed docs pages such as https://www.medplum.com/docs/sdk/core.medplumclient.searchresourcepages