### PR TITLE
[Certification Provider App] Minor fixes

### DIFF
--- a/examples/medplum-provider/data/core/c1/questionnaires.json
+++ b/examples/medplum-provider/data/core/c1/questionnaires.json
@@ -334,7 +334,7 @@
         "resourceType": "Questionnaire",
         "status": "active",
         "name": "c1-certification",
-        "title": "C1 Certification",
+        "title": "Create Measure Report",
         "description": "Used to generate QRDA Cat I XML files for ONC C1 certification (315.c.1) - Record and Export capability.",
         "subjectType": ["Patient"],
         "identifier": [

--- a/examples/medplum-provider/src/bots/c1-patient-intake-bot.test.ts
+++ b/examples/medplum-provider/src/bots/c1-patient-intake-bot.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { ContentType, createReference, getReferenceString, SNOMED } from '@medplum/core';
+import { ContentType, createReference, getReferenceString, LOINC, SNOMED } from '@medplum/core';
 import { Questionnaire, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
-import { extensionURLMapping } from '../utils/intake-utils';
+import { extensionURLMapping, observationCategoryMapping, observationCodeMapping } from '../utils/intake-utils';
 import {
   patientIdentifier,
   patientIntakeQuestionnaire,
@@ -118,6 +118,32 @@ describe('C1 Patient Intake Bot', () => {
         { system: 'phone', value: '502-248-7743', use: 'home' },
         { system: 'email', value: 'cstrickland7064@example.com', use: 'home' },
       ]);
+    });
+  });
+
+  describe('Observation', () => {
+    test('creates an Observation for administrative sex', async () => {
+      const patient = await handler(medplum, { bot, input, contentType, secrets });
+
+      expect(patient.gender).toStrictEqual('male');
+
+      const observations = await medplum.searchResources('Observation', {
+        subject: getReferenceString(patient),
+        code: `${LOINC}|46098-0`,
+      });
+
+      expect(observations).toHaveLength(1);
+      const observation = observations[0];
+      expect(observation).toMatchObject({
+        resourceType: 'Observation',
+        status: 'final',
+        subject: createReference(patient),
+        code: observationCodeMapping.administrativeSex,
+        category: [observationCategoryMapping.socialHistory],
+        valueCodeableConcept: {
+          coding: [{ system: SNOMED, code: '248153007', display: 'Male' }],
+        },
+      });
     });
   });
 

--- a/examples/medplum-provider/src/bots/c1-patient-intake-bot.test.ts
+++ b/examples/medplum-provider/src/bots/c1-patient-intake-bot.test.ts
@@ -68,7 +68,7 @@ describe('C1 Patient Intake Bot', () => {
         ],
       });
       // Gender
-      expect(patient.gender).toStrictEqual('M');
+      expect(patient.gender).toStrictEqual('male');
       // Rance and Ethnicity
       expect(patient.extension).toStrictEqual([
         {

--- a/examples/medplum-provider/src/bots/c1-patient-intake-bot.ts
+++ b/examples/medplum-provider/src/bots/c1-patient-intake-bot.ts
@@ -11,8 +11,12 @@ import {
   getGroupRepeatedAnswers,
   getHumanName,
   getPatientAddress,
+  getPatientAdministrativeSex,
   getPatientGender,
+  observationCategoryMapping,
+  observationCodeMapping,
   PROFILE_URLS,
+  upsertObservation,
 } from '../utils/intake-utils';
 
 export async function handler(medplum: MedplumClient, event: BotEvent<QuestionnaireResponse>): Promise<Patient> {
@@ -91,6 +95,16 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
   // is configured for "create"-only event.
   response.subject = createReference(patient);
   await medplum.createResource(response);
+
+  // Handle observations
+  await upsertObservation(
+    medplum,
+    patient,
+    observationCodeMapping.administrativeSex,
+    observationCategoryMapping.socialHistory,
+    'valueCodeableConcept',
+    getPatientAdministrativeSex(answers['gender-identity']?.valueCoding?.code)
+  );
 
   // Handle encounter
   const encounters = getGroupRepeatedAnswers(questionnaire, response, 'encounters');

--- a/examples/medplum-provider/src/bots/c1-patient-intake-bot.ts
+++ b/examples/medplum-provider/src/bots/c1-patient-intake-bot.ts
@@ -11,6 +11,7 @@ import {
   getGroupRepeatedAnswers,
   getHumanName,
   getPatientAddress,
+  getPatientGender,
   PROFILE_URLS,
 } from '../utils/intake-utils';
 
@@ -68,7 +69,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
   }
 
   if (answers['gender-identity']?.valueCoding?.code) {
-    patient.gender = answers['gender-identity'].valueCoding.code as Patient['gender'];
+    patient.gender = getPatientGender(answers['gender-identity'].valueCoding.code);
   }
 
   patient.telecom = [];

--- a/examples/medplum-provider/src/pages/c1/C1CertificationPage.tsx
+++ b/examples/medplum-provider/src/pages/c1/C1CertificationPage.tsx
@@ -10,9 +10,6 @@ import { JSX, useState } from 'react';
 import { useLocation, useParams } from 'react-router';
 import { C1_CERTIFICATION_BOT_IDENTIFIER, MEDPLUM_BOTS } from '../../constants';
 
-const NOTIFICATION_ID = 'c1-certification';
-const NOTIFICATION_TITLE = 'C1 Certification';
-
 export function C1CertificationPage(): JSX.Element {
   const { id } = useParams() as { id: string };
   const location = useLocation();
@@ -23,6 +20,10 @@ export function C1CertificationPage(): JSX.Element {
   const medplum = useMedplum();
 
   async function handleSubmit(questionnaireResponse: QuestionnaireResponse): Promise<void> {
+    if (!questionnaire) {
+      return;
+    }
+
     if (subjectList && subjectList.length > 0) {
       const patientIds = subjectList.map((subject) => subject.split('/')[1]).join(',');
       questionnaireResponse.item = questionnaireResponse.item || [];
@@ -32,9 +33,10 @@ export function C1CertificationPage(): JSX.Element {
       });
     }
 
+    const { id: notificationId, title: notificationTitle } = questionnaire;
     notifications.show({
-      id: NOTIFICATION_ID,
-      title: NOTIFICATION_TITLE,
+      id: notificationId,
+      title: notificationTitle,
       loading: true,
       message: 'Generating QRDA files...',
       autoClose: false,
@@ -56,8 +58,8 @@ export function C1CertificationPage(): JSX.Element {
       }
 
       notifications.update({
-        id: NOTIFICATION_ID,
-        title: NOTIFICATION_TITLE,
+        id: notificationId,
+        title: notificationTitle,
         color: 'green',
         message: 'Done',
         icon: <IconCheck size="1rem" />,
@@ -67,8 +69,8 @@ export function C1CertificationPage(): JSX.Element {
       });
     } catch (error) {
       notifications.update({
-        id: NOTIFICATION_ID,
-        title: NOTIFICATION_TITLE,
+        id: notificationId,
+        title: notificationTitle,
         color: 'red',
         message: normalizeErrorString(error),
         icon: <IconX size="1rem" />,

--- a/examples/medplum-provider/src/utils/intake-utils.ts
+++ b/examples/medplum-provider/src/utils/intake-utils.ts
@@ -28,8 +28,8 @@ export const PROFILE_URLS: Record<string, string> = {
 };
 
 export const extensionURLMapping: Record<string, string> = {
-  race: HTTP_HL7_ORG + '/fhir/us/core/StructureDefinition/us-core-race',
-  ethnicity: HTTP_HL7_ORG + '/fhir/us/core/StructureDefinition/us-core-ethnicity',
+  race: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836',
+  ethnicity: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837',
   veteran: HTTP_HL7_ORG + '/fhir/us/military-service/StructureDefinition/military-service-veteran-status',
   patientBirthTime: HTTP_HL7_ORG + '/fhir/StructureDefinition/patient-birthTime',
   // Custom
@@ -409,4 +409,17 @@ export function getPatientAddress(answers: Record<string, QuestionnaireResponseI
 
   // To simplify the demo, we're assuming the address is always a home address
   return Object.keys(patientAddress).length > 0 ? { use: 'home', type: 'physical', ...patientAddress } : undefined;
+}
+
+export function getPatientGender(code: string | undefined): Patient['gender'] {
+  if (!code) {
+    return undefined;
+  }
+  const map: { [key: string]: Patient['gender'] } = {
+    F: 'female',
+    M: 'male',
+    OTH: 'other',
+    UNK: 'unknown',
+  };
+  return map[code];
 }

--- a/examples/medplum-provider/src/utils/intake-utils.ts
+++ b/examples/medplum-provider/src/utils/intake-utils.ts
@@ -1,11 +1,22 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { createReference, getReferenceString, HTTP_HL7_ORG, MedplumClient, SNOMED } from '@medplum/core';
+import {
+  addProfileToResource,
+  createReference,
+  getReferenceString,
+  HTTP_HL7_ORG,
+  HTTP_TERMINOLOGY_HL7_ORG,
+  LOINC,
+  MedplumClient,
+  SNOMED,
+} from '@medplum/core';
 import {
   Address,
+  CodeableConcept,
   Coding,
   Condition,
   HumanName,
+  Observation,
   Patient,
   Questionnaire,
   QuestionnaireItem,
@@ -27,6 +38,26 @@ export const PROFILE_URLS: Record<string, string> = {
   ObservationSmokingStatus: `${HTTP_HL7_ORG}/fhir/us/core/StructureDefinition/us-core-smokingstatus`,
 };
 
+export const observationCodeMapping: Record<string, CodeableConcept> = {
+  administrativeSex: {
+    coding: [{ code: '46098-0', system: LOINC, display: 'Administrative Sex' }],
+    text: 'Administrative Sex',
+  },
+};
+
+export const observationCategoryMapping: Record<string, CodeableConcept> = {
+  socialHistory: {
+    coding: [
+      {
+        system: HTTP_TERMINOLOGY_HL7_ORG + '/CodeSystem/observation-category',
+        code: 'social-history',
+        display: 'Social History',
+      },
+    ],
+    text: 'Social History',
+  },
+};
+
 export const extensionURLMapping: Record<string, string> = {
   race: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836',
   ethnicity: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837',
@@ -36,6 +67,61 @@ export const extensionURLMapping: Record<string, string> = {
   encounterDescription: 'https://medplum.com/fhir/StructureDefinition/encounter-description',
   procedureRank: 'https://medplum.com/fhir/StructureDefinition/procedure-rank',
 };
+
+type ObservationQuestionnaireItemType = 'valueCodeableConcept' | 'valueDateTime';
+
+/**
+ * This function takes data about an Observation and creates or updates an existing
+ * resource with the same patient and code.
+ *
+ * @param medplum - A Medplum client
+ * @param patient - A Patient resource that will be stored as the subject
+ * @param code - A code for the observation
+ * @param category - A category for the observation
+ * @param answerType - The value[x] field where the answer should be stored
+ * @param value - The value to be stored in the observation
+ * @param profileUrl - An optional profile URL to be added to the resource
+ */
+export async function upsertObservation(
+  medplum: MedplumClient,
+  patient: Patient,
+  code: CodeableConcept,
+  category: CodeableConcept,
+  answerType: ObservationQuestionnaireItemType,
+  value: QuestionnaireResponseItemAnswer | undefined,
+  profileUrl?: string
+): Promise<void> {
+  if (!value || !code) {
+    return;
+  }
+
+  let observation: Observation = {
+    resourceType: 'Observation',
+    status: 'final',
+    subject: createReference(patient),
+    code: code,
+    category: [category],
+    effectiveDateTime: new Date().toISOString(),
+  };
+
+  if (profileUrl) {
+    observation = addProfileToResource(observation, profileUrl);
+  }
+
+  if (answerType === 'valueCodeableConcept') {
+    observation.valueCodeableConcept = {
+      coding: [value],
+    };
+  } else if (answerType === 'valueDateTime') {
+    observation.valueDateTime = value.valueDateTime;
+  }
+
+  const coding = code.coding?.[0] as Coding;
+  await medplum.upsertResource(observation, {
+    code: `${coding.system}|${coding.code}`,
+    subject: getReferenceString(patient),
+  });
+}
 
 type ExtensionQuestionnaireItemType = 'valueCoding' | 'valueBoolean';
 
@@ -420,6 +506,25 @@ export function getPatientGender(code: string | undefined): Patient['gender'] {
     M: 'male',
     OTH: 'other',
     UNK: 'unknown',
+  };
+  return map[code];
+}
+
+export function getPatientAdministrativeSex(code: string | undefined): Coding | undefined {
+  if (!code) {
+    return undefined;
+  }
+  const map: { [key: string]: Coding } = {
+    F: {
+      system: SNOMED,
+      code: '248152002',
+      display: 'Female',
+    },
+    M: {
+      system: SNOMED,
+      code: '248153007',
+      display: 'Male',
+    },
   };
   return map[code];
 }

--- a/examples/medplum-provider/src/utils/qrda-generator.ts
+++ b/examples/medplum-provider/src/utils/qrda-generator.ts
@@ -214,16 +214,8 @@ function buildRecordTarget(patient: Patient): Record<string, any> {
   const email = patient.telecom?.find((t) => t.system === 'email');
   const identifier = patient.identifier?.find((i) => i.system === 'http://example.com/patientId')?.value;
   const gender = patient.gender ? { female: 'F', male: 'M', other: 'OTH', unknown: 'UNK' }[patient.gender] : '';
-  const raceExtension = getExtensionValue(
-    patient,
-    'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
-    'ombCategory'
-  ) as Coding;
-  const ethnicityExtension = getExtensionValue(
-    patient,
-    'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
-    'ombCategory'
-  ) as Coding;
+  const raceExtension = getExtensionValue(patient, extensionURLMapping.race, 'ombCategory') as Coding;
+  const ethnicityExtension = getExtensionValue(patient, extensionURLMapping.ethnicity, 'ombCategory') as Coding;
   const birthDateTime = getExtensionValue((patient as any)._birthDate, extensionURLMapping.patientBirthTime) as string;
 
   return {

--- a/examples/medplum-provider/src/utils/qrda-generator.ts
+++ b/examples/medplum-provider/src/utils/qrda-generator.ts
@@ -213,6 +213,7 @@ function buildRecordTarget(patient: Patient): Record<string, any> {
   const telecom = patient.telecom?.find((t) => t.system === 'phone');
   const email = patient.telecom?.find((t) => t.system === 'email');
   const identifier = patient.identifier?.find((i) => i.system === 'http://example.com/patientId')?.value;
+  const gender = patient.gender ? { female: 'F', male: 'M', other: 'OTH', unknown: 'UNK' }[patient.gender] : '';
   const raceExtension = getExtensionValue(
     patient,
     'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
@@ -251,7 +252,7 @@ function buildRecordTarget(patient: Patient): Record<string, any> {
           family: patientName?.family ?? '',
         },
         administrativeGenderCode: {
-          '@_code': patient.gender,
+          '@_code': gender,
           '@_codeSystem': '2.16.840.1.113883.5.1',
           '@_codeSystemName': 'AdministrativeGender',
         },


### PR DESCRIPTION
## Description

- Adjust extension URL for race and ethnicity.
- Adjust gender code parsing.
- Rename questionnaire title from `C1 Certification` to `Create Measure Report`, and use this in the related notification toast.
- Create administrative sex observation 

## Steps to test

- C1 flow
  - Create a new Patient (Intake form)
  - Generate the QRDA file