### PR TITLE
Ensure all pre and post commit hooks fire

### DIFF
--- a/packages/server/src/fhir/repo.test.ts
+++ b/packages/server/src/fhir/repo.test.ts
@@ -1287,6 +1287,52 @@ describe('FHIR Repo', () => {
       expect(cachedPatient.gender).toStrictEqual('unknown');
     }));
 
+  test.each(['commit', 'rollback'])('Post-commit handling on %s', async (mode) => {
+    const repo = getSystemRepo();
+    const loggerErrorSpy = jest.spyOn(getLogger(), 'error');
+    const finalPostCommit = jest.fn();
+
+    const error = new Error('Post-commit hook failed');
+    const promise = repo.withTransaction(async () => {
+      await repo.postCommit(async () => {
+        throw new Error('Post-commit hook failed');
+      });
+      await repo.postCommit(async () => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'Post-commit hook failed with string';
+      });
+      await repo.postCommit(finalPostCommit);
+      if (mode === 'rollback') {
+        throw new Error('Transaction failed');
+      }
+    });
+
+    if (mode === 'commit') {
+      await promise;
+      expect(finalPostCommit).toHaveBeenCalled();
+      expect(loggerErrorSpy).toHaveBeenCalledTimes(2);
+      expect(loggerErrorSpy).toHaveBeenCalledWith(expect.any(String), error);
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          err: 'Post-commit hook failed with string',
+        })
+      );
+    } else {
+      await expect(promise).rejects.toThrow('Transaction failed');
+      expect(finalPostCommit).not.toHaveBeenCalled();
+      expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          error: 'Transaction failed',
+        })
+      );
+    }
+
+    loggerErrorSpy.mockRestore();
+  });
+
   test('Handles resources with many entries stored in lookup table', async () =>
     withTestContext(async () => {
       const { repo } = await createTestProject({ withRepo: true });

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2509,7 +2509,15 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     const callbacks = this.preCommitCallbacks;
     this.preCommitCallbacks = [];
     for (const cb of callbacks) {
-      await cb();
+      try {
+        await cb();
+      } catch (err) {
+        if (err instanceof Error) {
+          getLogger().error('Error processing pre-commit callback', err);
+        } else {
+          getLogger().error('Error processing pre-commit callback', { err });
+        }
+      }
     }
   }
 
@@ -2525,7 +2533,15 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     const callbacks = this.postCommitCallbacks;
     this.postCommitCallbacks = [];
     for (const cb of callbacks) {
-      await cb();
+      try {
+        await cb();
+      } catch (err) {
+        if (err instanceof Error) {
+          getLogger().error('Error processing post-commit callback', err);
+        } else {
+          getLogger().error('Error processing post-commit callback', { err });
+        }
+      }
     }
   }
 

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -724,7 +724,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     await this.postCommit(async () => this.handleBinaryUpdate(existing, result));
     await this.postCommit(async () => {
       const project = await this.getProjectById(projectId);
-      await addBackgroundJobs(this, result, existing, { project, interaction });
+      await addBackgroundJobs(result, existing, { project, interaction });
     });
 
     const output = deepClone(result);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -691,9 +691,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
 
     const result = { ...updated, meta: resultMeta };
 
-    const project = this.getProjectId(existing, updated);
-    if (project) {
-      resultMeta.project = project;
+    const projectId = this.getProjectId(existing, updated);
+    if (projectId) {
+      resultMeta.project = projectId;
     }
     const accounts = await this.getAccounts(existing, updated);
     if (accounts) {
@@ -721,11 +721,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
     }
 
     await this.handleStorage(result, create);
-    await this.postCommit(async () => {
-      await this.handleBinaryUpdate(existing, result);
-      const project = await this.getProjectById(result.meta?.project);
-      await addBackgroundJobs(result, existing, { project, interaction });
-    });
+    await this.postCommit(() => this.handleBinaryUpdate(existing, result));
+    const project = await this.getProjectById(projectId);
+    await addBackgroundJobs(this, result, existing, { project, interaction });
 
     const output = deepClone(result);
     return this.removeHiddenFields(output);

--- a/packages/server/src/workers/index.test.ts
+++ b/packages/server/src/workers/index.test.ts
@@ -1,10 +1,16 @@
-import { closeWorkers, initWorkers } from '.';
+import { BackgroundJobContext, WithId } from '@medplum/core';
+import { Patient } from '@medplum/fhirtypes';
+import { addBackgroundJobs, closeWorkers, initWorkers } from '.';
 import { loadTestConfig } from '../config/loader';
 import { closeDatabase, initDatabase } from '../database';
 import { loadStructureDefinitions } from '../fhir/structure';
+import { getLogger } from '../logger';
 import { closeRedis, initRedis } from '../redis';
 import { seedDatabase } from '../seed';
 import { initBinaryStorage } from '../storage/loader';
+import * as cronModule from './cron';
+import * as downloadModule from './download';
+import * as subscriptionModule from './subscription';
 
 describe('Workers', () => {
   beforeAll(() => {
@@ -21,5 +27,42 @@ describe('Workers', () => {
     await closeWorkers();
     await closeDatabase();
     await closeRedis();
+  });
+
+  describe('addBackgroundJobs', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test.each(['error', 'string'])('Errors handled', async (errorType) => {
+      const resource: WithId<Patient> = {
+        resourceType: 'Patient',
+        id: '123',
+        meta: {
+          versionId: '1',
+        },
+      };
+
+      const loggerErrorSpy = jest.spyOn(getLogger(), 'error');
+
+      const subSpy = jest.spyOn(subscriptionModule, 'addSubscriptionJobs').mockImplementation(() => {
+        throw errorType === 'error' ? new Error('Test error') : 'Test error';
+      });
+
+      const downloadSpy = jest.spyOn(downloadModule, 'addDownloadJobs').mockImplementation(() => {
+        throw errorType === 'error' ? new Error('Test error') : 'Test error';
+      });
+
+      const cronSpy = jest.spyOn(cronModule, 'addCronJobs').mockImplementation(() => {
+        throw errorType === 'error' ? new Error('Test error') : 'Test error';
+      });
+
+      await addBackgroundJobs(resource, undefined, {} as BackgroundJobContext);
+
+      expect(subSpy).toHaveBeenCalledTimes(1);
+      expect(downloadSpy).toHaveBeenCalledTimes(1);
+      expect(cronSpy).toHaveBeenCalledTimes(1);
+      expect(loggerErrorSpy).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -54,7 +54,7 @@ export async function addBackgroundJobs(
   context: BackgroundJobContext
 ): Promise<void> {
   try {
-    await repo.postCommit(() => addSubscriptionJobs(resource, previousVersion, context));
+    await addSubscriptionJobs(resource, previousVersion, context);
   } catch (err) {
     getLogger().error('Error adding subscription jobs', {
       resourceType: resource.resourceType,
@@ -64,7 +64,7 @@ export async function addBackgroundJobs(
   }
 
   try {
-    await repo.postCommit(() => addDownloadJobs(resource, context));
+    await addDownloadJobs(resource, context);
   } catch (err) {
     getLogger().error('Error adding download jobs', {
       resourceType: resource.resourceType,
@@ -74,7 +74,7 @@ export async function addBackgroundJobs(
   }
 
   try {
-    await repo.postCommit(() => addCronJobs(resource, previousVersion, context));
+    await addCronJobs(resource, previousVersion, context);
   } catch (err) {
     getLogger().error('Error adding cron jobs', {
       resourceType: resource.resourceType,

--- a/packages/server/src/workers/index.ts
+++ b/packages/server/src/workers/index.ts
@@ -1,7 +1,6 @@
 import { BackgroundJobContext, WithId } from '@medplum/core';
 import { Resource } from '@medplum/fhirtypes';
 import { MedplumServerConfig } from '../config/types';
-import { Repository } from '../fhir/repo';
 import { getLogger, globalLogger } from '../logger';
 import { initBatchWorker } from './batch';
 import { addCronJobs, initCronWorker } from './cron';
@@ -42,13 +41,11 @@ export async function closeWorkers(): Promise<void> {
 
 /**
  * Adds all background jobs for a given resource.
- * @param repo - The repository to use for adding background jobs.
  * @param resource - The resource that was created or updated.
  * @param previousVersion - The previous version of the resource, if available.
  * @param context - The background job context.
  */
 export async function addBackgroundJobs(
-  repo: Repository,
   resource: WithId<Resource>,
   previousVersion: Resource | undefined,
   context: BackgroundJobContext


### PR DESCRIPTION
Previously, any thrown errors weren't caught which prevented attempting subsequent hooks.