### PR TITLE
add default for maxSearchOffset

### DIFF
--- a/packages/server/src/config/utils.test.ts
+++ b/packages/server/src/config/utils.test.ts
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { isBooleanConfig, isIntegerConfig, isObjectConfig } from './utils';
+import { addDefaults, isBooleanConfig, isIntegerConfig, isObjectConfig } from './utils';
 
 describe('utils', () => {
   test('isObjectConfig', () => {
@@ -15,5 +15,20 @@ describe('utils', () => {
   test('isIntegerConfig', () => {
     expect(isIntegerConfig('baseUrl')).toBe(false);
     expect(isIntegerConfig('port')).toBe(true);
+  });
+
+  test('addDefaults sets maxSearchOffset default', () => {
+    const config = addDefaults({
+      baseUrl: 'https://example.com',
+    } as any);
+    expect(config.maxSearchOffset).toBe(10_000);
+  });
+
+  test('addDefaults preserves existing maxSearchOffset', () => {
+    const config = addDefaults({
+      baseUrl: 'https://example.com',
+      maxSearchOffset: 5000,
+    } as any);
+    expect(config.maxSearchOffset).toBe(5000);
   });
 });

--- a/packages/server/src/config/utils.ts
+++ b/packages/server/src/config/utils.ts
@@ -30,6 +30,7 @@ export function addDefaults(config: MedplumServerConfig): ServerConfig {
   config.bullmq = { concurrency: 20, removeOnComplete: { count: 1 }, removeOnFail: { count: 1 }, ...config.bullmq };
   config.shutdownTimeoutMilliseconds ??= 30_000;
   config.accurateCountThreshold ??= 1_000_000;
+  config.maxSearchOffset ??= 10_000;
   config.defaultBotRuntimeVersion ??= 'awslambda';
   config.defaultProjectFeatures ??= [];
   config.defaultProjectSystemSetting ??= [];
@@ -65,6 +66,7 @@ type DefaultConfigKeys =
   | 'bullmq'
   | 'shutdownTimeoutMilliseconds'
   | 'accurateCountThreshold'
+  | 'maxSearchOffset'
   | 'defaultBotRuntimeVersion'
   | 'defaultProjectFeatures'
   | 'defaultProjectSystemSetting'


### PR DESCRIPTION
## Description
Fixes #7276 - Enforces the documented default value of 10,000 for `maxSearchOffset` when not specified in server configuration.

## Problem
The documentation stated that `maxSearchOffset` defaults to 10,000, but the server code did not actually enforce this default when the configuration was left unspecified, creating inconsistency between docs and actual behavior.

## Solution
- Added `config.maxSearchOffset ??= 10_000` in the `addDefaults` function
- Included `'maxSearchOffset'` in the `DefaultConfigKeys` type to ensure it's always present in server configuration
- Added test coverage to verify default application and value preservation

## Changes
- **packages/server/src/config/utils.ts**: Added default value enforcement
- **packages/server/src/config/utils.test.ts**: Added tests for default behavior

## Testing
- All existing tests pass
- New tests verify that:
  - When `maxSearchOffset` is not specified, it defaults to 10,000
  - When `maxSearchOffset` is explicitly set, that value is preserved

## Backward Compatibility
✅ This change is fully backward compatible - existing configurations that explicitly set `maxSearchOffset` continue to work unchanged.