### PR TITLE
fix(ci): add NSIS to PATH when building Windows agent

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: "20"
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: "remote:rw"
+      TURBO_CACHE: 'remote:rw'
     permissions:
       actions: read
       contents: write
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       # See: https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/examples.md#node---npm
       - name: Get npm cache directory
@@ -142,10 +142,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: "20"
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: "remote:rw"
+      TURBO_CACHE: 'remote:rw'
     permissions:
       actions: read
       contents: write
@@ -157,7 +157,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Cache node modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
@@ -218,10 +218,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
     env:
-      NODE_VERSION: "20"
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: "remote:rw"
+      TURBO_CACHE: 'remote:rw'
     permissions:
       actions: read
       contents: write
@@ -233,7 +233,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Cache node modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   id-token: write # Required for OIDC
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      NODE_VERSION: "20"
+      NODE_VERSION: '20'
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: "remote:rw"
+      TURBO_CACHE: 'remote:rw'
     permissions:
       actions: read
       contents: write
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Cache node modules
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -61,12 +61,12 @@ jobs:
       - name: Build
         run: npm run build:all
         env:
-          MEDPLUM_BASE_URL: "__MEDPLUM_BASE_URL__"
-          MEDPLUM_CLIENT_ID: "__MEDPLUM_CLIENT_ID__"
-          MEDPLUM_REGISTER_ENABLED: "__MEDPLUM_REGISTER_ENABLED__"
-          MEDPLUM_AWS_TEXTRACT_ENABLED: "__MEDPLUM_AWS_TEXTRACT_ENABLED__"
-          GOOGLE_CLIENT_ID: "__GOOGLE_CLIENT_ID__"
-          RECAPTCHA_SITE_KEY: "__RECAPTCHA_SITE_KEY__"
+          MEDPLUM_BASE_URL: '__MEDPLUM_BASE_URL__'
+          MEDPLUM_CLIENT_ID: '__MEDPLUM_CLIENT_ID__'
+          MEDPLUM_REGISTER_ENABLED: '__MEDPLUM_REGISTER_ENABLED__'
+          MEDPLUM_AWS_TEXTRACT_ENABLED: '__MEDPLUM_AWS_TEXTRACT_ENABLED__'
+          GOOGLE_CLIENT_ID: '__GOOGLE_CLIENT_ID__'
+          RECAPTCHA_SITE_KEY: '__RECAPTCHA_SITE_KEY__'
 
       - name: Update npm # Ensure npm 11.5.1 or later is installed
         run: npm install -g npm@latest
@@ -109,10 +109,10 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     env:
-      NODE_VERSION: "20"
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: "remote:rw"
+      TURBO_CACHE: 'remote:rw'
     permissions:
       actions: read
       contents: write
@@ -136,14 +136,14 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       # See: https://github.com/actions/cache/blob/5a3ec84eff668545956fd18022155c47e93e2684/examples.md#node---npm
       - name: Get npm cache directory
@@ -281,10 +281,10 @@ jobs:
     runs-on: ${{ matrix.arch.image }}
     timeout-minutes: 45
     env:
-      NODE_VERSION: "20"
+      NODE_VERSION: '20'
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_CACHE: "remote:rw"
+      TURBO_CACHE: 'remote:rw'
     permissions:
       actions: read
       contents: write
@@ -299,7 +299,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Cache node modules
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4


### PR DESCRIPTION
Fixes #7621 

Basically Chocolatey's NSIS package doesn't actually add `makensis` to PATH automatically...
We've been relying on the `makensis` in the PATH on the default `windows-latest` image, which previously pointed to the `windows-2022` image until very recently. After the `windows-latest` tag changed to `windows-2025`, NSIS is no longer in PATH by default on the base image, hence why we are seeing breakages.

The fix is to just manually add NSIS to PATH since we are already installing it ourselves.