### PR TITLE
Expunge project always expunges project resources

### DIFF
--- a/packages/server/src/fhir/operations/expunge.ts
+++ b/packages/server/src/fhir/operations/expunge.ts
@@ -24,7 +24,7 @@ export async function expungeHandler(req: FhirRequest): Promise<FhirResponse> {
 
   const { resourceType, id } = req.params;
   const { everything } = req.query;
-  if (everything === 'true') {
+  if (resourceType === 'Project' || everything === 'true') {
     const { baseUrl } = getConfig();
     const exec = new AsyncJobExecutor(ctx.repo);
     await exec.init(concatUrls(baseUrl, 'fhir/R4' + req.pathname));


### PR DESCRIPTION
This is in response to a customer reported issue, where they ended up in a bad state because `Project` resources were expunged, but all resources within the project remained.

Before this PR, you would have to explicitly pass in `everything=true` to expunge all contained resources.

After this PR, `Project` will always act as `everything=true`.

In contrast to `Patient`, where you could make a reasonable claim that you might want to expunge the `Patient` but not related resources, expunging a `Project` will leave things in a broken state.