### PR TITLE
fix(agent): fix SKIP_SIGNING definition based on env

### DIFF
--- a/scripts/build-agent-installer-win64.sh
+++ b/scripts/build-agent-installer-win64.sh
@@ -115,7 +115,8 @@ if [ -z "$SKIP_SIGNING" ]; then
 fi
 
 # Build the installer
-if [ -z "$SKIP_SIGNING" ]; then
+# If SKIP_SIGNING is not empty, then define SKIP_SIGNING symbol
+if [ -n "$SKIP_SIGNING" ]; then
   makensis -DSKIP_SIGNING installer.nsi # globally defines the SKIP_SIGNING symbol
 else
   makensis installer.nsi


### PR DESCRIPTION
The refactor to using `-z "$SKIP_SIGNING"` inverted the logic when it came to defining the symbol to trigger the NSIS script to sign the installer.

We might want to resign the last few agent Windows installer releases so that they are not unsigned 🤔 