### PR TITLE
fix(vmcontext): always pass new `require`

### DIFF
--- a/packages/server/src/bots/vmcontext.ts
+++ b/packages/server/src/bots/vmcontext.ts
@@ -51,7 +51,7 @@ export async function runInVmContext(request: BotExecutionContext): Promise<BotE
   const sandbox = {
     console: botConsole,
     fetch,
-    require: typeof require !== 'undefined' ? require : createRequire(import.meta.url),
+    require: createRequire(typeof __filename !== 'undefined' ? __filename : import.meta.url),
     ContentType,
     Hl7Message,
     MedplumClient,


### PR DESCRIPTION
Fixes issue where `vmcontext` bots were getting the error `Dynamic require of "@medplum/core" is not supported`