### PR TITLE
Fix color scheme segmented control highlight

### DIFF
--- a/packages/react/src/AppShell/Header.tsx
+++ b/packages/react/src/AppShell/Header.tsx
@@ -44,7 +44,7 @@ export function Header(props: HeaderProps): JSX.Element {
             width={260}
             shadow="xl"
             position="bottom-end"
-            transitionProps={{ transition: 'pop-top-right' }}
+            transitionProps={{ transition: 'fade-down' }}
             opened={userMenuOpened}
             onClose={() => setUserMenuOpened(false)}
           >


### PR DESCRIPTION
When using the "pop" family of transitions, `<FloatingIndicator>` components (such as the one used under the hood of a `<SegmentedControl>`) behave awkwardly - it appears that they compute position information based on the element size, and the "pop" transitions animate that by changing a `scale` transform.

This has been reported in Mantine and they do not plan on addressing this at the library level:
https://github.com/mantinedev/mantine/issues/3330

We have a couple options here, but the most expedient one is to change our transition style to something that does not animate `scale`. I've opted for "fade-down" which still looks good but doesn't trigger this bug.

Fade-down transition:
https://github.com/mantinedev/mantine/blob/8.3.7/packages/%40mantine/core/src/components/Transition/transitions.ts#L52-L56

## Screenshot Before
<img width="1254" height="1014" alt="before" src="https://github.com/user-attachments/assets/baa6cc81-c0ae-45f5-b284-58df84082dbc" />

## Screenshot After
<img width="1257" height="1013" alt="after" src="https://github.com/user-attachments/assets/a6b8739e-9dab-4695-9100-4a6847416b89" />
