### PR TITLE
Fix build warning

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -114,7 +114,7 @@ export function resolveId(input: Reference | Resource | undefined): string | und
  * Parses a reference and returns a tuple of [ResourceType, ID].
  * @param reference - A reference to a FHIR resource.
  * @returns A tuple containing the `ResourceType` and the ID of the resource.
- * @throws {OperationOutcomeError} If the reference cannot be parsed.
+ * @throws {@link OperationOutcomeError} If the reference cannot be parsed.
  */
 export function parseReference<T extends Resource>(reference: Reference<T> | undefined): [T['resourceType'], string] {
   if (reference?.reference === undefined) {


### PR DESCRIPTION
Not a great alternative, but this is a long-standing issue https://github.com/microsoft/tsdoc/issues/171

Excerpt from previous build output. 
```
> @medplum/core@4.5.1 api-extractor
> api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts


api-extractor 7.53.1  - https://api-extractor.com/

Using configuration from ./api-extractor.json
Analysis will use the bundled TypeScript version 5.9.3
Warning: src/utils.ts:117:34 - (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
Warning: src/utils.ts:117:12 - (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"

API Extractor completed successfully
```