### PR TITLE
[Certification Provider App] Refactor code to use `string` instead of `dateTime`

### DIFF
--- a/examples/medplum-provider/data/core/c1/questionnaires.json
+++ b/examples/medplum-provider/data/core/c1/questionnaires.json
@@ -39,7 +39,7 @@
               },
               {
                 "linkId": "dob",
-                "text": "Date of Birth",
+                "text": "Date of Birth (YYYY-MM-DDTHH:MM:SS+00:00)",
                 "type": "string"
               },
               {
@@ -126,13 +126,13 @@
               },
               {
                 "linkId": "encounter-period-start",
-                "text": "Relevant Period Start",
+                "text": "Relevant Period Start (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string",
                 "required": true
               },
               {
                 "linkId": "encounter-period-end",
-                "text": "Relevant Period End",
+                "text": "Relevant Period End (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string",
                 "required": true
               },
@@ -228,12 +228,12 @@
               },
               {
                 "linkId": "procedure-period-start",
-                "text": "Relevant Date/Time",
+                "text": "Relevant Date/Time (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string"
               },
               {
                 "linkId": "procedure-performed-datetime",
-                "text": "Author Date/Time",
+                "text": "Author Date/Time (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string"
               },
               {
@@ -281,12 +281,12 @@
               },
               {
                 "linkId": "procedure-period-start",
-                "text": "Relevant Date/Time",
+                "text": "Relevant Date/Time (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string"
               },
               {
                 "linkId": "procedure-performed-datetime",
-                "text": "Author Date/Time",
+                "text": "Author Date/Time (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string"
               },
               {
@@ -316,7 +316,7 @@
               },
               {
                 "linkId": "payer-period-start",
-                "text": "Relevant Period Start",
+                "text": "Relevant Period Start (YYYY-MM-DDTHH:MM:SS.000Z)",
                 "type": "string"
               }
             ]
@@ -361,7 +361,7 @@
           },
           {
             "linkId": "measure-period-start",
-            "text": "Measure Period Start",
+            "text": "Measure Period Start (YYYY-MM-DDTHH:MM:SS.000Z)",
             "type": "string",
             "required": true,
             "initial": [
@@ -372,7 +372,7 @@
           },
           {
             "linkId": "measure-period-end",
-            "text": "Measure Period End",
+            "text": "Measure Period End (YYYY-MM-DDTHH:MM:SS.000Z)",
             "type": "string",
             "required": true,
             "initial": [

--- a/examples/medplum-provider/data/core/c1/questionnaires.json
+++ b/examples/medplum-provider/data/core/c1/questionnaires.json
@@ -40,7 +40,7 @@
               {
                 "linkId": "dob",
                 "text": "Date of Birth",
-                "type": "dateTime"
+                "type": "string"
               },
               {
                 "linkId": "street",
@@ -127,13 +127,13 @@
               {
                 "linkId": "encounter-period-start",
                 "text": "Relevant Period Start",
-                "type": "dateTime",
+                "type": "string",
                 "required": true
               },
               {
                 "linkId": "encounter-period-end",
                 "text": "Relevant Period End",
-                "type": "dateTime",
+                "type": "string",
                 "required": true
               },
               {
@@ -229,12 +229,12 @@
               {
                 "linkId": "procedure-period-start",
                 "text": "Relevant Date/Time",
-                "type": "dateTime"
+                "type": "string"
               },
               {
                 "linkId": "procedure-performed-datetime",
                 "text": "Author Date/Time",
-                "type": "dateTime"
+                "type": "string"
               },
               {
                 "linkId": "procedure-medical-reason",
@@ -282,12 +282,12 @@
               {
                 "linkId": "procedure-period-start",
                 "text": "Relevant Date/Time",
-                "type": "dateTime"
+                "type": "string"
               },
               {
                 "linkId": "procedure-performed-datetime",
                 "text": "Author Date/Time",
-                "type": "dateTime"
+                "type": "string"
               },
               {
                 "linkId": "procedure-medical-reason",
@@ -317,7 +317,7 @@
               {
                 "linkId": "payer-period-start",
                 "text": "Relevant Period Start",
-                "type": "dateTime"
+                "type": "string"
               }
             ]
           }
@@ -362,22 +362,22 @@
           {
             "linkId": "measure-period-start",
             "text": "Measure Period Start",
-            "type": "dateTime",
+            "type": "string",
             "required": true,
             "initial": [
               {
-                "valueDateTime": "2023-01-01T00:00:00"
+                "valueString": "2023-01-01T00:00:00.000Z"
               }
             ]
           },
           {
             "linkId": "measure-period-end",
             "text": "Measure Period End",
-            "type": "dateTime",
+            "type": "string",
             "required": true,
             "initial": [
               {
-                "valueDateTime": "2023-12-31T23:59:59"
+                "valueString": "2023-12-31T23:59:59.000Z"
               }
             ]
           }

--- a/examples/medplum-provider/data/example/json/0_Bob_Henry.json
+++ b/examples/medplum-provider/data/example/json/0_Bob_Henry.json
@@ -26,7 +26,7 @@
           "linkId": "dob",
           "answer": [
             {
-              "valueDateTime": "1975-05-27T15:25:00"
+              "valueString": "1975-05-27T15:25:00+00:00"
             }
           ]
         },
@@ -159,7 +159,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-03-21T08:00:00"
+              "valueString": "2023-03-21T08:00:00.000Z"
             }
           ]
         },
@@ -167,7 +167,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-03-21T08:30:00"
+              "valueString": "2023-03-21T08:30:00.000Z"
             }
           ]
         }
@@ -192,7 +192,7 @@
           "linkId": "payer-period-start",
           "answer": [
             {
-              "valueDateTime": "2022-12-25T00:00:00"
+              "valueString": "2022-12-25T00:00:00.000Z"
             }
           ]
         }

--- a/examples/medplum-provider/data/example/json/1_Curtis_Strickland.json
+++ b/examples/medplum-provider/data/example/json/1_Curtis_Strickland.json
@@ -26,7 +26,7 @@
           "linkId": "dob",
           "answer": [
             {
-              "valueDateTime": "1997-11-21T19:45:00"
+              "valueString": "1997-11-21T19:45:00+00:00"
             }
           ]
         },
@@ -159,7 +159,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-02-23T08:00:00"
+              "valueString": "2023-02-23T08:00:00.000Z"
             }
           ]
         },
@@ -167,7 +167,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-02-23T08:30:00"
+              "valueString": "2023-02-23T08:30:00.000Z"
             }
           ]
         }
@@ -200,7 +200,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-10-12T08:00:00"
+              "valueString": "2023-10-12T08:00:00.000Z"
             }
           ]
         },
@@ -208,7 +208,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-10-12T08:30:00"
+              "valueString": "2023-10-12T08:30:00.000Z"
             }
           ]
         }
@@ -241,7 +241,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-11-11T08:30:00"
+              "valueString": "2023-11-11T08:30:00.000Z"
             }
           ]
         },
@@ -249,7 +249,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-11-11T09:30:00"
+              "valueString": "2023-11-11T09:30:00.000Z"
             }
           ]
         }
@@ -274,7 +274,7 @@
           "linkId": "procedure-performed-datetime",
           "answer": [
             {
-              "valueDateTime": "2023-11-11T08:30:00"
+              "valueString": "2023-11-11T08:30:00.000Z"
             }
           ]
         },
@@ -311,7 +311,7 @@
           "linkId": "payer-period-start",
           "answer": [
             {
-              "valueDateTime": "2022-12-21T00:00:00"
+              "valueString": "2022-12-21T00:00:00.000Z"
             }
           ]
         }

--- a/examples/medplum-provider/data/example/json/2_Julian_Johnston.json
+++ b/examples/medplum-provider/data/example/json/2_Julian_Johnston.json
@@ -26,7 +26,7 @@
           "linkId": "dob",
           "answer": [
             {
-              "valueDateTime": "1983-10-09T15:00:00"
+              "valueString": "1983-10-09T15:00:00+00:00"
             }
           ]
         },
@@ -159,7 +159,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-04-01T15:00:00"
+              "valueString": "2023-04-01T15:00:00.000Z"
             }
           ]
         },
@@ -167,7 +167,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-04-01T16:00:00"
+              "valueString": "2023-04-01T16:00:00.000Z"
             }
           ]
         },
@@ -220,7 +220,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-06-04T08:00:00"
+              "valueString": "2023-06-04T08:00:00.000Z"
             }
           ]
         },
@@ -228,7 +228,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-06-04T09:00:00"
+              "valueString": "2023-06-04T09:00:00.000Z"
             }
           ]
         }
@@ -261,7 +261,7 @@
           "linkId": "encounter-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-09-02T08:00:00"
+              "valueString": "2023-09-02T08:00:00.000Z"
             }
           ]
         },
@@ -269,7 +269,7 @@
           "linkId": "encounter-period-end",
           "answer": [
             {
-              "valueDateTime": "2023-09-07T09:00:00"
+              "valueString": "2023-09-07T09:00:00.000Z"
             }
           ]
         },
@@ -306,7 +306,7 @@
           "linkId": "procedure-period-start",
           "answer": [
             {
-              "valueDateTime": "2023-04-01T16:00:00"
+              "valueString": "2023-04-01T16:00:00.000Z"
             }
           ]
         },
@@ -314,7 +314,7 @@
           "linkId": "procedure-performed-datetime",
           "answer": [
             {
-              "valueDateTime": "2023-04-01T16:00:00"
+              "valueString": "2023-04-01T16:00:00.000Z"
             }
           ]
         },
@@ -351,7 +351,7 @@
           "linkId": "payer-period-start",
           "answer": [
             {
-              "valueDateTime": "2022-12-12T00:00:00"
+              "valueString": "2022-12-12T00:00:00.000Z"
             }
           ]
         }

--- a/examples/medplum-provider/package.json
+++ b/examples/medplum-provider/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch",
-    "bots:build": "npm run clean && npm run lint && tsc && node --no-warnings esbuild-script.mjs",
+    "bots:build": "npm run clean && node --no-warnings esbuild-script.mjs",
     "bots:deploy": "npx medplum bot deploy $1"
   },
   "prettier": {

--- a/examples/medplum-provider/package.json
+++ b/examples/medplum-provider/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch",
-    "bots:build": "npm run clean && node --no-warnings esbuild-script.mjs",
+    "bots:build": "npm run clean && npm run lint && tsc && node --no-warnings esbuild-script.mjs",
     "bots:deploy": "npx medplum bot deploy $1"
   },
   "prettier": {

--- a/examples/medplum-provider/src/bots/c1-certification-bot.test.ts
+++ b/examples/medplum-provider/src/bots/c1-certification-bot.test.ts
@@ -13,8 +13,8 @@ describe('C1 Certification Bot', () => {
   const contentType = ContentType.FHIR_JSON;
   const secrets = {};
   const measure = 'cms68v14';
-  const periodStart = '2023-01-01T00:00:00';
-  const periodEnd = '2023-12-31T23:59:59';
+  const periodStart = '2023-01-01T00:00:00.000Z';
+  const periodEnd = '2023-12-31T23:59:59.000Z';
 
   beforeEach(async () => {
     medplum = new MockClient();
@@ -30,11 +30,11 @@ describe('C1 Certification Bot', () => {
         },
         {
           linkId: 'measure-period-start',
-          answer: [{ valueDateTime: periodStart }],
+          answer: [{ valueString: periodStart }],
         },
         {
           linkId: 'measure-period-end',
-          answer: [{ valueDateTime: periodEnd }],
+          answer: [{ valueString: periodEnd }],
         },
         {
           linkId: 'patient-ids',
@@ -94,7 +94,7 @@ describe('C1 Certification Bot', () => {
       status: 'finished',
       class: { system: 'http://terminology.hl7.org/CodeSystem/v3-ActCode', code: 'AMB' },
       subject: createReference(patient1),
-      period: { start: '2023-02-15T08:00:00', end: '2023-02-15T09:00:00' },
+      period: { start: '2023-02-15T08:00:00.000Z', end: '2023-02-15T09:00:00.000Z' },
     });
     let patient2Media = await medplum.searchResources('Media', {
       subject: getReferenceString(patient2),

--- a/examples/medplum-provider/src/bots/c1-certification-bot.ts
+++ b/examples/medplum-provider/src/bots/c1-certification-bot.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { BotEvent, ContentType, createReference, getQuestionnaireAnswers, MedplumClient } from '@medplum/core';
+import {
+  BotEvent,
+  ContentType,
+  createReference,
+  getQuestionnaireAnswers,
+  isDateTimeString,
+  MedplumClient,
+} from '@medplum/core';
 import { Media, QuestionnaireResponse } from '@medplum/fhirtypes';
 import { generateQRDACategoryI } from '../utils/qrda-generator';
 import JSZip from 'jszip';
@@ -22,8 +29,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
 
   const answers = getQuestionnaireAnswers(questionnaireResponse);
   const measure = answers['measure']?.valueCoding?.code;
-  const periodStart = answers['measure-period-start']?.valueDateTime;
-  const periodEnd = answers['measure-period-end']?.valueDateTime;
+  const periodStart = answers['measure-period-start']?.valueString;
+  const periodEnd = answers['measure-period-end']?.valueString;
   const patientIds = answers['patient-ids']?.valueString?.split(',');
 
   if (measure !== 'cms68v14') {
@@ -32,6 +39,10 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
 
   if (!periodStart || !periodEnd || !patientIds) {
     throw new Error('Missing required fields');
+  }
+
+  if (!isDateTimeString(periodStart) || !isDateTimeString(periodEnd)) {
+    throw new Error('Period start and end must be date time strings');
   }
 
   const zip = new JSZip();

--- a/examples/medplum-provider/src/bots/c1-patient-intake-bot.test.ts
+++ b/examples/medplum-provider/src/bots/c1-patient-intake-bot.test.ts
@@ -63,7 +63,7 @@ describe('C1 Patient Intake Bot', () => {
         extension: [
           {
             url: extensionURLMapping.patientBirthTime,
-            valueDateTime: '1997-11-21T19:45:00',
+            valueString: '1997-11-21T19:45:00+00:00',
           },
         ],
       });
@@ -186,8 +186,8 @@ describe('C1 Patient Intake Bot', () => {
       ]);
       expect(encounter.subject).toStrictEqual(createReference(patient));
       expect(encounter.period).toStrictEqual({
-        start: '2023-02-23T08:00:00',
-        end: '2023-02-23T08:30:00',
+        start: '2023-02-23T08:00:00.000Z',
+        end: '2023-02-23T08:30:00.000Z',
       });
       expect(encounter.length).toStrictEqual({ value: 0, unit: 'd' });
       expect(encounter.extension).toStrictEqual([
@@ -228,8 +228,8 @@ describe('C1 Patient Intake Bot', () => {
       ]);
       expect(encounter.subject).toStrictEqual(createReference(patient));
       expect(encounter.period).toStrictEqual({
-        start: '2023-10-12T08:00:00',
-        end: '2023-10-12T08:30:00',
+        start: '2023-10-12T08:00:00.000Z',
+        end: '2023-10-12T08:30:00.000Z',
       });
       expect(encounter.length).toStrictEqual({ value: 0, unit: 'd' });
       expect(encounter.extension).toStrictEqual([
@@ -272,8 +272,8 @@ describe('C1 Patient Intake Bot', () => {
     ]);
     expect(encounter.subject).toStrictEqual(createReference(patient));
     expect(encounter.period).toStrictEqual({
-      start: '2023-11-02T17:00:00',
-      end: '2023-11-02T18:00:00',
+      start: '2023-11-02T17:00:00.000Z',
+      end: '2023-11-02T18:00:00.000Z',
     });
     expect(encounter.length).toStrictEqual({ value: 0, unit: 'd' });
     expect(encounter.extension).toStrictEqual([
@@ -331,8 +331,8 @@ describe('C1 Patient Intake Bot', () => {
     ]);
     expect(encounter.subject).toStrictEqual(createReference(patient));
     expect(encounter.period).toStrictEqual({
-      start: '2023-11-11T08:30:00',
-      end: '2023-11-11T09:30:00',
+      start: '2023-11-11T08:30:00.000Z',
+      end: '2023-11-11T09:30:00.000Z',
     });
     expect(encounter.length).toStrictEqual({ value: 0, unit: 'd' });
     expect(encounter.extension).toStrictEqual([
@@ -390,7 +390,7 @@ describe('C1 Patient Intake Bot', () => {
           },
         ],
       });
-      expect(intervention.performedDateTime).toStrictEqual('2023-11-11T08:30:00');
+      expect(intervention.performedDateTime).toStrictEqual('2023-11-11T08:30:00.000Z');
       expect(intervention.statusReason?.coding?.[0]).toStrictEqual({
         system: 'http://snomed.info/sct',
         code: '183932001',
@@ -421,10 +421,10 @@ describe('C1 Patient Intake Bot', () => {
         ],
       });
       expect(intervention.performedPeriod).toStrictEqual({
-        start: '2023-12-04T08:30:00',
-        end: '2023-12-04T08:30:00',
+        start: '2023-12-04T08:30:00.000Z',
+        end: '2023-12-04T08:30:00.000Z',
       });
-      expect(intervention.performedDateTime).toStrictEqual('2023-12-04T15:00:00');
+      expect(intervention.performedDateTime).toStrictEqual('2023-12-04T15:00:00.000Z');
       expect(intervention.statusReason).toBeUndefined();
     });
 
@@ -450,10 +450,10 @@ describe('C1 Patient Intake Bot', () => {
         ],
       });
       expect(procedure.performedPeriod).toStrictEqual({
-        start: '2023-04-01T16:00:00',
-        end: '2023-04-01T16:00:00',
+        start: '2023-04-01T16:00:00.000Z',
+        end: '2023-04-01T16:00:00.000Z',
       });
-      expect(procedure.performedDateTime).toStrictEqual('2023-04-01T17:00:00');
+      expect(procedure.performedDateTime).toStrictEqual('2023-04-01T17:00:00.000Z');
       expect(procedure.statusReason?.coding?.[0]).toStrictEqual({
         system: 'http://snomed.info/sct',
         code: '183932001',
@@ -499,7 +499,7 @@ describe('C1 Patient Intake Bot', () => {
           },
         ],
       });
-      expect(coverage.period).toStrictEqual({ start: '2022-12-21T00:00:00' });
+      expect(coverage.period).toStrictEqual({ start: '2022-12-21T00:00:00.000Z' });
     });
   });
 });

--- a/examples/medplum-provider/src/bots/c1-patient-intake-bot.ts
+++ b/examples/medplum-provider/src/bots/c1-patient-intake-bot.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { MedplumClient, BotEvent, getQuestionnaireAnswers, addProfileToResource, createReference } from '@medplum/core';
+import {
+  addProfileToResource,
+  BotEvent,
+  createReference,
+  getQuestionnaireAnswers,
+  isDateTimeString,
+  MedplumClient,
+} from '@medplum/core';
 import { Patient, QuestionnaireResponse } from '@medplum/fhirtypes';
 import {
   addCoverage,
@@ -46,13 +53,17 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Questionna
     patient.name = [patientName];
   }
 
-  if (answers['dob']?.valueDateTime) {
-    patient.birthDate = answers['dob'].valueDateTime.split('T')[0];
+  const dob = answers['dob']?.valueString;
+  if (dob?.length && !isDateTimeString(dob)) {
+    throw new Error('dob must be a date time string');
+  }
+  if (dob) {
+    patient.birthDate = dob.split('T')[0];
     (patient as any)._birthDate = {
       extension: [
         {
           url: extensionURLMapping.patientBirthTime,
-          valueDateTime: answers['dob'].valueDateTime,
+          valueString: dob,
         },
       ],
     };

--- a/examples/medplum-provider/src/bots/test-data/patient-records.ts
+++ b/examples/medplum-provider/src/bots/test-data/patient-records.ts
@@ -17,7 +17,7 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
       item: [
         { linkId: 'first-name', answer: [{ valueString: 'Curtis' }] },
         { linkId: 'last-name', answer: [{ valueString: 'Strickland' }] },
-        { linkId: 'dob', answer: [{ valueDateTime: '1997-11-21T19:45:00' }] },
+        { linkId: 'dob', answer: [{ valueString: '1997-11-21T19:45:00+00:00' }] },
         { linkId: 'street', answer: [{ valueString: '3504 Turner Gateway Station' }] },
         { linkId: 'city', answer: [{ valueString: 'Hillborough' }] },
         { linkId: 'state', answer: [{ valueCoding: { code: 'CO' } }] },
@@ -76,11 +76,11 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'encounter-period-start',
-          answer: [{ valueDateTime: '2023-02-23T08:00:00' }],
+          answer: [{ valueString: '2023-02-23T08:00:00.000Z' }],
         },
         {
           linkId: 'encounter-period-end',
-          answer: [{ valueDateTime: '2023-02-23T08:30:00' }],
+          answer: [{ valueString: '2023-02-23T08:30:00.000Z' }],
         },
       ],
     },
@@ -106,11 +106,11 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'encounter-period-start',
-          answer: [{ valueDateTime: '2023-10-12T08:00:00' }],
+          answer: [{ valueString: '2023-10-12T08:00:00.000Z' }],
         },
         {
           linkId: 'encounter-period-end',
-          answer: [{ valueDateTime: '2023-10-12T08:30:00' }],
+          answer: [{ valueString: '2023-10-12T08:30:00.000Z' }],
         },
         {
           linkId: 'encounter-class',
@@ -149,11 +149,11 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'encounter-period-start',
-          answer: [{ valueDateTime: '2023-11-02T17:00:00' }],
+          answer: [{ valueString: '2023-11-02T17:00:00.000Z' }],
         },
         {
           linkId: 'encounter-period-end',
-          answer: [{ valueDateTime: '2023-11-02T18:00:00' }],
+          answer: [{ valueString: '2023-11-02T18:00:00.000Z' }],
         },
         {
           linkId: 'encounter-diagnosis',
@@ -195,11 +195,11 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'encounter-period-start',
-          answer: [{ valueDateTime: '2023-11-11T08:30:00' }],
+          answer: [{ valueString: '2023-11-11T08:30:00.000Z' }],
         },
         {
           linkId: 'encounter-period-end',
-          answer: [{ valueDateTime: '2023-11-11T09:30:00' }],
+          answer: [{ valueString: '2023-11-11T09:30:00.000Z' }],
         },
         {
           linkId: 'encounter-discharge-disposition',
@@ -233,7 +233,7 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'procedure-performed-datetime',
-          answer: [{ valueDateTime: '2023-11-11T08:30:00' }],
+          answer: [{ valueString: '2023-11-11T08:30:00.000Z' }],
         },
         {
           linkId: 'procedure-medical-reason',
@@ -267,11 +267,11 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'procedure-period-start',
-          answer: [{ valueDateTime: '2023-12-04T08:30:00' }],
+          answer: [{ valueString: '2023-12-04T08:30:00.000Z' }],
         },
         {
           linkId: 'procedure-performed-datetime',
-          answer: [{ valueDateTime: '2023-12-04T15:00:00' }],
+          answer: [{ valueString: '2023-12-04T15:00:00.000Z' }],
         },
       ],
     },
@@ -293,11 +293,11 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
         },
         {
           linkId: 'procedure-period-start',
-          answer: [{ valueDateTime: '2023-04-01T16:00:00' }],
+          answer: [{ valueString: '2023-04-01T16:00:00.000Z' }],
         },
         {
           linkId: 'procedure-performed-datetime',
-          answer: [{ valueDateTime: '2023-04-01T17:00:00' }],
+          answer: [{ valueString: '2023-04-01T17:00:00.000Z' }],
         },
         {
           linkId: 'procedure-medical-reason',
@@ -333,7 +333,7 @@ export const patientIntakeQuestionnaireResponse: QuestionnaireResponse = {
             },
           ],
         },
-        { linkId: 'payer-period-start', answer: [{ valueDateTime: '2022-12-21T00:00:00' }] },
+        { linkId: 'payer-period-start', answer: [{ valueString: '2022-12-21T00:00:00.000Z' }] },
       ],
     },
   ],
@@ -351,7 +351,7 @@ export const patientCurtisStrickland = {
     extension: [
       {
         url: extensionURLMapping.patientBirthTime,
-        valueDateTime: '1997-11-21T19:45:00',
+        valueString: '1997-11-21T19:45:00+00:00',
       },
     ],
   },
@@ -365,7 +365,7 @@ export const patientJulianJohnston = {
     extension: [
       {
         url: extensionURLMapping.patientBirthTime,
-        valueDateTime: '1983-10-09T15:00:00',
+        valueString: '1983-10-09T15:00:00+00:00',
       },
     ],
   },


### PR DESCRIPTION
## Description

Refactor questionnaires and bots to use `string` instead of `dateTime` due to timezone-aware datetimes created in questionnaire responses due to QuestionnaireForm submit behavior

> [!WARNING]
> **PLEASE NOTE:** After this change, on resource detail pages in app.medplum, the `JSON` tab will display datetimes in UTC (matching the values shown in patient record HTML files and QRDA XML files), while the `Details` tab will display timezone-aware values. 
>
> I attached a video below to demonstrate this (in the example, the user’s timezone is UTC-3), which is why the value shifts from 8 AM UTC to 5 AM timezone-aware.

[Screencast from 26-09-2025 17:24:41.webm](https://github.com/user-attachments/assets/58f0edbd-1260-4919-b261-779bbccf15e2)


## Steps to test

- C1 flow
  - Create a new Patient (Intake form)
  - Generate the QRDA file