### PR TITLE
Fixes #7436 - mark AWS SDK packages as external

### DIFF
--- a/examples/medplum-demo-bots/esbuild-script.mjs
+++ b/examples/medplum-demo-bots/esbuild-script.mjs
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /* global console */
 /* global process */
-/* eslint no-console: "off" */
-/*eslint no-process-exit: "off"*/
+/* eslint no-process-exit: "off" */
 
 import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };
 import esbuild from 'esbuild';
@@ -10,7 +11,7 @@ import fastGlob from 'fast-glob';
 // Find all TypeScript files in your source directory
 const entryPoints = fastGlob.sync('./src/**/*.ts').filter((file) => !file.endsWith('test.ts'));
 
-const botLayerDeps = Object.keys(botLayer.dependencies);
+const botLayerDeps = [...Object.keys(botLayer.dependencies), '@aws-sdk/client-*'];
 
 // Define the esbuild options
 const esbuildOptions = {


### PR DESCRIPTION
AWS SDK packages are preinstalled on AWS Lambdas (https://stackoverflow.com/questions/53566478/which-npm-modules-are-preinstalled-in-aws-lambda-execution-environment), so we can mark them as external.

Context: https://discord.com/channels/905144809105260605/1418633123905667092/1418633123905667092