### PR TITLE
fix(ci): fix macos agent build failing on publish

### DIFF
--- a/scripts/build-agent-macos.sh
+++ b/scripts/build-agent-macos.sh
@@ -30,6 +30,27 @@ sha256sum "medplum-agent-$MEDPLUM_VERSION-macos" > "medplum-agent-$MEDPLUM_VERSI
 # Check the installer checksum
 sha256sum --check "medplum-agent-$MEDPLUM_VERSION-macos.sha256"
 
+if [ -z "$SKIP_SIGNING" ]; then
+  # Generate a GPG signature for the installer
+  # --batch = Use batch mode. Never ask, do not allow interactive commands.
+  # --yes = Assume "yes" on most questions. Should not be used in an option file.
+  # --pinentry-mode loopback = Allows the passphrase to be set via command line or fd.
+  # --passphrase-fd 0 = Read the passphrase from file descriptor 0 (stdin).
+  # --local-user = Specify the key to use for signing.
+  # --detach-sign --armor = Create a detached ASCII armored signature.
+  echo "$GPG_PASSPHRASE" | gpg \
+    --batch \
+    --yes \
+    --pinentry-mode loopback \
+    --passphrase-fd 0 \
+    --local-user "$GPG_KEY_ID" \
+    --detach-sign --armor \
+    "medplum-agent-$MEDPLUM_VERSION-macos"
+
+  # Check the signature
+  gpg --verify "medplum-agent-$MEDPLUM_VERSION-macos.asc"
+fi
+
 # Check the build output within dist folder
 ls -la
 


### PR DESCRIPTION
See: https://github.com/medplum/medplum/actions/runs/19083943790/job/54519620323

Basically, signing the binary failed on macos because we didn't copy-paste that step into the script when we added that for Linux and Windows, which was only surfaced on the first run of the `Publish` action since that was added to that job.