### PR TITLE
feat: implement Helm chart security and stability improvements

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -65,15 +65,19 @@ spec:
             {{- toYaml .Values.deployment.env | nindent 12 }}
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
         {{- with .Values.deployment.sidecars }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.volumes }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
+      {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/templates/poddisruptionbudget.yaml
+++ b/charts/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "medplum.fullname" . }}
+  namespace: {{ include "medplum.namespace" . }}
+  labels:
+    {{- include "medplum.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "medplum.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -14,8 +14,10 @@ global:
 
 serviceAccount:
   annotations:
-    iam.gke.io/gcp-service-account: [MY_GCP_SERVICE_ACCOUNT] # Your Google Cloud Platform service account e.i: medplum-server@[MY_PROJECT_ID].iam.gserviceaccount.com
-    # azure.workload.identity/client-id: "7f644391-4b27-4f76-8427-17bae90d7ee8" # Azure Managed Identity Client ID
+    # Set your Google Cloud Platform service account (e.g., medplum-server@[MY_PROJECT_ID].iam.gserviceaccount.com)
+    # iam.gke.io/gcp-service-account: ""
+    # Set your Azure Managed Identity Client ID for Azure workload identity
+    # azure.workload.identity/client-id: ""
 
 namespace: medplum
 
@@ -30,18 +32,49 @@ deployment:
   resources:
     requests:
       memory: "1Gi"
+      cpu: "500m"
     limits:
       memory: "2Gi"
+      cpu: "1000m"
   autoscaling:
     enabled: true
   # Structure this deployment.sidecar value as if you were adding the container
   # to the Deployment's spec.template.spec.containers key.
   sidecars: []
 
+# Security contexts for pods and containers
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# Pod Disruption Budget settings
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  # Alternative: maxUnavailable: 1
+
 service: {}
 
 ingress:
   deploy: true
-  domain: [MY_DOMAIN] # Your domain name
-  tlsSecretName: [TLS_SECRET_NAME] # Azure only
+  # Set your domain name (e.g., medplum.example.com)
+  domain: ""
+  # Set your TLS secret name (Azure only)
+  tlsSecretName: ""
   


### PR DESCRIPTION
- Add security contexts with non-root user (65532), dropped capabilities, and readonly root filesystem
- Add CPU limits (1000m) and requests (500m) to complement existing memory constraints
- Create Pod Disruption Budget template with configurable minAvailable setting
- Remove hardcoded placeholders ([MY_DOMAIN], [MY_GCP_SERVICE_ACCOUNT], [TLS_SECRET_NAME])
- Add temporary volume mount for /tmp to support readonly root filesystem
- Add comprehensive documentation and comments for required configuration values

Fixes #7030