### PR TITLE
Specify --no-deprecated in upgrade script

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -117,7 +117,7 @@ if [ "$LAST_STEP" -lt 1 ]; then
     # --target - Determines the version to upgrade to
     # "minor" - Upgrade to the highest minor version without bumping the major version
     # `enginesNode` makes sure that packages can be run against the node requirement specified in the monorepo "engines.node"
-    npx npm-check-updates --workspaces --root --upgrade --cooldown "$COOLDOWN" --reject "$EXCLUDE" --target minor --enginesNode
+    npx npm-check-updates --workspaces --root --upgrade --no-deprecated --cooldown "$COOLDOWN" --reject "$EXCLUDE" --target minor --enginesNode
 
     # Commit and push before running NPM install
     git add -u .
@@ -158,7 +158,7 @@ if [ "$LAST_STEP" -lt 3 ]; then
     # Next, optimistically upgrade to the latest versions
     # "latest" - Upgrade to whatever the package's "latest" git tag points to.
     # `enginesNode` makes sure that packages can be run against the node requirement specified in the monorepo "engines.node"
-    npx npm-check-updates --workspaces --root --upgrade --cooldown "$COOLDOWN" --reject "$EXCLUDE $MAJOR_EXCLUDE" --target latest --enginesNode
+    npx npm-check-updates --workspaces --root --upgrade --no-deprecated --cooldown "$COOLDOWN" --reject "$EXCLUDE $MAJOR_EXCLUDE" --target latest --enginesNode
 
     # Check for changes in the working directory
     if git diff --quiet; then


### PR DESCRIPTION
See [this action run](https://github.com/medplum/medplum/actions/runs/18115564221/job/51550438491#step:5:212) where `ncu` chose [a deprecated](https://www.npmjs.com/package/@aws-sdk/lib-storage/v/3.896.0) version of `aws-sdk/lib-storage`