### PR TITLE
Log post-deploy migration errors

### DIFF
--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -45,8 +45,11 @@ async function synchronouslyRunPostDeployMigration(systemRepo: Repository, versi
 }
 
 describe('Seed', () => {
+  const originalConsoleLog = console.log;
+  let consoleLogSpy: jest.SpyInstance;
+
   beforeAll(async () => {
-    console.log = jest.fn();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn());
 
     const config = await loadTestConfig();
     config.database.runMigrations = true;
@@ -64,6 +67,7 @@ describe('Seed', () => {
 
   afterAll(async () => {
     await shutdownApp();
+    consoleLogSpy.mockRestore();
   });
 
   test('Seeder completes successfully', () =>
@@ -79,6 +83,10 @@ describe('Seed', () => {
       expect(preDeployVersion).toBeGreaterThanOrEqual(67);
 
       const postDeployVersion = await getPostDeployVersion(pool);
+      // only show log messages if post-deploy migrations did not run successfully
+      if (getLatestPostDeployMigrationVersion() !== postDeployVersion) {
+        consoleLogSpy.mock.calls.forEach((call) => originalConsoleLog(...call));
+      }
       expect(postDeployVersion).toEqual(getLatestPostDeployMigrationVersion());
 
       // Make sure the first project is a super admin

--- a/packages/server/src/workers/post-deploy-migration.ts
+++ b/packages/server/src/workers/post-deploy-migration.ts
@@ -1,4 +1,4 @@
-import { getReferenceString, WithId } from '@medplum/core';
+import { getReferenceString, normalizeErrorString, WithId } from '@medplum/core';
 import { AsyncJob, Parameters } from '@medplum/fhirtypes';
 import { Job, JobsOptions, Queue, QueueBaseOptions, Worker } from 'bullmq';
 import * as semver from 'semver';
@@ -155,6 +155,13 @@ async function runDynamicMigration(
     const output = getAsyncJobOutputFromMigrationActionResults(results);
     await exec.completeJob(repo, output);
   } catch (err: any) {
+    const errorMsg = normalizeErrorString(err);
+    globalLogger.error('Post-deploy migration threw an error', {
+      error: errorMsg,
+      asyncJob: getReferenceString(asyncJob),
+      type: job.data.type,
+      dataVersion: asyncJob.dataVersion,
+    });
     await exec.failJob(repo, err);
   }
   return 'finished';
@@ -176,6 +183,13 @@ export async function runCustomMigration(
     const output = getAsyncJobOutputFromMigrationActionResults(results);
     await exec.completeJob(repo, output);
   } catch (err: any) {
+    const errorMsg = normalizeErrorString(err);
+    globalLogger.error('Post-deploy migration threw an error', {
+      error: errorMsg,
+      asyncJob: getReferenceString(asyncJob),
+      type: jobData.type,
+      dataVersion: asyncJob.dataVersion,
+    });
     await exec.failJob(repo, err);
   }
   return 'finished';


### PR DESCRIPTION
They were already getting captured in the associated `AsyncJob.output`, but now they are also more easily visible during testing.