### PR TITLE
feat(server): optimizing queries on token array columns by merging conditions

### DIFF
--- a/packages/server/src/fhir/token-column.test.ts
+++ b/packages/server/src/fhir/token-column.test.ts
@@ -139,12 +139,8 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
 
-      expect(expr).toBeInstanceOf(Disjunction);
-      const disjunction = expr as Disjunction;
-      expect(disjunction.expressions).toHaveLength(1);
-
-      const cond = disjunction.expressions[0] as Condition;
-      expect(cond).toBeInstanceOf(Condition);
+      expect(expr).toBeInstanceOf(Condition);
+      const cond = expr as Condition;
       expect(cond.column).toBeInstanceOf(Column);
       expect((cond.column as Column).actualColumnName).toBe('__identifier');
       expect(cond.operator).toBe('ARRAY_OVERLAPS');
@@ -169,12 +165,8 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
 
-      expect(expr).toBeInstanceOf(Disjunction);
-      const disjunction = expr as Disjunction;
-      expect(disjunction.expressions).toHaveLength(1);
-
-      const cond = disjunction.expressions[0] as Condition;
-      expect(cond).toBeInstanceOf(Condition);
+      expect(expr).toBeInstanceOf(Condition);
+      const cond = expr as Condition;
       expect(cond.operator).toBe('ARRAY_OVERLAPS');
 
       // Searching for just the value - parameter is now an array
@@ -196,11 +188,8 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
 
-      expect(expr).toBeInstanceOf(Disjunction);
-      const disjunction = expr as Disjunction;
-      expect(disjunction.expressions).toHaveLength(1);
-
-      const cond = disjunction.expressions[0] as Condition;
+      expect(expr).toBeInstanceOf(Condition);
+      const cond = expr as Condition;
       expect(cond.operator).toBe('ARRAY_OVERLAPS');
 
       // Searching for just the system - parameter is now an array
@@ -222,11 +211,8 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
 
-      expect(expr).toBeInstanceOf(Disjunction);
-      const disjunction = expr as Disjunction;
-      expect(disjunction.expressions).toHaveLength(1);
-
-      const cond = disjunction.expressions[0] as Condition;
+      expect(expr).toBeInstanceOf(Condition);
+      const cond = expr as Condition;
       expect(cond.operator).toBe('ARRAY_OVERLAPS');
 
       // Searching for NULL_SYSTEM with value - parameter is now an array
@@ -249,12 +235,8 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
 
-      expect(expr).toBeInstanceOf(Disjunction);
-      const disjunction = expr as Disjunction;
-      // Now creates a single expression with both values in the parameter array
-      expect(disjunction.expressions).toHaveLength(1);
-
-      const cond = disjunction.expressions[0] as Condition;
+      expect(expr).toBeInstanceOf(Condition);
+      const cond = expr as Condition;
       expect(cond.operator).toBe('ARRAY_OVERLAPS');
 
       // Both hashes are now in a single parameter array (more efficient SQL)
@@ -277,8 +259,7 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
 
-      const disjunction = expr as Disjunction;
-      const cond = disjunction.expressions[0] as Condition;
+      const cond = expr as Condition;
 
       // Should NOT be lowercased (identifiers are case-sensitive) - parameter is now an array
       const expectedHash = hashTokenColumnValue(DELIM + 'ABC123');
@@ -299,8 +280,7 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       const expr = buildTokenColumnsSearchFilter('ResearchStudy', 'ResearchStudy', param, filter);
 
-      const disjunction = expr as Disjunction;
-      const cond = disjunction.expressions[0] as Condition;
+      const cond = expr as Condition;
 
       expect((cond.column as Column).actualColumnName).toBe('__sharedTokens');
 
@@ -327,7 +307,7 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       expect(expr).toBeInstanceOf(Negation);
       const negation = expr as Negation;
-      expect(negation.expression).toBeInstanceOf(Disjunction);
+      expect(negation.expression).toBeInstanceOf(Condition);
     });
 
     test('NOT_EQUALS operator with single value', () => {
@@ -346,7 +326,7 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       expect(expr).toBeInstanceOf(Negation);
       const negation = expr as Negation;
-      expect(negation.expression).toBeInstanceOf(Disjunction);
+      expect(negation.expression).toBeInstanceOf(Condition);
     });
 
     test('NOT operator with comma-separated values', () => {
@@ -365,13 +345,11 @@ describe('buildTokenColumnsSearchFilter', () => {
 
       expect(expr).toBeInstanceOf(Negation);
       const negation = expr as Negation;
-      expect(negation.expression).toBeInstanceOf(Disjunction);
+      expect(negation.expression).toBeInstanceOf(Condition);
 
       // The inner disjunction now has 1 expression with both values in the parameter array
-      const disjunction = negation.expression as Disjunction;
-      expect(disjunction.expressions).toHaveLength(1);
-
-      const cond = disjunction.expressions[0] as Condition;
+      const cond = negation.expression as Condition;
+      expect(cond.operator).toBe('ARRAY_OVERLAPS');
       const expectedHash1 = hashTokenColumnValue(DELIM + '12345');
       const expectedHash2 = hashTokenColumnValue(DELIM + '67890');
       expect(cond.parameter).toEqual([expectedHash1, expectedHash2]);
@@ -646,12 +624,10 @@ describe('buildTokenColumnsSearchFilter', () => {
         value: '12345',
       };
 
-      const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter);
+      const expr = buildTokenColumnsSearchFilter('Patient', 'Patient', param, filter) as Condition;
 
-      expect(expr).toBeInstanceOf(Disjunction);
-      const disjunction = expr as Disjunction;
-      const cond = disjunction.expressions[0] as TypedCondition<'ARRAY_OVERLAPS'>;
-      expect(cond.operator).toBe('ARRAY_OVERLAPS');
+      expect(expr).toBeInstanceOf(Condition);
+      expect(expr.operator).toBe('ARRAY_OVERLAPS');
     });
   });
 

--- a/packages/server/src/fhir/token-column.ts
+++ b/packages/server/src/fhir/token-column.ts
@@ -184,7 +184,7 @@ export function buildTokenColumnsSearchFilter(
       filter.operator satisfies TokenQueryOperator;
 
       // https://www.hl7.org/fhir/r4/search.html#combining
-      const expressions = buildTokenColumnsWhereConditionEqualsAndExact(
+      const expression = buildTokenColumnsWhereConditionEqualsAndExact(
         impl,
         tableName,
         filter.code,
@@ -192,11 +192,11 @@ export function buildTokenColumnsSearchFilter(
         filter.value
       );
 
-      const expression = new Disjunction(expressions);
       if (filter.operator === FhirOperator.NOT || filter.operator === FhirOperator.NOT_EQUALS) {
         return new Negation(expression);
+      } else {
+        return expression;
       }
-      return expression;
     }
     case FhirOperator.MISSING:
     case FhirOperator.PRESENT: {
@@ -314,7 +314,7 @@ function buildTokenColumnsWhereConditionEqualsAndExact(
   code: string,
   operator: TokenQueryOperator,
   filterValue: string
-): Expression[] {
+): Expression {
   const searchStrings: string[] = [];
   const queries = splitSearchOnComma(filterValue).map((query) => query.trim());
   for (const query of queries) {
@@ -358,8 +358,7 @@ function buildTokenColumnsWhereConditionEqualsAndExact(
     searchStrings,
     'UUID[]'
   );
-  // list of one to match the signature of the function
-  return [condition];
+  return condition;
 }
 
 export function escapeRegexString(str: string): string {


### PR DESCRIPTION
## Summary

The current code generates sub-optimal queries such as:

```sql
select
	"Task"."id",
	"Task"."lastUpdated",
	"Task"."content"
from
	"Task"
where
-- shortened for abbreviation
and ("Task"."___tag" @> array[$13]::UUID[]
	or "Task"."___tag" @> array[$14]::UUID[]
	or "Task"."___tag" @> array[$15]::UUID[]
	or "Task"."___tag" @> array[$16]::UUID[]
	or "Task"."___tag" @> array[$17]::UUID[]
	or "Task"."___tag" @> array[$18]::UUID[]
	or "Task"."___tag" @> array[$19]::UUID[]
	or "Task"."___tag" @> array[$20]::UUID[]
	or "Task"."___tag" @> array[$21]::UUID[]
	or "Task"."___tag" @> array[$22]::UUID[]
	or "Task"."___tag" @> array[$23]::UUID[]
	or "Task"."___tag" @> array[$24]::UUID[]
	or "Task"."___tag" @> array[$25]::UUID[]
	or "Task"."___tag" @> array[$26]::UUID[]
	or "Task"."___tag" @> array[$27]::UUID[]
	or "Task"."___tag" @> array[$28]::UUID[]
	or "Task"."___tag" @> array[$29]::UUID[]
	or "Task"."___tag" @> array[$30]::UUID[]
	or "Task"."___tag" @> array[$31]::UUID[]
	or "Task"."___tag" @> array[$32]::UUID[]
	or "Task"."___tag" @> array[$33]::UUID[]
	or "Task"."___tag" @> array[$34]::UUID[]
	or "Task"."___tag" @> array[$35]::UUID[])))
```

Queries like this, besides the aesthetics, are also difficult for PostgreSQL to optimize, resulting in query plans such as (shortened for readability):

```
      ->  Bitmap Heap Scan on "Task"  (cost=3106.61..4193.78 rows=57 width=205) (actual time=60.235..177.756 rows=6212 loops=1)
	    Recheck Cond: (((___tag @> '{e602907a-a73d-570f-a131-95004e3f7a82}'::uuid[]) OR (___tag @> '{66c6b667-60f0-52d7-8986-239132731ae4}'::uuid[]) OR (___tag @> '{542ba5cf-4efc-5d04-93ab-f23ad4181a7e}'::uuid[]) OR (___tag @> '{9e2097e5-03ef-5cc2-9d5a-0e89c0a11cac}'::uuid[]) OR (___tag @> '{2080d429-b7fd-57b6-ae7e-ff3eada82079}'::uuid[]) OR (___tag @> '{848e40be-8fe5-5905-abcc-d7d444617371}'::uuid[]) OR (___tag @> '{6d56068d-056a-5a48-929a-f3a7a8a6fc8b}'::uuid[]) OR (___tag @> '{0023aea4-9358-5041-bcbb-6f3cbe4fbb58}'::uuid[]) OR (___tag @> '{2b9bebf3-942b-5841-8d7b-b847eb9509c4}'::uuid[]) OR (___tag @> '{27d09587-91a7-50e1-84a7-f7266785e66c}'::uuid[]) OR (___tag @> '{26644ac9-334a-5775-a3ed-792f64d7c868}'::uuid[]) OR (___tag @> '{f37cf46d-71ab-5527-9b5b-d147536b31b6}'::uuid[]) OR (___tag @> '{cf4a2b11-e25e-5550-a223-f449c1640d44}'::uuid[]) OR (___tag @> '{fafbcfa7-9756-5895-a458-56b6037ca8bd}'::uuid[]) OR (___tag @> '{4c3b69f1-a8e0-57e4-aa87-cff0b3f7b65d}'::uuid[]) OR (___tag @> '{e87da7da-d2bb-51e4-88ef-cc43efe8ed5e}'::uuid[]) OR (___tag @> '{b316a9df-c5d0-5c5c-bb6b-3351e5bb42fe}'::uuid[]) OR (___tag @> '{15e5699a-7775-59f8-bbe1-664857d0418e}'::uuid[]) OR (___tag @> '{dac5fcb6-5578-5ccb-a184-d990a173264b}'::uuid[]) OR (___tag @> '{173578ac-0ad9-5c6a-bef9-ab57abaf65c8}'::uuid[]) OR (___tag @> '{73ed7430-d703-5dc5-a701-f2a73c548697}'::uuid[]) OR (___tag @> '{2973e373-d545-5c68-bc01-d18b2d9db794}'::uuid[]) OR (___tag @> '{7f2f5270-10dc-5537-9449-03737ef1c26d}'::uuid[])) AND ("projectId" = 'fc27d50d-623c-48db-aa04-176d9133474e'::uuid))
	    Filter: ((NOT deleted) AND (status <> ALL ('{completed,rejected,accepted,cancelled,draft}'::text[])))
	    Rows Removed by Filter: 74915
	    Heap Blocks: exact=70217
	    Buffers: shared hit=72462
	    ->  BitmapAnd  (cost=3106.61..3106.61 rows=926 width=0) (actual time=46.912..46.923 rows=0 loops=1)
		  Buffers: shared hit=2245
		  ->  BitmapOr  (cost=582.07..582.07 rows=90746 width=0) (actual time=17.062..17.073 rows=0 loops=1)
			Buffers: shared hit=131
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..8.57 rows=888 width=0) (actual time=0.169..0.169 rows=1025 loops=1)
			      Index Cond: (___tag @> '{e602907a-a73d-570f-a131-95004e3f7a82}'::uuid[])
			      Buffers: shared hit=4
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..118.52 rows=21164 width=0) (actual time=3.772..3.772 rows=21513 loops=1)
			      Index Cond: (___tag @> '{66c6b667-60f0-52d7-8986-239132731ae4}'::uuid[])
			      Buffers: shared hit=16
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..6.48 rows=470 width=0) (actual time=0.076..0.077 rows=510 loops=1)
			      Index Cond: (___tag @> '{542ba5cf-4efc-5d04-93ab-f23ad4181a7e}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..83.94 rows=14737 width=0) (actual time=3.032..3.033 rows=14239 loops=1)
			      Index Cond: (___tag @> '{9e2097e5-03ef-5cc2-9d5a-0e89c0a11cac}'::uuid[])
			      Buffers: shared hit=13
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.65 rows=105 width=0) (actual time=0.025..0.025 rows=139 loops=1)
			      Index Cond: (___tag @> '{2080d429-b7fd-57b6-ae7e-ff3eada82079}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.39 rows=52 width=0) (actual time=0.024..0.025 rows=109 loops=1)
			      Index Cond: (___tag @> '{848e40be-8fe5-5905-abcc-d7d444617371}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..10.92 rows=1359 width=0) (actual time=0.203..0.203 rows=1520 loops=1)
			      Index Cond: (___tag @> '{6d56068d-056a-5a48-929a-f3a7a8a6fc8b}'::uuid[])
			      Buffers: shared hit=4
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..11.18 rows=1411 width=0) (actual time=0.192..0.193 rows=1495 loops=1)
			      Index Cond: (___tag @> '{0023aea4-9358-5041-bcbb-6f3cbe4fbb58}'::uuid[])
			      Buffers: shared hit=4
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.26 rows=26 width=0) (actual time=0.011..0.011 rows=38 loops=1)
			      Index Cond: (___tag @> '{2b9bebf3-942b-5841-8d7b-b847eb9509c4}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..51.96 rows=8832 width=0) (actual time=1.222..1.222 rows=9151 loops=1)
			      Index Cond: (___tag @> '{27d09587-91a7-50e1-84a7-f7266785e66c}'::uuid[])
			      Buffers: shared hit=9
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..88.12 rows=15573 width=0) (actual time=4.908..4.908 rows=17698 loops=1)
			      Index Cond: (___tag @> '{26644ac9-334a-5775-a3ed-792f64d7c868}'::uuid[])
			      Buffers: shared hit=14
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..13.80 rows=1934 width=0) (actual time=0.245..0.245 rows=1714 loops=1)
			      Index Cond: (___tag @> '{f37cf46d-71ab-5527-9b5b-d147536b31b6}'::uuid[])
			      Buffers: shared hit=4
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..6.74 rows=523 width=0) (actual time=0.060..0.060 rows=393 loops=1)
			      Index Cond: (___tag @> '{cf4a2b11-e25e-5550-a223-f449c1640d44}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.26 rows=26 width=0) (actual time=0.006..0.006 rows=6 loops=1)
			      Index Cond: (___tag @> '{fafbcfa7-9756-5895-a458-56b6037ca8bd}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.26 rows=26 width=0) (actual time=0.006..0.006 rows=6 loops=1)
			      Index Cond: (___tag @> '{4c3b69f1-a8e0-57e4-aa87-cff0b3f7b65d}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.39 rows=52 width=0) (actual time=0.007..0.007 rows=15 loops=1)
			      Index Cond: (___tag @> '{e87da7da-d2bb-51e4-88ef-cc43efe8ed5e}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.26 rows=26 width=0) (actual time=0.009..0.009 rows=7 loops=1)
			      Index Cond: (___tag @> '{b316a9df-c5d0-5c5c-bb6b-3351e5bb42fe}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..4.26 rows=26 width=0) (actual time=0.011..0.011 rows=31 loops=1)
			      Index Cond: (___tag @> '{15e5699a-7775-59f8-bbe1-664857d0418e}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..8.57 rows=888 width=0) (actual time=0.139..0.139 rows=952 loops=1)
			      Index Cond: (___tag @> '{dac5fcb6-5578-5ccb-a184-d990a173264b}'::uuid[])
			      Buffers: shared hit=4
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..79.23 rows=13796 width=0) (actual time=1.790..1.790 rows=13339 loops=1)
			      Index Cond: (___tag @> '{173578ac-0ad9-5c6a-bef9-ab57abaf65c8}'::uuid[])
			      Buffers: shared hit=13
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..5.43 rows=261 width=0) (actual time=0.062..0.063 rows=352 loops=1)
			      Index Cond: (___tag @> '{73ed7430-d703-5dc5-a701-f2a73c548697}'::uuid[])
			      Buffers: shared hit=3
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..26.52 rows=4233 width=0) (actual time=0.557..0.557 rows=3876 loops=1)
			      Index Cond: (___tag @> '{2973e373-d545-5c68-bc01-d18b2d9db794}'::uuid[])
			      Buffers: shared hit=7
			->  Bitmap Index Scan on "Task____tag_idx"  (cost=0.00..27.04 rows=4337 width=0) (actual time=0.529..0.529 rows=3747 loops=1)
			      Index Cond: (___tag @> '{7f2f5270-10dc-5537-9449-03737ef1c26d}'::uuid[])
			      Buffers: shared hit=6
```

Note:
* separate index scan for every condition
*  the `Recheck Cond` where the each record has to be scanned.


## Impact

These queries are some of the slowest in our prod system, affecting `CarePlan`, `Patient`, `Task`, `AuditEvent`. Some queries have as many 1500 parameters, and take up to a minute before they time out.

Perhaps the better long-term solution is to improve `buildTokenColumnsSearchFilter()` to better handle values split on commas, but I believe this is a decent stopgap measure.

All existing tests pass without modification, and new ones have been added for the new `combineExpressions()` function.  More advice on what kinds of tests to write are welcome.
