### PR TITLE
Update default Aurora PostgreSQL version to 16.9

### DIFF
--- a/packages/cdk/src/backend.ts
+++ b/packages/cdk/src/backend.ts
@@ -102,7 +102,7 @@ export class BackEnd extends Construct {
     if (!this.rdsSecretsArn) {
       const { engine, majorVersion } = getPostgresEngine(
         config.rdsInstanceVersion,
-        rds.AuroraPostgresEngineVersion.VER_12_9
+        rds.AuroraPostgresEngineVersion.VER_16_9
       );
 
       const clusterParameters: NonNullable<rds.ParameterGroupProps['parameters']> = {


### PR DESCRIPTION
The [self host install guide for AWS ](https://www.medplum.com/docs/self-hosting/install-on-aws) don't include a guide or steps to include the Postgres engine version key in CDK config file and so the default value of 12.9 is used.

[Version 12.9 is now deprecated](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html#postgresql-versions-version12) and incurs significant Amazon RDS Extended Support costs which are typically 100% of the hosting cost itself.