### PR TITLE
Prefer `String#replaceAll()` over `String#replace()`

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -94,7 +94,7 @@ jobs:
                     if (!folder.endsWith('.0')) {
                         continue;
                     }
-                    const folderVersion = parseInt(folder.replace(/\./g,''));
+                    const folderVersion = parseInt(folder.replaceAll('.',''));
                     if (folderVersion > maxVersion) {
                         const signtoolFilename = `${windowsKitsFolder}${folder}/x64/signtool.exe`;
                         try {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,7 +198,7 @@ jobs:
                     if (!folder.endsWith('.0')) {
                         continue;
                     }
-                    const folderVersion = parseInt(folder.replace(/\./g,''));
+                    const folderVersion = parseInt(folder.replaceAll('.',''));
                     if (folderVersion > maxVersion) {
                         const signtoolFilename = `${windowsKitsFolder}${folder}/x64/signtool.exe`;
                         try {

--- a/examples/medplum-demo-bots/src/epic/epic-query-patient.ts
+++ b/examples/medplum-demo-bots/src/epic/epic-query-patient.ts
@@ -22,7 +22,7 @@ export async function handler(medplum: MedplumClient, event: BotEvent<Patient>):
   }
 
   // Handles unknown issue with newlines in private key
-  const privateKeyString = event.secrets['EPIC_PRIVATE_KEY']?.valueString?.replace(/\\n/g, '\n');
+  const privateKeyString = event.secrets['EPIC_PRIVATE_KEY']?.valueString?.replaceAll('\\n', '\n');
   if (!privateKeyString) {
     throw new Error('Missing EPIC_PRIVATE_KEY');
   }

--- a/examples/medplum-healthie-importer/src/healthie/questionnaire-response.ts
+++ b/examples/medplum-healthie-importer/src/healthie/questionnaire-response.ts
@@ -135,9 +135,9 @@ export function convertHealthieFormAnswerGroupToFhir(
 export function createSlug(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '') // Remove special characters
-    .replace(/\s+/g, '-') // Replace spaces with hyphens
-    .replace(/-+/g, '-') // Replace multiple hyphens with single
+    .replaceAll(/[^a-z0-9\s-]/g, '') // Remove special characters
+    .replaceAll(/\s+/g, '-') // Replace spaces with hyphens
+    .replaceAll(/-+/g, '-') // Replace multiple hyphens with single
     .trim();
 }
 

--- a/examples/medplum-provider/src/components/encountertasks/TaskStatusPanel.tsx
+++ b/examples/medplum-provider/src/components/encountertasks/TaskStatusPanel.tsx
@@ -31,7 +31,7 @@ export const TaskStatusPanel = (props: TaskStatusPanelProps): JSX.Element => {
                   style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 0 }}
                   rightSection={<IconChevronDown size={16} />}
                 >
-                  {task.status.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())}
+                  {task.status.replaceAll('-', ' ').replaceAll(/\b\w/g, (char) => char.toUpperCase())}
                 </Badge>
               </Menu.Target>
               <Menu.Dropdown style={{ width: 140 }}>
@@ -54,7 +54,7 @@ export const TaskStatusPanel = (props: TaskStatusPanelProps): JSX.Element => {
             </Menu>
           ) : (
             <Badge variant="light" color={badgeColor} size="lg">
-              {task.status.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())}
+              {task.status.replaceAll('-', ' ').replaceAll(/\b\w/g, (char) => char.toUpperCase())}
             </Badge>
           )}
         </Flex>

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -11,7 +11,7 @@ import { UPGRADE_MANIFEST_PATH } from './upgrader-utils';
 
 const TEMP_LOG_FILE = path.join(
   dirname(UPGRADE_MANIFEST_PATH),
-  `stop-service-logs-${new Date().toISOString().replace(/:\s*/g, '-')}.txt`
+  `stop-service-logs-${new Date().toISOString().replaceAll(/:\s*/g, '-')}.txt`
 );
 
 export async function main(argv: string[]): Promise<void> {

--- a/packages/agent/src/upgrader-utils.ts
+++ b/packages/agent/src/upgrader-utils.ts
@@ -11,7 +11,7 @@ import type streamWeb from 'node:stream/web';
 export const UPGRADE_MANIFEST_PATH = resolve(__dirname, 'upgrade.json');
 export const UPGRADER_LOG_PATH = resolve(
   __dirname,
-  `upgrader-logs-${new Date().toISOString().replace(/:\s*/g, '-')}.txt`
+  `upgrader-logs-${new Date().toISOString().replaceAll(/:\s*/g, '-')}.txt`
 );
 export const RELEASES_PATH = resolve(__dirname);
 

--- a/packages/ccda/src/datetime.ts
+++ b/packages/ccda/src/datetime.ts
@@ -94,7 +94,7 @@ export function mapFhirToCcdaDate(date: string | undefined): string | undefined 
   if (!date) {
     return undefined;
   }
-  return date.substring(0, 10).replace(/-/g, '');
+  return date.substring(0, 10).replaceAll('-', '');
 }
 
 /**
@@ -113,8 +113,8 @@ export function mapFhirToCcdaDateTime(dateTime: string | undefined): string | un
 
   const outTime = (time ?? '')
     .replaceAll(/\.\d+/g, '') // Remove decimal point seconds
-    .replaceAll(/:/g, '') // Remove colons
-    .replaceAll(/Z/g, '+0000'); // Replace Z with +0000
+    .replaceAll(':', '') // Remove colons
+    .replaceAll('Z', '+0000'); // Replace Z with +0000
 
   return `${outDate}${outTime}`;
 }

--- a/packages/ccda/src/fhir-to-ccda/utils.ts
+++ b/packages/ccda/src/fhir-to-ccda/utils.ts
@@ -99,7 +99,7 @@ export function mapBirthDate(birthDate: string | undefined): CcdaTimeStamp | und
     return undefined;
   }
   return {
-    '@_value': birthDate.replace(/-/g, ''),
+    '@_value': birthDate.replaceAll('-', ''),
   };
 }
 

--- a/packages/cli/src/bulk.ts
+++ b/packages/cli/src/bulk.ts
@@ -37,7 +37,7 @@ bulkExportCommand
     response.output?.forEach(async ({ type, url }) => {
       const fileUrl = new URL(url as string);
       const data = await medplum.download(url as string);
-      const fileName = `${type}_${fileUrl.pathname}`.replace(/[^a-zA-Z0-9]+/g, '_') + '.ndjson';
+      const fileName = `${type}_${fileUrl.pathname}`.replaceAll(/[^a-zA-Z0-9]+/g, '_') + '.ndjson';
       const path = resolve(targetDirectory ?? '', fileName);
 
       writeFile(`${path}`, await data.text(), () => {

--- a/packages/cli/src/util/color.ts
+++ b/packages/cli/src/util/color.ts
@@ -19,5 +19,5 @@ export const color = {
 
 // Bold text wrapped in ** **
 export const processDescription = (desc: string): string => {
-  return desc.replace(/\*\*(.*?)\*\*/g, (_, text) => color.bold(text));
+  return desc.replaceAll(/\*\*(.*?)\*\*/g, (_, text) => color.bold(text));
 };

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -121,7 +121,7 @@ export async function createBot(
 }
 
 export function readBotConfigs(botName: string): MedplumBotConfig[] {
-  const regExBotName = new RegExp('^' + escapeRegex(botName).replace(/\\\*/g, '.*') + '$');
+  const regExBotName = new RegExp('^' + escapeRegex(botName).replaceAll(String.raw`\*`, '.*') + '$');
   const botConfigs = readConfig()?.bots?.filter((b) => regExBotName.test(b.name));
   if (!botConfigs) {
     return [];
@@ -196,7 +196,7 @@ function addBotToConfig(botConfig: MedplumBotConfig): void {
 }
 
 function escapeRegex(str: string): string {
-  return str.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+  return str.replaceAll(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
 /**

--- a/packages/core/src/base64.ts
+++ b/packages/core/src/base64.ts
@@ -53,8 +53,8 @@ export function encodeBase64(data: string): string {
  */
 export function encodeBase64Url(data: string): string {
   return encodeBase64(data)
-    .replace(/\+/g, '-') // Replace + with -
-    .replace(/\//g, '_') // Replace / with _
+    .replaceAll('+', '-') // Replace + with -
+    .replaceAll('/', '_') // Replace / with _
     .replace(/[=]{1,2}$/, ''); // Remove trailing =
 }
 
@@ -65,6 +65,6 @@ export function encodeBase64Url(data: string): string {
  */
 export function decodeBase64Url(data: string): string {
   data = data.padEnd(data.length + ((4 - (data.length % 4)) % 4), '=');
-  const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
+  const base64 = data.replaceAll('-', '+').replaceAll('_', '/');
   return decodeBase64(base64);
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1889,7 +1889,7 @@ export class MedplumClient extends TypedEventTarget<MedplumClientEventMap> {
         expression,
         target
       }
-    }`.replace(/\s+/g, ' ');
+    }`.replaceAll(/\s+/g, ' ');
 
         const response = (await this.graphql(query)) as SchemaGraphQLResponse;
 

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -29,7 +29,7 @@ export async function encryptSHA256(str: string): Promise<ArrayBuffer> {
  * @returns A random UUID.
  */
 export function generateId(): string {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replaceAll(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);

--- a/packages/core/src/filebuilder.test.ts
+++ b/packages/core/src/filebuilder.test.ts
@@ -24,6 +24,6 @@ describe('FileBuilder', () => {
     const longLine = 'word '.repeat(50);
     fb.append(longLine);
     expect(fb.toString().split('\n').length).toBeGreaterThan(2);
-    expect(fb.toString().replace(/\n/g, ' ')).toEqual(longLine);
+    expect(fb.toString().replaceAll('\n', ' ')).toEqual(longLine);
   });
 });

--- a/packages/core/src/hl7.ts
+++ b/packages/core/src/hl7.ts
@@ -682,7 +682,7 @@ export function formatHl7DateTime(isoDate: Date | string): string {
   // Replace "T" and all dashes (-) and colons (:) with empty strings
   // Replace Z with "+0000"
   // Replace the last 3 digits before 'Z' with the 4-digit milliseconds
-  let result = isoString.replace(/[-:T]/g, '').replace(/(\.\d+)?Z$/, '');
+  let result = isoString.replaceAll(/[-:T]/g, '').replace(/(\.\d+)?Z$/, '');
 
   const milliseconds = date.getUTCMilliseconds();
   if (milliseconds > 0) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -352,7 +352,7 @@ export function getPropertyDisplayName(propertyName: string): string {
   // Then normalize whitespace to single space character
   // For example, for property name "birthDate",
   // the display name is "Birth Date".
-  return words.map(capitalizeDisplayWord).join(' ').replace('_', ' ').replace(/\s+/g, ' ');
+  return words.map(capitalizeDisplayWord).join(' ').replace('_', ' ').replaceAll(/\s+/g, ' ');
 }
 
 const capitalizedWords = new Set(['ID', 'IP', 'PKCE', 'JWKS', 'URI', 'URL', 'OMB', 'UDI']);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1478,13 +1478,13 @@ export function flatMapFilter<T, U>(arr: T[] | undefined, fn: (value: T, idx: nu
  */
 export function escapeHtml(unsafe: string): string {
   return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/“/g, '&ldquo;')
-    .replace(/”/g, '&rdquo;')
-    .replace(/‘/g, '&lsquo;')
-    .replace(/’/g, '&rsquo;')
-    .replace(/…/g, '&hellip;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('“', '&ldquo;')
+    .replaceAll('”', '&rdquo;')
+    .replaceAll('‘', '&lsquo;')
+    .replaceAll('’', '&rsquo;')
+    .replaceAll('…', '&hellip;');
 }

--- a/packages/generator/src/compare.ts
+++ b/packages/generator/src/compare.ts
@@ -235,11 +235,11 @@ function escapeXml(str: string): string {
     return str;
   }
   return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
 }
 
 function unescapeXml(str: string): string {

--- a/packages/generator/src/docs.ts
+++ b/packages/generator/src/docs.ts
@@ -477,7 +477,7 @@ function extractResourceDescriptions(
       for (const div of divs) {
         const h2 = div.querySelector('h2');
         if (h2) {
-          const h2Text = h2.textContent?.toLowerCase().replace(/\s/g, '') || '';
+          const h2Text = h2.textContent?.toLowerCase().replaceAll(/\s/g, '') || '';
 
           const paragraphHTML = sanitizeNodeContent(div, dom.window);
 

--- a/packages/react/src/AppShell/HeaderSearchInput.tsx
+++ b/packages/react/src/AppShell/HeaderSearchInput.tsx
@@ -130,7 +130,7 @@ function buildGraphQLQuery(input: string): string {
           display
         }
       }
-    }`.replace(/\s+/g, ' ');
+    }`.replaceAll(/\s+/g, ' ');
   }
   return `{
     Patients1: PatientList(name: ${escaped}, _count: 5) {
@@ -170,7 +170,7 @@ function buildGraphQLQuery(input: string): string {
         display
       }
     }
-  }`.replace(/\s+/g, ' ');
+  }`.replaceAll(/\s+/g, ' ');
 }
 
 /**

--- a/packages/react/src/ReferenceInput/ReferenceInput.tsx
+++ b/packages/react/src/ReferenceInput/ReferenceInput.tsx
@@ -271,7 +271,7 @@ async function fetchResourceTypeOfProfile(
         name,
         title,
       }
-    }`.replace(/\s+/g, ' ');
+    }`.replaceAll(/\s+/g, ' ');
 
   const response = (await medplum.graphql(query)) as ResourceTypeGraphQLResponse;
 

--- a/packages/react/src/SearchControl/SearchUtils.tsx
+++ b/packages/react/src/SearchControl/SearchUtils.tsx
@@ -490,13 +490,13 @@ export function buildFieldNameString(key: string): string {
   tmp = tmp.replace('[x]', '');
 
   // Convert camel case to space separated
-  tmp = tmp.replace(/([A-Z])/g, ' $1');
+  tmp = tmp.replaceAll(/([A-Z])/g, ' $1');
 
   // Convert dashes and underscores to spaces
-  tmp = tmp.replace(/[-_]/g, ' ');
+  tmp = tmp.replaceAll(/[-_]/g, ' ');
 
   // Normalize whitespace to single space character
-  tmp = tmp.replace(/\s+/g, ' ');
+  tmp = tmp.replaceAll(/\s+/g, ' ');
 
   // Trim
   tmp = tmp.trim();

--- a/packages/react/src/StatusBadge/StatusBadge.tsx
+++ b/packages/react/src/StatusBadge/StatusBadge.tsx
@@ -77,7 +77,7 @@ export function StatusBadge(props: StatusBadgeProps): JSX.Element {
 
   return (
     <Badge color={props.color || statusToColor[status]} {...badgeProps}>
-      {status.replace(/-/g, ' ')}
+      {status.replaceAll('-', ' ')}
     </Badge>
   );
 }

--- a/packages/react/src/utils/dom.ts
+++ b/packages/react/src/utils/dom.ts
@@ -92,7 +92,7 @@ export function exportJsonFile(jsonString: string, fileName?: string): void {
   const link = document.createElement('a');
   link.href = url;
 
-  const linkName = fileName ?? new Date().toISOString().replace(/\D/g, '');
+  const linkName = fileName ?? new Date().toISOString().replaceAll(/\D/g, '');
   link.download = `${linkName}.json`;
 
   document.body.appendChild(link);

--- a/packages/server/src/config/loader.ts
+++ b/packages/server/src/config/loader.ts
@@ -125,7 +125,7 @@ function loadEnvConfig(): MedplumServerConfig {
     }
 
     // Convert key from CAPITAL_CASE to camelCase
-    key = key.toLowerCase().replace(/_([a-z])/g, (g) => g[1].toUpperCase());
+    key = key.toLowerCase().replaceAll(/_([a-z])/g, (g) => g[1].toUpperCase());
 
     if (isIntegerConfig(key)) {
       currConfig[key] = parseInt(value ?? '', 10);

--- a/packages/server/src/fhir/operations/csv.ts
+++ b/packages/server/src/fhir/operations/csv.ts
@@ -166,7 +166,7 @@ function csvEscape(input: unknown): string {
 const CSV_INJECTION_CHARS = ['=', '+', '-', '@'];
 
 function csvEscapeString(input: string): string {
-  let result = input.trim().replace(/"/g, '""');
+  let result = input.trim().replaceAll('"', '""');
   if (result.length > 0 && CSV_INJECTION_CHARS.includes(result[0])) {
     result = "'" + result;
   }

--- a/packages/server/src/fhir/operations/utils/cms1500pdf.ts
+++ b/packages/server/src/fhir/operations/utils/cms1500pdf.ts
@@ -349,7 +349,7 @@ export function getSimplePhone(phone: string | undefined): string | undefined {
   }
 
   // Remove all remaining non-digit characters
-  return result.replace(/\D/g, '');
+  return result.replaceAll(/\D/g, '');
 }
 
 function getPhoneAreaCode(phone: string | undefined): string | undefined {

--- a/packages/server/src/fhir/sql.ts
+++ b/packages/server/src/fhir/sql.ts
@@ -205,12 +205,12 @@ function formatTsquery(filter: string | undefined): string | undefined {
     return undefined;
   }
 
-  const noPunctuation = filter.replace(/[^\p{Letter}\p{Number}-]/gu, ' ').trim();
+  const noPunctuation = filter.replaceAll(/[^\p{Letter}\p{Number}-]/gu, ' ').trim();
   if (!noPunctuation) {
     return undefined;
   }
 
-  return noPunctuation.replace(/\s+/g, ':* & ') + ':*';
+  return noPunctuation.replaceAll(/\s+/g, ':* & ') + ':*';
 }
 
 export interface Expression {

--- a/packages/server/src/fhir/token-column.ts
+++ b/packages/server/src/fhir/token-column.ts
@@ -376,5 +376,5 @@ export function escapeRegexString(str: string): string {
   // { } - define quantifiers
   // \ - escapes a special character
   // | - alternation (OR operator)
-  return str.replace(/[.^$*+?()[\]{}\\|]/g, '\\$&');
+  return str.replaceAll(/[.^$*+?()[\]{}\\|]/g, '\\$&');
 }

--- a/packages/server/src/workers/utils.ts
+++ b/packages/server/src/workers/utils.ts
@@ -133,7 +133,7 @@ export function isJobSuccessful(subscription: Subscription, status: number): boo
   }
 
   // Removing any white space
-  const codesTrimSpace = successCodes.valueString.replace(/ /g, '');
+  const codesTrimSpace = successCodes.valueString.replaceAll(' ', '');
   const listOfSuccessCodes = codesTrimSpace.split(',');
 
   for (const code of listOfSuccessCodes) {


### PR DESCRIPTION
- Shows more explicit intention to perform multiple replacements
- Allows using string literals as the search pattern when not needing Regex power

See: https://sonarcloud.io/organizations/medplum/rules?open=typescript%3AS7781&rule_key=typescript%3AS7781