### PR TITLE
Encourage correct column and table alias usage

### DIFF
--- a/packages/server/src/fhir/lookups/lookuptable.ts
+++ b/packages/server/src/fhir/lookups/lookuptable.ts
@@ -197,7 +197,11 @@ export abstract class LookupTable {
     const lookupTableName = this.getTableName(resourceType);
     const joinName = selectQuery.getNextJoinAlias();
     const columnName = this.getColumnName(sortRule.code);
-    const joinOnExpression = new Condition(new Column(resourceType, 'id'), '=', new Column(joinName, 'resourceId'));
+    const joinOnExpression = new Condition(
+      new Column(selectQuery.effectiveTableName, 'id'),
+      '=',
+      new Column(joinName, 'resourceId')
+    );
     selectQuery.join(
       'LEFT JOIN',
       new SelectQuery(lookupTableName).distinctOn('resourceId').column('resourceId').column(columnName),

--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -296,7 +296,7 @@ export function expansionQuery(
             query = addDescendants(query, codeSystem, condition.value);
           }
           if (condition.op !== 'is-a') {
-            query.where(new Column(query.tableName, 'code'), '!=', condition.value);
+            query.where(new Column(query.effectiveTableName, 'code'), '!=', condition.value);
           }
           break;
         case '=':
@@ -351,7 +351,7 @@ function addAbstractFilter(query: SelectQuery): SelectQuery {
     'Coding_Property',
     propertyTable,
     new Conjunction([
-      new Condition(new Column(query.tableName, 'id'), '=', new Column(propertyTable, 'coding')),
+      new Condition(new Column(query.effectiveTableName, 'id'), '=', new Column(propertyTable, 'coding')),
       new Condition(new Column(propertyTable, 'value'), '=', 'true'),
     ])
   );

--- a/packages/server/src/fhir/operations/utils/terminology.ts
+++ b/packages/server/src/fhir/operations/utils/terminology.ts
@@ -111,7 +111,7 @@ export function addPropertyFilter(
 ): SelectQuery {
   const propertyQuery = new SelectQuery('Coding_Property').whereExpr(
     new Conjunction([
-      new Condition(new Column(query.tableName, 'id'), '=', new Column('Coding_Property', 'coding')),
+      new Condition(new Column(query.effectiveTableName, 'id'), '=', new Column('Coding_Property', 'coding')),
       new Condition('value', operator, value),
     ])
   );
@@ -122,7 +122,7 @@ export function addPropertyFilter(
     'CodeSystem_Property',
     csPropertyTable,
     new Conjunction([
-      new Condition(new Column(csPropertyTable, 'id'), '=', new Column(propertyQuery.tableName, 'property')),
+      new Condition(new Column(csPropertyTable, 'id'), '=', new Column(propertyQuery.effectiveTableName, 'property')),
       new Condition(new Column(csPropertyTable, 'code'), '=', property),
       new Condition(new Column(csPropertyTable, 'system'), '=', codeSystem.id),
     ])

--- a/packages/server/src/fhir/search.ts
+++ b/packages/server/src/fhir/search.ts
@@ -170,7 +170,7 @@ export async function searchByReferenceImpl<T extends Resource>(
           badRequest(`Invalid reference search parameter on ${resourceType}: ${referenceField}`)
         );
       }
-      const expr = buildReferenceEqualsCondition(builder.tableName, impl, referenceValues[0]);
+      const expr = buildReferenceEqualsCondition(builder.effectiveTableName, impl, referenceValues[0]);
       referenceConditions.push(expr);
       builder.whereExpr(expr);
 
@@ -188,7 +188,7 @@ export async function searchByReferenceImpl<T extends Resource>(
     }
     // Update each column with the current reference value literal
     for (const column of referenceColumns) {
-      column.columnName = `'${refValue}'`;
+      column.actualColumnName = `'${refValue}'`;
     }
     unionAllBuilder.add(searchQuery);
   }
@@ -1587,11 +1587,11 @@ function buildChainedSearchUsingReferenceTable(
   let innerQuery: SelectQuery;
   if (link.implementation.type === SearchParameterType.CANONICAL) {
     innerQuery = new SelectQuery(currentTable).whereExpr(
-      getCanonicalJoinCondition(selectQuery.tableName, link, currentTable)
+      getCanonicalJoinCondition(selectQuery.effectiveTableName, link, currentTable)
     );
   } else {
     innerQuery = new SelectQuery(currentTable).whereExpr(
-      lookupTableJoinCondition(selectQuery.tableName, link, currentTable)
+      lookupTableJoinCondition(selectQuery.effectiveTableName, link, currentTable)
     );
     currentTable = linkLiteralReference(innerQuery, currentTable, link);
   }

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -211,15 +211,23 @@ export interface Expression {
 
 export class Column implements Expression {
   readonly tableName: string | undefined;
-  columnName: string;
+  actualColumnName: string;
   readonly raw?: boolean;
   readonly alias?: string;
 
   constructor(tableName: string | undefined, columnName: string, raw?: boolean, alias?: string) {
     this.tableName = tableName;
-    this.columnName = columnName;
+    this.actualColumnName = columnName;
     this.raw = raw;
     this.alias = alias;
+  }
+
+  /**
+   * @returns - the column name to be used in the SQL query.
+   * This is the alias if provided, otherwise the actual column name.
+   */
+  get effectiveColumnName(): string {
+    return this.alias || this.actualColumnName;
   }
 
   buildSql(sql: SqlBuilder): void {
@@ -407,7 +415,7 @@ export class Union implements Expression {
   }
 }
 
-export type JoinType = 'INNER JOIN' | 'LEFT JOIN' | 'INNER JOIN LATERAL';
+export type JoinType = 'INNER JOIN' | 'LEFT JOIN' | 'INNER JOIN LATERAL' | 'LEFT JOIN LATERAL';
 
 export class Join {
   readonly joinType: JoinType;
@@ -463,13 +471,13 @@ export class SqlBuilder {
 
   appendColumn(column: Column): this {
     if (column.raw) {
-      this.append(column.columnName);
+      this.append(column.actualColumnName);
     } else {
       if (column.tableName) {
         this.appendIdentifier(column.tableName);
         this.append('.');
       }
-      this.appendIdentifier(column.columnName);
+      this.appendIdentifier(column.actualColumnName);
     }
     if (column.alias) {
       this.append(' AS ');
@@ -591,15 +599,21 @@ export function normalizeDatabaseError(err: any): OperationOutcomeError {
 }
 
 export abstract class BaseQuery {
-  readonly tableName: string;
+  readonly actualTableName: string;
   readonly predicate: Conjunction;
   explain: boolean | string[] = false;
-  readonly alias?: string;
 
-  constructor(tableName: string, alias?: string) {
-    this.tableName = tableName;
-    this.alias = alias;
+  constructor(tableName: string) {
+    this.actualTableName = tableName;
     this.predicate = new Conjunction([]);
+  }
+
+  /**
+   * @returns - the table name to be used in the SQL query.
+   * This is the alias if provided, otherwise the actual table name.
+   */
+  get effectiveTableName(): string {
+    return this.actualTableName;
   }
 
   whereExpr(expression: Expression): this {
@@ -608,7 +622,7 @@ export abstract class BaseQuery {
   }
 
   where(column: Column | string, operator?: keyof typeof Operator, value?: any, type?: string): this {
-    this.predicate.where(getColumn(column, this.tableName), operator, value, type);
+    this.predicate.where(getColumn(column, this.actualTableName), operator, value, type);
     return this;
   }
 
@@ -633,21 +647,27 @@ export class SelectQuery extends BaseQuery implements Expression {
   readonly joins: Join[];
   readonly groupBys: GroupBy[];
   readonly orderBys: OrderBy[];
+  private readonly alias?: string;
   with?: CTE;
   limit_: number;
   offset_: number;
   joinCount = 0;
 
   constructor(tableName: string, innerQuery?: SelectQuery | Union | ValuesQuery, alias?: string) {
-    super(tableName, alias);
+    super(tableName);
     this.innerQuery = innerQuery;
     this.distinctOns = [];
     this.columns = [];
     this.joins = [];
     this.groupBys = [];
     this.orderBys = [];
+    this.alias = alias;
     this.limit_ = 0;
     this.offset_ = 0;
+  }
+
+  get effectiveTableName(): string {
+    return this.alias || this.actualTableName;
   }
 
   withRecursive(name: string, expr: Expression): this {
@@ -656,7 +676,7 @@ export class SelectQuery extends BaseQuery implements Expression {
   }
 
   distinctOn(column: Column | string): this {
-    this.distinctOns.push(getColumn(column, this.tableName));
+    this.distinctOns.push(getColumn(column, this.effectiveTableName));
     return this;
   }
 
@@ -666,13 +686,13 @@ export class SelectQuery extends BaseQuery implements Expression {
   }
 
   column(column: Column | string): this {
-    this.columns.push(getColumn(column, this.tableName));
+    this.columns.push(getColumn(column, this.effectiveTableName));
     return this;
   }
 
   addColumns(columns: Column[]): this {
     for (const col of columns) {
-      this.columns.push(new Column(this.tableName, col.columnName));
+      this.columns.push(new Column(this.effectiveTableName, col.effectiveColumnName));
     }
     return this;
   }
@@ -682,23 +702,18 @@ export class SelectQuery extends BaseQuery implements Expression {
     return `T${this.joinCount}`;
   }
 
-  join(
-    joinType: 'INNER JOIN' | 'INNER JOIN LATERAL' | 'LEFT JOIN',
-    joinItem: SelectQuery | string,
-    joinAlias: string,
-    onExpression: Expression
-  ): this {
+  join(joinType: JoinType, joinItem: SelectQuery | string, joinAlias: string, onExpression: Expression): this {
     this.joins.push(new Join(joinType, joinItem, joinAlias, onExpression));
     return this;
   }
 
   groupBy(column: Column | string): this {
-    this.groupBys.push(new GroupBy(getColumn(column, this.tableName)));
+    this.groupBys.push(new GroupBy(getColumn(column, this.effectiveTableName)));
     return this;
   }
 
   orderBy(column: Column | string, descending?: boolean): this {
-    this.orderBys.push(new OrderBy(getColumn(column, this.tableName), descending));
+    this.orderBys.push(new OrderBy(getColumn(column, this.effectiveTableName), descending));
     return this;
   }
 
@@ -801,7 +816,7 @@ export class SelectQuery extends BaseQuery implements Expression {
       sql.append(') AS ');
     }
 
-    sql.appendIdentifier(this.tableName);
+    sql.appendIdentifier(this.actualTableName);
     if (this.alias) {
       sql.append(' ');
       sql.appendIdentifier(this.alias);
@@ -866,7 +881,7 @@ export class ArraySubquery implements Expression {
     sql.append('EXISTS(SELECT 1 FROM unnest(');
     sql.appendColumn(this.column);
     sql.append(') AS ');
-    sql.appendIdentifier(this.column.columnName);
+    sql.appendIdentifier(this.column.effectiveColumnName);
     sql.append(' WHERE ');
     sql.appendExpression(this.filter);
     sql.append(' LIMIT 1');
@@ -905,14 +920,14 @@ export class InsertQuery extends BaseQuery {
   }
 
   returnColumn(column: Column | string): this {
-    this.returnColumns = append(this.returnColumns, column instanceof Column ? column.columnName : column);
+    this.returnColumns = append(this.returnColumns, column instanceof Column ? column.effectiveColumnName : column);
     return this;
   }
 
   async execute(conn: Pool | PoolClient): Promise<{ rowCount: number; rows: any[] }> {
     const sql = new SqlBuilder();
     sql.append('INSERT INTO ');
-    sql.appendIdentifier(this.tableName);
+    sql.appendIdentifier(this.actualTableName);
     if (this.values) {
       const columnNames = Object.keys(this.values[0]);
       this.appendColumns(sql, columnNames);
@@ -1021,7 +1036,7 @@ export class DeleteQuery extends BaseQuery {
   async execute(conn: Pool | PoolClient): Promise<any[]> {
     const sql = new SqlBuilder();
     sql.append('DELETE FROM ');
-    sql.appendIdentifier(this.tableName);
+    sql.appendIdentifier(this.actualTableName);
 
     if (this.usingTables) {
       sql.append(' USING ');


### PR DESCRIPTION
Stemmed from discovering the need for the change in `lookuptable.ts` when experimenting with a different JOIN clause.