### PR TITLE
avoid vitest config error and expand tsconfig exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
     "noEmit": true,
     "isolatedModules": true
   },
-  "exclude": ["node_modules", "**/dist/*"]
+  "exclude": ["node_modules", "**/node_modules", "**/dist", "packages/docs/build"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: ['packages/*/vite{,st}.config.ts', 'examples/*/vite{,st}.config.ts'],
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,0 @@
-export default ['packages/*/', 'examples/*/'];


### PR DESCRIPTION
Most importantly, previously we weren't excluding `packages/<package>/node_modules`