### PR TITLE
Fixed cli-wrapper double execution

### DIFF
--- a/packages/cli-wrapper/src/index.ts
+++ b/packages/cli-wrapper/src/index.ts
@@ -1,9 +1,1 @@
-import { run } from '@medplum/cli';
-import { normalizeErrorString } from '@medplum/core';
-
-if (require.main === module) {
-  run().catch((err) => {
-    console.error('Unhandled error:', normalizeErrorString(err));
-    process.exit(1);
-  });
-}
+import '@medplum/cli';

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -87,6 +87,7 @@ async function startWebServer(medplum: MedplumClient): Promise<void> {
         res.end(`Error: ${normalizeErrorString(err)}`);
       } finally {
         server.close();
+        process.exit(0);
       }
     } else {
       res.writeHead(404, { 'Content-Type': ContentType.TEXT });


### PR DESCRIPTION
This broke the login command:

<img width="2026" height="994" alt="image" src="https://github.com/user-attachments/assets/8de1c7f5-e9a5-4ff6-aec1-4261a1bb363a" />


Drive-by fix, call `process.exit(0);` to speed up the local web server shutdown process.