### PR TITLE
Write null literals in generated SQL

### DIFF
--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -527,6 +527,8 @@ export class SqlBuilder {
   param(value: any): this {
     if (value instanceof Column) {
       this.appendColumn(value);
+    } else if (value === null || value === undefined) {
+      this.append('NULL');
     } else {
       this.values.push(value);
       this.sql.push('$' + this.values.length);


### PR DESCRIPTION
To ameliorate issues where large INSERT statements might run out of SQL placeholders (~16k max in Postgres), we can handle `NULL` as a special case and write it literally into the generated SQL, since it does not have an identifiable type and doesn't work well with prepared statements/placeholders.  This is expected to significantly reduce the number of placeholders needed for most large insertion query patterns
