### PR TITLE
Fix typo in the docs

### DIFF
--- a/packages/examples/src/communications/organizing-communications.ts
+++ b/packages/examples/src/communications/organizing-communications.ts
@@ -56,7 +56,7 @@ await medplum.searchResources('Communication', {
 
 /*
 // start-block searchThreadsWithMessagesCli
-medplum get 'Communication?part-of:missing=true&_revinclude:Communication:part-of'
+medplum get 'Communication?part-of:missing=true&_revinclude=Communication:part-of'
 // end-block searchThreadsWithMessagesCli
 
 // start-block searchThreadsWithMessagesCurl


### PR DESCRIPTION
Fix a minor typo that shows up here - https://www.medplum.com/docs/communications/organizing-communications#putting-it-all-together