### PR TITLE
Always declare top-level github actions permissions

### DIFF
--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -11,9 +11,15 @@ on:
       - main
       - medplum/test-actions
 
+permissions:
+  contents: read
+
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,10 +2,16 @@ name: 'Chromatic'
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,9 +22,9 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -3,11 +3,17 @@ on:
   workflow_run:
     workflows: [Build]
     types: [completed]
+
+permissions:
+  contents: read
+
 jobs:
   coveralls:
     name: Coveralls
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,6 @@ permissions:
 jobs:
   labeler:
     permissions:
-      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,12 +3,18 @@ on:
   workflow_run:
     workflows: [Build]
     types: [completed]
+
+permissions:
+  contents: read
+
 jobs:
   sonar:
     name: Sonar
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Automated workflows tokens should follow the principle of least privilege.  We should always set the default permission to "read only".

https://securityscorecards.dev/viewer/?uri=github.com%2Fmedplum%2Fmedplum

https://github.com/ossf/scorecard/blob/cd152cb6742c5b8f2f3d2b5193b41d9c50905198/docs/checks.md#token-permissions