### PR TITLE
Fixed fhirtypes license headers

### DIFF
--- a/packages/fhirtypes/dist/AccessPolicy.d.ts
+++ b/packages/fhirtypes/dist/AccessPolicy.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Account.d.ts
+++ b/packages/fhirtypes/dist/Account.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ActivityDefinition.d.ts
+++ b/packages/fhirtypes/dist/ActivityDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Address.d.ts
+++ b/packages/fhirtypes/dist/Address.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/AdverseEvent.d.ts
+++ b/packages/fhirtypes/dist/AdverseEvent.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Age.d.ts
+++ b/packages/fhirtypes/dist/Age.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Agent.d.ts
+++ b/packages/fhirtypes/dist/Agent.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/AllergyIntolerance.d.ts
+++ b/packages/fhirtypes/dist/AllergyIntolerance.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Annotation.d.ts
+++ b/packages/fhirtypes/dist/Annotation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Appointment.d.ts
+++ b/packages/fhirtypes/dist/Appointment.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/AppointmentResponse.d.ts
+++ b/packages/fhirtypes/dist/AppointmentResponse.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/AsyncJob.d.ts
+++ b/packages/fhirtypes/dist/AsyncJob.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Attachment.d.ts
+++ b/packages/fhirtypes/dist/Attachment.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/AuditEvent.d.ts
+++ b/packages/fhirtypes/dist/AuditEvent.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/BackboneElement.d.ts
+++ b/packages/fhirtypes/dist/BackboneElement.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Basic.d.ts
+++ b/packages/fhirtypes/dist/Basic.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Binary.d.ts
+++ b/packages/fhirtypes/dist/Binary.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/BiologicallyDerivedProduct.d.ts
+++ b/packages/fhirtypes/dist/BiologicallyDerivedProduct.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/BodyStructure.d.ts
+++ b/packages/fhirtypes/dist/BodyStructure.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Bot.d.ts
+++ b/packages/fhirtypes/dist/Bot.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/BulkDataExport.d.ts
+++ b/packages/fhirtypes/dist/BulkDataExport.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Bundle.d.ts
+++ b/packages/fhirtypes/dist/Bundle.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CapabilityStatement.d.ts
+++ b/packages/fhirtypes/dist/CapabilityStatement.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CarePlan.d.ts
+++ b/packages/fhirtypes/dist/CarePlan.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CareTeam.d.ts
+++ b/packages/fhirtypes/dist/CareTeam.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CatalogEntry.d.ts
+++ b/packages/fhirtypes/dist/CatalogEntry.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ChargeItem.d.ts
+++ b/packages/fhirtypes/dist/ChargeItem.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ChargeItemDefinition.d.ts
+++ b/packages/fhirtypes/dist/ChargeItemDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Claim.d.ts
+++ b/packages/fhirtypes/dist/Claim.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ClaimResponse.d.ts
+++ b/packages/fhirtypes/dist/ClaimResponse.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ClientApplication.d.ts
+++ b/packages/fhirtypes/dist/ClientApplication.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ClinicalImpression.d.ts
+++ b/packages/fhirtypes/dist/ClinicalImpression.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CodeSystem.d.ts
+++ b/packages/fhirtypes/dist/CodeSystem.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CodeableConcept.d.ts
+++ b/packages/fhirtypes/dist/CodeableConcept.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Coding.d.ts
+++ b/packages/fhirtypes/dist/Coding.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Communication.d.ts
+++ b/packages/fhirtypes/dist/Communication.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CommunicationRequest.d.ts
+++ b/packages/fhirtypes/dist/CommunicationRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CompartmentDefinition.d.ts
+++ b/packages/fhirtypes/dist/CompartmentDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Composition.d.ts
+++ b/packages/fhirtypes/dist/Composition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ConceptMap.d.ts
+++ b/packages/fhirtypes/dist/ConceptMap.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Condition.d.ts
+++ b/packages/fhirtypes/dist/Condition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Consent.d.ts
+++ b/packages/fhirtypes/dist/Consent.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ContactDetail.d.ts
+++ b/packages/fhirtypes/dist/ContactDetail.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ContactPoint.d.ts
+++ b/packages/fhirtypes/dist/ContactPoint.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Contract.d.ts
+++ b/packages/fhirtypes/dist/Contract.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Contributor.d.ts
+++ b/packages/fhirtypes/dist/Contributor.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Count.d.ts
+++ b/packages/fhirtypes/dist/Count.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Coverage.d.ts
+++ b/packages/fhirtypes/dist/Coverage.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CoverageEligibilityRequest.d.ts
+++ b/packages/fhirtypes/dist/CoverageEligibilityRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/CoverageEligibilityResponse.d.ts
+++ b/packages/fhirtypes/dist/CoverageEligibilityResponse.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DataRequirement.d.ts
+++ b/packages/fhirtypes/dist/DataRequirement.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DetectedIssue.d.ts
+++ b/packages/fhirtypes/dist/DetectedIssue.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Device.d.ts
+++ b/packages/fhirtypes/dist/Device.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DeviceDefinition.d.ts
+++ b/packages/fhirtypes/dist/DeviceDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DeviceMetric.d.ts
+++ b/packages/fhirtypes/dist/DeviceMetric.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DeviceRequest.d.ts
+++ b/packages/fhirtypes/dist/DeviceRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DeviceUseStatement.d.ts
+++ b/packages/fhirtypes/dist/DeviceUseStatement.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DiagnosticReport.d.ts
+++ b/packages/fhirtypes/dist/DiagnosticReport.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Distance.d.ts
+++ b/packages/fhirtypes/dist/Distance.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DocumentManifest.d.ts
+++ b/packages/fhirtypes/dist/DocumentManifest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DocumentReference.d.ts
+++ b/packages/fhirtypes/dist/DocumentReference.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/DomainConfiguration.d.ts
+++ b/packages/fhirtypes/dist/DomainConfiguration.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Dosage.d.ts
+++ b/packages/fhirtypes/dist/Dosage.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Duration.d.ts
+++ b/packages/fhirtypes/dist/Duration.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/EffectEvidenceSynthesis.d.ts
+++ b/packages/fhirtypes/dist/EffectEvidenceSynthesis.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Element.d.ts
+++ b/packages/fhirtypes/dist/Element.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ElementDefinition.d.ts
+++ b/packages/fhirtypes/dist/ElementDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Encounter.d.ts
+++ b/packages/fhirtypes/dist/Encounter.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Endpoint.d.ts
+++ b/packages/fhirtypes/dist/Endpoint.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/EnrollmentRequest.d.ts
+++ b/packages/fhirtypes/dist/EnrollmentRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/EnrollmentResponse.d.ts
+++ b/packages/fhirtypes/dist/EnrollmentResponse.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/EpisodeOfCare.d.ts
+++ b/packages/fhirtypes/dist/EpisodeOfCare.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/EventDefinition.d.ts
+++ b/packages/fhirtypes/dist/EventDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Evidence.d.ts
+++ b/packages/fhirtypes/dist/Evidence.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/EvidenceVariable.d.ts
+++ b/packages/fhirtypes/dist/EvidenceVariable.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ExampleScenario.d.ts
+++ b/packages/fhirtypes/dist/ExampleScenario.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ExplanationOfBenefit.d.ts
+++ b/packages/fhirtypes/dist/ExplanationOfBenefit.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Expression.d.ts
+++ b/packages/fhirtypes/dist/Expression.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Extension.d.ts
+++ b/packages/fhirtypes/dist/Extension.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/FamilyMemberHistory.d.ts
+++ b/packages/fhirtypes/dist/FamilyMemberHistory.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Flag.d.ts
+++ b/packages/fhirtypes/dist/Flag.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Goal.d.ts
+++ b/packages/fhirtypes/dist/Goal.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/GraphDefinition.d.ts
+++ b/packages/fhirtypes/dist/GraphDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Group.d.ts
+++ b/packages/fhirtypes/dist/Group.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/GuidanceResponse.d.ts
+++ b/packages/fhirtypes/dist/GuidanceResponse.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/HealthcareService.d.ts
+++ b/packages/fhirtypes/dist/HealthcareService.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/HumanName.d.ts
+++ b/packages/fhirtypes/dist/HumanName.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Identifier.d.ts
+++ b/packages/fhirtypes/dist/Identifier.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/IdentityProvider.d.ts
+++ b/packages/fhirtypes/dist/IdentityProvider.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ImagingStudy.d.ts
+++ b/packages/fhirtypes/dist/ImagingStudy.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Immunization.d.ts
+++ b/packages/fhirtypes/dist/Immunization.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ImmunizationEvaluation.d.ts
+++ b/packages/fhirtypes/dist/ImmunizationEvaluation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ImmunizationRecommendation.d.ts
+++ b/packages/fhirtypes/dist/ImmunizationRecommendation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ImplementationGuide.d.ts
+++ b/packages/fhirtypes/dist/ImplementationGuide.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/InsurancePlan.d.ts
+++ b/packages/fhirtypes/dist/InsurancePlan.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Invoice.d.ts
+++ b/packages/fhirtypes/dist/Invoice.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/JsonWebKey.d.ts
+++ b/packages/fhirtypes/dist/JsonWebKey.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Library.d.ts
+++ b/packages/fhirtypes/dist/Library.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Linkage.d.ts
+++ b/packages/fhirtypes/dist/Linkage.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/List.d.ts
+++ b/packages/fhirtypes/dist/List.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Location.d.ts
+++ b/packages/fhirtypes/dist/Location.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Login.d.ts
+++ b/packages/fhirtypes/dist/Login.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MarketingStatus.d.ts
+++ b/packages/fhirtypes/dist/MarketingStatus.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Measure.d.ts
+++ b/packages/fhirtypes/dist/Measure.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MeasureReport.d.ts
+++ b/packages/fhirtypes/dist/MeasureReport.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Media.d.ts
+++ b/packages/fhirtypes/dist/Media.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Medication.d.ts
+++ b/packages/fhirtypes/dist/Medication.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicationAdministration.d.ts
+++ b/packages/fhirtypes/dist/MedicationAdministration.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicationDispense.d.ts
+++ b/packages/fhirtypes/dist/MedicationDispense.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicationKnowledge.d.ts
+++ b/packages/fhirtypes/dist/MedicationKnowledge.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicationRequest.d.ts
+++ b/packages/fhirtypes/dist/MedicationRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicationStatement.d.ts
+++ b/packages/fhirtypes/dist/MedicationStatement.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProduct.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProduct.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductAuthorization.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductAuthorization.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductContraindication.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductContraindication.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductIndication.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductIndication.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductIngredient.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductIngredient.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductInteraction.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductInteraction.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductManufactured.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductManufactured.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductPackaged.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductPackaged.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductPharmaceutical.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductPharmaceutical.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MedicinalProductUndesirableEffect.d.ts
+++ b/packages/fhirtypes/dist/MedicinalProductUndesirableEffect.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MessageDefinition.d.ts
+++ b/packages/fhirtypes/dist/MessageDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MessageHeader.d.ts
+++ b/packages/fhirtypes/dist/MessageHeader.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Meta.d.ts
+++ b/packages/fhirtypes/dist/Meta.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MetadataResource.d.ts
+++ b/packages/fhirtypes/dist/MetadataResource.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MolecularSequence.d.ts
+++ b/packages/fhirtypes/dist/MolecularSequence.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Money.d.ts
+++ b/packages/fhirtypes/dist/Money.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/MoneyQuantity.d.ts
+++ b/packages/fhirtypes/dist/MoneyQuantity.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/NamingSystem.d.ts
+++ b/packages/fhirtypes/dist/NamingSystem.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Narrative.d.ts
+++ b/packages/fhirtypes/dist/Narrative.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/NutritionOrder.d.ts
+++ b/packages/fhirtypes/dist/NutritionOrder.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Observation.d.ts
+++ b/packages/fhirtypes/dist/Observation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ObservationDefinition.d.ts
+++ b/packages/fhirtypes/dist/ObservationDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/OperationDefinition.d.ts
+++ b/packages/fhirtypes/dist/OperationDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/OperationOutcome.d.ts
+++ b/packages/fhirtypes/dist/OperationOutcome.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Organization.d.ts
+++ b/packages/fhirtypes/dist/Organization.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/OrganizationAffiliation.d.ts
+++ b/packages/fhirtypes/dist/OrganizationAffiliation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ParameterDefinition.d.ts
+++ b/packages/fhirtypes/dist/ParameterDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Parameters.d.ts
+++ b/packages/fhirtypes/dist/Parameters.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
+++ b/packages/fhirtypes/dist/PasswordChangeRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Patient.d.ts
+++ b/packages/fhirtypes/dist/Patient.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/PaymentNotice.d.ts
+++ b/packages/fhirtypes/dist/PaymentNotice.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/PaymentReconciliation.d.ts
+++ b/packages/fhirtypes/dist/PaymentReconciliation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Period.d.ts
+++ b/packages/fhirtypes/dist/Period.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Person.d.ts
+++ b/packages/fhirtypes/dist/Person.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/PlanDefinition.d.ts
+++ b/packages/fhirtypes/dist/PlanDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Population.d.ts
+++ b/packages/fhirtypes/dist/Population.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Practitioner.d.ts
+++ b/packages/fhirtypes/dist/Practitioner.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/PractitionerRole.d.ts
+++ b/packages/fhirtypes/dist/PractitionerRole.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Procedure.d.ts
+++ b/packages/fhirtypes/dist/Procedure.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ProdCharacteristic.d.ts
+++ b/packages/fhirtypes/dist/ProdCharacteristic.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ProductShelfLife.d.ts
+++ b/packages/fhirtypes/dist/ProductShelfLife.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ProjectMembership.d.ts
+++ b/packages/fhirtypes/dist/ProjectMembership.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Provenance.d.ts
+++ b/packages/fhirtypes/dist/Provenance.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Quantity.d.ts
+++ b/packages/fhirtypes/dist/Quantity.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Questionnaire.d.ts
+++ b/packages/fhirtypes/dist/Questionnaire.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/QuestionnaireResponse.d.ts
+++ b/packages/fhirtypes/dist/QuestionnaireResponse.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Range.d.ts
+++ b/packages/fhirtypes/dist/Range.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Ratio.d.ts
+++ b/packages/fhirtypes/dist/Ratio.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Reference.d.ts
+++ b/packages/fhirtypes/dist/Reference.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/RelatedArtifact.d.ts
+++ b/packages/fhirtypes/dist/RelatedArtifact.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/RelatedPerson.d.ts
+++ b/packages/fhirtypes/dist/RelatedPerson.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/RequestGroup.d.ts
+++ b/packages/fhirtypes/dist/RequestGroup.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ResearchDefinition.d.ts
+++ b/packages/fhirtypes/dist/ResearchDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ResearchElementDefinition.d.ts
+++ b/packages/fhirtypes/dist/ResearchElementDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ResearchStudy.d.ts
+++ b/packages/fhirtypes/dist/ResearchStudy.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ResearchSubject.d.ts
+++ b/packages/fhirtypes/dist/ResearchSubject.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Resource.d.ts
+++ b/packages/fhirtypes/dist/Resource.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ResourceType.d.ts
+++ b/packages/fhirtypes/dist/ResourceType.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/RiskAssessment.d.ts
+++ b/packages/fhirtypes/dist/RiskAssessment.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/RiskEvidenceSynthesis.d.ts
+++ b/packages/fhirtypes/dist/RiskEvidenceSynthesis.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SampledData.d.ts
+++ b/packages/fhirtypes/dist/SampledData.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Schedule.d.ts
+++ b/packages/fhirtypes/dist/Schedule.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SearchParameter.d.ts
+++ b/packages/fhirtypes/dist/SearchParameter.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ServiceRequest.d.ts
+++ b/packages/fhirtypes/dist/ServiceRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Signature.d.ts
+++ b/packages/fhirtypes/dist/Signature.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SimpleQuantity.d.ts
+++ b/packages/fhirtypes/dist/SimpleQuantity.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Slot.d.ts
+++ b/packages/fhirtypes/dist/Slot.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SmartAppLaunch.d.ts
+++ b/packages/fhirtypes/dist/SmartAppLaunch.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Specimen.d.ts
+++ b/packages/fhirtypes/dist/Specimen.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SpecimenDefinition.d.ts
+++ b/packages/fhirtypes/dist/SpecimenDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/StructureDefinition.d.ts
+++ b/packages/fhirtypes/dist/StructureDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/StructureMap.d.ts
+++ b/packages/fhirtypes/dist/StructureMap.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Subscription.d.ts
+++ b/packages/fhirtypes/dist/Subscription.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubscriptionStatus.d.ts
+++ b/packages/fhirtypes/dist/SubscriptionStatus.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Substance.d.ts
+++ b/packages/fhirtypes/dist/Substance.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstanceAmount.d.ts
+++ b/packages/fhirtypes/dist/SubstanceAmount.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstanceNucleicAcid.d.ts
+++ b/packages/fhirtypes/dist/SubstanceNucleicAcid.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstancePolymer.d.ts
+++ b/packages/fhirtypes/dist/SubstancePolymer.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstanceProtein.d.ts
+++ b/packages/fhirtypes/dist/SubstanceProtein.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstanceReferenceInformation.d.ts
+++ b/packages/fhirtypes/dist/SubstanceReferenceInformation.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstanceSourceMaterial.d.ts
+++ b/packages/fhirtypes/dist/SubstanceSourceMaterial.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SubstanceSpecification.d.ts
+++ b/packages/fhirtypes/dist/SubstanceSpecification.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SupplyDelivery.d.ts
+++ b/packages/fhirtypes/dist/SupplyDelivery.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/SupplyRequest.d.ts
+++ b/packages/fhirtypes/dist/SupplyRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Task.d.ts
+++ b/packages/fhirtypes/dist/Task.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/TerminologyCapabilities.d.ts
+++ b/packages/fhirtypes/dist/TerminologyCapabilities.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/TestReport.d.ts
+++ b/packages/fhirtypes/dist/TestReport.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/TestScript.d.ts
+++ b/packages/fhirtypes/dist/TestScript.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/Timing.d.ts
+++ b/packages/fhirtypes/dist/Timing.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/TriggerDefinition.d.ts
+++ b/packages/fhirtypes/dist/TriggerDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/UsageContext.d.ts
+++ b/packages/fhirtypes/dist/UsageContext.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/User.d.ts
+++ b/packages/fhirtypes/dist/User.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/UserConfiguration.d.ts
+++ b/packages/fhirtypes/dist/UserConfiguration.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/UserSecurityRequest.d.ts
+++ b/packages/fhirtypes/dist/UserSecurityRequest.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ValueSet.d.ts
+++ b/packages/fhirtypes/dist/ValueSet.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/VerificationResult.d.ts
+++ b/packages/fhirtypes/dist/VerificationResult.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/ViewDefinition.d.ts
+++ b/packages/fhirtypes/dist/ViewDefinition.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/VisionPrescription.d.ts
+++ b/packages/fhirtypes/dist/VisionPrescription.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.

--- a/packages/fhirtypes/dist/index.d.ts
+++ b/packages/fhirtypes/dist/index.d.ts
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
+// SPDX-License-Identifier: Apache-2.0
 /*
  * This is a generated file
  * Do not edit manually.


### PR DESCRIPTION
Follow-up to https://github.com/medplum/medplum/pull/7190

These weren't caught because they're in `dist`.  We did update the codegen tool though, so this is just getting the output files up to date with the codegen tool.