### PR TITLE
Fixes #7647 - handle contained resources in ResourceDiffTable

### DIFF
--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
-import type { Patient } from '@medplum/fhirtypes';
+import type { MedicationRequest, Patient } from '@medplum/fhirtypes';
 import { MockClient } from '@medplum/mock';
 import { MedplumProvider } from '@medplum/react-hooks';
 import { act, render, screen } from '../test-utils/render';
@@ -243,5 +243,46 @@ describe('ResourceDiffTable', () => {
 
     // There should be 2 download links
     expect(screen.getAllByText('Download')).toHaveLength(2);
+  });
+
+  test('Handles changes in contained resources', async () => {
+    console.warn = jest.fn();
+
+    const original: MedicationRequest = {
+      resourceType: 'MedicationRequest',
+      id: '123',
+      status: 'active',
+      intent: 'order',
+      subject: { reference: 'Patient/456' },
+      contained: [
+        {
+          resourceType: 'Medication',
+          id: 'med1',
+          code: { text: 'Before' },
+        },
+      ],
+    };
+
+    const revised: MedicationRequest = {
+      resourceType: 'MedicationRequest',
+      id: '123',
+      status: 'active',
+      intent: 'order',
+      subject: { reference: 'Patient/456' },
+      contained: [
+        {
+          resourceType: 'Medication',
+          id: 'med1',
+          code: { text: 'After' },
+        },
+      ],
+    };
+
+    await act(async () => {
+      setup({ original, revised });
+    });
+
+    expect(await screen.findByText('Replace contained[0].code.text')).toBeInTheDocument();
+    expect(console.warn).toHaveBeenCalledWith('Failed to get element definition', expect.anything());
   });
 });

--- a/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
+++ b/packages/react/src/ResourceDiffTable/ResourceDiffTable.tsx
@@ -143,13 +143,18 @@ function jsonPathToFhirPath(path: string): string {
 }
 
 function tryGetElementDefinition(resourceType: string, fhirPath: string): InternalSchemaElement | undefined {
-  const details = getSearchParameterDetails(resourceType, {
-    resourceType: 'SearchParameter',
-    base: [resourceType],
-    code: resourceType + '.' + fhirPath,
-    expression: resourceType + '.' + fhirPath,
-  } as SearchParameter);
-  return details?.elementDefinitions?.[0];
+  try {
+    const details = getSearchParameterDetails(resourceType, {
+      resourceType: 'SearchParameter',
+      base: [resourceType],
+      code: resourceType + '.' + fhirPath,
+      expression: resourceType + '.' + fhirPath,
+    } as SearchParameter);
+    return details?.elementDefinitions?.[0];
+  } catch (err) {
+    console.warn('Failed to get element definition', { resourceType, fhirPath, err });
+    return undefined;
+  }
 }
 
 function touchUpValue(


### PR DESCRIPTION
When building the diff table, we attempt to crawl the JSON Patch path to get the `ElementDefinition` of the changed value.  Unfortunately, that logic does not handle crawling into contained resources at this time.  Luckily, we already have logic for handling `ElementDefinition` not found, so the easy fix here is to just swallow the exception and return `undefined`.