### PR TITLE
Provider: Integrations page clean-up

### DIFF
--- a/examples/medplum-provider/src/components/IntegrationCard.tsx
+++ b/examples/medplum-provider/src/components/IntegrationCard.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Avatar, Badge, Button, Group, Paper, Text } from '@mantine/core';
-import { IconAt } from '@tabler/icons-react';
+import { IconWorld } from '@tabler/icons-react';
 import { JSX } from 'react';
 import classes from './IntegrationCard.module.css';
 
@@ -17,24 +17,31 @@ export interface IntegrationCardProps {
 
 export function IntegrationCard(props: IntegrationCardProps): JSX.Element {
   return (
-    <Paper radius="md" withBorder shadow="md" p="sm" bg="var(--mantine-color-body)" maw={300}>
+    <Paper radius="md" withBorder shadow="md" p="md" bg="var(--mantine-color-body)" maw={300}>
       <Group wrap="nowrap">
-        <Avatar src={props.imageUrl} size={48} radius="md" />
+        <Avatar src={props.imageUrl} size={48} radius="md" style={{ border: '1px solid var(--mantine-color-gray-2)' }} />
         <div>
-          <Text fz="lg" fw={500}>
+          <Text fz="xl" fw={800}>
             {props.name}
           </Text>
-          <Group wrap="nowrap" gap={4} mt={3}>
-            <IconAt stroke={1.5} size={16} className={classes.icon} />
+          <Group wrap="nowrap" gap={4} mt={-2}>
+            <IconWorld stroke={2} size={12} color="var(--mantine-primary-color-6)" className={classes.icon} />
             <Text fz="xs" c="dimmed">
-              {props.displayUrl}
+              <a 
+                href={props.url} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ color: 'var(--mantine-primary-color-6)', textDecoration: 'none' }}
+              >
+                {props.displayUrl}
+              </a>
             </Text>
           </Group>
         </div>
       </Group>
-      <Group mt="sm">
+      <Group mt="sm" gap={4}>
         {props.tags.map((tag) => (
-          <Badge variant="light" color="gray" key={tag}>
+          <Badge variant="light" color="gray" key={tag} size='sm'>
             {tag}
           </Badge>
         ))}

--- a/examples/medplum-provider/src/pages/IntegrationsPage.tsx
+++ b/examples/medplum-provider/src/pages/IntegrationsPage.tsx
@@ -204,7 +204,7 @@ export function IntegrationsPage(): JSX.Element {
   }
 
   return (
-    <Flex mih={50} gap="md" justify="flex-start" align="flex-start" direction="row" wrap="wrap" m="xl">
+    <Flex mih={50} gap="md" justify="center" align="flex-end" direction="row" wrap="wrap" m="xl">
       {integrations.map((i) => (
         <IntegrationCard
           key={i.name}


### PR DESCRIPTION
This PR includes mostly visual edits for the Integrations page in the provider app.

Key changes:
- Text styling and spacing to optimize visual hierarchy
- Live links for vendor URLs
- Centered layout to match other app sections

After:
<img width="1490" height="931" alt="Screenshot 2025-08-19 at 11 53 33 AM" src="https://github.com/user-attachments/assets/2b63b00e-ff1e-4d60-922f-d691fc42bdd3" />

Before:
<img width="1492" height="939" alt="Screenshot 2025-08-19 at 11 53 23 AM" src="https://github.com/user-attachments/assets/f3f90875-ca59-4527-8919-d91b40b8ccff" />
