### PR TITLE
Fixes #7906 - handle xhtml properties in react components

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,7 +34,7 @@ export interface TypedValue {
 
 /**
  * List of property types.
- * http://www.hl7.org/fhir/valueset-defined-types.html
+ * http://www.hl7.org/fhir/R4/valueset-defined-types.html
  * The list here includes additions found from StructureDefinition resources.
  */
 export const PropertyType = {
@@ -53,6 +53,8 @@ export const PropertyType = {
   Distance: 'Distance',
   Dosage: 'Dosage',
   Duration: 'Duration',
+  Element: 'Element',
+  ElementDefinition: 'ElementDefinition',
   Expression: 'Expression',
   Extension: 'Extension',
   HumanName: 'HumanName',
@@ -60,6 +62,7 @@ export const PropertyType = {
   MarketingStatus: 'MarketingStatus',
   Meta: 'Meta',
   Money: 'Money',
+  MoneyQuantity: 'MoneyQuantity',
   Narrative: 'Narrative',
   ParameterDefinition: 'ParameterDefinition',
   Period: 'Period',
@@ -73,6 +76,7 @@ export const PropertyType = {
   RelatedArtifact: 'RelatedArtifact',
   SampledData: 'SampledData',
   Signature: 'Signature',
+  SimpleQuantity: 'SimpleQuantity',
   SubstanceAmount: 'SubstanceAmount',
   SystemString: 'http://hl7.org/fhirpath/System.String',
   Timing: 'Timing',
@@ -97,6 +101,7 @@ export const PropertyType = {
   uri: 'uri',
   url: 'url',
   uuid: 'uuid',
+  xhtml: 'xhtml',
 } as const;
 
 /**

--- a/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
+++ b/packages/react/src/ResourcePropertyDisplay/ResourcePropertyDisplay.tsx
@@ -113,6 +113,7 @@ export function ResourcePropertyDisplay(props: ResourcePropertyDisplayProps): JS
     case PropertyType.unsignedInt:
     case PropertyType.uri:
     case PropertyType.url:
+    case PropertyType.xhtml:
       return <>{value}</>;
     case PropertyType.canonical:
       return <ReferenceDisplay value={{ reference: value }} link={props.link} />;

--- a/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
+++ b/packages/react/src/ResourcePropertyInput/ResourcePropertyInput.tsx
@@ -321,6 +321,7 @@ export function ElementDefinitionTypeInput(props: ElementDefinitionTypeInputProp
       );
     case PropertyType.base64Binary:
     case PropertyType.markdown:
+    case PropertyType.xhtml:
       return (
         <Textarea
           {...getPrimitiveInputProps()}


### PR DESCRIPTION
<img width="1429" height="1286" alt="image" src="https://github.com/user-attachments/assets/382ca24f-1ad8-46e3-a97d-2515cf68e136" />

Also fixed in edit mode:

<img width="1439" height="327" alt="image" src="https://github.com/user-attachments/assets/a11d8be0-20e7-49fb-bb19-087701ae5506" />
