### PR TITLE
Fixes #7066 - provider messages style tweaks

### DIFF
--- a/examples/medplum-provider/src/components/messages/ChatList.tsx
+++ b/examples/medplum-provider/src/components/messages/ChatList.tsx
@@ -64,7 +64,7 @@ export const ChatList = (props: ChatListProps): JSX.Element => {
   }, [lastCommunications]);
 
   return (
-    <Stack gap={0} p="xs">
+    <Stack gap={0}>
       {communications.map((communication: Communication) => {
         const lastCommunication = lastCommunicationsMap.get(createReference(communication).reference);
         const _isSelected = selectedCommunication?.id === communication.id;

--- a/examples/medplum-provider/src/components/messages/ChatListItem.module.css
+++ b/examples/medplum-provider/src/components/messages/ChatListItem.module.css
@@ -12,5 +12,5 @@
 }
 
 .contentContainer.selected {
-  background: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-8));
+  background: light-dark(var(--mantine-color-gray-2),  var(--mantine-color-dark-8));
 }

--- a/examples/medplum-provider/src/components/messages/ChatListItem.module.css
+++ b/examples/medplum-provider/src/components/messages/ChatListItem.module.css
@@ -12,5 +12,5 @@
 }
 
 .contentContainer.selected {
-  background: var(--mantine-color-gray-2);
+  background: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-8));
 }

--- a/examples/medplum-provider/src/components/messages/ChatListItem.tsx
+++ b/examples/medplum-provider/src/components/messages/ChatListItem.tsx
@@ -17,8 +17,8 @@ export const ChatListItem = (props: ChatListItemProps): JSX.Element => {
   const { topic, lastCommunication, isSelected, onClick } = props;
   const patientResource = useResource(topic.subject as Reference<Patient>);
   const patientName = formatHumanName(patientResource?.name?.[0] as HumanName);
-  const lastMsg = lastCommunication?.payload?.[0]?.contentString || 'No preview';
-  const content = lastMsg.length > 100 ? lastMsg.slice(0, 100) + '...' : lastMsg;
+  const lastMsg = lastCommunication?.payload?.[0]?.contentString;
+  const content = lastMsg?.length && lastMsg.length > 100 ? lastMsg.slice(0, 100) + '...' : lastMsg;
 
   return (
     <Group
@@ -37,7 +37,7 @@ export const ChatListItem = (props: ChatListItemProps): JSX.Element => {
           {patientName}
         </Text>
         <Text size="sm" fw={400} c="gray.7" lineClamp={2} className={classes.content}>
-          {topic.sender?.display ? `${topic.sender.display}: ${content}` : content}
+          {content ? `${topic.sender?.display}: ${content}` : `No messages available`}
         </Text>
         <Text size="xs" c="gray.6" style={{ marginTop: 2 }}>
           {lastCommunication ? formatDateTime(lastCommunication.sent) : ''}

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.module.css
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.module.css
@@ -5,3 +5,7 @@
   height: calc(100vh - 60px);
   overflow: hidden;
 }
+
+.rightBorder {
+  border-right: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-gray-8));
+}

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -77,8 +77,8 @@ export function MessagesPage(): JSX.Element {
                 <Divider />
                 <Flex p="md" gap="xs">
                   <Button
-                    variant={status === 'in-progress' ? 'filled' : 'outline'}
-                    color="black"
+                    variant={status === 'in-progress' ? 'filled' : 'default'}
+                    color="gray"
                     h={24}
                     radius="xl"
                     onClick={() => setStatus('in-progress')}
@@ -87,8 +87,8 @@ export function MessagesPage(): JSX.Element {
                   </Button>
 
                   <Button
-                    variant={status === 'completed' ? 'filled' : 'outline'}
-                    color="black"
+                    variant={status === 'completed' ? 'filled' : 'default'}
+                    color="gray"
                     h={24}
                     radius="xl"
                     onClick={() => setStatus('completed')}
@@ -177,7 +177,7 @@ export function MessagesPage(): JSX.Element {
           </Flex>
 
           {/* Right sidebar - Patient summary */}
-          <Flex direction="column" w="25%" h="100%">
+          <Flex direction="column" w="25%" h="100%" style={{ borderLeft: '1px solid var(--mantine-color-gray-3)' }}>
             {selectedThread && (
               <ScrollArea p={0} h="100%" scrollbarSize={10} type="hover" scrollHideDelay={250}>
                 <PatientSummary key={selectedThread.id} patient={selectedThread.subject as Reference<Patient>} />

--- a/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
+++ b/examples/medplum-provider/src/pages/messages/MessagesPage.tsx
@@ -63,7 +63,7 @@ export function MessagesPage(): JSX.Element {
       <div className={classes.container}>
         <Flex h="100%" w="100%">
           {/* Left sidebar - Messages list */}
-          <Flex direction="column" w="25%" h="100%" style={{ borderRight: '1px solid var(--mantine-color-gray-3)' }}>
+          <Flex direction="column" w="25%" h="100%" className={classes.rightBorder}>
             <Paper h="100%">
               <ScrollArea h="100%" scrollbarSize={10} type="hover" scrollHideDelay={250}>
                 <Flex h={64} align="center" justify="space-between" p="md">
@@ -125,7 +125,7 @@ export function MessagesPage(): JSX.Element {
           </Flex>
 
           {/* Main chat area */}
-          <Flex direction="column" w="50%" h="100%">
+          <Flex direction="column" w="50%" h="100%" className={classes.rightBorder}>
             {selectedThread && (
               <Paper h="100%">
                 <Stack h="100%" gap={0}>
@@ -177,7 +177,7 @@ export function MessagesPage(): JSX.Element {
           </Flex>
 
           {/* Right sidebar - Patient summary */}
-          <Flex direction="column" w="25%" h="100%" style={{ borderLeft: '1px solid var(--mantine-color-gray-3)' }}>
+          <Flex direction="column" w="25%" h="100%">
             {selectedThread && (
               <ScrollArea p={0} h="100%" scrollbarSize={10} type="hover" scrollHideDelay={250}>
                 <PatientSummary key={selectedThread.id} patient={selectedThread.subject as Reference<Patient>} />

--- a/examples/medplum-provider/vite.config.ts
+++ b/examples/medplum-provider/vite.config.ts
@@ -12,7 +12,7 @@ const alias: NonNullable<UserConfig['resolve']>['alias'] = Object.fromEntries(
     '@medplum/core': path.resolve(__dirname, '../../packages/core/src'),
     '@medplum/dosespot-react': path.resolve(__dirname, '../../packages/dosespot-react/src'),
     '@medplum/react$': path.resolve(__dirname, '../../packages/react/src'),
-    '@medplum/react/styles.css': path.resolve(__dirname, '../../packages/react/dist/styles.css'),
+    '@medplum/react/styles.css': path.resolve(__dirname, '../../packages/react/dist/esm/index.css'),
     '@medplum/react-hooks': path.resolve(__dirname, '../../packages/react-hooks/src'),
     '@medplum/health-gorilla-core': path.resolve(__dirname, '../../packages/health-gorilla-core/src'),
     '@medplum/health-gorilla-react': path.resolve(__dirname, '../../packages/health-gorilla-react/src'),

--- a/packages/react/src/chat/BaseChat/BaseChat.module.css
+++ b/packages/react/src/chat/BaseChat/BaseChat.module.css
@@ -62,11 +62,6 @@
   }
 }
 
-.chatBubbleName {
-  margin-bottom: 5px;
-  font-weight: 500;
-}
-
 .chatBubbleNameRight {
   text-align: right;
 }

--- a/packages/react/src/chat/BaseChat/BaseChat.tsx
+++ b/packages/react/src/chat/BaseChat/BaseChat.tsx
@@ -235,19 +235,6 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
     }
   });
 
-  const myLastDeliveredId = useMemo<string>(() => {
-    let i = communications.length;
-
-    while (i--) {
-      const comm = communications[i];
-      if (comm.sender?.reference === profileRefStr && comm.received) {
-        return comm.id as string;
-      }
-    }
-
-    return '';
-  }, [communications, profileRefStr]);
-
   if (!profile) {
     return null;
   }
@@ -287,7 +274,6 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
               const prevCommunication = i > 0 ? communications[i - 1] : undefined;
               const prevCommTime = prevCommunication ? parseSentTime(prevCommunication) : undefined;
               const currCommTime = parseSentTime(c);
-              const showDelivered = !!c.received && c.id === myLastDeliveredId;
               return (
                 <Stack key={`${c.id}--${c.meta?.versionId ?? 'no-version'}`} align="stretch">
                   {(!prevCommTime || currCommTime !== prevCommTime) && (
@@ -297,13 +283,8 @@ export function BaseChat(props: BaseChatProps): JSX.Element | null {
                   )}
                   {c.sender?.reference === profileRefStr ? (
                     <Group justify="flex-end" align="flex-end" gap="xs" mb="sm">
-                      <ChatBubble alignment="right" communication={c} showDelivered={showDelivered} />
-                      <ResourceAvatar
-                        radius="xl"
-                        color="orange"
-                        value={c.sender}
-                        mb={!showDelivered ? 'sm' : undefined}
-                      />
+                      <ChatBubble alignment="right" communication={c} />
+                      <ResourceAvatar radius="xl" color="orange" value={c.sender} mb="sm" />
                     </Group>
                   ) : (
                     <Group justify="flex-start" align="flex-end" gap="xs" mb="sm">


### PR DESCRIPTION
Before:

<img width="1475" height="475" alt="image" src="https://github.com/user-attachments/assets/4e6b17a3-e2fd-4f85-9335-930461917e33" />


After:

<img width="1471" height="469" alt="image" src="https://github.com/user-attachments/assets/5807b2ef-2369-427c-a59f-f16306c9eec9" />

Changes:
* Removed horizontal padding from messages list
* Changed message separator from time to date
* Added message time to each individual message
* Made message metadata font size smaller
* Switched some custom CSS to Mantine components