### PR TITLE
[Example] Encounter Follow-Up Email bot and subscription 

### DIFF
--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/README.md
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/README.md
@@ -1,0 +1,54 @@
+# Encounter Follow-up Email Bot
+
+An automated bot that sends follow-up emails to patients after their encounters are finished.
+
+## Overview
+
+This bot monitors FHIR Encounter resources and automatically sends personalized follow-up emails to patients when an encounter status changes to "finished".
+
+## Prerequisites
+
+- **Email Feature Flag**: The Medplum project must have the email feature flag enabled to allow bots to send emails
+- Patient must have an email address in their telecom information
+- Encounter must have a subject (patient) reference
+
+## Usage
+
+### Setup
+
+1. **Deploy the Bot**: Upload the bot code to your Medplum server
+2. **Create Subscription**: Use the provided `encounter-follow-up-email-subscription.json` to create a FHIR Subscription
+3. **Configure Bot ID**: Update the subscription JSON file with your bot's ID in the endpoint URL
+
+### How It Works
+
+The bot is triggered automatically when an Encounter resource is updated to status "finished". The subscription monitors for:
+
+- **Criteria**: `Encounter?status=finished`
+- **Trigger**: Any encounter status change to "finished"
+- **Payload**: Full encounter resource sent to bot
+
+### Requirements
+
+- **Patient Email**: Patients must have email addresses in their telecom information
+- **Encounter Data**: Encounters must have:
+  - Subject (patient) reference
+  - Participant with provider information
+  - Period with start date
+
+### Email Template
+
+The bot sends HTML emails containing:
+
+- Personalized greeting with patient name
+- Provider name and appointment date
+- Link to view visit summary
+- Link to schedule follow-up appointments
+
+### Testing
+
+Run the test suite to verify bot functionality:
+
+```bash
+npm test encounter-follow-up-email-bot.test.ts
+```

--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.test.ts
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.test.ts
@@ -452,7 +452,7 @@ describe('Encounter Follow-up Email Bot', () => {
 
     expect(sendEmailSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        html: expect.stringContaining('href="example.com/Appointment/12345"'),
+        html: expect.stringContaining('href="https://example.com/Appointment/12345"'),
       })
     );
     sendEmailSpy.mockRestore();
@@ -486,7 +486,7 @@ describe('Encounter Follow-up Email Bot', () => {
 
     expect(sendEmailSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        html: expect.stringContaining('href="example.com/Appointment/"'),
+        html: expect.stringContaining('href="https://example.com/Appointment/"'),
       })
     );
     sendEmailSpy.mockRestore();

--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.test.ts
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.test.ts
@@ -1,0 +1,609 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { createReference, indexSearchParameterBundle, indexStructureDefinitionBundle } from '@medplum/core';
+import { SEARCH_PARAMETER_BUNDLE_FILES, readJson } from '@medplum/definitions';
+import { Bundle, Encounter, Patient, Practitioner, SearchParameter } from '@medplum/fhirtypes';
+import { MockClient } from '@medplum/mock';
+import { expect, test, describe, beforeAll, vi } from 'vitest';
+import { handler } from './encounter-follow-up-email-bot';
+
+describe('Encounter Follow-up Email Bot', () => {
+  beforeAll(() => {
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-types.json') as Bundle);
+    indexStructureDefinitionBundle(readJson('fhir/r4/profiles-resources.json') as Bundle);
+    for (const filename of SEARCH_PARAMETER_BUNDLE_FILES) {
+      indexSearchParameterBundle(readJson(filename) as Bundle<SearchParameter>);
+    }
+  });
+
+  test('Success - sends follow-up email for finished encounter', async () => {
+    const medplum = new MockClient();
+
+    // Create patient with email
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [
+        {
+          family: 'Smith',
+          given: ['John'],
+        },
+      ],
+      telecom: [
+        {
+          system: 'email',
+          value: 'john.smith@example.com',
+        },
+      ],
+    });
+
+    // Create practitioner
+    const practitioner: Practitioner = await medplum.createResource({
+      resourceType: 'Practitioner',
+      name: [
+        {
+          family: 'Johnson',
+          given: ['Dr. Jane'],
+        },
+      ],
+    });
+
+    // Create finished encounter
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      participant: [
+        {
+          type: [
+            {
+              coding: [
+                {
+                  code: 'PPRF',
+                  system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType',
+                  display: 'Primary Performer',
+                },
+              ],
+            },
+          ],
+          individual: {
+            reference: `Practitioner/${practitioner.id}`,
+            display: 'Dr. Jane Johnson',
+          },
+        },
+      ],
+      period: {
+        start: '2024-01-15T10:00:00Z',
+      },
+      appointment: [
+        {
+          reference: 'Appointment/123',
+        },
+      ],
+    });
+
+    // Mock sendEmail to capture the call
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    // Invoke the bot
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    // Verify email was sent
+    expect(sendEmailSpy).toHaveBeenCalledWith({
+      to: 'john.smith@example.com',
+      subject: 'Follow up from your appointment with Dr. Jane Johnson - Monday, January 15',
+      html: expect.stringContaining('Hello John Smith'),
+    });
+
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Skips non-finished encounters', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'in-progress', // Not finished
+      subject: createReference(patient),
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Skips if previous encounter was also finished', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+    });
+
+    // Mock readHistory to return a previous finished encounter
+    const readHistorySpy = vi.spyOn(medplum, 'readHistory').mockResolvedValue({
+      entry: [
+        { resource: encounter }, // Current encounter
+        { resource: { ...encounter, status: 'finished' } }, // Previous encounter (also finished)
+      ],
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    readHistorySpy.mockRestore();
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Handles encounter with no subject reference', async () => {
+    const medplum = new MockClient();
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      // No subject reference
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith('Encounter has no subject reference, skipping email');
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Handles patient read error', async () => {
+    const medplum = new MockClient();
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: { reference: 'Patient/invalid-id' },
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to read patient reference:', expect.any(Error));
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Handles patient with no email address', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      // No telecom/email
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith('Patient has no email address, skipping email');
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Extracts provider name from primary performer', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const practitioner: Practitioner = await medplum.createResource({
+      resourceType: 'Practitioner',
+      name: [{ family: 'Johnson', given: ['Dr. Jane'] }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      participant: [
+        {
+          type: [
+            {
+              coding: [
+                {
+                  code: 'PPRF',
+                  system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType',
+                  display: 'Primary Performer',
+                },
+              ],
+            },
+          ],
+          individual: {
+            reference: `Practitioner/${practitioner.id}`,
+            display: 'Dr. Jane Johnson',
+          },
+        },
+      ],
+      period: { start: '2024-01-15T10:00:00Z' },
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining('Dr. Jane Johnson'),
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Falls back to any practitioner when no primary performer', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const practitioner: Practitioner = await medplum.createResource({
+      resourceType: 'Practitioner',
+      name: [{ family: 'Johnson', given: ['Dr. Jane'] }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      participant: [
+        {
+          individual: {
+            reference: `Practitioner/${practitioner.id}`,
+            display: 'Dr. Jane Johnson',
+          },
+        },
+      ],
+      period: { start: '2024-01-15T10:00:00Z' },
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining('Dr. Jane Johnson'),
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Handles missing provider name gracefully', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      // No participants
+      period: { start: '2024-01-15T10:00:00Z' },
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Follow up from your appointment with  - Monday, January 15',
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Formats patient name correctly', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [
+        {
+          family: 'Smith',
+          given: ['John', 'Michael'],
+        },
+      ],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      period: { start: '2024-01-15T10:00:00Z' },
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining('Hello John Michael Smith'),
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Extracts appointment ID from encounter', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      period: { start: '2024-01-15T10:00:00Z' },
+      appointment: [{ reference: 'Appointment/12345' }],
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining('href="example.com/Appointment/12345"'),
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Handles missing appointment reference', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      period: { start: '2024-01-15T10:00:00Z' },
+      // No appointment reference
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining('href="example.com/Appointment/"'),
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+  test('Uses provider display name from participant', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      participant: [
+        {
+          type: [
+            {
+              coding: [
+                {
+                  code: 'PPRF',
+                  system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType',
+                  display: 'Primary Performer',
+                },
+              ],
+            },
+          ],
+          individual: {
+            reference: 'Practitioner/123',
+            display: 'Dr. Jane Johnson',
+          },
+        },
+      ],
+      period: { start: '2024-01-15T10:00:00Z' },
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Follow up from your appointment with Dr. Jane Johnson - Monday, January 15',
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+
+
+  test('Formats provider name with prefix, given, and family names when no display field', async () => {
+    const medplum = new MockClient();
+
+    const patient: Patient = await medplum.createResource({
+      resourceType: 'Patient',
+      name: [{ family: 'Smith', given: ['John'] }],
+      telecom: [{ system: 'email', value: 'john.smith@example.com' }],
+    });
+
+    const practitioner: Practitioner = await medplum.createResource({
+      resourceType: 'Practitioner',
+      name: [
+        {
+          prefix: ['Dr.'],
+          given: ['Jane', 'Elizabeth'],
+          family: 'Johnson',
+        },
+      ],
+    });
+
+    const encounter: Encounter = await medplum.createResource({
+      resourceType: 'Encounter',
+      status: 'finished',
+      subject: createReference(patient),
+      participant: [
+        {
+          type: [
+            {
+              coding: [
+                {
+                  code: 'PPRF',
+                  system: 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType',
+                  display: 'Primary Performer',
+                },
+              ],
+            },
+          ],
+          individual: {
+            reference: `Practitioner/${practitioner.id}`,
+          },
+        },
+      ],
+      period: { start: '2024-01-15T10:00:00Z' },
+    });
+
+    const sendEmailSpy = vi.spyOn(medplum, 'sendEmail').mockResolvedValue(undefined);
+
+    await handler(medplum, {
+      bot: { reference: 'Bot/123' },
+      input: encounter,
+      contentType: 'application/fhir+json',
+      secrets: {},
+    });
+
+    expect(sendEmailSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Follow up from your appointment with Dr. Jane Elizabeth Johnson - Monday, January 15',
+      })
+    );
+    sendEmailSpy.mockRestore();
+  });
+});

--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.ts
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { BotEvent, MedplumClient } from '@medplum/core';
+import { Encounter, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
+
+
+export async function handler(medplum: MedplumClient, event: BotEvent<Encounter>): Promise<void>{  
+  const encounter = event.input as Encounter;
+  if (encounter.status !== 'finished') {
+    return;
+  }
+
+  const previousEncounters = await medplum.readHistory('Encounter', encounter.id as string, { count: 2 } );
+  const previousEncounter = previousEncounters?.entry?.[1]?.resource;
+  if (previousEncounter && previousEncounter.status === 'finished') {
+    return;
+  }
+  if (!encounter.subject) {
+    console.log('Encounter has no subject reference, skipping email');
+    return;
+  }
+
+  const subjectReference = encounter.subject as Reference<Patient>;
+  let patient: Patient;
+  try {
+    patient = await medplum.readReference(subjectReference);
+  } catch (error) {
+    console.log(`Failed to read patient reference:`, error);
+    return;
+  }
+
+  const patientEmail = patient.telecom?.find((telecom) => telecom.system === 'email')?.value;
+  if (!patientEmail) {
+    console.log('Patient has no email address, skipping email');
+    return;
+  }
+
+  let providerName = '';
+  let providerParticipant = encounter.participant
+    ?.find((participant) =>
+      participant.type?.some((type) =>
+        type.coding?.some((coding) => 
+          coding.code === 'PPRF' || 
+          coding.system === 'http://terminology.hl7.org/CodeSystem/v3-ParticipationType' ||
+          coding.display?.toLowerCase().includes('primary performer')
+        )
+      )
+    );
+
+  if (!providerParticipant) {
+    providerParticipant = encounter.participant?.find((participant) => 
+      participant.individual?.reference?.includes('Practitioner')
+    );
+  }
+
+  if (providerParticipant?.individual?.display) {
+    providerName = providerParticipant.individual.display;
+  } else if (providerParticipant?.individual?.reference) {
+    try {
+      const practitioner = await medplum.readReference(providerParticipant.individual as Reference<Practitioner>);
+      if (practitioner.name?.[0]?.text) {
+        providerName = practitioner.name[0].text;
+      } else if (practitioner.name?.[0]?.family) {
+        const prefix = practitioner.name[0].prefix?.join(' ') || '';
+        const given = practitioner.name[0].given?.join(' ') || '';
+        const family = practitioner.name[0].family || '';
+        const parts = [prefix, given, family].filter(part => part.trim() !== '');
+        providerName = parts.join(' ') || 'Provider';
+      }
+    } catch (error) {
+      console.log(`Failed to read provider reference:`, error);
+    }
+  }
+
+  let encounterDate = '';
+  if (encounter.period?.start) {
+    const date = new Date(encounter.period.start);
+    if (!isNaN(date.getTime())) {
+      encounterDate = date.toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+      });
+    }
+  }
+
+  let patientName = patient.name?.[0]?.text;
+  if (!patientName) {
+    patientName = encounter.subject?.display || 'Patient';
+  }
+  if (!patientName) {
+    const given = patient.name?.[0]?.given?.join(' ') || '';
+    const family = patient.name?.[0]?.family || '';
+    patientName = (given + ' ' + family).trim();
+  }
+
+  const appointmentId = encounter.appointment?.[0]?.reference?.split('/').pop() || '';
+  await medplum.sendEmail({
+    to: patientEmail,
+    subject: `Follow up from your appointment with ${providerName} - ${encounterDate}`,
+    html:`
+      <p>Hello ${patientName},</p>
+      <p>Following up from your appointment with ${providerName} today.</p>
+      <p><a href="example.com/Appointment/${appointmentId}">View your visit summary</a></p>
+      <p>Remember to <a href="example.com/get-care">schedule a follow up</a></p>
+    `,
+  });
+}

--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.ts
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.ts
@@ -4,7 +4,7 @@
 import { BotEvent, MedplumClient } from '@medplum/core';
 import { Encounter, Patient, Practitioner, Reference } from '@medplum/fhirtypes';
 
-
+const PATIENT_APP_URL =  'https://example.com';
 export async function handler(medplum: MedplumClient, event: BotEvent<Encounter>): Promise<void>{  
   const encounter = event.input as Encounter;
   if (encounter.status !== 'finished') {
@@ -102,8 +102,8 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Encounter>
     html:`
       <p>Hello ${patientName},</p>
       <p>Following up from your appointment with ${providerName} today.</p>
-      <p><a href="example.com/Appointment/${appointmentId}">View your visit summary</a></p>
-      <p>Remember to <a href="example.com/get-care">schedule a follow up</a></p>
+      <p><a href="${PATIENT_APP_URL}/Appointment/${appointmentId}">View your visit summary</a></p>
+      <p>Remember to <a href="${PATIENT_APP_URL}/get-care">schedule a follow up</a></p>
     `,
   });
 }

--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.ts
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-bot.ts
@@ -87,12 +87,12 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Encounter>
 
   let patientName = patient.name?.[0]?.text;
   if (!patientName) {
-    patientName = encounter.subject?.display || 'Patient';
-  }
-  if (!patientName) {
     const given = patient.name?.[0]?.given?.join(' ') || '';
     const family = patient.name?.[0]?.family || '';
     patientName = (given + ' ' + family).trim();
+  }
+  if (!patientName) {
+    patientName = encounter.subject?.display || 'Patient';
   }
 
   const appointmentId = encounter.appointment?.[0]?.reference?.split('/').pop() || '';

--- a/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-subscription.json
+++ b/examples/medplum-demo-bots/src/encounter-follow-up-email-bots/encounter-follow-up-email-subscription.json
@@ -1,0 +1,17 @@
+{
+    "resourceType": "Subscription",
+    "status": "active",
+    "criteria": "Encounter?status=finished",
+    "reason": "Encounter Follow Up Email Bot",
+    "channel": {
+        "type": "rest-hook",
+        "endpoint": "Bot/<YOUR_BOT_ID>",
+        "payload": "application/fhir+json"
+    },
+    "extension": [
+        {
+            "url": "https://medplum.com/fhir/StructureDefinition/subscription-supported-interaction",
+            "valueCode": "update"
+        }
+    ]
+}


### PR DESCRIPTION
## Add Encounter Follow-up Email Bot

Automated bot that sends personalized follow-up emails to patients when encounters are marked as "finished".

### What's Added
- **Bot Implementation**: Monitors FHIR Encounter resources and sends follow-up emails
- **Subscription Config**: FHIR subscription for triggering the bot
- **Bot tests**: Tests of the bot’s functionality
- **Documentation**: Complete README with setup instructions

### Requirements
- Email feature flag must be enabled on Medplum project
- Patients must have email addresses in telecom information
- Bot needs read permissions for Patient and Practitioner resources

https://github.com/user-attachments/assets/59d644bb-b366-4cd4-a458-b5d458d34feb



