### PR TITLE
Fix query for descendent-of ValueSet expansion

### DIFF
--- a/packages/server/src/fhir/operations/expand.test.ts
+++ b/packages/server/src/fhir/operations/expand.test.ts
@@ -649,39 +649,131 @@ describe('Expand', () => {
     expect(res3.body.issue[0].details.text).toMatch(/invalid filter/i);
   });
 
-  test('Includes ancestor code in is-a filter', async () => {
-    const res = await request(app)
-      .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/care-team-category')}`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
-    const expansion = res.body.expansion as ValueSetExpansion;
+  describe('Hierarchy filters', () => {
+    const codeSystem: CodeSystem = {
+      resourceType: 'CodeSystem',
+      status: 'draft',
+      content: 'example',
+      url: 'http://example.com/CodeSystem/' + randomUUID(),
+      hierarchyMeaning: 'is-a',
+      concept: [
+        {
+          code: 'PAR',
+          display: 'parent',
+          concept: [
+            {
+              code: 'CHD',
+              display: 'child',
+            },
+            {
+              code: 'PET',
+              display: 'pet',
+            },
+          ],
+        },
+      ],
+    };
+    const isaValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      status: 'draft',
+      compose: {
+        include: [{ system: codeSystem.url, filter: [{ property: 'code', op: 'is-a', value: 'PAR' }] }],
+      },
+    };
+    const descendentValueSet: ValueSet = {
+      resourceType: 'ValueSet',
+      url: 'http://example.com/ValueSet/' + randomUUID(),
+      status: 'draft',
+      compose: {
+        include: [{ system: codeSystem.url, filter: [{ property: 'code', op: 'descendent-of', value: 'PAR' }] }],
+      },
+    };
 
-    expect(expansion.contains).toHaveLength(1);
-    expect(expansion.contains?.[0]).toEqual<ValueSetExpansionContains>({
-      system: LOINC,
-      code: 'LA28865-6',
-      display: expect.stringMatching(/care team/i),
+    beforeAll(async () => {
+      const csRes = await request(app)
+        .post(`/fhir/R4/CodeSystem`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send(codeSystem);
+      expect(csRes.status).toBe(201);
+
+      const vsRes1 = await request(app)
+        .post(`/fhir/R4/ValueSet`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send(isaValueSet);
+      expect(vsRes1.status).toBe(201);
+
+      const vsRes2 = await request(app)
+        .post(`/fhir/R4/ValueSet`)
+        .set('Authorization', 'Bearer ' + accessToken)
+        .set('Content-Type', ContentType.FHIR_JSON)
+        .send(descendentValueSet);
+      expect(vsRes2.status).toBe(201);
     });
-  });
 
-  test('Excludes ancestor code in descendent-of filter', async () => {
-    const res = await request(app)
-      .get(`/fhir/R4/ValueSet/$expand?url=${encodeURIComponent('http://hl7.org/fhir/ValueSet/inactive')}`)
-      .set('Authorization', 'Bearer ' + accessToken);
-    expect(res.status).toStrictEqual(200);
-    const expansion = res.body.expansion as ValueSetExpansion;
-    const system = 'http://terminology.hl7.org/CodeSystem/v3-ActMood';
+    test('Includes ancestor code in is-a filter', async () => {
+      const res = await request(app)
+        .get(`/fhir/R4/ValueSet/$expand?url=${isaValueSet.url}`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(res.status).toStrictEqual(200);
+      const expansion = res.body.expansion as ValueSetExpansion;
 
-    expect(expansion.contains).toHaveLength(5);
-    expect(expansion.contains).toStrictEqual(
-      expect.arrayContaining([
-        { system, code: 'CRT', display: 'criterion' },
-        { system, code: 'GOL', display: 'goal' },
-        { system, code: 'RSK', display: 'risk' },
-        { system, code: 'EXPEC', display: 'expectation' },
-        { system, code: 'OPT', display: 'option' },
-      ])
-    );
+      const system = codeSystem.url;
+      expect(expansion.contains).toHaveLength(3);
+      expect(expansion.contains).toStrictEqual(
+        expect.arrayContaining<ValueSetExpansionContains>([
+          { system, code: 'PAR', display: 'parent' },
+          { system, code: 'CHD', display: 'child' },
+          { system, code: 'PET', display: 'pet' },
+        ])
+      );
+    });
+
+    test('Text filter with is-a', async () => {
+      const res = await request(app)
+        .get(`/fhir/R4/ValueSet/$expand?url=${isaValueSet.url}&filter=chi`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(res.status).toStrictEqual(200);
+      const expansion = res.body.expansion as ValueSetExpansion;
+
+      const system = codeSystem.url;
+      expect(expansion.contains).toHaveLength(1);
+      expect(expansion.contains).toStrictEqual(
+        expect.arrayContaining<ValueSetExpansionContains>([{ system, code: 'CHD', display: 'child' }])
+      );
+    });
+
+    test('Excludes ancestor code in descendent-of filter', async () => {
+      const res = await request(app)
+        .get(`/fhir/R4/ValueSet/$expand?url=${descendentValueSet.url}`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      console.log(res.body.issue);
+      expect(res.status).toStrictEqual(200);
+      const expansion = res.body.expansion as ValueSetExpansion;
+
+      const system = codeSystem.url;
+      expect(expansion.contains).toHaveLength(2);
+      expect(expansion.contains).toStrictEqual(
+        expect.arrayContaining([
+          { system, code: 'CHD', display: 'child' },
+          { system, code: 'PET', display: 'pet' },
+        ])
+      );
+    });
+
+    test('Text filter with descendent-of', async () => {
+      const res = await request(app)
+        .get(`/fhir/R4/ValueSet/$expand?url=${descendentValueSet.url}&filter=pet`)
+        .set('Authorization', 'Bearer ' + accessToken);
+      expect(res.status).toStrictEqual(200);
+      const expansion = res.body.expansion as ValueSetExpansion;
+
+      const system = codeSystem.url;
+      expect(expansion.contains).toHaveLength(1);
+      expect(expansion.contains).toStrictEqual(expect.arrayContaining([{ system, code: 'PET', display: 'pet' }]));
+    });
   });
 
   test('Recursive subsumption', async () => {

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -292,7 +292,7 @@ export function expansionQuery(
             query = addDescendants(query, codeSystem, condition.value);
           }
           if (condition.op !== 'is-a') {
-            query.where(new Column('Coding', 'code'), '!=', condition.value);
+            query.where(new Column(query.tableName, 'code'), '!=', condition.value);
           }
           break;
         case '=':


### PR DESCRIPTION
The query for expanding a ValueSet with a `descendent-of` filter was causing errors, due to an erroneous reference directly to the `Coding` table instead of the recursive union CTE being searched over.  This issue was masked by the fact that we [started directly using precomputed expansions](#5414) a while back, which changed the behavior of the relevant unit tests without our knowledge