### PR TITLE
Jest 30

### DIFF
--- a/packages/app/src/BulkAppPage.test.tsx
+++ b/packages/app/src/BulkAppPage.test.tsx
@@ -10,13 +10,6 @@ const medplum = new MockClient();
 
 describe('BulkAppPage', () => {
   async function setup(url: string): Promise<void> {
-    const urlObj = new URL(url, 'http://localhost');
-    Object.defineProperty(window, 'location', {
-      value: {
-        href: urlObj.href,
-        search: urlObj.search,
-      },
-    });
     await act(async () => {
       render(
         <MedplumProvider medplum={medplum}>

--- a/packages/app/src/OAuthPage.test.tsx
+++ b/packages/app/src/OAuthPage.test.tsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { locationUtils } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react';
 import crypto from 'crypto';
 import { MemoryRouter } from 'react-router';
-import { TextEncoder } from 'util';
 import { AppRoutes } from './AppRoutes';
 import { act, render, screen, userEvent, UserEvent, waitFor } from './test-utils/render';
 
@@ -15,7 +15,7 @@ describe('OAuthPage', () => {
     const user = userEvent.setup();
     await act(async () => {
       render(
-        <MedplumProvider medplum={medplum}>
+        <MedplumProvider medplum={medplum} navigate={jest.fn()}>
           <MemoryRouter initialEntries={[url]} initialIndex={0}>
             <AppRoutes />
           </MemoryRouter>
@@ -27,10 +27,6 @@ describe('OAuthPage', () => {
   }
 
   beforeAll(() => {
-    Object.defineProperty(global, 'TextEncoder', {
-      value: TextEncoder,
-    });
-
     Object.defineProperty(global.self, 'crypto', {
       value: crypto.webcrypto,
     });
@@ -42,10 +38,7 @@ describe('OAuthPage', () => {
   });
 
   test('Success', async () => {
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { assign: jest.fn() },
-    });
+    locationUtils.assign = jest.fn();
 
     const user = await setup(
       '/oauth?client_id=123&redirect_uri=https://example.com/callback&scope=openid+profile&state=abc&nonce=xyz'
@@ -63,8 +56,8 @@ describe('OAuthPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Set scope' }));
 
-    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
-    expect(window.location.assign).toHaveBeenCalled();
+    await waitFor(() => expect(locationUtils.assign).toHaveBeenCalled());
+    expect(locationUtils.assign).toHaveBeenCalled();
   });
 
   test('Forgot password', async () => {

--- a/packages/app/src/OAuthPage.tsx
+++ b/packages/app/src/OAuthPage.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Title } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { CodeChallengeMethod, normalizeErrorString } from '@medplum/core';
+import { CodeChallengeMethod, locationUtils, normalizeErrorString } from '@medplum/core';
 import { ClientApplicationSignInForm } from '@medplum/fhirtypes';
 import { Logo, SignInForm, useMedplum } from '@medplum/react';
 import { JSX, useEffect, useState } from 'react';
@@ -55,7 +55,7 @@ export function OAuthPage(): JSX.Element | null {
       }
     }
     redirectUrl.searchParams.set('code', code);
-    window.location.assign(redirectUrl.toString());
+    locationUtils.assign(redirectUrl.toString());
   }
 
   return (

--- a/packages/app/src/resource/AppsPage.test.tsx
+++ b/packages/app/src/resource/AppsPage.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
-import { forbidden, OperationOutcomeError } from '@medplum/core';
+import { forbidden, locationUtils, OperationOutcomeError } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { ErrorBoundary, Loading, MedplumProvider } from '@medplum/react';
 import { Suspense } from 'react';
@@ -42,13 +42,7 @@ describe('AppsPage', () => {
   });
 
   test('Patient Smart App Launch', async () => {
-    Object.defineProperty(window, 'location', {
-      value: {
-        pathname: '/Patient/123/apps',
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
+    locationUtils.assign = jest.fn();
 
     await setup('/Patient/123/apps');
     expect(await screen.findByText('Apps')).toBeInTheDocument();
@@ -59,17 +53,11 @@ describe('AppsPage', () => {
       fireEvent.click(screen.getByText('Inferno Client'));
     });
 
-    expect(window.location.assign).toHaveBeenCalled();
+    expect(locationUtils.assign).toHaveBeenCalled();
   });
 
   test('Encounter Smart App Launch', async () => {
-    Object.defineProperty(window, 'location', {
-      value: {
-        pathname: '/Encounter/123/apps',
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
+    locationUtils.assign = jest.fn();
 
     await setup('/Encounter/123/apps');
     expect(await screen.findByText('Apps')).toBeInTheDocument();
@@ -80,7 +68,7 @@ describe('AppsPage', () => {
       fireEvent.click(screen.getByText('Inferno Client'));
     });
 
-    expect(window.location.assign).toHaveBeenCalled();
+    expect(locationUtils.assign).toHaveBeenCalled();
   });
 
   test('Access denied to ClientApplications', async () => {

--- a/packages/app/src/resource/ToolsPage.test.tsx
+++ b/packages/app/src/resource/ToolsPage.test.tsx
@@ -555,8 +555,6 @@ describe('ToolsPage', () => {
       return [serverError(new Error('Something is broken'))];
     });
 
-    const medplumGetSpy = jest.spyOn(medplum, 'get');
-
     agent = await medplum.createResource<Agent>({
       resourceType: 'Agent',
       name: 'Agente - Upgrade error',
@@ -584,14 +582,16 @@ describe('ToolsPage', () => {
       screen.findByText('Are you sure you want to upgrade this agent from version 3.2.13 to version 3.2.14?')
     ).resolves.toBeInTheDocument();
 
+    const medplumGetSpy = jest.spyOn(medplum, 'get');
+
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /confirm upgrade/i }));
     });
 
-    expect(medplumGetSpy).toHaveBeenCalledWith(
-      medplum.fhirUrl('Agent', agent.id as string, '$upgrade'),
-      expect.objectContaining({ cache: 'reload' })
-    );
+    const upgradeUrl = medplum.fhirUrl('Agent', agent.id as string, '$upgrade');
+    upgradeUrl.searchParams.set('force', 'false');
+
+    expect(medplumGetSpy).toHaveBeenCalledWith(upgradeUrl, expect.objectContaining({ cache: 'reload' }));
 
     await act(async () => {
       await sleep(500);

--- a/packages/app/src/resource/ToolsPage.tsx
+++ b/packages/app/src/resource/ToolsPage.tsx
@@ -152,8 +152,10 @@ export function ToolsPage(): JSX.Element | null {
   const handleUpgrade = useCallback(
     (force: boolean) => {
       setUpgrading(true);
+      const upgradeUrl = medplum.fhirUrl('Agent', id, '$upgrade');
+      upgradeUrl.searchParams.set('force', String(force));
       medplum
-        .get(medplum.fhirUrl('Agent', id, '$upgrade', `?force=${force}`), { cache: 'reload' })
+        .get(upgradeUrl, { cache: 'reload' })
         .then((_result: Bundle<Parameters>) => {
           showSuccess('Agent upgraded successfully.');
         })

--- a/packages/core/src/base64.test.ts
+++ b/packages/core/src/base64.test.ts
@@ -2,13 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 import { decodeBase64, decodeBase64Url, encodeBase64, encodeBase64Url } from './base64';
 
-const originalWindow = globalThis.window;
-const originalBuffer = globalThis.Buffer;
+// Mock the environment module
+jest.mock('./environment');
+
+import * as environment from './environment';
+
+const mockEnvironment = environment as jest.Mocked<typeof environment>;
 
 describe('Base64', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   test('Browser', () => {
-    Object.defineProperty(globalThis, 'Buffer', { get: () => undefined });
-    Object.defineProperty(globalThis, 'window', { get: () => originalWindow });
+    // Mock browser environment
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(true);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(false);
+    mockEnvironment.getWindow.mockReturnValue(window as any);
 
     const encoded = encodeBase64('Hello world');
     expect(encoded).toBe('SGVsbG8gd29ybGQ=');
@@ -24,8 +34,10 @@ describe('Base64', () => {
   });
 
   test('Node.js', () => {
-    Object.defineProperty(globalThis, 'Buffer', { get: () => originalBuffer });
-    Object.defineProperty(globalThis, 'window', { get: () => undefined });
+    // Mock Node.js environment
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(false);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(true);
+    mockEnvironment.getBuffer.mockReturnValue(Buffer as any);
 
     const encoded = encodeBase64('Hello world');
     expect(encoded).toBe('SGVsbG8gd29ybGQ=');
@@ -41,8 +53,9 @@ describe('Base64', () => {
   });
 
   test('Error', () => {
-    Object.defineProperty(globalThis, 'Buffer', { get: () => undefined });
-    Object.defineProperty(globalThis, 'window', { get: () => undefined });
+    // Mock environment with neither browser nor Node.js
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(false);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(false);
 
     expect(() => encodeBase64('Hello world')).toThrow('Unable to encode base64');
     expect(() => decodeBase64('SGVsbG8gd29ybGQ=')).toThrow('Unable to decode base64');
@@ -55,14 +68,15 @@ describe('Base64URL', () => {
   const unicodeString = '👋🌍';
   const unicodeStringBase64Url = '8J-Ri_CfjI0';
 
-  afterEach(() => {
-    Object.defineProperty(globalThis, 'Buffer', { value: originalBuffer, configurable: true });
-    Object.defineProperty(globalThis, 'window', { value: originalWindow, configurable: true });
+  beforeEach(() => {
+    jest.resetAllMocks();
   });
 
   test('Browser', () => {
-    Object.defineProperty(globalThis, 'Buffer', { value: undefined, configurable: true });
-    Object.defineProperty(globalThis, 'window', { value: originalWindow, configurable: true });
+    // Mock browser environment
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(true);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(false);
+    mockEnvironment.getWindow.mockReturnValue(window as any);
 
     // Test encoding
     expect(encodeBase64Url(paddingString)).toBe(paddingStringBase64Url);
@@ -74,8 +88,10 @@ describe('Base64URL', () => {
   });
 
   test('Node.js', () => {
-    Object.defineProperty(globalThis, 'Buffer', { value: originalBuffer, configurable: true });
-    Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });
+    // Mock Node.js environment
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(false);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(true);
+    mockEnvironment.getBuffer.mockReturnValue(Buffer as any);
 
     // Test encoding
     expect(encodeBase64Url(paddingString)).toBe(paddingStringBase64Url);

--- a/packages/core/src/base64.ts
+++ b/packages/core/src/base64.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import { getBuffer, isBrowserEnvironment } from './environment';
+
 /**
  * Decodes a base64 string.
  * Handles both browser and Node environments.
@@ -10,13 +12,14 @@
  */
 
 export function decodeBase64(data: string): string {
-  if (typeof window !== 'undefined') {
+  if (isBrowserEnvironment()) {
     const binaryString = window.atob(data);
     const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
     return new window.TextDecoder().decode(bytes);
   }
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(data, 'base64').toString('utf-8');
+  const BufferConstructor = getBuffer();
+  if (BufferConstructor) {
+    return BufferConstructor.from(data, 'base64').toString('utf-8');
   }
   throw new Error('Unable to decode base64');
 }
@@ -29,14 +32,15 @@ export function decodeBase64(data: string): string {
  * @returns The base-64 encoded string.
  */
 export function encodeBase64(data: string): string {
-  if (typeof window !== 'undefined') {
+  if (isBrowserEnvironment()) {
     const utf8Bytes = new window.TextEncoder().encode(data);
     // utf8Bytes is a Uint8Array, but String.fromCharCode expects a sequence of numbers.
     const binaryString = String.fromCharCode.apply(null, utf8Bytes as unknown as number[]);
     return window.btoa(binaryString);
   }
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(data, 'utf8').toString('base64');
+  const BufferConstructor = getBuffer();
+  if (BufferConstructor) {
+    return BufferConstructor.from(data, 'utf8').toString('base64');
   }
   throw new Error('Unable to encode base64');
 }

--- a/packages/core/src/client-test-utils.ts
+++ b/packages/core/src/client-test-utils.ts
@@ -51,11 +51,16 @@ export function mockFetchResponse(status: number, body: any, headers?: Record<st
     streamRead = true;
     return body;
   };
+  const blobReader = async (): Promise<Blob> => {
+    return {
+      text: streamReader,
+    } as Blob;
+  };
   return {
     ok: status < 400,
     status,
     headers: headersMap,
-    blob: streamReader,
+    blob: blobReader,
     json: streamReader,
     text: streamReader,
   } as unknown as Response;

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -29,6 +29,7 @@ import {
 } from './client';
 import { createFakeJwt, mockFetch, mockFetchResponse } from './client-test-utils';
 import { ContentType } from './contenttype';
+import * as environment from './environment';
 import {
   OperationOutcomeError,
   accepted,
@@ -45,6 +46,18 @@ import {
 import { MockAsyncClientStorage } from './storage';
 import { getDataType, isDataTypeLoaded, isProfileLoaded } from './typeschema/types';
 import { ProfileResource, WithId, createReference, sleep } from './utils';
+
+// Mock the environment module
+jest.mock('./environment');
+
+const mockEnvironment = environment as jest.Mocked<typeof environment> & {
+  locationUtils: {
+    assign: jest.MockedFunction<(url: string) => void>;
+    reload: jest.MockedFunction<() => void>;
+    getSearch: jest.MockedFunction<() => string>;
+    getOrigin: jest.MockedFunction<() => string>;
+  };
+};
 
 const EXAMPLE_XML = `
 <note>
@@ -189,8 +202,7 @@ const profileExtensionSD = {
     ],
   },
 };
-const originalWindow = globalThis.window;
-const originalBuffer = globalThis.Buffer;
+// Default environment mocks - will be overridden in specific tests
 
 describe('Client', () => {
   beforeAll(() => {
@@ -200,8 +212,12 @@ describe('Client', () => {
 
   beforeEach(() => {
     localStorage.clear();
-    Object.defineProperty(globalThis, 'Buffer', { get: () => originalBuffer });
-    Object.defineProperty(globalThis, 'window', { get: () => originalWindow });
+    jest.resetAllMocks();
+    // Default to browser environment for most tests
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(true);
+    mockEnvironment.getWindow.mockReturnValue(window as any);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(false);
+    mockEnvironment.getBuffer.mockReturnValue(undefined);
   });
 
   afterAll(() => {
@@ -431,12 +447,10 @@ describe('Client', () => {
   });
 
   test('SignInWithRedirect', async () => {
-    // Mock window.location.assign
+    // Mock locationUtils.assign and locationUtils.getSearch
     const assign = jest.fn();
-    Object.defineProperty(window, 'location', {
-      value: { assign },
-      writable: true,
-    });
+    mockEnvironment.locationUtils.assign.mockImplementation(assign);
+    mockEnvironment.locationUtils.getSearch.mockReturnValue('');
 
     const fetch = mockFetch(200, (url) => {
       if (url.includes('/oauth2/token')) {
@@ -460,13 +474,7 @@ describe('Client', () => {
     expect(assign).toHaveBeenCalledWith(expect.stringMatching(/authorize\?.+scope=/));
 
     // Mock response code
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-        search: new URLSearchParams({ code: 'test-code' }),
-      },
-      writable: true,
-    });
+    mockEnvironment.locationUtils.getSearch.mockReturnValue('?code=test-code');
 
     // Next, test processing the response code
     const result2 = await client.signInWithRedirect();
@@ -474,27 +482,19 @@ describe('Client', () => {
   });
 
   test('SignOutWithRedirect', async () => {
-    // Mock window.location.assign
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
+    // Mock locationUtils.assign
+    const assign = jest.fn();
+    mockEnvironment.locationUtils.assign.mockImplementation(assign);
 
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
     client.signOutWithRedirect();
-    expect(window.location.assign).toHaveBeenCalled();
+    expect(assign).toHaveBeenCalled();
   });
 
   test('Sign in with external auth', async () => {
     const assign = jest.fn();
-    Object.defineProperty(window, 'location', {
-      value: { assign },
-      writable: true,
-    });
+    mockEnvironment.locationUtils.assign.mockImplementation(assign);
 
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
@@ -514,10 +514,7 @@ describe('Client', () => {
 
   test('Sign in with external auth -- disabled PKCE', async () => {
     const assign = jest.fn();
-    Object.defineProperty(window, 'location', {
-      value: { assign },
-      writable: true,
-    });
+    mockEnvironment.locationUtils.assign.mockImplementation(assign);
 
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
@@ -536,12 +533,8 @@ describe('Client', () => {
   });
 
   test('Sign in with external auth -- no crypto.subtle', async () => {
-    const originalAssign = window.location.assign;
     const assign = jest.fn();
-    Object.defineProperty(window, 'location', {
-      value: { assign },
-      writable: true,
-    });
+    mockEnvironment.locationUtils.assign.mockImplementation(assign);
 
     const originalSubtle = crypto.subtle;
     Object.defineProperty(crypto, 'subtle', {
@@ -566,11 +559,6 @@ describe('Client', () => {
 
     Object.defineProperty(crypto, 'subtle', {
       value: originalSubtle,
-      writable: true,
-    });
-
-    Object.defineProperty(window, 'location', {
-      value: { assign: originalAssign },
       writable: true,
     });
   });
@@ -925,8 +913,11 @@ describe('Client', () => {
   });
 
   test('Basic auth in browser', async () => {
-    Object.defineProperty(globalThis, 'Buffer', { get: () => undefined });
-    Object.defineProperty(globalThis, 'window', { get: () => originalWindow });
+    // Mock browser environment (already set in beforeEach, but explicit for clarity)
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(true);
+    mockEnvironment.getWindow.mockReturnValue(window as any);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(false);
+    mockEnvironment.getBuffer.mockReturnValue(undefined);
 
     const fetch = mockFetch(200, () => {
       return { resourceType: 'Patient', id: '123' };
@@ -952,8 +943,11 @@ describe('Client', () => {
   });
 
   test('Basic auth in Node.js', async () => {
-    Object.defineProperty(globalThis, 'Buffer', { get: () => originalBuffer });
-    Object.defineProperty(globalThis, 'window', { get: () => undefined });
+    // Mock Node.js environment
+    mockEnvironment.isBrowserEnvironment.mockReturnValue(false);
+    mockEnvironment.getWindow.mockReturnValue(undefined);
+    mockEnvironment.isNodeEnvironment.mockReturnValue(true);
+    mockEnvironment.getBuffer.mockReturnValue(Buffer as any);
 
     const fetch = mockFetch(200, () => {
       return { resourceType: 'Patient', id: '123' };
@@ -2712,17 +2706,13 @@ describe('Client', () => {
   });
 
   test('Storage events', async () => {
-    // Make window.location writeable
-    Object.defineProperty(window, 'location', {
-      value: { assign: {} },
-      writable: true,
-    });
+    // Mock locationUtils.reload
+    const mockReload = jest.fn();
+    mockEnvironment.locationUtils.reload.mockImplementation(mockReload);
 
     const mockAddEventListener = jest.fn();
-    const mockReload = jest.fn();
 
     window.addEventListener = mockAddEventListener;
-    window.location.reload = mockReload;
 
     const fetch = mockFetch(200, {});
     const client = new MedplumClient({ fetch });
@@ -3353,18 +3343,11 @@ describe('Client', () => {
     const baseUrl = 'https://api.medplum.com/';
     const fhirUrlPath = 'fhir/R4/';
     const accessToken = 'fake';
-    let fetch: FetchLike;
-    let client: MedplumClient;
-
-    beforeAll(() => {
-      fetch = mockFetch(200, (url: string) => ({
-        text: () => Promise.resolve(url),
-      }));
-      client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
-      client.setAccessToken(accessToken);
-    });
 
     test('Downloading resources via URL', async () => {
+      const fetch = mockFetch(200, (url: string) => url);
+      const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
       const blob = await client.download(baseUrl);
       expect(fetch).toHaveBeenCalledWith(
         baseUrl,
@@ -3380,6 +3363,9 @@ describe('Client', () => {
     });
 
     test('Downloading resources via `Binary/{id}` URL', async () => {
+      const fetch = mockFetch(200, (url: string) => url);
+      const client = new MedplumClient({ fetch, baseUrl, fhirUrlPath });
+      client.setAccessToken(accessToken);
       const blob = await client.download('Binary/fake-id');
       expect(fetch).toHaveBeenCalledWith(
         `${baseUrl}${fhirUrlPath}Binary/fake-id`,

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -42,6 +42,7 @@ import { encodeBase64 } from './base64';
 import { LRUCache } from './cache';
 import { ContentType } from './contenttype';
 import { encryptSHA256, getRandomString } from './crypto';
+import { isBrowserEnvironment, locationUtils } from './environment';
 import { TypedEventTarget } from './eventtarget';
 import {
   CurrentContext,
@@ -916,7 +917,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     this.refreshGracePeriod = options?.refreshGracePeriod ?? DEFAULT_REFRESH_GRACE_PERIOD;
 
     this.cacheTime =
-      options?.cacheTime ?? (typeof window === 'undefined' ? DEFAULT_NODE_CACHE_TIME : DEFAULT_BROWSER_CACHE_TIME);
+      options?.cacheTime ?? (!isBrowserEnvironment() ? DEFAULT_NODE_CACHE_TIME : DEFAULT_BROWSER_CACHE_TIME);
     if (this.cacheTime > 0) {
       this.requestCache = new LRUCache(options?.resourceCacheSize ?? DEFAULT_RESOURCE_CACHE_SIZE);
     } else {
@@ -1057,7 +1058,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    */
   clear(): void {
     this.storage.clear();
-    if (typeof window !== 'undefined') {
+    if (isBrowserEnvironment()) {
       sessionStorage.clear();
     }
     this.clearActiveLogin();
@@ -1381,7 +1382,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @returns The user profile resource if available.
    */
   async signInWithRedirect(loginParams?: Partial<BaseLoginRequest>): Promise<ProfileResource | undefined> {
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = new URLSearchParams(locationUtils.getSearch());
     const code = urlParams.get('code');
     if (!code) {
       await this.requestAuthorization(loginParams);
@@ -1396,7 +1397,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
    * @category Authentication
    */
   signOutWithRedirect(): void {
-    window.location.assign(this.logoutUrl);
+    locationUtils.assign(this.logoutUrl);
   }
 
   /**
@@ -1419,7 +1420,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     if (pkceEnabled) {
       loginRequest = await this.ensureCodeChallenge(baseLogin);
     }
-    window.location.assign(
+    locationUtils.assign(
       this.getExternalAuthRedirectUri(authorizeUrl, clientId, redirectUri, loginRequest, pkceEnabled)
     );
   }
@@ -3498,7 +3499,11 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
   }
 
   private setCurrentRateLimit(res: Response): void {
-    const rateLimitHeader = res.headers?.get('ratelimit');
+    // Handle cases where response might not have headers property (e.g., in tests)
+    if (!res?.headers || typeof res.headers.get !== 'function') {
+      return;
+    }
+    const rateLimitHeader = res.headers.get('ratelimit');
     if (rateLimitHeader) {
       this.currentRateLimits = rateLimitHeader;
     }
@@ -3758,11 +3763,11 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('state', sessionStorage.getItem('pkceState') as string);
     url.searchParams.set('client_id', loginRequest.clientId ?? (this.clientId as string));
-    url.searchParams.set('redirect_uri', loginRequest.redirectUri ?? getWindowOrigin());
+    url.searchParams.set('redirect_uri', loginRequest.redirectUri ?? locationUtils.getOrigin());
     url.searchParams.set('code_challenge_method', loginRequest.codeChallengeMethod as string);
     url.searchParams.set('code_challenge', loginRequest.codeChallenge as string);
     url.searchParams.set('scope', loginRequest.scope ?? 'openid profile');
-    window.location.assign(url.toString());
+    locationUtils.assign(url.toString());
   }
 
   /**
@@ -3778,7 +3783,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
       grant_type: OAuthGrantType.AuthorizationCode,
       code,
       client_id: loginParams?.clientId ?? this.clientId ?? '',
-      redirect_uri: loginParams?.redirectUri ?? getWindowOrigin(),
+      redirect_uri: loginParams?.redirectUri ?? locationUtils.getOrigin(),
     };
 
     if (typeof sessionStorage !== 'undefined') {
@@ -4190,7 +4195,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         // On storage clear (key === null) or profile change (key === 'activeLogin', and profile in 'activeLogin' is different)
         // Refresh the page to ensure the active login is up to date.
         if (e.key === null) {
-          window.location.reload();
+          locationUtils.reload();
         } else if (e.key === 'activeLogin') {
           const oldState = (e.oldValue ? JSON.parse(e.oldValue) : undefined) as LoginState | undefined;
           const newState = (e.newValue ? JSON.parse(e.newValue) : undefined) as LoginState | undefined;
@@ -4198,7 +4203,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
             oldState?.profile.reference !== newState?.profile.reference ||
             !this.checkSessionDetailsMatchLogin(newState)
           ) {
-            window.location.reload();
+            locationUtils.reload();
           } else if (newState) {
             this.setAccessToken(newState.accessToken, newState.refreshToken);
           } else {
@@ -4311,18 +4316,6 @@ function getDefaultFetch(): FetchLike {
     throw new Error('Fetch not available in this environment');
   }
   return globalThis.fetch.bind(globalThis);
-}
-
-/**
- * Returns the base URL for the current page.
- * @returns The window origin string.
- * @category HTTP
- */
-function getWindowOrigin(): string {
-  if (typeof window === 'undefined') {
-    return '';
-  }
-  return window.location.protocol + '//' + window.location.host + '/';
 }
 
 /**

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Environment detection utilities that can be mocked in tests.
+ * These functions replace direct checks of global objects to avoid
+ * the need to manipulate non-configurable globalThis.window in Jest/JSDOM 23+.
+ */
+
+/**
+ * Returns true if running in a browser environment with window available.
+ * @returns True if in browser environment.
+ */
+export function isBrowserEnvironment(): boolean {
+  return typeof window !== 'undefined';
+}
+
+/**
+ * Returns true if running in Node.js environment with Buffer available.
+ * @returns True if in Node.js environment.
+ */
+export function isNodeEnvironment(): boolean {
+  return typeof Buffer !== 'undefined';
+}
+
+/**
+ * Returns the global window object if available.
+ * @returns The window object or undefined.
+ */
+export function getWindow(): Window | undefined {
+  return typeof window !== 'undefined' ? window : undefined;
+}
+
+/**
+ * Returns the global Buffer constructor if available.
+ * @returns The Buffer constructor or undefined.
+ */
+export function getBuffer(): typeof Buffer | undefined {
+  return typeof Buffer !== 'undefined' ? Buffer : undefined;
+}
+
+/**
+ * Location utilities that can be mocked in tests.
+ * These functions wrap window.location calls to avoid JSDOM 23+ restrictions.
+ */
+export const locationUtils = {
+  assign(url: string): void {
+    if (isBrowserEnvironment()) {
+      window.location.assign(url);
+    }
+  },
+
+  reload(): void {
+    if (isBrowserEnvironment()) {
+      window.location.reload();
+    }
+  },
+
+  getSearch(): string {
+    return isBrowserEnvironment() ? window.location.search : '';
+  },
+
+  getPathname(): string {
+    return isBrowserEnvironment() ? window.location.pathname : '';
+  },
+
+  getLocation(): string {
+    return isBrowserEnvironment() ? window.location.toString() : '';
+  },
+
+  getOrigin(): string {
+    return isBrowserEnvironment() ? window.location.protocol + '//' + window.location.host + '/' : '';
+  },
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './crypto';
 export * from './datasampler';
 export * from './default-values';
 export * from './elements-context';
+export * from './environment';
 export * from './eventtarget';
 export * from './fhircast';
 export * from './fhirlexer/parse';

--- a/packages/react/src/AppShell/Header.test.tsx
+++ b/packages/react/src/AppShell/Header.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { AppShell as MantineAppShell } from '@mantine/core';
+import { locationUtils } from '@medplum/core';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { MemoryRouter } from 'react-router';
@@ -64,13 +65,7 @@ describe('Header', () => {
   });
 
   test('Switch profile', async () => {
-    const reloadMock = jest.fn();
-
-    Object.defineProperty(window, 'location', {
-      value: {
-        reload: reloadMock,
-      },
-    });
+    const reloadSpy = jest.spyOn(locationUtils, 'reload').mockImplementation(() => {});
 
     window.localStorage.setItem(
       'activeLogin',
@@ -132,7 +127,7 @@ describe('Header', () => {
       fireEvent.click(screen.getByText('My Other Project'));
     });
 
-    expect(window.location.reload).toHaveBeenCalled();
+    expect(reloadSpy).toHaveBeenCalled();
   });
 
   test('Add another account', async () => {

--- a/packages/react/src/AppShell/HeaderDropdown.tsx
+++ b/packages/react/src/AppShell/HeaderDropdown.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   useMantineColorScheme,
 } from '@mantine/core';
-import { ProfileResource, getReferenceString } from '@medplum/core';
+import { ProfileResource, getReferenceString, locationUtils } from '@medplum/core';
 import { HumanName } from '@medplum/fhirtypes';
 import { useMedplumContext } from '@medplum/react-hooks';
 import { IconLogout, IconSettings, IconSwitchHorizontal } from '@tabler/icons-react';
@@ -46,7 +46,7 @@ export function HeaderDropdown(props: HeaderDropdownProps): JSX.Element {
               onClick={() => {
                 medplum
                   .setActiveLogin(login)
-                  .then(() => window.location.reload())
+                  .then(() => locationUtils.reload())
                   .catch(console.log);
               }}
             >

--- a/packages/react/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,27 +1,12 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { locationUtils } from '@medplum/core';
 import { JSX, useCallback, useEffect, useState } from 'react';
 import { render, screen } from '../test-utils/render';
 import { ErrorBoundary } from './ErrorBoundary';
 
 function ErrorComponent(): JSX.Element {
   throw new Error('Error');
-}
-
-class MockLocation {
-  #href: string;
-  constructor() {
-    this.#href = 'http://localhost/';
-  }
-  get href(): string {
-    return this.#href;
-  }
-  set href(val: string) {
-    this.#href = new URL(val, this.#href).toString();
-  }
-  toString(): string {
-    return this.#href;
-  }
 }
 
 interface TestAppProps {
@@ -40,7 +25,7 @@ function TestApp(props: TestAppProps): JSX.Element {
 
   useEffect(() => {
     if (shouldNavigate) {
-      window.location.href = '/another_url';
+      locationUtils.getLocation = () => '/another_url';
       rerender();
     }
   }, [shouldNavigate, rerender]);
@@ -57,28 +42,6 @@ function TestApp(props: TestAppProps): JSX.Element {
 }
 
 describe('ErrorBoundary', () => {
-  let originalLocation: Location;
-
-  beforeAll(() => {
-    originalLocation = window.location;
-  });
-
-  beforeEach(() => {
-    Object.defineProperty(window, 'location', {
-      value: new MockLocation(),
-      enumerable: true,
-      configurable: true,
-    });
-  });
-
-  afterAll(() => {
-    Object.defineProperty(window, 'location', {
-      value: originalLocation,
-      enumerable: true,
-      configurable: true,
-    });
-  });
-
   test('Renders children', () => {
     render(
       <div>

--- a/packages/react/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react/src/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Alert } from '@mantine/core';
-import { normalizeErrorString } from '@medplum/core';
+import { locationUtils, normalizeErrorString } from '@medplum/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { Component, ErrorInfo, ReactNode } from 'react';
 
@@ -23,17 +23,17 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { lastLocation: window.location.toString() };
+    this.state = { lastLocation: locationUtils.getLocation() };
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { error, lastLocation: window.location.toString() };
+    return { error, lastLocation: locationUtils.getLocation() };
   }
 
   componentDidUpdate(_prevProps: ErrorBoundaryProps, _prevState: ErrorBoundaryState): void {
-    if (window.location.toString() !== this.state.lastLocation) {
+    if (locationUtils.getLocation() !== this.state.lastLocation) {
       this.setState({
-        lastLocation: window.location.toString(),
+        lastLocation: locationUtils.getLocation(),
         error: undefined,
       });
     }
@@ -46,7 +46,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     if (nextState.error && !this.state.error) {
       return true;
     }
-    if (this.state.lastLocation !== window.location.toString()) {
+    if (this.state.lastLocation !== locationUtils.getLocation()) {
       return true;
     }
     return false;

--- a/packages/react/src/GoogleButton/GoogleButton.test.tsx
+++ b/packages/react/src/GoogleButton/GoogleButton.test.tsx
@@ -1,22 +1,18 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { locationUtils } from '@medplum/core';
 import { getGoogleClientId } from './GoogleButton.utils';
 
 describe('GoogleButton', () => {
   test('googleClientId', () => {
-    expect(getGoogleClientId('foo')).toBeDefined();
+    expect(getGoogleClientId('foo')).toStrictEqual('foo');
 
-    Object.defineProperty(window, 'location', {
-      value: {
-        protocol: 'https:',
-        host: 'app.medplum.com',
-      },
-    });
+    locationUtils.getOrigin = () => 'https://app.medplum.com';
     process.env.GOOGLE_AUTH_ORIGINS = 'https://app.medplum.com';
     process.env.GOOGLE_CLIENT_ID = 'foo';
-    expect(getGoogleClientId(undefined)).toBeDefined();
+    expect(getGoogleClientId(undefined)).toStrictEqual('foo');
 
-    window.location.host = 'evil.com';
+    locationUtils.getOrigin = () => 'https://evil.com';
     expect(getGoogleClientId(undefined)).toBeUndefined();
   });
 });

--- a/packages/react/src/GoogleButton/GoogleButton.utils.ts
+++ b/packages/react/src/GoogleButton/GoogleButton.utils.ts
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
+import { locationUtils } from '@medplum/core';
+
 export function getGoogleClientId(clientId: string | undefined): string | undefined {
   if (clientId) {
     return clientId;
   }
 
-  if (typeof window !== 'undefined') {
-    const origin = window.location.protocol + '//' + window.location.host;
+  const origin = locationUtils.getOrigin();
+  if (origin) {
     const authorizedOrigins = import.meta.env.GOOGLE_AUTH_ORIGINS?.split(',') ?? [];
     if (authorizedOrigins.includes(origin)) {
       return import.meta.env.GOOGLE_CLIENT_ID;

--- a/packages/react/src/MedplumLink/MedplumLink.test.tsx
+++ b/packages/react/src/MedplumLink/MedplumLink.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { MedplumClient } from '@medplum/core';
+import { locationUtils, MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router';
@@ -28,21 +28,20 @@ const medplum = new MedplumClient({
 });
 
 function setup(ui: ReactElement): void {
-  Object.defineProperty(window, 'location', {
-    value: {
-      assign: jest.fn(),
-    },
-    writable: true,
-  });
-
   render(
     <MemoryRouter>
-      <MedplumProvider medplum={medplum}>{ui}</MedplumProvider>
+      <MedplumProvider medplum={medplum} navigate={jest.fn()}>
+        {ui}
+      </MedplumProvider>
     </MemoryRouter>
   );
 }
 
 describe('MedplumLink', () => {
+  beforeEach(() => {
+    locationUtils.assign = jest.fn();
+  });
+
   test('Renders', () => {
     setup(<MedplumLink>test</MedplumLink>);
     expect(screen.getByText('test')).toBeDefined();

--- a/packages/react/src/PatientSummary/Labs.test.tsx
+++ b/packages/react/src/PatientSummary/Labs.test.tsx
@@ -58,6 +58,7 @@ describe('PatientSummary - Labs', () => {
     const reports: DiagnosticReport[] = [
       {
         resourceType: 'DiagnosticReport',
+        id: 'report1',
         status: 'final',
         code: { text: 'Test Report' },
         category: [{ coding: [{ code: 'LAB' }] }],
@@ -78,6 +79,7 @@ describe('PatientSummary - Labs', () => {
     const requests: ServiceRequest[] = [
       {
         resourceType: 'ServiceRequest',
+        id: 'sr1',
         status: 'active',
         code: { text: 'Test Request Active 1' },
         requisition: {
@@ -90,6 +92,7 @@ describe('PatientSummary - Labs', () => {
       },
       {
         resourceType: 'ServiceRequest',
+        id: 'sr2',
         status: 'active',
         code: { text: 'Test Request Active 2' },
         requisition: {
@@ -102,6 +105,7 @@ describe('PatientSummary - Labs', () => {
       },
       {
         resourceType: 'ServiceRequest',
+        id: 'sr3',
         status: 'active',
         code: { text: 'Test Request Active 3' },
         requisition: {
@@ -140,6 +144,7 @@ describe('PatientSummary - Labs', () => {
     const reports: DiagnosticReport[] = [
       {
         resourceType: 'DiagnosticReport',
+        id: 'report1',
         status: 'final',
         code: { text: 'Test Report Final' },
         category: [{ coding: [{ code: 'LAB' }] }],
@@ -186,6 +191,7 @@ describe('PatientSummary - Labs', () => {
     const reports: DiagnosticReport[] = [
       {
         resourceType: 'DiagnosticReport',
+        id: 'report1',
         status: 'final',
         code: { text: 'Test Report Final' },
         category: [{ coding: [{ code: 'LAB' }] }],
@@ -203,6 +209,7 @@ describe('PatientSummary - Labs', () => {
     const requests: ServiceRequest[] = [
       {
         resourceType: 'ServiceRequest',
+        id: 'sr1',
         status: 'active',
         code: { text: 'Test Request Active' },
         intent: 'order',
@@ -215,18 +222,21 @@ describe('PatientSummary - Labs', () => {
     const reports: DiagnosticReport[] = [
       {
         resourceType: 'DiagnosticReport',
+        id: 'report1',
         status: 'final',
         code: { text: 'Test Report Final' },
         category: [{ coding: [{ code: 'LAB' }] }],
       },
       {
         resourceType: 'DiagnosticReport',
+        id: 'report2',
         status: 'cancelled',
         code: { text: 'Test Report Cancelled' },
         category: [{ coding: [{ code: 'LAB' }] }],
       },
       {
         resourceType: 'DiagnosticReport',
+        id: 'report3',
         status: 'preliminary',
         code: { text: 'Test Report Preliminary' },
         category: [{ coding: [{ code: 'LAB' }] }],

--- a/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.test.tsx
+++ b/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import { createReference } from '@medplum/core';
+import { createReference, locationUtils } from '@medplum/core';
 import { HomerEncounter, HomerSimpson, MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { ReactNode } from 'react';
@@ -20,12 +20,9 @@ describe('SmartAppLaunchLink', () => {
   }
 
   test('Happy path', async () => {
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
+    // const assignSpy = jest.spyOn(locationUtils, 'assign').mockImplementation(() => undefined);
+    const mockAssign = jest.fn();
+    locationUtils.assign = mockAssign;
 
     setup(
       <SmartAppLaunchLink
@@ -43,10 +40,10 @@ describe('SmartAppLaunchLink', () => {
       fireEvent.click(screen.getByText('My SmartAppLaunchLink'));
     });
 
-    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
-    expect(window.location.assign).toHaveBeenCalled();
+    await waitFor(() => expect(mockAssign).toHaveBeenCalled());
+    expect(mockAssign).toHaveBeenCalled();
 
-    const url = (window.location.assign as jest.Mock).mock.calls[0][0];
+    const url = mockAssign.mock.calls[0][0];
     expect(url).toContain('https://example.com');
     expect(url).toContain('launch=');
     expect(url).toContain('iss=');

--- a/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.tsx
+++ b/packages/react/src/SmartAppLaunchLink/SmartAppLaunchLink.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Anchor, AnchorProps } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
-import { ensureTrailingSlash, normalizeErrorString } from '@medplum/core';
+import { ensureTrailingSlash, locationUtils, normalizeErrorString } from '@medplum/core';
 import { ClientApplication, Encounter, Patient, Reference, SmartAppLaunch } from '@medplum/fhirtypes';
 import { useMedplum } from '@medplum/react-hooks';
 import { JSX, ReactNode } from 'react';
@@ -29,7 +29,7 @@ export function SmartAppLaunchLink(props: SmartAppLaunchLinkProps): JSX.Element 
         const url = new URL(client.launchUri as string);
         url.searchParams.set('iss', ensureTrailingSlash(medplum.fhirUrl().toString()));
         url.searchParams.set('launch', result.id as string);
-        window.location.assign(url.toString());
+        locationUtils.assign(url.toString());
       })
       .catch((err) => showNotification({ color: 'red', message: normalizeErrorString(err), autoClose: false }));
   }

--- a/packages/react/src/auth/AuthenticationForm.tsx
+++ b/packages/react/src/auth/AuthenticationForm.tsx
@@ -5,6 +5,7 @@ import {
   BaseLoginRequest,
   GoogleCredentialResponse,
   GoogleLoginRequest,
+  locationUtils,
   LoginAuthenticationResponse,
   normalizeOperationOutcome,
 } from '@medplum/core';
@@ -65,7 +66,7 @@ export function EmailForm(props: EmailFormProps): JSX.Element {
       });
       const url = new URL(authMethod.authorizeUrl);
       url.searchParams.set('state', state);
-      window.location.assign(url.toString());
+      locationUtils.assign(url.toString());
       return true;
     },
     [medplum, baseLoginRequest]

--- a/packages/react/src/auth/SignInForm.test.tsx
+++ b/packages/react/src/auth/SignInForm.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { Title } from '@mantine/core';
-import { allOk, badRequest, GoogleCredentialResponse, MedplumClient } from '@medplum/core';
+import { allOk, badRequest, GoogleCredentialResponse, locationUtils, MedplumClient } from '@medplum/core';
 import { MedplumProvider } from '@medplum/react-hooks';
 import crypto from 'crypto';
 import { MemoryRouter } from 'react-router';
@@ -719,12 +719,7 @@ describe('SignInForm', () => {
   });
 
   test('Redirect to external auth', async () => {
-    Object.defineProperty(window, 'location', {
-      value: {
-        assign: jest.fn(),
-      },
-      writable: true,
-    });
+    const assignSpy = jest.spyOn(locationUtils, 'assign').mockImplementation(() => {});
 
     await setup({});
 
@@ -738,8 +733,8 @@ describe('SignInForm', () => {
       fireEvent.click(screen.getByText('Next'));
     });
 
-    await waitFor(() => expect(window.location.assign).toHaveBeenCalled());
-    expect(window.location.assign).toHaveBeenCalled();
+    await waitFor(() => expect(assignSpy).toHaveBeenCalled());
+    expect(assignSpy).toHaveBeenCalled();
   });
 
   test('MFA -- Success', async () => {


### PR DESCRIPTION
Extracting `locationUtils` from the [Jest 30](https://github.com/medplum/medplum/pull/7487) pull request.

Jest 30 upgrades JSDOM from v21 to v26.  JSDOM became a lot more strict over those versions.  In particular, you no longer can modify `window` or `window.location`, which we used in a bunch of tests to emulate various browser transitions, or trying to detect when running in browser vs Node.js environments.

