### PR TITLE
Refactor FHIRPath string handling

### DIFF
--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -177,7 +177,7 @@ export class Tokenizer {
       }
       if (char2 === 'u') {
         this.advance();
-        const hex = this.str.substring(this.pos.index, this.pos.index + 4).match(/^[0-9a-fA-F]{4}$/)?.[0];
+        const hex = /^[0-9a-fA-F]{4}$/.exec(this.str.substring(this.pos.index, this.pos.index + 4))?.[0];
         if (!hex) {
           // From the spec: https://build.fhir.org/ig/HL7/FHIRPath/#string
           // If a \ is used at the beginning of a non-escape sequence, it will be ignored and will not appear in the sequence.

--- a/packages/core/src/fhirlexer/tokenize.ts
+++ b/packages/core/src/fhirlexer/tokenize.ts
@@ -30,6 +30,17 @@ const STANDARD_UNITS = [
   'milliseconds',
 ];
 
+const ESCAPE_MAP: Record<string, string> = {
+  "'": "'",
+  '"': '"',
+  '`': '`',
+  r: '\r',
+  n: '\n',
+  t: '\t',
+  f: '\f',
+  '\\': '\\',
+};
+
 export interface TokenizerOptions {
   dateTimeLiterals?: boolean;
   symbolRegex?: RegExp;
@@ -159,37 +170,10 @@ export class Tokenizer {
     if (char1 === '\\') {
       this.advance();
       const char2 = this.curr();
-      if (char2 === "'") {
+      const escaped = ESCAPE_MAP[char2];
+      if (escaped !== undefined) {
         this.advance();
-        return "'";
-      }
-      if (char2 === '"') {
-        this.advance();
-        return '"';
-      }
-      if (char2 === '`') {
-        this.advance();
-        return '`';
-      }
-      if (char2 === 'r') {
-        this.advance();
-        return '\r';
-      }
-      if (char2 === 'n') {
-        this.advance();
-        return '\n';
-      }
-      if (char2 === 't') {
-        this.advance();
-        return '\t';
-      }
-      if (char2 === 'f') {
-        this.advance();
-        return '\f';
-      }
-      if (char2 === '\\') {
-        this.advance();
-        return '\\';
+        return escaped;
       }
       if (char2 === 'u') {
         this.advance();

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -3630,6 +3630,25 @@ describe('FHIRPath Test Suite', () => {
         )
       ).toStrictEqual(["'wrapped in single quotes'"]);
     });
+
+    test('testReplaceMatches5', () => {
+      /**
+       * Example taken from:
+       * https://build.fhir.org/ig/HL7/FHIRPath/#replacematchesregex--string-substitution-string--string
+       *
+       * '11/30/1972'.replaceMatches('\\b(?<month>\\d{1,2})/(?<day>\\d{1,2})/(?<year>\\d{2,4})\\b','${day}-${month}-${year}')
+       *
+       * Note:
+       * The above string is a FHIRPath string. So when we want to re-create the exact same
+       * character sequence in javascript, we need to escape the backslashes or use String.raw.
+       */
+      const regexFhirPathString = String.raw`'\\b(?<month>\\d{1,2})/(?<day>\\d{1,2})/(?<year>\\d{2,4})\\b'`;
+      // eslint-disable-next-line no-template-curly-in-string
+      const substitutionFhirPathString = "'${day}-${month}-${year}'";
+      expect(
+        evalFhirPath(`'11/30/1972'.replaceMatches(${regexFhirPathString}, ${substitutionFhirPathString})`, {})
+      ).toStrictEqual(['30-11-1972']);
+    });
   });
 
   // more "real-world" tests using FHIRPath to evaluate hypothetical constraints on AccessPolicy or Subscription resources

--- a/packages/core/src/fhirpath/fhirpath.test.ts
+++ b/packages/core/src/fhirpath/fhirpath.test.ts
@@ -3607,6 +3607,31 @@ describe('FHIRPath Test Suite', () => {
     });
   });
 
+  describe('testReplaceMatches', () => {
+    test('testReplaceMatches1', () => {
+      expect(evalFhirPath("'abc'.replaceMatches('c', 'cd')", {})).toStrictEqual(['abcd']);
+    });
+
+    test('testReplaceMatches2', () => {
+      expect(evalFhirPath("'abc'.replaceMatches('uvw', 'xyz')", {})).toStrictEqual(['abc']);
+    });
+
+    test('testReplaceMatches3', () => {
+      // See base StructureDefinition invariant sdf-8a:
+      // https://hl7.org/fhir/R4/structuredefinition-definitions.html#StructureDefinition.differential
+      expect(evalFhirPath("'Extension.url'.replaceMatches('\\\\..*', '')", {})).toStrictEqual(['Extension']);
+    });
+
+    test('testReplaceMatches4', () => {
+      expect(
+        evalFhirPath(
+          `'\\"wrapped in double quotes\\"'.replaceMatches('\\"', '\\'').replaceMatches('double', 'single')`,
+          {}
+        )
+      ).toStrictEqual(["'wrapped in single quotes'"]);
+    });
+  });
+
   // more "real-world" tests using FHIRPath to evaluate hypothetical constraints on AccessPolicy or Subscription resources
   describe('testRealWorldConstraints', () => {
     const RESOURCE_CONSTRAINT = "hiddenFields.select(substring(0, indexOf('.'))).distinct().subsetOf(readonlyFields)";

--- a/packages/core/src/fhirpath/functions.ts
+++ b/packages/core/src/fhirpath/functions.ts
@@ -1300,7 +1300,13 @@ export const functions: Record<string, FhirPathFunction> = {
    */
   replaceMatches: (context: AtomContext, input: TypedValue[], regexAtom: Atom, substitionAtom: Atom): TypedValue[] => {
     return applyStringFunc(
-      (str, pattern, substition) => str.replaceAll(new RegExp(pattern as string, 'g'), substition as string),
+      (str, pattern, substition) =>
+        str.replaceAll(
+          new RegExp(pattern as string, 'g'),
+          // The substition string may contain ${...} placeholders. Replace them with $<...>
+          // See https://build.fhir.org/ig/HL7/FHIRPath/#replacematchesregex--string-substitution-string--string
+          (substition as string).replaceAll(/\$\{(\w+)\}/g, '$<$1>')
+        ),
       context,
       input,
       regexAtom,


### PR DESCRIPTION
See issue: https://github.com/medplum/medplum/issues/7391

Initially, I thought the fix would only require adjusting the string-to-regex behavior in the `replaceMatches` function. However, I discovered that the FHIRPath string parsing itself may not handle escape sequences correctly.

This PR highlights those issues and provides a possible solution. Consider it a starting point for discussion rather than a final implementation.

@codyebberson I had to adjust some tokenizer tests. Could you please check if I might have broken something there?

FYI, if I'm slow to respond, it's because I just left for vacation. I'll be back in a week.