### PR TITLE
Fix typo in sidebar label for patient deduplication

### DIFF
--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -135,7 +135,7 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
-          label: 'Patient Dedupliaction Architectures',
+          label: 'Patient Deduplication Architectures',
           link: {
             type: 'doc',
             id: 'fhir-datastore/patient-deduplication/patient-deduplication',


### PR DESCRIPTION
Typo in sidebar