### PR TITLE
fix: CCDA to FHIR converter attribute mapping

### DIFF
--- a/packages/ccda/src/ccda-to-fhir.ts
+++ b/packages/ccda/src/ccda-to-fhir.ts
@@ -276,7 +276,7 @@ class CcdaToFhirConverter {
       return undefined;
     }
     return addresses?.map((addr) => ({
-      '@_use': addr['@_use'] ? ADDRESS_USE_MAPPER.mapCcdaToFhir(addr['@_use']) : undefined,
+      use: addr['@_use'] ? ADDRESS_USE_MAPPER.mapCcdaToFhir(addr['@_use']) : undefined,
       line: addr.streetAddressLine,
       city: addr.city,
       state: addr.state,
@@ -290,7 +290,7 @@ class CcdaToFhirConverter {
       return undefined;
     }
     return telecoms?.map((tel) => ({
-      '@_use': tel['@_use'] ? TELECOM_USE_MAPPER.mapCcdaToFhir(tel['@_use']) : undefined,
+      use: tel['@_use'] ? TELECOM_USE_MAPPER.mapCcdaToFhir(tel['@_use']) : undefined,
       system: this.getTelecomSystem(tel['@_value']),
       value: this.getTelecomValue(tel['@_value']),
     }));


### PR DESCRIPTION
Remove incorrect `@_use` attribute in address and telecom mappings - should just be `use`