### PR TITLE
Dependency upgrade for autofix-ci's Node.js

### DIFF
--- a/.github/workflows/autofix-ci.yml
+++ b/.github/workflows/autofix-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22'
+          node-version: '24'
 
       - run: npm ci
       - run: npm run prettier


### PR DESCRIPTION
I believe we're using Node v24 now

Signed-off-by: Karl Pietrzak <karl@medplum.com>
