### PR TITLE
Added NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+Medplum
+Copyright 2020–2025 Orangebot, Inc. and Medplum contributors
+
+This product includes software developed by Orangebot, Inc. and
+other contributors under the Apache License, Version 2.0.
+
+"Medplum" is a registered trademark of Orangebot, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+


### PR DESCRIPTION
This PR adds a top-level `NOTICE` file in compliance with the Apache License 2.0.

* Documents copyright attribution: Orangebot, Inc. and Medplum contributors
* Affirms that “Medplum” is a registered trademark of Orangebot, Inc.
* Aligns with best practices for Apache 2.0 projects
* Provides clarity for downstream users and redistributors

This file complements the existing `LICENSE` and will be included in all distributed artifacts (NPM packages, Docker images, etc.).
