### PR TITLE
fix(agent): actually close hl7 clients on stop

### DIFF
--- a/packages/agent/src/app.ts
+++ b/packages/agent/src/app.ts
@@ -576,8 +576,8 @@ export class App {
 
     if (this.hl7Clients.size !== 0) {
       const clientClosePromises = [];
-      for (const channel of this.channels.values()) {
-        clientClosePromises.push(channel.stop());
+      for (const client of this.hl7Clients.values()) {
+        clientClosePromises.push(client.close());
       }
       await Promise.all(clientClosePromises);
     }


### PR DESCRIPTION
Looks like there was a bug introduced by some copy-pasta that is not well-exercised in the wild since `App#stop` is mostly used in tests