### PR TITLE
Add Task to Patient compartment

### DIFF
--- a/packages/definitions/dist/fhir/r4/compartmentdefinition-patient.json
+++ b/packages/definitions/dist/fhir/r4/compartmentdefinition-patient.json
@@ -535,7 +535,8 @@
     "param" : ["subject"]
   },
   {
-    "code" : "Task"
+    "code" : "Task",
+    "param" : ["patient", "focus"]
   },
   {
     "code" : "TerminologyCapabilities"


### PR DESCRIPTION
Backported from the current proposed [R6 CompartmentDefinition](https://build.fhir.org/compartmentdefinition-patient.html), this adds `Task` resources that reference a patient via `patient` or `focus` fields to that patient's FHIR compartment

Resolves #5787 