### PR TITLE
fix the MCP server url in ReadMe for streamable http

### DIFF
--- a/packages/server/src/mcp/README.md
+++ b/packages/server/src/mcp/README.md
@@ -16,7 +16,7 @@ npx @modelcontextprotocol/inspector
 
 Set "Transport Type" to "Streamable HTTP" (recommended transport).
 
-Set "URL" to the `/mcp` path on your server, e.g. `http://localhost:8103/mcp`.
+Set "URL" to the `/mcp/stream` path on your server, e.g. `http://localhost:8103/mcp/stream`.
 
 ### Testing SSE
 


### PR DESCRIPTION
Was testing the MCP server capabilities in Medplum and noticed the url in the documentation for Streamable HTTP should be `/mcp/stream` instead of `/mcp`.

Verified this using MCP Inspector.