### PR TITLE
Search IR

### DIFF
--- a/packages/core/src/fhirpath/utils.test.ts
+++ b/packages/core/src/fhirpath/utils.test.ts
@@ -378,5 +378,17 @@ describe('FHIRPath utils', () => {
       start: '2020-01-01T12:34:56.000Z',
       end: '2020-01-01T12:34:56.999Z',
     });
+
+    // Normalize date strings with time zone offsets
+    expect(toPeriod('2020-01-01T12:34:56.000+01:00')).toMatchObject({
+      start: '2020-01-01T11:34:56.000Z',
+      end: '2020-01-01T11:34:56.000Z',
+    });
+
+    // Normalize periods with time zone offsets
+    expect(toPeriod({ start: '2020-01-01T12:34:56.000+01:00', end: '2020-01-01T12:34:56.999+01:00' })).toMatchObject({
+      start: '2020-01-01T11:34:56.000Z',
+      end: '2020-01-01T11:34:56.999Z',
+    });
   });
 });

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -502,19 +502,18 @@ export function toPeriod(input: unknown): Period | undefined {
     return undefined;
   }
 
-  if (isDateString(input)) {
+  if (isDateString(input) || isDateTimeString(input)) {
     return {
       start: dateStringToInstantString(input, '0000-00-00T00:00:00.000Z'),
       end: dateStringToInstantString(input, 'xxxx-12-31T23:59:59.999Z'),
     };
   }
 
-  if (isDateTimeString(input)) {
-    return { start: input, end: input };
-  }
-
   if (isPeriod(input)) {
-    return input;
+    return {
+      start: input.start ? dateStringToInstantString(input.start, '0000-00-00T00:00:00.000Z') : undefined,
+      end: input.end ? dateStringToInstantString(input.end, 'xxxx-12-31T23:59:59.999Z') : undefined,
+    };
   }
 
   return undefined;
@@ -525,8 +524,7 @@ function dateStringToInstantString(input: string, fill: string): string {
   // The time zone offset is valid, but for this function to work as expected, we need to normalize.
   // Note that the "+" or "-" comes after the seconds, so we must check after the "T" character.
   if (input.includes('+', 10) || input.includes('-', 10)) {
-    const date = new Date(input);
-    return date.toISOString().replace('Z', 'T00:00:00.000Z');
+    return new Date(input).toISOString();
   }
 
   // Input can be any subset of YYYY-MM-DDThh:mm:ss.sssZ

--- a/packages/core/src/fhirpath/utils.ts
+++ b/packages/core/src/fhirpath/utils.ts
@@ -521,6 +521,14 @@ export function toPeriod(input: unknown): Period | undefined {
 }
 
 function dateStringToInstantString(input: string, fill: string): string {
+  // For any input with a time zone offset, we need to normalize it to "Z" time zone.
+  // The time zone offset is valid, but for this function to work as expected, we need to normalize.
+  // Note that the "+" or "-" comes after the seconds, so we must check after the "T" character.
+  if (input.includes('+', 10) || input.includes('-', 10)) {
+    const date = new Date(input);
+    return date.toISOString().replace('Z', 'T00:00:00.000Z');
+  }
+
   // Input can be any subset of YYYY-MM-DDThh:mm:ss.sssZ
   return input + fill.substring(input.length);
 }

--- a/packages/core/src/format.test.ts
+++ b/packages/core/src/format.test.ts
@@ -30,6 +30,9 @@ describe('typedValueToString', () => {
   expect(typedValueToString({ type: 'Quantity', value: { value: 1, unit: 'kg' } })).toStrictEqual('1 kg');
   expect(typedValueToString({ type: 'Reference', value: { reference: 'Patient/x' } })).toStrictEqual('Patient/x');
   expect(typedValueToString({ type: 'string', value: 'x' })).toStrictEqual('x');
+  expect(typedValueToString({ type: 'boolean', value: true })).toStrictEqual('true');
+  expect(typedValueToString({ type: 'boolean', value: false })).toStrictEqual('false');
+  expect(typedValueToString({ type: 'boolean', value: undefined })).toStrictEqual('');
 });
 
 test('formatReferenceString', () => {

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -35,7 +35,7 @@ export interface HumanNameFormatOptions {
  * @returns The string representation of the typed value.
  */
 export function typedValueToString(typedValue: TypedValue | undefined): string {
-  if (!typedValue?.value) {
+  if (!typedValue) {
     return '';
   }
   switch (typedValue.type) {
@@ -54,7 +54,7 @@ export function typedValueToString(typedValue: TypedValue | undefined): string {
     case 'Reference':
       return formatReferenceString(typedValue.value);
     default:
-      return typedValue.value.toString();
+      return typedValue.value?.toString() ?? '';
   }
 }
 

--- a/packages/core/src/format.ts
+++ b/packages/core/src/format.ts
@@ -35,7 +35,7 @@ export interface HumanNameFormatOptions {
  * @returns The string representation of the typed value.
  */
 export function typedValueToString(typedValue: TypedValue | undefined): string {
-  if (!typedValue) {
+  if (!typedValue?.value) {
     return '';
   }
   switch (typedValue.type) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export * from './outcomes';
 export * from './readablepromise';
 export * from './schema';
 export * from './search/details';
+export * from './search/ir';
 export * from './search/match';
 export * from './search/search';
 export * from './sftp';

--- a/packages/core/src/search/details.test.ts
+++ b/packages/core/src/search/details.test.ts
@@ -257,6 +257,9 @@ describe('SearchParameterDetails', () => {
     const details = getSearchParameterDetails('Condition', searchParam);
     expect(details).toBeDefined();
     expect(details.array).toBe(false);
+    expect(details.elementDefinitions).toHaveLength(1);
+    expect(details.elementDefinitions?.[0]?.type).toHaveLength(1);
+    expect(details.elementDefinitions?.[0]?.type?.[0]?.code).toBe('dateTime');
   });
 
   test('us-core-ethnicity', () => {

--- a/packages/core/src/search/details.ts
+++ b/packages/core/src/search/details.ts
@@ -11,7 +11,7 @@ import {
   UnionAtom,
 } from '../fhirpath/atoms';
 import { parseFhirPath } from '../fhirpath/parse';
-import { PropertyType, getElementDefinition, globalSchema } from '../types';
+import { getElementDefinition, globalSchema, PropertyType } from '../types';
 import { InternalSchemaElement } from '../typeschema/types';
 import { lazy } from '../utils';
 
@@ -105,6 +105,7 @@ function buildSearchParameterDetails(resourceType: string, searchParam: SearchPa
       flattenedExpression().endsWith('extension.value.coding.code')
     ) {
       builder.array = true;
+      builder.propertyTypes.clear();
       builder.propertyTypes.add('code');
     } else {
       crawlSearchParameterDetails(builder, atomArray, resourceType, 1);
@@ -117,12 +118,16 @@ function buildSearchParameterDetails(resourceType: string, searchParam: SearchPa
     // extension were parsed since it specifies a cardinality of 0..1.
     if (flattenedExpression().endsWith('extension.valueDateTime')) {
       builder.array = false;
+      builder.propertyTypes.clear();
+      builder.propertyTypes.add('dateTime');
     }
   }
 
   const result: SearchParameterDetails = {
     type: getSearchParameterType(searchParam, builder.propertyTypes),
-    elementDefinitions: builder.elementDefinitions,
+    elementDefinitions: builder.elementDefinitions
+      .map((ed) => ({ ...ed, type: ed.type?.filter((t) => builder.propertyTypes.has(t.code)) }))
+      .filter((ed) => ed.type && ed.type.length > 0),
     parsedExpression: getParsedExpressionForResourceType(resourceType, searchParam.expression as string),
     array: builder.array,
   };

--- a/packages/core/src/search/ir.test.ts
+++ b/packages/core/src/search/ir.test.ts
@@ -1,0 +1,169 @@
+import { CodeableConcept, Coding, ContactPoint, Identifier } from '@medplum/fhirtypes';
+import { toTypedValue } from '../fhirpath/utils';
+import {
+  convertToDateSearchIR,
+  convertToNumberSearchIR,
+  convertToQuantitySearchIR,
+  convertToReferenceSearchIR,
+  convertToStringSearchIR,
+  convertToTokenSearchIR,
+  convertToUriSearchIR,
+} from './ir';
+
+describe('Search IR', () => {
+  test('convertToNumberSearchIR', () => {
+    expect(convertToNumberSearchIR([])).toStrictEqual([]);
+    expect(convertToNumberSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToNumberSearchIR([toTypedValue('foo')])).toStrictEqual([]);
+    expect(convertToNumberSearchIR([toTypedValue(42)])).toStrictEqual([42]);
+  });
+
+  test('convertToDateSearchIR', () => {
+    expect(convertToDateSearchIR([])).toStrictEqual([]);
+    expect(convertToDateSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToDateSearchIR([toTypedValue('foo')])).toStrictEqual([]);
+    expect(convertToDateSearchIR([{ type: 'date', value: '2020-01-01' }])).toStrictEqual([
+      { start: '2020-01-01T00:00:00.000Z', end: '2020-01-01T23:59:59.999Z' },
+    ]);
+  });
+
+  test('convertToStringSearchIR', () => {
+    expect(convertToStringSearchIR([])).toStrictEqual([]);
+    expect(convertToStringSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToStringSearchIR([toTypedValue('foo')])).toStrictEqual(['foo']);
+    expect(convertToStringSearchIR([toTypedValue(42)])).toStrictEqual(['42']);
+  });
+
+  test('convertToReferenceSearchIR', () => {
+    expect(convertToReferenceSearchIR([])).toStrictEqual([]);
+    expect(convertToReferenceSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToReferenceSearchIR([toTypedValue(42)])).toStrictEqual([]);
+
+    // canonical string
+    expect(convertToReferenceSearchIR([{ type: 'canonical', value: 'foo' }])).toStrictEqual(['foo']);
+
+    // normal reference
+    expect(convertToReferenceSearchIR([{ type: 'Reference', value: { reference: 'Patient/123' } }])).toStrictEqual([
+      'Patient/123',
+    ]);
+
+    // inline resource
+    expect(
+      convertToReferenceSearchIR([{ type: 'Patient', value: { resourceType: 'Patient', id: '456' } }])
+    ).toStrictEqual(['Patient/456']);
+
+    // identifier
+    expect(
+      convertToReferenceSearchIR([
+        { type: 'Reference', value: { identifier: { system: 'https://example.com', value: '789' } } },
+      ])
+    ).toStrictEqual(['identifier:https://example.com|789']);
+  });
+
+  test('convertToQuantitySearchIR', () => {
+    expect(convertToQuantitySearchIR([])).toStrictEqual([]);
+    expect(convertToQuantitySearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToQuantitySearchIR([toTypedValue(42)])).toStrictEqual([
+      { value: 42, unit: '', system: '', code: '' },
+    ]);
+    expect(convertToQuantitySearchIR([{ type: 'Quantity', value: { value: 56, unit: 'kg' } }])).toStrictEqual([
+      { value: 56, unit: 'kg' },
+    ]);
+  });
+
+  test('convertToUriSearchIR', () => {
+    expect(convertToUriSearchIR([])).toStrictEqual([]);
+    expect(convertToUriSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToUriSearchIR([toTypedValue(42)])).toStrictEqual([]);
+    expect(convertToUriSearchIR([toTypedValue('foo')])).toStrictEqual(['foo']);
+  });
+
+  test('convertToTokenSearchIR', () => {
+    expect(convertToTokenSearchIR([])).toStrictEqual([]);
+    expect(convertToTokenSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+
+    // string
+    expect(convertToTokenSearchIR([toTypedValue('foo')])).toStrictEqual([{ system: undefined, value: 'foo' }]);
+    expect(
+      convertToTokenSearchIR([toTypedValue('foo'), toTypedValue('foo'), toTypedValue('foo'), toTypedValue('foo')])
+    ).toStrictEqual([{ system: undefined, value: 'foo' }]);
+    expect(convertToTokenSearchIR([toTypedValue(42)])).toStrictEqual([{ system: undefined, value: '42' }]);
+
+    // Identifier
+    expect(
+      convertToTokenSearchIR([
+        { type: 'Identifier', value: { system: 'https://example.com', value: '789' } satisfies Identifier },
+      ])
+    ).toStrictEqual([{ system: 'https://example.com', value: '789' }]);
+
+    // Identifier type text
+    expect(
+      convertToTokenSearchIR([
+        {
+          type: 'Identifier',
+          value: { system: 'https://example.com', value: '789', type: { text: 'foo' } } satisfies Identifier,
+        },
+      ])
+    ).toStrictEqual([
+      { system: undefined, value: 'foo' },
+      { system: 'https://example.com', value: '789' },
+    ]);
+
+    // CodeableConcept
+    expect(
+      convertToTokenSearchIR([
+        {
+          type: 'CodeableConcept',
+          value: { coding: [{ system: 'https://example.com', code: '789' }] } satisfies CodeableConcept,
+        },
+      ])
+    ).toStrictEqual([{ system: 'https://example.com', value: '789' }]);
+
+    // CodeableConcept with text
+    expect(
+      convertToTokenSearchIR([
+        {
+          type: 'CodeableConcept',
+          value: { coding: [{ system: 'https://example.com', code: '789' }], text: 'foo' } satisfies CodeableConcept,
+        },
+      ])
+    ).toStrictEqual([
+      { system: undefined, value: 'foo' },
+      { system: 'https://example.com', value: '789' },
+    ]);
+
+    // CodeableConcept only text
+    expect(
+      convertToTokenSearchIR([
+        {
+          type: 'CodeableConcept',
+          value: { text: 'foo' } satisfies CodeableConcept,
+        },
+      ])
+    ).toStrictEqual([{ system: undefined, value: 'foo' }]);
+
+    // Coding
+    expect(
+      convertToTokenSearchIR([
+        { type: 'Coding', value: { system: 'https://example.com', code: '789' } satisfies Coding },
+      ])
+    ).toStrictEqual([{ system: 'https://example.com', value: '789' }]);
+
+    // Coding with display
+    expect(
+      convertToTokenSearchIR([
+        { type: 'Coding', value: { system: 'https://example.com', code: '789', display: 'foo' } satisfies Coding },
+      ])
+    ).toStrictEqual([
+      { system: undefined, value: 'foo' },
+      { system: 'https://example.com', value: '789' },
+    ]);
+
+    // ContactPoint
+    expect(
+      convertToTokenSearchIR([
+        { type: 'ContactPoint', value: { system: 'phone', value: '789' } satisfies ContactPoint },
+      ])
+    ).toStrictEqual([{ system: 'phone', value: '789' }]);
+  });
+});

--- a/packages/core/src/search/ir.test.ts
+++ b/packages/core/src/search/ir.test.ts
@@ -14,8 +14,11 @@ describe('Search IR', () => {
   test('convertToSearchableNumbers', () => {
     expect(convertToSearchableNumbers([])).toStrictEqual([]);
     expect(convertToSearchableNumbers([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(
+      convertToSearchableNumbers([{ type: 'Range', value: { low: { value: 10 }, high: { value: 20 } } }])
+    ).toStrictEqual([[10, 20]]);
     expect(convertToSearchableNumbers([toTypedValue('foo')])).toStrictEqual([]);
-    expect(convertToSearchableNumbers([toTypedValue(42)])).toStrictEqual([42]);
+    expect(convertToSearchableNumbers([toTypedValue(42)])).toStrictEqual([[42, 42]]);
   });
 
   test('convertToSearchableDates', () => {

--- a/packages/core/src/search/ir.test.ts
+++ b/packages/core/src/search/ir.test.ts
@@ -1,104 +1,102 @@
 import { CodeableConcept, Coding, ContactPoint, Identifier } from '@medplum/fhirtypes';
 import { toTypedValue } from '../fhirpath/utils';
 import {
-  convertToDateSearchIR,
-  convertToNumberSearchIR,
-  convertToQuantitySearchIR,
-  convertToReferenceSearchIR,
-  convertToStringSearchIR,
-  convertToTokenSearchIR,
-  convertToUriSearchIR,
+  convertToSearchableDates,
+  convertToSearchableNumbers,
+  convertToSearchableQuantities,
+  convertToSearchableReferences,
+  convertToSearchableStrings,
+  convertToSearchableTokens,
+  convertToSearchableUris,
 } from './ir';
 
 describe('Search IR', () => {
-  test('convertToNumberSearchIR', () => {
-    expect(convertToNumberSearchIR([])).toStrictEqual([]);
-    expect(convertToNumberSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
-    expect(convertToNumberSearchIR([toTypedValue('foo')])).toStrictEqual([]);
-    expect(convertToNumberSearchIR([toTypedValue(42)])).toStrictEqual([42]);
+  test('convertToSearchableNumbers', () => {
+    expect(convertToSearchableNumbers([])).toStrictEqual([]);
+    expect(convertToSearchableNumbers([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToSearchableNumbers([toTypedValue('foo')])).toStrictEqual([]);
+    expect(convertToSearchableNumbers([toTypedValue(42)])).toStrictEqual([42]);
   });
 
-  test('convertToDateSearchIR', () => {
-    expect(convertToDateSearchIR([])).toStrictEqual([]);
-    expect(convertToDateSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
-    expect(convertToDateSearchIR([toTypedValue('foo')])).toStrictEqual([]);
-    expect(convertToDateSearchIR([{ type: 'date', value: '2020-01-01' }])).toStrictEqual([
+  test('convertToSearchableDates', () => {
+    expect(convertToSearchableDates([])).toStrictEqual([]);
+    expect(convertToSearchableDates([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToSearchableDates([toTypedValue('foo')])).toStrictEqual([]);
+    expect(convertToSearchableDates([{ type: 'date', value: '2020-01-01' }])).toStrictEqual([
       { start: '2020-01-01T00:00:00.000Z', end: '2020-01-01T23:59:59.999Z' },
     ]);
   });
 
-  test('convertToStringSearchIR', () => {
-    expect(convertToStringSearchIR([])).toStrictEqual([]);
-    expect(convertToStringSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
-    expect(convertToStringSearchIR([toTypedValue('foo')])).toStrictEqual(['foo']);
-    expect(convertToStringSearchIR([toTypedValue(42)])).toStrictEqual(['42']);
+  test('convertToSearchableStrings', () => {
+    expect(convertToSearchableStrings([])).toStrictEqual([]);
+    expect(convertToSearchableStrings([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToSearchableStrings([toTypedValue('foo')])).toStrictEqual(['foo']);
+    expect(convertToSearchableStrings([toTypedValue(42)])).toStrictEqual(['42']);
   });
 
-  test('convertToReferenceSearchIR', () => {
-    expect(convertToReferenceSearchIR([])).toStrictEqual([]);
-    expect(convertToReferenceSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
-    expect(convertToReferenceSearchIR([toTypedValue(42)])).toStrictEqual([]);
+  test('convertToSearchableReferences', () => {
+    expect(convertToSearchableReferences([])).toStrictEqual([]);
+    expect(convertToSearchableReferences([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToSearchableReferences([toTypedValue(42)])).toStrictEqual([]);
 
     // canonical string
-    expect(convertToReferenceSearchIR([{ type: 'canonical', value: 'foo' }])).toStrictEqual(['foo']);
+    expect(convertToSearchableReferences([{ type: 'canonical', value: 'foo' }])).toStrictEqual(['foo']);
 
     // normal reference
-    expect(convertToReferenceSearchIR([{ type: 'Reference', value: { reference: 'Patient/123' } }])).toStrictEqual([
+    expect(convertToSearchableReferences([{ type: 'Reference', value: { reference: 'Patient/123' } }])).toStrictEqual([
       'Patient/123',
     ]);
 
     // inline resource
     expect(
-      convertToReferenceSearchIR([{ type: 'Patient', value: { resourceType: 'Patient', id: '456' } }])
+      convertToSearchableReferences([{ type: 'Patient', value: { resourceType: 'Patient', id: '456' } }])
     ).toStrictEqual(['Patient/456']);
 
     // identifier
     expect(
-      convertToReferenceSearchIR([
+      convertToSearchableReferences([
         { type: 'Reference', value: { identifier: { system: 'https://example.com', value: '789' } } },
       ])
     ).toStrictEqual(['identifier:https://example.com|789']);
   });
 
-  test('convertToQuantitySearchIR', () => {
-    expect(convertToQuantitySearchIR([])).toStrictEqual([]);
-    expect(convertToQuantitySearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
-    expect(convertToQuantitySearchIR([toTypedValue(42)])).toStrictEqual([
-      { value: 42, unit: '', system: '', code: '' },
-    ]);
-    expect(convertToQuantitySearchIR([{ type: 'Quantity', value: { value: 56, unit: 'kg' } }])).toStrictEqual([
+  test('convertToSearchableQuantities', () => {
+    expect(convertToSearchableQuantities([])).toStrictEqual([]);
+    expect(convertToSearchableQuantities([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToSearchableQuantities([toTypedValue(42)])).toStrictEqual([{ value: 42 }]);
+    expect(convertToSearchableQuantities([{ type: 'Quantity', value: { value: 56, unit: 'kg' } }])).toStrictEqual([
       { value: 56, unit: 'kg' },
     ]);
   });
 
-  test('convertToUriSearchIR', () => {
-    expect(convertToUriSearchIR([])).toStrictEqual([]);
-    expect(convertToUriSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
-    expect(convertToUriSearchIR([toTypedValue(42)])).toStrictEqual([]);
-    expect(convertToUriSearchIR([toTypedValue('foo')])).toStrictEqual(['foo']);
+  test('convertToSearchableUris', () => {
+    expect(convertToSearchableUris([])).toStrictEqual([]);
+    expect(convertToSearchableUris([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+    expect(convertToSearchableUris([toTypedValue(42)])).toStrictEqual([]);
+    expect(convertToSearchableUris([toTypedValue('foo')])).toStrictEqual(['foo']);
   });
 
-  test('convertToTokenSearchIR', () => {
-    expect(convertToTokenSearchIR([])).toStrictEqual([]);
-    expect(convertToTokenSearchIR([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
+  test('convertToSearchableTokens', () => {
+    expect(convertToSearchableTokens([])).toStrictEqual([]);
+    expect(convertToSearchableTokens([{ type: 'undefined', value: undefined }])).toStrictEqual([]);
 
     // string
-    expect(convertToTokenSearchIR([toTypedValue('foo')])).toStrictEqual([{ system: undefined, value: 'foo' }]);
+    expect(convertToSearchableTokens([toTypedValue('foo')])).toStrictEqual([{ system: undefined, value: 'foo' }]);
     expect(
-      convertToTokenSearchIR([toTypedValue('foo'), toTypedValue('foo'), toTypedValue('foo'), toTypedValue('foo')])
+      convertToSearchableTokens([toTypedValue('foo'), toTypedValue('foo'), toTypedValue('foo'), toTypedValue('foo')])
     ).toStrictEqual([{ system: undefined, value: 'foo' }]);
-    expect(convertToTokenSearchIR([toTypedValue(42)])).toStrictEqual([{ system: undefined, value: '42' }]);
+    expect(convertToSearchableTokens([toTypedValue(42)])).toStrictEqual([{ system: undefined, value: '42' }]);
 
     // Identifier
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         { type: 'Identifier', value: { system: 'https://example.com', value: '789' } satisfies Identifier },
       ])
     ).toStrictEqual([{ system: 'https://example.com', value: '789' }]);
 
     // Identifier type text
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         {
           type: 'Identifier',
           value: { system: 'https://example.com', value: '789', type: { text: 'foo' } } satisfies Identifier,
@@ -111,7 +109,7 @@ describe('Search IR', () => {
 
     // CodeableConcept
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         {
           type: 'CodeableConcept',
           value: { coding: [{ system: 'https://example.com', code: '789' }] } satisfies CodeableConcept,
@@ -121,7 +119,7 @@ describe('Search IR', () => {
 
     // CodeableConcept with text
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         {
           type: 'CodeableConcept',
           value: { coding: [{ system: 'https://example.com', code: '789' }], text: 'foo' } satisfies CodeableConcept,
@@ -134,7 +132,7 @@ describe('Search IR', () => {
 
     // CodeableConcept only text
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         {
           type: 'CodeableConcept',
           value: { text: 'foo' } satisfies CodeableConcept,
@@ -142,16 +140,26 @@ describe('Search IR', () => {
       ])
     ).toStrictEqual([{ system: undefined, value: 'foo' }]);
 
+    // CodeableConcept empty
+    expect(
+      convertToSearchableTokens([
+        {
+          type: 'CodeableConcept',
+          value: {} satisfies CodeableConcept,
+        },
+      ])
+    ).toStrictEqual([]);
+
     // Coding
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         { type: 'Coding', value: { system: 'https://example.com', code: '789' } satisfies Coding },
       ])
     ).toStrictEqual([{ system: 'https://example.com', value: '789' }]);
 
     // Coding with display
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         { type: 'Coding', value: { system: 'https://example.com', code: '789', display: 'foo' } satisfies Coding },
       ])
     ).toStrictEqual([
@@ -161,7 +169,7 @@ describe('Search IR', () => {
 
     // ContactPoint
     expect(
-      convertToTokenSearchIR([
+      convertToSearchableTokens([
         { type: 'ContactPoint', value: { system: 'phone', value: '789' } satisfies ContactPoint },
       ])
     ).toStrictEqual([{ system: 'phone', value: '789' }]);

--- a/packages/core/src/search/ir.ts
+++ b/packages/core/src/search/ir.ts
@@ -73,6 +73,9 @@ export function convertToReferenceSearchIR(typedValues: TypedValue[]): Reference
   const result: ReferenceSearchIR[] = [];
   for (const typedValue of typedValues) {
     const { value } = typedValue;
+    if (!value) {
+      continue;
+    }
     if (isString(value)) {
       // Handle "canonical" properties such as QuestionnaireResponse.questionnaire
       // This is a reference string that is not a FHIR reference
@@ -107,7 +110,7 @@ export function convertToQuantitySearchIR(typedValues: TypedValue[]): QuantitySe
 }
 
 export function convertToUriSearchIR(typedValues: TypedValue[]): UriSearchIR[] {
-  const result: StringSearchIR[] = [];
+  const result: UriSearchIR[] = [];
   for (const typedValue of typedValues) {
     if (isString(typedValue.value)) {
       result.push(typedValue.value);

--- a/packages/core/src/search/ir.ts
+++ b/packages/core/src/search/ir.ts
@@ -25,20 +25,13 @@ import { typedValueToString } from '../format';
 import { isReference, PropertyType, TypedValue } from '../types';
 import { getReferenceString, isResourceWithId, isString } from '../utils';
 
-export interface TokenSearchIR {
+export interface SearchableToken {
   readonly system: string | undefined;
   readonly value: string | undefined;
 }
 
-export type NumberSearchIR = number;
-export type DateSearchIR = Period;
-export type StringSearchIR = string;
-export type ReferenceSearchIR = string;
-export type QuantitySearchIR = Quantity;
-export type UriSearchIR = string;
-
-export function convertToNumberSearchIR(typedValues: TypedValue[]): NumberSearchIR[] {
-  const result: NumberSearchIR[] = [];
+export function convertToSearchableNumbers(typedValues: TypedValue[]): number[] {
+  const result: number[] = [];
   for (const typedValue of typedValues) {
     if (typeof typedValue.value === 'number') {
       result.push(typedValue.value);
@@ -47,8 +40,8 @@ export function convertToNumberSearchIR(typedValues: TypedValue[]): NumberSearch
   return result;
 }
 
-export function convertToDateSearchIR(typedValues: TypedValue[]): DateSearchIR[] {
-  const result: DateSearchIR[] = [];
+export function convertToSearchableDates(typedValues: TypedValue[]): Period[] {
+  const result: Period[] = [];
   for (const typedValue of typedValues) {
     const period = toPeriod(typedValue.value);
     if (period) {
@@ -58,8 +51,8 @@ export function convertToDateSearchIR(typedValues: TypedValue[]): DateSearchIR[]
   return result;
 }
 
-export function convertToStringSearchIR(typedValues: TypedValue[]): StringSearchIR[] {
-  const result: StringSearchIR[] = [];
+export function convertToSearchableStrings(typedValues: TypedValue[]): string[] {
+  const result: string[] = [];
   for (const typedValue of typedValues) {
     const str = typedValueToString(typedValue);
     if (str) {
@@ -69,8 +62,8 @@ export function convertToStringSearchIR(typedValues: TypedValue[]): StringSearch
   return result;
 }
 
-export function convertToReferenceSearchIR(typedValues: TypedValue[]): ReferenceSearchIR[] {
-  const result: ReferenceSearchIR[] = [];
+export function convertToSearchableReferences(typedValues: TypedValue[]): string[] {
+  const result: string[] = [];
   for (const typedValue of typedValues) {
     const { value } = typedValue;
     if (!value) {
@@ -96,21 +89,21 @@ export function convertToReferenceSearchIR(typedValues: TypedValue[]): Reference
   return result;
 }
 
-export function convertToQuantitySearchIR(typedValues: TypedValue[]): QuantitySearchIR[] {
-  const result: QuantitySearchIR[] = [];
+export function convertToSearchableQuantities(typedValues: TypedValue[]): Quantity[] {
+  const result: Quantity[] = [];
   for (const typedValue of typedValues) {
     const { value } = typedValue;
     if (typeof value === 'number') {
-      result.push({ value, unit: '', system: '', code: '' });
-    } else if (isQuantity(typedValue.value)) {
-      result.push(typedValue.value as Quantity);
+      result.push({ value });
+    } else if (isQuantity(value)) {
+      result.push(value);
     }
   }
   return result;
 }
 
-export function convertToUriSearchIR(typedValues: TypedValue[]): UriSearchIR[] {
-  const result: UriSearchIR[] = [];
+export function convertToSearchableUris(typedValues: TypedValue[]): string[] {
+  const result: string[] = [];
   for (const typedValue of typedValues) {
     if (isString(typedValue.value)) {
       result.push(typedValue.value);
@@ -124,8 +117,8 @@ export interface TokensContext {
   textSearchSystem?: string;
 }
 
-export function convertToTokenSearchIR(typedValues: TypedValue[], context: TokensContext = {}): TokenSearchIR[] {
-  const result: TokenSearchIR[] = [];
+export function convertToSearchableTokens(typedValues: TypedValue[], context: TokensContext = {}): SearchableToken[] {
+  const result: SearchableToken[] = [];
   for (const typedValue of typedValues) {
     buildTokens(context, result, typedValue);
   }
@@ -138,7 +131,7 @@ export function convertToTokenSearchIR(typedValues: TypedValue[], context: Token
  * @param result - The result array where tokens will be added.
  * @param typedValue - A typed value to be indexed for the search parameter.
  */
-function buildTokens(context: TokensContext, result: TokenSearchIR[], typedValue: TypedValue): void {
+function buildTokens(context: TokensContext, result: SearchableToken[], typedValue: TypedValue): void {
   const { type, value } = typedValue;
 
   switch (type) {
@@ -166,7 +159,7 @@ function buildTokens(context: TokensContext, result: TokenSearchIR[], typedValue
  * @param identifier - The Identifier object to be indexed.
  */
 function buildIdentifierToken(
-  result: TokenSearchIR[],
+  result: SearchableToken[],
   context: TokensContext,
   identifier: Identifier | undefined
 ): void {
@@ -183,7 +176,7 @@ function buildIdentifierToken(
  * @param codeableConcept - The CodeableConcept object to be indexed.
  */
 function buildCodeableConceptToken(
-  result: TokenSearchIR[],
+  result: SearchableToken[],
   context: TokensContext,
   codeableConcept: CodeableConcept | undefined
 ): void {
@@ -203,7 +196,7 @@ function buildCodeableConceptToken(
  * @param context - Context for building tokens.
  * @param coding - The Coding object to be indexed.
  */
-function buildCodingToken(result: TokenSearchIR[], context: TokensContext, coding: Coding | undefined): void {
+function buildCodingToken(result: SearchableToken[], context: TokensContext, coding: Coding | undefined): void {
   if (coding) {
     if (coding.display) {
       buildSimpleToken(result, context, context.textSearchSystem, coding.display);
@@ -219,7 +212,7 @@ function buildCodingToken(result: TokenSearchIR[], context: TokensContext, codin
  * @param contactPoint - The ContactPoint object to be indexed.
  */
 function buildContactPointToken(
-  result: TokenSearchIR[],
+  result: SearchableToken[],
   context: TokensContext,
   contactPoint: ContactPoint | undefined
 ): void {
@@ -236,7 +229,7 @@ function buildContactPointToken(
  * @param value - The token value.
  */
 function buildSimpleToken(
-  result: TokenSearchIR[],
+  result: SearchableToken[],
   context: TokensContext,
   system: string | undefined,
   value: string | undefined

--- a/packages/core/src/search/ir.ts
+++ b/packages/core/src/search/ir.ts
@@ -30,11 +30,13 @@ export interface SearchableToken {
   readonly value: string | undefined;
 }
 
-export function convertToSearchableNumbers(typedValues: TypedValue[]): number[] {
-  const result: number[] = [];
+export function convertToSearchableNumbers(typedValues: TypedValue[]): [number | undefined, number | undefined][] {
+  const result: [number | undefined, number | undefined][] = [];
   for (const typedValue of typedValues) {
-    if (typeof typedValue.value === 'number') {
-      result.push(typedValue.value);
+    if (typedValue.type === PropertyType.Range) {
+      result.push([typedValue.value?.low?.value, typedValue.value?.high?.value]);
+    } else if (typeof typedValue.value === 'number') {
+      result.push([typedValue.value, typedValue.value]);
     }
   }
   return result;

--- a/packages/core/src/search/ir.ts
+++ b/packages/core/src/search/ir.ts
@@ -1,0 +1,150 @@
+// Search Immediate Representation (IR) module
+//
+// https://hl7.org/fhir/R4/search.html
+//
+// FHIR R4 has the following search parameter types:
+//  1. Number
+//  2. Date/DateTime
+//  3. String
+//  4. Token
+//  5. Reference
+//  6. Composite
+//  7. Quantity
+//  8. URI
+//  9. Special
+//
+// To make matters more complicated, we must consider that these search parameters can be applied
+// to many different underlying element types.
+//
+// To make our lives easier, we will use a simple Immediate Representation (IR) format to represent the search parameters.
+// All underlying element types will be mapped to the IR format for the corresponding search parameter type.
+
+import { CodeableConcept, Coding, ContactPoint, Identifier, Period, Quantity } from '@medplum/fhirtypes';
+import { isQuantity, toPeriod } from '../fhirpath/utils';
+import { typedValueToString } from '../format';
+import { isReference, TypedValue } from '../types';
+import { isString } from '../utils';
+
+export type NumberSearchIR = number;
+export type DateSearchIR = Period;
+export type StringSearchIR = string;
+export type TokenSearchIR = Coding;
+export type ReferenceSearchIR = string;
+export type QuantitySearchIR = Quantity;
+export type UriSearchIR = string;
+
+export function convertToNumberSearchIR(typedValues: TypedValue[]): NumberSearchIR[] {
+  const result: NumberSearchIR[] = [];
+  for (const typedValue of typedValues) {
+    if (typeof typedValue.value === 'number') {
+      result.push(typedValue.value);
+    }
+  }
+  return result;
+}
+
+export function convertToDateSearchIR(typedValues: TypedValue[]): DateSearchIR[] {
+  const result: DateSearchIR[] = [];
+  for (const typedValue of typedValues) {
+    const period = toPeriod(typedValue.value);
+    if (period) {
+      result.push(period);
+    }
+  }
+  return result;
+}
+
+export function convertToStringSearchIR(typedValues: TypedValue[]): StringSearchIR[] {
+  const result: StringSearchIR[] = [];
+  for (const typedValue of typedValues) {
+    const str = typedValueToString(typedValue);
+    if (str) {
+      result.push(str);
+    }
+  }
+  return result;
+}
+
+export function convertToTokenSearchIR(typedValues: TypedValue[]): TokenSearchIR[] {
+  const result: TokenSearchIR[] = [];
+  for (const typedValue of typedValues) {
+    switch (typedValue.type) {
+      case 'boolean':
+        result.push({ code: typedValue.value.toString() });
+        break;
+      case 'code':
+      case 'id':
+      case 'string':
+      case 'uri':
+        result.push({ code: typedValue.value });
+        break;
+      case 'Coding':
+        result.push(typedValue.value as Coding);
+        break;
+      case 'CodeableConcept':
+        {
+          const cc = typedValue.value as CodeableConcept;
+          if (cc.coding) {
+            for (const coding of cc.coding) {
+              result.push(coding);
+            }
+          }
+          if (cc.text) {
+            result.push({ code: cc.text });
+          }
+        }
+        break;
+      case 'ContactPoint':
+        {
+          const contactPoint = typedValue.value as ContactPoint;
+          result.push({
+            system: contactPoint.system,
+            code: contactPoint.value,
+          });
+        }
+        break;
+      case 'Identifier':
+        {
+          const identifier = typedValue.value as Identifier;
+          result.push({
+            system: identifier.system,
+            code: identifier.value,
+          });
+        }
+        break;
+    }
+  }
+  return result;
+}
+
+export function convertToReferenceSearchIR(typedValues: TypedValue[]): ReferenceSearchIR[] {
+  const result: ReferenceSearchIR[] = [];
+  for (const typedValue of typedValues) {
+    if (isString(typedValue.value)) {
+      result.push(typedValue.value);
+    } else if (isReference(typedValue.value)) {
+      result.push(typedValue.value.reference);
+    }
+  }
+  return result;
+}
+
+export function convertToQuantitySearchIR(typedValues: TypedValue[]): QuantitySearchIR[] {
+  const result: QuantitySearchIR[] = [];
+  for (const typedValue of typedValues) {
+    if (isQuantity(typedValue.value)) {
+      result.push(typedValue.value as Quantity);
+    }
+  }
+  return result;
+}
+
+export function convertToUriSearchIR(typedValues: TypedValue[]): UriSearchIR[] {
+  const result: StringSearchIR[] = [];
+  for (const typedValue of typedValues) {
+    if (isString(typedValue.value)) {
+      result.push(typedValue.value);
+    }
+  }
+  return result;
+}

--- a/packages/core/src/search/match.test.ts
+++ b/packages/core/src/search/match.test.ts
@@ -3,6 +3,7 @@ import {
   ActivityDefinition,
   Bundle,
   DiagnosticReport,
+  Location,
   Observation,
   Patient,
   Practitioner,
@@ -839,7 +840,12 @@ describe('Search matching', () => {
         resourceType: 'Task',
         status: 'accepted',
         intent: 'order',
-        restriction: { period: { start: '2025-05-15T12:00:00.000Z' } },
+        restriction: {
+          period: {
+            start: '2025-05-15T12:00:00.000Z',
+            end: '2025-05-15T13:00:00.000Z',
+          },
+        },
       };
 
       test('true', () => {
@@ -1105,5 +1111,17 @@ describe('Search matching', () => {
         filters: [{ code: '_tag', operator: Operator.NOT_EQUALS, value: 'RESTRICTED' }],
       })
     ).toBe(true);
+  });
+
+  test('Special not implemented', () => {
+    const resource: Location = {
+      resourceType: 'Location',
+    };
+
+    const search1: SearchRequest = {
+      resourceType: 'Location',
+      filters: [{ code: 'near', operator: Operator.EQUALS, value: 'foo' }],
+    };
+    expect(matchesSearchRequest(resource, search1)).toBe(false);
   });
 });

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -128,16 +128,16 @@ function matchesTokenValue(resourceValue: TokenSearchIR, filterValue: string): b
       return false;
     } else if (!system) {
       // [parameter]=|[code]: the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property
-      return !resourceValue.system && resourceValue.code?.toLowerCase() === value;
+      return !resourceValue.system && resourceValue.value?.toLowerCase() === value;
     }
 
     // [parameter]=[system]|: any element where the value of [system] matches the system property of the Identifier or Coding
     // [parameter]=[system]|[code]: the value of [code] matches a Coding.code or Identifier.value, and the value of [system] matches the system property of the Identifier or Coding
-    return resourceValue.system?.toLowerCase() === system && (!value || resourceValue.code?.toLowerCase() === value);
+    return resourceValue.system?.toLowerCase() === system && (!value || resourceValue.value?.toLowerCase() === value);
   }
 
   // [parameter]=[code]: the value of [code] matches a Coding.code or Identifier.value irrespective of the value of the system property
-  return resourceValue.code?.toLowerCase() === filterValue.toLowerCase();
+  return resourceValue.value?.toLowerCase() === filterValue.toLowerCase();
 }
 
 function matchesStringFilter(typedValues: TypedValue[], filter: Filter): boolean {

--- a/packages/core/src/search/match.ts
+++ b/packages/core/src/search/match.ts
@@ -1,9 +1,16 @@
-import { CodeableConcept, Identifier, Reference, Resource, SearchParameter } from '@medplum/fhirtypes';
-import { evalFhirPath } from '../fhirpath/parse';
-import { isPeriod } from '../fhirpath/utils';
-import { PropertyType, globalSchema } from '../types';
-import { isString } from '../utils';
-import { SearchParameterType, getSearchParameterDetails } from './details';
+import { Resource } from '@medplum/fhirtypes';
+import { evalFhirPathTyped } from '../fhirpath/parse';
+import { toPeriod, toTypedValue } from '../fhirpath/utils';
+import { TypedValue, globalSchema } from '../types';
+import {
+  DateSearchIR,
+  StringSearchIR,
+  TokenSearchIR,
+  convertToDateSearchIR,
+  convertToReferenceSearchIR,
+  convertToStringSearchIR,
+  convertToTokenSearchIR,
+} from './ir';
 import { Filter, Operator, SearchRequest, splitSearchOnComma } from './search';
 
 /**
@@ -38,19 +45,20 @@ function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, f
   if (!searchParam) {
     return false;
   }
+  const typedValues = evalFhirPathTyped(searchParam.expression as string, [toTypedValue(resource)]);
   if (filter.operator === Operator.MISSING || filter.operator === Operator.PRESENT) {
-    return matchesMissingOrPresent(resource, filter, searchParam);
+    return matchesMissingOrPresent(typedValues, filter);
   }
   switch (searchParam.type) {
     case 'reference':
-      return matchesReferenceFilter(resource, filter, searchParam);
+      return matchesReferenceFilter(typedValues, filter);
     case 'string':
     case 'uri':
-      return matchesStringFilter(resource, filter, searchParam);
+      return matchesStringFilter(typedValues, filter);
     case 'token':
-      return matchesTokenFilter(resource, filter, searchParam);
+      return matchesTokenFilter(typedValues, filter);
     case 'date':
-      return matchesDateFilter(resource, filter, searchParam);
+      return matchesDateFilter(typedValues, filter);
     default:
       // Unknown search parameter or search parameter type
       // Default fail the check
@@ -58,27 +66,25 @@ function matchesSearchFilter(resource: Resource, searchRequest: SearchRequest, f
   }
 }
 
-function matchesMissingOrPresent(resource: Resource, filter: Filter, searchParam: SearchParameter): boolean {
-  const values = evalFhirPath(searchParam.expression as string, resource);
-  const exists = values.length > 0;
+function matchesMissingOrPresent(typedValues: TypedValue[], filter: Filter): boolean {
+  const exists = typedValues.length > 0;
   const desired =
     (filter.operator === Operator.MISSING && filter.value === 'false') ||
     (filter.operator === Operator.PRESENT && filter.value === 'true');
   return desired === exists;
 }
 
-function matchesReferenceFilter(resource: Resource, filter: Filter, searchParam: SearchParameter): boolean {
-  const values = evalFhirPath(searchParam.expression as string, resource) as (Reference | string)[];
+function matchesReferenceFilter(typedValues: TypedValue[], filter: Filter): boolean {
   const negated = isNegated(filter.operator);
 
-  if (filter.value === '' && values.length === 0) {
+  if (filter.value === '' && typedValues.length === 0) {
     // If the filter operator is "equals", then the filter matches.
     // If the filter operator is "not equals", then the filter does not match.
     return filter.operator === Operator.EQUALS;
   }
 
   // Normalize the values array into reference strings
-  const references = values.map((value) => (typeof value === 'string' ? value : value.reference));
+  const references = convertToReferenceSearchIR(typedValues);
 
   for (const filterValue of splitSearchOnComma(filter.value)) {
     let match = references.includes(filterValue);
@@ -98,49 +104,13 @@ function matchesReferenceFilter(resource: Resource, filter: Filter, searchParam:
   return negated;
 }
 
-function matchesTokenFilter(resource: Resource, filter: Filter, searchParam: SearchParameter): boolean {
-  const details = getSearchParameterDetails(resource.resourceType, searchParam);
-  if (details.type === SearchParameterType.BOOLEAN) {
-    return matchesBooleanFilter(resource, filter, searchParam);
-  } else {
-    return matchesStringFilter(resource, filter, searchParam, true);
-  }
-}
-
-function matchesBooleanFilter(resource: Resource, filter: Filter, searchParam: SearchParameter): boolean {
-  const values = evalFhirPath(searchParam.expression as string, resource);
-  const expected = filter.value === 'true';
-  const result = values.includes(expected);
-  return isNegated(filter.operator) ? !result : result;
-}
-
-function matchesStringFilter(
-  resource: Resource,
-  filter: Filter,
-  searchParam: SearchParameter,
-  asToken?: boolean
-): boolean {
-  const details = getSearchParameterDetails(resource.resourceType, searchParam);
-  const searchParamElementType = details.elementDefinitions?.[0]?.type?.[0]?.code;
-  const resourceValues = evalFhirPath(searchParam.expression as string, resource);
+function matchesTokenFilter(typedValues: TypedValue[], filter: Filter): boolean {
+  const resourceValues = convertToTokenSearchIR(typedValues);
   const filterValues = splitSearchOnComma(filter.value);
   const negated = isNegated(filter.operator);
   for (const resourceValue of resourceValues) {
     for (const filterValue of filterValues) {
-      let match;
-      if (searchParamElementType === PropertyType.Identifier) {
-        match = matchesTokenIdentifierValue(resourceValue as Identifier, filter.operator, filterValue);
-      } else if (searchParamElementType === PropertyType.CodeableConcept) {
-        match = matchesTokenCodeableConceptValue(resourceValue as CodeableConcept, filter.operator, filterValue);
-      } else if (searchParamElementType === PropertyType.Coding) {
-        match = matchesTokenCodeableConceptValue(
-          { coding: [resourceValue] } as CodeableConcept,
-          filter.operator,
-          filterValue
-        );
-      } else {
-        match = matchesStringValue(resourceValue, filter.operator, filterValue, asToken);
-      }
+      const match = matchesTokenValue(resourceValue, filterValue);
       if (match) {
         return !negated;
       }
@@ -151,90 +121,32 @@ function matchesStringFilter(
   return negated;
 }
 
-function matchesStringValue(
-  resourceValue: unknown,
-  operator: Operator,
-  filterValue: string,
-  asToken?: boolean
-): boolean {
-  if (asToken && filterValue.includes('|')) {
-    const [system, code] = filterValue.split('|');
-    return (
-      matchesStringValue(resourceValue, operator, system, false) &&
-      (!code || matchesStringValue(resourceValue, operator, code, false))
-    );
-  }
-  let str = '';
-  if (resourceValue) {
-    if (typeof resourceValue === 'string') {
-      str = resourceValue;
-    } else if (typeof resourceValue === 'object') {
-      str = JSON.stringify(resourceValue);
-    }
-  }
-  return str.toLowerCase().includes(filterValue.toLowerCase());
-}
-
-function matchesTokenIdentifierValue(resourceValue: Identifier, operator: Operator, filterValue: string): boolean {
+function matchesTokenValue(resourceValue: TokenSearchIR, filterValue: string): boolean {
   if (filterValue.includes('|')) {
     const [system, value] = filterValue.split('|').map((s) => s.toLowerCase());
     if (!system && !value) {
       return false;
     } else if (!system) {
       // [parameter]=|[code]: the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property
-      return !resourceValue.system && resourceValue.value?.toLowerCase() === value;
+      return !resourceValue.system && resourceValue.code?.toLowerCase() === value;
     }
 
     // [parameter]=[system]|: any element where the value of [system] matches the system property of the Identifier or Coding
     // [parameter]=[system]|[code]: the value of [code] matches a Coding.code or Identifier.value, and the value of [system] matches the system property of the Identifier or Coding
-    return resourceValue.system?.toLowerCase() === system && (!value || resourceValue.value?.toLowerCase() === value);
+    return resourceValue.system?.toLowerCase() === system && (!value || resourceValue.code?.toLowerCase() === value);
   }
 
   // [parameter]=[code]: the value of [code] matches a Coding.code or Identifier.value irrespective of the value of the system property
-  return resourceValue.value?.toLowerCase() === filterValue.toLowerCase();
+  return resourceValue.code?.toLowerCase() === filterValue.toLowerCase();
 }
 
-function matchesTokenCodeableConceptValue(
-  resourceValue: CodeableConcept,
-  _operator: Operator,
-  filterValue: string
-): boolean {
-  if (filterValue.includes('|')) {
-    const [system, code] = filterValue.split('|').map((s) => s.toLowerCase());
-    if (!system && !code) {
-      return false;
-    } else if (!system) {
-      // [parameter]=|[code]: the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property
-      return resourceValue.coding?.some((coding) => !coding.system && coding.code?.toLowerCase() === code) ?? false;
-    }
-
-    // [parameter]=[system]|: any element where the value of [system] matches the system property of the Identifier or Coding
-    // [parameter]=[system]|[code]: the value of [code] matches a Coding.code or Identifier.value, and the value of [system] matches the system property of the Identifier or Coding
-    return (
-      resourceValue.coding?.some(
-        (coding) => coding.system?.toLowerCase() === system && (!code || coding.code?.toLowerCase() === code)
-      ) ?? false
-    );
-  }
-
-  // [parameter]=[code]: the value of [code] matches a Coding.code or Identifier.value irrespective of the value of the system property
-  return (
-    resourceValue.text?.toLowerCase() === filterValue.toLowerCase() ||
-    (resourceValue.coding?.some((coding) => coding.code?.toLowerCase() === filterValue.toLowerCase()) ?? false)
-  );
-}
-
-function matchesDateFilter(resource: Resource, filter: Filter, searchParam: SearchParameter): boolean {
-  const resourceValues = evalFhirPath(searchParam.expression as string, resource);
+function matchesStringFilter(typedValues: TypedValue[], filter: Filter): boolean {
+  const resourceValues = convertToStringSearchIR(typedValues);
   const filterValues = splitSearchOnComma(filter.value);
   const negated = isNegated(filter.operator);
   for (const resourceValue of resourceValues) {
     for (const filterValue of filterValues) {
-      const match = matchesDateValue(
-        buildDateTimeColumn(resourceValue),
-        filter.operator,
-        buildDateTimeColumn(filterValue) as string
-      );
+      const match = matchesStringValue(resourceValue, filterValue);
       if (match) {
         return !negated;
       }
@@ -245,54 +157,61 @@ function matchesDateFilter(resource: Resource, filter: Filter, searchParam: Sear
   return negated;
 }
 
-function matchesDateValue(resourceValue: string | undefined, operator: Operator, filterValue: string): boolean {
+function matchesStringValue(resourceValue: StringSearchIR, filterValue: string): boolean {
+  return resourceValue.toLowerCase().includes(filterValue.toLowerCase());
+}
+
+function matchesDateFilter(typedValues: TypedValue[], filter: Filter): boolean {
+  const resourceValues = convertToDateSearchIR(typedValues);
+  const filterValues = splitSearchOnComma(filter.value);
+  const negated = isNegated(filter.operator);
+  for (const resourceValue of resourceValues) {
+    for (const filterValue of filterValues) {
+      const match = matchesDateValue(resourceValue, filter.operator, filterValue);
+      if (match) {
+        return !negated;
+      }
+    }
+  }
+  // If "not equals" and no matches, then return true
+  // If "equals" and no matches, then return false
+  return negated;
+}
+
+function matchesDateValue(resourceValue: DateSearchIR, operator: Operator, filterValue: string): boolean {
   if (!resourceValue) {
     return false;
   }
+  const filterPeriod = toPeriod(filterValue);
+  if (!filterPeriod) {
+    return false;
+  }
+
+  const resourceStart = resourceValue.start ?? '0000';
+  const resourceEnd = resourceValue.end ?? '9999';
+  const filterStart = filterPeriod.start as string;
+  const filterEnd = filterPeriod.end as string;
+
   switch (operator) {
-    case Operator.STARTS_AFTER:
-    case Operator.GREATER_THAN:
-      return resourceValue > filterValue;
-    case Operator.GREATER_THAN_OR_EQUALS:
-      return resourceValue >= filterValue;
-    case Operator.ENDS_BEFORE:
-    case Operator.LESS_THAN:
-      return resourceValue < filterValue;
-    case Operator.LESS_THAN_OR_EQUALS:
-      return resourceValue <= filterValue;
+    case Operator.APPROXIMATELY:
     case Operator.EQUALS:
-    case Operator.NOT_EQUALS:
-      return resourceValue === filterValue;
+    case Operator.NOT_EQUALS: // Negation handled in the caller
+      return resourceStart < filterEnd && resourceEnd > filterStart;
+    case Operator.LESS_THAN:
+      return resourceStart < filterStart;
+    case Operator.GREATER_THAN:
+      return resourceEnd > filterEnd;
+    case Operator.LESS_THAN_OR_EQUALS:
+      return resourceStart <= filterEnd;
+    case Operator.GREATER_THAN_OR_EQUALS:
+      return resourceEnd >= filterStart;
+    case Operator.STARTS_AFTER:
+      return resourceStart > filterEnd;
+    case Operator.ENDS_BEFORE:
+      return resourceEnd < filterStart;
     default:
       return false;
   }
-}
-
-/**
- * Builds the column value for a date/time parameter.
- * Tries to parse the date string.
- * Silently ignores failure.
- * @param value - The FHIRPath result.
- * @returns The date/time string if parsed; undefined otherwise.
- */
-function buildDateTimeColumn(value: unknown): string | undefined {
-  if (isString(value)) {
-    try {
-      const date = new Date(value);
-      return date.toISOString();
-    } catch (err) {
-      console.debug('Failed to parse date', value, err);
-    }
-  } else if (isPeriod(value)) {
-    // Can be a Period
-    if ('start' in value) {
-      return buildDateTimeColumn(value.start);
-    }
-    if ('end' in value) {
-      return buildDateTimeColumn(value.end);
-    }
-  }
-  return undefined;
 }
 
 function isNegated(operator: Operator): boolean {

--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -549,7 +549,6 @@ export class MemoryRepository extends FhirRepository<undefined> {
 
   withTransaction<TResult>(callback: (client: undefined) => Promise<TResult>): Promise<TResult> {
     // MockRepository currently does not support transactions
-    console.debug('WARN: MockRepository does not support transactions');
     return callback(undefined);
   }
 }

--- a/packages/server/src/email/email.test.ts
+++ b/packages/server/src/email/email.test.ts
@@ -295,9 +295,7 @@ describe('Email', () => {
           },
         ],
       })
-    ).rejects.toThrow(
-      'Invalid email options: The "chunk" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object'
-    );
+    ).rejects.toThrow(/Invalid email options/);
 
     expect(mockSESv2Client.send.callCount).toBe(0);
     expect(mockSESv2Client).toHaveReceivedCommandTimes(SendEmailCommand, 0);

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -5,13 +5,13 @@ import {
   arrayify,
   BackgroundJobInteraction,
   badRequest,
-  convertToDateSearchIR,
-  convertToNumberSearchIR,
-  convertToQuantitySearchIR,
-  convertToReferenceSearchIR,
-  convertToStringSearchIR,
-  convertToTokenSearchIR,
-  convertToUriSearchIR,
+  convertToSearchableDates,
+  convertToSearchableNumbers,
+  convertToSearchableQuantities,
+  convertToSearchableReferences,
+  convertToSearchableStrings,
+  convertToSearchableTokens,
+  convertToSearchableUris,
   createReference,
   deepClone,
   deepEquals,
@@ -1688,43 +1688,43 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       // "Date" column is a special case that only applies when the following conditions are true:
       // 1. The search parameter is a date type.
       // 2. The underlying FHIR ElementDefinition referred to by the search parameter has a type of "date".
-      return convertToDateSearchIR(typedValues)
+      return convertToSearchableDates(typedValues)
         .map((p) => (p.start ?? p.end)?.substring(0, 10))
         .filter(Boolean) as string[];
     }
 
     if (details.type === SearchParameterType.DATETIME) {
-      return convertToDateSearchIR(typedValues)
+      return convertToSearchableDates(typedValues)
         .map((p) => p.start ?? p.end)
         .filter(Boolean) as string[];
     }
 
     if (searchParam.type === 'number') {
-      return convertToNumberSearchIR(typedValues).filter((n) => n !== undefined);
+      return convertToSearchableNumbers(typedValues).filter((n) => n !== undefined);
     }
 
     if (searchParam.type === 'quantity') {
-      return convertToQuantitySearchIR(typedValues)
+      return convertToSearchableQuantities(typedValues)
         .map((q) => q.value)
         .filter((q) => q !== undefined);
     }
 
     if (searchParam.type === 'reference') {
-      return convertToReferenceSearchIR(typedValues).map(truncateTextColumn).filter(Boolean);
+      return convertToSearchableReferences(typedValues).map(truncateTextColumn).filter(Boolean);
     }
 
     if (searchParam.type === 'token') {
-      return convertToTokenSearchIR(typedValues)
+      return convertToSearchableTokens(typedValues)
         .map((t) => truncateTextColumn(t.value))
         .filter(Boolean);
     }
 
     if (searchParam.type === 'string') {
-      return convertToStringSearchIR(typedValues).map(truncateTextColumn).filter(Boolean);
+      return convertToSearchableStrings(typedValues).map(truncateTextColumn).filter(Boolean);
     }
 
     if (searchParam.type === 'uri') {
-      return convertToUriSearchIR(typedValues).map(truncateTextColumn).filter(Boolean);
+      return convertToSearchableUris(typedValues).map(truncateTextColumn).filter(Boolean);
     }
 
     if (searchParam.type === 'special' || searchParam.type === 'composite') {

--- a/packages/server/src/fhir/tokens.ts
+++ b/packages/server/src/fhir/tokens.ts
@@ -1,6 +1,6 @@
 import {
   badRequest,
-  convertToTokenSearchIR,
+  convertToSearchableTokens,
   evalFhirPathTyped,
   getSearchParameterDetails,
   OperationOutcomeError,
@@ -102,7 +102,7 @@ export function buildTokensForSearchParameter(
     textSearchSystem,
   };
 
-  const tokens = convertToTokenSearchIR(typedValues, context);
+  const tokens = convertToSearchableTokens(typedValues, context);
   for (const token of tokens) {
     result.push({
       code: searchParam.code,

--- a/packages/server/src/fhir/tokens.ts
+++ b/packages/server/src/fhir/tokens.ts
@@ -1,14 +1,15 @@
 import {
   badRequest,
+  convertToTokenSearchIR,
   evalFhirPathTyped,
   getSearchParameterDetails,
   OperationOutcomeError,
   Operator,
   PropertyType,
+  TokensContext,
   toTypedValue,
-  TypedValue,
 } from '@medplum/core';
-import { CodeableConcept, Coding, ContactPoint, Identifier, Resource, SearchParameter } from '@medplum/fhirtypes';
+import { Resource, SearchParameter } from '@medplum/fhirtypes';
 
 export interface Token {
   readonly code: string;
@@ -97,132 +98,16 @@ export function buildTokensForSearchParameter(
   const typedValues = evalFhirPathTyped(details.parsedExpression, [toTypedValue(resource)]);
 
   const context: TokensContext = {
-    searchParam,
     caseInsensitive: getTokenIndexType(searchParam, resource.resourceType) === TokenIndexTypes.CASE_INSENSITIVE,
     textSearchSystem,
   };
 
-  for (const typedValue of typedValues) {
-    buildTokens(context, result, typedValue);
-  }
-}
-
-interface TokensContext {
-  searchParam: SearchParameter;
-  caseInsensitive: boolean;
-  textSearchSystem?: string;
-}
-
-/**
- * Builds a list of zero or more tokens for a search parameter and value.
- * @param context - The context for building tokens.
- * @param result - The result array where tokens will be added.
- * @param typedValue - A typed value to be indexed for the search parameter.
- */
-function buildTokens(context: TokensContext, result: Token[], typedValue: TypedValue): void {
-  const { type, value } = typedValue;
-
-  switch (type) {
-    case PropertyType.Identifier:
-      buildIdentifierToken(result, context, value as Identifier);
-      break;
-    case PropertyType.CodeableConcept:
-      buildCodeableConceptToken(result, context, value as CodeableConcept);
-      break;
-    case PropertyType.Coding:
-      buildCodingToken(result, context, value as Coding);
-      break;
-    case PropertyType.ContactPoint:
-      buildContactPointToken(result, context, value as ContactPoint);
-      break;
-    default:
-      buildSimpleToken(result, context, undefined, value?.toString() as string | undefined);
-  }
-}
-
-/**
- * Builds an identifier token.
- * @param result - The result array where tokens will be added.
- * @param context - Context for building tokens.
- * @param identifier - The Identifier object to be indexed.
- */
-function buildIdentifierToken(result: Token[], context: TokensContext, identifier: Identifier | undefined): void {
-  if (identifier?.type?.text) {
-    buildSimpleToken(result, context, context.textSearchSystem, identifier.type.text);
-  }
-  buildSimpleToken(result, context, identifier?.system, identifier?.value);
-}
-
-/**
- * Builds zero or more CodeableConcept tokens.
- * @param result - The result array where tokens will be added.
- * @param context - Context for building tokens.
- * @param codeableConcept - The CodeableConcept object to be indexed.
- */
-function buildCodeableConceptToken(
-  result: Token[],
-  context: TokensContext,
-  codeableConcept: CodeableConcept | undefined
-): void {
-  if (codeableConcept?.text) {
-    buildSimpleToken(result, context, context.textSearchSystem, codeableConcept.text);
-  }
-  if (codeableConcept?.coding) {
-    for (const coding of codeableConcept.coding) {
-      buildCodingToken(result, context, coding);
-    }
-  }
-}
-
-/**
- * Builds a Coding token.
- * @param result - The result array where tokens will be added.
- * @param context - Context for building tokens.
- * @param coding - The Coding object to be indexed.
- */
-function buildCodingToken(result: Token[], context: TokensContext, coding: Coding | undefined): void {
-  if (coding) {
-    if (coding.display) {
-      buildSimpleToken(result, context, context.textSearchSystem, coding.display);
-    }
-    buildSimpleToken(result, context, coding.system, coding.code);
-  }
-}
-
-/**
- * Builds a ContactPoint token.
- * @param result - The result array where tokens will be added.
- * @param context - Context for building tokens.
- * @param contactPoint - The ContactPoint object to be indexed.
- */
-function buildContactPointToken(result: Token[], context: TokensContext, contactPoint: ContactPoint | undefined): void {
-  if (contactPoint) {
-    buildSimpleToken(result, context, contactPoint.system, contactPoint.value?.toLocaleLowerCase());
-  }
-}
-
-/**
- * Builds a simple token.
- * @param result - The result array where tokens will be added.
- * @param context - Context for building tokens.
- * @param system - The token system.
- * @param value - The token value.
- */
-function buildSimpleToken(
-  result: Token[],
-  context: TokensContext,
-  system: string | undefined,
-  value: string | undefined
-): void {
-  // Only add the token if there is a system or a value, and if it is not already in the list.
-  if (
-    (system || value) &&
-    !result.some((token) => token.code === context.searchParam.code && token.system === system && token.value === value)
-  ) {
+  const tokens = convertToTokenSearchIR(typedValues, context);
+  for (const token of tokens) {
     result.push({
-      code: context.searchParam.code as string,
-      system,
-      value: value && context.caseInsensitive ? value.toLocaleLowerCase() : value,
+      code: searchParam.code,
+      system: token.system,
+      value: context.caseInsensitive ? token.value?.toLocaleLowerCase() : token.value,
     });
   }
 }


### PR DESCRIPTION
This unifies portions of the 2 search implementations (in-memory and database).

Historically, we have considered the database implementation to be the "main" one, and the in-memory implementation to be an "extra" for supplementary use cases.  However, over time, we have used the in-memory implementation more and more.  For example, it is now used when evaluating subscription criteria or access policy criteria.  Under those circumstances, it is now more important than ever that these search implementations be aligned for maximum correctness.