### PR TITLE
Replace gin_clean_pending_list() with VACUUM

### DIFF
--- a/packages/app/src/admin/db/GINIndexes.tsx
+++ b/packages/app/src/admin/db/GINIndexes.tsx
@@ -63,9 +63,8 @@ export function GINIndexes(): JSX.Element {
   }, [medplum, table, refreshTable]);
 
   const handleConfigureResponse = (response: Parameters): void => {
-    const indexes = response.parameter?.filter((p) => p.name === 'result');
     setModalTitle('Configure results');
-    setModalContent(<pre>{JSON.stringify(indexes, null, 2)}</pre>);
+    setModalContent(<pre>{JSON.stringify(response, null, 2)}</pre>);
     openModal();
     setRefreshTable((prev) => (prev + 1) % 100);
   };

--- a/packages/server/src/fhir/operations/db-configure-indexes.test.ts
+++ b/packages/server/src/fhir/operations/db-configure-indexes.test.ts
@@ -126,44 +126,20 @@ describe('dbgetginindexes', () => {
       resourceType: 'Parameters',
       parameter: [
         {
-          name: 'result',
+          name: 'action',
           part: [
             {
-              name: 'schemaName',
-              valueString: 'public',
-            },
-            {
-              name: 'tableName',
-              valueString: 'Gin_Index_Configure_Test_Table',
-            },
-            {
-              name: 'indexName',
-              valueString: 'Gin_Index_Configure_Test_Table_aaa_idx',
-            },
-            {
-              name: 'setSql',
+              name: 'sql',
               valueString:
                 'ALTER INDEX public."Gin_Index_Configure_Test_Table_aaa_idx" SET (fastupdate = true, gin_pending_list_limit = 128)',
             },
           ],
         },
         {
-          name: 'result',
+          name: 'action',
           part: [
             {
-              name: 'schemaName',
-              valueString: 'public',
-            },
-            {
-              name: 'tableName',
-              valueString: 'Gin_Index_Configure_Test_Table',
-            },
-            {
-              name: 'indexName',
-              valueString: 'Gin_Index_Configure_Test_Table_bbb_idx',
-            },
-            {
-              name: 'setSql',
+              name: 'sql',
               valueString:
                 'ALTER INDEX public."Gin_Index_Configure_Test_Table_bbb_idx" SET (fastupdate = true, gin_pending_list_limit = 128)',
             },
@@ -200,71 +176,48 @@ describe('dbgetginindexes', () => {
         ],
       });
     expect(res.status).toBe(200);
-    expect(res.body.parameter).toHaveLength(3);
     expect(res.body).toStrictEqual({
       resourceType: 'Parameters',
       parameter: [
         {
-          name: 'result',
+          name: 'action',
           part: [
             {
-              name: 'schemaName',
-              valueString: 'public',
-            },
-            {
-              name: 'tableName',
-              valueString: 'Gin_Index_Configure_Test_Table',
-            },
-            {
-              name: 'indexName',
-              valueString: 'Gin_Index_Configure_Test_Table_aaa_idx',
-            },
-            {
-              name: 'resetSql',
+              name: 'sql',
               valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_aaa_idx" RESET (gin_pending_list_limit)',
             },
+          ],
+        },
+        {
+          name: 'action',
+          part: [
             {
-              name: 'setSql',
+              name: 'sql',
               valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_aaa_idx" SET (fastupdate = false)',
             },
           ],
         },
         {
-          name: 'result',
+          name: 'action',
           part: [
             {
-              name: 'schemaName',
-              valueString: 'public',
-            },
-            {
-              name: 'tableName',
-              valueString: 'Gin_Index_Configure_Test_Table',
-            },
-            {
-              name: 'indexName',
-              valueString: 'Gin_Index_Configure_Test_Table_bbb_idx',
-            },
-            {
-              name: 'resetSql',
+              name: 'sql',
               valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_bbb_idx" RESET (gin_pending_list_limit)',
             },
+          ],
+        },
+        {
+          name: 'action',
+          part: [
             {
-              name: 'setSql',
+              name: 'sql',
               valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_bbb_idx" SET (fastupdate = false)',
             },
           ],
         },
         {
-          name: 'vacuumResult',
+          name: 'action',
           part: [
-            {
-              name: 'schemaName',
-              valueString: 'public',
-            },
-            {
-              name: 'tableName',
-              valueString: 'Gin_Index_Configure_Test_Table',
-            },
             {
               name: 'sql',
               valueString: 'VACUUM "Gin_Index_Configure_Test_Table"',

--- a/packages/server/src/fhir/operations/db-configure-indexes.test.ts
+++ b/packages/server/src/fhir/operations/db-configure-indexes.test.ts
@@ -140,6 +140,11 @@ describe('dbgetginindexes', () => {
               name: 'indexName',
               valueString: 'Gin_Index_Configure_Test_Table_aaa_idx',
             },
+            {
+              name: 'setSql',
+              valueString:
+                'ALTER INDEX public."Gin_Index_Configure_Test_Table_aaa_idx" SET (fastupdate = true, gin_pending_list_limit = 128)',
+            },
           ],
         },
         {
@@ -156,6 +161,11 @@ describe('dbgetginindexes', () => {
             {
               name: 'indexName',
               valueString: 'Gin_Index_Configure_Test_Table_bbb_idx',
+            },
+            {
+              name: 'setSql',
+              valueString:
+                'ALTER INDEX public."Gin_Index_Configure_Test_Table_bbb_idx" SET (fastupdate = true, gin_pending_list_limit = 128)',
             },
           ],
         },
@@ -190,7 +200,7 @@ describe('dbgetginindexes', () => {
         ],
       });
     expect(res.status).toBe(200);
-    expect(res.body.parameter).toHaveLength(2);
+    expect(res.body.parameter).toHaveLength(3);
     expect(res.body).toStrictEqual({
       resourceType: 'Parameters',
       parameter: [
@@ -210,8 +220,12 @@ describe('dbgetginindexes', () => {
               valueString: 'Gin_Index_Configure_Test_Table_aaa_idx',
             },
             {
-              name: 'pagesCleaned',
-              valueString: '0',
+              name: 'resetSql',
+              valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_aaa_idx" RESET (gin_pending_list_limit)',
+            },
+            {
+              name: 'setSql',
+              valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_aaa_idx" SET (fastupdate = false)',
             },
           ],
         },
@@ -231,8 +245,33 @@ describe('dbgetginindexes', () => {
               valueString: 'Gin_Index_Configure_Test_Table_bbb_idx',
             },
             {
-              name: 'pagesCleaned',
-              valueString: '0',
+              name: 'resetSql',
+              valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_bbb_idx" RESET (gin_pending_list_limit)',
+            },
+            {
+              name: 'setSql',
+              valueString: 'ALTER INDEX public."Gin_Index_Configure_Test_Table_bbb_idx" SET (fastupdate = false)',
+            },
+          ],
+        },
+        {
+          name: 'vacuumResult',
+          part: [
+            {
+              name: 'schemaName',
+              valueString: 'public',
+            },
+            {
+              name: 'tableName',
+              valueString: 'Gin_Index_Configure_Test_Table',
+            },
+            {
+              name: 'sql',
+              valueString: 'VACUUM "Gin_Index_Configure_Test_Table"',
+            },
+            {
+              name: 'durationMs',
+              valueInteger: expect.any(Number),
             },
           ],
         },


### PR DESCRIPTION
Calling gin_clean_pending_list() directly bypasses PostgreSQL's normal lock ordering protocol. When you call it manually, you're jumping straight to index maintenance without establishing proper lock hierarchy, which allows deadlocks to form.