### PR TITLE
Add bot-layer as server dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9330,6 +9330,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
       "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -9339,6 +9340,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
       "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@isaacs/balanced-match": "^4.0.1"
@@ -27383,6 +27385,7 @@
       "version": "11.3.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
       "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -28280,6 +28283,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -29301,6 +29305,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -31996,6 +32001,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -35952,6 +35958,7 @@
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
       "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
@@ -42429,6 +42436,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -46412,6 +46420,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -48343,6 +48352,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -49227,6 +49237,7 @@
         "@google-cloud/secret-manager": "6.1.0",
         "@google-cloud/storage": "7.17.0",
         "@kubernetes/client-node": "1.3.0",
+        "@medplum/bot-layer": "4.3.11",
         "@medplum/ccda": "4.3.11",
         "@medplum/core": "4.3.11",
         "@medplum/definitions": "4.3.11",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,6 +45,7 @@
     "@google-cloud/secret-manager": "6.1.0",
     "@google-cloud/storage": "7.17.0",
     "@kubernetes/client-node": "1.3.0",
+    "@medplum/bot-layer": "4.3.11",
     "@medplum/ccda": "4.3.11",
     "@medplum/core": "4.3.11",
     "@medplum/definitions": "4.3.11",

--- a/scripts/build-docker-server.sh
+++ b/scripts/build-docker-server.sh
@@ -24,6 +24,7 @@ tar \
   -czf medplum-server.tar.gz \
   package.json \
   package-lock.json \
+  packages/bot-layer/package.json \
   packages/ccda/package.json \
   packages/ccda/dist \
   packages/core/package.json \


### PR DESCRIPTION
Adding `@medplum/bot-layer` as a dependency in `@medplum/server`. This change resolves an issue where VMContext bots fail to find certain dependencies that are included in the bot layer but not in the server itself.

Context: 
* Discord: https://discord.com/channels/905144809105260605/1410568332507353148/1410568332507353148
* Slack: https://medplum.slack.com/archives/C08S24G1SV7/p1756482855540489

***

### Summary

This pull request addresses a long-standing issue where **Medplum Bots** running in **VMContext** environments fail to load certain dependencies, even though they're listed in the documentation as available. The specific error, `"Cannot find module 'ssh2-sftp-client'"`, was reported by a user and highlighted a discrepancy between our code and the documentation.

### The Problem

Our VMContext bots, which are used in local and self-hosted deployments, rely on the `@medplum/server` package for their dependencies. However, the `@medplum/bot-layer` package—which is a separate component used to manage dependencies for **AWS Lambda bots**—contains libraries like `ssh2-sftp-client` that are not present in `@medplum/server`. This created a dependency gap. When a user tried to run a bot locally that used a library from the bot layer, the bot would fail with an error because the server couldn't find the required module. This was especially confusing for users because our documentation states that the `ssh2-sftp-client` library is provided. 

### The Solution

By adding `@medplum/bot-layer` as a dependency to `@medplum/server`, we ensure that all the necessary libraries are available to both VMContext bots and Lambda bots. This change eliminates the dependency gap and aligns the behavior of our local and hosted environments, making it a smoother experience for our users, especially those running self-hosted Medplum instances. This also brings the code into alignment with our documentation.

### Changes Made

* Added `@medplum/bot-layer` to the `dependencies` list in `packages/server/package.json`.

### Verification

I've tested this change by cloning the `medplum-demo-bots` repository, removing the `node_modules` and `dist` folders, and running the `sftp-upload` bot locally. The bot now successfully connects to an SFTP server without throwing the `"Cannot find module 'ssh2-sftp-client'"` error.

This PR makes Medplum more reliable and predictable for our self-hosted users, directly addressing the feedback we received from our community.