### PR TITLE
Make default value explicit

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -517,6 +517,7 @@ export class BackEnd extends Construct {
       desiredCount: config.desiredServerCount,
       securityGroups: [this.fargateSecurityGroup],
       healthCheckGracePeriod: Duration.minutes(5),
+      minHealthyPercent: 50, // 50% is the default; make it explicit
     });
 
     // Add autoscaling


### PR DESCRIPTION
Addressing a warning when looking at a CDK diff