### PR TITLE
Simplify invalid index handling

### DIFF
--- a/packages/server/src/migrations/migrate-functions.test.ts
+++ b/packages/server/src/migrations/migrate-functions.test.ts
@@ -99,9 +99,9 @@ describe('migrate-functions', () => {
         })
       );
 
-      // Simulate an index that failed during creation: invalid and not live
+      // Simulate an index that failed during creation: invalid
       await client.query(
-        `UPDATE pg_index SET indisvalid = false, indislive = false 
+        `UPDATE pg_index SET indisvalid = false
       FROM pg_class WHERE pg_class.oid = pg_index.indexrelid 
       AND pg_class.relname = $1`,
         [indexName]
@@ -112,7 +112,6 @@ describe('migrate-functions', () => {
         expect.objectContaining({
           index_name: indexName,
           is_valid: false,
-          is_live: false,
           index_definition: indexDefinition,
         })
       );
@@ -132,29 +131,6 @@ describe('migrate-functions', () => {
           is_live: true,
           index_definition: indexDefinition,
         })
-      );
-
-      // Simulate an index that is being created by some other client: invalid but live
-      await client.query(
-        `UPDATE pg_index SET indisvalid = false, indislive = true 
-      FROM pg_class WHERE pg_class.oid = pg_index.indexrelid 
-      AND pg_class.relname = $1`,
-        [indexName]
-      );
-      const simulateCompetingClientIndexes = await getTableIndexes(client, tableName);
-      expect(simulateCompetingClientIndexes).toHaveLength(1);
-      expect(simulateCompetingClientIndexes[0]).toEqual(
-        expect.objectContaining({
-          index_name: indexName,
-          is_valid: false,
-          is_live: true,
-          index_definition: indexDefinition,
-        })
-      );
-
-      // Fails because index is being created by some other client
-      await expect(idempotentCreateIndex(client, [], indexName, createIndexSql)).rejects.toThrow(
-        'Another client is actively creating index'
       );
     });
   });

--- a/packages/server/src/migrations/migrate-functions.ts
+++ b/packages/server/src/migrations/migrate-functions.ts
@@ -30,29 +30,24 @@ export async function idempotentCreateIndex(
   indexName: string,
   createIndexSql: string
 ): Promise<void> {
-  const existsResult = await client.query<{ exists: boolean; live: boolean; invalid: boolean }>(
+  const existsResult = await client.query<{
+    exists: boolean;
+    is_valid: boolean;
+  }>(
     `SELECT 
        EXISTS(SELECT 1 FROM pg_class WHERE relname = $1) AS exists,
        EXISTS(SELECT 1 
            FROM pg_index idx 
            JOIN pg_class i ON i.oid = idx.indexrelid 
-           WHERE i.relname = $1 AND idx.indislive
-       ) AS live,
-       EXISTS(SELECT 1 
-           FROM pg_index idx 
-           JOIN pg_class i ON i.oid = idx.indexrelid 
-           WHERE i.relname = $1 AND NOT idx.indisvalid
-       ) AS invalid`,
+           WHERE i.relname = $1 AND idx.indisvalid
+       ) AS is_valid`,
     [indexName]
   );
-  const { invalid, live } = existsResult.rows[0];
+  const { is_valid } = existsResult.rows[0];
   let exists = existsResult.rows[0].exists;
 
-  if (exists && invalid) {
-    if (live) {
-      throw new Error('Another client is actively creating index ' + indexName);
-    }
-
+  // Drop index if it is not valid
+  if (exists && !is_valid) {
     const start = Date.now();
     const dropQuery = `DROP INDEX IF EXISTS ${escapeIdentifier(indexName)}`;
     await client.query(dropQuery);
@@ -62,6 +57,7 @@ export async function idempotentCreateIndex(
     exists = false;
   }
 
+  // create index if it doesn't exist
   if (!exists) {
     const start = Date.now();
     await client.query(createIndexSql);


### PR DESCRIPTION
The previous reliance on `islive` was faulty. Simplifying the approach to not try to work around something else already trying to create the index at the same time.