### PR TITLE
docs(agent): rm outdated alpha warning

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -2,11 +2,6 @@
 
 On-prem agent for device connectivity.
 
-> [!WARNING]
-> The Medplum Agent is currently in "alpha", and not ready for production use.
->
-> Please [contact Medplum](mailto:hello@medplum.com) if you would like to learn more or get involved.
-
 ## Building
 
 Published releases are built using Github Actions. See the [installer build script](../../scripts/build-agent-installer.sh) for details.
@@ -62,6 +57,7 @@ docker run --rm \
 ```
 
 Optionally set the `MEDPLUM_LOG_LEVEL` environment variable
+
 ```bash
   -e MEDPLUM_LOG_LEVEL="DEBUG"
 ```


### PR DESCRIPTION
Agent hasn't been in alpha for a while but we have forgotten to update the README