### PR TITLE
Add npm dedupe to upgrade process

### DIFF
--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -23,7 +23,7 @@ done
 # If called with "--update", then use npm i
 if [ "$1" == "--update" ]; then
   rm -rf package-lock.json
-  npm i --strict-peer-deps
+  npm i --strict-peer-deps --prefer-dedupe
 else
   npm ci --strict-peer-deps
 fi


### PR DESCRIPTION
This PR updates our dependency upgrade process by adding `--prefer-dedupe` to our `npm install` command.

This flag tells npm to prioritize a flattened dependency tree during the installation process itself. In a large monorepo with many nested packages, this will:
1. Reduce duplicates during the initial install.
2. Result in a smaller `node_modules` folder from the start.

This is a clean, single-step optimization that improves the efficiency and reliability of our dependency management process. It's a best practice for monorepos that will help us avoid unnecessary package bloat.

See: https://docs.npmjs.com/cli/v7/commands/npm-dedupe

(thanks Gemini)