### PR TITLE
Batched update migrate function

### DIFF
--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -277,11 +277,11 @@ describe('SqlBuilder', () => {
   describe('UpdateQuery', () => {
     test('Simple Update', () => {
       const sql = new SqlBuilder();
-      new UpdateQuery('MyTable', [
-        [new Column(undefined, 'id'), 123],
-        [new Column(undefined, 'name'), 'new-name'],
-      ]).buildSql(sql);
-      expect(sql.toString()).toBe('UPDATE "MyTable" SET "id" = $1, "name" = $2');
+      const update = new UpdateQuery('MyTable');
+      update.set('id', 123);
+      update.set('name', 'new-name');
+      update.buildSql(sql);
+      expect(sql.toString()).toBe('UPDATE "MyTable" SET "MyTable"."id" = $1, "MyTable"."name" = $2');
       expect(sql.getValues()).toStrictEqual([123, 'new-name']);
     });
 
@@ -293,20 +293,14 @@ describe('SqlBuilder', () => {
       };
 
       const sql = new SqlBuilder();
-      const updateQuery = new UpdateQuery(
-        'MyTable',
-        [
-          [new Column(undefined, 'id'), 123],
-          [new Column(undefined, 'name'), 'new-name'],
-        ],
-        [new Column(undefined, 'id')],
-        cte
-      );
-
-      updateQuery.where(new Column('MyCTE', 'id'), '=', new Column('MyTable', 'id'));
-      updateQuery.buildSql(sql);
+      const update = new UpdateQuery('MyTable', ['id']);
+      update.from(cte);
+      update.set('id', 123);
+      update.set('name', 'new-name');
+      update.where(new Column('MyCTE', 'id'), '=', new Column('MyTable', 'id'));
+      update.buildSql(sql);
       expect(sql.toString()).toBe(
-        'WITH "MyCTE" AS (SELECT "MyTable"."id", "MyTable"."name" FROM "MyTable" WHERE "MyTable"."projectId" IS NULL LIMIT 10) UPDATE "MyTable" SET "id" = $1, "name" = $2 FROM "MyCTE" WHERE "MyCTE"."id" = "MyTable"."id" RETURNING "id"'
+        'WITH "MyCTE" AS (SELECT "MyTable"."id", "MyTable"."name" FROM "MyTable" WHERE "MyTable"."projectId" IS NULL LIMIT 10) UPDATE "MyTable" SET "MyTable"."id" = $1, "MyTable"."name" = $2 FROM "MyCTE" WHERE "MyCTE"."id" = "MyTable"."id" RETURNING "MyTable"."id"'
       );
       expect(sql.getValues()).toStrictEqual([123, 'new-name']);
     });

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -277,10 +277,10 @@ describe('SqlBuilder', () => {
   describe('UpdateQuery', () => {
     test('Simple Update', () => {
       const sql = new SqlBuilder();
-      const update = new UpdateQuery('MyTable');
+      const update = new UpdateQuery('MyTable', ['id', 'name']);
       update.set('id', 123);
       update.buildSql(sql);
-      expect(sql.toString()).toBe('UPDATE "MyTable" SET "id" = $1');
+      expect(sql.toString()).toBe('UPDATE "MyTable" SET "id" = $1 RETURNING "MyTable"."id", "MyTable"."name"');
       expect(sql.getValues()).toStrictEqual([123]);
     });
 

--- a/packages/server/src/fhir/sql.test.ts
+++ b/packages/server/src/fhir/sql.test.ts
@@ -279,10 +279,9 @@ describe('SqlBuilder', () => {
       const sql = new SqlBuilder();
       const update = new UpdateQuery('MyTable');
       update.set('id', 123);
-      update.set('name', 'new-name');
       update.buildSql(sql);
-      expect(sql.toString()).toBe('UPDATE "MyTable" SET "MyTable"."id" = $1, "MyTable"."name" = $2');
-      expect(sql.getValues()).toStrictEqual([123, 'new-name']);
+      expect(sql.toString()).toBe('UPDATE "MyTable" SET "id" = $1');
+      expect(sql.getValues()).toStrictEqual([123]);
     });
 
     test('with CTE and RETURNING', () => {
@@ -300,7 +299,7 @@ describe('SqlBuilder', () => {
       update.where(new Column('MyCTE', 'id'), '=', new Column('MyTable', 'id'));
       update.buildSql(sql);
       expect(sql.toString()).toBe(
-        'WITH "MyCTE" AS (SELECT "MyTable"."id", "MyTable"."name" FROM "MyTable" WHERE "MyTable"."projectId" IS NULL LIMIT 10) UPDATE "MyTable" SET "MyTable"."id" = $1, "MyTable"."name" = $2 FROM "MyCTE" WHERE "MyCTE"."id" = "MyTable"."id" RETURNING "MyTable"."id"'
+        'WITH "MyCTE" AS (SELECT "MyTable"."id", "MyTable"."name" FROM "MyTable" WHERE "MyTable"."projectId" IS NULL LIMIT 10) UPDATE "MyTable" SET "id" = $1, "name" = $2 FROM "MyCTE" WHERE "MyCTE"."id" = "MyTable"."id" RETURNING "MyTable"."id"'
       );
       expect(sql.getValues()).toStrictEqual([123, 'new-name']);
     });

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -891,8 +891,8 @@ export class ArraySubquery implements Expression {
 
 export class UpdateQuery extends BaseQuery {
   private _from?: CTE;
-  readonly setColumns: [Column, any][];
-  readonly returning?: Column[];
+  private readonly setColumns: [Column, any][];
+  private readonly returning?: Column[];
 
   constructor(tableName: string, returning?: (Column | string)[]) {
     super(tableName);
@@ -933,7 +933,7 @@ export class UpdateQuery extends BaseQuery {
     sql.append(' SET ');
 
     let firstSet = true;
-    for (const [column, expr] of this.setColumns ?? []) {
+    for (const [column, expr] of this.setColumns) {
       if (!firstSet) {
         sql.append(', ');
       }

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -892,7 +892,7 @@ export class ArraySubquery implements Expression {
 export class UpdateQuery extends BaseQuery {
   private _from?: CTE;
   private readonly setColumns: [Column, any][];
-  private readonly returning?: Column[];
+  readonly returning?: Column[];
 
   constructor(tableName: string, returning?: (Column | string)[]) {
     super(tableName);

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -891,7 +891,7 @@ export class ArraySubquery implements Expression {
 
 export class UpdateQuery extends BaseQuery {
   private _from?: CTE;
-  private setColumns: [Column, any][];
+  readonly setColumns: [Column, any][];
   readonly returning?: Column[];
 
   constructor(tableName: string, returning?: (Column | string)[]) {
@@ -918,7 +918,6 @@ export class UpdateQuery extends BaseQuery {
   }
 
   buildSql(sql: SqlBuilder): void {
-    // TODO extract CTE handling to own buildSql?
     if (this._from) {
       sql.append('WITH ');
       if (this._from.recursive) {

--- a/packages/server/src/migrations/migrate-functions.test.ts
+++ b/packages/server/src/migrations/migrate-functions.test.ts
@@ -4,7 +4,8 @@ import { Client, escapeIdentifier, Pool } from 'pg';
 import { loadTestConfig } from '../config/loader';
 import { MedplumServerConfig } from '../config/types';
 import { closeDatabase, DatabaseMode, getDatabasePool, initDatabase } from '../database';
-import { analyzeTable, idempotentCreateIndex, nonBlockingAlterColumnNotNull } from './migrate-functions';
+import { Column, SelectQuery, UpdateQuery } from '../fhir/sql';
+import { analyzeTable, batchedUpdate, idempotentCreateIndex, nonBlockingAlterColumnNotNull } from './migrate-functions';
 import { MigrationActionResult } from './types';
 
 interface IndexInfo {
@@ -174,6 +175,50 @@ describe('migrate-functions', () => {
       await expect(client.query(`INSERT INTO ${escapedTableName} (id, name) VALUES (4, NULL)`)).rejects.toThrow(
         /violates not-null constraint/
       );
+    });
+  });
+
+  describe('batchedUpdate', () => {
+    test.each([1, 10])('should update rows in batches with %i maxIterations', async (maxIterations) => {
+      await client.query(
+        `INSERT INTO ${escapedTableName} (id, name) VALUES (1, NULL), (2, NULL), (3, 'not null'), (4, NULL)`
+      );
+
+      const results: MigrationActionResult[] = [];
+      const update = new UpdateQuery(tableName, ['id']);
+      const cte = { name: 'cte', expr: new SelectQuery(tableName).column('id').where('name', '=', null).limit(2) };
+      update.from(cte);
+      update.set('name', 'new default');
+      update.where(new Column(cte.name, 'id'), '=', new Column(tableName, 'id'));
+
+      if (maxIterations < 3) {
+        await expect(batchedUpdate(client, results, update, maxIterations)).rejects.toThrow(
+          `Exceeded max iterations of ${maxIterations}`
+        );
+        return;
+      }
+
+      await batchedUpdate(client, results, update, maxIterations);
+
+      const expectedQuery =
+        'WITH "cte" AS (SELECT "Test_Table"."id" FROM "Test_Table" WHERE "Test_Table"."name" IS NULL LIMIT 2) UPDATE "Test_Table" SET "name" = $1 FROM "cte" WHERE "cte"."id" = "Test_Table"."id" RETURNING "Test_Table"."id"';
+
+      expect(results).toEqual([
+        {
+          name: expectedQuery,
+          durationMs: expect.any(Number),
+          iterations: 3,
+        },
+      ]);
+
+      const result = await client.query(`SELECT * FROM ${escapedTableName} ORDER BY id`);
+      expect(result.rowCount).toBe(4);
+      expect(result.rows).toStrictEqual([
+        { id: 1, name: 'new default' },
+        { id: 2, name: 'new default' },
+        { id: 3, name: 'not null' },
+        { id: 4, name: 'new default' },
+      ]);
     });
   });
 });

--- a/packages/server/src/migrations/types.ts
+++ b/packages/server/src/migrations/types.ts
@@ -62,4 +62,8 @@ export type MigrationAction =
   | { type: 'ADD_CONSTRAINT'; tableName: string; constraintName: string; constraintExpression: string }
   | { type: 'ANALYZE_TABLE'; tableName: string };
 
-export type MigrationActionResult = { name: string; durationMs: number };
+export interface MigrationActionResult {
+  name: string;
+  durationMs: number;
+  [key: string]: string | number | undefined;
+}

--- a/packages/server/src/workers/post-deploy-migration.ts
+++ b/packages/server/src/workers/post-deploy-migration.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { getReferenceString, normalizeErrorString, WithId } from '@medplum/core';
-import { AsyncJob, Parameters } from '@medplum/fhirtypes';
+import {
+  capitalize,
+  getReferenceString,
+  normalizeErrorString,
+  PropertyType,
+  toTypedValue,
+  WithId,
+} from '@medplum/core';
+import { AsyncJob, Parameters, ParametersParameter } from '@medplum/fhirtypes';
 import { Job, JobsOptions, Queue, QueueBaseOptions, Worker } from 'bullmq';
 import * as semver from 'semver';
 import { getRequestContext, tryRunInRequestContext } from '../context';
@@ -201,14 +208,34 @@ function getAsyncJobOutputFromMigrationActionResults(results: MigrationActionRes
   return {
     resourceType: 'Parameters',
     parameter: results.map((r) => {
+      const { name, durationMs, ...rest } = r;
+      const part: ParametersParameter[] = [
+        {
+          name: 'durationMs',
+          valueInteger: durationMs,
+        },
+      ];
+      for (const [name, value] of Object.entries(rest)) {
+        const typedValue = toTypedValue(value);
+        if (typedValue.type === 'undefined') {
+          continue;
+        }
+        if ([PropertyType.integer, PropertyType.decimal, PropertyType.boolean].includes(typedValue.type as any)) {
+          part.push({
+            name: name,
+            ['value' + capitalize(typedValue.type)]: value,
+          });
+        } else {
+          part.push({
+            name: name,
+            valueString: value?.toString(),
+          });
+        }
+      }
+
       return {
-        name: r.name,
-        part: [
-          {
-            name: 'durationMs',
-            valueInteger: r.durationMs,
-          },
-        ],
+        name,
+        part,
       };
     }),
   };


### PR DESCRIPTION
`v25` is vulnerable to failing due to serialization errors on resource types containing many system resources. To avoid that, add a mechanism for performing the update in batches.