### PR TITLE
Fixes #7729 - default super admin email, password, client

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -223,7 +223,7 @@ export function initAppServices(config: MedplumServerConfig): Promise<void> {
 
   return requestContextStore.run(AuthenticatedRequestContext.system(), async () => {
     await initDatabase(config);
-    await seedDatabase();
+    await seedDatabase(config);
     await initKeys(config);
     initBinaryStorage(config.binaryStorage);
     initWorkers(config);

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import { splitN } from '@medplum/core';
+import { randomUUID } from 'crypto';
 import { mkdtempSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -87,6 +88,8 @@ export async function loadTestConfig(): Promise<MedplumServerConfig> {
   config.emailProvider = 'none';
   config.logLevel = 'error';
   config.defaultRateLimit = -1; // Disable rate limiter by default in tests
+  config.defaultSuperAdminClientId = randomUUID();
+  config.defaultSuperAdminClientSecret = randomUUID();
   return config;
 }
 

--- a/packages/server/src/config/types.ts
+++ b/packages/server/src/config/types.ts
@@ -57,6 +57,10 @@ export interface MedplumServerConfig {
   heartbeatEnabled?: boolean;
   accurateCountThreshold: number;
   maxSearchOffset?: number;
+  defaultSuperAdminEmail?: string;
+  defaultSuperAdminPassword?: string;
+  defaultSuperAdminClientId?: string;
+  defaultSuperAdminClientSecret?: string;
   defaultBotRuntimeVersion: 'awslambda' | 'vmcontext';
   defaultProjectFeatures?: (
     | 'aws-comprehend'

--- a/packages/server/src/seed.test.ts
+++ b/packages/server/src/seed.test.ts
@@ -75,9 +75,11 @@ describe('Seed', () => {
 
   test('Seeder completes successfully', () =>
     withTestContext(async () => {
+      const config = await loadTestConfig();
+
       // Seeder was already run as part of `initAppServices`, but run it again
       // incase it is ever removed from `initAppServices`
-      await seedDatabase();
+      await seedDatabase(config);
 
       // Make sure all database migrations have run
       const pool = getDatabasePool(DatabaseMode.WRITER);
@@ -101,6 +103,6 @@ describe('Seed', () => {
       expect(project.strictMode).toBe(true);
 
       // Second time, seeder should silently ignore
-      await seedDatabase();
+      await seedDatabase(config);
     }));
 });

--- a/packages/server/src/workers/index.test.ts
+++ b/packages/server/src/workers/index.test.ts
@@ -23,7 +23,7 @@ describe('Workers', () => {
     const config = await loadTestConfig();
     initRedis(config.redis);
     await initDatabase(config);
-    await seedDatabase();
+    await seedDatabase(config);
     initBinaryStorage('file:binary');
     initWorkers(config);
     await closeWorkers();


### PR DESCRIPTION
Before:  When first launching Medplum server, the user had to login with default credentials and then change password.

After: Medplum server config option includes options for `defaultSuperAdminEmail` and `defaultSuperAdminPassword`.

Also: Server config includes options for `defaultSuperAdminClientId` and `defaultSuperAdminClientPassword`, which will create a new default `ClientApplication`