### PR TITLE
Fix version commit hash to length 7

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -67,7 +67,7 @@ jobs:
         # This forces git shorthash to match between @medplum/agent and @medplum/core
         run: |
           set -e
-          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent
@@ -179,7 +179,7 @@ jobs:
         # This forces git shorthash to match between @medplum/agent and @medplum/core
         run: |
           set -e
-          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent
@@ -255,7 +255,7 @@ jobs:
         # This forces git shorthash to match between @medplum/agent and @medplum/core
         run: |
           set -e
-          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent
@@ -331,7 +331,7 @@ jobs:
         # This forces git shorthash to match between @medplum/agent and @medplum/core
         run: |
           set -e
-          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,7 +171,7 @@ jobs:
         # This forces git shorthash to match between @medplum/agent and @medplum/core
         run: |
           set -e
-          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent
@@ -321,7 +321,7 @@ jobs:
         # This forces git shorthash to match between @medplum/agent and @medplum/core
         run: |
           set -e
-          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "MEDPLUM_GIT_SHORTHASH=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
 
       - name: Build
         run: npm run build -- --filter=@medplum/agent

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -14,7 +14,7 @@ if (!existsSync(path.join(__dirname, '.env'))) {
 
 let gitHash;
 try {
-  gitHash = execSync('git rev-parse --short HEAD').toString().trim();
+  gitHash = execSync('git rev-parse --short=7 HEAD').toString().trim();
 } catch (_err) {
   gitHash = 'unknown'; // Default value when not in a git repository
 }

--- a/packages/core/esbuild.mjs
+++ b/packages/core/esbuild.mjs
@@ -11,7 +11,7 @@ import packageJson from './package.json' with { type: 'json' };
 
 let gitHash;
 try {
-  gitHash = execSync('git rev-parse --short HEAD').toString().trim();
+  gitHash = execSync('git rev-parse --short=7 HEAD').toString().trim();
 } catch (_error) {
   gitHash = 'unknown'; // Default value when not in a git repository
 }


### PR DESCRIPTION
Git adjusts the length of this commit hash based on the uniqueness of the commits in the repository, but we would like to set this to a fixed length. We're choosing 7 to match Github UI elements.