### PR TITLE
Enable NPM Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
       - 'v*'
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
 
 jobs:
@@ -67,10 +68,11 @@ jobs:
           GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
           RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
 
+      - name: Update npm # Ensure npm 11.5.1 or later is installed
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
         run: ./scripts/publish.sh
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Sync example repos
         run: ./scripts/update-example-changes.sh "${{ secrets.SYNC_REPO_TOKEN }}"


### PR DESCRIPTION
See: https://docs.npmjs.com/trusted-publishers

After this, we can delete the `NPM_TOKEN` secret and invalidate all NPM tokens.