### PR TITLE
ci(test): lean into turbo, set turbo concurrency to 1

### DIFF
--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -6,7 +6,7 @@
  * Source: https://stackoverflow.com/a/46432113
  */
 
-// TODO: Remove this comment. Just busting the build cache - BUMP
+// TODO: Remove this comment. Just busting the build cache - BUMP AGAIN
 
 export class LRUCache<T> {
   private readonly max: number;

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -6,7 +6,7 @@
  * Source: https://stackoverflow.com/a/46432113
  */
 
-// TODO: Remove this comment. Just busting the build cache
+// TODO: Remove this comment. Just busting the build cache - BUMP
 
 export class LRUCache<T> {
   private readonly max: number;

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -6,6 +6,8 @@
  * Source: https://stackoverflow.com/a/46432113
  */
 
+// TODO: Remove this comment. Just busting the build cache
+
 export class LRUCache<T> {
   private readonly max: number;
   private readonly cache: Map<string, T>;

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,7 +21,7 @@ mkdir -p coverage/combined
 # It will try to work through dependencies first
 # We can instead reduce overhead of context switching by setting concurrency to 1 and allowing jest to handle concurrency within one test suite
 # We leave out the server tests from this batch since (for now) we need to manually run the seed test separately
-npx turbo run test --filter=@medplum/app --filter=@medplum/agent --concurrency=1
+npx turbo run test --filter=!@medplum/docs --filter=!@medplum/server --concurrency=1
 
 # Seed the database for server tests
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,7 +21,7 @@ mkdir -p coverage/combined
 # It will try to work through dependencies first
 # We can instead reduce overhead of context switching by setting concurrency to 1 and allowing jest to handle concurrency within one test suite
 # We leave out the server tests from this batch since (for now) we need to manually run the seed test separately
-npx turbo run test --filter=!@medplum/docs --filter=!@medplum/server --concurrency=1
+npx turbo run test --filter=!@medplum/docs --filter=!@medplum/server --concurrency=2
 
 # Seed the database for server tests
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions
@@ -31,10 +31,10 @@ SHOULD_RUN_SEED_TEST=$(date) time npx turbo run test:seed --filter=@medplum/serv
 cp "packages/server/coverage/coverage-final.json" "coverage/packages/coverage-server-seed.json"
 
 # Finally run the rest of the server tests
-npx turbo run test --filter=@medplum/server --concurrency=1
+npx turbo run test --filter=@medplum/server
 
 # Now run tests for all examples
-npx turbo run test --filter="./examples/*" --concurrency=1
+npx turbo run test --filter="./examples/*" --concurrency=2
 
 # Find all coverage-final.json files in packages subdirectories
 for coverage_file in packages/*/coverage/coverage-final.json; do

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,27 +14,27 @@ rm -rf coverage
 mkdir -p coverage/packages
 mkdir -p coverage/combined
 
-# Seed the database
+# Test
+# Run them separately because code coverage is resource intensive
+# Previously we iterated over the directories in packages/ here and called test on each one, one-by-one
+# This didn't actually do what we wanted it to do, since if a package (say @medplum/agent), depends on other packages
+# It will try to work through dependencies first
+# We can instead reduce overhead of context switching by setting concurrency to 1 and allowing jest to handle concurrency within one test suite
+# We leave out the server tests from this batch since (for now) we need to manually run the seed test separately
+npx turbo run test --filter=@medplum/app --filter=@medplum/agent --concurrency=1
+
+# Seed the database for server tests
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions
 # On a normal developer machine, this is run only rarely when setting up a new database
 # This test must be run first, and cannot be run concurrently with other tests
-SHOULD_RUN_SEED_TEST=$(date) time npx turbo run test:seed --filter=./packages/server -- --coverage
+SHOULD_RUN_SEED_TEST=$(date) time npx turbo run test:seed --filter=@medplum/server -- --coverage
 cp "packages/server/coverage/coverage-final.json" "coverage/packages/coverage-server-seed.json"
 
-# Test
-# Run them separately because code coverage is resource intensive
+# Finally run the rest of the server tests
+npx turbo run test --filter=@medplum/server --concurrency=1
 
-for dir in `ls packages`; do
-  if test -f "packages/$dir/package.json" && grep -q "\"test\":" "packages/$dir/package.json"; then
-    npx turbo run test --filter=./packages/$dir -- --coverage
-  fi
-done
-
-for dir in `ls examples`; do
-  if test -f "examples/$dir/package.json" && grep -q "\"test\":" "examples/$dir/package.json"; then
-    npx turbo run test --filter=./examples/$dir
-  fi
-done
+# Now run tests for all examples
+npx turbo run test --filter="./examples/*" --concurrency=1
 
 # Find all coverage-final.json files in packages subdirectories
 for coverage_file in packages/*/coverage/coverage-final.json; do

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,9 +19,9 @@ mkdir -p coverage/combined
 # Previously we iterated over the directories in packages/ here and called test on each one, one-by-one
 # This didn't actually do what we wanted it to do, since if a package (say @medplum/agent), depends on other packages
 # It will try to work through dependencies first
-# We can instead reduce overhead of context switching by setting concurrency to 1 and allowing jest to handle concurrency within one test suite
+# We can instead reduce overhead of context switching by setting concurrency and allowing jest to handle concurrency within one test suite
 # We leave out the server tests from this batch since (for now) we need to manually run the seed test separately
-npx turbo run test --filter=!@medplum/docs --filter=!@medplum/server --concurrency=2
+npx turbo run test --filter=!@medplum/docs --filter=!@medplum/server
 
 # Seed the database for server tests
 # This is a special "test" which runs all of the seed logic, such as setting up structure definitions
@@ -34,7 +34,7 @@ cp "packages/server/coverage/coverage-final.json" "coverage/packages/coverage-se
 npx turbo run test --filter=@medplum/server
 
 # Now run tests for all examples
-npx turbo run test --filter="./examples/*" --concurrency=2
+npx turbo run test --filter="./examples/*"
 
 # Find all coverage-final.json files in packages subdirectories
 for coverage_file in packages/*/coverage/coverage-final.json; do


### PR DESCRIPTION
This is just a test to see how this setup performs in CI. Theoretically this simplifies the concurrency model and allows Jest to handle concurrency on a per task basis which should theoretically help prevent resource exhaustion on the smallish GitHub CI boxes