### PR TITLE
Fixes #7014 - remove signature header requirement

### DIFF
--- a/packages/server/src/webhook/routes.test.ts
+++ b/packages/server/src/webhook/routes.test.ts
@@ -156,15 +156,6 @@ describe('Anonymous webhooks', () => {
     await shutdownApp();
   });
 
-  test('Missing signature header', async () => {
-    const res = await request(app)
-      .post(`/webhook/${botMembership.id}`)
-      .set('Content-Type', ContentType.TEXT)
-      .send('input');
-    expect(res.status).toBe(403);
-    expect(res.text).toStrictEqual('Missing required signature header');
-  });
-
   test('Missing invalid ID', async () => {
     const res = await request(app)
       .post(`/webhook/${randomUUID()}`)

--- a/packages/server/src/webhook/routes.ts
+++ b/packages/server/src/webhook/routes.ts
@@ -9,37 +9,9 @@ import { getSystemRepo } from '../fhir/repo';
 import { sendBinaryResponse } from '../fhir/response';
 
 /**
- * Allowed signature headers are:
- *
- *   - `X-Signature` - standard generic signature header
- *   - `X-HMAC-Signature` - standard HMAC signature header
- *      - See: https://consensus.stoplight.io/docs/fax-services/1c4979f1d8ca0-fax-inbound-notification
- *   - `X-Cal-Signature-256` - Cal.com specific signature header
- *      - See: https://cal.com/docs/developing/guides/automation/webhooks
- *   - `X-Twilio-Email-Event-Webhook-Signature` - Twilio SendGrid specific signature header
- *     - See: https://www.twilio.com/docs/sendgrid/for-developers/tracking-events/getting-started-event-webhook-security-features
- *   - `X-Twilio-Signature` - Twilio specific signature header
- *     - See: https://www.twilio.com/docs/usage/webhooks/webhooks-security
- */
-const SIGNATURE_HEADERS = [
-  'x-signature',
-  'x-hmac-signature',
-  'x-cal-signature-256',
-  'x-twilio-email-event-webhook-signature',
-  'x-twilio-signature',
-];
-
-/**
  * Handles HTTP requests for anonymous webhooks.
  */
 export const webhookHandler = asyncWrap(async (req: Request, res: Response) => {
-  // At least one of the allowed signature headers must be present
-  const hasSignatureHeader = SIGNATURE_HEADERS.some((header) => req.header(header));
-  if (!hasSignatureHeader) {
-    res.status(403).send('Missing required signature header');
-    return;
-  }
-
   const systemRepo = getSystemRepo();
   const id = req.params.id;
   const runAs = await systemRepo.readResource<ProjectMembership>('ProjectMembership', id);


### PR DESCRIPTION
As discussed in #7014 now that we have a formal opt-in for `Bot.publicWebhook`, we can remove this arbitrary signature requirement.