### PR TITLE
Log resource type in AuditEvent when create fails

### DIFF
--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -315,7 +315,10 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       return result;
     } catch (err) {
       const durationMs = Date.now() - startTime;
-      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, { durationMs });
+      this.logEvent(CreateInteraction, AuditEventOutcome.MinorFailure, err, {
+        durationMs,
+        resource: { type: resource.resourceType },
+      });
       throw err;
     }
   }


### PR DESCRIPTION
Adds the type of resource that was being created when the failure occurred, e.g.:
```js
{
  "resourceType": "AuditEvent",
  "type": {
    "system": "http://terminology.hl7.org/CodeSystem/audit-event-type",
    "code": "rest",
    "display": "Restful Operation"
  },
  "subtype": [
    {
      "system": "http://hl7.org/fhir/restful-interaction",
      "code": "create",
      "display": "create"
    }
  ],
  "action": "C",
  "recorded": "2025-07-08T18:53:36.038Z",
  "source": {
    "observer": {
      "identifier": {
        "value": "http://localhost:8103/"
      }
    }
  },
  "agent": [
    {
      "who": {
        "reference": "Practitioner/0197eb60-f9ef-761e-bea4-beed1a812569",
        "display": "Medplum Admin"
      },
      "requestor": true,
      "network": {
        "address": "::ffff:127.0.0.1",
        "type": "2"
      }
    }
  ],
  "outcome": "4",
  "outcomeDesc": "Invalid additional property \"status\" (Patient.status)",
  "entity": [
    {
      "what": {
        "type": "Patient" // <-- New property
      }
    }
  ]
}
```