### PR TITLE
Add divider line to PatientPage content

### DIFF
--- a/examples/medplum-provider/src/pages/patient/PatientPage.module.css
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.module.css
@@ -20,4 +20,5 @@
   width: calc(100% - 350px);
   height: 100%;
   overflow: auto;
+  border-inline-start: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-gray-8));
 }

--- a/examples/medplum-provider/src/pages/patient/PatientPage.module.css
+++ b/examples/medplum-provider/src/pages/patient/PatientPage.module.css
@@ -20,5 +20,5 @@
   width: calc(100% - 350px);
   height: 100%;
   overflow: auto;
-  border-inline-start: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-gray-8));
+  border-inline-start: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }


### PR DESCRIPTION
This very simply adds a vertical divider line between the PatientSummary sidebar and the content section on the PatientPage for contrast 🦨

<img width="1727" height="991" alt="Screenshot 2025-08-14 at 2 45 50 PM" src="https://github.com/user-attachments/assets/9fb1d861-7954-462c-ab5e-a729847ef16a" />
