### PR TITLE
Fix server relative paths

### DIFF
--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -4,7 +4,6 @@ import { splitN } from '@medplum/core';
 import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { fileURLToPath } from 'url';
 import { loadAwsConfig } from '../cloud/aws/config';
 import { loadAzureConfig } from '../cloud/azure/config';
 import { loadGcpConfig } from '../cloud/gcp/config';
@@ -148,5 +147,5 @@ function loadEnvConfig(): MedplumServerConfig {
  * @returns The configuration.
  */
 async function loadFileConfig(path: string): Promise<MedplumServerConfig> {
-  return JSON.parse(readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), { encoding: 'utf8' }));
+  return JSON.parse(readFileSync(path, { encoding: 'utf8' }));
 }

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.ts
@@ -9,9 +9,9 @@ import {
   HTTP_HL7_ORG,
 } from '@medplum/core';
 import type { Address, Claim, HumanName, Practitioner, RelatedPerson } from '@medplum/fhirtypes';
-import path from 'path';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Content, TDocumentDefinitions } from 'pdfmake/interfaces';
-import { fileURLToPath } from 'url';
 import { getAuthenticatedContext } from '../../../context';
 
 const PAGE_WIDTH = 612;
@@ -106,7 +106,7 @@ export async function getClaimPDFDocDefinition(claim: Claim): Promise<TDocumentD
     pageMargins: 0,
     content: [
       {
-        image: path.relative(process.cwd(), fileURLToPath(new URL('../../../../static/cms1500.png', import.meta.url))),
+        image: relative(process.cwd(), resolve(getDirName(), '../../../../static/cms1500.png')),
         absolutePosition: { x: 0, y: 0 },
         width: PAGE_WIDTH,
         height: PAGE_HEIGHT,
@@ -393,4 +393,13 @@ export function formatHumanName(name: HumanName | undefined): string {
   }
 
   return parts.join(', ');
+}
+
+/**
+ * Returns the directory name of the current module.
+ * Works with both CommonJS and ES modules.
+ * @returns The directory name of the current module.
+ */
+function getDirName(): string {
+  return typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
 }


### PR DESCRIPTION
Fixes regression in CMS1500 base PNG loader due to `__dirname` and ESM related changes.

Original line:

```ts
image: path.relative(process.cwd(), path.resolve(__dirname, '../../../../static/cms1500.png')),
```

Then the broken line when porting to ESM, which assumes that the server will always be run in the proper current working directory.

```ts
image: path.relative(process.cwd(), path.resolve('./static/cms1500.png')),
```

And now our updated line:

```ts
image: relative(process.cwd(), resolve(getDirName(), '../../../../static/cms1500.png')),
```

With this helper:

```
/**
 * Returns the directory name of the current module.
 * Works with both CommonJS and ES modules.
 * @returns The directory name of the current module.
 */
function getDirName(): string {
  return typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
}
```

We use that same helper in `@medplu/definitions`.  Probably an opportunity for abstraction or shared utility.