### PR TITLE
fix(definitions): include FHIR JSON definitions in NPM package

### DIFF
--- a/packages/definitions/package.json
+++ b/packages/definitions/package.json
@@ -45,12 +45,13 @@
   "types": "dist/esm/index.d.ts",
   "files": [
     "dist/cjs",
-    "dist/esm"
+    "dist/esm",
+    "dist/fhir"
   ],
   "scripts": {
     "api-extractor": "api-extractor run --local && cp dist/types.d.ts dist/cjs/index.d.ts && cp dist/types.d.ts dist/esm/index.d.ts",
     "build": "npm run clean && tsc && node build.mjs && npm run api-extractor",
-    "clean": "rimraf --glob \"dist/!(fhir)\"",
+    "clean": "rimraf dist",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "jest"


### PR DESCRIPTION
it appears they were missed, as they are missing from the published modules on npmjs

Signed-off-by: Karl Pietrzak <karl@medplum.com>
