### PR TITLE
Add ServiceRequest.reason-code search parameter

### DIFF
--- a/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
@@ -1650,6 +1650,23 @@
           "VisionPrescription"
         ]
       }
+    },
+    {
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/ServiceRequest-reasonCode",
+      "resource": {
+        "resourceType": "SearchParameter",
+        "id": "ServiceRequest-reasonCode",
+        "url": "https://medplum.com/fhir/SearchParameter/ServiceRequest-reasonCode",
+        "version": "4.0.1",
+        "name": "reasonCode",
+        "status": "draft",
+        "publisher": "Medplum",
+        "description": "Coded value representing the reason for this ServiceRequest.  NOTE: The underlying field will change in FHIR R5 to ServiceRequest.reason.where(concept.exists())",
+        "code": "reason",
+        "base": ["ServiceRequest"],
+        "type": "token",
+        "expression": "ServiceRequest.reasonCode"
+      }
     }
   ]
 }

--- a/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
@@ -1662,7 +1662,7 @@
         "status": "draft",
         "publisher": "Medplum",
         "description": "Coded value representing the reason for this ServiceRequest.  NOTE: The underlying field will change in FHIR R5 to ServiceRequest.reason.where(concept.exists())",
-        "code": "reason",
+        "code": "reasonCode",
         "base": ["ServiceRequest"],
         "type": "token",
         "expression": "ServiceRequest.reasonCode"

--- a/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
+++ b/packages/definitions/dist/fhir/r4/search-parameters-medplum.json
@@ -1652,17 +1652,17 @@
       }
     },
     {
-      "fullUrl": "https://medplum.com/fhir/SearchParameter/ServiceRequest-reasonCode",
+      "fullUrl": "https://medplum.com/fhir/SearchParameter/ServiceRequest-reason-code",
       "resource": {
         "resourceType": "SearchParameter",
-        "id": "ServiceRequest-reasonCode",
-        "url": "https://medplum.com/fhir/SearchParameter/ServiceRequest-reasonCode",
+        "id": "ServiceRequest-reason-code",
+        "url": "https://medplum.com/fhir/SearchParameter/ServiceRequest-reason-code",
         "version": "4.0.1",
-        "name": "reasonCode",
+        "name": "reason-code",
         "status": "draft",
         "publisher": "Medplum",
-        "description": "Coded value representing the reason for this ServiceRequest.  NOTE: The underlying field will change in FHIR R5 to ServiceRequest.reason.where(concept.exists())",
-        "code": "reasonCode",
+        "description": "Coded value representing the reason for this ServiceRequest.  NOTE: The underlying field will change in FHIR R6 to ServiceRequest.reason.concept",
+        "code": "reason-code",
         "base": ["ServiceRequest"],
         "type": "token",
         "expression": "ServiceRequest.reasonCode"

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -268,7 +268,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * 6. 06/12/25 - Added columns per token search parameter (https://github.com/medplum/medplum/pull/6727)
    * 7. 06/25/25 - Added search params `ProjectMembership-identifier`, `Immunization-encounter`, `AllergyIntolerance-encounter` (https://github.com/medplum/medplum/pull/6868)
    * 8. 08/06/25 - Added Task to Patient compartment (https://github.com/medplum/medplum/pull/7194)
-   * 9. 08/19/25 - Added search parameter `ServiceRequest-reasonCode` (https://github.com/medplum/medplum/pull/7271)
+   * 9. 08/19/25 - Added search parameter `ServiceRequest-reason-code` (https://github.com/medplum/medplum/pull/7271)
    *
    */
   static readonly VERSION: number = 9;

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -268,9 +268,10 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * 6. 06/12/25 - Added columns per token search parameter (https://github.com/medplum/medplum/pull/6727)
    * 7. 06/25/25 - Added search params `ProjectMembership-identifier`, `Immunization-encounter`, `AllergyIntolerance-encounter` (https://github.com/medplum/medplum/pull/6868)
    * 8. 08/06/25 - Added Task to Patient compartment (https://github.com/medplum/medplum/pull/7194)
+   * 9. 08/19/25 - Added search parameter `ServiceRequest-reason` (https://github.com/medplum/medplum/pull/7271)
    *
    */
-  static readonly VERSION: number = 8;
+  static readonly VERSION: number = 9;
 
   constructor(context: RepositoryContext, conn?: PoolClient) {
     super();

--- a/packages/server/src/fhir/repo.ts
+++ b/packages/server/src/fhir/repo.ts
@@ -268,7 +268,7 @@ export class Repository extends FhirRepository<PoolClient> implements Disposable
    * 6. 06/12/25 - Added columns per token search parameter (https://github.com/medplum/medplum/pull/6727)
    * 7. 06/25/25 - Added search params `ProjectMembership-identifier`, `Immunization-encounter`, `AllergyIntolerance-encounter` (https://github.com/medplum/medplum/pull/6868)
    * 8. 08/06/25 - Added Task to Patient compartment (https://github.com/medplum/medplum/pull/7194)
-   * 9. 08/19/25 - Added search parameter `ServiceRequest-reason` (https://github.com/medplum/medplum/pull/7271)
+   * 9. 08/19/25 - Added search parameter `ServiceRequest-reasonCode` (https://github.com/medplum/medplum/pull/7271)
    *
    */
   static readonly VERSION: number = 9;

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -76,5 +76,8 @@
   },
   "v22": {
     "serverVersion": "4.3.11"
+  },
+  "v23": {
+    "serverVersion": "4.3.11"
   }
 }

--- a/packages/server/src/migrations/data/data-version-manifest.json
+++ b/packages/server/src/migrations/data/data-version-manifest.json
@@ -73,5 +73,8 @@
   },
   "v21": {
     "serverVersion": "4.3.9"
+  },
+  "v22": {
+    "serverVersion": "4.3.11"
   }
 }

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -22,3 +22,4 @@ export * as v18 from './v18';
 export * as v19 from './v19';
 export * as v20 from './v20';
 export * as v21 from './v21';
+export * as v22 from './v22';

--- a/packages/server/src/migrations/data/index.ts
+++ b/packages/server/src/migrations/data/index.ts
@@ -23,3 +23,4 @@ export * as v19 from './v19';
 export * as v20 from './v20';
 export * as v21 from './v21';
 export * as v22 from './v22';
+export * as v23 from './v23';

--- a/packages/server/src/migrations/data/v22.ts
+++ b/packages/server/src/migrations/data/v22.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { PoolClient } from 'pg';
+import { prepareCustomMigrationJobData, runCustomMigration } from '../../workers/post-deploy-migration';
+import * as fns from '../migrate-functions';
+import { withLongRunningDatabaseClient } from '../migration-utils';
+import { MigrationActionResult } from '../types';
+import { CustomPostDeployMigration } from './types';
+
+export const migration: CustomPostDeployMigration = {
+  type: 'custom',
+  prepareJobData: (asyncJob) => prepareCustomMigrationJobData(asyncJob),
+  run: async (repo, job, jobData) => {
+    return runCustomMigration(repo, job, jobData, async () => {
+      return withLongRunningDatabaseClient(async (client) => {
+        const results: MigrationActionResult[] = [];
+        await run(client, results);
+        return results;
+      });
+    });
+  },
+};
+
+// prettier-ignore
+async function run(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
+  await fns.idempotentCreateIndex(client, results, 'ServiceRequest___reason_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ServiceRequest___reason_idx" ON "ServiceRequest" USING gin ("__reason")`);
+  await fns.idempotentCreateIndex(client, results, 'ServiceRequest___reasonTextTrgm_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ServiceRequest___reasonTextTrgm_idx" ON "ServiceRequest" USING gin (token_array_to_text("__reasonText") gin_trgm_ops)`);
+}

--- a/packages/server/src/migrations/data/v22.ts
+++ b/packages/server/src/migrations/data/v22.ts
@@ -23,6 +23,6 @@ export const migration: CustomPostDeployMigration = {
 
 // prettier-ignore
 async function run(client: PoolClient, results: MigrationActionResult[]): Promise<void> {
-  await fns.idempotentCreateIndex(client, results, 'ServiceRequest___reason_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ServiceRequest___reason_idx" ON "ServiceRequest" USING gin ("__reason")`);
-  await fns.idempotentCreateIndex(client, results, 'ServiceRequest___reasonTextTrgm_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ServiceRequest___reasonTextTrgm_idx" ON "ServiceRequest" USING gin (token_array_to_text("__reasonText") gin_trgm_ops)`);
+  await fns.idempotentCreateIndex(client, results, 'ServiceRequest___reasonCode_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ServiceRequest___reasonCode_idx" ON "ServiceRequest" USING gin ("__reasonCode")`);
+  await fns.idempotentCreateIndex(client, results, 'ServiceRequest___reasonCodeTextTrgm_idx', `CREATE INDEX CONCURRENTLY IF NOT EXISTS "ServiceRequest___reasonCodeTextTrgm_idx" ON "ServiceRequest" USING gin (token_array_to_text("__reasonCodeText") gin_trgm_ops)`);
 }

--- a/packages/server/src/migrations/data/v23.ts
+++ b/packages/server/src/migrations/data/v23.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { WithId } from '@medplum/core';
+import { AsyncJob, ResourceType } from '@medplum/fhirtypes';
+import { prepareReindexJobData, ReindexJob, ReindexPostDeployMigration } from '../../workers/reindex';
+
+// Repository.VERSION was bumped to 9 for the ServiceRequest.reason-code search parameter,
+// so reindex all resources with a lower version.
+const maxResourceVersion = 8;
+
+export const migration: ReindexPostDeployMigration = {
+  type: 'reindex',
+  prepareJobData(asyncJob: WithId<AsyncJob>) {
+    // Also reindex Task, which was placed into the Patient compartment in a previous migration
+    const resourceTypes: ResourceType[] = ['ServiceRequest', 'Task'];
+    return prepareReindexJobData(resourceTypes, asyncJob.id, undefined, maxResourceVersion);
+  },
+  run: async (repo, job, jobData) => {
+    return new ReindexJob(repo).execute(job, jobData);
+  },
+};

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -1,5 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
 
 export * as v1 from './v1';
 export * as v2 from './v2';

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
-// SPDX-License-Identifier: Apache-2.0
-
 /*
  * This is a generated file
  * Do not edit manually.
@@ -103,3 +100,4 @@ export * as v92 from './v92';
 export * as v93 from './v93';
 export * as v94 from './v94';
 export * as v95 from './v95';
+export * as v96 from './v96';

--- a/packages/server/src/migrations/schema/index.ts
+++ b/packages/server/src/migrations/schema/index.ts
@@ -1,7 +1,5 @@
-/*
- * This is a generated file
- * Do not edit manually.
- */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 
 export * as v1 from './v1';
 export * as v2 from './v2';

--- a/packages/server/src/migrations/schema/v96.ts
+++ b/packages/server/src/migrations/schema/v96.ts
@@ -11,7 +11,7 @@ import * as fns from '../migrate-functions';
 // prettier-ignore
 export async function run(client: PoolClient): Promise<void> {
   const results: { name: string; durationMs: number }[] = []
-  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reason" UUID[]`);
-  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonText" TEXT[]`);
-  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonSort" TEXT`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonCode" UUID[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonCodeText" TEXT[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonCodeSort" TEXT`);
 }

--- a/packages/server/src/migrations/schema/v96.ts
+++ b/packages/server/src/migrations/schema/v96.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * This is a generated file
+ * Do not edit manually.
+ */
+
+import { PoolClient } from 'pg';
+import * as fns from '../migrate-functions';
+
+// prettier-ignore
+export async function run(client: PoolClient): Promise<void> {
+  const results: { name: string; durationMs: number }[] = []
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reason" UUID[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonText" TEXT[]`);
+  await fns.query(client, results, `ALTER TABLE IF EXISTS "ServiceRequest" ADD COLUMN IF NOT EXISTS "__reasonSort" TEXT`);
+}


### PR DESCRIPTION
Adding a non-standard search parameter for `ServiceRequest.reasonCode`.  This underlying field will change in FHIR R5, being replaced by a new `ServiceRequest.reason` field of type `CodeableReference`

Resolves #7247 