### PR TITLE
lint: add `no-only-tests` rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -131,7 +131,7 @@
         "react-router": "7.8.0",
         "rimraf": "6.0.1",
         "ts-node": "10.9.2",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1",
         "vitest": "3.2.4"
       },
@@ -173,7 +173,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -217,7 +217,7 @@
         "react-chartjs-2": "5.3.0",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -265,7 +265,7 @@
         "ssh2-sftp-client": "12.0.1",
         "stripe": "18.4.0",
         "twilio": "^5.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vitest": "3.2.4"
       },
       "engines": {
@@ -309,7 +309,7 @@
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
         "rimraf": "6.0.1",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -349,7 +349,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -402,7 +402,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -444,7 +444,7 @@
         "fast-glob": "3.3.3",
         "node-fetch": "2.7.0",
         "ts-node": "10.9.2",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vitest": "3.2.4"
       }
     },
@@ -482,7 +482,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -523,7 +523,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -564,7 +564,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -607,7 +607,7 @@
         "@types/react-dom": "19.1.7",
         "eslint": "8.57.1",
         "eslint-config-next": "15.4.6",
-        "typescript": "5.9.2"
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -753,7 +753,7 @@
         "eslint-config-next": "15.4.6",
         "postcss": "8.5.6",
         "postcss-preset-mantine": "1.18.0",
-        "typescript": "5.9.2"
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -801,7 +801,7 @@
         "react-router": "7.8.0",
         "rimraf": "6.0.1",
         "ts-node": "10.9.2",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1",
         "vitest": "3.2.4"
       },
@@ -847,7 +847,7 @@
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
         "rimraf": "6.0.1",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1",
         "vitest": "3.2.4"
       },
@@ -900,7 +900,7 @@
         "react-big-calendar": "1.19.4",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1",
         "vitest": "3.2.4"
       },
@@ -934,7 +934,7 @@
         "@vitejs/plugin-react": "5.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -986,7 +986,7 @@
         "react-router": "7.8.0",
         "rimraf": "6.0.1",
         "ts-node": "10.9.2",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1",
         "vitest": "3.2.4"
       },
@@ -1032,7 +1032,7 @@
         "react-router": "7.8.0",
         "rimraf": "6.0.1",
         "ts-node": "10.9.2",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1",
         "vitest": "3.2.4"
       },
@@ -1074,7 +1074,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -1116,7 +1116,7 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-router": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite": "7.1.1"
       },
       "engines": {
@@ -25866,6 +25866,16 @@
         "node": "*"
       }
     },
+    "node_modules/eslint-plugin-no-only-tests": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz",
+      "integrity": "sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -48928,7 +48938,7 @@
         "react-intersection-observer": "9.16.0",
         "react-router": "7.8.0",
         "react-router-dom": "7.8.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "url-loader": "4.1.1"
       },
       "engines": {
@@ -49000,6 +49010,7 @@
         "eslint": "8.57.1",
         "eslint-plugin-header": "3.1.1",
         "eslint-plugin-jsdoc": "52.0.4",
+        "eslint-plugin-no-only-tests": "3.3.0",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20"
       },
@@ -49012,6 +49023,7 @@
         "eslint": "^8",
         "eslint-plugin-header": "^3",
         "eslint-plugin-jsdoc": "^50",
+        "eslint-plugin-no-only-tests": "^3.3.0",
         "eslint-plugin-react-hooks": "^4",
         "eslint-plugin-react-refresh": "^0"
       }
@@ -49240,7 +49252,7 @@
         "sinon": "21.0.0",
         "storybook": "8.6.14",
         "storybook-addon-mantine": "5.0.0",
-        "typescript": "5.9.2",
+        "typescript": "5.8.3",
         "vite-plugin-turbosnap": "1.0.3"
       },
       "engines": {
@@ -49297,7 +49309,7 @@
         "jest-websocket-mock": "2.5.0",
         "react": "19.1.1",
         "react-dom": "19.1.1",
-        "typescript": "5.9.2"
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"

--- a/packages/eslint-config/index.cjs
+++ b/packages/eslint-config/index.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'header', 'react-refresh'],
+  plugins: ['@typescript-eslint', 'header', 'react-refresh', 'no-only-tests'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -163,6 +163,9 @@ module.exports = {
         ' SPDX-License-Identifier: Apache-2.0',
       ],
     ],
+
+    // No Only Tests
+    'no-only-tests/no-only-tests': ['error', { fix: true }],
   },
   ignorePatterns: [
     'coverage',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,6 +24,7 @@
     "eslint": "8.57.1",
     "eslint-plugin-jsdoc": "52.0.4",
     "eslint-plugin-header": "3.1.1",
+    "eslint-plugin-no-only-tests": "3.3.0",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.20"
   },
@@ -33,6 +34,7 @@
     "eslint": "^8",
     "eslint-plugin-jsdoc": "^50",
     "eslint-plugin-header": "^3",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-react-hooks": "^4",
     "eslint-plugin-react-refresh": "^0"
   },


### PR DESCRIPTION
This rule will catch when `test.only` is accidentally commited, before tests or Sonar runs, and will attempt to autofix it in CI. This should greatly reduce the pain of accidental `test.only` commits 🎉 