### PR TITLE
$set-accounts only updating meta.accounts and meta.account

### DIFF
--- a/packages/fhir-router/src/repo.ts
+++ b/packages/fhir-router/src/repo.ts
@@ -27,6 +27,7 @@ export type CreateResourceOptions = {
 
 export type UpdateResourceOptions = {
   ifMatch?: string;
+  inheritAccounts?: boolean;
 };
 
 export const RepositoryMode = {

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -2084,6 +2084,39 @@ describe('AccessPolicy', () => {
       expect(patient3.meta?.accounts).toHaveLength(1);
       expect(patient3.meta?.accounts).toContainEqual({ reference: account2 });
 
+      // Specify properties in the meta object without overwriting the existing accounts
+      const patient4 = await adminRepo.updateResource<Patient>({
+        ...patient3,
+        meta: {
+          security: [{
+            system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
+            code: 'N',
+          }],
+          tag: [{
+            system: 'http://example.com',
+            code: 'example-tag',
+          }],
+        },
+      }, { inheritAccounts: true });
+      expect(patient4.meta?.security).toHaveLength(1);
+      expect(patient4.meta?.accounts).toHaveLength(1);//did not get overwritten by the new accounts
+
+      // If inheritAccounts is not specified, then the accounts will be overwritten
+      const patient5 = await adminRepo.updateResource<Patient>({
+        ...patient4,
+        meta: {
+          security: [{
+            system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
+            code: 'N',
+          }],
+          tag: [{
+            system: 'http://example.com',
+            code: 'example-tag',
+          }],
+        },
+      });
+      expect(patient5.meta?.accounts).toBeUndefined();//accounts were overwritten
+
       // Remove patient accounts as project admin
       // Project admin should be allowed to clear accounts
       const clearedPatient = await adminRepo.updateResource<Patient>({

--- a/packages/server/src/fhir/accesspolicy.test.ts
+++ b/packages/server/src/fhir/accesspolicy.test.ts
@@ -2085,37 +2085,48 @@ describe('AccessPolicy', () => {
       expect(patient3.meta?.accounts).toContainEqual({ reference: account2 });
 
       // Specify properties in the meta object without overwriting the existing accounts
-      const patient4 = await adminRepo.updateResource<Patient>({
-        ...patient3,
-        meta: {
-          security: [{
-            system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
-            code: 'N',
-          }],
-          tag: [{
-            system: 'http://example.com',
-            code: 'example-tag',
-          }],
+      const patient4 = await adminRepo.updateResource<Patient>(
+        {
+          ...patient3,
+          meta: {
+            security: [
+              {
+                system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
+                code: 'N',
+              },
+            ],
+            tag: [
+              {
+                system: 'http://example.com',
+                code: 'example-tag',
+              },
+            ],
+          },
         },
-      }, { inheritAccounts: true });
+        { inheritAccounts: true }
+      );
       expect(patient4.meta?.security).toHaveLength(1);
-      expect(patient4.meta?.accounts).toHaveLength(1);//did not get overwritten by the new accounts
+      expect(patient4.meta?.accounts).toHaveLength(1); //did not get overwritten by the new accounts
 
       // If inheritAccounts is not specified, then the accounts will be overwritten
       const patient5 = await adminRepo.updateResource<Patient>({
         ...patient4,
         meta: {
-          security: [{
-            system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
-            code: 'N',
-          }],
-          tag: [{
-            system: 'http://example.com',
-            code: 'example-tag',
-          }],
+          security: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
+              code: 'N',
+            },
+          ],
+          tag: [
+            {
+              system: 'http://example.com',
+              code: 'example-tag',
+            },
+          ],
         },
       });
-      expect(patient5.meta?.accounts).toBeUndefined();//accounts were overwritten
+      expect(patient5.meta?.accounts).toBeUndefined(); //accounts were overwritten
 
       // Remove patient accounts as project admin
       // Project admin should be allowed to clear accounts

--- a/packages/server/src/fhir/operations/patientsetaccounts.test.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.test.ts
@@ -232,9 +232,15 @@ describe('Patient Set Accounts Operation', () => {
     const res2 = await request(app)
       .post(`/fhir/R4/Patient/${patient.id}/$set-accounts`)
       .set('Authorization', 'Bearer ' + accessToken)
+      .set('x-medplum', 'extended')
       .send({
         resourceType: 'Parameters',
-        parameter: [],
+        parameter: [
+          {
+            name: 'accounts',
+            valueReference: createReference(organization1),
+          },
+        ],
       });
     expect(res2.status).toBe(200);
 
@@ -243,6 +249,7 @@ describe('Patient Set Accounts Operation', () => {
       .set('Authorization', 'Bearer ' + accessToken);
     expect(res4.status).toBe(200);
     const updatedCommunication = res4.body as Communication;
+    expect(updatedCommunication.meta?.accounts).toHaveLength(1);
     expect(updatedCommunication.meta?.security).toBeDefined();
   });
 

--- a/packages/server/src/fhir/operations/patientsetaccounts.test.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.test.ts
@@ -1,5 +1,5 @@
 import { createReference } from '@medplum/core';
-import { Bundle, DiagnosticReport, Observation, Organization, Patient } from '@medplum/fhirtypes';
+import { Bundle, Communication, DiagnosticReport, Observation, Organization, Patient } from '@medplum/fhirtypes';
 import express from 'express';
 import request from 'supertest';
 import { initApp, shutdownApp } from '../../app';
@@ -204,6 +204,46 @@ describe('Patient Set Accounts Operation', () => {
       query: {},
     });
     expect(res[0].issue?.[0]?.details?.text).toBe('Must specify Patient ID');
+  });
+
+  test("Do not delete a resource in patient's compartment's meta.security field when set-accounts is called", async () => {
+    //Create a Communication in Patient's compartment with a security tag
+    const res1 = await request(app)
+      .post(`/fhir/R4/Communication`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Communication',
+        subject: createReference(patient),
+        status: 'completed',
+        meta: {
+          security: [
+            {
+              system: 'http://terminology.hl7.org/CodeSystem/v3-Confidentiality',
+              code: 'N',
+            },
+          ],
+        },
+      } satisfies Communication);
+
+    expect(res1.status).toBe(201);
+    const communication = res1.body as Communication;
+    expect(communication.meta?.security).toBeDefined();
+
+    const res2 = await request(app)
+      .post(`/fhir/R4/Patient/${patient.id}/$set-accounts`)
+      .set('Authorization', 'Bearer ' + accessToken)
+      .send({
+        resourceType: 'Parameters',
+        parameter: [],
+      });
+    expect(res2.status).toBe(200);
+
+    const res4 = await request(app)
+      .get(`/fhir/R4/Communication/${communication.id}`)
+      .set('Authorization', 'Bearer ' + accessToken);
+    expect(res4.status).toBe(200);
+    const updatedCommunication = res4.body as Communication;
+    expect(updatedCommunication.meta?.security).toBeDefined();
   });
 
   test('Non admin user trying to set accounts', async () => {

--- a/packages/server/src/fhir/operations/patientsetaccounts.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.ts
@@ -93,7 +93,7 @@ export async function patientSetAccountsHandler(req: FhirRequest): Promise<FhirR
           account: undefined,
         };
 
-        await ctx.repo.updateResource(resource);
+        await ctx.repo.updateResource(resource, { inheritAccounts: true });
         count++;
       }
     }

--- a/packages/server/src/fhir/operations/patientsetaccounts.ts
+++ b/packages/server/src/fhir/operations/patientsetaccounts.ts
@@ -86,7 +86,12 @@ export async function patientSetAccountsHandler(req: FhirRequest): Promise<FhirR
     if (entry.search?.mode === 'match') {
       const resource = entry.resource;
       if (resource && resource.resourceType !== 'Patient') {
-        delete resource.meta;
+        resource.meta = {
+          //persist other meta fields (ex. tag, security, etc.)
+          ...resource.meta,
+          accounts: undefined, //don't define here. Instead, inherit from the patient resource on update
+          account: undefined,
+        };
 
         await ctx.repo.updateResource(resource);
         count++;

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -628,7 +628,9 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       let result: WithId<T>;
       if (options?.ifMatch) {
         // Conditional update requires transaction
-        result = await this.withTransaction(() => this.updateResourceImpl(resource, false, options.ifMatch, options?.inheritAccounts));
+        result = await this.withTransaction(() =>
+          this.updateResourceImpl(resource, false, options.ifMatch, options?.inheritAccounts)
+        );
       } else {
         result = await this.updateResourceImpl(resource, false, undefined, options?.inheritAccounts);
       }

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -628,9 +628,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
       let result: WithId<T>;
       if (options?.ifMatch) {
         // Conditional update requires transaction
-        result = await this.withTransaction(() =>
-          this.updateResourceImpl(resource, false, options)
-        );
+        result = await this.withTransaction(() => this.updateResourceImpl(resource, false, options));
       } else {
         result = await this.updateResourceImpl(resource, false, options);
       }


### PR DESCRIPTION
### Current behavior
When you call `Patient/<id>/$set-accounts`, and a resource in that Patient's compartment has a `meta.security`, the `meta.security` field gets unintentionally deleted. 

### Desired behavior
The `Patient/<id>/$set-accounts` does not touch any of the other `meta` fields