### PR TITLE
Fixed license header in build scripts

### DIFF
--- a/examples/foomedical/postcss.config.mjs
+++ b/examples/foomedical/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-chart-demo/esbuild-script.mjs
+++ b/examples/medplum-chart-demo/esbuild-script.mjs
@@ -1,7 +1,7 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /* global process */
-/* eslint no-console: "off" */
-/*eslint no-process-exit: "off"*/
+/* global console */
 
 import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };
 import esbuild from 'esbuild';

--- a/examples/medplum-chart-demo/postcss.config.mjs
+++ b/examples/medplum-chart-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-chat-demo/postcss.config.mjs
+++ b/examples/medplum-chat-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-eligibility-demo/postcss.config.mjs
+++ b/examples/medplum-eligibility-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-fhircast-demo/postcss.config.mjs
+++ b/examples/medplum-fhircast-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-health-gorilla-demo/src/postcss.config.mjs
+++ b/examples/medplum-health-gorilla-demo/src/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-healthie-importer/esbuild-script.mjs
+++ b/examples/medplum-healthie-importer/esbuild-script.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 /*eslint no-process-exit: "off"*/
 
 import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };

--- a/examples/medplum-hello-world/postcss.config.mjs
+++ b/examples/medplum-hello-world/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-live-chat-demo/postcss.config.mjs
+++ b/examples/medplum-live-chat-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-mso-demo/postcss.config.mjs
+++ b/examples/medplum-mso-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-nextauth-demo/next.config.mjs
+++ b/examples/medplum-nextauth-demo/next.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,

--- a/examples/medplum-nextjs-demo/next.config.mjs
+++ b/examples/medplum-nextjs-demo/next.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,

--- a/examples/medplum-patient-intake-demo/esbuild-script.mjs
+++ b/examples/medplum-patient-intake-demo/esbuild-script.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 /*eslint no-process-exit: "off"*/
 
 import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };

--- a/examples/medplum-patient-intake-demo/postcss.config.mjs
+++ b/examples/medplum-patient-intake-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-photon-integration/esbuild-script.mjs
+++ b/examples/medplum-photon-integration/esbuild-script.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 /*eslint no-process-exit: "off"*/
 
 import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };

--- a/examples/medplum-photon-integration/postcss.config.mjs
+++ b/examples/medplum-photon-integration/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-provider/postcss.config.mjs
+++ b/examples/medplum-provider/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-scheduling-demo/esbuild-script.mjs
+++ b/examples/medplum-scheduling-demo/esbuild-script.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 /*eslint no-process-exit: "off"*/
 
 import botLayer from '@medplum/bot-layer/package.json' with { type: 'json' };

--- a/examples/medplum-scheduling-demo/postcss.config.mjs
+++ b/examples/medplum-scheduling-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-task-demo/postcss.config.mjs
+++ b/examples/medplum-task-demo/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/examples/medplum-valueset-selector/postcss.config.mjs
+++ b/examples/medplum-valueset-selector/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/packages/agent/esbuild.mjs
+++ b/packages/agent/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'node:fs';

--- a/packages/app/postcss.config.mjs
+++ b/packages/app/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 

--- a/packages/ccda/esbuild.mjs
+++ b/packages/ccda/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/cdk/esbuild.mjs
+++ b/packages/cdk/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/cli-wrapper/esbuild.mjs
+++ b/packages/cli-wrapper/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'node:fs';

--- a/packages/cli/esbuild.mjs
+++ b/packages/cli/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'node:fs';

--- a/packages/core/esbuild.mjs
+++ b/packages/core/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import { execSync } from 'child_process';
 import esbuild from 'esbuild';

--- a/packages/create-medplum/esbuild.mjs
+++ b/packages/create-medplum/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'node:fs';

--- a/packages/dosespot-react/esbuild.mjs
+++ b/packages/dosespot-react/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/fhir-router/esbuild.mjs
+++ b/packages/fhir-router/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/health-gorilla-core/esbuild.mjs
+++ b/packages/health-gorilla-core/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/health-gorilla-react/esbuild.mjs
+++ b/packages/health-gorilla-react/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/hl7/esbuild.mjs
+++ b/packages/hl7/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/mock/esbuild.mjs
+++ b/packages/mock/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import esbuild from 'esbuild';
 import { writeFileSync } from 'fs';

--- a/packages/react-hooks/esbuild.mjs
+++ b/packages/react-hooks/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import dotenv from 'dotenv';
 import esbuild from 'esbuild';

--- a/packages/react/esbuild.mjs
+++ b/packages/react/esbuild.mjs
@@ -1,6 +1,8 @@
-/* global console */
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
+
 /* global process */
-/* eslint no-console: "off" */
+/* global console */
 
 import dotenv from 'dotenv';
 import esbuild from 'esbuild';

--- a/packages/react/postcss.config.mjs
+++ b/packages/react/postcss.config.mjs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 import mantinePreset from 'postcss-preset-mantine';
 import simpleVars from 'postcss-simple-vars';
 


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/7190

In the original PR, we added the required license header to all "source" files, but we missed all build scripts.