### PR TITLE
Use ILIKE operator for ValueSet/$expand filter query

### DIFF
--- a/packages/server/src/fhir/operations/expand.ts
+++ b/packages/server/src/fhir/operations/expand.ts
@@ -328,7 +328,7 @@ function addExpansionFilters(query: SelectQuery, params: ValueSetExpandParameter
           new Conjunction(
             params.filter
               .split(/\s+/g)
-              .map((filter) => new Condition('display', 'LOWER_LIKE', `%${escapeLikeString(filter)}%`))
+              .map((filter) => new Condition('display', 'ILIKE', `%${escapeLikeString(filter)}%`))
           ),
         ])
       )


### PR DESCRIPTION
Removing the `lower()` function from the generated SQL makes better use of the available `gin_trgm_ops` index.  Tested on my laptop with a data set including 5 partial copies of the UMLS data set and specifically the SNOMED code system:
```
medplum=# select count(*) from "Coding";
  count
---------
 5060954

medplum=# select count(*) from "Coding_Property";
  count
----------
 38313744
```

The test query searches for a deeply-nested SNOMED code by a combination of text ("gunshot left butt") and hierarchical (`descendent-of`) filters:
```sql
SELECT id,code,display,"synonymOf" FROM "Coding" 
WHERE (
  "Coding"."system" = 'f0347c4a-5c58-4027-bf2a-78efbaef08c4'
  AND EXISTS(
    WITH RECURSIVE "cte_ancestors" AS (
      SELECT 
        "origin"."id", 
        "origin"."code", 
        "origin"."display", 
        "origin"."synonymOf" 
      FROM "Coding" "origin" 
      WHERE (
        "origin"."system" = 'f0347c4a-5c58-4027-bf2a-78efbaef08c4'
        AND "origin"."code" = "Coding"."code"
      ) 
      UNION SELECT 
        "Coding"."id", 
        "Coding"."code", 
        "Coding"."display", 
        "Coding"."synonymOf" 
      FROM "Coding" 
        INNER JOIN "Coding_Property" AS "T1" ON "Coding"."id" = "T1"."target" 
        INNER JOIN "CodeSystem_Property" AS "T2" ON (
          "T1"."property" = "T2"."id" 
          AND "T2"."code" = 'parent'
        ) 
        INNER JOIN "cte_ancestors" AS "T3" ON (
          "T1"."coding" = "T3"."id" 
          OR "T1"."coding" = "T3"."synonymOf"
        ) 
      WHERE "Coding"."system" = 'f0347c4a-5c58-4027-bf2a-78efbaef08c4'
    ) 
    SELECT 
      "cte_ancestors"."id", 
      "cte_ancestors"."code", 
      "cte_ancestors"."display", 
      "cte_ancestors"."synonymOf" 
    FROM "cte_ancestors" 
    WHERE "cte_ancestors"."code" = '404684003'
    LIMIT 1
  ) AND "Coding"."code" <> '404684003'
  AND (
    "Coding"."code" = 'gunshot left butt'
    OR (
      display ILIKE '%gunshot%'
      AND display ILIKE '%left%'
      AND display ILIKE '%butt%'
      -- LOWER("display") LIKE '%gunshot%'
      -- AND LOWER("display") LIKE '%left%'
      -- AND LOWER("display") LIKE '%butt%'
    )
  )
) 
ORDER BY strict_word_similarity("display", 'gunshot left butt') DESC
LIMIT 11;
```

This resulted in significantly better index usage by the query planner: [before][before] vs. [after][after]

[before]: https://explain.dalibo.com/plan/226943gcf356hb3f#plan/node/3
[after]: https://explain.dalibo.com/plan/99c100g9638d64g7#plan/node/6