### PR TITLE
Added Type parameter to `isReference`

### DIFF
--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -110,6 +110,7 @@ describe('Type Utils', () => {
   });
 
   test('isReference', () => {
+    // Basic reference validation (no resourceType parameter)
     expect(isReference(undefined)).toBe(false);
     expect(isReference(null)).toBe(false);
     expect(isReference('Patient')).toBe(false);
@@ -117,6 +118,39 @@ describe('Type Utils', () => {
     expect(isReference({ resourceType: 'Patient' })).toBe(false);
     expect(isReference({ reference: 'Patient/123' })).toBe(true);
     expect(isReference({ reference: { value: '123' } })).toBe(false);
+
+    // Test with resourceType parameter - matching cases
+    expect(isReference({ reference: 'Patient/123' }, 'Patient')).toBe(true);
+    expect(isReference({ reference: 'Observation/456' }, 'Observation')).toBe(true);
+    expect(isReference({ reference: 'Organization/789' }, 'Organization')).toBe(true);
+    expect(isReference({ reference: 'Practitioner/abc' }, 'Practitioner')).toBe(true);
+
+    // Test with resourceType parameter - non-matching cases
+    expect(isReference({ reference: 'Patient/123' }, 'Observation')).toBe(false);
+    expect(isReference({ reference: 'Observation/456' }, 'Patient')).toBe(false);
+    expect(isReference({ reference: 'AppointmentResponse/789' }, 'Appointment')).toBe(false);
+
+    // Test with resourceType parameter - edge cases
+    expect(isReference({ reference: 'Patient' }, 'Patient')).toBe(false); // no ID or query parameters
+    expect(isReference({ reference: 'Patient?name=John' }, 'Patient')).toBe(true); // query parameters
+    expect(isReference({ reference: 'Patient/123?version=1' }, 'Patient')).toBe(true); // ID with query
+
+    // Test case sensitivity
+    expect(isReference({ reference: 'patient/123' }, 'Patient')).toBe(false);
+
+    // Test partial matches (should not match)
+    expect(isReference({ reference: 'MyPatient/123' }, 'Patient')).toBe(false);
+    expect(isReference({ reference: 'PatientData/123' }, 'Patient')).toBe(false);
+
+    // Test invalid reference values with resourceType
+    expect(isReference(undefined, 'Patient')).toBe(false);
+    expect(isReference(null, 'Patient')).toBe(false);
+    expect(isReference({}, 'Patient')).toBe(false);
+    expect(isReference({ reference: { value: '123' } }, 'Patient')).toBe(false);
+
+    // Test empty and malformed references
+    expect(isReference({ reference: '' }, 'Patient')).toBe(false);
+    expect(isReference({ reference: '/' }, 'Patient')).toBe(false);
   });
 
   test.each<[TypedValue, string]>([

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -451,12 +451,23 @@ export function isResource<T extends Resource>(value: unknown, resourceType?: T[
 /**
  * Type guard to validate that an object is a FHIR reference
  * @param value - The object to check
+ * @param resourceType - Checks that the reference is of the given type
  * @returns True if the input is of type 'object' and contains property 'reference'
  */
+
 export function isReference<T extends Resource = Resource>(
-  value: unknown
+  value: unknown,
+  resourceType?: T['resourceType']
 ): value is Reference<T> & { reference: string } {
-  return !!(value && typeof value === 'object' && 'reference' in value && typeof value.reference === 'string');
+  // if the value is an object with a reference property and the reference is a string, then it is a reference
+  if (value && typeof value === 'object' && 'reference' in value && typeof value.reference === 'string') {
+    // if resourceType is provided, check if the reference matches the resource type
+    if (resourceType) {
+      return value.reference.match(new RegExp(`^${resourceType}(/|\\?)`)) !== null;
+    }
+    return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
Add an optional type parameter to assert that the input reference is of a certain type. 

This helps avoid downstream casting by clients  isReference is called