### PR TITLE
Address otel SDK deprecation warning

### DIFF
--- a/packages/server/src/otel/instrumentation.ts
+++ b/packages/server/src/otel/instrumentation.ts
@@ -94,7 +94,12 @@ export function initOpenTelemetry(): void {
     }),
   ];
 
-  sdk = new NodeSDK({ resource, instrumentations, metricReader, traceExporter });
+  sdk = new NodeSDK({
+    resource,
+    instrumentations,
+    metricReaders: metricReader ? [metricReader] : undefined,
+    traceExporter,
+  });
   sdk.start();
 }
 


### PR DESCRIPTION
Previously getting the warning:

The 'metricReader' option is deprecated. Please use 'metricReaders' instead.

See https://github.com/open-telemetry/opentelemetry-js/pull/5777