### PR TITLE
Fixes #7427 - Add process to VMContext sandbox

### DIFF
--- a/packages/server/src/bots/vmcontext.ts
+++ b/packages/server/src/bots/vmcontext.ts
@@ -52,6 +52,7 @@ export async function runInVmContext(request: BotExecutionContext): Promise<BotE
     console: botConsole,
     fetch,
     require: createRequire(typeof __filename === 'undefined' ? import.meta.url : __filename),
+    process,
     ContentType,
     Hl7Message,
     MedplumClient,


### PR DESCRIPTION
  - Adds `process` global to VMContext sandbox to support libraries like AWS SDK
  - Resolves "process is not defined" errors when bots use Node.js libraries that depend on process