### PR TITLE
Replace flushdb with a less destructive alternative

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -10,7 +10,8 @@ import { getConfig, loadTestConfig } from './config/loader';
 import { DatabaseMode, getDatabasePool } from './database';
 import { globalLogger } from './logger';
 import { getRedis } from './redis';
-import { createTestProject, deleteRedisKeys, initTestAuth, TestRedisConfig } from './test.setup';
+import type { TestRedisConfig } from './test.setup';
+import { createTestProject, deleteRedisKeys, initTestAuth } from './test.setup';
 
 describe('App', () => {
   test('Get HTTP config', async () => {

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -11,7 +11,8 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { getRedis } from '../redis';
-import { createTestProject, deleteRedisKeys, TestRedisConfig } from '../test.setup';
+import type { TestRedisConfig } from '../test.setup';
+import { createTestProject, deleteRedisKeys } from '../test.setup';
 
 describe('FHIR Rate Limits', () => {
   let app: Express;

--- a/packages/server/src/fhir/fhirquota.test.ts
+++ b/packages/server/src/fhir/fhirquota.test.ts
@@ -11,25 +11,28 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { getRedis } from '../redis';
-import { createTestProject } from '../test.setup';
+import { createTestProject, deleteRedisKeys, TestRedisConfig } from '../test.setup';
 
 describe('FHIR Rate Limits', () => {
   let app: Express;
   let config: MedplumServerConfig;
+  let redisConfig: TestRedisConfig;
   let accessToken: string;
 
   beforeAll(async () => {
     config = await loadTestConfig();
+    redisConfig = config.redis as TestRedisConfig;
   });
 
   beforeEach(async () => {
     app = express();
     config.defaultRateLimit = -1;
-    config.redis.db = 6; // Use different temp Redis instance for these tests
+    redisConfig.db = 6; // Use different temp Redis instance for these tests
+    redisConfig.keyPrefix = 'fhir-quota:';
   });
 
   afterEach(async () => {
-    await getRedis().flushdb();
+    await deleteRedisKeys(getRedis(), redisConfig.keyPrefix);
     expect(await shutdownApp()).toBeUndefined();
   });
 

--- a/packages/server/src/fhir/resource-cap.test.ts
+++ b/packages/server/src/fhir/resource-cap.test.ts
@@ -8,26 +8,30 @@ import { initApp, shutdownApp } from '../app';
 import { loadTestConfig } from '../config/loader';
 import type { MedplumServerConfig } from '../config/types';
 import { getRedis } from '../redis';
-import { createTestProject } from '../test.setup';
+import type { TestRedisConfig } from '../test.setup';
+import { createTestProject, deleteRedisKeys } from '../test.setup';
 import { getSystemRepo } from './repo';
 
 describe('FHIR Resource Limits', () => {
   let app: Express;
   let config: MedplumServerConfig;
+  let redisConfig: TestRedisConfig;
 
   beforeAll(async () => {
     config = await loadTestConfig();
+    redisConfig = config.redis as TestRedisConfig;
   });
 
   beforeEach(async () => {
     app = express();
     config.defaultRateLimit = -1;
-    config.redis.db = 6; // Use different temp Redis instance for these tests
+    redisConfig.db = 6; // Use different temp Redis instance for these tests
+    redisConfig.keyPrefix = 'resource-cap:';
     await initApp(app, config);
   });
 
   afterEach(async () => {
-    await getRedis().flushdb();
+    await deleteRedisKeys(getRedis(), redisConfig.keyPrefix);
     expect(await shutdownApp()).toBeUndefined();
   });
 

--- a/packages/server/src/redis.test.ts
+++ b/packages/server/src/redis.test.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { randomUUID } from 'crypto';
 import { Redis } from 'ioredis';
 import { loadTestConfig } from './config/loader';
 import type { MedplumServerConfig } from './config/types';
 import { closeRedis, getRedis, getRedisSubscriber, getRedisSubscriberCount, initRedis } from './redis';
+import { deleteRedisKeys } from './test.setup';
 
 describe('Redis', () => {
   let config: MedplumServerConfig;
@@ -86,6 +88,58 @@ describe('Redis', () => {
       clearTimeout(timer);
 
       await closeRedis();
+    });
+  });
+
+  // `deleteRedisKeys` is for tests only (i.e. in test.setup.ts), so testing it is a bit meta,
+  // but the function is just complicated enough that it testing is merited
+  describe('deleteRedisKeys', () => {
+    let r1: Redis | undefined;
+    let r2: Redis | undefined;
+
+    afterEach(async () => {
+      if (r1) {
+        await r1.quit();
+        r1 = undefined;
+      }
+      if (r2) {
+        await r2.quit();
+        r2 = undefined;
+      }
+    });
+
+    test('Deletes keys by prefix', async () => {
+      const config1 = await loadTestConfig();
+      const config2 = await loadTestConfig();
+      config1.redis.db = 8;
+      config2.redis.db = 8;
+
+      const prefix1 = randomUUID() + ':';
+      const prefix2 = randomUUID() + ':';
+
+      r1 = new Redis({ ...config1.redis, keyPrefix: prefix1 });
+      r2 = new Redis({ ...config2.redis, keyPrefix: prefix2 });
+
+      await r1.set('key1', 'r1.val1');
+      await r1.set('key2', 'r1.val2');
+      await r1.set('key3', 'r1.val3');
+      await r1.set('key4', 'r1.val4');
+      await r1.set('key5', 'r1.val5');
+
+      await r2.set('key1', 'r2.val1');
+
+      await expect(r1.get('key1')).resolves.toEqual('r1.val1');
+      await expect(r2.get('key1')).resolves.toEqual('r2.val1');
+
+      await expect(deleteRedisKeys(r1, prefix1)).resolves.toEqual(5);
+
+      await expect(r1.get('key1')).resolves.toBeNull();
+      await expect(r2.get('key1')).resolves.toEqual('r2.val1');
+
+      await expect(deleteRedisKeys(r2, prefix2)).resolves.toEqual(1);
+
+      await expect(r1.get('key1')).resolves.toBeNull();
+      await expect(r2.get('key1')).resolves.toBeNull();
     });
   });
 });

--- a/packages/server/src/redis.test.ts
+++ b/packages/server/src/redis.test.ts
@@ -92,7 +92,7 @@ describe('Redis', () => {
   });
 
   // `deleteRedisKeys` is for tests only (i.e. in test.setup.ts), so testing it is a bit meta,
-  // but the function is just complicated enough that it testing is merited
+  // but the function is just complicated enough that testing is merited
   describe('deleteRedisKeys', () => {
     let r1: Redis | undefined;
     let r2: Redis | undefined;

--- a/packages/server/src/test.setup.ts
+++ b/packages/server/src/test.setup.ts
@@ -16,10 +16,12 @@ import type {
 import { randomUUID } from 'crypto';
 import { setDefaultResultOrder } from 'dns';
 import type { Express } from 'express';
+import type Redis from 'ioredis';
 import type internal from 'stream';
 import request from 'supertest';
 import type { ServerInviteResponse } from './admin/invite';
 import { inviteUser } from './admin/invite';
+import type { MedplumRedisConfig } from './config/types';
 import { AuthenticatedRequestContext } from './context';
 import type { RepositoryContext } from './fhir/repo';
 import { Repository, getSystemRepo } from './fhir/repo';
@@ -313,4 +315,50 @@ export function streamToString(stream: internal.Readable): Promise<string> {
     stream.on('error', (err) => reject(err));
     stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
   });
+}
+
+export type TestRedisConfig = MedplumRedisConfig & {
+  keyPrefix: string;
+};
+
+/**
+ * Deletes all keys from the given Redis instance that match the given prefix. This should be preferred to
+ * `flushdb` when possible.
+ *
+ * @param redisInstance - The Redis instance to delete keys from.
+ * @param prefix - The prefix to match against.
+ * @returns The number of keys deleted.
+ */
+export async function deleteRedisKeys(redisInstance: Redis, prefix: string): Promise<number> {
+  const stream = redisInstance.scanStream({
+    match: prefix + '*',
+    count: 100, // Process 100 keys per batch
+  });
+
+  let totalDeleted = 0;
+  const deletePromises: Promise<number>[] = [];
+
+  stream.on('data', (keys: string[]) => {
+    if (keys.length > 0) {
+      // ioredis does NOT include options.keyPrefix in the keys returned by `scanStream`,
+      // so we need to remove it manually before calling del, where ioredis automatically
+      // includes the keyPrefix in the keys passed to del
+      const keysToDelete = redisInstance.options.keyPrefix
+        ? keys.map((k) => (k.startsWith(prefix) ? k.replace(prefix, '') : k))
+        : keys;
+      if (keysToDelete.length > 0) {
+        deletePromises.push(redisInstance.del(keysToDelete));
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    stream.on('end', () => resolve());
+    stream.on('error', (err) => reject(err));
+  });
+
+  const deletedCounts = await Promise.all(deletePromises);
+  totalDeleted = deletedCounts.reduce((sum, count) => sum + count, 0);
+
+  return totalDeleted;
 }


### PR DESCRIPTION
I don't love the introduction of `TestRedisConfig` to allow the usage of `keyPrefix`, but I more strongly don't think it should be added to `MedplumRedisConfig`...

Fixes #7446 