### PR TITLE
QuestionnaireForm undefined values

### DIFF
--- a/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireForm.test.tsx
@@ -2480,7 +2480,7 @@ describe('QuestionnaireForm', () => {
     const response3 = onSubmit.mock.calls[2][0];
     const answers3 = getQuestionnaireAnswers(response3);
 
-    expect(answers3['q1']).toMatchObject({ valueString: undefined });
+    expect(answers3['q1']).toBeUndefined();
     expect(answers3['q2']).toMatchObject({ valueBoolean: false });
   });
 

--- a/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
+++ b/packages/react/src/QuestionnaireForm/QuestionnaireFormItem.tsx
@@ -127,7 +127,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) =>
-            onChangeAnswer([{ valueDecimal: e.currentTarget.value === '' ? undefined : e.currentTarget.valueAsNumber }])
+            onChangeAnswer(e.currentTarget.value === '' ? [] : [{ valueDecimal: e.currentTarget.valueAsNumber }])
           }
         />
       );
@@ -142,7 +142,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           required={props.required ?? item.required}
           defaultValue={defaultValue?.value}
           onChange={(e) =>
-            onChangeAnswer([{ valueInteger: e.currentTarget.value === '' ? undefined : e.currentTarget.valueAsNumber }])
+            onChangeAnswer(e.currentTarget.value === '' ? [] : [{ valueInteger: e.currentTarget.valueAsNumber }])
           }
         />
       );
@@ -191,7 +191,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           defaultValue={defaultValue?.value}
           onChange={(e) => {
             const value = e.currentTarget.value;
-            onChangeAnswer([{ valueString: value === '' ? undefined : value }]);
+            onChangeAnswer(value === '' ? [] : [{ valueString: value }]);
           }}
         />
       );
@@ -205,7 +205,7 @@ export function QuestionnaireFormItem(props: QuestionnaireFormItemProps): JSX.El
           defaultValue={defaultValue?.value}
           onChange={(e) => {
             const value = e.currentTarget.value;
-            onChangeAnswer([{ valueString: value === '' ? undefined : value }]);
+            onChangeAnswer(value === '' ? [] : [{ valueString: value }]);
           }}
         />
       );


### PR DESCRIPTION
When we started using useQuestionnaireForm. [{ valueString: undefined }] is returning [{}].
That causes 
```
{
    "resourceType": "OperationOutcome",
    "issue": [
        {
            "severity": "error",
            "code": "structure",
            "details": {
                "text": "Invalid empty non-primitive value"
            },
            "expression": [
                "QuestionnaireResponse.item[1].answer[0]"
            ]
        }
    ],
    "extension": [
        {
            "url": "https://medplum.com/fhir/StructureDefinition/tracing",
            "extension": [
                {
                    "url": "requestId",
                    "valueId": "2a75adad-f64f-48ab-b4c5-394f796c1e38"
                },
                {
                    "url": "traceId",
                    "valueId": "1-689d1b33-0c27f4732589e4dd110c57d0"
                }
            ]
        }
    ]
}
```

Fix to not return any object in the array/empty array.