### PR TITLE
test(server): run tests against PostgreSQL 18 as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22]
-        pg-version: [13, 17, 18]
+        pg-version: [13, 18]
         redis-version: [6, 7]
     env:
       NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22]
-        pg-version: [13, 17]
+        pg-version: [13, 17, 18]
         redis-version: [6, 7]
     env:
       NODE_OPTIONS: --max-old-space-size=8192
@@ -261,7 +261,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20, 22]
-        pg-version: [13, 17]
+        pg-version: [13, 17, 18]
         redis-version: [6, 7]
     env:
       NODE_OPTIONS: --max-old-space-size=8192


### PR DESCRIPTION
PostgreSQL 18 just became available on Docker Hub, so introducing it to our test matrix increases our effective test coverage.

https://hub.docker.com/layers/library/postgres/18
