### PR TITLE
Limit history items shown

### DIFF
--- a/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
+++ b/packages/react/src/ResourceTimeline/ResourceTimeline.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ActionIcon, Center, Group, Loader, ScrollArea, TextInput } from '@mantine/core';
+import { ActionIcon, Button, Center, Group, Loader, ScrollArea, TextInput } from '@mantine/core';
 import { showNotification, updateNotification } from '@mantine/notifications';
 import { MedplumClient, ProfileResource, createReference, normalizeErrorString } from '@medplum/core';
 import {
@@ -55,6 +55,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
   const resource = useResource(props.value);
   const [history, setHistory] = useState<Bundle>();
   const [items, setItems] = useState<Resource[]>([]);
+  const [countToShow, setCountToShow] = useState(10);
   const loadTimelineResources = props.loadTimelineResources;
 
   const itemsRef = useRef<Resource[]>(items);
@@ -231,6 +232,9 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
     );
   }
 
+  // TODO: Handle null history items for deleted versions.
+  const itemsToShow = items.filter((item) => item).slice(0, countToShow);
+
   return (
     <Timeline>
       {props.createCommunication && (
@@ -275,11 +279,7 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
           </Form>
         </Panel>
       )}
-      {items.map((item) => {
-        if (!item) {
-          // TODO: Handle null history items for deleted versions.
-          return null;
-        }
+      {itemsToShow.map((item) => {
         const key = `${item.resourceType}/${item.id}/${item.meta?.versionId}`;
         const menu = props.getMenu
           ? props.getMenu({
@@ -308,6 +308,11 @@ export function ResourceTimeline<T extends Resource>(props: ResourceTimelineProp
             );
         }
       })}
+      {countToShow < items.length && (
+        <Group justify="center" pb="lg">
+          <Button onClick={() => setCountToShow(countToShow + 10)}>Show More</Button>
+        </Group>
+      )}
     </Timeline>
   );
 }


### PR DESCRIPTION
We may want to refine if/when we limit the number of items shown; e.g. only bother doing this if `items.length > 20`, but this seems like a reasonable starting point.