### PR TITLE
UI improvements to resource history pages

### DIFF
--- a/packages/app/src/AppRoutes.tsx
+++ b/packages/app/src/AppRoutes.tsx
@@ -94,8 +94,6 @@ export function AppRoutes(): JSX.Element {
         </Route>
         <Route path="/lab/assays" element={<AssaysPage />} />
         <Route path="/lab/panels" element={<PanelsPage />} />
-        <Route path="/:resourceType/:id/_history/:versionId/:tab" element={<ResourceVersionPage />} />
-        <Route path="/:resourceType/:id/_history/:versionId" element={<ResourceVersionPage />} />
         <Route path="/:resourceType/new" element={<CreateResourcePage />}>
           <Route index element={<FormCreatePage />} />
           <Route path="form" element={<FormCreatePage />} />
@@ -115,7 +113,16 @@ export function AppRoutes(): JSX.Element {
           <Route path="details" element={<DetailsPage />} />
           <Route path="edit" element={<EditPage />} />
           <Route path="editor" element={<BotEditor />} />
-          <Route path="history" element={<HistoryPage />} />
+          <Route path="history">
+            <Route index element={<HistoryPage />} />
+            <Route path=":versionId/:tab" element={<ResourceVersionPage />} />
+            <Route path=":versionId" element={<ResourceVersionPage />} />
+          </Route>
+          <Route path="_history">
+            <Route index element={<HistoryPage />} />
+            <Route path=":versionId/:tab" element={<ResourceVersionPage />} />
+            <Route path=":versionId" element={<ResourceVersionPage />} />
+          </Route>
           <Route path="json" element={<JsonPage />} />
           <Route path="preview" element={<PreviewPage />} />
           <Route path="responses" element={<QuestionnaireResponsePage />} />

--- a/packages/app/src/resource/BlamePage.tsx
+++ b/packages/app/src/resource/BlamePage.tsx
@@ -1,5 +1,6 @@
+import { Container } from '@mantine/core';
 import { ResourceType } from '@medplum/fhirtypes';
-import { Document, ResourceBlame, useMedplum } from '@medplum/react';
+import { Panel, ResourceBlame, useMedplum } from '@medplum/react';
 import { JSX } from 'react';
 import { useParams } from 'react-router';
 
@@ -9,8 +10,10 @@ export function BlamePage(): JSX.Element | null {
   const history = medplum.readHistory(resourceType, id).read();
 
   return (
-    <Document>
-      <ResourceBlame history={history} />
-    </Document>
+    <Container maw={1200}>
+      <Panel>
+        <ResourceBlame history={history} />
+      </Panel>
+    </Container>
   );
 }

--- a/packages/app/src/resource/ResourceVersionPage.test.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.test.tsx
@@ -83,4 +83,18 @@ describe('ResourceVersionPage', () => {
 
     expect(screen.getByText('Raw')).toBeInTheDocument();
   });
+
+  test('Next button', async () => {
+    await act(async () => {
+      setup('/Practitioner/123/_history/1');
+    });
+
+    expect(await screen.findByLabelText('Next page')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Next page'));
+    });
+
+    expect(screen.getByText('Raw')).toBeInTheDocument();
+  });
 });

--- a/packages/app/src/resource/ResourceVersionPage.test.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.test.tsx
@@ -30,8 +30,8 @@ describe('ResourceVersionPage', () => {
       await jest.runAllTimersAsync();
     });
 
-    expect(await screen.findByText('Resource not found')).toBeInTheDocument();
-    expect(screen.getByText('Resource not found')).toBeInTheDocument();
+    expect(await screen.findByText('Not found')).toBeInTheDocument();
+    expect(screen.getByText('Not found')).toBeInTheDocument();
   });
 
   test('Version not found', async () => {

--- a/packages/app/src/resource/ResourceVersionPage.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.tsx
@@ -1,6 +1,17 @@
-import { Paper, Tabs, Text, Title } from '@mantine/core';
+import { Box, Container, Group, Pagination, SegmentedControl, SimpleGrid, Stack, Title } from '@mantine/core';
+import { formatDateTime } from '@medplum/core';
 import { Bundle, OperationOutcome, Resource, ResourceType } from '@medplum/fhirtypes';
-import { Container, Document, Loading, MedplumLink, ResourceDiff, useMedplum } from '@medplum/react';
+import {
+  DescriptionList,
+  DescriptionListEntry,
+  Document,
+  Loading,
+  MedplumLink,
+  Panel,
+  ResourceBadge,
+  ResourceDiff,
+  useMedplum,
+} from '@medplum/react';
 import { JSX, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -57,54 +68,49 @@ export function ResourceVersionPage(): JSX.Element {
   const value = entries[index].resource as Resource;
   const prev = index < entries.length - 1 ? entries[index + 1].resource : undefined;
   const defaultTab = 'diff';
+  const currTab = tab || defaultTab;
+  const paginationIndex = entries.length - index;
   return (
-    <Tabs
-      value={tab || defaultTab}
-      onChange={(name) =>
-        navigate(`/${resourceType}/${id}/_history/${versionId}/${name || defaultTab}`)?.catch(console.error)
-      }
-    >
-      <Paper>
-        <Container fluid p="md">
-          <Text>{`${resourceType} ${id}`}</Text>
-        </Container>
-        <Tabs.List>
-          <Tabs.Tab value="diff">Diff</Tabs.Tab>
-          <Tabs.Tab value="raw">Raw</Tabs.Tab>
-        </Tabs.List>
-      </Paper>
-
-      <Document>
-        {error && <pre data-testid="error">{JSON.stringify(error, undefined, 2)}</pre>}
-        <Tabs.Panel value="diff">
-          {prev ? (
-            <>
-              <ul>
-                <li>Current: {value.meta?.versionId}</li>
-                <li>
-                  Previous:{' '}
-                  <MedplumLink to={`/${resourceType}/${id}/_history/${prev.meta?.versionId}`}>
-                    {prev.meta?.versionId}
-                  </MedplumLink>
-                </li>
-              </ul>
-              <ResourceDiff original={prev} revised={value} />
-            </>
-          ) : (
-            <>
-              <ul>
-                <li>Current: {value.meta?.versionId}</li>
-                <li>Previous: (none)</li>
-              </ul>
-              <pre>{JSON.stringify(value, undefined, 2)}</pre>
-            </>
-          )}
-        </Tabs.Panel>
-
-        <Tabs.Panel value="raw">
-          <pre>{JSON.stringify(value, undefined, 2)}</pre>
-        </Tabs.Panel>
-      </Document>
-    </Tabs>
+    <Container maw={1200}>
+      <Panel>
+        <Stack gap="lg">
+          {error && <pre data-testid="error">{JSON.stringify(error, undefined, 2)}</pre>}
+          <SimpleGrid cols={2} mb="lg">
+            <Pagination
+              total={entries.length}
+              value={paginationIndex}
+              onChange={(newIndex) => {
+                const newEntry = entries[entries.length - newIndex];
+                const newVersionId = newEntry.resource?.meta?.versionId;
+                navigate(`/${resourceType}/${id}/_history/${newVersionId}/${currTab}`)?.catch(console.error);
+              }}
+            />
+            <Group justify="right">
+              <SegmentedControl
+                data={[
+                  { value: 'diff', label: 'Diff' },
+                  { value: 'raw', label: 'Raw' },
+                ]}
+                value={currTab}
+                onChange={(name) =>
+                  navigate(`/${resourceType}/${id}/_history/${versionId}/${name || defaultTab}`)?.catch(console.error)
+                }
+              />
+            </Group>
+          </SimpleGrid>
+          <Box mb="lg">
+            <DescriptionList compact>
+              <DescriptionListEntry term="Version ID">{value.meta?.versionId}</DescriptionListEntry>
+              <DescriptionListEntry term="Author">
+                <ResourceBadge key={value.meta?.author?.reference} value={value.meta?.author} link={true} />
+              </DescriptionListEntry>
+              <DescriptionListEntry term="Date/Time">{formatDateTime(value.meta?.lastUpdated)}</DescriptionListEntry>
+            </DescriptionList>
+          </Box>
+          {currTab === 'diff' && <ResourceDiff original={prev ?? ({ resourceType, id } as Resource)} revised={value} />}
+          {currTab === 'raw' && <pre style={{ fontSize: '9pt' }}>{JSON.stringify(value, undefined, 2)}</pre>}
+        </Stack>
+      </Panel>
+    </Container>
   );
 }

--- a/packages/app/src/resource/ResourceVersionPage.tsx
+++ b/packages/app/src/resource/ResourceVersionPage.tsx
@@ -5,6 +5,7 @@ import {
   DescriptionList,
   DescriptionListEntry,
   Document,
+  getPaginationControlProps,
   Loading,
   MedplumLink,
   Panel,
@@ -45,16 +46,7 @@ export function ResourceVersionPage(): JSX.Element {
     return <Loading />;
   }
 
-  if (!historyBundle) {
-    return (
-      <Document>
-        <Title>Resource not found</Title>
-        <MedplumLink to={`/${resourceType}`}>Return to search page</MedplumLink>
-      </Document>
-    );
-  }
-
-  const entries = historyBundle.entry ?? [];
+  const entries = historyBundle?.entry ?? [];
   const index = entries.findIndex((entry) => entry.resource?.meta?.versionId === versionId);
   if (index === -1) {
     return (
@@ -79,11 +71,12 @@ export function ResourceVersionPage(): JSX.Element {
             <Pagination
               total={entries.length}
               value={paginationIndex}
-              onChange={(newIndex) => {
-                const newEntry = entries[entries.length - newIndex];
-                const newVersionId = newEntry.resource?.meta?.versionId;
-                navigate(`/${resourceType}/${id}/_history/${newVersionId}/${currTab}`)?.catch(console.error);
-              }}
+              getControlProps={getPaginationControlProps}
+              onChange={(newIndex) =>
+                navigate(
+                  `/${resourceType}/${id}/_history/${entries[entries.length - newIndex]?.resource?.meta?.versionId}/${currTab}`
+                )?.catch(console.error)
+              }
             />
             <Group justify="right">
               <SegmentedControl

--- a/packages/react/src/ResourceBlame/ResourceBlame.module.css
+++ b/packages/react/src/ResourceBlame/ResourceBlame.module.css
@@ -8,7 +8,7 @@
   border-radius: var(--mantine-radius-sm);
   border-spacing: 0;
   font-size: var(--mantine-font-size-xs);
-  width: 100px;
+  width: 100%;
 
   & td {
     padding: 2px 4px 0 4px;
@@ -19,10 +19,12 @@
 
 .startRow {
   border-top: 0.1px solid var(--mantine-color-gray-3);
+  white-space: nowrap;
 }
 
 .normalRow {
   border-top: 0;
+  white-space: nowrap;
 }
 
 .author {
@@ -31,7 +33,8 @@
 
 .dateTime {
   border-right: 0.1px solid var(--mantine-color-gray-3);
-  line-height: 20px;
+  line-height: 10px;
+  text-align: right;
 }
 
 .lineNumber {
@@ -45,7 +48,7 @@
 
 .line {
   font-family: var(--mantine-font-family-monospace);
-  font-size: var(--mantine-font-size-sm);
+  font-size: var(--mantine-font-size-xs);
   padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
 }
 

--- a/packages/react/src/ResourceBlame/ResourceBlame.tsx
+++ b/packages/react/src/ResourceBlame/ResourceBlame.tsx
@@ -2,7 +2,7 @@ import { Bundle, Resource, ResourceType } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { JSX, useEffect, useState } from 'react';
 import { MedplumLink } from '../MedplumLink/MedplumLink';
-import { ResourceBadge } from '../ResourceBadge/ResourceBadge';
+import { ResourceName } from '../ResourceName/ResourceName';
 import { blame } from '../utils/blame';
 import classes from './ResourceBlame.module.css';
 import { getTimeString, getVersionUrl } from './ResourceBlame.utils';
@@ -44,10 +44,10 @@ export function ResourceBlame(props: ResourceBlameProps): JSX.Element | null {
               {row.span > 0 && (
                 <>
                   <td className={classes.author} rowSpan={row.span}>
-                    <ResourceBadge value={row.meta.author} link={true} />
+                    <ResourceName value={row.meta.author} link={true} fz="xs" />
                   </td>
                   <td className={classes.dateTime} rowSpan={row.span}>
-                    <MedplumLink to={getVersionUrl(resource, row.meta.versionId as string)}>
+                    <MedplumLink to={getVersionUrl(resource, row.meta.versionId as string)} fz="xs">
                       {getTimeString(row.meta.lastUpdated as string)}
                     </MedplumLink>
                   </td>

--- a/packages/react/src/SearchControl/SearchControl.tsx
+++ b/packages/react/src/SearchControl/SearchControl.tsx
@@ -41,6 +41,7 @@ import { SearchFilterValueDialog } from '../SearchFilterValueDialog/SearchFilter
 import { SearchFilterValueDisplay } from '../SearchFilterValueDisplay/SearchFilterValueDisplay';
 import { SearchPopupMenu } from '../SearchPopupMenu/SearchPopupMenu';
 import { isAuxClick, isCheckboxCell, killEvent } from '../utils/dom';
+import { getPaginationControlProps } from '../utils/pagination';
 import classes from './SearchControl.module.css';
 import { getFieldDefinitions } from './SearchControlField';
 import { addFilter, buildFieldNameString, getOpString, renderValue, setPage } from './SearchUtils';
@@ -478,16 +479,7 @@ export function SearchControl(props: SearchControlProps): JSX.Element {
             value={getPage(memoizedSearch)}
             total={getTotalPages(memoizedSearch, lastResult)}
             onChange={(newPage) => emitSearchChange(setPage(memoizedSearch, newPage))}
-            getControlProps={(control) => {
-              switch (control) {
-                case 'previous':
-                  return { 'aria-label': 'Previous page' };
-                case 'next':
-                  return { 'aria-label': 'Next page' };
-                default:
-                  return {};
-              }
-            }}
+            getControlProps={getPaginationControlProps}
           />
         </Center>
       )}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -108,6 +108,7 @@ export * from './TimingInput/TimingInput';
 export * from './utils/date';
 export * from './utils/dom';
 export * from './utils/outcomes';
+export * from './utils/pagination';
 export * from './utils/recaptcha';
 export * from './utils/script';
 export * from './ValueSetAutocomplete/ValueSetAutocomplete';

--- a/packages/react/src/utils/pagination.test.ts
+++ b/packages/react/src/utils/pagination.test.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { getPaginationControlProps } from './pagination';
+
+describe('Pagination utils', () => {
+  test('getPaginationControlProps', () => {
+    expect(getPaginationControlProps('next')).toStrictEqual({ 'aria-label': 'Next page' });
+    expect(getPaginationControlProps('previous')).toStrictEqual({ 'aria-label': 'Previous page' });
+    expect(getPaginationControlProps('first')).toStrictEqual({ 'aria-label': 'First page' });
+    expect(getPaginationControlProps('last')).toStrictEqual({ 'aria-label': 'Last page' });
+    expect(getPaginationControlProps('unknown')).toStrictEqual({});
+  });
+});

--- a/packages/react/src/utils/pagination.ts
+++ b/packages/react/src/utils/pagination.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Returns control properties for pagination controls.
+ * This is specifically for the Mantine Pagination component.
+ * See: https://v7.mantine.dev/core/pagination/?t=props
+ * @param controlName - The name of the pagination control (e.g., 'previous', 'next').
+ * @returns The properties for the pagination control.
+ */
+export function getPaginationControlProps(controlName: string): Record<string, string> {
+  // "next" | "previous" | "first" | "last"
+  switch (controlName) {
+    case 'next':
+      return { 'aria-label': 'Next page' };
+    case 'previous':
+      return { 'aria-label': 'Previous page' };
+    case 'first':
+      return { 'aria-label': 'First page' };
+    case 'last':
+      return { 'aria-label': 'Last page' };
+    default:
+      return {};
+  }
+}


### PR DESCRIPTION
Before, the "Resource Version" page was outside of the resource context, so you lost the details bar, and there wasn't an easy way to get back to other resource tabs.  Also, you could only jump one resource at a time:

<img width="1710" height="641" alt="image" src="https://github.com/user-attachments/assets/d3df6ae4-5796-4ba8-abbb-ff9bb53cbf06" />


After:
* Inside the resource context, so resource tabs are still there
* Use Mantine `<Pagination>` for navigating through past versions
* Move the "Diff" vs "Raw" selector to a little control in the top left
* Show author and last updated time stamp at the top so you don't need to hunt through the JSON to find it

<img width="1710" height="797" alt="image" src="https://github.com/user-attachments/assets/006b3f21-c5e7-425b-9276-36d2babd3c5a" />
