### PR TITLE
Avoid redundant redis/db reads in buildAccessPolicyResources

### DIFF
--- a/packages/server/src/fhir/accesspolicy.ts
+++ b/packages/server/src/fhir/accesspolicy.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright Orangebot, Inc. and Medplum contributors
 // SPDX-License-Identifier: Apache-2.0
 import type { ProfileResource, WithId } from '@medplum/core';
-import { createReference, getReferenceString, isResource, isString, projectAdminResourceTypes, resolveId } from '@medplum/core';
+import {
+  createReference,
+  getReferenceString,
+  isResource,
+  isString,
+  projectAdminResourceTypes,
+  resolveId,
+} from '@medplum/core';
 import type {
   AccessPolicy,
   AccessPolicyIpAccessRule,


### PR DESCRIPTION
Hey team- let me know your thoughts on this. Wasn't sure how errors should be handled here although I imagine it would be safe to cast the `policyReferenceString`/`access.policy.reference` as string.

The inspiration is that we have several 'products' on our 'platform' deployed in an MSO model for span of control. Each product has a fine-grained, parameterized `AccessPolicy`. Superusers who have access to each product and `Organization` could have hundreds of entries within their `ProjectMembership.access`, introducing noticeable latency when repeatedly looking up the same `AccessPolicy`.

<img width="2198" height="1044" alt="image" src="https://github.com/user-attachments/assets/ef7c2407-7d3d-46b4-a9a8-4cca66085a86" />
