### PR TITLE
Remove happy-path logging in transaction retries

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -144,7 +144,7 @@ describe('App', () => {
         .send(patient);
       expect(res1.status).toBe(201);
       expect(res1.body).toMatchObject(patient);
-      expect(process.stdout.write).toHaveBeenCalledTimes(2);
+      expect(process.stdout.write).toHaveBeenCalledTimes(1);
 
       const calls = (process.stdout.write as jest.Mock).mock.calls;
       const logLine = calls[calls.length - 1][0];
@@ -180,7 +180,7 @@ describe('App', () => {
         .send(patient);
       expect(res1.status).toBe(201);
       expect(res1.body).toMatchObject(patient);
-      expect(process.stdout.write).toHaveBeenCalledTimes(2);
+      expect(process.stdout.write).toHaveBeenCalledTimes(1);
 
       const logLine = (process.stdout.write as jest.Mock).mock.calls[0][0];
       const logObj = JSON.parse(logLine);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -2434,11 +2434,14 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
         const client = await this.beginTransaction(options?.serializable ? 'SERIALIZABLE' : undefined);
         const result = await callback(client);
         await this.commitTransaction();
-        getLogger().info('Completed transaction', {
-          attempt,
-          attemptDurationMs: Date.now() - attemptStartTime,
-          transactionAttempts,
-        });
+        if (attempt > 0) {
+          getLogger().info('Completed transaction', {
+            attempt,
+            attemptDurationMs: Date.now() - attemptStartTime,
+            transactionAttempts,
+            serializable: options?.serializable ?? false,
+          });
+        }
         return result;
       } catch (err) {
         const operationOutcomeError = normalizeDatabaseError(err);


### PR DESCRIPTION
Quite a few of these can wind up getting logged and are somewhat redundant.