### PR TITLE
fix(agent): fix running via tsx (revert to cjs)

### DIFF
--- a/packages/agent/esbuild.mjs
+++ b/packages/agent/esbuild.mjs
@@ -15,9 +15,6 @@ const options = {
   resolveExtensions: ['.js', '.ts'],
   target: 'es2021',
   tsconfig: 'tsconfig.json',
-  define: {
-    'import.meta.main': 'true',
-  },
 };
 
 // The single executable application feature only supports running a single embedded CommonJS file.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -13,7 +13,7 @@
   },
   "license": "Apache-2.0",
   "author": "Medplum <hello@medplum.com>",
-  "type": "module",
+  "type": "commonjs",
   "files": [
     "dist"
   ],

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -83,7 +83,7 @@ export async function main(argv: string[]): Promise<void> {
   }
 }
 
-if (import.meta.main) {
+if (require.main === module) {
   main(process.argv).catch((err) => {
     console.log(err);
     process.exit(1);


### PR DESCRIPTION
Was unable to run `npm run agent` since `tsx` respects `package.json`, which says the agent is a module. This means `__dirname` is not present in the runtime, which causes `tsx` to fail.